### PR TITLE
[Agent][Agenda] Visuel du RDV dans agenda

### DIFF
--- a/app/assets/stylesheets/components/_calendar.scss
+++ b/app/assets/stylesheets/components/_calendar.scss
@@ -113,13 +113,13 @@
 }
 
 .fc-event-past, .fc-event-excused, .fc-event-not_excused {
-  filter: opacity(30%);
+  background-color: #dedede !important;
 }
 
 .fc-event-excused, .fc-event-not_excused {
   .fc-content .fc-title {
     text-decoration: line-through;
-  } 
+  }
 }
 .external-event {
   cursor: move;
@@ -146,6 +146,16 @@
   .fc-content {
     color: $white;
   }
+  &.fc-event-small{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    line-height: 0.65rem;
+    padding: 0;
+  }
+}
+.fc-event-container {
+  margin: 0 !important;
 }
 
 @include media-breakpoint-down(sm) {

--- a/app/javascript/packs/components/calendar.js
+++ b/app/javascript/packs/components/calendar.js
@@ -53,6 +53,9 @@ document.addEventListener('turbolinks:load', function() {
         if(info.event.extendedProps.past == true) {
           $(info.el).addClass("fc-event-past");
         };
+        if(info.event.extendedProps.duration <= 30) {
+          $(info.el).addClass("fc-event-small");
+        };
         $(info.el).addClass("fc-event-"+ info.event.extendedProps.status);
         $(info.el).attr("data-rightbar", "true");
         if (info.event.rendering == 'background') {

--- a/app/javascript/packs/components/calendar.js
+++ b/app/javascript/packs/components/calendar.js
@@ -50,6 +50,7 @@ document.addEventListener('turbolinks:load', function() {
       minTime: '07:00:00',
       maxTime: '20:00:00',
       eventRender: function (info) {
+        $(info.el).attr("title", `${moment(info.event.start).format('H:mm')} - ${info.event.title} / ${info.event.extendedProps.duration} min`)
         if(info.event.extendedProps.past == true) {
           $(info.el).addClass("fc-event-past");
         };

--- a/app/javascript/packs/components/calendar.js
+++ b/app/javascript/packs/components/calendar.js
@@ -50,7 +50,9 @@ document.addEventListener('turbolinks:load', function() {
       minTime: '07:00:00',
       maxTime: '20:00:00',
       eventRender: function (info) {
-        $(info.el).attr("title", `${moment(info.event.start).format('H:mm')} - ${info.event.title} / ${info.event.extendedProps.duration} min`)
+        if (info.event.extendedProps.duration) {
+          $(info.el).attr("title", `${moment(info.event.start).format('H:mm')} - ${info.event.title} / ${info.event.extendedProps.duration} min`)
+        }
         if(info.event.extendedProps.past == true) {
           $(info.el).addClass("fc-event-past");
         };

--- a/app/views/agents/rdvs/index.json.jbuilder
+++ b/app/views/agents/rdvs/index.json.jbuilder
@@ -3,6 +3,7 @@ json.array! @rdvs do |rdv|
   json.extendedProps do
     json.status rdv.status
     json.past rdv.past?
+    json.duration rdv.duration_in_min
   end
   json.start rdv.starts_at
   json.end rdv.ends_at

--- a/spec/controllers/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/agents/rdvs_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
         expect(first["end"]).to eq(rdv1.ends_at.as_json)
         expect(first["backgroundColor"]).to eq(rdv1.motif.color)
         expect(first["url"]).to eq(organisation_rdv_path(rdv1.organisation, rdv1))
-        expect(first["extendedProps"]).to eq({ status: rdv1.status, past: rdv1.past? }.as_json)
+        expect(first["extendedProps"]).to eq({ status: rdv1.status, past: rdv1.past?, duration: rdv.duration_in_min }.as_json)
 
         second = @parsed_response[1]
         expect(second.size).to eq(6)
@@ -45,7 +45,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
         expect(second["end"]).to eq(rdv2.ends_at.as_json)
         expect(second["backgroundColor"]).to eq(rdv2.motif.color)
         expect(second["url"]).to eq(organisation_rdv_path(rdv2.organisation, rdv2))
-        expect(first["extendedProps"]).to eq({ status: rdv1.status, past: rdv1.past? }.as_json)
+        expect(first["extendedProps"]).to eq({ status: rdv1.status, past: rdv1.past?, duration: rdv.duration_in_min }.as_json)
       end
     end
   end


### PR DESCRIPTION
Voila le visuel pour des RDV passé (plus de supperposition avec le nom de la plage) pour des durées de 30, 25, 20, 15, 10 min.

Je pense qu'a terme il faudrait analyser le % des RDV de - de 30min... S'il il est élevé on devra spliter les heures en tranche de 20min.

<img width="382" alt="Capture d’écran 2020-01-09 à 09 50 23" src="https://user-images.githubusercontent.com/29787388/72052480-88020000-32c5-11ea-8d39-3f8596ad8331.png">
