### PR TITLE
[Test] Rajouter un test sur la prise de RDV  sur un autre calendrier / Plage ouverture / Absence

### DIFF
--- a/spec/controllers/agents/absences_controller_spec.rb
+++ b/spec/controllers/agents/absences_controller_spec.rb
@@ -17,13 +17,10 @@ RSpec.describe Agents::AbsencesController, type: :controller do
         let!(:absence1) { create(:absence, agent: agent, first_day: Date.new(2019, 7, 21), start_time: Tod::TimeOfDay.new(8), end_time: Tod::TimeOfDay.new(10)) }
         let!(:absence2) { create(:absence, agent: agent, first_day: Date.new(2019, 8, 20), start_time: Tod::TimeOfDay.new(8), end_day: Date.new(2019, 8, 31), end_time: Tod::TimeOfDay.new(22)) }
 
-        before do
-          sign_in agent
-        end
-
         subject { get :index, params: { format: "json", organisation_id: organisation_id, agent_id: agent.id, start: start_time, end: end_time } }
 
         before do
+          sign_in agent
           subject
           @parsed_response = JSON.parse(response.body)
         end
@@ -38,7 +35,7 @@ RSpec.describe Agents::AbsencesController, type: :controller do
 
             first = @parsed_response[0]
             expect(first.size).to eq(5)
-            expect(first["title"]).to eq("Absence")
+            expect(first["title"]).to eq(expected_absence.title)
             expect(first["start"]).to eq(expected_absence_starts_at.as_json)
             expect(first["end"]).to eq(expected_absence_ends_at.as_json)
             expect(first["backgroundColor"]).to eq("#7f8c8d")

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -1,8 +1,12 @@
 FactoryBot.define do
+  sequence(:absence_title) { |n| "Absence #{n}" }
+
   factory :absence do
+    title { generate(:absence_title) }
     organisation { Organisation.first || create(:organisation) }
-    agent { Agent.first || create(:agent) }
     first_day { Date.new(2019, 7, 4) }
+    end_day { Date.new(2019, 8, 4) }
+    agent { Agent.first || create(:agent) }
     start_time { Tod::TimeOfDay.new(10) }
     end_time { Tod::TimeOfDay.new(15, 30) }
     no_recurrence

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     title { generate(:absence_title) }
     organisation { Organisation.first || create(:organisation) }
     first_day { Date.new(2019, 7, 4) }
-    end_day { Date.new(2019, 8, 4) }
     agent { Agent.first || create(:agent) }
     start_time { Tod::TimeOfDay.new(10) }
     end_time { Tod::TimeOfDay.new(15, 30) }

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
       confirmed_at { nil }
     end
     trait :secretaire do
-      service { create(:service, :secretariat) }
+      service { Service.find_by(name: "Secrétariat") || create(:service, :secretariat) }
     end
     trait :with_multiple_organisations do
       organisations { create_list(:organisation, 3) }

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
         create_list(:rdv, 5, motif: motif)
       end
     end
-    service { Service.first || create(:service) }
+    service { Service.where.not(name: "Secrétariat").first || create(:service) }
     trait :by_phone do
       by_phone { true }
     end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -1,0 +1,76 @@
+describe "Agent can CRUD absences" do
+  let!(:agent) { create(:agent, :admin) }
+  let!(:other_agent) { create(:agent, organisations: [agent.organisations.first]) }
+  let!(:absence) { create(:absence, agent: agent) }
+  let(:new_absence) { build(:absence) }
+
+  before do
+    login_as(agent, scope: :agent)
+    visit authenticated_agent_root_path
+    click_link "Vos absences"
+  end
+
+  context 'for an agent' do
+    scenario "default" do
+      crud_absence(agent, agent)
+    end
+  end
+
+  context 'for a secretaire' do
+    let(:agent) { create(:agent, :secretaire) }
+
+    scenario "cannot create absence" do
+      expect_page_title("Vos absences")
+      click_link 'Créer une pabsence', match: :first
+      expect(page).to have_content("Aucun motif disponible. Vous ne pouvez pas créer de absence.")
+    end
+
+    context 'with motif for_secretariat' do
+      let!(:motif) { create(:motif, :for_secretariat) }
+      let(:absence) { create(:absence, agent: agent, motifs: [motif]) }
+
+      scenario "can crud a absence" do
+        crud_absence(agent, agent)
+      end
+    end
+  end
+
+  context 'for an other agent calendar' do
+    let!(:absence) { create(:absence, agent: other_agent) }
+
+    scenario "can crud a absence" do
+      # select(other_agent.full_name, from: :id)
+      visit organisation_agent_absences_path(agent.organisations.first.id, other_agent.id)
+      crud_absence(agent, other_agent)
+    end
+  end
+
+  def crud_absence(current_agent, agent_crud)
+    title =  agent_crud == current_agent ? "Vos absences" : "absences de #{agent_crud.full_name_and_service}"
+
+    expect_page_title(title)
+    click_link absence.title
+
+    expect_page_title("Modifier la absence")
+    fill_in 'Description', with: 'La belle plage'
+    click_button('Modifier')
+
+    expect_page_title(title)
+    click_link 'La belle plage'
+
+    click_link('Supprimer')
+    expect_page_title(title)
+    empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé de absence" : "#{agent_crud.full_name} n'a pas encore créé de absence"
+    expect_page_with_no_record_text(empty_text)
+
+    click_link 'Créer une absence', match: :first
+
+    expect_page_title("Nouvelle absence")
+    fill_in 'Description', with: new_absence.title
+    check absence.motifs.first.name
+    click_button 'Créer'
+
+    expect_page_title(title)
+    click_link new_absence.title
+  end
+end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -49,7 +49,7 @@ describe "Agent can CRUD absences" do
     expect_page_title("Nouvelle absence")
     fill_in 'Description', with: new_absence.title
     fill_in "absence[first_day]", with: new_absence.first_day
-    fill_in "absence[end_day]", with: new_absence.end_day
+    fill_in "absence[end_day]", with: new_absence.first_day + 1.day
     click_button 'Créer'
 
     expect_page_title(title)

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -2,7 +2,7 @@ describe "Agent can CRUD absences" do
   let!(:agent) { create(:agent, :admin) }
   let!(:other_agent) { create(:agent, organisations: [agent.organisations.first]) }
   let!(:absence) { create(:absence, agent: agent) }
-  let(:new_absence) { build(:absence) }
+  let!(:new_absence) { build(:absence) }
 
   before do
     login_as(agent, scope: :agent)
@@ -13,25 +13,6 @@ describe "Agent can CRUD absences" do
   context 'for an agent' do
     scenario "default" do
       crud_absence(agent, agent)
-    end
-  end
-
-  context 'for a secretaire' do
-    let(:agent) { create(:agent, :secretaire) }
-
-    scenario "cannot create absence" do
-      expect_page_title("Vos absences")
-      click_link 'Créer une pabsence', match: :first
-      expect(page).to have_content("Aucun motif disponible. Vous ne pouvez pas créer de absence.")
-    end
-
-    context 'with motif for_secretariat' do
-      let!(:motif) { create(:motif, :for_secretariat) }
-      let(:absence) { create(:absence, agent: agent, motifs: [motif]) }
-
-      scenario "can crud a absence" do
-        crud_absence(agent, agent)
-      end
     end
   end
 
@@ -46,28 +27,29 @@ describe "Agent can CRUD absences" do
   end
 
   def crud_absence(current_agent, agent_crud)
-    title = agent_crud == current_agent ? "Vos absences" : "absences de #{agent_crud.full_name_and_service}"
+    title = agent_crud == current_agent ? "Vos absences" : "Absences de #{agent_crud.full_name_and_service}"
 
     expect_page_title(title)
     click_link absence.title
 
-    expect_page_title("Modifier la absence")
-    fill_in 'Description', with: 'La belle plage'
+    expect_page_title("Modifier l'absence")
+    fill_in 'Description', with: 'La belle absence'
     click_button('Modifier')
 
     expect_page_title(title)
-    click_link 'La belle plage'
+    click_link 'La belle absence'
 
     click_link('Supprimer')
     expect_page_title(title)
-    empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé de absence" : "#{agent_crud.full_name} n'a pas encore créé de absence"
+    empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé d'absence" : "#{agent_crud.full_name} n'a pas encore créé d'absence"
     expect_page_with_no_record_text(empty_text)
 
     click_link 'Créer une absence', match: :first
 
     expect_page_title("Nouvelle absence")
     fill_in 'Description', with: new_absence.title
-    check absence.motifs.first.name
+    fill_in "absence[first_day]", with: new_absence.first_day
+    fill_in "absence[end_day]", with: new_absence.end_day
     click_button 'Créer'
 
     expect_page_title(title)

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -46,7 +46,7 @@ describe "Agent can CRUD absences" do
   end
 
   def crud_absence(current_agent, agent_crud)
-    title =  agent_crud == current_agent ? "Vos absences" : "absences de #{agent_crud.full_name_and_service}"
+    title = agent_crud == current_agent ? "Vos absences" : "absences de #{agent_crud.full_name_and_service}"
 
     expect_page_title(title)
     click_link absence.title

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -1,65 +1,76 @@
 describe "Agent can CRUD users" do
-  let(:agent) { create(:agent) }
-  let(:secretaire) { create(:agent, :secretaire) }
+  let!(:agent) { create(:agent, :admin) }
+  let!(:other_agent) { create(:agent, organisations: [agent.organisations.first]) }
   let!(:plage_ouverture) { create(:plage_ouverture, agent: agent) }
   let(:new_plage_ouverture) { build(:plage_ouverture) }
 
+  before do
+    login_as(agent, scope: :agent)
+    visit authenticated_agent_root_path
+    click_link "Vos plages d'ouverture"
+  end
+
   context 'for an agent' do
-    before do
-      login_as(agent, scope: :agent)
-      visit authenticated_agent_root_path
-      click_link "Vos plages d'ouverture"
-    end
-
     scenario "default" do
-      expect_page_title("Vos plages d'ouverture")
-      click_link plage_ouverture.title
-
-      expect_page_title("Modifier la plage d'ouverture")
-      fill_in 'Description', with: 'La belle plage'
-      click_button('Modifier')
-
-      expect_page_title("Vos plages d'ouverture")
-      click_link 'La belle plage'
-
-      click_link('Supprimer')
-      expect_page_title("Vos plages d'ouverture")
-      expect_page_with_no_record_text("Vous n'avez pas encore créé de plage d'ouverture")
-
-      click_link 'Créer une plage d\'ouverture', match: :first
-
-      expect_page_title("Nouvelle plage d'ouverture")
-      fill_in 'Description', with: new_plage_ouverture.title
-      check agent.service.motifs.first.name
-      click_button 'Créer'
-
-      expect_page_title("Vos plages d'ouverture")
-      click_link new_plage_ouverture.title
+      crud_plage_ouverture(agent, agent)
     end
   end
 
   context 'for a secretaire' do
-    before do
-      login_as(secretaire, scope: :agent)
-      visit authenticated_agent_root_path
-      click_link "Vos plages d'ouverture"
-    end
+    let(:agent) { create(:agent, :secretaire) }
+
     scenario "cannot create plage_ouverture" do
       expect_page_title("Vos plages d'ouverture")
       click_link 'Créer une plage d\'ouverture', match: :first
       expect(page).to have_content("Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.")
     end
+
     context 'with motif for_secretariat' do
       let!(:motif) { create(:motif, :for_secretariat) }
-      scenario "can create a plage_ouverture" do
-        click_link 'Créer une plage d\'ouverture', match: :first
-        fill_in 'Description', with: new_plage_ouverture.title
-        check motif.name
-        click_button 'Créer'
+      let(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif]) }
 
-        expect_page_title("Vos plages d'ouverture")
-        click_link new_plage_ouverture.title
+      scenario "can crud a plage_ouverture" do
+        crud_plage_ouverture(agent, agent)
       end
     end
+  end
+
+  context 'for an other agent calendar' do
+    let!(:plage_ouverture) { create(:plage_ouverture, agent: other_agent) }
+
+    scenario "can crud a plage_ouverture" do
+      # select(other_agent.full_name, from: :id)
+      visit organisation_agent_plage_ouvertures_path(agent.organisations.first.id, other_agent.id)
+      crud_plage_ouverture(agent, other_agent)
+    end
+  end
+
+  def crud_plage_ouverture(current_agent, agent_crud)
+    title =  agent_crud == current_agent ? "Vos plages d'ouverture" : "Plages d'ouverture de #{agent_crud.full_name_and_service}"
+
+    expect_page_title(title)
+    click_link plage_ouverture.title
+
+    expect_page_title("Modifier la plage d'ouverture")
+    fill_in 'Description', with: 'La belle plage'
+    click_button('Modifier')
+
+    expect_page_title(title)
+    click_link 'La belle plage'
+
+    click_link('Supprimer')
+    expect_page_title(title)
+    empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé de plage d'ouverture" : "#{agent_crud.full_name} n'a pas encore créé de plage d'ouverture"
+    expect_page_with_no_record_text(empty_text)
+
+    click_link 'Créer une plage d\'ouverture', match: :first
+
+    expect_page_title("Nouvelle plage d'ouverture")
+    fill_in 'Description', with: new_plage_ouverture.title
+    check plage_ouverture.motifs.first.name
+    click_button 'Créer'
+
+    expect_page_title(title)
+    click_link new_plage_ouverture.title
   end
 end

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can CRUD users" do
+describe "Agent can CRUD plage d'ouverture" do
   let!(:agent) { create(:agent, :admin) }
   let!(:other_agent) { create(:agent, organisations: [agent.organisations.first]) }
   let!(:plage_ouverture) { create(:plage_ouverture, agent: agent) }


### PR DESCRIPTION
```
# select(other_agent.full_name, from: :id)
visit organisation_agent_absences_path(agent.organisations.first.id, other_agent.id)
```
Le `onchange: "Turbolinks.visit($('.select2-input option:selected').attr('data-url'))"` n'est pas pris en compte