### PR TITLE
Struture le champs ATTENDEE comme attendu dans le RFC

### DIFF
--- a/app/models/plage_ouverture/ics.rb
+++ b/app/models/plage_ouverture/ics.rb
@@ -22,7 +22,7 @@ class PlageOuverture::Ics
       e.description = ""
       e.location    = plage_ouverture.lieu.address
       e.ip_class    = "PUBLIC"
-      e.attendee    = plage_ouverture.agent.email
+      e.attendee    = "mailto:#{plage_ouverture.agent.email}"
       e.rrule       = rrule
     end
 

--- a/app/models/rdv/ics.rb
+++ b/app/models/rdv/ics.rb
@@ -25,7 +25,7 @@ class Rdv::Ics
       e.uid         = rdv.uuid
       e.sequence    = rdv.sequence
       e.ip_class    = "PRIVATE"
-      e.attendee    = user.email
+      e.attendee    = "mailto:#{user.email}"
     end
 
     cal.ip_method = "REQUEST"

--- a/spec/models/plage_ouverture/ics_spec.rb
+++ b/spec/models/plage_ouverture/ics_spec.rb
@@ -10,7 +10,7 @@ describe PlageOuverture::Ics, type: :model do
       is_expected.to match("DTSTART;TZID=Europe/Paris:20190722T080000")
       is_expected.to include("DTEND;TZID=Europe/Paris:20190722T120000")
       is_expected.to include("LOCATION:#{plage_ouverture.lieu.address}")
-      is_expected.to include("ATTENDEE:#{plage_ouverture.agent.email}")
+      is_expected.to include("ATTENDEE:mailto:#{plage_ouverture.agent.email}")
       is_expected.to include("CLASS:PUBLIC")
       is_expected.to include("METHOD:REQUEST")
     end

--- a/spec/models/rdv/ics_spec.rb
+++ b/spec/models/rdv/ics_spec.rb
@@ -14,7 +14,7 @@ describe Rdv::Ics, type: :model do
       is_expected.to include("UID:")
       is_expected.to include("DESCRIPTION:Infos et annulation:")
       is_expected.to include("LOCATION:10 rue de la Ferronerie 44100 Nantes")
-      is_expected.to include("ATTENDEE:#{user.email}")
+      is_expected.to include("ATTENDEE:mailto:#{user.email}")
       is_expected.to include("CLASS:PRIVATE")
       is_expected.to include("METHOD:REQUEST")
     end


### PR DESCRIPTION
* Définition du champ ATTENDEE / https://tools.ietf.org/html/rfc5545#section-3.8.4.1
* Définition de la valeur CAL-ADDRESS / https://tools.ietf.org/html/rfc5545#section-3.3.3


Tentative de résolution de [[agent] [Outlook] la plage d'ouverture envoyée de rdv-solidarités vers Outlook n'apparaît pas dans l'outlook (soit erreur à l'ouverture de la PJ/ soit ne s’intègre pas à l'Outlook)](https://trello.com/c/wmYVeX4z/568-agent-outlook-la-plage-douverture-envoy%C3%A9e-de-rdv-solidarit%C3%A9s-vers-outlook-nappara%C3%AEt-pas-dans-loutlook-soit-erreur-%C3%A0-louverture-d)