### PR TITLE
improve seeds and add .ruby-gemset to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-debug.log*
 
 .DS_Store
 .env
+
+.ruby-gemset

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,14 +1,53 @@
-Organisation.create!(name: "MDS du 75", phone_number: "0123456789", departement: "75")
+org1 = Organisation.create!(name: "MDS du 75", phone_number: "0123456789", departement: "75")
 
-Service.create!(name: "Protection Maternelle Infantile", short_name: "PMI")
-Service.create!(name: "Service Social", short_name: "Service Social")
+service1 = Service.create!(name: "Protection Maternelle Infantile", short_name: "PMI")
+_service2 = Service.create!(name: "Service Social", short_name: "Service Social")
 
-Lieu.create!(name: "Maison Paris Sud", organisation_id: 1, address: "18 Rue des Terres au Curé, 75013 Paris", latitude: 48.85295, longitude: 2.34998)
+lieu1 = Lieu.create!(
+  name: "Maison Paris Sud",
+  organisation: org1,
+  address: "18 Rue des Terres au Curé, 75013 Paris",
+  latitude: 48.85295,
+  longitude: 2.34998
+)
 
-Motif.create!(name: 'Consultation médicale', color: '#FF7C00', organisation_id: 1, service_id: 1)
+motif1 = Motif.create!(
+  name: 'Consultation médicale',
+  color: '#FF7C00',
+  organisation: org1,
+  service: service1,
+  online: true
+)
 
 3.times do |_u|
-  User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.email, birth_date: Faker::Date.birthday, password: Faker::Internet.password, organisation_ids: [1])
+  User.create!(
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
+    email: Faker::Internet.email,
+    birth_date: Faker::Date.birthday,
+    password: '123456',
+    organisations: [org1]
+  )
 end
 
-Agent.create!(email: 'contact@rdv-solidarites.fr', role: 1, first_name: 'Johnny', last_name: 'Validay', password: '123456', service_id: 1, organisation_ids: [1])
+agent1 = Agent.create!(
+  email: 'contact@rdv-solidarites.fr',
+  role: 1, # == admin
+  first_name: 'Johnny',
+  last_name: 'Validay',
+  password: '123456',
+  service: service1,
+  organisations: [org1]
+)
+
+_plage_ouverture1 = PlageOuverture.create!(
+  title: 'Permanence classique',
+  organisation: org1,
+  agent: agent1,
+  lieu: lieu1,
+  motifs: [motif1],
+  first_day: Date.tomorrow,
+  start_time: Tod::TimeOfDay.new(8),
+  end_time: Tod::TimeOfDay.new(12),
+  recurrence: Montrose.every(:day)
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,8 +14,8 @@ lieu1 = Lieu.create!(
 motif1 = Motif.create!(
   name: 'Consultation médicale',
   color: '#FF7C00',
-  organisation: org1,
-  service: service1,
+  organisation_id: org1.id,
+  service_id: service1.id,
   online: true
 )
 
@@ -36,16 +36,16 @@ agent1 = Agent.create!(
   first_name: 'Johnny',
   last_name: 'Validay',
   password: '123456',
-  service: service1,
+  service_id: service1.id,
   organisation_ids: [org1.id]
 )
 
 _plage_ouverture1 = PlageOuverture.create!(
   title: 'Permanence classique',
-  organisation: org1,
-  agent: agent1,
-  lieu: lieu1,
-  motifs: [motif1],
+  organisation_id: org1.id,
+  agent_id: agent1.id,
+  lieu_id: lieu1.id,
+  motif_ids: [motif1.id],
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(8),
   end_time: Tod::TimeOfDay.new(12),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,9 @@
+# when trying to create models using direct associations like
+# `organisation: org1` instead of `organisation_id: org1.id`
+# CircleCI throws ActiveRecord::AssociationTypeMismatch that seems to indicate
+# that the model files are loaded twice, or something related to HABTM
+# associations..
+
 org1 = Organisation.create!(name: "MDS du 75", phone_number: "0123456789", departement: "75")
 
 service1 = Service.create!(name: "Protection Maternelle Infantile", short_name: "PMI")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,7 @@ motif1 = Motif.create!(
     email: Faker::Internet.email,
     birth_date: Faker::Date.birthday,
     password: '123456',
-    organisations: [org1]
+    organisation_ids: [org1.id]
   )
 end
 
@@ -37,7 +37,7 @@ agent1 = Agent.create!(
   last_name: 'Validay',
   password: '123456',
   service: service1,
-  organisations: [org1]
+  organisation_ids: [org1.id]
 )
 
 _plage_ouverture1 = PlageOuverture.create!(


### PR DESCRIPTION
Improve seeds:
- pass variables instead of relying on first id being 1
- improve created models attributes defaults
- create a PlageOuverture model

and the .ruby-gemset file is useful for `rvm`, my terminal is configured to auto switch gemset when entering this repo (it's a bit overkill considering bundler but I'm used to it)