### PR TITLE
force logging to STDOUT in development with foreman

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,12 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # allows to see debug logs when running with foreman / overmind
+  # cf https://github.com/rails/sprockets-rails/issues/376#issuecomment-287560399
+  logger = ActiveSupport::Logger.new(STDOUT)
+  logger.formatter = config.log_formatter
+  config.logger = ActiveSupport::TaggedLogging.new(logger)
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 


### PR DESCRIPTION
this allows seeing the default development logs with the router etc. 
By default on my machine, using foreman (or overmind) I don't see these logs. can you confirm that you prefer it this way @jjf21 and @yaf?