### PR TITLE
[VAD] disable secretariat option in motif config when VAD

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,6 +28,7 @@
 @import "components/timeline";
 @import "components/progress_bars";
 @import "components/recurrence";
+@import "components/utilities";
 
 // Plugins
 @import "actiontext";

--- a/app/assets/stylesheets/components/_utilities.scss
+++ b/app/assets/stylesheets/components/_utilities.scss
@@ -1,3 +1,7 @@
 .bg-overlay {
   background: rgba(255, 255, 255, .9);
 }
+
+.translucent {
+  opacity: 0.5;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,6 +31,7 @@ import { PopulateLibelle } from 'packs/components/populate-libelle';
 import { Analytic } from 'packs/components/analytic.js';
 import { PlacesInput } from 'packs/components/places-input.js';
 import { ShowHidePassword } from 'packs/components/show-hide-password.js';
+import { MotifForm } from 'packs/components/motif-form.js';
 import 'packs/components/calendar';
 import 'packs/components/select2';
 import 'packs/components/tooltip';
@@ -107,4 +108,6 @@ $(document).on('turbolinks:load', function() {
   new InviteUserOnCreate();
 
   new ShowHidePassword();
+
+  new MotifForm();
 });

--- a/app/javascript/packs/components/motif-form.js
+++ b/app/javascript/packs/components/motif-form.js
@@ -1,0 +1,39 @@
+class MotifForm {
+
+  setSecretariatEnabled(enabled) {
+    // short circuit if no change
+    if (enabled == this.secretariatEnabled) return;
+
+    const secretariatCheckbox = document.
+      querySelector('input[type=checkbox][name=\"motif[for_secretariat]\"]')
+    if (!enabled) secretariatCheckbox.checked = false // uncheck before disabling
+    secretariatCheckbox.disabled = !enabled
+    secretariatCheckbox.closest('.card').classList.toggle('translucent', !enabled)
+
+    this.secretariatEnabled = enabled
+  }
+
+  constructor() {
+    // short circuit when not on the motif form page
+    const inputs = document.querySelectorAll("input[name=\"motif[location_type]\"")
+    if (!inputs) return false;
+
+    // initial boolean value is true as the html displays the input enabled in
+    // all cases
+    this.secretariatEnabled = true
+
+    // initial toggle depends on whether the 'home' radio is checked
+    const initialValue = !document.querySelector("#motif_location_type_home:checked");
+    this.setSecretariatEnabled(initialValue)
+
+    // attach listeners to all radio buttons. the change event is triggered only
+    // on the one that's being selected
+    inputs.forEach(input => {
+      input.addEventListener('change', e => {
+        this.setSecretariatEnabled(e.currentTarget.value != 'home')
+      })
+    })
+  }
+}
+
+export { MotifForm };


### PR DESCRIPTION
VAD motifs cannot be performed by the secretariat

when VAD is checked:
- force uncheck secretaraiat
- disable the secretariat checkbox 
- make secretariat block grayed out (translucent) so it's clear it's not compatible.

---

I try to write mostly vanilla JS and as little jQuery as possible, let me know if you don't like it