### PR TITLE
[Tech] Refactor rdv.name_for_user and agent to separate helpers

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -3,6 +3,14 @@ module RdvsHelper
     "Le #{l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)"
   end
 
+  def rdv_title_for_agent(rdv)
+    "#{rdv.created_by_user? ? "@ " : ""}#{rdv.users&.map(&:full_name)&.to_sentence}"
+  end
+
+  def rdv_title_for_user(rdv, user)
+    "#{user.full_name} <> #{rdv.motif&.name}"
+  end
+
   def agents_to_sentence(rdv)
     rdv.agents.map(&:full_name_and_service).sort.to_sentence
   end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -74,14 +74,6 @@ class Rdv < ApplicationRecord
     end
   end
 
-  def name_for_agent
-    "#{created_by_user? ? "@ " : ""}#{users&.map(&:full_name)&.to_sentence}"
-  end
-
-  def name_for_user(user)
-    "#{user.full_name} <> #{motif&.name}"
-  end
-
   def notify?
     !motif.disable_notifications_for_users
   end

--- a/app/models/rdv/ics.rb
+++ b/app/models/rdv/ics.rb
@@ -1,6 +1,7 @@
 class Rdv::Ics
   include ActiveModel::Model
   include Rails.application.routes.url_helpers
+  include RdvsHelper
 
   attr_accessor :rdv
   validates :rdv, presence: true
@@ -19,7 +20,7 @@ class Rdv::Ics
     cal.event do |e|
       e.dtstart     = Icalendar::Values::DateTime.new(rdv.starts_at, 'tzid' => tzid)
       e.dtend       = Icalendar::Values::DateTime.new(rdv.ends_at, 'tzid' => tzid)
-      e.summary     = "RDV #{rdv.name_for_user(user)}"
+      e.summary     = "RDV #{rdv_title_for_user(rdv, user)}"
       e.description = description
       e.location    = rdv.location unless rdv.motif.phone?
       e.uid         = rdv.uuid

--- a/app/views/agents/rdvs/index.json.jbuilder
+++ b/app/views/agents/rdvs/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @rdvs do |rdv|
-  json.title rdv.name_for_agent
+  json.title rdv_title_for_agent(rdv)
   json.extendedProps do
     json.status rdv.status
     json.motif rdv.motif.name

--- a/app/views/agents/rdvs/show.html.slim
+++ b/app/views/agents/rdvs/show.html.slim
@@ -1,5 +1,5 @@
 - content_for :title do
-  = @rdv.name_for_agent
+  = rdv_title_for_agent(@rdv)
   - if @rdv.cancelled?
     span.badge.badge-danger
 

--- a/spec/controllers/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/agents/rdvs_controller_spec.rb
@@ -2,8 +2,9 @@ RSpec.describe Agents::RdvsController, type: :controller do
   render_views
 
   let(:agent) { create(:agent) }
-  let(:organisation_id) { agent.organisation_ids.first }
-  let!(:rdv) { create(:rdv, agent_ids: [agent.id], organisation_id: organisation_id) }
+  let(:organisation) { agent.organisations.first }
+  let!(:user) { create(:user, first_name: "Marie", last_name: "Denis") }
+  let!(:rdv) { create(:rdv, agents: [agent], users: [user], organisation: organisation) }
 
   before do
     sign_in agent
@@ -13,7 +14,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
     let!(:rdv1) { create(:rdv, agents: [agent], starts_at: Time.zone.parse("21/07/2019 08:00")) }
     let!(:rdv2) { create(:rdv, agents: [agent], starts_at: Time.zone.parse("21/07/2019 07:00")) }
 
-    subject { get(:index, params: { organisation_id: organisation_id, agent_id: agent.id, start: start_time, end: end_time }, as: :json) }
+    subject { get(:index, params: { organisation_id: organisation.id, agent_id: agent.id, start: start_time, end: end_time }, as: :json) }
 
     before do
       subject
@@ -31,7 +32,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
 
         first = @parsed_response[0]
         expect(first.size).to eq(6)
-        expect(first["title"]).to eq(rdv1.name_for_agent)
+        expect(first["title"]).to eq("Marie DENIS")
         expect(first["start"]).to eq(rdv1.starts_at.as_json)
         expect(first["end"]).to eq(rdv1.ends_at.as_json)
         expect(first["backgroundColor"]).to eq(rdv1.motif.color)
@@ -40,7 +41,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
 
         second = @parsed_response[1]
         expect(second.size).to eq(6)
-        expect(second["title"]).to eq(rdv2.name_for_agent)
+        expect(second["title"]).to eq("Marie DENIS")
         expect(second["start"]).to eq(rdv2.starts_at.as_json)
         expect(second["end"]).to eq(rdv2.ends_at.as_json)
         expect(second["backgroundColor"]).to eq(rdv2.motif.color)
@@ -52,14 +53,14 @@ RSpec.describe Agents::RdvsController, type: :controller do
 
   describe "GET #edit" do
     it "returns a success response" do
-      get :edit, params: { organisation_id: organisation_id, id: rdv.to_param }
+      get :edit, params: { organisation_id: organisation.id, id: rdv.to_param }
       expect(response).to be_successful
     end
   end
 
   describe "PUT #update" do
     subject do
-      put :update, params: { organisation_id: organisation_id, id: rdv.to_param, rdv: new_attributes }
+      put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
       rdv.reload
     end
 
@@ -100,14 +101,14 @@ RSpec.describe Agents::RdvsController, type: :controller do
 
   describe "GET #show" do
     it "returns a success response" do
-      get :show, params: { organisation_id: organisation_id, id: rdv.id }
+      get :show, params: { organisation_id: organisation.id, id: rdv.id }
       expect(response).to be_successful
     end
   end
 
   describe "POST #status" do
     subject do
-      post :status, params: { organisation_id: organisation_id, id: rdv.id, rdv: { status: "waiting" }, format: "js" }
+      post :status, params: { organisation_id: organisation.id, id: rdv.id, rdv: { status: "waiting" }, format: "js" }
       rdv.reload
     end
 
@@ -124,7 +125,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
   describe "DELETE destroy" do
     it "cancel rdv" do
       expect do
-        delete :destroy, params: { organisation_id: organisation_id, id: rdv.id }
+        delete :destroy, params: { organisation_id: organisation.id, id: rdv.id }
       end.to change { Rdv.count }.by(-1)
     end
   end

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -1,0 +1,26 @@
+describe RdvsHelper do
+  let(:motif) { build(:motif, name: "Consultation normale") }
+  let(:user) { build(:user, first_name: "Marie", last_name: "DENIS") }
+  let(:rdv) { build(:rdv, users: [user], motif: motif) }
+
+  describe "#rdv_title_for_user" do
+    subject { helper.rdv_title_for_user(rdv, user) }
+    it { should eq "Marie DENIS <> Consultation normale" }
+  end
+
+  describe "#rdv_title_for_agent" do
+    subject { helper.rdv_title_for_agent(rdv) }
+    it { should eq "Marie DENIS" }
+
+    context "multiple users" do
+      let(:user2) { build(:user, first_name: "Lea", last_name: "CAVE") }
+      let(:rdv) { build(:rdv, users: [user, user2], motif: motif) }
+      it { should eq "Marie DENIS et Lea CAVE" }
+    end
+
+    context "created by user (online)" do
+      let(:rdv) { build(:rdv, users: [user], motif: motif, created_by: :user) }
+      it { should eq "@ Marie DENIS" }
+    end
+  end
+end

--- a/spec/models/rdv/ics_spec.rb
+++ b/spec/models/rdv/ics_spec.rb
@@ -1,25 +1,27 @@
 describe Rdv::Ics, type: :model do
   describe '#to_ical_for' do
-    let(:rdv) { create(:rdv) }
-    let(:rdv_by_phone) { create :rdv, :by_phone }
-    let(:user) { rdv.users.first }
+    let(:motif) { create(:motif, name: "Consultation initiale") }
+    let(:user) { create(:user, first_name: "elisa", last_name: "simon", email: "elisa@simon.fr") }
+    let(:rdv) { create(:rdv, users: [user], motif: motif) }
+    # let(:rdv_by_phone) { create(:rdv, :by_phone) }  # unused
     let(:ics) { Rdv::Ics.new(rdv: rdv) }
     subject { ics.to_ical_for(user) }
 
     it do
-      is_expected.to include("SUMMARY:RDV #{rdv.name_for_user(user)}")
+      is_expected.to include("SUMMARY:RDV Elisa SIMON <> Consultation initiale")
       is_expected.to match("DTSTART;TZID=Europe/Paris:20190704T150000")
       is_expected.to include("DTEND;TZID=Europe/Paris:20190704T154500")
       is_expected.to include("SEQUENCE:0")
       is_expected.to include("UID:")
       is_expected.to include("DESCRIPTION:Infos et annulation:")
       is_expected.to include("LOCATION:10 rue de la Ferronerie 44100 Nantes")
-      is_expected.to include("ATTENDEE:mailto:#{user.email}")
+      is_expected.to include("ATTENDEE:mailto:elisa@simon.fr")
       is_expected.to include("CLASS:PRIVATE")
       is_expected.to include("METHOD:REQUEST")
     end
 
     context 'when the motif is by_phone' do
+      # TODO: this does not test for RDVs by phone at all.
       it { is_expected.to include("LOCATION:") }
     end
   end


### PR DESCRIPTION
preliminary to #534 where I'll be adding behaviour to these methods.

I don't think these methods belong to the RDV model but to a helper as they are only presentational. 

I've slightly refactored the specs to expect for more 'hardcoded' instead of dynamic values that rely on the seeds generated by the factories. I find it much less error prone and more explicit this way. 

I've also added a dedicated spec file for the RdvsHelper where I'm unit testing these methods

this PR can be read commit by commit