### PR TITLE
[VAD] display VAD information in agents RDVs and calendar views

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -7,7 +7,7 @@ module RdvsHelper
     (rdv.created_by_user? ? "@ " : "") +
       rdv.users&.map(&:full_name)&.to_sentence +
       (rdv.motif.home? ? " 🏠" : "") +
-      (rdv.motif.phone? ? " 📞" : "")
+      (rdv.motif.phone? ? " ☎️" : "")
   end
 
   def rdv_title_for_user(rdv, user)

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -4,7 +4,10 @@ module RdvsHelper
   end
 
   def rdv_title_for_agent(rdv)
-    "#{rdv.created_by_user? ? "@ " : ""}#{rdv.users&.map(&:full_name)&.to_sentence}"
+    (rdv.created_by_user? ? "@ " : "") +
+      rdv.users&.map(&:full_name)&.to_sentence +
+      (rdv.motif.home? ? " 🏠" : "") +
+      (rdv.motif.phone? ? " 📞" : "")
   end
 
   def rdv_title_for_user(rdv, user)

--- a/app/views/agents/rdvs/_rdv_details.html.slim
+++ b/app/views/agents/rdvs/_rdv_details.html.slim
@@ -13,6 +13,10 @@ p.card-text
   p.card-text
     i.fa.fa-fw.fa-phone>
     | RDV téléphonique
+- elsif Flipflop.visite_a_domicile? && rdv.motif.home?
+  p.card-text
+    i.fa.fa-fw.fa-home>
+    | RDV à domicile
 p.card-text
   strong> Professionnel(s) :
   = agents_to_sentence(rdv)

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -20,8 +20,8 @@ FactoryBot.define do
     trait :past do
       starts_at { 2.days.ago }
     end
-    trait :by_phone do
-      motif { build(:motif, :by_phone) }
+    trait :at_home do
+      motif { build(:motif, :at_home) }
     end
     trait :excused do
       cancelled_at { 2.days.ago }

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -25,7 +25,7 @@ describe RdvsHelper do
 
     context "phone RDV" do
       let(:rdv) { build(:rdv, :by_phone, users: [user]) }
-      it { should eq "Marie DENIS 📞" }
+      it { should eq "Marie DENIS ☎️" }
     end
 
     context "at home RDV" do

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -22,5 +22,15 @@ describe RdvsHelper do
       let(:rdv) { build(:rdv, users: [user], motif: motif, created_by: :user) }
       it { should eq "@ Marie DENIS" }
     end
+
+    context "phone RDV" do
+      let(:rdv) { build(:rdv, :by_phone, users: [user]) }
+      it { should eq "Marie DENIS 📞" }
+    end
+
+    context "at home RDV" do
+      let(:rdv) { build(:rdv, :at_home, users: [user]) }
+      it { should eq "Marie DENIS 🏠" }
+    end
   end
 end


### PR DESCRIPTION
linked to https://trello.com/c/T9BNYXUH/595-vadagent-identifier-les-rdv-%C3%A0-domicile

I didn't fully respect the specs:

- I used emojis instead of fa-icons in the calendar view to simplify both coding and testing
- For balance I also added an icon for phone meetings

<img width="692" alt="Screenshot 2020-04-07 at 09 24 44" src="https://user-images.githubusercontent.com/883348/78641552-b33ec000-78b1-11ea-9a36-a81b1c6698f7.png">

<img width="1123" alt="Screenshot 2020-04-07 at 09 24 33" src="https://user-images.githubusercontent.com/883348/78641525-a9b55800-78b1-11ea-9703-80a59b2500b8.png">