### PR TITLE
Enable content security policy in report only mode

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,35 @@
-# Be sure to restart your server when you modify this file.
+unless Rails.env.test?
+  # Be sure to restart your server when you modify this file.
 
-# Define an application-wide content security policy
-# For further information see the following documentation
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+  # Define an application-wide content security policy
+  # For further information see the following documentation
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+  Rails.application.config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self, :data, "https://fonts.gstatic.com"
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.style_src   :self, :unsafe_inline, "fonts.googleapis.com"
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+    if Rails.env.development?
+      policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "localhost:3035"
+      policy.connect_src :self, "*.algolia.net", "localhost:3035", "ws://localhost:3035"
+    else
+      policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr"
+      policy.connect_src :self, "*.algolia.net"
+    end
 
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+    # Specify URI for violation reports
+    # https://docs.sentry.io/error-reporting/security-policy-reporting/#content-security-policy
+    policy.report_uri ENV["CSP_REPORT_URI"]
+  end
 
-# Report CSP violations to a specified URI
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+  # If you are using UJS then enable automatic nonce generation
+  # Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
+  # Report CSP violations to a specified URI
+  # For further information see the following documentation:
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+  Rails.application.config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
https://trello.com/c/hCBelpsx/218-secu-r%C3%A9gler-les-points-remont%C3%A9s-par-securityheaderscom

Une première tentative en mode report-only pour ne rien casser.

TODO si approuvée : 
- [x] Ajouter les variables d'ENV en démo et prod : `SENTRY_PROJECT_ID` et `SENTRY_KEY`