### PR TITLE
[VAD] Update agents RDV wizard to choose a location

### DIFF
--- a/app/controllers/agents/rdv_wizard_steps_controller.rb
+++ b/app/controllers/agents/rdv_wizard_steps_controller.rb
@@ -59,10 +59,10 @@ class Agents::RdvWizardStepsController < AgentAuthController
   end
 
   def rdv_params
-    params.require(:rdv).permit(PERMITTED_PARAMS)
+    params.require(:rdv).permit(PERMITTED_PARAMS).merge(params.permit(:plage_ouverture_location))
   end
 
   def query_params
-    params.permit(PERMITTED_PARAMS)
+    params.permit(:plage_ouverture_location, *PERMITTED_PARAMS)
   end
 end

--- a/app/controllers/agents/rdv_wizard_steps_controller.rb
+++ b/app/controllers/agents/rdv_wizard_steps_controller.rb
@@ -10,7 +10,7 @@ class Agents::RdvWizardStepsController < AgentAuthController
   def new
     @rdv_wizard = rdv_wizard_for(query_params)
     @rdv = @rdv_wizard.rdv
-    @agents_authorize = agents_authorized if current_step == 'step2'
+    @agents_authorize = agents_authorized if current_step == 'step3'
     skip_authorization
     render current_step
   end

--- a/app/form_models/rdv_wizard.rb
+++ b/app/form_models/rdv_wizard.rb
@@ -25,7 +25,7 @@ module RdvWizard
       if @rdv.motif&.public_office?
         @rdv.location ||= @plage_ouverture_location
       elsif @rdv.motif&.home?
-        @rdv.location ||= @rdv.users.select { _1.address.present? }.first&.address
+        @rdv.location ||= @rdv.users.map(&:address).map(&:presence).compact.first
       end
     end
 

--- a/app/form_models/rdv_wizard.rb
+++ b/app/form_models/rdv_wizard.rb
@@ -6,20 +6,27 @@ module RdvWizard
   class Base
     include ActiveModel::Model
 
-    attr_accessor :rdv
+    attr_accessor :rdv, :plage_ouverture_location
 
     # delegates all getters and setters to rdv
     delegate(*::Rdv.attribute_names, to: :rdv)
-    delegate :motif, :organisation, :agents, :to_query, to: :rdv
+    delegate :motif, :organisation, :agents, to: :rdv
 
-    def initialize(agent, organisation, rdv_attributes)
-      defaults = {
+    def initialize(agent, organisation, attributes)
+      @plage_ouverture_location = attributes[:plage_ouverture_location]
+      rdv_attributes = attributes.to_h.symbolize_keys.reject { |k, _v| k == :plage_ouverture_location }
+      rdv_defaults = {
         agent_ids: [agent.id],
         organisation_id: organisation.id,
         starts_at: Time.zone.now,
       }
-      @rdv = ::Rdv.new(defaults.merge(rdv_attributes))
+      @rdv = ::Rdv.new(rdv_defaults.merge(rdv_attributes))
       @rdv.duration_in_min ||= @rdv.motif.default_duration_in_min if @rdv.motif.present?
+      @rdv.location ||= @plage_ouverture_location if @rdv.motif&.public_office?
+    end
+
+    def to_query
+      rdv.to_query.merge(plage_ouverture_location: plage_ouverture_location)
     end
   end
 

--- a/app/form_models/rdv_wizard.rb
+++ b/app/form_models/rdv_wizard.rb
@@ -10,7 +10,7 @@ module RdvWizard
 
     # delegates all getters and setters to rdv
     delegate(*::Rdv.attribute_names, to: :rdv)
-    delegate :motif, :organisation, :agents, to: :rdv
+    delegate :motif, :organisation, :agents, :users, to: :rdv
 
     def initialize(agent, organisation, attributes)
       @plage_ouverture_location = attributes[:plage_ouverture_location]
@@ -35,7 +35,7 @@ module RdvWizard
   end
 
   class Step2 < Step1
-    validates :duration_in_min, :starts_at, :agents, presence: true
+    validates :users, presence: true
   end
 
   class Step3 < Step2; end

--- a/app/form_models/rdv_wizard.rb
+++ b/app/form_models/rdv_wizard.rb
@@ -22,7 +22,11 @@ module RdvWizard
       }
       @rdv = ::Rdv.new(rdv_defaults.merge(rdv_attributes))
       @rdv.duration_in_min ||= @rdv.motif.default_duration_in_min if @rdv.motif.present?
-      @rdv.location ||= @plage_ouverture_location if @rdv.motif&.public_office?
+      if @rdv.motif&.public_office?
+        @rdv.location ||= @plage_ouverture_location
+      elsif @rdv.motif&.home?
+        @rdv.location ||= @rdv.users.select { _1.address.present? }.first&.address
+      end
     end
 
     def to_query

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -1,4 +1,14 @@
 module MotifsHelper
+  def motif_name_with_location_type(motif)
+    if motif.phone?
+      motif.name + " (Par tél.)"
+    elsif Flipflop.visite_a_domicile? && motif.home?
+      motif.name + " (À domicile)"
+    else
+      motif.name
+    end
+  end
+
   def motif_badges(motif)
     [
       motif.online ? content_tag(:span, 'En ligne', class: 'badge badge-danger') : nil,

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -25,6 +25,8 @@ module RdvsHelper
   end
 
   def users_to_sentence(rdv)
+    return rdv.users.map(&:full_name).sort.to_sentence if current_agent
+
     users = []
     rdv.users.each do |user|
       users << user if user == current_user || current_user.relatives.include?(user)

--- a/app/javascript/packs/components/calendar.js
+++ b/app/javascript/packs/components/calendar.js
@@ -48,7 +48,7 @@ document.addEventListener('turbolinks:load', function() {
           .filter(e => startDate.isBetween(e.start, e.end, null, "[]"));
 
         if (plage_ouvertures[0] !== undefined) {
-          params.location = plage_ouvertures[0].extendedProps.location;
+          params['plage_ouverture_location'] = plage_ouvertures[0].extendedProps.location;
         }
         window.location = Routes.new_organisation_rdv_wizard_step_path(params);
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -9,6 +9,8 @@ class Rdv < ApplicationRecord
   enum status: { unknown: 0, waiting: 1, seen: 2, excused: 3, notexcused: 4 }
   enum created_by: { agent: 0, user: 1, file_attente: 2 }, _prefix: :created_by
 
+  delegate :home?, :phone?, :public_office?, to: :motif
+
   validates :users, :organisation, :motif, :starts_at, :duration_in_min, :agents, presence: true
 
   scope :active, -> { where(cancelled_at: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -137,6 +137,10 @@ class User < ApplicationRecord
     errors.empty?
   end
 
+  def address
+    super.presence || responsible&.address
+  end
+
   protected
 
   def password_required?

--- a/app/views/agents/creneaux/agent_searches/_creneaux.html.slim
+++ b/app/views/agents/creneaux/agent_searches/_creneaux.html.slim
@@ -15,7 +15,7 @@ div id="creneaux-lieu-#{lieu.id}"
         - if creneaux_for_date.any?
           - creneaux_for_date.each do |date, creneaux|
             - creneaux.sort_by(&:starts_at).each do |creneau|
-              = link_to new_organisation_rdv_wizard_step_path(step: 3, starts_at: creneau.starts_at, motif_id: motif.id, location: lieu.address, organisation_id: motif.organisation_id, duration_in_min: motif.default_duration_in_min, "agent_ids[]": creneau.agent_id), class: "btn btn-light mr-1 mb-1 w-100" do
+              = link_to new_organisation_rdv_wizard_step_path(step: 3, starts_at: creneau.starts_at, motif_id: motif.id, plage_ouverture_location: lieu.address, organisation_id: motif.organisation_id, duration_in_min: motif.default_duration_in_min, "agent_ids[]": creneau.agent_id), class: "btn btn-light mr-1 mb-1 w-100" do
                 = l(creneau.starts_at, format: "%H:%M")
                 br
                 small= creneau.agent_name

--- a/app/views/agents/creneaux/agent_searches/_creneaux.html.slim
+++ b/app/views/agents/creneaux/agent_searches/_creneaux.html.slim
@@ -15,7 +15,7 @@ div id="creneaux-lieu-#{lieu.id}"
         - if creneaux_for_date.any?
           - creneaux_for_date.each do |date, creneaux|
             - creneaux.sort_by(&:starts_at).each do |creneau|
-              = link_to new_organisation_rdv_wizard_step_path(step: 3, starts_at: creneau.starts_at, motif_id: motif.id, plage_ouverture_location: lieu.address, organisation_id: motif.organisation_id, duration_in_min: motif.default_duration_in_min, "agent_ids[]": creneau.agent_id), class: "btn btn-light mr-1 mb-1 w-100" do
+              = link_to new_organisation_rdv_wizard_step_path(step: 2, starts_at: creneau.starts_at, motif_id: motif.id, plage_ouverture_location: lieu.address, organisation_id: motif.organisation_id, duration_in_min: motif.default_duration_in_min, "agent_ids[]": creneau.agent_id), class: "btn btn-light mr-1 mb-1 w-100" do
                 = l(creneau.starts_at, format: "%H:%M")
                 br
                 small= creneau.agent_name

--- a/app/views/agents/creneaux/agent_searches/index.html.slim
+++ b/app/views/agents/creneaux/agent_searches/index.html.slim
@@ -7,7 +7,7 @@
     = simple_form_for(Creneau::AgentSearch.new, remote: true, url: organisation_agent_searches_path(@organisation), method: :get) do |f|
       .row
         .col-md-3
-          = f.input :motif_id, collection: @motifs, required: true, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' }
+          = f.input :motif_id, collection: @motifs, label_method: -> { motif_name_with_location_type(_1) }, required: true, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' }
         .col-md-2
           = date_input(f, :from_date, label = "À partir du")
         .col-md-3

--- a/app/views/agents/rdv_wizard_steps/step1.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step1.html.slim
@@ -16,15 +16,13 @@
   .card-body
     = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
     = simple_form_for(@rdv, url: organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|
+      = f.input_field :starts_at, as: :hidden
       = hidden_field_tag 'plage_ouverture_location', @rdv_wizard.plage_ouverture_location
-
-      = f.association(:motif, collection: policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent), label_method: -> { motif_name_with_location_type(_1) }, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' })
-
-      = f.input :starts_at, as: :hidden
       - @rdv.agents.each do |p|
         / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
         = f.hidden_field "agent_ids][", value: p.id
 
+      = f.association(:motif, collection: policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent), label_method: -> { motif_name_with_location_type(_1) }, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' })
       .row
         .col.text-left
           = link_to 'Revenir en arrière', organisation_agent_path(current_organisation, @agent), class: 'btn btn-link'

--- a/app/views/agents/rdv_wizard_steps/step1.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step1.html.slim
@@ -16,10 +16,9 @@
   .card-body
     = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
     = simple_form_for(@rdv, url: organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|
+      = hidden_field_tag 'plage_ouverture_location', @rdv_wizard.plage_ouverture_location
       = f.association :motif, collection: policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent), include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' }
       = f.input :starts_at, as: :hidden
-      = f.input :location, as: :hidden
-      = f.input :location, as: :hidden
       - @rdv.agents.each do |p|
         / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
         = f.hidden_field "agent_ids][", value: p.id

--- a/app/views/agents/rdv_wizard_steps/step1.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step1.html.slim
@@ -17,7 +17,9 @@
     = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
     = simple_form_for(@rdv, url: organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|
       = hidden_field_tag 'plage_ouverture_location', @rdv_wizard.plage_ouverture_location
-      = f.association :motif, collection: policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent), include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' }
+
+      = f.association(:motif, collection: policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent), label_method: -> { motif_name_with_location_type(_1) }, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' })
+
       = f.input :starts_at, as: :hidden
       - @rdv.agents.each do |p|
         / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field

--- a/app/views/agents/rdv_wizard_steps/step1.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step1.html.slim
@@ -8,11 +8,6 @@
         li.list-group-item
           i.fa.fa-check.fa-fw.mr-1.text-success
           = "Commence le : #{l(@rdv.starts_at, format: :human)}"
-      - if @rdv.location.present?
-        li.list-group-item
-          i.fa.fa-check.fa-fw.mr-1.text-success
-          | Lieu :&nbsp;
-          = human_location(@rdv)
   .card-body
     = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
     = simple_form_for(@rdv, url: organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|

--- a/app/views/agents/rdv_wizard_steps/step2.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step2.html.slim
@@ -6,7 +6,7 @@
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | Motif :&nbsp;
-      = @rdv.motif.name
+      = motif_name_with_location_type(@rdv.motif)
 
   .card-body
     = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }

--- a/app/views/agents/rdv_wizard_steps/step2.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step2.html.slim
@@ -1,8 +1,12 @@
 - content_for :title do
-  | Choisir la durée et la date
+  | Choisir le ou les usagers
 
 .card
   ul.list-group.list-group-flush
+    - if @rdv.starts_at.present?
+      li.list-group-item
+        i.fa.fa-check.fa-fw.mr-1.text-success
+        = "Commence le : #{l(@rdv.starts_at, format: :human)}"
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | Motif :&nbsp;
@@ -10,22 +14,21 @@
 
   .card-body
     = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
+
     = simple_form_for(@rdv, url: organisation_rdv_wizard_step_path(current_organisation, step: 2)) do |f|
-      = f.association :motif, as: :hidden,  wrapper_html: { class: 'm-0' }
-      .form-row
-        .col-md-6= datetime_input(f, :starts_at)
-        .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"
+      = f.input_field :motif_id, as: :hidden
+      = f.input_field :starts_at, as: :hidden
+      = hidden_field_tag 'plage_ouverture_location', @rdv_wizard.plage_ouverture_location
+      - @rdv.agents.each do |p|
+        / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
+        = f.hidden_field "agent_ids][", value: p.id
 
-      - unless @rdv.motif.phone?
-        = f.input :location, input_html: { class: "places-js-container" }
-
-        .mb-1
-          - current_organisation.lieux.each do |l|
-            => button_tag type: "button", onclick: "document.querySelector('#rdv_location').value = '#{escape_javascript(l.address)}'", class: "btn btn-outline-secondary btn-sm mb-1" do
-              => l.name
-              = map_tag_marker(l.address)
-
-      = f.association :agents, collection: @agents_authorize, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
+      = f.association :users,
+        collection: @rdv.users,
+        label_method: lambda { |user| full_name_and_birthdate(user) },
+        input_html: { multiple: true, required: false, class: 'select2-input', data: { "select-options": { ajax: { url: search_organisation_users_path(current_organisation), dataType: 'json', delay: 250 }} } },
+        hint: raw("L'usager n'existe pas ? #{link_to "Créer un usager", new_organisation_user_path(current_organisation, modal: true), data: { modal: true }}.")
+      = f.input :notes, input_html: { rows: 4 }
 
       .row
         .col.text-left

--- a/app/views/agents/rdv_wizard_steps/step3.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step3.html.slim
@@ -1,5 +1,5 @@
 - content_for :title do
-  | Choisir l'usager
+  | Choisir la durée et la date
 
 .card
   ul.list-group.list-group-flush
@@ -7,42 +7,37 @@
       i.fa.fa-check.fa-fw.mr-1.text-success
       | Motif :&nbsp;
       = motif_name_with_location_type(@rdv.motif)
-    - if @rdv.location.present?
-      li.list-group-item
-        i.fa.fa-check.fa-fw.mr-1.text-success
-        | Lieu :&nbsp;
-        = human_location(@rdv)
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
-      | Professionnels :&nbsp;
-      = agents_to_sentence(@rdv)
-    li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.text-success
-      = "Durée : #{@rdv.duration_in_min} minutes"
-    li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.text-success
-      = "Commence le : #{l(@rdv.starts_at, format: :human)}"
+      | Usager(s) :&nbsp;
+      = users_to_sentence(@rdv)
 
   .card-body
-    = render partial: 'layouts/model_errors', locals: { model: @rdv }
-
+    = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
     = simple_form_for(@rdv, url: organisation_rdvs_path(current_organisation)) do |f|
-      = f.association :motif, as: :hidden
-      = f.input :location, as: :hidden
-      - @rdv.agents.each do |p|
+      = f.input :notes, as: :hidden, wrapper_html: { class: 'm-0' }
+      = f.association :motif, as: :hidden,  wrapper_html: { class: 'm-0' }
+      .form-row
+        .col-md-6= datetime_input(f, :starts_at)
+        .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"
+
+      - unless @rdv.motif.phone?
+        = f.input :location, input_html: { class: "places-js-container" }
+
+        .mb-1
+          - current_organisation.lieux.each do |l|
+            => button_tag type: "button", onclick: "document.querySelector('#rdv_location').value = '#{escape_javascript(l.address)}'", class: "btn btn-outline-secondary btn-sm mb-1" do
+              => l.name
+              = map_tag_marker(l.address)
+
+      - @rdv.users.each do |user|
         / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
-        = f.hidden_field "agent_ids][", value: p.id
-      = f.input :duration_in_min, as: :hidden
-      = f.input :starts_at, as: :hidden
-      = f.association :users,
-        collection: @rdv.users,
-        label_method: lambda { |user| full_name_and_birthdate(user) },
-        input_html: { multiple: true, class: 'select2-input', data: { "select-options": { ajax: { url: search_organisation_users_path(current_organisation), dataType: 'json', delay: 250 }} } },
-        hint: raw("L'usager n'existe pas ? #{link_to "Créer", new_organisation_user_path(current_organisation, modal: true), data: { modal: true }}.")
-      = f.input :notes, input_html: { rows: 4 }
+        = f.hidden_field "user_ids][", value: user.id
+
+      = f.association :agents, collection: @agents_authorize, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
 
       .row
         .col.text-left
-          = link_to 'Revenir en arrière', new_organisation_rdv_wizard_step_path(@rdv.to_query.merge(step: 2)), class: 'btn btn-link'
+          = link_to 'Revenir en arrière', new_organisation_rdv_wizard_step_path(@rdv_wizard.to_query.merge(step: 2)), class: 'btn btn-link'
         .col.text-right
-          = f.button :submit, 'Continuer'
+          = f.button :submit, 'Créer RDV'

--- a/app/views/agents/rdv_wizard_steps/step3.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step3.html.slim
@@ -6,7 +6,7 @@
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | Motif :&nbsp;
-      = @rdv.motif.name
+      = motif_name_with_location_type(@rdv.motif)
     - if @rdv.location.present?
       li.list-group-item
         i.fa.fa-check.fa-fw.mr-1.text-success

--- a/app/views/agents/rdv_wizard_steps/step3.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step3.html.slim
@@ -21,15 +21,19 @@
         .col-md-6= datetime_input(f, :starts_at)
         .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"
 
-      - unless @rdv.motif.phone?
+      - if @rdv.public_office?
         = f.input :location, input_html: { class: "places-js-container" }
-
         .mb-1
           - current_organisation.lieux.each do |l|
             => button_tag type: "button", onclick: "document.querySelector('#rdv_location').value = '#{escape_javascript(l.address)}'", class: "btn btn-outline-secondary btn-sm mb-1" do
               => l.name
               = map_tag_marker(l.address)
-
+      - elsif @rdv.home?
+        = f.input :location, label: "Lieu (RDV à domicile)", input_html: { class: "places-js-container" }
+        .mb-2
+          - @rdv.users.select { _1.address.present? }.each do |user|
+            => button_tag type: "button", onclick: "document.querySelector('#rdv_location').value = '#{escape_javascript(user.address)}'", class: "btn btn-outline-secondary btn-sm mb-1" do
+              = "🏠 Chez #{user.full_name}"
       - @rdv.users.each do |user|
         / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
         = f.hidden_field "user_ids][", value: user.id

--- a/app/views/agents/rdv_wizard_steps/step3.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step3.html.slim
@@ -7,10 +7,11 @@
       i.fa.fa-check.fa-fw.mr-1.text-success
       | Motif :&nbsp;
       = @rdv.motif.name
-    li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.text-success
-      | Lieu :&nbsp;
-      = human_location(@rdv)
+    - if @rdv.location.present?
+      li.list-group-item
+        i.fa.fa-check.fa-fw.mr-1.text-success
+        | Lieu :&nbsp;
+        = human_location(@rdv)
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | Professionnels :&nbsp;

--- a/app/views/agents/users/_form.html.slim
+++ b/app/views/agents/users/_form.html.slim
@@ -34,6 +34,7 @@
   .text-right
     - if user.persisted?
       = link_to "Annuler", organisation_user_path(current_organisation, user), class: "btn btn-link"
+      = f.button :submit
     - else
       = link_to "Annuler", organisation_users_path(current_organisation), class: "btn btn-link"
-    = f.button :submit
+      = f.button :submit, "Créer usager"

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -21,6 +21,9 @@ FactoryBot.define do
     trait :at_home do
       location_type { :home }
     end
+    trait :at_public_office do
+      location_type { :public_office }
+    end
     trait :by_phone do
       location_type { :phone }
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     family_situation { 'divorced' }
     logement { 'sdf' }
     number_of_children { 12 }
+    responsible { nil }
     trait :unconfirmed do
       confirmed_at { nil }
     end

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -57,16 +57,16 @@ describe "Agent can create a Rdv with creneau search" do
     # Select creneau
     first(:link, "09:30").click
 
-    # Step 3
-    expect_page_title("Choisir l'usager")
-    expect_checked("Motif : #{motif.name}")
-    expect_checked("Lieu : #{lieu.address}")
-    expect_checked("Durée : #{motif.default_duration_in_min} minutes")
-    expect_checked("Professionnels : #{agent.full_name_and_service}")
-
+    # Step 2
+    expect_page_title("Choisir le ou les usagers")
     select_user(user)
-
     click_button('Continuer')
+
+    # Step 3
+    expect_page_title("Choisir la durée et la date")
+    expect_checked("Motif : #{motif.name}")
+    expect(find_field('rdv[location]').value).to eq(lieu.address)
+    click_button('Créer RDV')
 
     expect(user.rdvs.count).to eq(1)
     rdv = user.rdvs.first

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -22,6 +22,34 @@ describe "Agent can create a Rdv with wizard" do
     click_button('Continuer')
 
     # Step 2
+    expect_page_title("Choisir le ou les usagers")
+    expect_checked("Motif : #{motif.name}")
+    select_user(user)
+    expect(page).to have_link('Créer un usager')
+    click_link('Créer un usager')
+
+    # create user with mail
+    expect(find("#modal-holder")).to have_content("Nouvel usager")
+    fill_in :user_first_name, with: "Jean-Paul"
+    fill_in :user_last_name, with: "Orvoir"
+    fill_in :user_email, with: "jporvoir@bidule.com"
+    sleep(1) # wait for scroll to not interfere with form input
+    page.execute_script "$('#mainModal').scrollTop(1000)"
+    click_button('Créer usager')
+    sleep(1) # wait for modal to hide completely
+
+    # create user without email
+    click_link('Créer un usager')
+    fill_in :user_first_name, with: "Jean-Marie"
+    fill_in :user_last_name, with: "Lapin"
+    sleep(1) # wait for scroll to not interfere with form input
+    page.execute_script "$('#mainModal').scrollTop(1000)"
+    click_button('Créer usager')
+    sleep(1) # wait for modal to hide completely
+
+    click_button('Continuer')
+
+    # Step 3
     expect_page_title("Choisir la durée et la date")
     expect_checked(motif.name)
     expect(page).to have_selector("input#rdv_duration_in_min[value='#{motif.default_duration_in_min}']")
@@ -31,40 +59,7 @@ describe "Agent can create a Rdv with wizard" do
 
     select_agent(agent)
     select_agent(agent2)
-    click_button('Continuer')
-
-    # Step 3
-    expect_page_title("Choisir l'usager")
-    expect_checked("Motif : #{motif.name}")
-    expect_checked("Lieu : 79 Rue de Plaisance, 92250 La Garenne-Colombes")
-    expect_checked("Durée : 35 minutes")
-    expect_checked("Professionnels : #{agent.full_name_and_service} et #{agent2.full_name_and_service}")
-    expect_checked("Commence le : vendredi 11 octobre 2019 à 14h15")
-
-    select_user(user)
-    expect(page).to have_link('Créer')
-    click_link('Créer')
-
-    expect(find("#modal-holder")).to have_content("Nouvel usager")
-
-    fill_in :user_first_name, with: "Jean-Paul"
-    fill_in :user_last_name, with: "Orvoir"
-    fill_in :user_email, with: "jporvoir@bidule.com"
-    sleep(1) # wait for scroll to not interfere with form input
-    page.execute_script "$('#mainModal').scrollTop(1000)"
-    click_button('Créer')
-    sleep(1) # wait for modal to hide completely
-
-    # create user without email
-    click_link('Créer')
-    fill_in :user_first_name, with: "Jean-Marie"
-    fill_in :user_last_name, with: "Lapin"
-    sleep(1) # wait for scroll to not interfere with form input
-    page.execute_script "$('#mainModal').scrollTop(1000)"
-    click_button('Créer')
-    sleep(1) # wait for modal to hide completely
-
-    click_button('Continuer')
+    click_button('Créer RDV')
 
     expect(user.rdvs.count).to eq(1)
     rdv = user.rdvs.first

--- a/spec/form_models/rdv_wizard_spec.rb
+++ b/spec/form_models/rdv_wizard_spec.rb
@@ -43,6 +43,12 @@ describe RdvWizard do
           let!(:motif) { create(:motif, :at_home) }
           let!(:user) { create(:user, address: "10 rue du havre") }
           it { should eq("10 rue du havre") }
+
+          context "a different address is given in the wizard" do
+            let(:rdv_attributes) { { user_ids: [user.id], motif_id: motif.id, location: "20 rue des PTT" } }
+
+            it { should eq("20 rue des PTT") }
+          end
         end
         context "motif is at home but user doesn't have an address" do
           let!(:motif) { create(:motif, :at_home) }


### PR DESCRIPTION
https://trello.com/c/SbLo91uF/594-vad-pose-dun-rdv-sur-lagenda

ℹ️ this PR can be read commit by commit, they are pretty self-contained
ℹ️ Screenshots below 👇

Updates in the RDV Wizard:
- Reorder the steps : you now choose users before choosing the date, location and agents
- Ask for a location for VAD rdvs. Defaults to the first user's address
- Display motifs 'options' (online / phone / VAD) in the dropdown and labels
- Slightly change the header row of already selected options during step 2
- explicited a few wordings : 
  - "Choisir l'usager" -> "Choisir le ou les usagers"
  - "Créer" -> Créer un usager / Créer RDV

Updates in "Trouver un Creneau":
- Display motifs 'options' (online / phone / VAD) in the dropdown
- Redirect towards step 2 of the RDV wizard (pick users) instead of step 3 

new steps ordering:

Step 1 
<img width="630" alt="Screenshot 2020-04-09 at 11 30 27" src="https://user-images.githubusercontent.com/883348/78880976-75c76780-7a56-11ea-983c-ed1438d6e611.png">



Step 2
<img width="639" alt="Screenshot 2020-04-09 at 11 30 34" src="https://user-images.githubusercontent.com/883348/78880988-79f38500-7a56-11ea-9d38-9274322d9328.png">


Step 3
<img width="625" alt="Screenshot 2020-04-09 at 11 30 40" src="https://user-images.githubusercontent.com/883348/78881004-7eb83900-7a56-11ea-90e4-b9120687159c.png">


