### PR TITLE
[refactor] masque les warning ruby

### DIFF
--- a/config/initializers/remove_ruby_warnings.rb
+++ b/config/initializers/remove_ruby_warnings.rb
@@ -1,0 +1,1 @@
+Warning[:deprecated] = false


### PR DESCRIPTION
Il y a plusieurs façon de le faire. Je propose celle-ci qui à le mérite d'afficher le l'intention dans le code (c'est explicite et partagé).

L'autre façon de le faire serait d'utiliser les RUBY_OPTS. peut-être moins simple ?