### PR TITLE
automatically take screenshots when integration specs fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,8 @@ jobs:
               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
             echo $COMMAND
             eval $COMMAND
-      - store_test_results:
-          path: test-results
+      - store_artifacts:
+          path: tmp/capybara
   lint:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,11 +88,13 @@ jobs:
           command: |
             COMMAND="bundle exec rspec --profile 10 \
               --format RspecJunitFormatter \
-              --out ~/test_results/rspec.xml \
+              --out test-results/rspec.xml \
               --format progress \
               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
             echo $COMMAND
             eval $COMMAND
+      - store_test_results:
+          path: test-results
       - store_artifacts:
           path: tmp/capybara
   lint:

--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'capybara-selenium'
   gem 'capybara-email'
+  gem 'capybara-screenshot'
   gem 'webdrivers', '~> 4.0'
   gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
     capybara-email (3.0.1)
       capybara (>= 2.4, < 4.0)
       mail
+    capybara-screenshot (1.0.24)
+      capybara (>= 1.0, < 4)
+      launchy
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
@@ -497,6 +500,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   capybara-email
+  capybara-screenshot
   capybara-selenium
   chartkick (~> 3.3.0)
   daemons

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,9 +17,10 @@ require 'database_cleaner'
 require 'capybara/rspec'
 require 'capybara/email/rspec'
 require 'webdrivers'
+require 'capybara-screenshot/rspec'
 
 chrome_bin = ENV.fetch('GOOGLE_CHROME_SHIM', nil)
-Capybara.register_driver :chrome do |app|
+Capybara.register_driver :selenium do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: chrome_bin ? { binary: chrome_bin } : {}
   )
@@ -34,9 +35,10 @@ end
 Capybara.configure do |config|
   port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
   config.app_host = "http://localhost:#{port}"
+  # config.asset_host = "http://localhost:#{port}"  # for screenshots
   config.server_host = "localhost"
   config.server_port = port
-  config.javascript_driver = :chrome
+  config.javascript_driver = :selenium
   config.server = :puma, { Silent: true }
 end
 


### PR DESCRIPTION
linked to https://trello.com/c/yibIcLXq/601-fix-randomly-failing-feature-specs

this PR makes integration specs take a screenshot (HTML + png) upon each failure.

Locally:

<img width="1437" alt="Screenshot 2020-04-14 at 15 59 50" src="https://user-images.githubusercontent.com/883348/79233336-ffb56d00-7e68-11ea-8990-c793dc0218ff.png">


On CircleCI : 

<img width="481" alt="Screenshot 2020-04-14 at 15 54 59" src="https://user-images.githubusercontent.com/883348/79232895-65edc000-7e68-11ea-9268-0124c06505fc.png">

cf https://github.com/mattheworiordan/capybara-screenshot/
and https://github.com/mattheworiordan/capybara-screenshot/issues/211#issuecomment-321857907 
and https://circleci.com/docs/2.0/artifacts/

I also fixed the `store_test_results` directive that was pointing to the wrong directory. It lets us see a formatted view of failing tests on CircleCI: 

<img width="870" alt="Screenshot 2020-04-14 at 15 56 18" src="https://user-images.githubusercontent.com/883348/79233014-92094100-7e68-11ea-9092-535b3fe5e107.png">
