### PR TITLE
[Tech] write chrome headless logs to files during feature specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -155,6 +155,7 @@ RSpec.configure do |config|
   config.after(:each, js: true) do |example|
     next unless example.exception # only write logs for failed tests
 
+    FileUtils.mkdir_p "tmp/capybara"
     [:browser, :driver].each do |source|
       errors = Capybara.page.driver.browser.manage.logs.get(source)
       fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,19 +152,13 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
-  # write chrome headless browser and driver logs
-  config.before(:each, js: true) do
-    FileUtils.mkdir_p "tmp/capybara"
-    Dir.glob("tmp/capybara/chrome.*.log").each { File.delete(_1) }
-  end
-
   config.after(:each, js: true) do |example|
     next unless example.exception # only write logs for failed tests
 
     [:browser, :driver].each do |source|
       errors = Capybara.page.driver.browser.manage.logs.get(source)
       fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"
-      File.open(fp, 'a') do |f|
+      File.open(fp, 'w') do |f|
         f << "// empty logs" if errors.empty?
         errors.each do |e|
           f << "#{e.timestamp} [#{e.level}]: #{e.message}"


### PR DESCRIPTION
linked to https://trello.com/c/yibIcLXq/601-fix-randomly-failing-feature-specs

logs are written to `tmp/capybara/chrome.spec_full_description.browser/driver.log` and on CircleCI they are uploaded as artifacts so you can see them after the tests have run. 

note: they may still be duplicated across different specs, I'm not sure if the logs are cleared between tests