### PR TITLE
[tech] add CI failure Slack notifications for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
 
 defaults: &defaults
   working_directory: ~/lapins
@@ -57,6 +59,9 @@ jobs:
       - *yarn_restore_cache
       - *yarn_save_cache
       - *yarn_install
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
   test:
     <<: *defaults
     parallelism: 3
@@ -97,6 +102,9 @@ jobs:
           path: test-results
       - store_artifacts:
           path: tmp/capybara
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
   lint:
     <<: *defaults
     steps:
@@ -108,6 +116,9 @@ jobs:
       - run:
           name: Run linters
           command: bundle exec rake ci
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
 
 workflows:
   version: 2


### PR DESCRIPTION
this will notify us on slack when a job's build/test/lint step fails on the master branch only.

cf https://circleci.com/orbs/registry/orb/circleci/slack

I added the `SLACK_WEBHOOK` env var on CircleCI 

I tested once by switching to this branch and failing a test on purpose, it seemd to work

<img width="774" alt="Screenshot 2020-04-17 at 13 38 59" src="https://user-images.githubusercontent.com/883348/79565336-ce2ee280-80b0-11ea-9ae8-bc183b2dfd38.png">
