### PR TITLE
[Annulation] ne pas notifier l'usager pour les rdv dans le passé

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -77,7 +77,7 @@ class Rdv < ApplicationRecord
   end
 
   def notify?
-    !motif.disable_notifications_for_users && starts_at.to_date >= Date.today
+    !motif.disable_notifications_for_users && !starts_at.to_date.past?
   end
 
   def lieu

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -77,7 +77,7 @@ class Rdv < ApplicationRecord
   end
 
   def notify?
-    !motif.disable_notifications_for_users
+    !motif.disable_notifications_for_users && starts_at.to_date >= Date.today
   end
 
   def lieu

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :rdv do
     duration_in_min { 45 }
-    starts_at { Time.zone.local(2019, 7, 4, 15, 0) }
+    starts_at { DateTime.now }
     location { "10 rue de la Ferronerie 44100 Nantes" }
     organisation { Organisation.first || create(:organisation) }
     motif { Motif.first || build(:motif) }

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :rdv do
     duration_in_min { 45 }
-    starts_at { DateTime.now }
+    starts_at { Time.zone.now }
     location { "10 rue de la Ferronerie 44100 Nantes" }
     organisation { Organisation.first || create(:organisation) }
     motif { Motif.first || build(:motif) }

--- a/spec/models/rdv/ics_spec.rb
+++ b/spec/models/rdv/ics_spec.rb
@@ -2,8 +2,7 @@ describe Rdv::Ics, type: :model do
   describe '#to_ical_for' do
     let(:motif) { create(:motif, name: "Consultation initiale") }
     let(:user) { create(:user, first_name: "elisa", last_name: "simon", email: "elisa@simon.fr") }
-    let(:rdv) { create(:rdv, users: [user], motif: motif) }
-    # let(:rdv_by_phone) { create(:rdv, :by_phone) }  # unused
+    let(:rdv) { create(:rdv, users: [user], motif: motif, starts_at: Time.zone.local(2019, 7, 4, 15, 0)) }
     let(:ics) { Rdv::Ics.new(rdv: rdv) }
     subject { ics.to_ical_for(user) }
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -141,14 +141,14 @@ describe Rdv, type: :model do
   end
 
   describe "#notify?" do
-    it "true avec un rendez-vous dans le futur dans le futur" do
+    it "true avec un rendez-vous dans le futur" do
       rdv = build(:rdv, starts_at: DateTime.now + 1.day)
-      expect(rdv.notify?).to be_truthy
+      expect(rdv.notify?).to be true
     end
 
     it "false avec un rendez-vous dans le passé" do
       rdv = build(:rdv, starts_at: DateTime.now - 1.day)
-      expect(rdv.notify?).to be_falsy
+      expect(rdv.notify?).to be false
     end
   end
 end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -1,4 +1,8 @@
 describe Rdv, type: :model do
+  it "a une fabrique valide" do
+    expect(build(:rdv)).to be_valid
+  end
+
   describe "#send_notifications_to_users" do
     let(:rdv) { build(:rdv) }
 
@@ -133,6 +137,18 @@ describe Rdv, type: :model do
         rdv.save
         expect(rdv.valid?).to eq(true)
       end
+    end
+  end
+
+  describe "#notify?" do
+    it "true avec un rendez-vous dans le futur dans le futur" do
+      rdv = build(:rdv, starts_at: DateTime.now + 1.day)
+      expect(rdv.notify?).to be_truthy
+    end
+
+    it "false avec un rendez-vous dans le passé" do
+      rdv = build(:rdv, starts_at: DateTime.now - 1.day)
+      expect(rdv.notify?).to be_falsy
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/nDvnpBQd/546-annulation-supprimer-les-motifs-de-confirmation-pour-les-rdv-pass%C3%A9s