### PR TITLE
Feature/mailer previews

### DIFF
--- a/app/controllers/admin/mailer_previews_controller.rb
+++ b/app/controllers/admin/mailer_previews_controller.rb
@@ -1,0 +1,96 @@
+# adapted from https://github.com/rails/rails/blob/master/railties/lib/rails/mailers_controller.rb
+# rubocop:disable all
+module Admin
+  class MailerPreviewsController < Admin::ApplicationController
+
+    before_action :find_preview, only: :show
+    around_action :set_locale, only: :show
+
+    helper_method :part_query, :locale_query
+
+    content_security_policy(false)
+
+    def index
+      @previews = ActionMailer::Preview.all
+    end
+
+    def show
+      if params[:id] == @preview.preview_name
+        @page_title = "Mailer Previews for #{@preview.preview_name}"
+        render action: "mailer"
+      else
+        @email_action = File.basename(params[:id])
+
+        if @preview.email_exists?(@email_action)
+          @page_title = "Mailer Preview for #{@preview.preview_name}##{@email_action}"
+          @email = @preview.call(@email_action, params)
+
+          if params[:part]
+            part_type = Mime::Type.lookup(params[:part])
+
+            if part = find_part(part_type)
+              response.content_type = part_type
+              render plain: part.respond_to?(:decoded) ? part.decoded : part
+            else
+              raise AbstractController::ActionNotFound, "Email part '#{part_type}' not found in #{@preview.name}##{@email_action}"
+            end
+          else
+            @part = find_preferred_part(request.format, Mime[:html], Mime[:text])
+            render action: "email", layout: false, formats: [:html]
+          end
+        else
+          raise AbstractController::ActionNotFound, "Email '#{@email_action}' not found in #{@preview.name}"
+        end
+      end
+    end
+
+    private
+
+    def find_preview
+      candidates = []
+      params[:id].to_s.scan(%r{/|$}) { candidates << $` }
+      preview = candidates.detect { |candidate| ActionMailer::Preview.exists?(candidate) }
+
+      if preview
+        @preview = ActionMailer::Preview.find(preview)
+      else
+        raise AbstractController::ActionNotFound, "Mailer preview '#{params[:id]}' not found"
+      end
+    end
+
+    def find_preferred_part(*formats) # :doc:
+      formats.each do |format|
+        if part = @email.find_first_mime_type(format)
+          return part
+        end
+      end
+
+      if formats.any? { |f| @email.mime_type == f }
+        @email
+      end
+    end
+
+    def find_part(format) # :doc:
+      if part = @email.find_first_mime_type(format)
+        part
+      elsif @email.mime_type == format
+        @email
+      end
+    end
+
+    def part_query(mime_type)
+      request.query_parameters.merge(part: mime_type).to_query
+    end
+
+    def locale_query(locale)
+      request.query_parameters.merge(locale: locale).to_query
+    end
+
+    def set_locale
+      I18n.with_locale(params[:locale] || I18n.default_locale) do
+        yield
+      end
+    end
+  end
+end
+# rubocop:enable all

--- a/app/controllers/admin/mailer_previews_controller.rb
+++ b/app/controllers/admin/mailer_previews_controller.rb
@@ -36,6 +36,8 @@ module Admin
         @part = find_preferred_part(request.format, Mime[:html], Mime[:text])
         render action: "email"
       end
+    rescue ActiveRecord::RecordNotFound
+      render plain: 'could not find preview AR instance'
     end
 
     private

--- a/app/dashboards/mailer_preview_dashboard.rb
+++ b/app/dashboards/mailer_preview_dashboard.rb
@@ -1,0 +1,7 @@
+# cf https://github.com/thoughtbot/administrate/blob/master/docs/adding_controllers_without_related_model.md
+
+require "administrate/custom_dashboard"
+
+class MailerPreviewDashboard < Administrate::CustomDashboard
+  resource "MailerPreview" # for administrate views, not an actual resource
+end

--- a/app/views/admin/mailer_previews/email.html.erb
+++ b/app/views/admin/mailer_previews/email.html.erb
@@ -1,0 +1,164 @@
+<%# adapted from https://github.com/rails/rails/blob/master/railties/lib/rails/templates/rails/mailers/email.html.erb %>
+<!DOCTYPE html>
+<html><head>
+<title><%= @page_title %></title>
+<meta name="viewport" content="width=device-width" />
+<style type="text/css">
+  html, body, iframe {
+    height: 100%;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  header {
+    width: 100%;
+    padding: 10px 0 0 0;
+    margin: 0;
+    background: white;
+    font: 12px "Lucida Grande", sans-serif;
+    border-bottom: 1px solid #dedede;
+    overflow: hidden;
+  }
+
+  dl {
+    margin: 0 0 10px 0;
+    padding: 0;
+  }
+
+  dt {
+    width: 80px;
+    padding: 1px;
+    float: left;
+    clear: left;
+    text-align: right;
+    color: #7f7f7f;
+  }
+
+  dd {
+    margin-left: 90px; /* 80px + 10px */
+    padding: 1px;
+  }
+
+  dd:empty:before {
+    content: "\00a0"; // &nbsp;
+  }
+
+  iframe {
+    border: 0;
+    width: 100%;
+  }
+</style>
+</head>
+
+<body>
+<header>
+  <dl>
+    <% if @email.respond_to?(:smtp_envelope_from) && Array(@email.from) != Array(@email.smtp_envelope_from) %>
+      <dt>SMTP-From:</dt>
+      <dd><%= @email.smtp_envelope_from %></dd>
+    <% end %>
+
+    <% if @email.respond_to?(:smtp_envelope_to) && @email.to != @email.smtp_envelope_to %>
+      <dt>SMTP-To:</dt>
+      <dd><%= @email.smtp_envelope_to %></dd>
+    <% end %>
+
+    <dt>From:</dt>
+    <dd><%= @email.header['from'] %></dd>
+
+    <% if @email.reply_to %>
+      <dt>Reply-To:</dt>
+      <dd><%= @email.header['reply-to'] %></dd>
+    <% end %>
+
+    <dt>To:</dt>
+    <dd><%= @email.header['to'] %></dd>
+
+    <% if @email.cc %>
+      <dt>CC:</dt>
+      <dd><%= @email.header['cc'] %></dd>
+    <% end %>
+
+    <dt>Date:</dt>
+    <dd><%= Time.current.rfc2822 %></dd>
+
+    <dt>Subject:</dt>
+    <dd><strong><%= @email.subject %></strong></dd>
+
+    <% unless @email.attachments.nil? || @email.attachments.empty? %>
+      <dt>Attachments:</dt>
+      <dd>
+        <% @email.attachments.each do |a| %>
+          <% filename = a.respond_to?(:original_filename) ? a.original_filename : a.filename %>
+          <%= link_to filename, "data:application/octet-stream;charset=utf-8;base64,#{Base64.encode64(a.body.to_s)}", download: filename %>
+        <% end %>
+      </dd>
+    <% end %>
+
+    <dt>Format:</dt>
+    <% if @email.multipart? %>
+      <dd>
+        <select id="part" onchange="refreshBody(false);">
+          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="<%= part_query('text/html') %>">View as HTML email</option>
+          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="<%= part_query('text/plain') %>">View as plain-text email</option>
+        </select>
+      </dd>
+    <% else %>
+      <dd id="mime_type" data-mime-type="<%= part_query(@email.mime_type) %>"><%= @email.mime_type == 'text/html' ? 'HTML email' : 'plain-text email' %></dd>
+    <% end %>
+
+    <% if I18n.available_locales.count > 1 %>
+      <dt>Locale:</dt>
+      <dd>
+        <select id="locale" onchange="refreshBody(true);">
+          <% I18n.available_locales.each do |locale| %>
+            <option <%= I18n.locale == locale ? 'selected' : '' %> value="<%= locale_query(locale) %>"><%= locale %></option>
+          <% end %>
+        </select>
+      </dd>
+    <% end %>
+  </dl>
+</header>
+
+<% if @part && @part.mime_type %>
+  <iframe seamless name="messageBody" src="?<%= part_query(@part.mime_type) %>"></iframe>
+<% else %>
+  <p>
+    You are trying to preview an email that does not have any content.
+    This is probably because the <em>mail</em> method has not been called in <em><%= @preview.preview_name %>#<%= @email_action %></em>.
+  </p>
+<% end %>
+
+<script>
+  function refreshBody(reload) {
+    var part_select = document.querySelector('select#part');
+    var locale_select = document.querySelector('select#locale');
+    var iframe = document.getElementsByName('messageBody')[0];
+    var part_param = part_select ?
+      part_select.options[part_select.selectedIndex].value :
+      document.querySelector('#mime_type').dataset.mimeType;
+    var locale_param = locale_select ? locale_select.options[locale_select.selectedIndex].value : null;
+    var fresh_location;
+    if (locale_param) {
+      fresh_location = '?' + part_param + '&' + locale_param;
+    } else {
+      fresh_location = '?' + part_param;
+    }
+    iframe.contentWindow.location = fresh_location;
+
+    var url = location.pathname.replace(/\.(txt|html)$/, '');
+    var format = /html/.test(part_param) ? '.html' : '.txt';
+    var state_to_replace = locale_param ? (url + format + '?' + locale_param) : (url + format);
+
+    if (reload) {
+      location.href = state_to_replace;
+    } else if (history.replaceState) {
+      window.history.replaceState({}, '', state_to_replace);
+    }
+  }
+</script>
+
+</body>
+</html>

--- a/app/views/admin/mailer_previews/email.html.erb
+++ b/app/views/admin/mailer_previews/email.html.erb
@@ -1,135 +1,87 @@
 <%# adapted from https://github.com/rails/rails/blob/master/railties/lib/rails/templates/rails/mailers/email.html.erb %>
-<!DOCTYPE html>
-<html><head>
-<title><%= @page_title %></title>
-<meta name="viewport" content="width=device-width" />
-<style type="text/css">
-  html, body, iframe {
-    height: 100%;
-  }
 
-  body {
-    margin: 0;
-  }
+<div class='main-content__header'>
+  <h1>Mail Preview: <%= @page_title %></h1>
+</div>
+<div class='main-content__body' data-turbolinks="false">
+  <header>
+    <dl>
+      <% if @email.respond_to?(:smtp_envelope_from) && Array(@email.from) != Array(@email.smtp_envelope_from) %>
+        <dt>SMTP-From:</dt>
+        <dd><%= @email.smtp_envelope_from %></dd>
+      <% end %>
 
-  header {
-    width: 100%;
-    padding: 10px 0 0 0;
-    margin: 0;
-    background: white;
-    font: 12px "Lucida Grande", sans-serif;
-    border-bottom: 1px solid #dedede;
-    overflow: hidden;
-  }
+      <% if @email.respond_to?(:smtp_envelope_to) && @email.to != @email.smtp_envelope_to %>
+        <dt>SMTP-To:</dt>
+        <dd><%= @email.smtp_envelope_to %></dd>
+      <% end %>
 
-  dl {
-    margin: 0 0 10px 0;
-    padding: 0;
-  }
+      <dt>From:</dt>
+      <dd><%= @email.header['from'] %></dd>
 
-  dt {
-    width: 80px;
-    padding: 1px;
-    float: left;
-    clear: left;
-    text-align: right;
-    color: #7f7f7f;
-  }
+      <% if @email.reply_to %>
+        <dt>Reply-To:</dt>
+        <dd><%= @email.header['reply-to'] %></dd>
+      <% end %>
 
-  dd {
-    margin-left: 90px; /* 80px + 10px */
-    padding: 1px;
-  }
+      <dt>To:</dt>
+      <dd><%= @email.header['to'] %></dd>
 
-  dd:empty:before {
-    content: "\00a0"; // &nbsp;
-  }
+      <% if @email.cc %>
+        <dt>CC:</dt>
+        <dd><%= @email.header['cc'] %></dd>
+      <% end %>
 
-  iframe {
-    border: 0;
-    width: 100%;
-  }
-</style>
-</head>
+      <dt>Date:</dt>
+      <dd><%= Time.current.rfc2822 %></dd>
 
-<body>
-<header>
-  <dl>
-    <% if @email.respond_to?(:smtp_envelope_from) && Array(@email.from) != Array(@email.smtp_envelope_from) %>
-      <dt>SMTP-From:</dt>
-      <dd><%= @email.smtp_envelope_from %></dd>
-    <% end %>
+      <dt>Subject:</dt>
+      <dd><strong><%= @email.subject %></strong></dd>
 
-    <% if @email.respond_to?(:smtp_envelope_to) && @email.to != @email.smtp_envelope_to %>
-      <dt>SMTP-To:</dt>
-      <dd><%= @email.smtp_envelope_to %></dd>
-    <% end %>
-
-    <dt>From:</dt>
-    <dd><%= @email.header['from'] %></dd>
-
-    <% if @email.reply_to %>
-      <dt>Reply-To:</dt>
-      <dd><%= @email.header['reply-to'] %></dd>
-    <% end %>
-
-    <dt>To:</dt>
-    <dd><%= @email.header['to'] %></dd>
-
-    <% if @email.cc %>
-      <dt>CC:</dt>
-      <dd><%= @email.header['cc'] %></dd>
-    <% end %>
-
-    <dt>Date:</dt>
-    <dd><%= Time.current.rfc2822 %></dd>
-
-    <dt>Subject:</dt>
-    <dd><strong><%= @email.subject %></strong></dd>
-
-    <% unless @email.attachments.nil? || @email.attachments.empty? %>
-      <dt>Attachments:</dt>
-      <dd>
-        <% @email.attachments.each do |a| %>
-          <% filename = a.respond_to?(:original_filename) ? a.original_filename : a.filename %>
-          <%= link_to filename, "data:application/octet-stream;charset=utf-8;base64,#{Base64.encode64(a.body.to_s)}", download: filename %>
-        <% end %>
-      </dd>
-    <% end %>
-
-    <dt>Format:</dt>
-    <% if @email.multipart? %>
-      <dd>
-        <select id="part" onchange="refreshBody(false);">
-          <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="<%= part_query('text/html') %>">View as HTML email</option>
-          <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="<%= part_query('text/plain') %>">View as plain-text email</option>
-        </select>
-      </dd>
-    <% else %>
-      <dd id="mime_type" data-mime-type="<%= part_query(@email.mime_type) %>"><%= @email.mime_type == 'text/html' ? 'HTML email' : 'plain-text email' %></dd>
-    <% end %>
-
-    <% if I18n.available_locales.count > 1 %>
-      <dt>Locale:</dt>
-      <dd>
-        <select id="locale" onchange="refreshBody(true);">
-          <% I18n.available_locales.each do |locale| %>
-            <option <%= I18n.locale == locale ? 'selected' : '' %> value="<%= locale_query(locale) %>"><%= locale %></option>
+      <% unless @email.attachments.nil? || @email.attachments.empty? %>
+        <dt>Attachments:</dt>
+        <dd>
+          <% @email.attachments.each do |a| %>
+            <% filename = a.respond_to?(:original_filename) ? a.original_filename : a.filename %>
+            <%= link_to filename, "data:application/octet-stream;charset=utf-8;base64,#{Base64.encode64(a.body.to_s)}", download: filename %>
           <% end %>
-        </select>
-      </dd>
-    <% end %>
-  </dl>
-</header>
+        </dd>
+      <% end %>
 
-<% if @part && @part.mime_type %>
-  <iframe seamless name="messageBody" src="?<%= part_query(@part.mime_type) %>"></iframe>
-<% else %>
-  <p>
-    You are trying to preview an email that does not have any content.
-    This is probably because the <em>mail</em> method has not been called in <em><%= @preview.preview_name %>#<%= @email_action %></em>.
-  </p>
-<% end %>
+      <dt>Format:</dt>
+      <% if @email.multipart? %>
+        <dd>
+          <select id="part" onchange="refreshBody(false);">
+            <option <%= request.format == Mime[:html] ? 'selected' : '' %> value="<%= part_query('text/html') %>">View as HTML email</option>
+            <option <%= request.format == Mime[:text] ? 'selected' : '' %> value="<%= part_query('text/plain') %>">View as plain-text email</option>
+          </select>
+        </dd>
+      <% else %>
+        <dd id="mime_type" data-mime-type="<%= part_query(@email.mime_type) %>"><%= @email.mime_type == 'text/html' ? 'HTML email' : 'plain-text email' %></dd>
+      <% end %>
+
+      <% if I18n.available_locales.count > 1 %>
+        <dt>Locale:</dt>
+        <dd>
+          <select id="locale" onchange="refreshBody(true);">
+            <% I18n.available_locales.each do |locale| %>
+              <option <%= I18n.locale == locale ? 'selected' : '' %> value="<%= locale_query(locale) %>"><%= locale %></option>
+            <% end %>
+          </select>
+        </dd>
+      <% end %>
+    </dl>
+  </header>
+
+  <% if @part && @part.mime_type %>
+    <iframe seamless name="messageBody" src="?<%= part_query(@part.mime_type) %>"></iframe>
+  <% else %>
+    <p>
+      You are trying to preview an email that does not have any content.
+      This is probably because the <em>mail</em> method has not been called in <em><%= @preview.preview_name %>#<%= @email_action %></em>.
+    </p>
+  <% end %>
+</div>
 
 <script>
   function refreshBody(reload) {
@@ -160,5 +112,56 @@
   }
 </script>
 
-</body>
-</html>
+<style type="text/css">
+  .main-content__body{
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  iframe[name=messageBody]{
+    flex: 1;
+  }
+
+  header {
+    width: 100%;
+    padding: 10px 0 0 0;
+    margin: 0;
+    background: white;
+    font: 12px "Lucida Grande", sans-serif;
+    border-bottom: 1px solid #dedede;
+    overflow: hidden;
+  }
+
+  header select {
+    width: initial;
+  }
+
+  dl {
+    margin: 0 0 10px 0 !important;
+    padding: 0;
+  }
+
+  dt {
+    margin-top: 0 !important;
+    width: 80px;
+    padding: 1px;
+    float: left;
+    clear: left;
+    text-align: right;
+    color: #7f7f7f;
+  }
+
+  dd {
+    margin-left: 90px !important;  /* 80px + 10px */
+    padding: 1px;
+  }
+
+  dd:empty:before {
+    content: "\00a0"; // &nbsp;
+  }
+
+  iframe {
+    border: 0;
+    width: 100%;
+  }
+</style>

--- a/app/views/admin/mailer_previews/index.html.erb
+++ b/app/views/admin/mailer_previews/index.html.erb
@@ -1,0 +1,18 @@
+<%# adapted from https://github.com/rails/rails/blob/master/railties/lib/rails/templates/rails/mailers/index.html.erb %>
+<div class='main-content__header'>
+  <h1>Mailer Previews</h1>
+</div>
+<div class='main-content__body' data-turbolinks="false">
+  <% @previews.each do |preview| %>
+    <div style='margin-bottom: 12px;'>
+      <h3><%= preview.preview_name.titleize %></h3>
+      <ul>
+        <% preview.emails.each do |email| %>
+          <li>
+            <%= link_to(email, admin_mailer_preview_path("#{preview.preview_name}/#{email}")) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module Lapin
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    config.i18n.available_locales = [:fr]
     config.i18n.default_locale = :fr
     config.action_view.raise_on_missing_translations = true
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Lapin
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    config.i18n.available_locales = [:fr]
+    config.i18n.available_locales = [:fr, :en]
     config.i18n.default_locale = :fr
     config.action_view.raise_on_missing_translations = true
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resources :absences
     resources :motif_libelles
     resources :webhook_endpoints
+    resources :mailer_previews, only: [:index, :show]
     root to: "agents#index"
 
     authenticate :super_admin do

--- a/spec/mailers/previews/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/rdv_mailer_preview.rb
@@ -10,21 +10,29 @@ class RdvMailerPreview < ActionMailer::Preview
 
   def send_ics_to_user_CONTEXT_visite_a_domicile
     rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :home }).last
+    raise ActiveRecord::RecordNotFound unless rdv
+
     RdvMailer.send_ics_to_user(rdv, rdv.users.first)
   end
 
   def send_ics_to_user_CONTEXT_phone
     rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :phone }).last
+    raise ActiveRecord::RecordNotFound unless rdv
+
     RdvMailer.send_ics_to_user(rdv, rdv.users.first)
   end
 
   def send_ics_to_user_CONTEXT_public_office
     rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :public_office }).last
+    raise ActiveRecord::RecordNotFound unless rdv
+
     RdvMailer.send_ics_to_user(rdv, rdv.users.first)
   end
 
   def cancel_by_agent
     rdv = Rdv.active.last
+    raise ActiveRecord::RecordNotFound unless rdv
+
     RdvMailer.cancel_by_agent(rdv, rdv.users.first)
   end
 


### PR DESCRIPTION
cette PR ajoute les mailer previews dans l'admin: 
<img width="1552" alt="Screenshot 2020-04-20 at 18 40 12" src="https://user-images.githubusercontent.com/883348/79776697-64276f00-8336-11ea-97e1-e0560be56aaa.png">
<img width="1552" alt="Screenshot 2020-04-21 at 11 50 38" src="https://user-images.githubusercontent.com/883348/79852011-63d6b480-83c6-11ea-91e3-16e5cb4cfe16.png">



J'ai du copier et adapter des fichiers depuis Rails ce qui n'est vraiment pas tres cool mais a priori il n'y a pas de maniere simple de rendre ces previews accessibles en environnements non dev.

ca permet la de : 
- reutiliser l'authentification actuelle de l'admin
- utiliser le template d'admin (pour l'index uniquement mais on pourrait faire l'effort pour le show aussi)
- etre 'evolutif' si on veut faire des tweaks pour les contextes des differents mails previews.

on pourra rajouter des previews de sms sur le meme modele a l'avenir