### PR TITLE
[Rspec] Failed test / array order

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,7 +61,10 @@ describe User, type: :model do
 
       describe "with many organisations" do
         let(:organisations) { [organisation, create(:organisation)] }
-        it { expect { subject }.not_to change(user, :organisation_ids) }
+        it "should not change organisations" do
+          subject
+          expect(organisations).to match_array(user.organisations)
+        end
       end
     end
 


### PR DESCRIPTION
```  1) User#add_organisation when organisation is associated with many organisations is expected not to change `User#organisation_ids`
     Failure/Error: it { expect { subject }.not_to change(user, :organisation_ids) }
       expected `User#organisation_ids` not to have changed, but did change from [67, 68] to [68, 67]
     # ./spec/models/user_spec.rb:64:in `block (5 levels) in <main>'```

https://stackoverflow.com/a/19436763