### PR TITLE
enable Capybara.disable_animation option to prevent some flaky tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,7 @@ Capybara.configure do |config|
   config.server_port = port
   config.javascript_driver = :selenium
   config.server = :puma, { Silent: true }
+  config.disable_animation = true
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
ca a l'air d'aider en tout cas en local, et au moins pour le `spec/features/agents/admin_can_configure_the_organisation_spec.rb:92` "Voir le Motif"