### PR TITLE
Fix VAD RDV mails time format

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -219,7 +219,7 @@ fr:
       short: "%e %b à %Hh%M"
       short_approx: "%e %b vers %Hh%M"
       human: "%A %d %B %Y à %Hh%M"
-      human_approx: "%A %d %B %Y vers Hh%M"
+      human_approx: "%A %d %B %Y vers %Hh%M"
     pm: pm
   public_office: "au local"
   phone: "par téléphone"


### PR DESCRIPTION
https://trello.com/c/E9Hfq5L2/678-vadnotifications-heure-pas-affich%C3%A9e-dans-le-mail-de-confirmation-de-rdv-vad