### PR TITLE
Fix searches with unavailable motifs

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -4,12 +4,12 @@ class LieuxController < ApplicationController
 
   def index
     @organisations = Organisation.where(departement: @departement)
-    @lieux = Lieu.for_service_motif_and_departement(@service_id, @motif, @departement)
+    @lieux = Lieu.for_service_motif_and_departement(@service_id, @motif_name, @departement)
 
     @next_availability_by_lieux = {}
     @lieux.each do |lieu|
       if !Flipflop.corona? || ['62', '64'].include?(@departement)
-        @next_availability_by_lieux[lieu.id] = Creneau.next_availability_for_motif_and_lieu(@motif, lieu, Date.today)
+        @next_availability_by_lieux[lieu.id] = Creneau.next_availability_for_motif_and_lieu(@motif_name, lieu, Date.today)
       end
     end
 
@@ -28,13 +28,13 @@ class LieuxController < ApplicationController
     @lieu = Lieu.find(params[:id])
 
     if !Flipflop.corona? || ['62', '64'].include?(@departement)
-      @creneaux = Creneau.for_motif_and_lieu_from_date_range(@motif, @lieu, @date_range)
-      @next_availability = @creneaux.empty? ? Creneau.next_availability_for_motif_and_lieu(@motif, @lieu, @date_range.end) : nil
+      @creneaux = Creneau.for_motif_and_lieu_from_date_range(@motif_name, @lieu, @date_range)
+      @next_availability = @creneaux.empty? ? Creneau.next_availability_for_motif_and_lieu(@motif_name, @lieu, @date_range.end) : nil
     else
       @creneaux = []
       @next_availability = nil
     end
-    @max_booking_delay = Motif.active.online.joins(:organisation).where(organisations: { departement: @departement }, name: @motif).maximum('max_booking_delay')
+    @max_booking_delay = Motif.active.online.joins(:organisation).where(organisations: { departement: @departement }, name: @motif_name).maximum('max_booking_delay')
     respond_to do |format|
       format.html
       format.js
@@ -50,11 +50,11 @@ class LieuxController < ApplicationController
   def set_lieu_variables
     @query = search_params.to_hash
     @departement = search_params[:departement]
-    @motif = search_params[:motif]
+    @motif_name = search_params[:motif]
     @where = search_params[:where]
     @service_id = search_params[:service]
     @service = Service.find(@service_id)
-    @motifs = Motif.names_for_service_and_departement(@service, @departement)
+    @motif_names = Motif.names_for_service_and_departement(@service, @departement)
     @latitude = search_params[:latitude]
     @longitude = search_params[:longitude]
   end

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -34,7 +34,8 @@ class LieuxController < ApplicationController
       @creneaux = []
       @next_availability = nil
     end
-    @max_booking_delay = Motif.active.online.joins(:organisation).where(organisations: { departement: @departement }, name: @motif_name).maximum('max_booking_delay')
+    @matching_motifs = @max_booking_delay = Motif.active.online.joins(:organisation).where(organisations: { departement: @departement }, name: @motif_name)
+    @max_booking_delay = @matching_motifs.maximum('max_booking_delay')
     respond_to do |format|
       format.html
       format.js

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -34,7 +34,7 @@ class LieuxController < ApplicationController
       @creneaux = []
       @next_availability = nil
     end
-    @matching_motifs = @max_booking_delay = Motif.active.online.joins(:organisation).where(organisations: { departement: @departement }, name: @motif_name)
+    @matching_motifs = Motif.active.online.joins(:organisation).where(organisations: { departement: @departement }, name: @motif_name)
     @max_booking_delay = @matching_motifs.maximum('max_booking_delay')
     respond_to do |format|
       format.html

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -31,7 +31,7 @@ class WelcomeController < ApplicationController
   end
 
   def welcome_service
-    @motifs = Motif.names_for_service_and_departement(@service, @departement)
+    @motif_names = Motif.names_for_service_and_departement(@service, @departement)
   end
 
   def set_lieu_variables

--- a/app/views/common/_search_form.html.slim
+++ b/app/views/common/_search_form.html.slim
@@ -16,9 +16,9 @@
             = f.input :service, label: false, disabled: true, readonly: true, input_html: { value: @service.name, class: "form-control-lg" }, wrapper_html: { class: 'mb-1 mb-lg-0' }
           .col-lg-3.align-self-end= link_to "Modifier le service", welcome_departement_path(@departement, where: @where, latitude: @latitude, longitude: @longitude), class: 'btn btn-light btn-lg w-100 text-center'
 
-        - if @motifs.any?
+        - if @motif_names.any?
           .form-row.d-flex.justify-content-md-center.mb-2
-            .col-lg-9= f.input :motif, label: @motif.present? ? false : "Votre motif", collection: @motifs, selected: @motif, required: true, include_blank: "Choisissez un motif", input_html: { class: 'select2-input' }, wrapper_html: { class: 'mb-1 mb-lg-0' }
+            .col-lg-9= f.input :motif, label: @motif_name.present? ? false : "Votre motif", collection: @motif_names, selected: @motif_name, required: true, include_blank: "Choisissez un motif", input_html: { class: 'select2-input' }, wrapper_html: { class: 'mb-1 mb-lg-0' }
             .col-lg-3.align-self-end= f.button :submit, "Choisir ce motif", class: 'btn btn-secondary btn-lg w-100 text-center'
         - else
           h2.text-white.text-center.my-3 La prise de RDV n'est pas encore disponible dans ce département.
@@ -40,4 +40,3 @@
           = f.button :button, id: "search_submit", class: 'btn-secondary btn-lg w-100 text-center', disabled: true do
             i.fa.fa-search>
             | Rechercher
-

--- a/app/views/lieux/show.html.slim
+++ b/app/views/lieux/show.html.slim
@@ -11,4 +11,7 @@
         .card-body
           h5.card-title= @lieu.name
           h6.card-subtitle.mb-3= @lieu.address
-          = render 'common/creneaux', lieu: @lieu, creneaux: @creneaux, date_range: @date_range, motif: @motif_name, departement: @departement, where: @where, max_booking_delay: @max_booking_delay
+          - if @matching_motifs.present?
+            = render 'common/creneaux', lieu: @lieu, creneaux: @creneaux, date_range: @date_range, motif: @motif_name, departement: @departement, where: @where, max_booking_delay: @max_booking_delay
+          - else
+            .alert.alert-warning= "Le motif <b>#{@motif_name}</b> n'est plus disponible à la réservation à <b>#{@lieu.name}</b>".html_safe

--- a/app/views/lieux/show.html.slim
+++ b/app/views/lieux/show.html.slim
@@ -11,4 +11,4 @@
         .card-body
           h5.card-title= @lieu.name
           h6.card-subtitle.mb-3= @lieu.address
-          = render 'common/creneaux', lieu: @lieu, creneaux: @creneaux, date_range: @date_range, motif: @motif, departement: @departement, where: @where, max_booking_delay: @max_booking_delay
+          = render 'common/creneaux', lieu: @lieu, creneaux: @creneaux, date_range: @date_range, motif: @motif_name, departement: @departement, where: @where, max_booking_delay: @max_booking_delay

--- a/app/views/lieux/show.js.erb
+++ b/app/views/lieux/show.js.erb
@@ -1,1 +1,1 @@
-document.querySelector("#creneaux-lieu-<%= @lieu.id %>").innerHTML = "<%= escape_javascript(render 'common/creneaux', lieu: @lieu, creneaux: @creneaux, date_range: @date_range, motif: @motif, departement: @departement, where: @where, max_booking_delay: @max_booking_delay) %>";
+document.querySelector("#creneaux-lieu-<%= @lieu.id %>").innerHTML = "<%= escape_javascript(render 'common/creneaux', lieu: @lieu, creneaux: @creneaux, date_range: @date_range, motif: @motif_name, departement: @departement, where: @where, max_booking_delay: @max_booking_delay) %>";


### PR DESCRIPTION
cf https://trello.com/c/PHIBzZko/690-r%C3%A9parer-les-recherches-pour-des-motifs-devenus-indisponibles-%C3%A0-la-r%C3%A9servation-en-ligne

pour reproduire le cas problematique facilement : 
- creer un RDV dans le futur puis l'annuler
- garder ouvert le mail de notif d'annulation envoyé au user
- passer le motif du RDV en "indisponible à la résa en ligne" 
- cliquer sur le lien du motif

aujourd'hui ça lève une 500 : https://sentry.io/organizations/lapins/issues/1614694881/?project=1811205

cette PR modifie le comportement pour que gerer ca plus soft et afficher un message d'erreur explicite : 

<img width="1552" alt="Screenshot 2020-04-21 at 16 33 16" src="https://user-images.githubusercontent.com/883348/79878913-49b0cc80-83ee-11ea-9e52-ed53ca232a99.png">

note: 
je n'ai pas pu m'empecher de renommer les variables `@motifs` et `@motif` qui contiennent des noms de motifs et pas des motifs. 