### PR TITLE
allow motifs with same name but different location types

### DIFF
--- a/app/controllers/agents/motifs_controller.rb
+++ b/app/controllers/agents/motifs_controller.rb
@@ -25,14 +25,10 @@ class Agents::MotifsController < AgentAuthController
   end
 
   def create
-    @motif = Motif.where(name: motif_params[:name], organisation_id: @organisation.id).first_or_initialize(motif_params)
+    @motif = Motif.new(motif_params)
+    @motif.organisation = @organisation
     authorize(@motif)
-    if @motif.id
-      @motif.update(motif_params.merge(deleted_at: nil))
-    else
-      @motif.organisation = @organisation
-      flash[:notice] = "Motif créé." if @motif.save
-    end
+    flash[:notice] = "Motif créé." if @motif.save
     respond_right_bar_with @motif, location: organisation_motifs_path(@motif.organisation)
   end
 

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -7,7 +7,7 @@ class Motif < ApplicationRecord
 
   enum location_type: [:public_office, :phone, :home]
 
-  validates :name, presence: true, uniqueness: { scope: :organisation }
+  validates :name, presence: true, uniqueness: { scope: [:organisation, :location_type] }
   validates :color, :service, :default_duration_in_min, :min_booking_delay, :max_booking_delay, presence: true
   validates :min_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
   validates :max_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -6,8 +6,8 @@ class Motif < ApplicationRecord
   has_and_belongs_to_many :plage_ouvertures, -> { distinct }
 
   enum location_type: [:public_office, :phone, :home]
+  validates :name, presence: true, uniqueness: { scope: [:organisation, :location_type], conditions: -> { where(deleted_at: nil) }, message: "est déjà utilisé pour un motif avec le même type de RDV" }
 
-  validates :name, presence: true, uniqueness: { scope: [:organisation, :location_type] }
   validates :color, :service, :default_duration_in_min, :min_booking_delay, :max_booking_delay, presence: true
   validates :min_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
   validates :max_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }

--- a/spec/controllers/agents/motifs_controller_spec.rb
+++ b/spec/controllers/agents/motifs_controller_spec.rb
@@ -73,10 +73,12 @@ RSpec.describe Agents::MotifsController, type: :controller do
         build(:motif, name: old_motif.name).attributes
       end
 
-      it "creates a new motif" do
-        expect do
-          post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
-        end.to change(Motif, :count).by(1)
+      subject do
+        post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
+      end
+
+      it "creates a new Motif" do
+        expect { subject }.to change(Motif, :count).by(1)
       end
     end
   end

--- a/spec/controllers/agents/motifs_controller_spec.rb
+++ b/spec/controllers/agents/motifs_controller_spec.rb
@@ -73,21 +73,10 @@ RSpec.describe Agents::MotifsController, type: :controller do
         build(:motif, name: old_motif.name).attributes
       end
 
-      it "creates a new Motif" do
+      it "creates a new motif" do
         expect do
           post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
-        end.to change(Motif, :count).by(0)
-      end
-
-      it "reactivate the motif" do
-        post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
-        old_motif.reload
-        expect(old_motif.deleted_at).to be_nil
-      end
-
-      it "redirects to the created motif" do
-        post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
-        expect(response).to redirect_to(organisation_motifs_path(organisation_id))
+        end.to change(Motif, :count).by(1)
       end
     end
   end


### PR DESCRIPTION
resoud deux tickets car en fait difficilement dissociables:
https://trello.com/c/PqADEs7M/689-agentvad-permettre-la-cr%C3%A9ation-de-motifs-de-m%C3%AAme-libell%C3%A9s-mais-de-types-de-rdv-diff%C3%A9rents
et
https://trello.com/c/dC6NiD9C/699-agent-retirer-le-comportement-createorupdate-%C3%A0-la-cr%C3%A9ation-de-motif

cette PR change la contrainte d'unicité des motifs, aujourd'hui la contrainte est : 
- aucun motif avec le même nom au sein d'une orga.

maintenant : 

- aucun motif **actif** (non-supprimé) avec le même nom et le même `location_type` au sein d'une orga

je n'ai pas rajouté de tests car je pense que ça reviendrait à tester AR et que les tests ne seraient pas plus lisibles que le code mais c'est discutable