### PR TITLE
let agents bypass booking delays in trouver un creneau interface

### DIFF
--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -40,7 +40,7 @@ class Creneau
     !overlaps_rdv_or_absence?(rdvs) &&
       !overlaps_rdv_or_absence?(absences) &&
       !overlaps_jour_ferie? &&
-      (for_agents || (!too_soon? && !too_late?))
+      (for_agents || (respects_min_booking_delay? && respects_max_booking_delay?))
   end
 
   def to_rdv_for_user(user)
@@ -57,12 +57,12 @@ class Creneau
       users: [user])
   end
 
-  def too_soon?
-    (starts_at - motif.min_booking_delay.seconds) < Time.zone.now
+  def respects_min_booking_delay?
+    starts_at >= (Time.zone.now + motif.min_booking_delay.seconds)
   end
 
-  def too_late?
-    starts_at > (Time.zone.now + motif.max_booking_delay.seconds)
+  def respects_max_booking_delay?
+    starts_at <= (Time.zone.now + motif.max_booking_delay.seconds)
   end
 
   def overlaps_rdv_or_absence?(rdvs_or_absences)

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -36,12 +36,11 @@ class Creneau
     available_plages_ouverture.any?
   end
 
-  def available_with_rdvs_and_absences?(rdvs, absences)
+  def available_with_rdvs_and_absences?(rdvs, absences, for_agents: false)
     !overlaps_rdv_or_absence?(rdvs) &&
       !overlaps_rdv_or_absence?(absences) &&
       !overlaps_jour_ferie? &&
-      !too_soon? &&
-      !too_late?
+      (for_agents || (!too_soon? && !too_late?))
   end
 
   def to_rdv_for_user(user)
@@ -104,7 +103,7 @@ class Creneau
       rdvs = po.agent.rdvs.where(starts_at: inclusive_datetime_range).active
       absences_occurrences = po.agent.absences.flat_map { |a| a.occurences_for(inclusive_datetime_range) }
 
-      creneaux.select { |c| c.available_with_rdvs_and_absences?(rdvs, absences_occurrences) }
+      creneaux.select { |c| c.available_with_rdvs_and_absences?(rdvs, absences_occurrences, for_agents: for_agents) }
     end
 
     uniq_by = for_agents ? ->(c) { [c.starts_at, c.agent_id] } : ->(c) { c.starts_at }

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -40,7 +40,7 @@ class Creneau
     !overlaps_rdv_or_absence?(rdvs) &&
       !overlaps_rdv_or_absence?(absences) &&
       !overlaps_jour_ferie? &&
-      (for_agents || (respects_min_booking_delay? && respects_max_booking_delay?))
+      (for_agents || respects_booking_delays?)
   end
 
   def to_rdv_for_user(user)
@@ -63,6 +63,10 @@ class Creneau
 
   def respects_max_booking_delay?
     starts_at <= (Time.zone.now + motif.max_booking_delay.seconds)
+  end
+
+  def respects_booking_delays?
+    respects_min_booking_delay? && respects_max_booking_delay?
   end
 
   def overlaps_rdv_or_absence?(rdvs_or_absences)

--- a/app/views/common/_creneaux.html.slim
+++ b/app/views/common/_creneaux.html.slim
@@ -18,7 +18,7 @@ div id="creneaux-lieu-#{lieu.id}"
               = l(date, format: "%d %b")
             - creneaux_for_date = creneaux.group_by { |c| c.starts_at.to_date }.select { |k, v| k == date }
 
-            - if creneaux_for_date.any? && !creneaux_for_date[date].first.too_late?
+            - if creneaux_for_date.any? && creneaux_for_date[date].first.respects_max_booking_delay?
               - creneaux_for_date.each do |date, creneaux|
                 - creneaux.sort_by(&:starts_at).each do |creneau|
                   = link_to l(creneau.starts_at, format: "%H:%M"), new_users_rdv_path(starts_at: creneau.starts_at, motif_name: motif, lieu_id: lieu.id, departement: departement, where: where), class: "btn btn-light mr-1 mb-1 w-100"

--- a/spec/factories/creneau.rb
+++ b/spec/factories/creneau.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :creneau do
+    starts_at { 1.day.from_now }
+    motif
+
+    trait :does_not_respect_min_booking_delay do
+      starts_at { 1.day.from_now }
+      motif { build(:motif, min_booking_delay: 2.days) }
+    end
+
+    trait :does_not_respect_max_booking_delay do
+      starts_at { 10.days.from_now }
+      motif { build(:motif, max_booking_delay: 7.days) }
+    end
+  end
+end

--- a/spec/factories/creneau.rb
+++ b/spec/factories/creneau.rb
@@ -1,16 +1,18 @@
 FactoryBot.define do
   factory :creneau do
-    starts_at { 1.day.from_now }
+    starts_at { 10.days.from_now }
     motif
 
     trait :does_not_respect_min_booking_delay do
-      starts_at { 1.day.from_now }
-      motif { build(:motif, min_booking_delay: 2.days) }
+      motif { build(:motif, min_booking_delay: 14.days) }
     end
 
     trait :does_not_respect_max_booking_delay do
-      starts_at { 10.days.from_now }
       motif { build(:motif, max_booking_delay: 7.days) }
+    end
+
+    trait :respects_booking_delays do
+      motif { build(:motif, min_booking_delay: 1.day, max_booking_delay: 1.month) }
     end
   end
 end

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -405,21 +405,28 @@ describe Creneau, type: :model do
     end
   end
 
-  describe "#available_with_rdvs_and_absences?" do
-    context "does not respect min_booking_delay" do
-      let(:creneau) { build(:creneau, :does_not_respect_min_booking_delay) }
-      context "not for agents (default)" do
-        subject { creneau.available_with_rdvs_and_absences?([], []) }
-        it { should eq false }
-      end
-      context "for agents" do
-        subject { creneau.available_with_rdvs_and_absences?([], [], for_agents: true) }
-        it { should eq true }
-      end
+  describe "#respects_booking_delays?" do
+    subject { creneau.respects_booking_delays? }
+
+    context "creneau respects booking delays" do
+      let(:creneau) { build(:creneau, :respects_booking_delays) }
+      it { should be true }
     end
 
-    context "does not respect max_booking_delay" do
+    context "creneau does not respect min booking delay" do
+      let(:creneau) { build(:creneau, :does_not_respect_min_booking_delay) }
+      it { should be false }
+    end
+
+    context "creneau does not respect max booking delay" do
       let(:creneau) { build(:creneau, :does_not_respect_max_booking_delay) }
+      it { should be false }
+    end
+  end
+
+  describe "#available_with_rdvs_and_absences?" do
+    context "does not respect min or max booking delay" do
+      let(:creneau) { build(:creneau, :does_not_respect_min_booking_delay) }
       context "not for agents (default)" do
         subject { creneau.available_with_rdvs_and_absences?([], []) }
         it { should eq false }

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -209,44 +209,44 @@ describe Creneau, type: :model do
   end
 
   describe "#overlaps_rdv_or_absence?" do
-    let(:motif2) { create(:motif, name: "Visite 12 mois", default_duration_in_min: 60, online: online) }
-    let(:creneau) { Creneau.new(starts_at: Time.zone.local(2019, 9, 19, 9, 0), lieu_id: lieu.id, motif: motif2) }
+    let(:motif2) { build(:motif, name: "Visite 12 mois", default_duration_in_min: 60, online: online) }
+    let(:creneau) { build(:creneau, starts_at: Time.zone.local(2019, 9, 19, 9, 0), lieu_id: lieu.id, motif: motif2) }
 
     describe "for absences" do
       subject { creneau.overlaps_rdv_or_absence?([absence]) }
 
       describe "absence overlaps beginning of creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(8, 30), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(9, 30), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(8, 30), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(9, 30), agent: agent) }
         it { is_expected.to eq(true) }
       end
 
       describe "absence overlaps end of creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 30), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 30), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 30), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 30), agent: agent) }
         it { is_expected.to eq(true) }
       end
 
       describe "absence is inside creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 15), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(9, 30), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 15), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(9, 30), agent: agent) }
         it { is_expected.to eq(true) }
       end
 
       describe "absence is before creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(8, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(9, 0), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(8, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(9, 0), agent: agent) }
         it { is_expected.to eq(false) }
       end
 
       describe "absence is after creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(10, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 30), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(10, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 30), agent: agent) }
         it { is_expected.to eq(false) }
       end
 
       describe "absence is around creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(8, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 30), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(8, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 30), agent: agent) }
         it { is_expected.to eq(true) }
       end
 
       describe "absence is like creneau" do
-        let!(:absence) { create(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 0), agent: agent) }
+        let!(:absence) { build(:absence, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(10, 0), agent: agent) }
         it { is_expected.to eq(true) }
       end
     end
@@ -296,36 +296,36 @@ describe Creneau, type: :model do
 
     subject { creneau.available_plages_ouverture }
 
-    it { expect(subject).to contain_exactly(plage_ouverture) }
+    it { should contain_exactly(plage_ouverture) }
 
     describe "with an other plage_ouverture for this motif" do
       let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)) }
 
-      it { expect(subject).to contain_exactly(plage_ouverture, plage_ouverture2) }
+      it { should contain_exactly(plage_ouverture, plage_ouverture2) }
     end
 
     describe "with an other plage_ouverture with another motif" do
-      let(:motif2) { create(:motif, name: "Visite 12 mois", default_duration_in_min: 60, online: online) }
+      let(:motif2) { build(:motif, name: "Visite 12 mois", default_duration_in_min: 60, online: online) }
       let!(:plage_ouverture3) { create(:plage_ouverture, title: "Permanence visite 12 mois", motifs: [motif2], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11)) }
 
-      it { expect(subject).to contain_exactly(plage_ouverture) }
+      it { should contain_exactly(plage_ouverture) }
     end
 
     describe "with an other plage_ouverture but not opened the right time" do
-      let!(:plage_ouverture4) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(18)) }
+      let!(:plage_ouverture4) { build(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(18)) }
 
-      it { expect(subject).to contain_exactly(plage_ouverture) }
+      it { should contain_exactly(plage_ouverture) }
     end
 
     describe "with a rdv" do
       let!(:rdv) { create(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30) }
 
-      it { expect(subject).to eq([]) }
+      it { should eq([]) }
 
       describe "which is cancelled" do
-        let!(:rdv) { create(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30, cancelled_at: 2.days.ago) }
+        let!(:rdv) { build(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30, cancelled_at: 2.days.ago) }
 
-        it { expect(subject).to contain_exactly(plage_ouverture) }
+        it { should contain_exactly(plage_ouverture) }
       end
     end
   end
@@ -343,13 +343,13 @@ describe Creneau, type: :model do
     describe "with not online motif" do
       let(:online) { false }
 
-      it { expect(subject).to eq(nil) }
+      it { should eq(nil) }
     end
 
     describe "with absence" do
       let!(:absence) { create(:absence, agent: agent, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 0), end_day: Date.new(2019, 9, 19), end_time: Tod::TimeOfDay.new(12, 0)) }
 
-      it { expect(subject).to eq(nil) }
+      it { should eq(nil) }
 
       describe "when plage_ouverture is recurrence" do
         before { plage_ouverture.update(recurrence: Montrose.monthly.to_json) }
@@ -361,7 +361,7 @@ describe Creneau, type: :model do
     describe "with rdv" do
       let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 0), duration_in_min: 120, agents: [agent]) }
 
-      it { expect(subject).to eq(nil) }
+      it { should eq(nil) }
 
       context "which is cancelled" do
         let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], cancelled_at: Time.zone.local(2019, 9, 20, 9, 30)) }
@@ -377,35 +377,31 @@ describe Creneau, type: :model do
     end
   end
 
-  describe "#too_late?" do
-    let(:motif) { create(:motif, max_booking_delay: max_booking_delay) }
-    let(:max_booking_delay) { 40.days }
-    let(:creneau) { Creneau.new(starts_at: 30.days.from_now, motif: motif) }
+  describe "#too_soon?" do
+    subject { creneau.too_soon? }
 
-    subject { creneau.too_late? }
+    context "creneau respects min_booking_delay" do
+      let(:creneau) { build(:creneau, :respects_booking_delays) }
+      it { should be false }
+    end
 
-    it { is_expected.to be(false) }
-
-    context "when max_booking_delay is in 20 days" do
-      let(:max_booking_delay) { 20.days }
-
-      it { is_expected.to be(true) }
+    context "creneau does not respect min booking delay" do
+      let(:creneau) { build(:creneau, :does_not_respect_min_booking_delay) }
+      it { should be true }
     end
   end
 
-  describe "#too_soon?" do
-    let(:motif) { create(:motif, min_booking_delay: min_booking_delay) }
-    let(:min_booking_delay) { 30.minutes }
-    let(:creneau) { Creneau.new(starts_at: 1.hour.from_now, motif: motif) }
+  describe "#too_late?" do
+    subject { creneau.too_late? }
 
-    subject { creneau.too_soon? }
+    context "creneau respects max_booking_delay" do
+      let(:creneau) { build(:creneau, :respects_booking_delays) }
+      it { should be false }
+    end
 
-    it { is_expected.to be(false) }
-
-    context "when min_booking_delay is in 2 hours" do
-      let(:min_booking_delay) { 2.hours }
-
-      it { is_expected.to be(true) }
+    context "creneau does not respect max booking delay" do
+      let(:creneau) { build(:creneau, :does_not_respect_max_booking_delay) }
+      it { should be true }
     end
   end
 

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -377,31 +377,31 @@ describe Creneau, type: :model do
     end
   end
 
-  describe "#too_soon?" do
-    subject { creneau.too_soon? }
+  describe "#respects_min_booking_delay?" do
+    subject { creneau.respects_min_booking_delay? }
 
-    context "creneau respects min_booking_delay" do
+    context "creneau respects booking delays" do
       let(:creneau) { build(:creneau, :respects_booking_delays) }
-      it { should be false }
+      it { should be true }
     end
 
     context "creneau does not respect min booking delay" do
       let(:creneau) { build(:creneau, :does_not_respect_min_booking_delay) }
-      it { should be true }
+      it { should be false }
     end
   end
 
-  describe "#too_late?" do
-    subject { creneau.too_late? }
+  describe "#respects_max_booking_delay?" do
+    subject { creneau.respects_max_booking_delay? }
 
-    context "creneau respects max_booking_delay" do
+    context "creneau respects booking delays" do
       let(:creneau) { build(:creneau, :respects_booking_delays) }
-      it { should be false }
+      it { should be true }
     end
 
     context "creneau does not respect max booking delay" do
       let(:creneau) { build(:creneau, :does_not_respect_max_booking_delay) }
-      it { should be true }
+      it { should be false }
     end
   end
 

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -408,4 +408,30 @@ describe Creneau, type: :model do
       it { is_expected.to be(true) }
     end
   end
+
+  describe "#available_with_rdvs_and_absences?" do
+    context "does not respect min_booking_delay" do
+      let(:creneau) { build(:creneau, :does_not_respect_min_booking_delay) }
+      context "not for agents (default)" do
+        subject { creneau.available_with_rdvs_and_absences?([], []) }
+        it { should eq false }
+      end
+      context "for agents" do
+        subject { creneau.available_with_rdvs_and_absences?([], [], for_agents: true) }
+        it { should eq true }
+      end
+    end
+
+    context "does not respect max_booking_delay" do
+      let(:creneau) { build(:creneau, :does_not_respect_max_booking_delay) }
+      context "not for agents (default)" do
+        subject { creneau.available_with_rdvs_and_absences?([], []) }
+        it { should eq false }
+      end
+      context "for agents" do
+        subject { creneau.available_with_rdvs_and_absences?([], [], for_agents: true) }
+        it { should eq true }
+      end
+    end
+  end
 end


### PR DESCRIPTION
cf https://trello.com/c/zc0mkTqD/682-agenttrouver-un-cr%C3%A9neau-rendre-le-d%C3%A9lai-mini-et-maxi-inactif-c%C3%B4t%C3%A9-agent

J'ai ajouté des specs pour la méthode que je modifie et un peu refacto les existantes:
- moins de create, plus de build (= moins d'acces DB)
- introduction d'une factory Creneau. ca eloigne un peu le contexte du test @yaf mais ca me parait quand meme mieux pour pas répéter 50 fois les memes choses, et permettre de reutiliser un creneau qui ne respecte pas les booking delays ailleurs ... c'est discutable
- refacto les fonctions too_late? et too_soon? en respects_max/min_booking_delays (a l'envers donc). plus explicite et moins de doubles negations. 
- ajouté une methode qui regroupe les deux `respects_booking_delays`

cette PR peut etre lue commit par commit