### PR TITLE
Effectue la redirection avant la recherche de créneau

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -3,8 +3,9 @@ class LieuxController < ApplicationController
   layout 'welcome'
 
   def index
-    @organisations = Organisation.where(departement: @departement)
+
     @lieux = Lieu.for_service_motif_and_departement(@service_id, @motif_name, @departement)
+    return redirect_to lieu_path(@lieux.first, search: @query) if @lieux.size == 1
 
     @next_availability_by_lieux = {}
     unless online_bookings_suspended_because_of_corona?(@departement)
@@ -13,9 +14,9 @@ class LieuxController < ApplicationController
       end
     end
 
-    return redirect_to lieu_path(@lieux.first, search: @query) if @lieux.size == 1
-
     @lieux = @lieux.sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
+
+    @organisations = Organisation.where(departement: @departement)
     return unless @organisations.empty?
 
     flash.now[:notice] = "La prise de RDV n’est pas encore disponible dans ce département"

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -3,7 +3,6 @@ class LieuxController < ApplicationController
   layout 'welcome'
 
   def index
-
     @lieux = Lieu.for_service_motif_and_departement(@service_id, @motif_name, @departement)
     return redirect_to lieu_path(@lieux.first, search: @query) if @lieux.size == 1
 


### PR DESCRIPTION
Je ne pense pas que ça resolve complétement le problème, mais c'est un premier pas dans la bonne direction je crois.

https://trello.com/c/D1FkScBO/564-perf-optimiser-lieuxcontrollerindex

Nous faisions 2 fois le calcul de créneau dans le cas où il n'y a qu'un seul lieu. Maintenant, on le fait une fois que ce soit pour un ou plusieurs lieu.

Une piste que j'aimerais explorer c'est le fait de calculer les créneaux disponible AVANT de les afficher. Peut-être dans un autre ticket ? Comment procéder ?