### PR TITLE
refactor new relative modals + fix buggy modal during user new rdv flow

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,4 +73,15 @@ class ApplicationController < ActionController::Base
     # :user is the scope we are authenticating
     store_location_for(:user, request.fullpath)
   end
+
+  def add_get_param_to_url(url, new_params)
+    # cf https://stackoverflow.com/questions/7785793/add-parameter-to-url
+    uri = URI.parse(url)
+    new_query_ar = URI.decode_www_form(uri.query || '')
+    new_params.each do |k, v|
+      new_query_ar.append([k, v])
+    end
+    uri.query = URI.encode_www_form(new_query_ar)
+    uri.to_s
+  end
 end

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -9,8 +9,9 @@ class Users::RelativesController < UserAuthController
     @user.organisation_ids = current_user.organisation_ids
     authorize(@user)
     flash[:notice] = "#{@user.full_name} a été ajouté comme proche." if @user.save
-    location = params[:callback_path].present? ? params[:callback_path] : users_informations_path
-    redirect_to location
+    return_location_str = params[:callback_path].presence || users_informations_path.to_s
+    return_location = add_get_param_to_url(return_location_str, created_user_id: @user.id)
+    redirect_to return_location
   end
 
   def edit

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -3,12 +3,6 @@ class Users::RelativesController < UserAuthController
 
   before_action :set_user, only: [:edit, :update, :destroy]
 
-  def new
-    @user = User.new(responsible_id: current_user.id)
-    authorize(@user)
-    respond_modal_with @user
-  end
-
   def create
     @user = User.new(user_params)
     @user.responsible_id = current_user.id
@@ -16,7 +10,7 @@ class Users::RelativesController < UserAuthController
     authorize(@user)
     flash[:notice] = "#{@user.full_name} a été ajouté comme proche." if @user.save
     location = params[:callback_path].present? ? params[:callback_path] : users_informations_path
-    respond_modal_with @user, location: location.to_s
+    redirect_to location
   end
 
   def edit

--- a/app/views/common/_modal.html.slim
+++ b/app/views/common/_modal.html.slim
@@ -1,0 +1,13 @@
+div.modal.fade aria-hidden="true" aria-labelledby="mainModalLabel" role="dialog" tabindex="-1" id=local_assigns[:id]
+  .modal-dialog.modal-md
+    .modal-content
+      .modal-header.modal-colored-header.bg-primary
+        h4#mainModalLabel.modal-title.m-0.text-white.text-center.w-100
+          = local_assigns[:title]
+        button.close.text-white aria-hidden="true" data-dismiss="modal" type="button"  ×
+      .modal-body
+        = yield
+
+      .modal-footer
+        button.btn.btn-link data-dismiss="modal" type='button' Annuler
+        = yield :footer

--- a/app/views/users/rdvs/new.html.slim
+++ b/app/views/users/rdvs/new.html.slim
@@ -32,7 +32,7 @@
             .col
               i.fa.fa-check.fa-fw.mr-1.text-success
               | Date du rendez-vous :&nbsp;
-              = l(@starts_at, format: :human)
+              = l(@rdv.starts_at, format: :human)
             .col-auto
               = link_to "modifier", lieux_path(search: { departement: @departement, service: @motif.service.id, motif: @motif_name, where: @where })
 
@@ -49,7 +49,7 @@
           = f.input :starts_at, as: :hidden, wrapper_html: { class: 'mb-0' }
           = f.input :where, as: :hidden, input_html: { value: @where }, wrapper_html: { class: 'mb-0' }
           = f.input :departement, as: :hidden, input_html: { value: @departement }, wrapper_html: { class: 'mb-0' }
-          = f.association :users, label: "Pour qui prenez-vous rendez-vous ?", as: :radio_buttons, collection: current_user.available_users_for_rdv, checked: current_user.id, label_method: lambda { |user| full_name_and_birthdate(user) }, wrapper_html: { class: 'mb-0' }
+          = f.association :users, label: "Pour qui prenez-vous rendez-vous ?", as: :radio_buttons, collection: current_user.available_users_for_rdv, checked: @rdv.users.first&.id, label_method: lambda { |user| full_name_and_birthdate(user) }, wrapper_html: { class: 'mb-0' }
           .form-group
             = link_to "Ajouter un proche", "#", data: { toggle: "modal", target: "#js-add-relative-modal" }
 

--- a/app/views/users/rdvs/new.html.slim
+++ b/app/views/users/rdvs/new.html.slim
@@ -51,10 +51,12 @@
           = f.input :departement, as: :hidden, input_html: { value: @departement }, wrapper_html: { class: 'mb-0' }
           = f.association :users, label: "Pour qui prenez-vous rendez-vous ?", as: :radio_buttons, collection: current_user.available_users_for_rdv, checked: current_user.id, label_method: lambda { |user| full_name_and_birthdate(user) }, wrapper_html: { class: 'mb-0' }
           .form-group
-            = link_to "Ajouter un proche", new_relative_path(callback_path: request.url), data: { modal: true }
+            = link_to "Ajouter un proche", "#", data: { toggle: "modal", target: "#js-add-relative-modal" }
 
           .row
             .col
               = link_to "Revenir en arrière", lieux_path(search: { departement: @departement, service: @motif.service.id, motif: @motif_name, where: @where }), class: "btn btn-link"
             .col.text-right
               = f.button :submit, 'Continuer'
+
+= render 'users/relatives/new_modal', id: "js-add-relative-modal"

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,0 +1,16 @@
+= render partial: 'layouts/model_errors', locals: { model: f.object }
+= hidden_field '', :callback_path, value: params[:callback_path]
+.form-row
+  .col-md-6= f.input :first_name
+  .col-md-6= f.input :last_name
+= f.input :birth_date, as: :date, html5: true
+
+- unless local_assigns[:submit_buttons] == false
+  / # we don't want to show these buttons when including the form in modals
+  .row
+    .col.text-left
+      - if f.object.persisted?
+        = link_to "Supprimer", relative_path(f.object), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce proche ?"}
+    .col-text-right
+      = link_to "Annuler", users_informations_path, class: "btn btn-link"
+      = f.button :submit

--- a/app/views/users/relatives/_new_modal.html.slim
+++ b/app/views/users/relatives/_new_modal.html.slim
@@ -1,0 +1,5 @@
+= simple_form_for current_user.relatives.new, url: relatives_path(callback_path: request.url) do |f|
+  = render "common/modal", id: id, title: "Nouveau proche" do
+    = render 'users/relatives/form_fields', f: f, submit_buttons: false
+    = content_for :footer do
+      = f.button :submit

--- a/app/views/users/relatives/edit.html.slim
+++ b/app/views/users/relatives/edit.html.slim
@@ -3,4 +3,5 @@
     .card
       .card-body
         h4.card-title.mb-4 Modifier un proche
-        = render 'form', user: @user
+        = simple_form_for @user, url: relative_path(@user) do |f|
+          = render "form_fields", f: f

--- a/app/views/users/relatives/new.html.slim
+++ b/app/views/users/relatives/new.html.slim
@@ -1,4 +1,0 @@
-- content_for(:title) do
-  | Ajouter un proche
-
-= render 'form', user: @user

--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -39,4 +39,6 @@
                 .col-auto.text-right
                   = link_to "modifier", edit_relative_path(relative)
         .text-right
-          = link_to "Ajouter un proche", new_relative_path, class: "btn btn-outline-primary", data: { modal: true }
+          = link_to "Ajouter un proche", "#", class: "btn btn-outline-primary", data: { toggle: "modal", target: "#js-add-relative-modal" }
+
+= render 'users/relatives/new_modal', id: "js-add-relative-modal"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   authenticate :user do
     get "/users/informations", to: 'users/users#edit'
     patch "users/informations", to: 'users/users#update'
-    resources :relatives, except: [:index], controller: "users/relatives"
+    resources :relatives, except: [:index, :new], controller: "users/relatives"
   end
   authenticated :user do
     get "/users/rdvs", to: 'users/rdvs#index', as: :authenticated_user_root


### PR DESCRIPTION
cf https://trello.com/c/tw6BL4rZ/676-bug-usager-le-bouton-annuler-ou-fermer-la-fen%C3%AAtre-ne-fonctionne-pas-depuis-la-page-ajouter-un-proche

ce qui change fonctionnellement:
- la modal ajout de proche dans le flow de prise de rdv user est réparée. Elle était impossible à fermer, c'est corrigé
- les boutons de cette modal sont dans le footer de la modal ce qui change à peine le look
- lorsqu'on créé un user dans ce flow, il est automatiquement sélectionné pour le RDV

dans le refacto j'ai complètement changé la manière dont la modal est rendue car je n'étais pas du tout à l'aise avec la manière dont c'est fait dans l'appli aujourd'hui avec le data-modal: true, le modal.js, le layout modal, et le `respond_modal_with` dans les controllers.

Ce que j'ai fait est plus classique à mon sens : 
- la modale est rendue sur la page parente, en "cachée" par défaut par bootstrap
- on utilise les data attributs natifs bootstrap pour l'ouvrir et la fermer : `data-toggle="modal"` et `data-dismiss='modal'`
- il n'y a donc plus de call AJAX lors de l'ouverture de la modale

note: je ne vois plus que 3 `respond_modal_with` dans le code, tous dans `agents/users_controller.rb` donc si on decide de poursuivre le refacto dans le sens que je propose ca ne devrait pas etre trop dur