### PR TITLE
refactor new relative modal

### DIFF
--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -8,7 +8,11 @@ class Users::RelativesController < UserAuthController
     @user.responsible_id = current_user.id
     @user.organisation_ids = current_user.organisation_ids
     authorize(@user)
-    flash[:notice] = "#{@user.full_name} a été ajouté comme proche." if @user.save
+    if @user.save
+      flash[:success] = "#{@user.full_name} a été ajouté comme proche."
+    else
+      flash[:error] = "Impossible de créer le nouveau proche."
+    end
     location = params[:callback_path].present? ? params[:callback_path] : users_informations_path
     redirect_to location
   end

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -3,12 +3,6 @@ class Users::RelativesController < UserAuthController
 
   before_action :set_user, only: [:edit, :update, :destroy]
 
-  def new
-    @user = User.new(responsible_id: current_user.id)
-    authorize(@user)
-    respond_modal_with @user
-  end
-
   def create
     @user = User.new(user_params)
     @user.responsible_id = current_user.id
@@ -16,7 +10,7 @@ class Users::RelativesController < UserAuthController
     authorize(@user)
     flash[:notice] = "#{@user.full_name} a été ajouté comme proche." if @user.save
     location = params[:callback_path].present? ? params[:callback_path] : users_informations_path
-    respond_modal_with @user, location: location.to_s
+    redirect_to location
   end
 
   def edit

--- a/app/views/common/_modal.html.slim
+++ b/app/views/common/_modal.html.slim
@@ -1,0 +1,13 @@
+div.modal.fade aria-hidden="true" aria-labelledby="mainModalLabel" role="dialog" tabindex="-1" id=local_assigns[:id]
+  .modal-dialog.modal-md
+    .modal-content
+      .modal-header.modal-colored-header.bg-primary
+        h4#mainModalLabel.modal-title.m-0.text-white.text-center.w-100
+          = local_assigns[:title]
+        button.close.text-white aria-hidden="true" data-dismiss="modal" type="button"  ×
+      .modal-body
+        = yield
+
+      .modal-footer
+        button.btn.btn-link data-dismiss="modal" type='button' Annuler
+        = yield :footer

--- a/app/views/users/rdvs/new.html.slim
+++ b/app/views/users/rdvs/new.html.slim
@@ -51,10 +51,12 @@
           = f.input :departement, as: :hidden, input_html: { value: @departement }, wrapper_html: { class: 'mb-0' }
           = f.association :users, label: "Pour qui prenez-vous rendez-vous ?", as: :radio_buttons, collection: current_user.available_users_for_rdv, checked: current_user.id, label_method: lambda { |user| full_name_and_birthdate(user) }, wrapper_html: { class: 'mb-0' }
           .form-group
-            = link_to "Ajouter un proche", new_relative_path(callback_path: request.url), data: { modal: true }
+            = link_to "Ajouter un proche", "#", data: { toggle: "modal", target: "#js-add-relative-modal" }
 
           .row
             .col
               = link_to "Revenir en arrière", lieux_path(search: { departement: @departement, service: @motif.service.id, motif: @motif_name, where: @where }), class: "btn btn-link"
             .col.text-right
               = f.button :submit, 'Continuer'
+
+= render 'users/relatives/new_modal', id: "js-add-relative-modal"

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,0 +1,16 @@
+= render partial: 'layouts/model_errors', locals: { model: f.object }
+= hidden_field '', :callback_path, value: params[:callback_path]
+.form-row
+  .col-md-6= f.input :first_name
+  .col-md-6= f.input :last_name
+= f.input :birth_date, as: :date, html5: true
+
+- unless local_assigns[:submit_buttons] == false
+  / # we don't want to show these buttons when including the form in modals
+  .row
+    .col.text-left
+      - if f.object.persisted?
+        = link_to "Supprimer", relative_path(f.object), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce proche ?"}
+    .col-text-right
+      = link_to "Annuler", users_informations_path, class: "btn btn-link"
+      = f.button :submit

--- a/app/views/users/relatives/_new_modal.html.slim
+++ b/app/views/users/relatives/_new_modal.html.slim
@@ -1,0 +1,5 @@
+= simple_form_for current_user.relatives.new, url: relatives_path(callback_path: request.url) do |f|
+  = render "common/modal", id: id, title: "Nouveau proche" do
+    = render 'users/relatives/form_fields', f: f, submit_buttons: false
+    = content_for :footer do
+      = f.button :submit

--- a/app/views/users/relatives/edit.html.slim
+++ b/app/views/users/relatives/edit.html.slim
@@ -3,4 +3,5 @@
     .card
       .card-body
         h4.card-title.mb-4 Modifier un proche
-        = render 'form', user: @user
+        = simple_form_for @user, url: relative_path(@user) do |f|
+          = render "form_fields", f: f

--- a/app/views/users/relatives/new.html.slim
+++ b/app/views/users/relatives/new.html.slim
@@ -1,4 +1,0 @@
-- content_for(:title) do
-  | Ajouter un proche
-
-= render 'form', user: @user

--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -39,4 +39,6 @@
                 .col-auto.text-right
                   = link_to "modifier", edit_relative_path(relative)
         .text-right
-          = link_to "Ajouter un proche", new_relative_path, class: "btn btn-outline-primary", data: { modal: true }
+          = link_to "Ajouter un proche", "#", class: "btn btn-outline-primary", data: { toggle: "modal", target: "#js-add-relative-modal" }
+
+= render 'users/relatives/new_modal', id: "js-add-relative-modal"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
   authenticate :user do
     get "/users/informations", to: 'users/users#edit'
     patch "users/informations", to: 'users/users#update'
-    resources :relatives, except: [:index], controller: "users/relatives"
+    resources :relatives, except: [:index, :new], controller: "users/relatives"
   end
   authenticated :user do
     get "/users/rdvs", to: 'users/rdvs#index', as: :authenticated_user_root

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -26,21 +26,6 @@ RSpec.describe Users::RelativesController, type: :controller do
     end
   end
 
-  describe "GET #new" do
-    subject { get :new }
-
-    before { subject }
-
-    it "returns a success response" do
-      expect(response).to be_successful
-    end
-
-    it "should assign a new user" do
-      expect(response.body).to include("Ajouter un proche")
-      expect(assigns(:user)).to be_a_new(User)
-    end
-  end
-
   describe "POST #create" do
     subject { post :create, params: attributes }
 
@@ -60,8 +45,9 @@ RSpec.describe Users::RelativesController, type: :controller do
         expect(assigns(:user).organisation_ids).to eq(user.organisation_ids)
       end
 
-      it "redirects to user informations" do
+      it "redirects to user informations with a success flash" do
         subject
+        expect(flash[:success]).to be_present
         expect(response).to redirect_to(users_informations_path)
       end
     end
@@ -77,10 +63,10 @@ RSpec.describe Users::RelativesController, type: :controller do
         end.not_to change(User, :count)
       end
 
-      it "returns a success response (i.e. to display the 'new' template)" do
+      it "also redirects but with an error flash" do
         subject
-        expect(response).to be_successful
-        expect(response).to render_template(:new)
+        expect(flash[:error]).to be_present
+        expect(response).to redirect_to(users_informations_path)
       end
     end
   end

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -70,7 +70,7 @@ describe "User can search for rdvs" do
 
       # Add relative
       click_link("Ajouter un proche")
-      expect(page).to have_selector('h4', text: "Ajouter un proche")
+      expect(page).to have_selector('h4', text: "Nouveau proche")
       fill_in('Prénom', with: "Mathieu")
       fill_in('Nom', with: "Lapin")
       fill_in('Date de naissance', with: Date.yesterday)


### PR DESCRIPTION
cf https://trello.com/c/tw6BL4rZ/676-bug-usager-le-bouton-annuler-ou-fermer-la-fen%C3%AAtre-ne-fonctionne-pas-depuis-la-page-ajouter-un-proche

je change complètement la manière dont la modal est rendue car je ne suis pas à l'aise avec la manière dont c'est fait dans l'appli aujourd'hui avec le data-modal: true, le modal.js, le layout modal, et le `respond_modal_with` dans les controllers.

Ce que j'ai fait est plus classique à mon sens :

- la modale est rendue sur la page parente, en "cachée" par défaut par bootstrap
- on utilise les data attributs natifs bootstrap pour l'ouvrir et la fermer : data-toggle="modal" et data-dismiss='modal'
- il n'y a donc plus de call AJAX lors de l'ouverture de la modale

Il reste 3 autres `respond_modal_with` dans le code, tous dans agents/users_controller.rb donc si on decide de poursuivre le refacto dans le sens que je propose ca ne devrait pas etre trop dur

Si on va au bout de ce refacto pour les 3 autres occurences, voici les fichiers que l'on pourrait supprimer : 
- https://github.com/betagouv/rdv-solidarites.fr/blob/7d4b96573d9a6ab448d4bf4f468cdeb90dc42f92/app/controllers/modal_responder.rb
- https://github.com/betagouv/rdv-solidarites.fr/blob/7d4b96573d9a6ab448d4bf4f468cdeb90dc42f92/app/views/layouts/modal.html.slim
- https://github.com/betagouv/rdv-solidarites.fr/blob/7d4b96573d9a6ab448d4bf4f468cdeb90dc42f92/app/webpacker/components/modal.js#L1-L100

ainsi que certaines routes

notes:
- les vues dans cette PR sont assez imbriquées parce que le même formulaire est rendu à la fois dans des modales et une page `edit` séparée. J'ai découpé les fichiers pour être complètement DRY mais ça rend le code un peu moins lisible et plus compliqué que ce simple refacto pourrait l'être si le contenu de la modale n'était pas utilisé ailleurs.
- le comportement actuel depend de `respond_with` qui n'est plus une methode de rails mais de la gem `responders` dont on depend implicitement via devise. 
- full disclosure: Le nouveau comportement est legerement moins bien qu'avant : dans le cas d'erreur de validation, avant ca rendered le template new mais maintenant je fais quand meme un redirect avec un flash d'error. pour bien gerer ca, il faudrait soumettre le formulaire de la modale en AJAX, et attacher un handler au retour pour swapper le dom de la modale avec la reponse en cas d'erreur ou rediriger en cas de succes (OU ne pas le faire dans une modale mais comme un formulaire imbriqué tradi)