### PR TITLE
auto select newly created relative in users rdv form

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,6 +75,8 @@ class ApplicationController < ActionController::Base
   end
 
   def add_query_string_params_to_url(url, new_params)
+    return url if url.blank?
+
     # cf https://stackoverflow.com/questions/7785793/add-parameter-to-url
     parsed_uri = URI.parse(url)
     parsed_query_string = URI.decode_www_form(parsed_uri.query || '')

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,4 +73,13 @@ class ApplicationController < ActionController::Base
     # :user is the scope we are authenticating
     store_location_for(:user, request.fullpath)
   end
+
+  def add_query_string_params_to_url(url, new_params)
+    # cf https://stackoverflow.com/questions/7785793/add-parameter-to-url
+    parsed_uri = URI.parse(url)
+    parsed_query_string = URI.decode_www_form(parsed_uri.query || '')
+    new_params.each { |k, v| parsed_query_string.append([k, v]) }
+    parsed_uri.query = URI.encode_www_form(parsed_query_string)
+    parsed_uri.to_s
+  end
 end

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -6,7 +6,6 @@ class Users::RelativesController < UserAuthController
   def new
     @user = current_user.relatives.new
     authorize(@user)
-    @callback_path = params[:callback_path]
     respond_modal_with @user
   end
 
@@ -15,9 +14,12 @@ class Users::RelativesController < UserAuthController
     @user.responsible_id = current_user.id
     @user.organisation_ids = current_user.organisation_ids
     authorize(@user)
-    flash[:notice] = "#{@user.full_name} a été ajouté comme proche." if @user.save
-    location = params[:callback_path].presence || users_informations_path
-    respond_modal_with @user, location: location.to_s
+    return_location = request.referer
+    if @user.save
+      flash[:notice] = "#{@user.full_name} a été ajouté comme proche."
+      return_location = add_query_string_params_to_url(request.referer, created_user_id: @user.id)
+    end
+    respond_modal_with @user, location: return_location
   end
 
   def edit

--- a/app/views/users/rdvs/new.html.slim
+++ b/app/views/users/rdvs/new.html.slim
@@ -32,7 +32,7 @@
             .col
               i.fa.fa-check.fa-fw.mr-1.text-success
               | Date du rendez-vous :&nbsp;
-              = l(@starts_at, format: :human)
+              = l(@rdv.starts_at, format: :human)
             .col-auto
               = link_to "modifier", lieux_path(search: { departement: @departement, service: @motif.service.id, motif: @motif_name, where: @where })
 
@@ -49,9 +49,9 @@
           = f.input :starts_at, as: :hidden, wrapper_html: { class: 'mb-0' }
           = f.input :where, as: :hidden, input_html: { value: @where }, wrapper_html: { class: 'mb-0' }
           = f.input :departement, as: :hidden, input_html: { value: @departement }, wrapper_html: { class: 'mb-0' }
-          = f.association :users, label: "Pour qui prenez-vous rendez-vous ?", as: :radio_buttons, collection: current_user.available_users_for_rdv, checked: current_user.id, label_method: lambda { |user| full_name_and_birthdate(user) }, wrapper_html: { class: 'mb-0' }
+          = f.association :users, label: "Pour qui prenez-vous rendez-vous ?", as: :radio_buttons, collection: current_user.available_users_for_rdv, checked: @rdv.users.first&.id, label_method: lambda { |user| full_name_and_birthdate(user) }, wrapper_html: { class: 'mb-0' }
           .form-group
-            = link_to "Ajouter un proche", new_relative_path(callback_path: request.url), data: { modal: true }
+            = link_to "Ajouter un proche", new_relative_path, data: { modal: true }
 
           .row
             .col

--- a/app/views/users/relatives/new.html.slim
+++ b/app/views/users/relatives/new.html.slim
@@ -3,7 +3,6 @@
 
 = simple_form_for @user, url: relatives_path, remote: true, data: { modal: true } do |f|
   = render partial: 'layouts/model_errors', locals: { model: @user }
-  = hidden_field '', :callback_path, value: @callback_path
   = render "form_fields", f: f
   .row
     .col.text-right

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Users::RelativesController, type: :controller do
   end
 
   describe "POST #create" do
+    before { request.headers['HTTP_REFERER'] = users_informations_path }
     subject { post :create, params: attributes }
 
     context "with valid params" do
@@ -50,9 +51,7 @@ RSpec.describe Users::RelativesController, type: :controller do
       end
 
       it "creates a new User" do
-        expect do
-          subject
-        end.to change(User, :count).by(1)
+        expect { subject }.to change(User, :count).by(1)
       end
 
       it "set organisation_ids for relative" do
@@ -60,9 +59,9 @@ RSpec.describe Users::RelativesController, type: :controller do
         expect(assigns(:user).organisation_ids).to eq(user.organisation_ids)
       end
 
-      it "redirects to user informations" do
+      it "redirects to user informations with the newly created user id as a param" do
         subject
-        expect(response).to redirect_to(users_informations_path)
+        expect(response).to redirect_to(users_informations_path(created_user_id: User.last.id))
       end
     end
 


### PR DESCRIPTION
cf https://trello.com/c/E0ngGLpB/840-usager-dans-le-tunnel-de-prise-de-rdv-auto-s%C3%A9lectionner-le-proche-nouvellement-cr%C3%A9%C3%A9

pour le faire : 
- rajout d'un paramètre get `created_user_id` qui est ajouté à l'url vers laquelle la modale de création de proche retourne
- modification de l'action `users/rdvs#new` pour prendre en compte ce parametre, et generalement mieux hydrater l'objet `@rdv` et l'utiliser en priorité dans la vue

en refacto bonus dans cette PR : 
- remplacement du parametre `callback_path` explicitement passé par l'utilisation de `request.referer`