### PR TITLE
no past slots in find a slot interface

### DIFF
--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -1,14 +1,15 @@
 class CreneauxBuilderService < BaseService
-  def initialize(motif_name, lieu, inclusive_date_range, for_agents: false, agent_ids: nil)
+  def initialize(motif_name, lieu, inclusive_date_range, **options)
     @motif_name = motif_name
     @lieu = lieu
     @inclusive_date_range = inclusive_date_range
-    @for_agents = for_agents
-    @agent_ids = agent_ids
+    @for_agents = options.fetch(:for_agents, false)
+    @agent_ids = options.fetch(:agent_ids, nil)
   end
 
   def perform
     creneaux = plages_ouvertures.flat_map { |po| creneaux_for_plage_ouverture(po) }
+    creneaux = creneaux.select { |c| c.starts_at >= Time.zone.now }
     uniq_by = @for_agents ? ->(c) { [c.starts_at, c.agent_id] } : ->(c) { c.starts_at }
     creneaux.uniq(&uniq_by).sort_by(&:starts_at)
   end


### PR DESCRIPTION
cf https://trello.com/c/nb3LeyAY/833-ne-pas-afficher-les-cr%C3%A9neaux-pass%C3%A9s-dans-trouver-un-creneau-ceux-du-matin-du-jour-meme

cette PR est plus complexe qu'elle n'aurait pu l'etre mais j'avais commencé par rajouter une option `include_past` en pensant qu'on avait besoin des deux cas. finalement ce n'est pas le cas. mais j'ai gardé le refacto plus generique des 'options' dans le service, dites moi si vous voulez que je l'enleve.

Je pense que dans les tests au moins c'est plus lisible