### PR TITLE
fix turbolinks before cache hook for calendar

### DIFF
--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -118,9 +118,11 @@ document.addEventListener('turbolinks:load', function() {
 });
 
 document.addEventListener("turbolinks:before-cache", function() {
+  const calendarElt = document.getElementById('calendar')
+  if (!calendarElt) { return false }
   // force calendar reload on turbolinks re-visit, otherwise event listeners
   // are not attached
-  document.getElementById('calendar').innerHTML = ""
+  calendarElt.innerHTML = ""
   // fixes hanging tooltip on back
   $(".tooltip").removeClass("show")
 })


### PR DESCRIPTION
fix https://sentry.io/organizations/lapins/issues/1637402456/?project=1811205

le turoblinks before cache hook est executé sur toutes les pages, il faut rajouter un court circuit