### PR TITLE
explode has_and_belongs_to_many Rdv associations

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -14,7 +14,8 @@ class Agent < ApplicationRecord
   has_many :motifs, through: :service
   has_many :plage_ouvertures, dependent: :destroy
   has_many :absences, dependent: :destroy
-  has_and_belongs_to_many :rdvs, dependent: :destroy
+  has_many :agents_rdvs, dependent: :destroy
+  has_many :rdvs, dependent: :destroy, through: :agents_rdvs
   has_and_belongs_to_many :organisations, -> { distinct }
   has_and_belongs_to_many :users
 

--- a/app/models/agents_rdv.rb
+++ b/app/models/agents_rdv.rb
@@ -1,0 +1,4 @@
+class AgentsRdv < ApplicationRecord
+  belongs_to :rdv, touch: true
+  belongs_to :agent
+end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -5,8 +5,10 @@ class Rdv < ApplicationRecord
   belongs_to :organisation
   belongs_to :motif
   has_many :file_attentes, dependent: :destroy
-  has_and_belongs_to_many :agents
-  has_and_belongs_to_many :users, validate: false
+  has_many :agents_rdvs, inverse_of: :rdv, dependent: :destroy
+  has_many :agents, through: :agents_rdvs
+  has_many :rdvs_users, validate: false, inverse_of: :rdv, dependent: :destroy
+  has_many :users, through: :rdvs_users, validate: false
 
   has_many :webhook_endpoints, through: :organisation
 

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -1,0 +1,4 @@
+class RdvsUser < ApplicationRecord
+  belongs_to :rdv, touch: true, inverse_of: :rdvs_users
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable, :async
 
   has_and_belongs_to_many :organisations, -> { distinct }
-  has_and_belongs_to_many :rdvs
+  has_many :rdvs_users, dependent: :destroy
+  has_many :rdvs, through: :rdvs_users
   has_and_belongs_to_many :agents
   belongs_to :responsible, foreign_key: "responsible_id", class_name: "User", optional: true
   has_many :relatives, foreign_key: "responsible_id", class_name: "User"

--- a/db/migrate/20200505101547_add_id_to_rdvs_users_and_agents_users.rb
+++ b/db/migrate/20200505101547_add_id_to_rdvs_users_and_agents_users.rb
@@ -1,0 +1,6 @@
+class AddIdToRdvsUsersAndAgentsUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :rdvs_users, :id, :primary_key
+    add_column :agents_rdvs, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_27_093834) do
+ActiveRecord::Schema.define(version: 2020_05_05_101547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 2020_04_27_093834) do
     t.index ["organisation_id"], name: "index_agents_organisations_on_organisation_id"
   end
 
-  create_table "agents_rdvs", id: false, force: :cascade do |t|
+  create_table "agents_rdvs", force: :cascade do |t|
     t.bigint "agent_id"
     t.bigint "rdv_id"
     t.index ["agent_id"], name: "index_agents_rdvs_on_agent_id"
@@ -254,7 +254,7 @@ ActiveRecord::Schema.define(version: 2020_04_27_093834) do
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"
   end
 
-  create_table "rdvs_users", id: false, force: :cascade do |t|
+  create_table "rdvs_users", force: :cascade do |t|
     t.bigint "rdv_id"
     t.bigint "user_id"
     t.index ["rdv_id"], name: "index_rdvs_users_on_rdv_id"


### PR DESCRIPTION
this allows adding behaviour to the join tables (`rdvs_users` and `agents_rdvs`) items : 

1. `touch`ing the Rdv when an association is updated or created
2. use `dependent: :destroy` on rdv's `has_many :rdvs_users` and other associations

adding primary keys to the join tables is necessary for point 2.

this PR will help storing RDV's versions for agents and users updates in #598
