### PR TITLE
[Usager] clarifier les boutons lors de l'annulation

### DIFF
--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -36,7 +36,7 @@
     - unless defined?(hide_cancellation_infos) && hide_cancellation_infos
       - if rdv.cancellable?
         .text-right.mt-2
-          = link_to 'Annuler le RDV', users_rdv_cancel_path(rdv.id), data: { confirm: "Êtes-vous sûr de vouloir annuler ce RDV ?" }, method: :put, class: 'btn btn-outline-danger'
+          = link_to 'Annuler le RDV', users_rdv_cancel_path(rdv.id), data: { confirm: "Êtes-vous sûr de vouloir annuler ce RDV ?", true: 'Annuler le RDV', false: 'Non' }, method: :put, class: 'btn btn-outline-danger'
       - elsif !rdv.past? && !rdv.cancelled?
         p.font-italic
           | Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne. Prenez contact avec le secrétariat.

--- a/app/webpacker/components/confirm_modal.js
+++ b/app/webpacker/components/confirm_modal.js
@@ -1,0 +1,51 @@
+class ConfirmModal {
+
+  constructor() {
+    $(document).on('confirm', '[data-confirm]', function(e){
+      var $el = $(this);
+
+      showConfirmBox($el.data('confirm'), $el, (confirmed) => {
+        if (confirmed) {
+          $el[0].removeAttribute('data-confirm')
+          $el[0].click()
+        }
+      });
+      // prevent the default behaviour of showing the standard window.confirm dialog
+      return false;
+    });
+  }
+}
+
+function showConfirmBox(message, element, callback) {
+  var trueMessage = element.data('true') || "Ok"
+  var falseMessage = element.data('false') || "Annuler"
+
+  var html = `
+  <div class='modal' tabindex='-1' role='dialog'>
+    <div class='modal-dialog' role='document'>
+      <div class='modal-content'>
+        <div class='modal-header'>
+          <h5 class='modal-title'>Confirmation</h5>
+          <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+            <span aria-hidden='true'>&times;</span>
+          </button>
+        </div>
+        <div class='modal-body'>
+          <p>${message}</p>
+        </div>
+        <div class='modal-footer'>
+          <button type='button' class='btn btn-light' data-dismiss='modal'>${falseMessage}</button>
+          <button type='button' class='btn btn-danger js-yes'>${trueMessage}</button>
+        </div>
+      </div>
+    </div>
+  </div>`
+
+  $(html).modal();
+
+  $('.js-yes').one('click', () => {
+    callback(true);
+  });
+}
+
+export { ConfirmModal };

--- a/app/webpacker/packs/landing.js
+++ b/app/webpacker/packs/landing.js
@@ -4,6 +4,7 @@ require("chartkick")
 require("chart.js")
 import { PlacesInput } from 'components/places-input.js';
 import 'components/analytic.js';
+import { ConfirmModal } from 'components/confirm_modal';
 import { Modal } from 'components/modal';
 import 'components/browser-detection';
 import 'select2/dist/js/select2.min.js';
@@ -32,6 +33,7 @@ let setWhereValid = function (where, submit) {
 }
 
 $(document).on('turbolinks:load', function() {
+  new ConfirmModal();
   $('input[type="tel"]').mask('00 00 00 00 00')
   Holder.run();
   let placeJsContainer = document.querySelector('.places-js-container');


### PR DESCRIPTION
Ajout d'un composant confirm-modal qui intercepte la `dialog` rails_ujs et affiche une modal bootstrap.
Ajout des paramètres data-true & data-false pour afficher des textes "customs" sur les boutons de la modal.

<img width="633" alt="Capture d’écran 2020-05-05 à 14 14 54" src="https://user-images.githubusercontent.com/29787388/81064942-e25d4700-8eda-11ea-9a5d-07d6e36a01df.png">
