### PR TITLE
[Usager] clarifier les boutons lors de l'annulation

### DIFF
--- a/app/views/common/_modal_confirmation.html.erb
+++ b/app/views/common/_modal_confirmation.html.erb
@@ -9,11 +9,14 @@
       </div>
       <div class='modal-body'>
         <p>
-          <%= yield %>
+          <%= body_message %>
         </p>
       </div>
       <div class='modal-footer'>
-        <%= content_for :footer %>
+        <button type='button' class='btn btn-light' data-dismiss='modal'>
+          <%= local_assigns[:cancel_message] || "Annuler"  %>
+        </button>
+        <%= link_to local_assigns[:confirm_message] || "Confirmer", confirm_path, **local_assigns[:confirm_link_options] %>
       </div>
     </div>
   </div>

--- a/app/views/common/_modal_confirmation.html.erb
+++ b/app/views/common/_modal_confirmation.html.erb
@@ -1,0 +1,20 @@
+<div class='modal' tabindex='-1' role='dialog' id="<%= local_assigns[:id] %>">
+  <div class='modal-dialog' role='document'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <h5 class='modal-title'>Confirmation</h5>
+        <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+          <span aria-hidden='true'>&times;</span>
+        </button>
+      </div>
+      <div class='modal-body'>
+        <p>
+          <%= yield %>
+        </p>
+      </div>
+      <div class='modal-footer'>
+        <%= content_for :footer %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -41,9 +41,12 @@
         p.font-italic
           | Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne. Prenez contact avec le secrétariat.
 
-= render "common/modal_confirmation", id: "js-cancel-rdv-modal-#{rdv.id}" do
-  | Êtes-vous sûr de vouloir annuler ce RDV ?
-  = content_for :footer do
-    button type='button' class='btn btn-light' data-dismiss='modal'
-      | Non, annuler
-    = link_to "Oui, annuler le RDV", users_rdv_cancel_path(rdv.id), class: "btn btn-danger", method: :put
+= render( \
+  "common/modal_confirmation", \
+  id: "js-cancel-rdv-modal-#{rdv.id}", \
+  body_message: "Êtes-vous sûr de vouloir annuler ce RDV ?", \
+  cancel_message: "Non, annuler", \
+  confirm_path: users_rdv_cancel_path(rdv.id), \
+  confirm_message: "Oui, annuler le RDV", \
+  confirm_link_options: { class: "btn btn-danger", method: :put } \
+)

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -36,7 +36,14 @@
     - unless defined?(hide_cancellation_infos) && hide_cancellation_infos
       - if rdv.cancellable?
         .text-right.mt-2
-          = link_to 'Annuler le RDV', users_rdv_cancel_path(rdv.id), data: { confirm: "Êtes-vous sûr de vouloir annuler ce RDV ?" }, method: :put, class: 'btn btn-outline-danger'
+          = link_to 'Annuler le RDV', "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: 'btn btn-outline-danger'
       - elsif !rdv.past? && !rdv.cancelled?
         p.font-italic
           | Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne. Prenez contact avec le secrétariat.
+
+= render "common/modal_confirmation", id: "js-cancel-rdv-modal-#{rdv.id}" do
+  | Êtes-vous sûr de vouloir annuler ce RDV ?
+  = content_for :footer do
+    button type='button' class='btn btn-light' data-dismiss='modal'
+      | Non, annuler
+    = link_to "Oui, annuler le RDV", users_rdv_cancel_path(rdv.id), class: "btn btn-danger", method: :put

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -13,8 +13,8 @@ describe "User can manage their rdvs" do
     scenario "default", js: true do
       expect(page).to have_content(rdv.motif.name)
       click_link("Annuler le RDV")
-      alert = page.driver.browser.switch_to.alert
-      alert.accept
+      expect(page).to have_content("Confirmation")
+      click_link("Oui, annuler le RDV")
       expect(page).to have_selector('.badge', text: "Annulé")
     end
   end


### PR DESCRIPTION
autre facon de faire #616 sans JS additionnel 

On peut déplacer plus ou moins de choses dans le partial `_modal_confirmation.html`. J'y ai mis un peu moins de choses que Carl dans la version JS, car j'anticipe qu'il y aura aussi des confirmations "positives" où on voudra changer les couleurs et les styles des boutons du footer. donc j'ai completement extrait le footer