### PR TITLE
fix agents rdv creation validation failure flow

### DIFF
--- a/app/controllers/agents/rdv_wizard_steps_controller.rb
+++ b/app/controllers/agents/rdv_wizard_steps_controller.rb
@@ -10,7 +10,6 @@ class Agents::RdvWizardStepsController < AgentAuthController
   def new
     @rdv_wizard = rdv_wizard_for(query_params)
     @rdv = @rdv_wizard.rdv
-    @agents_authorize = agents_authorized if current_step == 'step3'
     skip_authorization
     render current_step
   end
@@ -48,14 +47,6 @@ class Agents::RdvWizardStepsController < AgentAuthController
   def rdv_wizard_for(request_params)
     klass = "RdvWizard::#{current_step.camelize}".constantize
     klass.new(current_agent, current_organisation, request_params)
-  end
-
-  def agents_authorized
-    return [] if @rdv_wizard.motif.nil?
-
-    agents = @rdv_wizard.motif.service.agents.complete.active.joins(:organisations).where(organisations: { id: current_organisation.id })
-    agents += current_organisation.agents.complete.active.includes(:service).secretariat if @rdv_wizard.motif.for_secretariat
-    agents
   end
 
   def rdv_params

--- a/app/controllers/agents/rdvs_controller.rb
+++ b/app/controllers/agents/rdvs_controller.rb
@@ -63,6 +63,7 @@ class Agents::RdvsController < AgentAuthController
     if @rdv.save
       redirect_to @rdv.agenda_path_for_agent(current_agent), notice: "Le rendez-vous a été créé."
     else
+      @rdv_wizard = RdvWizard::Step3.new(current_agent, current_organisation, @rdv.attributes)
       render 'agents/rdv_wizard_steps/step3', layout: 'application-small'
     end
   end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -41,6 +41,19 @@ class Motif < ApplicationRecord
          .uniq
   end
 
+  def authorized_agents
+    Agent
+      .joins(:organisations)
+      .where(organisations: { id: organisation.id })
+      .complete
+      .active
+      .where(service: authorized_services)
+  end
+
+  def authorized_services
+    for_secretariat ? [service, Service.secretariat] : [service]
+  end
+
   private
 
   def booking_delay_validation

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -6,6 +6,7 @@ class Service < ApplicationRecord
   SECRETARIAT = 'Secrétariat'.freeze
 
   scope :with_motifs, -> { where.not(name: SECRETARIAT) }
+  scope :secretariat, -> { where(name: SECRETARIAT).first }
 
   scope :with_online_and_active_motifs_for_departement, lambda { |departement|
                                                           where(id: Motif.online

--- a/app/views/agents/rdv_wizard_steps/step3.html.slim
+++ b/app/views/agents/rdv_wizard_steps/step3.html.slim
@@ -38,7 +38,7 @@
         / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
         = f.hidden_field "user_ids][", value: user.id
 
-      = f.association :agents, collection: @agents_authorize, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
+      = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
 
       .row
         .col.text-left

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -45,4 +45,28 @@ describe Rdv, type: :model do
       it { is_expected.to contain_exactly(motif, motif2, motif3) }
     end
   end
+
+  describe "#authorized_agents" do
+    let(:org1) { create(:organisation) }
+    let!(:service_pmi) { create(:service, name: "PMI") }
+    let!(:service_secretariat) { create(:service, name: Service::SECRETARIAT) }
+    let!(:agent_pmi1) { create(:agent, organisations: [org1], service: service_pmi) }
+    let!(:agent_pmi2) { create(:agent, organisations: [org1], service: service_pmi) }
+    let!(:agent_secretariat1) { create(:agent, organisations: [org1], service: service_secretariat) }
+    let!(:motif) { create(:motif, service: service_pmi, organisation: org1) }
+    subject { motif.authorized_agents.to_a }
+
+    it { should match_array([agent_pmi1, agent_pmi2]) }
+
+    context "motif is available for secretariat" do
+      let!(:motif) { create(:motif, service: service_pmi, organisation: org1, for_secretariat: true) }
+      it { should match_array([agent_pmi1, agent_pmi2, agent_secretariat1]) }
+    end
+
+    context "agent from same service but different orga" do
+      let(:org2) { create(:organisation) }
+      let!(:agent_pmi3) { create(:agent, organisations: [org2], service: service_pmi) }
+      it { should_not include(agent_pmi3) }
+    end
+  end
 end


### PR DESCRIPTION
fix https://sentry.io/organizations/lapins/issues/1649997289

c'est cassé quand il y a des erreurs validations car on render la step3 MAIS il manque la variable d'instance `@rdv_wizard` 😨 

j'ai corrigé ca, et j'en ai profité pour déplacer la variable d'instance `@agents_authorize` dans une méthode testée du modèle `Motif`