### PR TITLE
change rubocop lint rule for indentation : not aligned

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Layout/HashAlignment:
 Layout/ExtraSpacing:
   AllowForAlignment: true
 
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -69,7 +72,7 @@ Style/FormatStringToken:
 Style/HashEachMethods:
   Enabled: true
 
-Style/HashTransformKeys: 
+Style/HashTransformKeys:
   Enabled: true
 
 Style/HashTransformValues:

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -5,27 +5,33 @@ class Lieu < ApplicationRecord
 
   scope :for_motif, lambda { |motif|
     lieux_ids = PlageOuverture
-                .where.not("recurrence IS ? AND first_day < ?", nil, Time.zone.today)
-                .joins(:motifs).where(motifs: { id: motif.id, deleted_at: nil })
-                .map(&:lieu_id).uniq
+      .where.not("recurrence IS ? AND first_day < ?", nil, Time.zone.today)
+      .joins(:motifs)
+      .where(motifs: { id: motif.id, deleted_at: nil })
+      .map(&:lieu_id)
+      .uniq
     where(id: lieux_ids)
   }
 
   scope :for_motif_and_departement, lambda { |motif_name, departement|
     motifs_ids = Motif.active.online.joins(:organisation).where(organisations: { departement: departement }, name: motif_name)
     lieux_ids = PlageOuverture
-                .where.not("recurrence IS ? AND first_day < ?", nil, Time.zone.today)
-                .joins(:motifs).where(motifs: { id: motifs_ids })
-                .map(&:lieu_id).uniq
+      .where.not("recurrence IS ? AND first_day < ?", nil, Time.zone.today)
+      .joins(:motifs)
+      .where(motifs: { id: motifs_ids })
+      .map(&:lieu_id)
+      .uniq
     where(id: lieux_ids)
   }
 
   scope :for_service_motif_and_departement, lambda { |service_id, motif_name, departement|
     motifs_ids = Motif.active.online.joins(:organisation).where(organisations: { departement: departement }, name: motif_name, service_id: service_id)
     lieux_ids = PlageOuverture
-                .where.not("recurrence IS ? AND first_day < ?", nil, Time.zone.today)
-                .joins(:motifs).where(motifs: { id: motifs_ids })
-                .map(&:lieu_id).uniq
+      .where.not("recurrence IS ? AND first_day < ?", nil, Time.zone.today)
+      .joins(:motifs)
+      .where(motifs: { id: motifs_ids })
+      .map(&:lieu_id)
+      .uniq
     where(id: lieux_ids)
   }
 

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -33,12 +33,12 @@ class Motif < ApplicationRecord
 
   def self.names_for_service_and_departement(service, departement)
     Motif.online
-         .active
-         .joins(:organisation, :plage_ouvertures)
-         .where(organisations: { departement: departement })
-         .where(service_id: service.id)
-         .pluck(:name)
-         .uniq
+      .active
+      .joins(:organisation, :plage_ouvertures)
+      .where(organisations: { departement: departement })
+      .where(service_id: service.id)
+      .pluck(:name)
+      .uniq
   end
 
   private

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -33,12 +33,12 @@ class PlageOuverture < ApplicationRecord
   def self.for_motif_and_lieu_from_date_range(motif_name, lieu, inclusive_date_range, agent_ids = nil)
     motifs_ids = Motif.where(name: motif_name, organisation_id: lieu.organisation_id)
     results = PlageOuverture
-              .includes(:motifs_plageouvertures)
-              .where(lieu: lieu)
-              .where("plage_ouvertures.first_day <= ?", inclusive_date_range.end)
-              .joins(:motifs)
-              .where(motifs: { id: motifs_ids })
-              .includes(:motifs, agent: :absences)
+      .includes(:motifs_plageouvertures)
+      .where(lieu: lieu)
+      .where("plage_ouvertures.first_day <= ?", inclusive_date_range.end)
+      .joins(:motifs)
+      .where(motifs: { id: motifs_ids })
+      .includes(:motifs, agent: :absences)
 
     if agent_ids.present?
       results = results.where(agent_id: agent_ids)

--- a/lib/tasks/prod/massive_cancel.rake
+++ b/lib/tasks/prod/massive_cancel.rake
@@ -10,10 +10,11 @@ namespace :prod do
 
     args.with_defaults(end_date: DEFAULT_CANCEL_END_DATE)
     rdvs = Rdv.active.status('unknown_future')
-              .joins(:organisation).where.not(organisations: { id: EXCLUDED_ORGANISATIONS })
-              .where.not(organisations: { departement: EXCLUDED_DEPARTEMENTS })
-              .where.not(location: EXCLUDED_LIEUX)
-              .where('DATE(starts_at) < ?', args.end_date.to_date)
+      .joins(:organisation)
+      .where.not(organisations: { id: EXCLUDED_ORGANISATIONS })
+      .where.not(organisations: { departement: EXCLUDED_DEPARTEMENTS })
+      .where.not(location: EXCLUDED_LIEUX)
+      .where('DATE(starts_at) < ?', args.end_date.to_date)
     rdvs.each do |rdv|
       rdv.update(status: :excused, cancelled_at: Time.zone.now, notes: "[Annulation COVID-19]" + rdv.notes.to_s)
       rdv.users.map(&:user_to_notify).uniq.each do |user|


### PR DESCRIPTION
on etait en `aligned`:

```
variable_name = some_long_call
                .method_name_1
                .method2    
```

on passe a `indented`:

```
variable_name = some_long_call
  .method_name
  .method2
```

A est le défaut de rubocop, et c'est ce qu'on a aujourd'hui dans le code.
perso je deteste A : je trouve ça dur à faire, pas pratique car ça dépasse tout le temps des 80cols, et pas pratique parce qu'il faut tout réaligner si tu modifies la première ligne.

on en a discuté, je suis le seul a avoir un avis la dessus a priori https://startups-detat.slack.com/archives/C011EG2GDAT/p1588753650008600

