### PR TITLE
bump jQuery to 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "flatpickr": "^4.6.3",
     "fstream": "^1.0.12",
     "holderjs": "^2.9.6",
-    "jquery": "^3.4.0",
+    "jquery": "^3.5.1",
     "jquery-datetimepicker": "^2.5.21",
     "jquery-mask-plugin": "^1.14.16",
     "jquery-slimscroll": "^1.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3465,9 +3465,14 @@ jquery-slimscroll@^1.3.8:
   dependencies:
     jquery ">= 1.7"
 
-"jquery@>= 1.7", "jquery@>= 1.7.2", jquery@^3.4.0:
+"jquery@>= 1.7", "jquery@>= 1.7.2":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
Il semble y avoir une erreur sur l'inclusion du datetimepicker dans l'agenda des agents je n'ai pas compris pourquoi