### PR TITLE
add import corejs to application pack for polyfills

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,3 +1,4 @@
+import 'core-js/stable'
 require("@rails/ujs").start()
 require("turbolinks").start()
 require("chartkick")


### PR DESCRIPTION
seems to fix `forEach` is not a function on old browsers (chrome 49 and FF 48)

cf https://sentry.io/organizations/lapins/issues/1646162821/?environment=production&project=1811205

it's pretty intricate to me but it seems that polyfills are handled by `@babel/preset-env` which reads the `.browserslistrc` file that says `defaults` option, and Babel will make sure that our `import core-js` will only require the necessary polyfills. 

⚠️ when releasing double check on demo that this doesn't increase bundle size too much

Note: You can check which browsers we currently explicitly target by running `npx browserslist` (this is what the defaults rule currently yields) : 

```
and_chr 75
and_ff 67
and_qq 1.2
and_uc 12.12
android 67
baidu 7.12
chrome 75
chrome 74
chrome 73
edge 18
edge 17
firefox 68
firefox 67
firefox 60
ie 11
ie_mob 11
ios_saf 12.2-12.3
ios_saf 12.0-12.1
ios_saf 11.3-11.4
kaios 2.5
op_mini all
op_mob 46
opera 62
opera 60
safari 12.1
safari 12
samsung 9.2
samsung 8.2
```