### PR TITLE
[Stats] mauvais groupement sur histo « RDV Créés »

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,4 +84,5 @@ class ApplicationController < ActionController::Base
     parsed_uri.query = URI.encode_www_form(parsed_query_string)
     parsed_uri.to_s
   end
+  helper_method :add_query_string_params_to_url
 end

--- a/app/views/agents/organisations/stats/index.html.slim
+++ b/app/views/agents/organisations/stats/index.html.slim
@@ -2,4 +2,4 @@
   | Statistiques #{current_organisation.name}
   small Du #{l(Stat::DEFAULT_RANGE.first.to_date)} au #{l(Stat::DEFAULT_RANGE.last.to_date)}
 
-= render 'stats/statistics', stats: @stats, rdvs_stats_path: rdvs_organisation_stats_path(@organisation), users_stats_path: users_organisation_stats_path(@organisation), service_stats_path: rdvs_organisation_stats_path(@organisation, by_service: true)
+= render 'stats/statistics', stats: @stats, rdvs_stats_path: rdvs_organisation_stats_path(@organisation), users_stats_path: users_organisation_stats_path(@organisation)

--- a/app/views/agents/organisations/stats/index.html.slim
+++ b/app/views/agents/organisations/stats/index.html.slim
@@ -2,4 +2,4 @@
   | Statistiques #{current_organisation.name}
   small Du #{l(Stat::DEFAULT_RANGE.first.to_date)} au #{l(Stat::DEFAULT_RANGE.last.to_date)}
 
-= render 'stats/statistics', stats: @stats, rdvs_stats_path: rdvs_organisation_stats_path(@organisation), users_stats_path: users_organisation_stats_path(@organisation)
+= render 'stats/statistics', stats: @stats, rdvs_statistic_path: rdvs_organisation_stats_path(@organisation), users_stats_path: users_organisation_stats_path(@organisation)

--- a/app/views/stats/_statistics.html.slim
+++ b/app/views/stats/_statistics.html.slim
@@ -5,7 +5,7 @@
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés (#{stats.rdvs_for_default_range.count})
-    = column_chart rdvs_stats_path(by_service: true), stacked: true
+    = column_chart rdvs_stats_path, stacked: true
 
 - if request.path == stats_path
   .card.mb-5

--- a/app/views/stats/_statistics.html.slim
+++ b/app/views/stats/_statistics.html.slim
@@ -5,23 +5,23 @@
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés (#{stats.rdvs_for_default_range.count})
-    = column_chart rdvs_stats_path, stacked: true
+    = column_chart rdvs_statistic_path, stacked: true
 
 - if request.path == stats_path
   .card.mb-5
     .card-body
       h4.card-title.mb-3 RDV créés par département(#{stats.rdvs_for_default_range.count})
-      = column_chart add_query_string_params_to_url(rdvs_stats_path, by_departement: true), stacked: true
+      = column_chart add_query_string_params_to_url(rdvs_statistic_path, by_departement: true), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés par service (#{stats.rdvs_for_default_range.count})
-    = column_chart add_query_string_params_to_url(rdvs_stats_path, by_service: true), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_statistic_path, by_service: true), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV par type
-    = column_chart add_query_string_params_to_url(rdvs_stats_path, by_location_type: true), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_statistic_path, by_location_type: true), stacked: true
 
 .card.mb-5
   .card-body

--- a/app/views/stats/_statistics.html.slim
+++ b/app/views/stats/_statistics.html.slim
@@ -11,17 +11,17 @@
   .card.mb-5
     .card-body
       h4.card-title.mb-3 RDV créés par département(#{stats.rdvs_for_default_range.count})
-      = column_chart rdvs_stats_path(by_departement: true), stacked: true
+      = column_chart add_query_string_params_to_url(rdvs_stats_path, by_departement: true), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés par service (#{stats.rdvs_for_default_range.count})
-    = column_chart rdvs_stats_path(by_service: true), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_stats_path, by_service: true), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV par type
-    = column_chart rdvs_stats_path(by_location_type: true), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_stats_path, by_location_type: true), stacked: true
 
 .card.mb-5
   .card-body

--- a/app/views/stats/_statistics.html.slim
+++ b/app/views/stats/_statistics.html.slim
@@ -1,3 +1,5 @@
+- rdvs_statistic_path = rdvs_stats_path if !defined?(rdvs_statistic_path)
+
 .card.mb-5
   .card-body
     = render 'stats/rdv_counters', rdvs: stats.rdvs_for_default_range

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -5,4 +5,4 @@
     small Du #{l(Stat::DEFAULT_RANGE.first.to_date)} au #{l(Stat::DEFAULT_RANGE.last.to_date)}
 
 .container
-  = render 'statistics', stats: @stats
+  = render 'statistics', stats: @stats, rdvs_statistic_path: rdvs_stats_path

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -222,6 +222,6 @@ fr:
       human_approx: "%A %d %B %Y vers %Hh%M"
       dense: "%d/%m/%Y à %H:%M"
     pm: pm
-  public_office: "au local"
+  public_office: "sur place"
   phone: "par téléphone"
   home: "à domicile"

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -48,7 +48,7 @@ describe Stat, type: :model do
       stats = Stat.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
       expect(stats.rdvs_group_by_type[["par téléphone", "05/04/2020"]]).to eq(1)
-      expect(stats.rdvs_group_by_type[["au local", "05/04/2020"]]).to eq(1)
+      expect(stats.rdvs_group_by_type[["sur place", "05/04/2020"]]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/P1Tx7LoI/837-agentvos-statistiques-globales-les-donn%C3%A9es-contenus-dans-les-histogrammes-ne-sont-plus-lisibles

Pour le problème lié au scope de l'organisation:
On passe à la partial "statistic" une variable `rdvs_stats_path` avec le contexte.
Il y a 3 contextes:
- Statistiques globales de l'app
- Statistiques scopés à l'orga (pour les agents admins)
- Statistiques scopés à l'agent (pour chaque agent)

Cette variable était appelé `rdvs_stats_path(by_service: true)` et elle faisait donc appel à la vrai route de rails et nom à la variable passé à la partial.

J’ai renommé la variable en rdvs_statistic_path (qui n'est pas une route rails) pour éviter toute incompréhension.