### PR TITLE
fix ICS text encoding using 8bit

### DIFF
--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -2,7 +2,11 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
   def plage_ouverture_created(plage_ouverture)
     @plage_ouverture = plage_ouverture
     ics = PlageOuverture::Ics.new(plage_ouverture: @plage_ouverture)
-    attachments[ics.name] = { mime_type: 'text/calendar', content: ics.to_ical }
+    attachments[ics.name] = {
+      mime_type: 'text/calendar',
+      content: ics.to_ical,
+      encoding: "8bit", # fixes encoding issues in ICS
+    }
     mail(to: plage_ouverture.agent.email, subject: "Votre planning #{BRAND}")
   end
 end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -9,6 +9,7 @@ class Users::RdvMailer < ApplicationMailer
     attachments[ics.name] = {
       mime_type: 'text/calendar',
       content: ics.to_ical_for(user),
+      encoding: "8bit", # fixes encoding issues in ICS
     }
     mail(
       to: user.email,


### PR DESCRIPTION
cf https://trello.com/c/EoXzM9kK/826-v%C3%A9rifier-la-bonne-gestion-des-accents-dans-les-invitations-ical

the bug only reproduces when sending through SIB's SMTP. I enabled it locally by copying prod's config. This fix seems to be enough.

I really don't understand much to what's happening here, but I think the default is base64 but it's not perfect for plain text files like ICS ... I don't really know 😬 

https://en.wikipedia.org/wiki/MIME#Content-Transfer-Encoding