### PR TITLE
improve rdvs list view + improve printing options + add filter on date from calendar

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,6 +69,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 138
+  Exclude:
+    - 'app/models/user.rb'
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:

--- a/app/form_models/agent_rdv_search_form.rb
+++ b/app/form_models/agent_rdv_search_form.rb
@@ -1,0 +1,21 @@
+class AgentRdvSearchForm
+  include ActiveModel::Model
+
+  attr_accessor :organisation_id, :start, :end, :date, :agent_id, :user_id, :page, :status, :default_period, :show_user_details
+
+  # belongs_to :organisation, :agent
+
+  def initialize(attributes)
+    attributes[:date] = Date.parse(attributes[:date]) if attributes[:date].present?
+    attributes[:start] = Date.parse(attributes[:start]) if attributes[:start].present?
+    attributes[:end] = Date.parse(attributes[:end]) if attributes[:end].present?
+    attributes[:show_user_details] = ["1", "true"].include?(attributes[:show_user_details])
+    super(attributes)
+  end
+
+  def date_range_params
+    return nil if start.blank? || self.end.blank?
+
+    start..self.end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,8 +33,18 @@ module ApplicationHelper
     form.input(field, as: :string, input_html: { value: form.object.send(field)&.strftime("%d/%m/%Y %H:%M"), data: { behaviour: 'datetimepicker' }, autocomplete: "off" })
   end
 
-  def date_input(form, field, label = nil, input_html: {})
-    form.input(field, as: :string, label: label, input_html: { value: form.object.send(field)&.strftime("%d/%m/%Y"), data: { behaviour: 'datepicker' }, autocomplete: "off" }.deep_merge(input_html))
+  def date_input(form, field, label = nil, input_html: {}, **kwargs)
+    form.input(
+      field,
+      as: :string,
+      label: label,
+      input_html: {
+        value: form.object.send(field)&.strftime("%d/%m/%Y"),
+        data: { behaviour: 'datepicker' },
+        autocomplete: "off",
+      }.deep_merge(input_html),
+      **kwargs
+    )
   end
 
   def time_input(form, field)

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -1,6 +1,8 @@
 module RdvsHelper
-  def rdv_title(rdv)
-    "Le #{l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)"
+  def rdv_title(rdv, date_format: :human)
+    article = date_format == :time_only ? "À" : "Le"
+    "#{article} #{l(rdv.starts_at, format: date_format)} " \
+      "(durée : #{rdv.duration_in_min} minutes)"
   end
 
   def rdv_title_for_agent(rdv)
@@ -36,10 +38,6 @@ module RdvsHelper
 
   def rdv_status_tag(rdv)
     content_tag(:span, Rdv.human_enum_name(:status, rdv.status), class: 'badge badge-info')
-  end
-
-  def rdv_filter_status_tag
-    content_tag(:span, Rdv.human_enum_name(:status, params[:status]), class: 'badge badge-info') if params[:status].present?
   end
 
   def no_rdv_for_users

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -22,4 +22,50 @@ module UsersHelper
       organisation_users_path(current_organisation)
     end
   end
+
+  def user_details(user, *attributes, li_class: nil)
+    displayable_user = DisplayableUser.new(user)
+    attributes.map do |attr_name|
+      content_tag(:li, class: li_class) do
+        content_tag(:strong, "#{t("activerecord.attributes.user.#{attr_name}")} : ") +
+          content_tag(:span, displayable_user.send(attr_name))
+      end
+    end.join.html_safe
+  end
+end
+
+class DisplayableUser
+  include UsersHelper
+
+  delegate :first_name, :last_name, :birth_name, :address, :affiliation_number, :number_of_children, to: :user
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def birth_date
+    birth_date_and_age(@user)
+  end
+
+  def caisse_affiliation
+    User.human_enum_name(:caisse_affiliation, @user.caisse_affiliation)
+  end
+
+  def family_situation
+    User.human_enum_name(:family_situation, @user.family_situation)
+  end
+
+  def logement
+    User.human_enum_name(:logement, @user.logement)
+  end
+
+  def phone_number
+    @user.responsible_phone_number
+  end
+
+  def email
+    @user.responsible_email
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,10 +139,19 @@ class User < ApplicationRecord
   end
 
   def address
+    # TODO : this is dangerously hiding behaviour
     super.presence || responsible&.address
   end
 
-  private
+  def responsible_phone_number
+    relative? ? responsible.phone_number : phone_number
+  end
+
+  def responsible_email
+    relative? ? responsible.email : email
+  end
+
+  protected
 
   def password_required?
     false # users without passwords and emails can be created by agents

--- a/app/views/agents/agents/show.html.slim
+++ b/app/views/agents/agents/show.html.slim
@@ -23,7 +23,17 @@
       data-organisation-id="#{@organisation.id}"
       data-event-sources-json="#{[organisation_agent_rdvs_path(@organisation, @agent, status: @status, format: :json), organisation_agent_absences_path(@organisation, @agent), organisation_agent_plage_ouvertures_path(@organisation, @agent), jours_feries_path].to_json}"
     ]
-    .mt-3.my-1
+    .mt-3
+      = link_to organisation_agent_rdvs_path(current_organisation, @agent, date: @date, show_user_details: true), class: "js-link-print-rdvs" do
+        - if current_agent == @agent
+          ' 🖨 Liste détaillée des RDVs du
+          span.js-date
+          / date is filled from JS
+        - else
+          ' 🖨 Liste détaillée des RDVs du
+          span.js-date' &nbsp;
+          | pour #{@agent.full_name}
+    .my-1
       = link_to( \
           @agent == current_agent ? \
           "Créer/modifier vos plages d'ouvertures" : \

--- a/app/views/agents/organisations/rdvs/index.html.slim
+++ b/app/views/agents/organisations/rdvs/index.html.slim
@@ -1,3 +1,6 @@
+- content_for :title do
+  | Liste des RDV
+
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
@@ -6,5 +9,6 @@
       =link_to 'Vos statistiques', organisation_stats_path(current_organisation), class: 'text-white'
     li.breadcrumb-item.active Liste des RDV
 
-
-= render partial: 'agents/rdvs/rdvs_list', locals: {rdvs: @rdvs}
+.row.justify-content-center
+  .col-md-6
+    = render partial: 'agents/rdvs/rdvs_list', locals: {rdvs: @rdvs}

--- a/app/views/agents/rdvs/_rdv.html.slim
+++ b/app/views/agents/rdvs/_rdv.html.slim
@@ -1,7 +1,25 @@
-.card.mb-3
+.card.mb-3.print-border-bottom.print-border-top
   .card-body
     p.card-text
       i.fa.fa-fw.fa-calendar>
-      = link_to rdv_title(rdv), organisation_rdv_path(rdv.organisation, rdv)
+      = link_to rdv_title(rdv, { date_format: local_assigns[:date_format] }.compact), organisation_rdv_path(rdv.organisation, rdv)
       = rdv_status_tag(rdv)
-    = render 'agents/rdvs/rdv_details', rdv: rdv
+
+    - if local_assigns[:show_user_details]
+      .row
+        .col-md-6.mb-2
+          = render 'agents/rdvs/rdv_details', rdv: rdv, show_users: false
+        .col-md-6
+          .card-text
+            strong> Usager(s) :
+            .pl-2.pt-1
+              - rdv.users.order_by_last_name.each do |user|
+                div
+                  = link_to organisation_user_path(current_organisation, user) do
+                    b' #{user.full_name}
+                  - if user.responsible.present?
+                    | (proche de #{link_to(user.responsible.full_name, organisation_user_path(current_organisation, user.responsible))})
+                  ul.list-unstyled
+                    = user_details(user, :birth_date, :phone_number, :address, :email)
+    - else
+      = render 'agents/rdvs/rdv_details', rdv: rdv

--- a/app/views/agents/rdvs/_rdv_details.html.slim
+++ b/app/views/agents/rdvs/_rdv_details.html.slim
@@ -20,9 +20,10 @@ p.card-text
 p.card-text
   strong> Professionnel(s) :
   = agents_to_sentence(rdv)
-p.card-text
-  strong> Usager(s) :
-  = users_to_links(rdv)
+- if local_assigns.fetch(:show_users, true)
+  p.card-text
+    strong> Usager(s) :
+    = users_to_links(rdv)
 .card-text
   i.far.fa-fw.fa-sticky-note>
   strong> Notes libres :&nbsp;

--- a/app/views/agents/rdvs/_rdvs_list.html.slim
+++ b/app/views/agents/rdvs/_rdvs_list.html.slim
@@ -1,12 +1,10 @@
-- content_for :title do
-  | Liste des RDV
-  = rdv_filter_status_tag
-
 - if rdvs.any?
-  .row.justify-content-md-center
-    .col-md-6
-      = render partial: 'agents/rdvs/rdv', collection: rdvs
-      .d-flex.justify-content-center= paginate rdvs, theme: 'twitter-bootstrap-4'
+  = render( \
+    partial: 'agents/rdvs/rdv', \
+    collection: rdvs, \
+    locals: local_assigns.slice(:date_format, :show_user_details) \
+  )
+  .d-flex.justify-content-center= paginate rdvs, theme: 'twitter-bootstrap-4'
 - else
   .card
     .card-body

--- a/app/views/agents/rdvs/index.html.slim
+++ b/app/views/agents/rdvs/index.html.slim
@@ -1,7 +1,47 @@
+- content_for :title do
+  | Liste des RDV
+
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
-    li.breadcrumb-item
-      = link_to 'Vos statistiques', organisation_agent_stats_path(current_organisation, current_agent)
-    li.breadcrumb-item.active Liste des RDV
+    - if @form.date
+      li.breadcrumb-item
+        = link_to "Agenda de #{@agent.full_name}", organisation_agent_path(current_organisation, @agent, date: @form.date)
+    - else
+      li.breadcrumb-item
+        = link_to 'Vos statistiques', organisation_agent_stats_path(current_organisation, current_agent)
+      li.breadcrumb-item.active Liste des RDV
 
-= render partial: 'agents/rdvs/rdvs_list', locals: {rdvs: @rdvs.page(params[:page])}
+.row.justify-content-md-center
+  .col-md-6
+    .card.border-info
+      .card-header ⚙️ Filtres et options
+      .card-body
+        = simple_form_for(@form, method: "GET", url: url_for({}), as: "") do |f|
+          = f.input :agent_id, collection: [@agent], label: "Agent", label_method: :full_name, input_html: { class: 'select2-input', disabled: true }, wrapper: "horizontal_form"
+          - if @form.date.present?
+            = date_input(f, :date, label = "Date", wrapper: "horizontal_form")
+
+          - if @form.status.present?
+            = f.input :status, collection: Rdv.statuses.keys + ["unknown_past", "unknown_future"], label_method: -> { ::Rdv.human_enum_name(:status, _1) }, label: "Statut", wrapper: "horizontal_form"
+
+          div.my-1
+            = f.check_box :show_user_details, type: "checkbox"
+            span.pl-1= f.label :show_user_details do
+              | Afficher détails usagers 🔍
+          div.d-flex.justify-content-between
+            input.btn.btn-small.btn-primary.d-print-none type="submit" value="Rafraîchir la liste"
+            input.btn.btn-small.btn-link.d-print-none type="submit" value="Imprimer 🖨" onclick="window.print();return false;"
+
+- rdvs_list = render( \
+  'agents/rdvs/rdvs_list', \
+  rdvs: @rdvs.page(params[:page]), \
+  date_format: (@form.date.present? && :time_only), \
+  show_user_details: @form.show_user_details \
+)
+
+- if @form.show_user_details
+  = rdvs_list
+- else
+  .row.justify-content-center
+    .col-md-6
+      = rdvs_list

--- a/app/views/agents/users/_relative_information.html.slim
+++ b/app/views/agents/users/_relative_information.html.slim
@@ -1,5 +1,0 @@
-ul.list-unstyled.mb-5
-  - {first_name: user.first_name, last_name: user.last_name, birth_date: birth_date_and_age(user) }.each do |k,v|
-      li.mb-2 
-        strong= "#{t("activerecord.attributes.user.#{k}")} : "
-        | #{v}

--- a/app/views/agents/users/_responsible_information.html.slim
+++ b/app/views/agents/users/_responsible_information.html.slim
@@ -1,18 +1,12 @@
 ul.list-unstyled.mb-5
-  - {first_name: user.first_name, last_name: user.last_name, birth_name: user.birth_name, birth_date: birth_date_and_age(user), phone_number: user.phone_number, address: user.address, email: user.email}.each do |k,v|
-      li.mb-2
-        strong= "#{t("activerecord.attributes.user.#{k}")} : "
-        | #{v}
+  = user_details(user, :first_name, :last_name, :birth_name, :birth_date, :phone_number, :address, :email, li_class: "mb-2")
   - if user.pending_reconfirmation?
     .text-muted.mb-2
       | En attente de confirmation pour #{user.unconfirmed_email}
 
 h4.card-title.mb-3 Informations sociales
 ul.list-unstyled.mb-5
-  - {caisse_affiliation: User.human_enum_name(:caisse_affiliation, user.caisse_affiliation), affiliation_number: user.affiliation_number, family_situation: User.human_enum_name(:family_situation,user.family_situation), number_of_children: user.number_of_children, logement: User.human_enum_name(:logement, user.logement) }.each do |k,v|
-      li.mb-2
-        strong= "#{t("activerecord.attributes.user.#{k}")} : "
-        | #{v}
+  = user_details(user, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :logement, li_class: "mb-2")
   strong
     i.far.fa-fw.fa-sticky-note>
     | Notes libres :
@@ -23,7 +17,6 @@ ul.list-unstyled.mb-5
   - user.agents.includes([:service]).each do |agent|
     li.mb-2
     | #{agent.full_name_and_service}
-
 
 - unless organisation_user_path(current_organisation, user) == request.path
   .text-right

--- a/app/views/agents/users/_show_relative.html.slim
+++ b/app/views/agents/users/_show_relative.html.slim
@@ -18,10 +18,7 @@
       .card-body
         h4.card-title.mb-3 Informations de votre proche
         ul.list-unstyled
-          - {first_name: user.first_name, last_name: user.last_name, birth_date: birth_date_and_age(user) }.each do |k,v|
-              li.mb-2
-                strong= "#{t("activerecord.attributes.user.#{k}")} : "
-                | #{v}
+          = user_details(@user, :first_name, :last_name, :birth_date)
         .card-text
           i.far.fa-fw.fa-sticky-note>
           strong> Notes libres :

--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -76,6 +76,15 @@ document.addEventListener('turbolinks:load', function() {
       maxTime: '20:00:00',
       datesRender: function(info) {
         sessionStorage.setItem("calendarStartDate", JSON.stringify(info.view.currentStart))
+        const printLinkElt = document.querySelector(".js-link-print-rdvs")
+        printLinkElt.classList.toggle("d-none", info.view.type != "timeGridOneDay")
+        if (info.view.type != "timeGridOneDay") return
+
+        const url = new URL(printLinkElt.href)
+        const date = moment(info.view.currentStart)
+        printLinkElt.querySelector(".js-date").innerHTML = date.format("DD/MM/YYYY")
+        url.searchParams.set("date", date.format("YYYY-MM-DD"))
+        printLinkElt.href = url.toString()
       },
       eventRender: function (info) {
         let $el = $(info.el);

--- a/app/webpacker/stylesheets/print.scss
+++ b/app/webpacker/stylesheets/print.scss
@@ -1,11 +1,10 @@
-// 
+//
 // print.scss
 //
 
 @media print {
   .left-side-menu,
   .right-bar,
-  .page-title-box,
   .navbar-custom,
   .footer {
       display: none;
@@ -16,6 +15,18 @@
   .content,
   body {
     padding: 0;
-    margin: 0;
+    margin: 0 !important;
+  }
+  .card {
+    border-radius: 0 !important;
+  }
+  .card.print-border-bottom {
+    border-bottom: 1px solid #000;
+  }
+  .card.print-border-top {
+    border-top: 1px solid #000;
+  }
+  b, strong {
+    font-family: initial; // fix unreadable bold font in FF print
   }
 }

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -221,6 +221,7 @@ fr:
       human: "%A %d %B %Y à %Hh%M"
       human_approx: "%A %d %B %Y vers %Hh%M"
       dense: "%d/%m/%Y à %H:%M"
+      time_only: "%Hh%M"
     pm: pm
   public_office: "sur place"
   phone: "par téléphone"


### PR DESCRIPTION
cf https://trello.com/c/uNz3uw6C/222-agent-pouvoir-imprimer-la-liste-et-les-notes-des-rdv-du-jour

⚠️ Disclaimer : cette PR est un peu grosse et pas découpée en commits propres. Si vous le souhaitez, je peux extraire certains refactos dans des commits / PRs indépendantes

- Ajout d'un lien contextuel vers la liste de RDV de la journée en dessous du calendrier (`agents/rdvs#index`). Ce lien est maintenu à jour dynamiquement en JS lorsqu'on change de date / de type de vue.
- Sur `agents/rdvs#index`:
  - Support d'un nouveau filtre `date` (jusqu'ici uniquement date range supportés)
  - Ajout d'une nouvelle option d'affichage `user_details` qui deplie les coordonnees des users.
  - Ajout de delegates dans le modele `User` pour afficher les infos du responsable quand user est un proche
  - Rendu plus visible les filtres appliqués sur la page `agents/rdvs#index` : Regroupés et affichés dans une card tout en haut. C'est encore perfectible, et j'ai volontairement désactivé certains champs qui pourraient être activés pour aller plus vite (comme le champ agent). 
  - Extraction d'un form model : `AgentRdvSearchForm` . Il représente le formulaire utilisé dans les recherches de RDVs. Simplifie la creation du formulaire dans la vue + permet de regrouper des parametres.
- Amélioré la stylesheet pour les media `print` :  `col-md-6` devient `col-md-12` principalement pour utiliser la page entiere.
- Unrelated: suppression du code mort `_relative_information.html.slim`

Refactos envisagés pour plus tard : 
- fusionner au moins en partie les controlleurs et vues `agents/organisations/rdvs#index` et `agents/users/rdvs#index`

Bien vérifier que ca ne perturbe pas : 
- les stats
- les listes de RDVs par statut
- les listes de RDVs des users

<img width="1392" alt="Screenshot 2020-05-18 at 14 49 21" src="https://user-images.githubusercontent.com/883348/82215114-26a70900-9917-11ea-8a6a-9768250fefeb.png">

<img width="1392" alt="Screenshot 2020-05-18 at 14 49 34" src="https://user-images.githubusercontent.com/883348/82215119-2ad32680-9917-11ea-83ef-a415b127c8d4.png">

<img width="669" alt="Screenshot 2020-05-20 at 12 03 06" src="https://user-images.githubusercontent.com/883348/82433567-e8822480-9a91-11ea-97b3-2e14d9d67527.png">
