### PR TITLE
fix sending mails from review apps : introduce HOST_QUALIFIED env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,11 +74,13 @@ jobs:
       - run:
           environment:
             DATABASE_URL: "postgres://lapins_test@localhost:5432/lapins_test"
+            HOST_QUALIFIED: http://localhost:3000
           name: Test seed configuration
           command: bundle exec rake db:create db:schema:load db:migrate db:seed db:drop RAILS_ENV=test
       - run:
           environment:
             DATABASE_URL: "postgres://lapins_test@localhost:5432/lapins_test"
+            HOST_QUALIFIED: http://localhost:3000
           name: Create DB
           command: bundle exec rake db:create db:schema:load db:migrate RAILS_ENV=test
       - run:
@@ -89,6 +91,7 @@ jobs:
       - run:
           environment:
             DATABASE_URL: "postgres://lapins_test@localhost:5432/lapins_test"
+            HOST_QUALIFIED: http://localhost:3000
           name: Run Tests, Splitted by Timings
           command: |
             COMMAND="bundle exec rspec --profile 10 \

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma
-jobs: bin/delayed_job run
+jobs: bundle exec bin/delayed_job run
 postdeploy: bundle exec rake db:migrate

--- a/app/models/rdv/ics.rb
+++ b/app/models/rdv/ics.rb
@@ -37,7 +37,7 @@ class Rdv::Ics
   def description
     d = ""
     d += "RDV Téléphonique " if @rdv.motif.phone?
-    d += "Infos et annulation: #{rdvs_shorten_url(host: "https://#{ENV["HOST"]}")}"
+    d += "Infos et annulation: #{rdvs_shorten_url(host: ENV["HOST_QUALIFIED"])}"
     d
   end
 

--- a/app/services/twilio_text_messenger.rb
+++ b/app/services/twilio_text_messenger.rb
@@ -39,7 +39,7 @@ class TwilioTextMessenger
               else
                 "#{@rdv.location}\n"
               end
-    message += "Infos et annulation: #{rdvs_shorten_url(host: "https://#{ENV["HOST"]}")}"
+    message += "Infos et annulation: #{rdvs_shorten_url(host: ENV["HOST_QUALIFIED"])}"
     message += " / #{@rdv.organisation.phone_number}" if @rdv.organisation.phone_number
     message
   end
@@ -76,7 +76,7 @@ class TwilioTextMessenger
 
   def file_attente
     message = "Des créneaux se sont libérés plus tôt.\n"
-    message += "Cliquez pour voir les disponibilités : #{users_creneaux_index_url(rdv_id: @rdv.id, host: "https://#{ENV["HOST"]}")}"
+    message += "Cliquez pour voir les disponibilités : #{users_creneaux_index_url(rdv_id: @rdv.id, host: ENV["HOST_QUALIFIED"])}"
     message
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,13 +56,13 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :delayed_job
 
-  config.default_url_options = { host: ENV["HOST"] }
+  config.default_url_options = { host: ENV["HOST_QUALIFIED"].sub(%r{^https?:\/\/}, "") }
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { protocol: 'https', host: ENV["HOST"], utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
+  config.action_mailer.default_url_options = { protocol: 'https', host: ENV["HOST_QUALIFIED"].sub(%r{^https?:\/\/}, ""), utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
   config.action_mailer.smtp_settings = {
     address:        'smtp-relay.sendinblue.com',
     port:           '587',
@@ -72,7 +72,7 @@ Rails.application.configure do
     domain:         'rdv-solidarites.fr',
   }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.asset_host = "https://#{ENV["HOST"]}"
+  config.action_mailer.asset_host = ENV["HOST_QUALIFIED"]
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
actuellement : 
- en demo : `HOST=demo.rdv-solidarites.fr`
- sur les review apps: `HOST=https://demo-rdv-solidarites-pr653.osc-fr1.scalingo.io`

-> le https est 'en trop' sur les review apps. Cela cause des problemes, dont l'envoi de mails.

On ne peut pas corriger en enlevant le HTTPS du HOST des review apps, car il est mis automatiquement lors de la création des review apps, on n'a pas la main dessus.

On ne peut donc pas faire de fix sûr en une seule PR je pense, car il faudrait déployer le code + changer simultanément la variable d'env `HOST`. 

Solution proposée :
- introduction d'une nouvelle variable d'env `HOST_QUALIFIED` qui contient le HOST **avec** le protocole
- on s'assure qu'elle est bien configurée manuellement sur tous les envs actuels (demo, prod, review apps)
- on deploie cette PR
- une fois que demo et prod sont déployés : 
  - on modifie `HOST` en demo et en prod pour rajouter le protocole
  - on fait une nouvelle PR pour revenir a l'utilisation de `HOST` tout court, on supprime completement`HOST_QUALIFIED`partout

unrelated : Le fait d'utiliser `bundle` pour lancer delayed_job semble réparer le fait qu'on n'ait pas les exceptions dans sentry depuis les jobs