### PR TITLE
stop using temporary HOST_QUALIFIED in favor of HOST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,13 +74,13 @@ jobs:
       - run:
           environment:
             DATABASE_URL: "postgres://lapins_test@localhost:5432/lapins_test"
-            HOST_QUALIFIED: http://localhost:3000
+            HOST: http://localhost:3000
           name: Test seed configuration
           command: bundle exec rake db:create db:schema:load db:migrate db:seed db:drop RAILS_ENV=test
       - run:
           environment:
             DATABASE_URL: "postgres://lapins_test@localhost:5432/lapins_test"
-            HOST_QUALIFIED: http://localhost:3000
+            HOST: http://localhost:3000
           name: Create DB
           command: bundle exec rake db:create db:schema:load db:migrate RAILS_ENV=test
       - run:
@@ -91,7 +91,7 @@ jobs:
       - run:
           environment:
             DATABASE_URL: "postgres://lapins_test@localhost:5432/lapins_test"
-            HOST_QUALIFIED: http://localhost:3000
+            HOST: http://localhost:3000
           name: Run Tests, Splitted by Timings
           command: |
             COMMAND="bundle exec rspec --profile 10 \

--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
+HOST=http://localhost:5000
 GITHUB_APP_ID=change_me
 GITHUB_APP_SECRET=change_me
 PLACES_APP_ID=change_me

--- a/app/models/rdv/ics.rb
+++ b/app/models/rdv/ics.rb
@@ -37,7 +37,7 @@ class Rdv::Ics
   def description
     d = ""
     d += "RDV Téléphonique " if @rdv.motif.phone?
-    d += "Infos et annulation: #{rdvs_shorten_url(host: ENV["HOST_QUALIFIED"])}"
+    d += "Infos et annulation: #{rdvs_shorten_url(host: ENV["HOST"])}"
     d
   end
 

--- a/app/services/twilio_text_messenger.rb
+++ b/app/services/twilio_text_messenger.rb
@@ -39,7 +39,7 @@ class TwilioTextMessenger
               else
                 "#{@rdv.location}\n"
               end
-    message += "Infos et annulation: #{rdvs_shorten_url(host: ENV["HOST_QUALIFIED"])}"
+    message += "Infos et annulation: #{rdvs_shorten_url(host: ENV["HOST"])}"
     message += " / #{@rdv.organisation.phone_number}" if @rdv.organisation.phone_number
     message
   end
@@ -76,7 +76,7 @@ class TwilioTextMessenger
 
   def file_attente
     message = "Des créneaux se sont libérés plus tôt.\n"
-    message += "Cliquez pour voir les disponibilités : #{users_creneaux_index_url(rdv_id: @rdv.id, host: ENV["HOST_QUALIFIED"])}"
+    message += "Cliquez pour voir les disponibilités : #{users_creneaux_index_url(rdv_id: @rdv.id, host: ENV["HOST"])}"
     message
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,13 +56,13 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :delayed_job
 
-  config.default_url_options = { host: ENV["HOST_QUALIFIED"].sub(%r{^https?:\/\/}, "") }
+  config.default_url_options = { host: ENV["HOST"].sub(%r{^https?:\/\/}, "") }
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { protocol: 'https', host: ENV["HOST_QUALIFIED"].sub(%r{^https?:\/\/}, ""), utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
+  config.action_mailer.default_url_options = { protocol: 'https', host: ENV["HOST"].sub(%r{^https?:\/\/}, ""), utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
   config.action_mailer.smtp_settings = {
     address:        'smtp-relay.sendinblue.com',
     port:           '587',
@@ -72,7 +72,7 @@ Rails.application.configure do
     domain:         'rdv-solidarites.fr',
   }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.asset_host = ENV["HOST_QUALIFIED"]
+  config.action_mailer.asset_host = ENV["HOST"]
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Suite de la PR #653

On supprime HOST_QUALIFIED et on utilise HOST a la place.
Avant de deployer on s'assure que HOST est bien configuré avec le protocole sur demo et prod
une fois déployé on supprime HOST_QUALIFIED partout