### PR TITLE
[Stats] Fix les mauvaise données sur les stats agent

### DIFF
--- a/app/controllers/agents/organisations/stats_controller.rb
+++ b/app/controllers/agents/organisations/stats_controller.rb
@@ -12,6 +12,8 @@ class Agents::Organisations::StatsController < AgentAuthController
     stats = Stat.new(rdvs: policy_scope(Rdv))
     stats = if params[:by_service].present?
               stats.rdvs_group_by_service
+            elsif params[:by_location_type].present?
+              stats.rdvs_group_by_type
             else
               stats.rdvs_group_by_week_fr
             end

--- a/app/views/stats/_statistics.html.slim
+++ b/app/views/stats/_statistics.html.slim
@@ -22,7 +22,7 @@
 
 .card.mb-5
   .card-body
-    h4.card-title.mb-3 RDV par type
+    h4.card-title.mb-3 RDV par type (#{stats.rdvs_for_default_range.count})
     = column_chart add_query_string_params_to_url(rdvs_statistic_path, by_location_type: true), stacked: true
 
 .card.mb-5


### PR DESCRIPTION
Remonté pendant la démo, Il y a un problème de donnée sur `/organisations/1/stats` au niveau du graphique `RDV par type`

- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [ ] Attendre que les tests soient verts sur la CI
