### PR TITLE
added script to fill changelog easily

### DIFF
--- a/scripts/get_deployed_changes.rb
+++ b/scripts/get_deployed_changes.rb
@@ -1,0 +1,28 @@
+# gem install ruby-trello
+# then in terminal:
+# irb -rubygems
+# irb> require 'trello'
+# irb> Trello.open_public_key_url                         # copy your public key
+# irb> Trello.open_authorization_url key: 'yourpublickey' # copy your member token
+
+# ruby scripts/get_deployed_changes.rb
+
+require 'dotenv/load'
+require 'trello'
+
+Trello.configure do |config|
+  config.developer_public_key = ENV["TRELLO_DEVELOPER_PUBLIC_KEY"]
+  config.member_token = ENV["TRELLO_MEMBER_TOKEN"]
+end
+
+board = Trello::Board.find("5cdac252d7d01b6f728c0308")
+list_deployed = board.lists.last
+list_deployed.cards.each do |card|
+  puts "- [#{card.name}](#{card.short_url})"
+end
+
+if ARGV[0] == "--archive"
+  puts "archiving all deployed cards..."
+  list_deployed.archive_all_cards
+  puts "done"
+end


### PR DESCRIPTION
`$ ruby scripts/get_deployed_changes.rb --archive`

- prints the list of cards in the deployed column in MD format to be copied in the changelog.
- archives all cards in list.

