### PR TITLE
fix users rdv wizard specs with hardcoded date to avoid holidays

### DIFF
--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -4,8 +4,15 @@ describe Users::RdvWizardStepsController, type: :controller do
     let!(:motif) { create(:motif) }
     let!(:lieu) { create(:lieu) }
     let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu) }
-    let!(:creneau) { build(:creneau, motif: motif, starts_at: 10.days.from_now.change(hour: 10)) }
+    let!(:creneau) do
+      build(
+        :creneau,
+        motif: motif,
+        starts_at: Date.parse("2020-03-03").in_time_zone + 10.hours
+      )
+    end
 
+    before { travel_to Date.parse("2020-03-01").in_time_zone + 8.hours }
     before { sign_in user }
 
     let(:params) do


### PR DESCRIPTION
Le bug etait super ponctuel : dans 10 jours c'est le 1er juin et c'est férié. Donc impossible de reserver ce jour la. 

J'ai hardcodé les dates pour éviter que ca ne se reproduise