### PR TITLE
extract users registration form object

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -58,7 +58,6 @@ class Agents::UsersController < AgentAuthController
 
   def update
     authorize(@user)
-    @user.created_or_updated_by_agent = true
     @user.skip_reconfirmation! if @user.encrypted_password.blank?
     flash[:notice] = "L'usager a été modifié." if @user.update(user_params)
     if from_modal?
@@ -94,7 +93,6 @@ class Agents::UsersController < AgentAuthController
     @user = User.new(user_params)
     @user.organisation_ids = [current_organisation.id]
     @user.invited_by = current_agent
-    @user.created_or_updated_by_agent = true
     @organisation = current_organisation
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -18,6 +18,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
 
+  def build_resource(hash = {})
+    self.resource = Users::RegistrationForm.new(hash)
+  end
+
   def user_devise_layout
     user_signed_in? ? 'application_user' : 'registration'
   end

--- a/app/form_models/users/registration_form.rb
+++ b/app/form_models/users/registration_form.rb
@@ -6,24 +6,22 @@ class Users::RegistrationForm
   # these delegates are necessary for redirect after signup
   delegate :persisted?, :active_for_authentication?, :inactive_message, to: :user
 
-  validates :email, presence: true
-  validates :password, presence: true
+  validates :password, :email, presence: true
 
   def initialize(attributes)
     @user = User.new(attributes)
   end
 
   def save
-    user.save if valid?
+    if valid?
+      user.save
+    else
+      # I'd rather override the errors method but it's incredibly tricky
+      user.errors.each { |k, v| errors.add(k, v) }
+    end
   end
 
   def valid?
     [super, user.valid?].all?
-  end
-
-  def errors
-    e = super.deep_dup
-    e.copy!(user.errors)
-    e
   end
 end

--- a/app/form_models/users/registration_form.rb
+++ b/app/form_models/users/registration_form.rb
@@ -1,0 +1,29 @@
+class Users::RegistrationForm
+  include ActiveModel::Model
+
+  attr_reader :user
+  delegate :first_name, :last_name, :password, :email, :phone_number, to: :user
+  # these delegates are necessary for redirect after signup
+  delegate :persisted?, :active_for_authentication?, :inactive_message, to: :user
+
+  validates :email, presence: true
+  validates :password, presence: true
+
+  def initialize(attributes)
+    @user = User.new(attributes)
+  end
+
+  def save
+    user.save if valid?
+  end
+
+  def valid?
+    [super, user.valid?].all?
+  end
+
+  def errors
+    e = super.deep_dup
+    e.copy!(user.errors)
+    e
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   include FullNameConcern
   include AccountNormalizerConcern
 
-  attr_accessor :created_or_updated_by_agent, :invite_on_create
+  attr_accessor :invite_on_create
 
   devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable, :async
@@ -138,21 +138,15 @@ class User < ApplicationRecord
     super.presence || responsible&.address
   end
 
-  protected
+  private
 
   def password_required?
-    return false if created_or_updated_by_agent || relative?
-
-    super
+    false # users without passwords and emails can be created by agents
   end
 
   def email_required?
-    return false if created_or_updated_by_agent || relative?
-
-    super
+    false # users without passwords and emails can be created by agents
   end
-
-  private
 
   def set_organisation_ids_from_responsible
     self.organisation_ids = responsible.organisation_ids if responsible

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for resource, as: resource_name, url: registration_path(resource_name) do |f|
+= simple_form_for resource, as: :user, url: registration_path(resource_name) do |f|
   .text-center.w-75.m-auto
     h4.text-dark-50.text-center.mt-0.font-weight-bold.mb-4  Inscription
   = devise_error_messages!

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
     end
     trait :with_no_email do
       email { nil }
-      created_or_updated_by_agent { true }
     end
   end
 end

--- a/spec/form_models/users/registration_form_spec.rb
+++ b/spec/form_models/users/registration_form_spec.rb
@@ -1,0 +1,36 @@
+describe Users::RegistrationForm, type: :form_model do
+  let(:attributes) do
+    {
+      first_name: "jean",
+      last_name: "durand",
+      email: "jean@durand.fr",
+      password: "jeanjean"
+    }
+  end
+
+  describe "validations" do
+    it "should be valid with complete params" do
+      form = Users::RegistrationForm.new(attributes)
+      expect(form.valid?).to eq(true)
+      expect(form.errors).to be_empty
+    end
+
+    it "should not allow empty emails" do
+      form = Users::RegistrationForm.new(attributes.except(:email))
+      expect(form.valid?).to eq(false)
+      expect(form.errors.keys).to match_array([:email])
+    end
+
+    it "should not allow empty password" do
+      form = Users::RegistrationForm.new(attributes.except(:password))
+      expect(form.valid?).to eq(false)
+      expect(form.errors.keys).to match_array([:password])
+    end
+
+    it "also validates user model errors" do
+      form = Users::RegistrationForm.new(attributes.except(:first_name))
+      form.save
+      expect(form.errors.keys).to match_array([:first_name])
+    end
+  end
+end

--- a/spec/form_models/users/registration_form_spec.rb
+++ b/spec/form_models/users/registration_form_spec.rb
@@ -32,5 +32,13 @@ describe Users::RegistrationForm, type: :form_model do
       form.save
       expect(form.errors.keys).to match_array([:first_name])
     end
+
+    it "accessing errors multiple times causes no problem" do
+      form = Users::RegistrationForm.new(attributes.except(:email, :first_name))
+      form.save
+      form.save
+      expect(form.errors[:first_name].count).to eq 1
+      expect(form.errors[:first_name].count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
Extraction d'un form object `Users::RegistrationForm` qui est utilisé dans le sign up et le edit des users comme proxy pour le modele User. Cela permet de retirer le booleen `@user.created_or_updated_by_agent` qui met des validations conditionnelles dans le modele User.

sur le principe des Form Objects cf https://culttt.com/2015/11/04/using-form-objects-in-ruby-on-rails/ par ex

refacto préliminaire pour #669 