### PR TITLE
remove actual API calls from SMS specs + make them more explicit

### DIFF
--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -27,11 +27,9 @@ FactoryBot.define do
       cancelled_at { 2.days.ago }
       status { 'excused' }
     end
-
-    after(:build) { |rdv| rdv.class.skip_callback(:create, :after, :notify_rdv_created) }
-
-    factory :with_notify_rdv_created do
-      after(:create) { |user| user.send(:notify_rdv_created) }
+    trait :without_notify_created_callback do
+      after(:build) { |rdv| rdv.class.skip_callback(:create, :after, :notify_rdv_created) }
+      after(:create) { |rdv| rdv.class.set_callback(:create, :after, :notify_rdv_created) }
     end
   end
 end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -27,9 +27,5 @@ FactoryBot.define do
       cancelled_at { 2.days.ago }
       status { 'excused' }
     end
-    trait :without_notify_created_callback do
-      after(:build) { |rdv| rdv.class.skip_callback(:create, :after, :notify_rdv_created) }
-      after(:create) { |rdv| rdv.class.set_callback(:create, :after, :notify_rdv_created) }
-    end
   end
 end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -27,5 +27,11 @@ FactoryBot.define do
       cancelled_at { 2.days.ago }
       status { 'excused' }
     end
+
+    after(:build) { |rdv| rdv.class.skip_callback(:create, :after, :notify_rdv_created) }
+
+    factory :with_notify_rdv_created do
+      after(:create) { |user| user.send(:notify_rdv_created) }
+    end
   end
 end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -6,6 +6,9 @@ FactoryBot.define do
     trait :secretariat do
       name { 'Secrétariat' }
     end
+    trait :pmi do
+      name { 'PMI' }
+    end
 
     after(:build) do |service|
       unless service.short_name.present?

--- a/spec/services/twilio_text_messenger_spec.rb
+++ b/spec/services/twilio_text_messenger_spec.rb
@@ -1,62 +1,129 @@
-describe TwilioTextMessenger, type: :service do
-  let(:rdv) { create(:rdv) }
-  let(:user) { rdv.users.first }
+describe TwilioTextMessenger, type: :service, skip_mock_sms: true  do
+  let(:user) { create(:user, phone_number: "+33640404040") }
 
   describe "#send_sms" do
-    subject { twilio.send_sms }
+    let(:service_pmi) { create(:service, :pmi) }
+    let(:motif) { create(:motif, service: service_pmi) }
+    let(:motif_by_phone) { create(:motif, :by_phone, service: service_pmi) }
+    let(:twilio_client) { instance_double(Twilio::REST::Client) }
+    let(:twilio_messages_list) { instance_double(Twilio::REST::Api::V2010::AccountContext::MessageList) }
 
-    context "when sending a sms when rdv is created" do
-      let(:twilio) { TwilioTextMessenger.new(:rdv_created, rdv, user) }
-      it 'return Twilio Object when sms is sent' do
-        is_expected.to be_kind_of(Twilio::REST::Api::V2010::AccountContext::MessageInstance)
+    before do
+      expect(Twilio::REST::Client).to receive(:new).at_least(:once).and_return(twilio_client)
+      expect(twilio_client).to receive(:messages).at_least(:once).and_return(twilio_messages_list)
+    end
+
+    context "for rdv_created notifications" do
+      context "simple RDV" do
+        let(:rdv) do
+          create(
+            :rdv,
+            :without_notify_created_callback,
+            motif: motif,
+            users: [user],
+            location: "20 rue du Louvre, Paris",
+            starts_at: Time.zone.parse("2020-10-25 10:30")
+          )
+        end
+        it 'should call twilio message creation' do
+          expect(twilio_messages_list).to receive(:create).with(
+            from: ENV["TWILIO_PHONE_NUMBER"],
+            to: "+33640404040",
+            body: "RDV PMI 25 oct. à 10h30\n20 rue du Louvre, Paris\nInfos et annulation: #{ENV['HOST']}/r"
+          )
+          TwilioTextMessenger.new(:rdv_created, rdv, user).send_sms
+        end
       end
 
-      it { expect(subject.body).to include("RDV #{rdv.motif.service.name} #{I18n.l(rdv.starts_at, format: :short)}") }
-      it { expect(subject.body).to include(rdv.location.to_s) }
-
-      context 'RDV is by_phone' do
-        let(:rdv) { create(:rdv, :by_phone) }
-
-        it { expect(subject.body).to include("RDV Téléphonique") }
+      context 'phone RDV' do
+        let(:rdv) do
+          create(
+            :rdv,
+            :without_notify_created_callback,
+            motif: motif_by_phone,
+            users: [user],
+            starts_at: Time.zone.parse("2020-10-25 10:30"),
+          )
+        end
+        it "should call twilio message creation" do
+          expect(twilio_messages_list).to receive(:create).with(
+            from: ENV["TWILIO_PHONE_NUMBER"],
+            to: "+33640404040",
+            body: "RDV PMI 25 oct. à 10h30\nRDV Téléphonique\nInfos et annulation: #{ENV['HOST']}/r"
+          )
+          TwilioTextMessenger.new(:rdv_created, rdv, user).send_sms
+        end
       end
     end
 
     context "when sending a reminder sms" do
-      let(:twilio) { TwilioTextMessenger.new(:reminder, rdv, user) }
-      it 'return Twilio Object when sms is sent' do
-        is_expected.to be_kind_of(Twilio::REST::Api::V2010::AccountContext::MessageInstance)
+      let(:rdv) do
+        create(
+          :rdv,
+          :without_notify_created_callback,
+          location: "20 rue du Louvre, Paris",
+          motif: motif,
+          users: [user],
+          starts_at: Time.zone.parse("2020-10-25 10:30")
+        )
       end
-
-      it { expect(subject.body).to include("Rappel RDV #{rdv.motif.service.name} le #{I18n.localize(rdv.starts_at, format: :short)}") }
-      it { expect(subject.body).to include(rdv.location.to_s) }
+      it "should call twilio message creation" do
+        expect(twilio_messages_list).to receive(:create).with(
+          from: ENV["TWILIO_PHONE_NUMBER"],
+          to: "+33640404040",
+          body: "Rappel RDV PMI le 25 oct. à 10h30\n20 rue du Louvre, Paris\nInfos et annulation: #{ENV['HOST']}/r"
+        )
+        TwilioTextMessenger.new(:reminder, rdv, user).send_sms
+      end
     end
 
     context "when sending a file d'attente sms" do
-      let(:twilio) { TwilioTextMessenger.new(:file_attente, rdv, user, creneau_starts_at: Time.now) }
-      it 'return Twilio Object when sms is sent' do
-        is_expected.to be_kind_of(Twilio::REST::Api::V2010::AccountContext::MessageInstance)
+      let(:rdv) do
+        create(
+          :rdv,
+          :without_notify_created_callback,
+          users: [user]
+        )
       end
-
-      it { expect(subject.body).to include("Des créneaux se sont libérés plus tot.") }
-      it { expect(subject.body).to include("Cliquez pour voir les disponibilités :") }
+      it "should call twilio message creation" do
+        expect(twilio_messages_list).to receive(:create).with(
+          from: ENV["TWILIO_PHONE_NUMBER"],
+          to: "+33640404040",
+          body: "Des créneaux se sont libérés plus tot.\nCliquez pour voir les disponibilités : #{ENV['HOST']}/users/creneaux?rdv_id=#{rdv.id}"
+        )
+        TwilioTextMessenger.new(:file_attente, rdv, user, creneau_starts_at: Time.now).send_sms
+      end
     end
 
     context "when sending a rdv_cancelled_by_agent sms" do
-      let(:twilio) { TwilioTextMessenger.new(:rdv_cancelled, rdv, user) }
-      it 'return Twilio Object when sms is sent' do
-        is_expected.to be_kind_of(Twilio::REST::Api::V2010::AccountContext::MessageInstance)
+      let(:rdv) do
+        create(
+          :rdv,
+          :without_notify_created_callback,
+          motif: motif,
+          users: [user],
+          starts_at: Time.zone.parse("2020-10-25 10:30")
+        )
       end
-
-      it { expect(subject.body).to include("RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short)} a été annulé") }
+      it "should call twilio message creation" do
+        expect(twilio_messages_list).to receive(:create).with(
+          from: ENV["TWILIO_PHONE_NUMBER"],
+          to: "+33640404040",
+          body: "RDV PMI 25 oct. à 10h30 a été annulé\nAllez sur https://rdv-solidarites.fr pour reprendre RDV."
+        )
+        TwilioTextMessenger.new(:rdv_cancelled, rdv, user).send_sms
+      end
     end
   end
 
   describe "#replace_special_chars" do
-    let(:twilio) { TwilioTextMessenger.new(:rdv_created, rdv, user) }
-    let(:body) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }
-
-    subject { twilio.send(:replace_special_chars, body) }
-
-    it { is_expected.to eq("àaäaaèéeeeìiiiiòoöooùuüuuñcAAÄAAEÉEEEIIIIIOOÖOOUUÜUUÑÇ") }
+    it "should work" do
+      body = "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ"
+      expect(
+        TwilioTextMessenger
+          .new(:rdv_created, nil, user)
+          .send(:replace_special_chars, body)
+      ).to eq("àaäaaèéeeeìiiiiòoöooùuüuuñcAAÄAAEÉEEEIIIIIOOÖOOUUÜUUÑÇ")
+    end
   end
 end

--- a/spec/services/twilio_text_messenger_spec.rb
+++ b/spec/services/twilio_text_messenger_spec.rb
@@ -1,4 +1,4 @@
-describe TwilioTextMessenger, type: :service, skip_mock_sms: true  do
+describe TwilioTextMessenger, type: :service, skip_mock_sms: true do
   let(:user) { create(:user, phone_number: "+33640404040") }
 
   describe "#send_sms" do
@@ -38,7 +38,7 @@ describe TwilioTextMessenger, type: :service, skip_mock_sms: true  do
           create_rdv(
             motif: motif_by_phone,
             users: [user],
-            starts_at: Time.zone.parse("2020-10-25 10:30"),
+            starts_at: Time.zone.parse("2020-10-25 10:30")
           )
         end
         it "should call twilio message creation" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,7 +127,7 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 
-  config.before(:each, type: ->(v) { v != :service }) do
+  config.before(:each, skip_mock_sms: -> { _1 != true }) do
     allow_any_instance_of(TwilioTextMessenger).to receive(:send_sms).and_return(Twilio::REST::Api::V2010::AccountContext::MessageInstance)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,7 +127,9 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 
-  config.before(:each, skip_mock_sms: -> { _1 != true }) do
+  config.before(:each) do |example|
+    next if example.metadata[:skip_mock_sms]
+
     allow_any_instance_of(TwilioTextMessenger).to receive(:send_sms).and_return(Twilio::REST::Api::V2010::AccountContext::MessageInstance)
   end
 


### PR DESCRIPTION
https://trello.com/c/3kkrW3SI/832-enlever-les-tests-qui-font-des-calls-a-lapi-twilio

- enleve les appels a l'API en mockant le call a `messages.create` 
- rend les expectations plus explicites en les hardcodant et en comparant l'entiereté du body plutot que des sous parties. 