### PR TITLE
fix margins in rdv wizard step 2

### DIFF
--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -27,6 +27,7 @@
             .col-auto
               = link_to "modifier", lieux_path(search: @rdv_wizard.to_search_query)
 
+      .card-body
         = simple_form_for(@rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv))) do |f|
 
           = f.association :motif, as: :hidden, wrapper_html: { class: 'mb-0' }


### PR DESCRIPTION
## Lien vers ticket Trello ou bug Sentry

https://trello.com/c/R7tUmMdh/887-usager-bug-marges-dans-la-selection-usager-dans-la-prise-rdv

## Facultatif : Description de la fonctionnalité ou du bug

avant :
<img width="816" alt="Screenshot 2020-05-29 at 09 19 34" src="https://user-images.githubusercontent.com/883348/83247747-47d3e900-a1a4-11ea-81ee-a80e444fe7f6.png">

apres : 
<img width="738" alt="Screenshot 2020-05-29 at 12 02 47" src="https://user-images.githubusercontent.com/883348/83247763-515d5100-a1a4-11ea-994b-30040c333cb4.png">
