### PR TITLE
fix plage ouverture ICS opening in Outlook

### DIFF
--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -2,11 +2,22 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
   def plage_ouverture_created(plage_ouverture)
     @plage_ouverture = plage_ouverture
     ics = PlageOuverture::Ics.new(plage_ouverture: @plage_ouverture)
-    attachments[ics.name] = {
-      mime_type: 'text/calendar',
+    attachments["invite.ics"] = {
+      mime_type: 'application/ics',
       content: ics.to_ical,
       encoding: "8bit", # fixes encoding issues in ICS
     }
-    mail(to: plage_ouverture.agent.email, subject: "Votre planning #{BRAND}")
+    m = mail(
+      to: plage_ouverture.agent.email,
+      subject: "#{BRAND} #{plage_ouverture.title} - Plage d'ouverture"
+    )
+    m.add_part(
+      Mail::Part.new do
+        content_type "text/calendar; method=REQUEST"
+        body ics.to_ical
+        content_transfer_encoding "8bit"
+      end
+    )
+    m
   end
 end

--- a/app/models/rdv/ics.rb
+++ b/app/models/rdv/ics.rb
@@ -28,6 +28,7 @@ class Rdv::Ics
       e.sequence    = rdv.sequence
       e.ip_class    = "PRIVATE"
       e.attendee    = "mailto:#{user.email}"
+      e.organizer   = "mailto:contact@rdv-solidarites.fr"
     end
 
     cal.ip_method = "REQUEST"


### PR DESCRIPTION
## Lien vers ticket Trello ou bug Sentry

https://trello.com/c/wmYVeX4z/568-agent-outlook-la-plage-douverture-envoy%C3%A9e-de-rdv-solidarit%C3%A9s-vers-outlook-nappara%C3%AEt-pas-dans-loutlook-soit-erreur-%C3%A0-louverture-d

## Facultatif : Description de la fonctionnalité ou du bug

L'évenement ICS est maintenant reconnu par Outlook qui l'affiche en haut du mail avec des boutons pour "répondre" même si ce n'est pas possible et l'ajouter au calendrier facilement.

<img width="1392" alt="Screenshot 2020-05-29 at 18 00 54" src="https://user-images.githubusercontent.com/883348/83280523-13c5eb80-a1d7-11ea-9deb-eec32aff041b.png">

Les fichiers ICS envoyés avant n'étaient pas "cassés", mais juste pas interprétés par Outlook. Ce n'est pas documenté, mais Outlook interprète les ICS uniquement lorsqu'ils sont envoyés comme une `part` du mail inline, pas comme un `attachment`. 

Je suppose que les agents n'arrivaient pas à ouvrir les fichiers ICS car leurs ordinateurs sont configurés de manière particulière. Je n'ai pas de problème pour ouvrir les fichiers ICS envoyés en attachment depuis Outlook sur un windows 10 vierge. 

On pourrait faire de même pour les ICS des RDVs envoyés aux users. ça serait potentiellement plus pratique sur Outlook. 
