### PR TITLE
stop redirecting to unique lieu

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -4,7 +4,6 @@ class LieuxController < ApplicationController
 
   def index
     @lieux = Lieu.for_service_motif_and_departement(@service_id, @motif_name, @departement)
-    return redirect_to lieu_path(@lieux.first, search: @query) if @lieux.size == 1
     return redirect_to new_user_session_path, flash: { alert: I18n.t("motifs.follow_up_need_signed_user", motif_name: @motif_name) } if follow_up_rdv_and_offline_user?
 
     @next_availability_by_lieux = {}

--- a/app/views/lieux/index.html.slim
+++ b/app/views/lieux/index.html.slim
@@ -15,22 +15,22 @@
         p.font-weight-bold= "#{@lieux.size.to_s} lieux sont disponibles"
         - @lieux.each do |lieu|
           - next_availability = @next_availability_by_lieux[lieu.id]
-          .card.mb-3
+          .card.mb-3 class=("card-hoverable" if next_availability)
             .card-body
-              = link_to lieu_path(lieu, search: @query, date: next_availability&.starts_at), class: "d-block" do
-                .row
-                  .col-md
-                    h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-                    h6.card-subtitle.text-black-50.mb-2= @service.name
-                    h6.card-subtitle.text-black-50= lieu.address
-                  .col-md.align-self-center.pt-3.pt-md-0
-                    - if next_availability
+              .row
+                .col-md
+                  h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
+                  h6.card-subtitle.text-black-50.mb-2= @service.name
+                  h6.card-subtitle.text-black-50= lieu.address
+                .col-md.align-self-center.pt-3.pt-md-0.position-static
+                  - if next_availability
+                    = link_to lieu_path(lieu, search: @query, date: next_availability&.starts_at), class: "d-block stretched-link" do
                       .row
                         .col
                           | Prochaine disponibilité le
                           br
                           strong= l(next_availability.starts_at, format: :human)
                         .col-auto.align-self-center
-                         i.fa.fa-chevron-right
-                    - else
-                      em Aucune disponibilité
+                          i.fa.fa-chevron-right
+                  - else
+                    em Aucune disponibilité

--- a/app/webpacker/stylesheets/components/_cards.scss
+++ b/app/webpacker/stylesheets/components/_cards.scss
@@ -45,7 +45,7 @@
 .card-warning {
   border: 1px solid $warning;
   background-color: lighten($warning, 45%);
-} 
+}
 
 //Card disable loading (Custom Cards)
 .card-disabled {
@@ -86,7 +86,7 @@
 
 .card-pricing {
   position: relative;
-  
+
   .card-pricing-plan-name {
     padding-bottom: 20px;
   }
@@ -136,5 +136,12 @@
     font-weight: 700;
     border-radius: .25rem .25rem 0 0;
     margin: -1.5rem -1.5rem 1.5rem -1.5rem;
+  }
+}
+
+.card-hoverable {
+  border: 1px solid transparent;
+  &:hover {
+    border-color: $blue;
   }
 }

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -37,7 +37,7 @@ describe "User can search for rdvs" do
       expect(page).to have_content(lieu2.name)
 
       # Step 5
-      click_link(lieu.name)
+      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
       expect(page).to have_content(lieu.name)
       first(:link, "11:00").click
 


### PR DESCRIPTION
## Lien vers ticket Trello ou bug Sentry

https://trello.com/c/ojjMVtjb/872-usagerprise-de-rdv-toujours-passer-par-la-liste-de-lieux

## Facultatif : Description de la fonctionnalité ou du bug

- on passe toujours par la liste des lieux. avant, on pouvait être redirigé directement vers un lieu quand il n'y avait qu'un résultat
- ca sera plus explicite de passer par ici dans les cas ou il n'y a aucune disponibilité
- il y a maintenant une border qui apparait au hover des cards de lieux disponibles
- le hover est mieux désactivé pour les cards de lieux indisponibles

<img width="1552" alt="Screenshot 2020-06-02 at 09 46 53" src="https://user-images.githubusercontent.com/883348/83494075-026e2f00-a4b6-11ea-9dc0-181a2918bc75.png">

testable sur la review app: https://demo-rdv-solidarites-pr687.osc-fr1.scalingo.io/lieux?search%5Bdepartement%5D=75&search%5Blatitude%5D=48.8546&search%5Blongitude%5D=2.34771&search%5Bmotif_name%5D=%C3%8Atre+rappel%C3%A9+par+la+PMI&search%5Bservice%5D=1&search%5Bwhere%5D=Paris+75000


## Facultatif: Description du code de la PR

- j'ai utilisé les stretched links https://getbootstrap.com/docs/4.5/utilities/stretched-link/#identifying-the-containing-block pour faire un lien qui s'etend a tout le bloc parent

