### PR TITLE
fix charset encoding warning in plage ouverture mailer

### DIFF
--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -13,7 +13,7 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
     )
     m.add_part(
       Mail::Part.new do
-        content_type "text/calendar; method=REQUEST"
+        content_type "text/calendar; method=REQUEST; charset=utf-8"
         body ics.to_ical
         content_transfer_encoding "8bit"
       end


### PR DESCRIPTION
L'absence de ce charset déclenchait un warning lors des specs, par exemple lieux_controller_spec