### PR TITLE
add IE 11 to browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,2 @@
 defaults
+IE 11


### PR DESCRIPTION
blind fix attempt for https://trello.com/c/bR6ukPkS/890-reparer-closest-pour-ie-11-18

I could not manage to reproduce bug with closest through browserstack :/

It's very unclear which `closest` is generating this error as we don't have source maps connected on sentry. From looking at the code we only explicitly call the vanilla `closest` (not the jQuery one) at one point in the code : the motif form js (apart from the super admin interface). However the events on sentry are spread among the whole admin so it doesn't seem linked to that one. 

