### PR TITLE
fix canceling rdv starting soon for agents

### DIFF
--- a/app/views/agents/rdvs/_rdv_details.html.slim
+++ b/app/views/agents/rdvs/_rdv_details.html.slim
@@ -24,7 +24,7 @@ p.card-text
   p.card-text
     strong> Usager(s) :
     = users_to_links(rdv)
-.card-text
+p.card-text
   i.far.fa-fw.fa-sticky-note>
   strong> Notes libres :&nbsp;
   = display_notes(rdv.notes)

--- a/app/views/agents/rdvs/show.html.slim
+++ b/app/views/agents/rdvs/show.html.slim
@@ -21,7 +21,7 @@
           = link_to "voir dans l'agenda", organisation_agent_path(current_organisation, @rdv.agents.first, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date)
         = render 'rdv_details', rdv: @rdv
         .row
-          - if @rdv.cancellable?
+          - unless @rdv.cancelled?
             .col.text-left
               = link_to "Annuler", organisation_rdv_path(@rdv.organisation, @rdv, status: :excused), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
               | ou

--- a/app/views/agents/rdvs/show.html.slim
+++ b/app/views/agents/rdvs/show.html.slim
@@ -21,11 +21,11 @@
           = link_to "voir dans l'agenda", organisation_agent_path(current_organisation, @rdv.agents.first, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date)
         = render 'rdv_details', rdv: @rdv
         .row
-          - unless @rdv.cancelled?
-            .col.text-left
+          .col
+            - if !@rdv.past? && !@rdv.cancelled?
               = link_to "Annuler", organisation_rdv_path(@rdv.organisation, @rdv, status: :excused), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
               | ou
-              = link_to "Supprimer ❌", organisation_rdv_path(@rdv.organisation, @rdv), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
+            = link_to "Supprimer ❌", organisation_rdv_path(@rdv.organisation, @rdv), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
 
           .col.text-right
             = link_to "Modifier", edit_organisation_rdv_path(@rdv.organisation, @rdv), class: "btn btn-outline-primary", data: { rightbar: true }


### PR DESCRIPTION
## Lien vers ticket Trello ou bug Sentry

https://trello.com/c/nAhf9nW3/892-lagent-devrait-pouvoir-annuler-un-rdv-qui-a-lieu-dans-tres-peu-de-temps

j'ai aussi corrigé une marge en dessous des notes libres en passant