### PR TITLE
fix inviting agent with email capitalized differently

### DIFF
--- a/app/controllers/agents/invitations_controller.rb
+++ b/app/controllers/agents/invitations_controller.rb
@@ -8,7 +8,7 @@ class Agents::InvitationsController < Devise::InvitationsController
   end
 
   def create
-    agent = Agent.find_by(email: invite_params[:email])
+    agent = Agent.find_by(email: invite_params[:email].downcase)
     self.resource = agent.nil? ? invite_resource : agent
     resource_invited = resource.errors.empty?
     if resource_invited

--- a/spec/controllers/agents/invitations_controller_spec.rb
+++ b/spec/controllers/agents/invitations_controller_spec.rb
@@ -121,5 +121,25 @@ RSpec.describe Agents::InvitationsController, type: :controller do
         it { expect { subject }.not_to change(Agent, :count) }
       end
     end
+
+    context "when agent already exist but with different email capitalization" do
+      let(:params) do
+        {
+          email: "MARCO@demo.rdv-solidarites.fr",
+          organisation_id: organisation_id,
+          role: 'user',
+          service_id: service_id,
+        }
+      end
+      let!(:existing_agent) do
+        create(
+          :agent,
+          email: "marco@demo.rdv-solidarites.fr",
+          organisation_ids: [organisation_2.id]
+        )
+      end
+
+      it_behaves_like "existing user is added to organization"
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/ZCoXalEx/902-agent-erreur-invitation-email-diff%C3%A9rence-de-capitalisation

Sur la review app pour verifier que ca marche vous pouvez essayer de vous connecter en tant que martine@demo.rdv-solidarites.fr et inviter MAYA@demo.rdv-solidarites.fr