### PR TITLE
prevent window alerts for n+1 queries from bullet in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   # Check N+1 Queries / Eager loading
   config.after_initialize do
     Bullet.enable = true
-    Bullet.alert = true
+    # Bullet.alert = true
     Bullet.rails_logger = true
   end
 


### PR DESCRIPTION
it's annoying, we ignore them, and it's often for premature optimizations