### PR TITLE
fix sending SMS on RDV update

### DIFF
--- a/app/services/notifications/rdv/rdv_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_updated_service.rb
@@ -4,7 +4,8 @@ class Notifications::Rdv::RdvUpdatedService < ::BaseService
   protected
 
   def notify_user(user)
-    # TODO : it's weird that it uses the exacte same mail as for creations
+    # TODO : it's weird that it uses the exact same notifications as for creations
     Users::RdvMailer.rdv_created(@rdv, user).deliver_later if user.email.present?
+    TwilioSenderJob.perform_later(:rdv_created, @rdv, user) if user.formatted_phone
   end
 end


### PR DESCRIPTION
https://trello.com/c/F2nEwFc9/903-usagernotification-lorsquun-rdv-est-modifi%C3%A9-lusager-re%C3%A7oit-un-mail-de-confirmations-mais-plus-de-sms

j'avais cassé l'envoi de SMS lors de l'update de RDV dans mon refacto pour extraire des services d'envoi de notifs : https://github.com/betagouv/rdv-solidarites.fr/commit/2f39467cbb321e06226c15576d59ccaab1c9bf39

j'avais oublié de copier l'envoi de rdv_created a l'update, ce qui est un peu perturbant