### PR TITLE
[agent] add RDV notes to allowed attributes in versions history

### DIFF
--- a/app/views/agents/rdvs/show.html.slim
+++ b/app/views/agents/rdvs/show.html.slim
@@ -39,7 +39,7 @@
           = f.input :status, collection: Rdv.human_enum_collection(:status), as: :radio_buttons, label: ''
           .text-right= f.submit class: 'btn btn-secondary'
 
-.row data-controller='versions' data-versions-url=organisation_rdv_versions_path(@rdv.organisation, @rdv, only: ['user_ids', 'agent_ids', 'duration_in_min', 'status', 'starts_at', 'location'])
+.row data-controller='versions' data-versions-url=organisation_rdv_versions_path(@rdv.organisation, @rdv, only: ['user_ids', 'agent_ids', 'duration_in_min', 'status', 'starts_at', 'location', 'notes'])
   .col-md-12
     .card
       .card-header


### PR DESCRIPTION
https://trello.com/c/fD1aSsjR/899-agenthistorique-des-actions-les-modifications-sur-les-notes-libres-napparaissent-pas

on filtre les attributs affichés dans l'historique de version des RDVs, les notes n'y étaient pas pour l'instant

<img width="1552" alt="Screenshot 2020-06-05 at 17 35 27" src="https://user-images.githubusercontent.com/883348/83895455-0074cc00-a753-11ea-88da-6a95286ab320.png">
