### PR TITLE
fix export format from ods to xls + remove dead code

### DIFF
--- a/app/controllers/agents/organisations/rdvs_controller.rb
+++ b/app/controllers/agents/organisations/rdvs_controller.rb
@@ -6,7 +6,7 @@ class Agents::Organisations::RdvsController < AgentAuthController
     @rdvs = @rdvs.includes(:organisation, :motif, agents: :service).order(starts_at: :desc)
 
     respond_to do |format|
-      format.ods { send_data(RdvExporterService.perform_with(@rdvs, StringIO.new), filename: "stats.ods", type: "application/ods") }
+      format.xls { send_data(RdvExporterService.perform_with(@rdvs, StringIO.new), filename: "rdvs.xls", type: "application/xls") }
       format.html { @rdvs = @rdvs.page(params[:page]) }
     end
   end

--- a/app/controllers/agents/stats_controller.rb
+++ b/app/controllers/agents/stats_controller.rb
@@ -3,11 +3,6 @@ class Agents::StatsController < AgentAuthController
 
   def index
     @stats = Stat.new(rdvs: rdvs_for_current_agent)
-
-    respond_to do |format|
-      format.ods { send_data(RdvStatBuilderService.perform_with(current_organisation, StringIO.new), filename: "stats.ods", type: "application/ods") }
-      format.html
-    end
   end
 
   def rdvs

--- a/app/views/agents/stats/index.html.slim
+++ b/app/views/agents/stats/index.html.slim
@@ -5,7 +5,7 @@
 .card.mb-5
   .card-body
     = render 'stats/rdv_counters', rdvs: @stats.rdvs_for_default_range
-    = link_to organisation_rdvs_path(current_organisation, format: "ods"), class: "btn btn-link" do
+    = link_to organisation_rdvs_path(current_organisation, format: "xls"), class: "btn btn-link" do
       i.fa.fa-download>
       | Télécharger un export des RDVs de l'organisation
 

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,1 +1,1 @@
-Mime::Type.register "application/ods", :ods
+Mime::Type.register "application/xls", :xls


### PR DESCRIPTION
https://trello.com/c/MjwC5deL/897-agent-extraction-stats-impossible-douvrir-le-fichier

en fait la gem ne genere que du XLS, pas du ODS https://github.com/zdavatz/spreadsheet

ca marchait sur LibreOffice car il doit pas regarder l'extension pour decider du format, mais pas sur excel

j'ai aussi supprimé le code mort et buggé de stats_controller. l'export se faisait d'abord depuis ce controlleur mais on l'a déplacé pour le mettre dans rdvs_controller pour des raisons sémantiques