### PR TITLE
exporte des stats mensuels

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -17,7 +17,7 @@ class StatsController < ApplicationController
               stats.rdvs_group_by_week_fr
             end
     respond_to do |format|
-      format.xls { send_data(MonthlyStatsExporterService.perform_with(@rdvs, StringIO.new), filename: "rdvs.xls", type: "application/xls") }
+      format.xls { send_data(MonthlyStatsExporterService.perform_with(@rdvs, StringIO.new), filename: "stats.xls", type: "application/xls") }
       format.json { render json: stats.chart_json }
     end
   end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -16,7 +16,10 @@ class StatsController < ApplicationController
             else
               stats.rdvs_group_by_week_fr
             end
-    render json: stats.chart_json
+    respond_to do |format|
+      format.xls { send_data(MonthlyStatsExporterService.perform_with(@rdvs, StringIO.new), filename: "rdvs.xls", type: "application/xls") }
+      format.json { render json: stats.chart_json }
+    end
   end
 
   def users

--- a/app/services/monthly_stats_exporter_service.rb
+++ b/app/services/monthly_stats_exporter_service.rb
@@ -1,0 +1,43 @@
+class MonthlyStatsExporterService < BaseService
+  include XlsExporter
+
+  def initialize(rdvs, file)
+    @rdvs = rdvs
+    @file = file
+  end
+
+  def header
+    ["Nombre rdv", "Service", "Département", "Mois"].freeze
+  end
+
+  def build_lines(sheet)
+    counted_rdvs = count_rdv(@rdvs)
+    counted_rdvs.each_with_index do |(key, rdv_quantity), index|
+      row = sheet.row(index + 1)
+      row.concat(row_array_from(key, rdv_quantity))
+    end
+  end
+
+  def count_rdv(rdvs)
+    counted_rdvs = {}
+    rdvs.each do |rdv|
+      key = "#{rdv.organisation.departement}-#{rdv.motif.service.name}-#{rdv.starts_at.month}"
+      if counted_rdvs.keys.include?(key)
+        counted_rdvs[key] += 1
+      else
+        counted_rdvs[key] = 1
+      end
+    end
+    counted_rdvs
+  end
+
+  def row_array_from(key, rdv_quantity)
+    departement, service, month = *key.split("-")
+    [
+      rdv_quantity,
+      service,
+      departement,
+      month
+    ]
+  end
+end

--- a/app/services/rdv_exporter_service.rb
+++ b/app/services/rdv_exporter_service.rb
@@ -1,25 +1,20 @@
 class RdvExporterService < BaseService
-  TYPE = { "user" => "Usager", "agent" => "Agent", "file_attente" => "File d'attente" }.freeze
-  HourFormat = Spreadsheet::Format.new(number_format: 'hh:mm')
-  DateFormat = Spreadsheet::Format.new(number_format: 'DD/MM/YYYY')
-  HEADER = ["date prise rdv", "heure prise rdv", "date rdv", "heure rdv", "motif", "pris par", "statut", "agents"].freeze
+  include XlsExporter
 
   def initialize(rdvs, file)
-    Spreadsheet.client_encoding = 'UTF-8'
     @rdvs = rdvs
     @file = file
   end
 
-  def perform
-    workbook.write(@file)
-    @file.string
+  TYPE = { "user" => "Usager", "agent" => "Agent", "file_attente" => "File d'attente" }.freeze
+  HourFormat = Spreadsheet::Format.new(number_format: 'hh:mm')
+  DateFormat = Spreadsheet::Format.new(number_format: 'DD/MM/YYYY')
+
+  def header
+    ["date prise rdv", "heure prise rdv", "date rdv", "heure rdv", "motif", "pris par", "statut", "agents"].freeze
   end
 
-  def workbook
-    book = Spreadsheet::Workbook.new
-    sheet = book.create_worksheet
-    sheet.row(0).concat(HEADER)
-
+  def build_lines(sheet)
     @rdvs.each_with_index do |rdv, index|
       row = sheet.row(index + 1)
       row.set_format 0, DateFormat
@@ -29,7 +24,6 @@ class RdvExporterService < BaseService
 
       row.concat(row_array_from(rdv))
     end
-    book
   end
 
   def row_array_from(rdv)

--- a/app/services/xls_exporter.rb
+++ b/app/services/xls_exporter.rb
@@ -1,0 +1,15 @@
+module XlsExporter
+  def perform
+    Spreadsheet.client_encoding = 'UTF-8'
+    workbook.write(@file)
+    @file.string
+  end
+
+  def workbook
+    book = Spreadsheet::Workbook.new
+    sheet = book.create_worksheet
+    sheet.row(0).concat(header)
+    build_lines(sheet)
+    book
+  end
+end

--- a/app/views/stats/_statistics.html.slim
+++ b/app/views/stats/_statistics.html.slim
@@ -3,6 +3,9 @@
 .card.mb-5
   .card-body
     = render 'stats/rdv_counters', rdvs: stats.rdvs_for_default_range
+    = link_to rdvs_stats_path(format: "xls"), class: "btn btn-link" do
+      i.fa.fa-download>
+      | Télécharger un export des RDVs de l'organisation
 
 .card.mb-5
   .card-body

--- a/spec/services/monthly_stats_exporter_service_spec.rb
+++ b/spec/services/monthly_stats_exporter_service_spec.rb
@@ -1,0 +1,30 @@
+describe MonthlyStatsExporterService, type: :service do
+  context "with a sheet inside" do
+    it "have an header" do
+      sheet = MonthlyStatsExporterService.new([], StringIO.new).workbook.worksheet(0)
+      expect(sheet.row(0)).to eq(["Nombre rdv", "Service", "Département", "Mois"])
+    end
+
+    it "have a line for a RDV" do
+      rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33))
+      sheet = MonthlyStatsExporterService.new([rdv], StringIO.new).workbook.worksheet(0)
+      expect(sheet.row(1)[0]).to eq(1)
+      expect(sheet.row(1)[1]).to eq(rdv.motif.service.name)
+      expect(sheet.row(1)[2]).to eq(rdv.organisation.departement)
+      expect(sheet.row(1)[3]).to eq(rdv.starts_at.month.to_s)
+    end
+  end
+
+  describe "#count_rdvs" do
+    it "return empty hash with no Rdv" do
+      exporter = MonthlyStatsExporterService.new([], StringIO.new)
+      expect(exporter.count_rdv([])).to eq({})
+    end
+
+    it "return key with departement-motif-month and 1 as rdv number for one rdv " do
+      exporter = MonthlyStatsExporterService.new([], StringIO.new)
+      rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33))
+      expect(exporter.count_rdv([rdv])).to eq({ "#{rdv.organisation.departement}-#{rdv.motif.service.name}-#{rdv.starts_at.month}" => 1 })
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Zg9300Vj/900-extraction-des-stats-publiques

Export excel du nombre de rendez-vous par mois, par service et par département depuis la page publique de statistique.

Remaniement des deux exporteur pour mutualiser une partie du code commun, basé sur le principe de composition plutôt qu'héritage.

Ça laisse une duplication sur l'initialisation, peut-être du à l'héritage de la classe `BaseService`. Ça sera pour une prochaine fois peut-être.
