### PR TITLE
fixing ICS for zimbra using base64 encoding instead of 8bit

### DIFF
--- a/app/controllers/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/agents/plage_ouvertures_controller.rb
@@ -28,7 +28,7 @@ class Agents::PlageOuverturesController < AgentAuthController
     @plage_ouverture = PlageOuverture.new(plage_ouverture_params)
     @plage_ouverture.organisation = current_organisation
     authorize(@plage_ouverture)
-    flash[:notice] = "Plage d'ouverture créé." if @plage_ouverture.save
+    flash[:notice] = "Plage d'ouverture créée" if @plage_ouverture.save
     respond_right_bar_with @plage_ouverture, location: organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)
   end
 

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -4,8 +4,8 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
     ics = PlageOuverture::Ics.new(plage_ouverture: @plage_ouverture)
     attachments["invite.ics"] = {
       mime_type: 'application/ics',
-      content: ics.to_ical,
-      encoding: "8bit", # fixes encoding issues in ICS
+      content: Base64.encode64(ics.to_ical),
+      encoding: "base64", # seems necessary for attachments
     }
     m = mail(
       to: plage_ouverture.agent.email,
@@ -14,8 +14,9 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
     m.add_part(
       Mail::Part.new do
         content_type "text/calendar; method=REQUEST; charset=utf-8"
-        body ics.to_ical
-        content_transfer_encoding "8bit"
+        body Base64.encode64(ics.to_ical)
+        content_transfer_encoding "base64"
+        # quoted-printable would be more adapted but there seems to be an encoding problem with extra =0D
       end
     )
     m


### PR DESCRIPTION
https://trello.com/c/4RIwsw9A/922-r%C3%A9parer-ics-pour-zimbra

base64 n'est pas super adapté vu que ics est un format texte mais ca semble mieux marcher
avec 8bit ou quoted-printable on a des soucis d'encodage et de compatibilité sur zimbra et-ou outlook 

⚠️ en attente de validation d'Aude ou Elodie que ca ne casse rien pour le 62

<img width="1392" alt="Screenshot 2020-06-18 at 09 03 19" src="https://user-images.githubusercontent.com/883348/84988761-d94ecf00-b142-11ea-9136-83d44362fd37.png">
