### PR TITLE
[user] fix registration form labels translations explicitly

### DIFF
--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -3,12 +3,12 @@
     h4.text-dark-50.text-center.mt-0.font-weight-bold.mb-4  Inscription
   = devise_error_messages!
   .form-row
-    .col-6= f.input :first_name
-    .col-6= f.input :last_name
-  = f.input :email, as: :email, placeholder: 'nom.prenom@email.com', required: true
-  = f.input :phone_number, as: :tel, placeholder: '061010101010', hint: 'Vous recevrez les rappels et les informations du RDV sur ce numéro.'
+    .col-6= f.input :first_name, label: t('activerecord.attributes.user.first_name'), required: true
+    .col-6= f.input :last_name, label: t('activerecord.attributes.user.last_name'), required: true
+  = f.input :email, as: :email, placeholder: 'nom.prenom@email.com', required: true, label: t('activerecord.attributes.user.email')
+  = f.input :phone_number, as: :tel, placeholder: '061010101010', hint: 'Vous recevrez les rappels et les informations du RDV sur ce numéro.', label: t('activerecord.attributes.user.phone_number')
   .form-group
-    = f.label :password
+    = f.label :password, label: t('activerecord.attributes.user.password')
     = f.password_field :password, required: true, class: 'form-control ', placeholder: 'Votre mot de passe (au moins 6 caractères)', id: "password"
     span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
 


### PR DESCRIPTION
https://trello.com/c/MDclzKuB/923-bug-usager-inscription

ce n'est pas la meilleure maniere de corriger ce souci, mais je n'ai pas réussi a faire mieux.
dans l'ideal il faudrait que le form helper re-utilise tout seul les clés i18n du modele User. 
Je me suis un peu cassé la tete mais je ne comprends pas le fonctionnement, j'ai préféré abandonner pour l'instant et le faire explicitement simplement