### PR TITLE
[bug][user] fix coordinates order from addresse API 🙀

### DIFF
--- a/app/webpacker/components/places-input.js
+++ b/app/webpacker/components/places-input.js
@@ -40,8 +40,8 @@ class PlacesInput {
   remapBanFeatures = data => data.features.map(this.remapBanFeature)
 
   remapBanFeature = feature => ({
-    latitude: feature.geometry.coordinates[0],
-    longitude: feature.geometry.coordinates[1],
+    longitude: feature.geometry.coordinates[0],
+    latitude: feature.geometry.coordinates[1],
     departement: feature.properties.context.split(",")[0],
     value: this.getFeatureValueText(feature),
     ...feature.properties,


### PR DESCRIPTION
https://trello.com/c/XnqTAzbl/947-investigation-probl%C3%A8me-distance-recherche-christelle-cufay

La recherche via l'API adresse.data.gouv.fr renvoie les coordonnées sous la forme `[longitude, latitude]` et j'avais pris l'inverse 😨 

