### PR TITLE
Fix RDVs export for current agent scope

### DIFF
--- a/app/controllers/agents/organisations/rdvs_controller.rb
+++ b/app/controllers/agents/organisations/rdvs_controller.rb
@@ -4,6 +4,7 @@ class Agents::Organisations::RdvsController < AgentAuthController
     @rdvs = @rdvs.default_stats_period if params[:default_period].present?
     @rdvs = @rdvs.status(params[:status]) if params[:status].present?
     @rdvs = @rdvs.includes(:organisation, :motif, agents: :service).order(starts_at: :desc)
+    @rdvs = @rdvs.with_agent(Agent.find(params[:agent_id])) if params[:agent_id].present?
 
     respond_to do |format|
       format.xls { send_data(RdvExporterService.perform_with(@rdvs, StringIO.new), filename: "rdvs.xls", type: "application/xls") }

--- a/app/controllers/agents/stats_controller.rb
+++ b/app/controllers/agents/stats_controller.rb
@@ -13,6 +13,6 @@ class Agents::StatsController < AgentAuthController
   private
 
   def rdvs_for_current_agent
-    policy_scope(Rdv).joins(:agents).where(agents: { id: current_agent.id })
+    policy_scope(Rdv).with_agent(current_agent)
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -38,6 +38,7 @@ class Rdv < ApplicationRecord
     end
   }
   scope :default_stats_period, -> { where(created_at: Stat::DEFAULT_RANGE) }
+  scope :with_agent, ->(agent) { joins(:agents).where(agents: { id: agent.id }) }
 
   after_commit :reload_uuid, on: :create
 

--- a/app/views/agents/stats/index.html.slim
+++ b/app/views/agents/stats/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title do
-  | Statistiques #{current_agent.full_name}
-  small Du #{l(Stat::DEFAULT_RANGE.first.to_date)} au #{l(Stat::DEFAULT_RANGE.last.to_date)}
+  span> Statistiques #{current_agent.full_name}
+  small du #{l(Stat::DEFAULT_RANGE.first.to_date)} au #{l(Stat::DEFAULT_RANGE.last.to_date)}
 
 .card.mb-5
   .card-body

--- a/app/views/agents/stats/index.html.slim
+++ b/app/views/agents/stats/index.html.slim
@@ -5,9 +5,9 @@
 .card.mb-5
   .card-body
     = render 'stats/rdv_counters', rdvs: @stats.rdvs_for_default_range
-    = link_to organisation_rdvs_path(current_organisation, format: "xls"), class: "btn btn-link" do
+    = link_to organisation_rdvs_path(current_organisation, format: "xls", agent_id: current_agent.id), class: "btn btn-link" do
       i.fa.fa-download>
-      | Télécharger un export des RDVs de l'organisation
+      | Télécharger un export de vos RDVs
 
 .card.mb-5
   .card-body


### PR DESCRIPTION
https://trello.com/c/Jf6G6373/927-agent-limiter-les-stats-aux-rdvs-de-lagent-courant

le lien pour telecharger un export depuis la page "Vos Statistiques" renvoyait un export avec TOUS les rdvs du scope, cad ceux de toute l'orga pour les admins et les secretaires, et ceux des autres collegues du service pour les agents classiques. 