### PR TITLE
fix to never display phone instructions when it's absent

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -26,6 +26,8 @@ module WelcomeHelper
   end
 
   def urgency_number
+    return nil unless urgency_number_raw.present?
+
     human, raw = urgency_number_raw
     link_to human, "tel:#{raw}", class: 'urgency-number'
   end

--- a/app/views/common/_search_form.html.slim
+++ b/app/views/common/_search_form.html.slim
@@ -21,9 +21,10 @@
         .form-row.d-flex.justify-content-md-center.mb-2
           .col-lg-9= f.input :motif_name, label: @motif_name.present? ? false : "Votre motif", collection: @motif_names, selected: @motif_name, required: true, include_blank: "Choisissez un motif", input_html: { class: 'select2-input' }, wrapper_html: { class: 'mb-1 mb-lg-0' }
           .col-lg-3.align-self-end= f.button :submit, "Choisir ce motif", class: 'btn btn-secondary btn-lg w-100 text-center'
-          small.col-sm-12.pt-1.text-light.font-italic
-            | Si votre motif ne figure pas dans la liste contactez par tél le
-            u=< urgency_number
+          - if urgency_number
+            small.col-sm-12.pt-1.text-light.font-italic
+              | Si votre motif ne figure pas dans la liste contactez par téléphone le
+              u=< urgency_number
 
       - else
         .form-row.d-flex.justify-content-md-center.mb-2
@@ -31,9 +32,10 @@
             .col-lg-9
               = f.input :service, label: "Votre service", collection: @services, label_method: :name, value_method: :id, required: true, include_blank: "Choisissez un service", input_html: { class: 'form-control-lg w-100' }, wrapper_html: { class: 'mb-1 mb-lg-0' }
             .col-lg-3.align-self-end= f.button :submit, "Choisir ce service", class: 'btn btn-secondary btn-lg w-100 text-center'
-            small.col-sm-12.pt-1.text-light.font-italic
-              span> Si votre service ne figure pas dans la liste contactez par tél le
-              span>= urgency_number
+            - if urgency_number
+              small.col-sm-12.pt-1.text-light.font-italic
+                span> Si votre service ne figure pas dans la liste contactez par téléphone le
+                span>= urgency_number
           - else
             h2.text-white.text-center
               - if @organisations_departement.any? && sectorisation_enabled?(@departement)
@@ -42,8 +44,10 @@
                   span>, veuillez contacter le
                   span>= urgency_number
               - elsif @organisations_departement.any? && urgency_number
-                span> Votre département n'est pas disponible à la prise de RDV en ligne, veuillez contacter le
-                span>= urgency_number
+                span> Votre département n'est pas disponible à la prise de RDV en ligne
+                - if urgency_number
+                  span>, veuillez contacter le
+                  span>= urgency_number
               - else
                 | La prise de rendez-vous n'est pas disponible pour ce département.
       = render 'corona/info_rdv'

--- a/app/views/lieux/index.html.slim
+++ b/app/views/lieux/index.html.slim
@@ -36,8 +36,9 @@
                     em Aucune disponibilité
 
 
-        .row
-          .col-md-10
-            h4.card-title.mb-3.mt-0.text-muted Vous ne trouvez pas votre lieu ?
-            h6.card-subtitle.text-black-50.mb-2 Il est possible que la prise de rendez vous ne soit pas encore disponible.
-            h6.card-subtitle.text-black-50= "Prenez contact avec le #{urgency_number} pour plus d'informations".html_safe
+        - if urgency_number
+          .row
+            .col-md-10
+              h4.card-title.mb-3.mt-0.text-muted Vous ne trouvez pas votre lieu ?
+              h6.card-subtitle.text-black-50.mb-2 Il est possible que la prise de rendez vous ne soit pas encore disponible.
+              h6.card-subtitle.text-black-50= "Prenez contact avec le #{urgency_number} pour plus d'informations".html_safe


### PR DESCRIPTION
https://trello.com/c/USRqtFtw/946-o%C3%B9-ne-pas-afficher-le-num%C3%A9ro-de-tel-sil-ny-en-a-pas-dans-le-departement

j'avais cassé le comportement en introduisant la fonction intermediaire `urgency_number_raw`, je corrige ici + je rajoute un check dans le bloc "Vous ne trouvez pas votre lieu" meme si ca ne devrait quasiment jamais se produire.

difficile de verifier sur la review app, il faudrait creer une orga et des lieux dans le bon contexte un peu relou.
ce que j'ai fait en local pour verifier c'est commenter dans le welcome helper.