### PR TITLE
in user rdv search, fix link back to change service

### DIFF
--- a/app/views/common/_search_form.html.slim
+++ b/app/views/common/_search_form.html.slim
@@ -16,7 +16,7 @@
             = f.input :service, as: :hidden, input_html: { value: @service.id }, wrapper_html: { class: 'd-none' }
 
             = f.input :service, label: false, disabled: true, readonly: true, input_html: { value: @service.name, class: "form-control-lg" }, wrapper_html: { class: 'mb-1 mb-lg-0' }
-          .col-lg-3.align-self-end= link_to "Modifier le service", welcome_departement_path(@departement, where: @where, latitude: @latitude, longitude: @longitude), class: 'btn btn-light btn-lg w-100 text-center'
+          .col-lg-3.align-self-end= link_to "Modifier le service", welcome_departement_path(@departement, where: @where, latitude: @latitude, longitude: @longitude, city_code: @city_code), class: 'btn btn-light btn-lg w-100 text-center'
 
         .form-row.d-flex.justify-content-md-center.mb-2
           .col-lg-9= f.input :motif_name, label: @motif_name.present? ? false : "Votre motif", collection: @motif_names, selected: @motif_name, required: true, include_blank: "Choisissez un motif", input_html: { class: 'select2-input' }, wrapper_html: { class: 'mb-1 mb-lg-0' }


### PR DESCRIPTION
https://trello.com/c/BwuMXjmA/951-usager-bug-retour-au-service

pour verifier cliquer sur modifier le service depuis https://demo-rdv-solidarites-pr743.osc-fr1.scalingo.io/lieux?search%5Bcity_code%5D=62040&search%5Bdepartement%5D=62&search%5Blatitude%5D=50.732087&search%5Blongitude%5D=2.318718&search%5Bmotif_name%5D=%C3%8Atre+rappel%C3%A9+par+la+PMI&search%5Bservice%5D=1&search%5Bwhere%5D=Arques%2C+62510%2C+62%2C+Pas-de-Calais%2C+Hauts-de-France

(quand je vois cette url je me dis que ca serait cool d'enlever le namespace [search] des parametres get de la search!)