### PR TITLE
firefox ESR (extended support release) est sur la version 68

### DIFF
--- a/app/webpacker/components/browser-detection.js
+++ b/app/webpacker/components/browser-detection.js
@@ -4,7 +4,7 @@ const browser = Bowser.getParser(window.navigator.userAgent);
 document.addEventListener('turbolinks:load', function() {
   const oldBrowser = browser.satisfies({
     chrome: "<78",
-    firefox: "<70",
+    firefox: "<68",
     edge: "<17",
   });
 


### PR DESCRIPTION
https://trello.com/c/iVY5eZTe/527-home-bandeau-navigateur-obsol%C3%A8te

La version Extended Support Release de firefox est la 68. C'est pas la peine de forcer les personnes à avoir une version plus récente.