### PR TITLE
revoit l'affectation d'organisation coté controller uniquement

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,7 +176,7 @@ class User < ApplicationRecord
   end
 
   def set_organisation_ids_from_responsible
-    self.organisation_ids = responsible.organisation_ids if responsible
+    self.organisation_ids = responsible.organisation_ids if responsible && (responsible.user_profiles.map(&:organisation_id).sort != user_profiles.map(&:organisation_id).sort)
   end
 
   def set_email_to_null_if_blank

--- a/app/views/agents/users/_form.html.slim
+++ b/app/views/agents/users/_form.html.slim
@@ -45,6 +45,7 @@
     = f.input :birth_date, as: :date, html5: true
 
     = f.simple_fields_for :user_profiles, user_profile do |n|
+      = n.input :organisation_id, as: :hidden
       = n.input :notes, input_html: { rows: 6 }
 
   .text-right


### PR DESCRIPTION
hotfix : suite à la livraison de la séparation des notes et logements pour chaque organisation, la création des proches est cassée.

Ce patch vise à la réparer.

Il y avait, dans le model user, un mécanisme pour s'assurer que l'organisation d'un proche est la même que le parent. Cette vérification à lieu dans le controller, et crée un doublon dans le model.