### PR TITLE
move sectorisation link to parametres

### DIFF
--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -52,11 +52,6 @@
             i.fa.fa-chart-bar
             span Vos statistiques
             = unknown_past_agent_rdvs_danger_bage
-        - if current_agent.admin? && policy_scope(Organisation).count == 1
-          li.side-nav-item
-            = link_to departement_setup_checklist_path(current_organisation.departement), class: "side-nav-link" do
-              i.fa.fa-map>
-              | Sectorisation #{current_organisation.departement}
         - if current_agent.admin?
           li.side-nav-item
             = link_to '#', class: 'side-nav-link' do
@@ -80,6 +75,9 @@
                 = link_to 'Vos motifs', \
                   organisation_motifs_path(current_organisation), \
                   data: { route: 'agents/motifs#index' }
+              - if current_agent.admin? && policy_scope(Organisation).count == 1
+                li
+                  = link_to "Sectorisation #{current_organisation.departement}", departement_setup_checklist_path(current_organisation.departement)
               li
                 = link_to( \
                   organisation_stats_path(current_organisation), \


### PR DESCRIPTION
repond a 2 tickets :
1 bug https://trello.com/c/wQTXdPd0/973-agent-lien-sectorisation-dans-menu-d%C3%A9passe-en-responsive
1 oubli https://trello.com/c/S4oO0Vrh/958-agent-d%C3%A9placer-le-lien-sectorisation-dans-param%C3%A8tres

## avant

<img width="220" alt="Screenshot 2020-06-30 at 10 05 34" src="https://user-images.githubusercontent.com/883348/86100746-89b0c180-bab9-11ea-948e-d318569f7319.png">

<img width="247" alt="Screenshot 2020-06-30 at 10 05 45" src="https://user-images.githubusercontent.com/883348/86100734-861d3a80-bab9-11ea-9fa4-cd479d6ff940.png">

## apres

<img width="301" alt="Screenshot 2020-06-30 at 10 05 57" src="https://user-images.githubusercontent.com/883348/86100767-9208fc80-bab9-11ea-83c4-c898cc4ce8d6.png">
