### PR TITLE
[agent] add button to duplicate plage ouvertures

### DIFF
--- a/app/controllers/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/agents/plage_ouvertures_controller.rb
@@ -14,7 +14,14 @@ class Agents::PlageOuverturesController < AgentAuthController
 
   def new
     @agent = Agent.find(params[:agent_id])
-    @plage_ouverture = PlageOuverture.new(organisation: current_organisation, agent: @agent, first_day: Time.zone.now, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(12))
+    @plage_ouverture = PlageOuverture.new(
+      organisation: current_organisation,
+      agent: @agent,
+      first_day: Time.zone.now,
+      start_time: Tod::TimeOfDay.new(9),
+      end_time: Tod::TimeOfDay.new(12),
+      **params.permit(:title, :lieu_id, motif_ids: [])
+    )
     authorize(@plage_ouverture)
     respond_right_bar_with @plage_ouverture
   end

--- a/app/controllers/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/agents/plage_ouvertures_controller.rb
@@ -14,13 +14,21 @@ class Agents::PlageOuverturesController < AgentAuthController
 
   def new
     @agent = Agent.find(params[:agent_id])
+    if params[:duplicate_plage_ouverture_id].present?
+      original_po = PlageOuverture.find(params[:duplicate_plage_ouverture_id])
+      defaults = original_po.slice(:title, :lieu_id, :motif_ids, :first_day, :start_time, :end_time, :recurrence)
+    else
+      defaults = {
+        first_day: Time.zone.now,
+        start_time: Tod::TimeOfDay.new(9),
+        end_time: Tod::TimeOfDay.new(12),
+      }
+    end
+    puts "defaults is #{defaults}"
     @plage_ouverture = PlageOuverture.new(
       organisation: current_organisation,
       agent: @agent,
-      first_day: Time.zone.now,
-      start_time: Tod::TimeOfDay.new(9),
-      end_time: Tod::TimeOfDay.new(12),
-      **params.permit(:title, :lieu_id, motif_ids: [])
+      **defaults
     )
     authorize(@plage_ouverture)
     respond_right_bar_with @plage_ouverture

--- a/app/views/agents/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/agents/plage_ouvertures/_plage_ouverture.html.slim
@@ -13,3 +13,17 @@ tr
       = sanitize(display_recurrence(plage_ouverture).join("<br/>"))
     - else
       | Le #{l(plage_ouverture.first_day, format: :human)} #{display_time_range(plage_ouverture)}
+  td
+    div= link_to "Éditer", edit_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture), data: { rightbar: true }
+    div
+      = link_to( \
+        "Dupliquer", \
+        new_organisation_agent_plage_ouverture_path( \
+          current_organisation, \
+          @agent.id, \
+          title: plage_ouverture.title, \
+          lieu_id: plage_ouverture.lieu_id, \
+          motif_ids: plage_ouverture.motif_ids \
+        ), \
+        data: { rightbar: true } \
+      )

--- a/app/views/agents/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/agents/plage_ouvertures/_plage_ouverture.html.slim
@@ -21,9 +21,7 @@ tr
         new_organisation_agent_plage_ouverture_path( \
           current_organisation, \
           @agent.id, \
-          title: plage_ouverture.title, \
-          lieu_id: plage_ouverture.lieu_id, \
-          motif_ids: plage_ouverture.motif_ids \
+          duplicate_plage_ouverture_id: plage_ouverture.id \
         ), \
         data: { rightbar: true } \
       )

--- a/app/views/agents/plage_ouvertures/index.html.slim
+++ b/app/views/agents/plage_ouvertures/index.html.slim
@@ -20,6 +20,7 @@
             th Description
             th Motifs
             th Lieu
+            th Dates
             th
         tbody
           = render @plage_ouvertures


### PR DESCRIPTION
https://trello.com/c/etIgH5un/957-agent-plages-douverture-permettre-la-cr%C3%A9ation-successive-de-plages-douvertures-pour-une-m%C3%AAme-activit%C3%A9-sans-r%C3%A9currence-de-date

ajout d'un bouton dupliquer a coté des plages d'ouverture.
ouvre le formulaire de creation avec les motifs, la description et le lieu preremplis.

<img width="958" alt="Screenshot 2020-07-02 at 11 39 44" src="https://user-images.githubusercontent.com/883348/86343061-bbac5a00-bc58-11ea-89ce-dcd98e373f0e.png">
