### PR TITLE
[user] add forgot password link when registering with used email

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,5 @@
+class Users::PasswordsController < Devise::PasswordsController
+  def new
+    self.resource = resource_class.new(params.permit(:email))
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   validates :number_of_children, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :phone_number, phone: { allow_blank: true }
   validate :birth_date_validity
-  validate :user_is_not_duplicate, on: :create
+  validate :user_is_not_duplicate, on: :create, unless: -> { errors[:email]&.present? } # to avoid two similar errors on duplicate email
 
   accepts_nested_attributes_for :user_profiles
 

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -2,6 +2,8 @@
   .text-center.w-75.m-auto
     h4.text-dark-50.text-center.mt-0.font-weight-bold.mb-4  Inscription
   = devise_error_messages!
+  - if resource.errors[:email]&.include?(I18n.t('errors.messages.taken'))
+    .mb-3= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email)
   .form-row
     .col-6= f.input :first_name, label: t('activerecord.attributes.user.first_name'), required: true
     .col-6= f.input :last_name, label: t('activerecord.attributes.user.last_name'), required: true

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -134,7 +134,7 @@ fr:
       other_than: doit être différent de %{count}
       present: doit être vide
       required: doit exister
-      taken: n'est pas disponible
+      taken: est déjà utilisé
       too_long:
         one: est trop long (pas plus d'un caractère)
         other: est trop long (pas plus de %{count} caractères)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   end
 
   ## APP ##
-  devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'sessions' }
+  devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'sessions', passwords: 'users/passwords' }
 
   namespace :users do
     resource :rdv_wizard_step, only: [:new, :create]

--- a/spec/services/import_zone_rows_service_spec.rb
+++ b/spec/services/import_zone_rows_service_spec.rb
@@ -146,7 +146,7 @@ describe ImportZoneRowsService, type: :service do
         res = ImportZoneRowsService.perform_with(rows, '62', agent)
         expect(res[:valid]).to eq(false)
         expect(res[:counts][:imported]).to be_empty
-        expect(res[:row_errors][0]).to eq("Code de la commune (Code INSEE) n'est pas disponible")
+        expect(res[:row_errors][0]).to eq("Code de la commune (Code INSEE) est déjà utilisé")
         expect(Zone.count).to eq(1)
         expect(Zone.first.city_code).to eq('62040')
         expect(Zone.first.organisation).to eq(orga_arras_sud) # unchanged


### PR DESCRIPTION
https://trello.com/c/6dNrculW/943-usagerinscription-ajouter-lien-mot-de-passe-oubli%C3%A9-lorsque-lemail-est-d%C3%A9j%C3%A0-utilis%C3%A9

<img width="602" alt="Screenshot 2020-07-02 at 13 50 40" src="https://user-images.githubusercontent.com/883348/86356333-5a8e8180-bc6c-11ea-8d61-9205a643e4ed.png">

J'ai aussi fait en sorte que lorsqu'on clique sur mot de passe oublié ca transmette l'email automatiquement.