### PR TITLE
[user] resend invitation when user asks for confirmation but has been…

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,12 @@
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  def create
+    user = User.find_by_email(resource_params[:email])
+    if user&.invitation_sent_at? && !user&.invitation_accepted?
+      user.invite!
+      flash[:notice] = I18n.t("devise.confirmations.send_instructions")
+      return respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
+    end
+
+    super
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   end
 
   ## APP ##
-  devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'sessions', passwords: 'users/passwords' }
+  devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'sessions', passwords: 'users/passwords', confirmations: 'users/confirmations' }
 
   namespace :users do
     resource :rdv_wizard_step, only: [:new, :create]


### PR DESCRIPTION
https://trello.com/c/5ZCBnIuH/977-usagerinscription-renvoyer-mail-dinvitation-plutot-que-confirmation-pour-demander-mdp

⚠️ branching from `feature/user-forgot-password-on-sign-up` because same files edited. merge this other one first.

slightly hacky solution but should fix a tricky pb