### PR TITLE
[agent] do not consider soft deleted users in uniqueness checks

### DIFF
--- a/app/services/duplicate_user_finder_service.rb
+++ b/app/services/duplicate_user_finder_service.rb
@@ -6,16 +6,16 @@ class DuplicateUserFinderService
   end
 
   def perform
-    user_with_same_email = User.where.not(email: nil).find_by(email: @user.email)
+    user_with_same_email = users_in_scope.where.not(email: nil).find_by(email: @user.email)
     return user_with_same_email if user_with_same_email.present?
 
     similar_users = User.none
     if @user.phone_number.present?
-      similar_users = similar_users.or(User.where(phone_number: @user.phone_number))
+      similar_users = similar_users.or(users_in_scope.where(phone_number: @user.phone_number))
     end
     if @user.birth_date.present? && @user.first_name.present? && @user.last_name.present?
       similar_users = similar_users.or(
-        User.where(
+        users_in_scope.where(
           first_name: @user.first_name.capitalize,
           last_name: @user.last_name.upcase,
           birth_date: @user.birth_date
@@ -23,5 +23,11 @@ class DuplicateUserFinderService
       )
     end
     similar_users.left_joins(:rdvs).group(:id).order('COUNT(rdvs.id) DESC').first
+  end
+
+  private
+
+  def users_in_scope
+    User.active
   end
 end

--- a/db/migrate/20200702132842_add_email_original_to_users.rb
+++ b/db/migrate/20200702132842_add_email_original_to_users.rb
@@ -1,0 +1,16 @@
+class AddEmailOriginalToUsers < ActiveRecord::Migration[6.0]
+  def up
+    add_column :users, :email_original, :string
+    User.where.not(deleted_at: nil).each do |user|
+      user.update_columns(email_original: user.email, email: user.deleted_email)
+      # skip callbacks to avoid mail confirmation
+    end
+  end
+
+  def down
+    User.where.not(deleted_at: nil).each do |user|
+      user.update_columns(email: user.email_original)
+    end
+    remove_column :users, :email_original
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_09_203050) do
+ActiveRecord::Schema.define(version: 2020_07_02_132842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -314,6 +314,7 @@ ActiveRecord::Schema.define(version: 2020_06_09_203050) do
     t.datetime "deleted_at"
     t.string "birth_name"
     t.text "old_notes"
+    t.string "email_original"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -134,7 +134,7 @@ describe User, type: :model do
     end
 
     context 'belongs to multiple organisations and with organisation given' do
-      let(:user) { create(:user, :with_multiple_organisations) }
+      let(:user) { create(:user, :with_multiple_organisations, email: "jean@valjean.fr") }
       let(:deleted_org) { user.organisations.first }
       it { expect(user.organisations).not_to include(deleted_org) }
 
@@ -143,12 +143,15 @@ describe User, type: :model do
         expect(user.organisations.pluck(:id)).to match_array(left_orgs_ids)
       end
       it { expect(user.deleted_at).to be_nil }
+      it { expect(user.email).to eq "jean@valjean.fr" }
     end
 
     context 'belongs to one organisation and with organisation given' do
-      let(:user) { create(:user, organisations: [create(:organisation)]) }
+      let(:user) { create(:user, email: "jean@valjean.fr", organisations: [create(:organisation)]) }
       let(:deleted_org) { user.organisations.first }
       it { expect(user.deleted_at).to eq(now) }
+      it { expect(user.email).to end_with('deleted.rdv-solidarites.fr') }
+      it { expect(user.email_original).to eq('jean@valjean.fr') }
       it { expect(user.organisations).to be_empty }
     end
 

--- a/spec/services/duplicate_user_finder_service_spec.rb
+++ b/spec/services/duplicate_user_finder_service_spec.rb
@@ -23,16 +23,31 @@ describe DuplicateUserFinderService, type: :service do
       context "same email" do
         let!(:duplicated_user) { create(:user, email: "lapin@beta.fr") }
         it { should eq(duplicated_user) }
+
+        context "but soft deleted" do
+          before { duplicated_user.soft_delete }
+          it { should be_nil }
+        end
       end
 
       context "same main first_name, last_name, birth_date" do
         let!(:duplicated_user) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: '21/10/2000') }
         it { should eq(duplicated_user) }
+
+        context "but soft deleted" do
+          before { duplicated_user.soft_delete }
+          it { should be_nil }
+        end
       end
 
       context "same phone_number" do
         let!(:duplicated_user) { create(:user, phone_number: '0658032518') }
         it { should eq(duplicated_user) }
+
+        context "but soft deleted" do
+          before { duplicated_user.soft_delete }
+          it { should be_nil }
+        end
       end
 
       context "multiple account" do
@@ -40,6 +55,19 @@ describe DuplicateUserFinderService, type: :service do
         let!(:duplicated_user_2) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: '21/10/2000') }
         let!(:rdv) { create(:rdv, users: [duplicated_user_1]) }
         it { should eq(duplicated_user_1) }
+
+        context "but first soft deleted" do
+          before { duplicated_user_1.soft_delete }
+          it { should eq(duplicated_user_2) }
+        end
+
+        context "but both soft deleted" do
+          before do
+            duplicated_user_1.soft_delete
+            duplicated_user_2.soft_delete
+          end
+          it { should be_nil }
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/MbRWv7GQ/972-impossible-de-recr%C3%A9er-un-usager-supprim%C3%A9

I fixed 2 different issues preventing re-creating a user that was soft-deleted :

- scope to active users in DuplicateUserFinder => pretty obvious

- bypass users.email unicity => more tricky. The email unicity constraint is at the db level so we cannot just change the scope of the validation (and maybe it's best like that). What I did was that now soft deleted users have a dummy email like `user_34@deleted.rdv-solidarites.fr` and their original email is backuped in `users.email_original`. this allows re-creating a new user with the old email.

Also, I couldn't refrain from a little refacto of the `user#soft_delete` method please indulge me.