### PR TITLE
[agent] clear agenda refetch interval on browser tab blur

### DIFF
--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -17,12 +17,16 @@ class CalendarRdvSolidarites {
     this.data = this.calendarEl.dataset
     this.fullCalendarInstance = this.initFullCalendar(this.calendarEl)
     this.fullCalendarInstance.render();
-    const refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 3000);
 
-    $(document).on('turbolinks:before-cache turbolinks:before-render', function() {
-      clearTimeout(refreshCalendarInterval)
-    });
-
+    document.addEventListener('turbolinks:before-cache', this.clearRefetchInterval);
+    document.addEventListener('turbolinks:before-render', this.clearRefetchInterval);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        this.setRefetchInterval();
+      } else if (this.refreshCalendarInterval) {
+        this.clearRefetchInterval()
+      }
+    })
     document.addEventListener("turbolinks:before-cache", () => {
       // force calendar reload on turbolinks re-visit, otherwise event listeners
       // are not attached
@@ -32,7 +36,18 @@ class CalendarRdvSolidarites {
       // fixes hanging tooltip on back
       $(".tooltip").removeClass("show")
     })
+    this.setRefetchInterval()
+  }
 
+  setRefetchInterval = () => {
+    if (this.refreshCalendarInterval) return
+    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 1000)
+  }
+
+  clearRefetchInterval = () => {
+    if (!this.refreshCalendarInterval) return
+    clearTimeout(this.refreshCalendarInterval)
+    this.refreshCalendarInterval = null
   }
 
   initFullCalendar = () => {

--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -41,7 +41,7 @@ class CalendarRdvSolidarites {
 
   setRefetchInterval = () => {
     if (this.refreshCalendarInterval) return
-    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 1000)
+    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 30000)
   }
 
   clearRefetchInterval = () => {


### PR DESCRIPTION
https://trello.com/c/Fpw2RY9R/979-agentcalendrier-lorsquun-onglet-est-laiss%C3%A9-ouvert-longtemps-il-y-a-plein-dalertes-lorsquon-revient

`visibilitychange` seems decently supported 
https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event
https://caniuse.com/#search=visibilitychange

to test : 
- open a calendar page, open the network tab
- clear network requests and switch to another tab
- wait 1m +
- go back to the other tab
- check that there was no request in between BUT that requests re-start

repeat test but staying on the same tab but leaving the agenda (eg by navigating to absences with turbolinks)