### PR TITLE
install simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-debug.log*
 .env
 .ruby-gemset
 lapins.kdbx
+coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -125,4 +125,5 @@ group :test do
   gem 'capybara-screenshot'
   gem 'webdrivers', '~> 4.0'
   gem 'database_cleaner'
+  gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,7 @@ GEM
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.3)
+    docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -426,6 +427,10 @@ GEM
     simple_form (5.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -549,6 +554,7 @@ DEPENDENCIES
   sentry-raven
   sib-api-v3-sdk
   simple_form (~> 5.0)
+  simplecov
   skylight
   slim (~> 4.0)
   spreadsheet

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require 'capybara-screenshot/rspec'
 
 require 'simplecov'
 SimpleCov.refuse_coverage_drop
-SimpleCov.start
+SimpleCov.start 'rails'
 
 Capybara.register_driver :selenium do |app|
   # these args seem to reduce test flakyness

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,10 @@ require 'capybara/email/rspec'
 require 'webdrivers'
 require 'capybara-screenshot/rspec'
 
+require 'simplecov'
+SimpleCov.refuse_coverage_drop
+SimpleCov.start
+
 Capybara.register_driver :selenium do |app|
   # these args seem to reduce test flakyness
   # w3c false required for logs cf https://github.com/SeleniumHQ/selenium/issues/7270


### PR DESCRIPTION
Proposition lié à l'installation de SimpleCov.

Bien que je ne sois pas convaincu par les métriques de couverture de code par les tests, ça reste une information intéresante. Aussi je vous propose d'ajouter simplecov, une gem assez simple qui n'ajoute pas trop de dépendances.

Je l'ai configuré pour bloqué (exit code 3) en cas de réduction de la couverture actuelle. Nous avons une couverture de code à plus de 96%. Peut-être que nous pourrions dire de ne pas descendre en dessous de 95 % mais je me dit que l'idéal serait 100%.

![Capture d’écran de 2020-07-03 17-33-08](https://user-images.githubusercontent.com/42057/86482985-58ebb900-bd53-11ea-8077-26e5be8ce1bf.png)

Je ne versionne pas les résultats de couverture, j'ai peur que le contenu change à chaque fois qu'on execute les tests.

Il y a une information qui me semble intéressante pour améliorer nos tests : le nombre de fois où une ligne à été appeler. Si nous augmentons le nombre de test unitaire et réduisons le nombre de test de bout en bout, nous devrions réduire le nombre de fois où une ligne de code est executé... c'est à creuser.