### PR TITLE
increase viewport size in specs to regular desktop size

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'capybara-screenshot/rspec'
 Capybara.register_driver :selenium do |app|
   # these args seem to reduce test flakyness
   # w3c false required for logs cf https://github.com/SeleniumHQ/selenium/issues/7270
-  chrome_options = { args: %w[headless no-sandbox disable-gpu], w3c: false }
+  chrome_options = { args: %w[headless no-sandbox disable-gpu window-size=1500,1000], w3c: false }
   chrome_bin = ENV.fetch('GOOGLE_CHROME_SHIM', nil)
   chrome_options[:binary] = chrome_bin if chrome_bin
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(


### PR DESCRIPTION
tiny change that was annoying me when using `save_and_open_screenshot` : the default size is a tiny mobile view and our site is not that responsive especially for agents

before:
![capybara-202007070822207615698693](https://user-images.githubusercontent.com/883348/86739946-92177800-c036-11ea-9306-ed7eb449de4d.png)

after:
![capybara-20200707094823386060896](https://user-images.githubusercontent.com/883348/86740526-02be9480-c037-11ea-9f27-fd58e464a619.png)
