### PR TITLE
affiche les profiles usager pour chaque organisation

### DIFF
--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -54,6 +54,18 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   def user_params
-    params.permit(user: [:first_name, :last_name, :birth_name, :phone_number, :birth_date, :address, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :logement])
+    params.permit(user: [
+      :first_name,
+      :last_name,
+      :birth_name,
+      :phone_number,
+      :birth_date,
+      :address,
+      :caisse_affiliation,
+      :affiliation_number,
+      :family_situation,
+      :number_of_children,
+      user_profiles_attributes: [:logement, :id, :organisation_id]
+    ])
   end
 end

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -55,17 +55,17 @@ class Users::RdvWizardStepsController < UserAuthController
 
   def user_params
     params.permit(user: [
-      :first_name,
-      :last_name,
-      :birth_name,
-      :phone_number,
-      :birth_date,
-      :address,
-      :caisse_affiliation,
-      :affiliation_number,
-      :family_situation,
-      :number_of_children,
-      user_profiles_attributes: [:logement, :id, :organisation_id]
-    ])
+                    :first_name,
+                    :last_name,
+                    :birth_name,
+                    :phone_number,
+                    :birth_date,
+                    :address,
+                    :caisse_affiliation,
+                    :affiliation_number,
+                    :family_situation,
+                    :number_of_children,
+                    user_profiles_attributes: [:logement, :id, :organisation_id]
+                  ])
   end
 end

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -18,6 +18,18 @@ class Users::UsersController < UserAuthController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :birth_name, :phone_number, :birth_date, :address, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :logement)
+    params.require(:user).permit(
+      :first_name,
+      :last_name,
+      :birth_name,
+      :phone_number,
+      :birth_date,
+      :address,
+      :caisse_affiliation,
+      :affiliation_number,
+      :family_situation,
+      :number_of_children,
+      user_profiles_attributes: [:logement, :id, :organisation_id]
+    )
   end
 end

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -18,8 +18,12 @@
     .col-md-6= f.input :family_situation, collection: User.human_enum_collection(:family_situation)
     .col-md-6= f.input :number_of_children, input_html: { min: '0', max: '15', step: 'any' }
 
-  = f.simple_fields_for :user_profiles, UserProfile do |n|
-    = n.input :logement, collection: UserProfile.human_enum_collection(:logement)
+  - user.user_profiles.each do |profile|
+    fieldset
+      = f.simple_fields_for :user_profiles, profile do |n|
+        legend= profile.organisation.name
+        = n.input :organisation_id, as: :hidden
+        = n.input :logement, collection: UserProfile.human_enum_collection(:logement)
 
   - if local_assigns[:rdv_wizard].present?
     - rdv_wizard.each do |wizard_key, wizard_value|

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -18,12 +18,20 @@
     .col-md-6= f.input :family_situation, collection: User.human_enum_collection(:family_situation)
     .col-md-6= f.input :number_of_children, input_html: { min: '0', max: '15', step: 'any' }
 
-  - user.user_profiles.each do |profile|
-    fieldset
-      = f.simple_fields_for :user_profiles, profile do |n|
-        legend= profile.organisation.name
-        = n.input :organisation_id, as: :hidden
-        = n.input :logement, collection: UserProfile.human_enum_collection(:logement)
+  - if local_assigns[:rdv_wizard]
+    - current_organisation = Motif.find(rdv_wizard[:motif_id]).organisation
+    - profile = user.profile_for(current_organisation)
+    - profile ||= user.user_profiles.build(organisation: current_organisation)
+    = f.simple_fields_for :user_profiles, profile do |n|
+      = n.input :organisation_id, as: :hidden
+      = n.input :logement, collection: UserProfile.human_enum_collection(:logement)
+  - else
+    - user.user_profiles.each do |profile|
+      fieldset
+        = f.simple_fields_for :user_profiles, profile do |n|
+          legend= profile.organisation.name
+          = n.input :organisation_id, as: :hidden
+          = n.input :logement, collection: UserProfile.human_enum_collection(:logement)
 
   - if local_assigns[:rdv_wizard].present?
     - rdv_wizard.each do |wizard_key, wizard_value|


### PR DESCRIPTION
https://trello.com/c/PpjN4DMc/984-usager-etape-v%C3%A9rifier-mes-informations-le-champ-logement-appara%C3%AEt-2-fois

Du coté Usager, les informations ne sont pas contextualisées à une organisation. Nous affichons donc tout les éléments de chaque profile.

L'ajout consiste à afficher aussi le nom de l'organisation lié au profile pour rendre visible qu'il y a deux organisations qui ont deux informations.

Normalement, ces informations devraient être les même. Peut-être que nous pourrions, par la suite, rendre visible un soucis d'informations décallé entre organisation pour chaque usager. Mais c'est un autre ticket à faire.
