### PR TITLE
trigger change event for date inputs to fix plage ouverture recurrence creation bug

### DIFF
--- a/app/webpacker/components/datetimepicker.js
+++ b/app/webpacker/components/datetimepicker.js
@@ -10,6 +10,7 @@ class Datetimepicker {
       mask: true,
       scrollMonth: false,
       scrollInput: false,
+      onChangeDateTime: (_, $input) => { $input[0].dispatchEvent(new Event("change")); } // forces stimulus actions to execute
     });
     $("[data-behaviour='datetimepicker']").datetimepicker({
       format:'d/m/Y H:i',


### PR DESCRIPTION
cf https://trello.com/c/vXYTvvDg/1009-creation-de-plage-ouverture-jour-de-fin-pas-pris-en-compte

the bug was introduced when we started using the jQuery datetimepicker instead of the native HTML5 date input. The problem was that the `change` event was not triggered anymore, and thus the associated stimulus action to refresh the `recurrence` input was not being refreshed correctly. 

I've added a somewhat hacky fix to always trigger this change event for such inputs. We may do better when we remove stimulus