### PR TITLE
[lint] enforce double quotes style everywhere

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,7 @@ Style/HashTransformValues:
 Metrics/BlockLength:
   Exclude:
     - 'db/schema.rb'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  Enabled: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -142,13 +142,6 @@ Style/RedundantSelf:
   Exclude:
     - 'app/controllers/agents/invitations_controller.rb'
 
-# Offense count: 1822
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/Gemfile
+++ b/Gemfile
@@ -1,76 +1,76 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby "2.7.1"
 
-gem 'dotenv-rails', '~> 2.7.2' # dotenv should always be loaded before rails
+gem "dotenv-rails", "~> 2.7.2" # dotenv should always be loaded before rails
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0'
-gem 'sprockets-rails'
+gem "rails", "~> 6.0"
+gem "sprockets-rails"
 
 # Use Puma as the app server
-gem 'puma', '~> 3.12'
+gem "puma", "~> 3.12"
 
 # DB
-gem 'pg', '>= 0.18', '< 2.0'
-gem 'pg_search', '~> 2.3'
-gem 'kaminari', '~> 1.2'
-gem 'bootstrap4-kaminari-views', '~> 1.0'
-gem 'administrate', github: 'thoughtbot/administrate', branch: 'master' # to use PR #1579
-gem 'administrate-field-belongs_to_search', '~> 0.7'
-gem 'paper_trail'
+gem "pg", ">= 0.18", "< 2.0"
+gem "pg_search", "~> 2.3"
+gem "kaminari", "~> 1.2"
+gem "bootstrap4-kaminari-views", "~> 1.0"
+gem "administrate", github: "thoughtbot/administrate", branch: "master" # to use PR #1579
+gem "administrate-field-belongs_to_search", "~> 0.7"
+gem "paper_trail"
 
 # Devise / auth
-gem 'devise', '~> 4.7'
-gem 'devise_invitable', '~> 2.0'
-gem 'devise-async', '~> 1.0'
-gem 'omniauth-github', '~> 1.4'
-gem 'pundit', '~> 2.0'
+gem "devise", "~> 4.7"
+gem "devise_invitable", "~> 2.0"
+gem "devise-async", "~> 1.0"
+gem "omniauth-github", "~> 1.4"
+gem "pundit", "~> 2.0"
 
 # Jobs
-gem 'delayed_job_active_record', '~> 4.1.4'
-gem 'delayed_job_web'
-gem 'delayed_cron_job'
-gem 'daemons'
+gem "delayed_job_active_record", "~> 4.1.4"
+gem "delayed_job_web"
+gem "delayed_cron_job"
+gem "daemons"
 
 # Form
-gem 'simple_form', '~> 5.0'
-gem 'image_processing', '~> 1.8'
-gem 'phonelib'
+gem "simple_form", "~> 5.0"
+gem "image_processing", "~> 1.8"
+gem "phonelib"
 
 # Front
-gem "chartkick", '~> 3.3.0'
-gem 'groupdate', '~> 4.2'
-gem 'slim', '~> 4.0'
+gem "chartkick", "~> 3.3.0"
+gem "groupdate", "~> 4.2"
+gem "slim", "~> 4.0"
 
 ## Time Management
-gem 'montrose', '~> 0.11.2'
-gem 'tod', '~> 2.2'
-gem 'icalendar', '~> 2.5'
+gem "montrose", "~> 0.11.2"
+gem "tod", "~> 2.2"
+gem "icalendar", "~> 2.5"
 
 # Mailing
-gem 'premailer-rails'
+gem "premailer-rails"
 
 # SMS
-gem 'sib-api-v3-sdk'
+gem "sib-api-v3-sdk"
 
 # Web Hook
-gem 'blueprinter'
-gem 'typhoeus'
+gem "blueprinter"
+gem "typhoeus"
 
 # Ops
 gem "sentry-raven"
 gem "skylight"
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker'
+gem "webpacker"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+gem "jbuilder", "~> 2.5"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
@@ -83,45 +83,45 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
-gem 'spreadsheet'
+gem "bootsnap", ">= 1.1.0", require: false
+gem "spreadsheet"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'brakeman', require: false
-  gem 'rubocop', require: false
-  gem 'rspec-rails', '>= 4.0.0.beta'
-  gem 'rspec_junit_formatter', require: false
-  gem 'rails-controller-testing'
-  gem 'factory_bot'
-  gem 'meta_request', '~> 0.7'
-  gem 'bullet'
-  gem 'faker'
-  gem 'parallel_tests'
+  gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "brakeman", require: false
+  gem "rubocop", require: false
+  gem "rspec-rails", ">= 4.0.0.beta"
+  gem "rspec_junit_formatter", require: false
+  gem "rails-controller-testing"
+  gem "factory_bot"
+  gem "meta_request", "~> 0.7"
+  gem "bullet"
+  gem "faker"
+  gem "parallel_tests"
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem "web-console", ">= 3.3.0"
+  gem "listen", ">= 3.0.5", "< 3.2"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-commands-rspec'
-  gem 'guard-rspec', require: false
-  gem 'guard-spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'letter_opener', '~> 1.7'
-  gem 'fuubar'
-  gem 'better_errors'
-  gem 'binding_of_caller'
+  gem "spring"
+  gem "spring-commands-rspec"
+  gem "guard-rspec", require: false
+  gem "guard-spring"
+  gem "spring-watcher-listen", "~> 2.0.0"
+  gem "letter_opener", "~> 1.7"
+  gem "fuubar"
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :test do
-  gem 'capybara', '>= 2.15'
-  gem 'capybara-selenium'
-  gem 'capybara-email'
-  gem 'capybara-screenshot'
-  gem 'webdrivers', '~> 4.0'
-  gem 'database_cleaner'
+  gem "capybara", ">= 2.15"
+  gem "capybara-selenium"
+  gem "capybara-email"
+  gem "capybara-screenshot"
+  gem "webdrivers", "~> 4.0"
+  gem "database_cleaner"
 end

--- a/Guardfile
+++ b/Guardfile
@@ -69,8 +69,8 @@ guard :rspec, cmd: "bin/rspec" do
   end
 end
 
-guard 'spring', bundler: true do
-  watch('Gemfile.lock')
+guard "spring", bundler: true do
+  watch("Gemfile.lock")
   watch(%r{^config/})
   watch(%r{^spec/(support|factories)/})
   watch(%r{^spec/factory.rb})

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -37,7 +37,7 @@ module Admin
       requested_resource.invite!
       redirect_to(
         [namespace, requested_resource],
-        notice: 'Invitation envoyée'
+        notice: "Invitation envoyée"
       )
     end
   end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -38,7 +38,7 @@ module Admin
     end
 
     def sign_in_as_allowed?
-      ENV.fetch('SIGN_IN_AS_ALLOWED') { false }
+      ENV.fetch("SIGN_IN_AS_ALLOWED") { false }
     end
 
     # Override this value to specify the number of elements to display at a time

--- a/app/controllers/admin/mailer_previews_controller.rb
+++ b/app/controllers/admin/mailer_previews_controller.rb
@@ -35,7 +35,7 @@ module Admin
         render action: "email"
       end
     rescue ActiveRecord::RecordNotFound
-      render plain: 'could not find preview AR instance'
+      render plain: "could not find preview AR instance"
     end
 
     private

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -1,7 +1,7 @@
 class AgentAuthController < ApplicationController
   rescue_from Pundit::NotAuthorizedError, with: :agent_not_authorized
 
-  layout 'application_agent'
+  layout "application_agent"
   before_action :authenticate_agent!
   before_action :set_paper_trail_whodunnit
 

--- a/app/controllers/agents/lieux_controller.rb
+++ b/app/controllers/agents/lieux_controller.rb
@@ -2,7 +2,7 @@ class Agents::LieuxController < AgentAuthController
   respond_to :html, :json
 
   def index
-    @lieux = policy_scope(Lieu).includes(:organisation).order(Arel.sql('LOWER(name)')).page(params[:page])
+    @lieux = policy_scope(Lieu).includes(:organisation).order(Arel.sql("LOWER(name)")).page(params[:page])
   end
 
   def new
@@ -28,14 +28,14 @@ class Agents::LieuxController < AgentAuthController
   def update
     @lieu = Lieu.find(params[:id])
     authorize(@lieu)
-    flash[:notice] = 'Lieu a été modifié.' if @lieu.update(lieu_params)
+    flash[:notice] = "Lieu a été modifié." if @lieu.update(lieu_params)
     respond_right_bar_with @lieu, location: organisation_lieux_path(@lieu.organisation)
   end
 
   def destroy
     @lieu = Lieu.find(params[:id])
     authorize(@lieu)
-    flash[:notice] = 'Le lieu a été supprimé.' if @lieu.destroy
+    flash[:notice] = "Le lieu a été supprimé." if @lieu.destroy
     respond_right_bar_with @lieu, location: organisation_lieux_path(@lieu.organisation)
   end
 

--- a/app/controllers/agents/motifs_controller.rb
+++ b/app/controllers/agents/motifs_controller.rb
@@ -5,7 +5,7 @@ class Agents::MotifsController < AgentAuthController
   before_action :set_motif, only: [:show, :edit, :update, :destroy]
 
   def index
-    @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).order(Arel.sql('LOWER(name)')).page(params[:page])
+    @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).order(Arel.sql("LOWER(name)")).page(params[:page])
   end
 
   def new

--- a/app/controllers/agents/organisations_controller.rb
+++ b/app/controllers/agents/organisations_controller.rb
@@ -10,7 +10,7 @@ class Agents::OrganisationsController < AgentAuthController
       if policy_scope(Organisation).count == 1
 
     @organisations_by_departement = policy_scope(Organisation).group_by(&:departement)
-    render layout: 'registration'
+    render layout: "registration"
   end
 
   def show

--- a/app/controllers/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/agents/plage_ouvertures_controller.rb
@@ -14,9 +14,9 @@ class Agents::PlageOuverturesController < AgentAuthController
       f.html do
         @current_tab = filter_params[:current_tab]
         @plage_ouvertures = plage_ouvertures
-          .where(expired_cached: filter_params[:current_tab] == 'expired')
+          .where(expired_cached: filter_params[:current_tab] == "expired")
           .page(filter_params[:page])
-        @display_tabs = plage_ouvertures.where(expired_cached: true).any? || params[:current_tab] == 'expired'
+        @display_tabs = plage_ouvertures.where(expired_cached: true).any? || params[:current_tab] == "expired"
       end
     end
   end

--- a/app/controllers/agents/rdvs_controller.rb
+++ b/app/controllers/agents/rdvs_controller.rb
@@ -25,11 +25,11 @@ class Agents::RdvsController < AgentAuthController
     # TODO: replace this manual touch. It forces creating a version when an
     # agent or a user is removed from the RDV. the touch: true option on the
     # association does not do it for some reason I could not figure out
-    if params[:status] == 'excused'
+    if params[:status] == "excused"
       CancelRdvByAgentService.new(@rdv).perform
-      flash[:notice] = 'Le rendez-vous a été annulé.'
+      flash[:notice] = "Le rendez-vous a été annulé."
     elsif @rdv.update(rdv_params)
-      flash[:notice] = 'Le rendez-vous a été modifié.'
+      flash[:notice] = "Le rendez-vous a été modifié."
     end
     respond_right_bar_with @rdv, location: request.referer
   end
@@ -37,7 +37,7 @@ class Agents::RdvsController < AgentAuthController
   def status
     # TODO: remove this route and use #update
     authorize(@rdv)
-    cancelled_at = ['unknown', 'waiting', 'seen'].include?(status_params[:status]) ? nil : Time.zone.now
+    cancelled_at = ["unknown", "waiting", "seen"].include?(status_params[:status]) ? nil : Time.zone.now
     @rdv.update(status: status_params[:status], cancelled_at: cancelled_at)
     @rdv.file_attentes.delete_all
     flash[:notice] = "Le statut du RDV a été modifié"
@@ -63,7 +63,7 @@ class Agents::RdvsController < AgentAuthController
       redirect_to @rdv.agenda_path_for_agent(current_agent), notice: "Le rendez-vous a été créé."
     else
       @rdv_wizard = AgentRdvWizard::Step3.new(current_agent, current_organisation, @rdv.attributes)
-      render 'agents/rdv_wizard_steps/step3'
+      render "agents/rdv_wizard_steps/step3"
     end
   end
 

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -130,7 +130,7 @@ class Agents::UsersController < AgentAuthController
   def filter_users
     @users = @users.search_by_text(params[:user][:search])
     respond_to do |format|
-      format.js { render partial: 'search-results' }
+      format.js { render partial: "search-results" }
       format.html
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
   end
 
   def demo?
-    ENV['HOST']&.match(/demo/)
+    ENV["HOST"]&.match(/demo/)
   end
   helper_method :demo?
 
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
     user = current_agent || current_user
     {
       id: user&.id,
-      role: user&.class&.name || 'Guest',
+      role: user&.class&.name || "Guest",
       email: user&.email,
     }.compact
   end
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::Base
 
     # cf https://stackoverflow.com/questions/7785793/add-parameter-to-url
     parsed_uri = URI.parse(url)
-    parsed_query_string = URI.decode_www_form(parsed_uri.query || '')
+    parsed_query_string = URI.decode_www_form(parsed_uri.query || "")
     new_params.each { |k, v| parsed_query_string.append([k, v]) }
     parsed_uri.query = URI.encode_www_form(parsed_query_string)
     parsed_uri.to_s

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -16,7 +16,7 @@ class LieuxController < ApplicationController
     return unless @organisations.empty?
 
     flash.now[:notice] = "La prise de RDV n’est pas encore disponible dans ce département"
-    render 'welcome/index'
+    render "welcome/index"
   end
 
   def show
@@ -38,7 +38,7 @@ class LieuxController < ApplicationController
       @next_availability = FindAvailabilityService.perform_with(@motif_name, @lieu, @date_range.end, **options_to_build_creneaux) if @creneaux.empty?
     end
 
-    @max_booking_delay = @matching_motifs.maximum('max_booking_delay')
+    @max_booking_delay = @matching_motifs.maximum("max_booking_delay")
 
     respond_to do |format|
       format.html

--- a/app/controllers/modal_responder.rb
+++ b/app/controllers/modal_responder.rb
@@ -1,6 +1,6 @@
 class ModalResponder < ActionController::Responder
   cattr_accessor :modal_layout
-  self.modal_layout = 'modal'
+  self.modal_layout = "modal"
 
   def render(*args)
     options = args.extract_options!

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,5 +1,5 @@
 class OrganisationsController < ApplicationController
-  layout 'application'
+  layout "application"
 
   def new
     @organisation = Organisation.new

--- a/app/controllers/right_bar_responder.rb
+++ b/app/controllers/right_bar_responder.rb
@@ -1,6 +1,6 @@
 class RightBarResponder < ActionController::Responder
   cattr_accessor :right_bar_layout
-  self.right_bar_layout = 'right_bar'
+  self.right_bar_layout = "right_bar"
 
   def render(*args)
     options = args.extract_options!

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -23,7 +23,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def user_devise_layout
-    user_signed_in? ? 'application' : 'registration'
+    user_signed_in? ? "application" : "registration"
   end
 
   def after_inactive_sign_up_path_for(_)

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -16,7 +16,7 @@ class UserDashboard < Administrate::BaseDashboard
     email: Field::String,
     address: Field::String,
     phone_number: Field::String,
-    responsible: Field::BelongsToSearch.with_options(class_name: 'User'),
+    responsible: Field::BelongsToSearch.with_options(class_name: "User"),
     relatives: Field::HasMany.with_options(class_name: "User"),
     caisse_affiliation: EnumField,
     family_situation: EnumField,

--- a/app/form_models/zone_import_form.rb
+++ b/app/form_models/zone_import_form.rb
@@ -6,8 +6,8 @@ class ZoneImportForm
   validates :zones_file, presence: true
 
   def initialize(attributes = {})
-    attributes[:dry_run] = attributes[:dry_run] == '1' if attributes.key?(:dry_run)
-    attributes[:override_conflicts] = attributes[:override_conflicts] == '1' if attributes.key?(:override_conflicts)
+    attributes[:dry_run] = attributes[:dry_run] == "1" if attributes.key?(:dry_run)
+    attributes[:override_conflicts] = attributes[:override_conflicts] == "1" if attributes.key?(:override_conflicts)
     super(attributes)
   end
 

--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -1,9 +1,9 @@
 module AbsencesHelper
   def absence_tag(absence)
     if absence.in_progress?
-      content_tag(:span, 'En cours', class: 'badge badge-info')
+      content_tag(:span, "En cours", class: "badge badge-info")
     elsif absence.starts_at.past?
-      content_tag(:span, 'Passée', class: 'badge badge-light')
+      content_tag(:span, "Passée", class: "badge badge-light")
     end
   end
 end

--- a/app/helpers/agent_user_form_helper.rb
+++ b/app/helpers/agent_user_form_helper.rb
@@ -22,12 +22,12 @@ module AgentUserFormHelper
       relative: {
         "data-togglable": true,
         "data-responsability-type": "relative",
-        "class": ('d-none' if user.responsability_type != :relative)
+        "class": ("d-none" if user.responsability_type != :relative)
       },
       responsible: {
         "data-togglable": true,
         "data-responsability-type": "responsible",
-        "class": ('d-none' if user.responsability_type != :responsible)
+        "class": ("d-none" if user.responsability_type != :responsible)
       },
     }
   end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -4,15 +4,15 @@ module AgentsHelper
   end
 
   def me_tag(agent)
-    content_tag(:span, 'Vous', class: 'badge badge-info') if current_agent?(agent)
+    content_tag(:span, "Vous", class: "badge badge-info") if current_agent?(agent)
   end
 
   def admin_tag(agent)
-    content_tag(:span, 'Admin', class: 'badge badge-danger') if agent.admin?
+    content_tag(:span, "Admin", class: "badge badge-danger") if agent.admin?
   end
 
   def delete_dropdown_link(agent)
-    link_to 'Supprimer', organisation_agent_path(current_organisation, agent), data: { confirm: "Êtes-vous sûr de vouloir supprimer cet agent ?" }, method: :delete, class: 'dropdown-item' if policy([:agent, agent]).destroy?
+    link_to "Supprimer", organisation_agent_path(current_organisation, agent), data: { confirm: "Êtes-vous sûr de vouloir supprimer cet agent ?" }, method: :delete, class: "dropdown-item" if policy([:agent, agent]).destroy?
   end
 
   def build_link_to_rdv_wizard_params(creneau, user_ids)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,13 +13,13 @@ module ApplicationHelper
   def alert_class_for(alert)
     case alert
     when :success
-      'alert-success'
+      "alert-success"
     when :alert
-      'alert-warning'
+      "alert-warning"
     when :error
-      'alert-danger'
+      "alert-danger"
     when :notice
-      'alert-info'
+      "alert-info"
     else
       alert.to_s
     end
@@ -30,7 +30,7 @@ module ApplicationHelper
   end
 
   def datetime_input(form, field)
-    form.input(field, as: :string, input_html: { value: form.object.send(field)&.strftime("%d/%m/%Y %H:%M"), data: { behaviour: 'datetimepicker' }, autocomplete: "off" })
+    form.input(field, as: :string, input_html: { value: form.object.send(field)&.strftime("%d/%m/%Y %H:%M"), data: { behaviour: "datetimepicker" }, autocomplete: "off" })
   end
 
   def date_input(form, field, label = nil, input_html: {}, **kwargs)
@@ -40,7 +40,7 @@ module ApplicationHelper
       label: label,
       input_html: {
         value: form.object&.send(field)&.strftime("%d/%m/%Y"),
-        data: { behaviour: 'datepicker' },
+        data: { behaviour: "datepicker" },
         autocomplete: "off",
       }.deep_merge(input_html),
       **kwargs
@@ -48,21 +48,21 @@ module ApplicationHelper
   end
 
   def time_input(form, field)
-    form.input(field, as: :string, input_html: { value: form.object.send(field)&.strftime("%H:%M"), data: { behaviour: 'timepicker' }, autocomplete: "off" })
+    form.input(field, as: :string, input_html: { value: form.object.send(field)&.strftime("%H:%M"), data: { behaviour: "timepicker" }, autocomplete: "off" })
   end
 
   def add_button(label, path, header: false)
     link_to label, path, class: "btn #{header ? "btn-outline-white" : "btn-primary"}", data: { rightbar: true }
   end
 
-  def holder_tag(size, text = '', theme = nil, html_options = {}, holder_options = {})
+  def holder_tag(size, text = "", theme = nil, html_options = {}, holder_options = {})
     size = "#{size}x#{size}" unless size =~ /\A\d+p?x\d+\z/
 
     holder_options[:text] = text unless text.to_s.empty?
     holder_options[:theme] = theme unless theme.nil?
-    holder_options = holder_options.map { |e| e.join('=') }.join('&')
+    holder_options = holder_options.map { |e| e.join("=") }.join("&")
 
-    options = { src: '', data: { src: "holder.js/#{size}?#{holder_options}" } }
+    options = { src: "", data: { src: "holder.js/#{size}?#{holder_options}" } }
     options = options.merge(html_options)
 
     tag :img, options
@@ -73,25 +73,25 @@ module ApplicationHelper
   end
 
   def agents_or_users_body_class
-    agent_path? ? 'agents' : 'users'
+    agent_path? ? "agents" : "users"
   end
 
   def link_logo
     link_to root_path do
-      image_pack_tag 'logos/logo.svg', height: 40, alt: 'RDV Solidarités', class: 'd-inline logo'
+      image_pack_tag "logos/logo.svg", height: 40, alt: "RDV Solidarités", class: "d-inline logo"
     end
   end
 
   def map_tag_marker(title)
-    icon_tag_tooltip(title, 'map-marker-alt')
+    icon_tag_tooltip(title, "map-marker-alt")
   end
 
   def question_tag_tooltip(title)
-    icon_tag_tooltip(title, 'question-circle')
+    icon_tag_tooltip(title, "question-circle")
   end
 
   def icon_tag_tooltip(title, icon)
-    content_tag(:i, nil, class: "fa fa-#{icon}", data: { toggle: 'tooltip' }, title: title)
+    content_tag(:i, nil, class: "fa fa-#{icon}", data: { toggle: "tooltip" }, title: title)
   end
 
   def display_notes(notes)

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,6 +1,6 @@
 module DeviseHelper
   def devise_error_messages!
-    return '' if resource.errors.empty?
+    return "" if resource.errors.empty?
 
     messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
     html = <<-HTML

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -80,6 +80,6 @@ module PlageOuverturesHelper
   end
 
   def po_exceptionnelle_tag(plage_ouverture)
-    content_tag(:span, 'Exceptionnelle', class: 'badge badge-info') if plage_ouverture.exceptionnelle?
+    content_tag(:span, "Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
   end
 end

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -41,7 +41,7 @@ module RdvsHelper
   end
 
   def rdv_status_tag(rdv)
-    content_tag(:span, Rdv.human_enum_name(:status, rdv.status), class: 'badge badge-info')
+    content_tag(:span, Rdv.human_enum_name(:status, rdv.status), class: "badge badge-info")
   end
 
   def no_rdv_for_users
@@ -58,21 +58,21 @@ module RdvsHelper
 
   def rdv_tag(rdv)
     if rdv.cancelled_at
-      content_tag(:span, 'Annulé', class: 'badge badge-warning')
+      content_tag(:span, "Annulé", class: "badge badge-warning")
     elsif rdv.starts_at.future?
-      content_tag(:span, 'À venir', class: 'badge badge-info')
+      content_tag(:span, "À venir", class: "badge badge-info")
     end
   end
 
   def stats_rdv_path(status)
     case controller_name
-    when 'stats'
+    when "stats"
       if params[:agent_id].present?
         organisation_agent_rdvs_path(current_organisation, params[:agent_id], status: status, default_period: true)
       else
         organisation_rdvs_path(current_organisation, status: status, default_period: true)
       end
-    when 'users', 'relatives'
+    when "users", "relatives"
       organisation_user_rdvs_path(current_organisation, params[:id], status: status)
     end
   end
@@ -82,25 +82,25 @@ module RdvsHelper
   end
 
   def unknown_past_rdvs_danger_bage
-    unknown_past_rdvs = current_organisation.rdvs.status('unknown_past').where(created_at: Stat::DEFAULT_RANGE).count
+    unknown_past_rdvs = current_organisation.rdvs.status("unknown_past").where(created_at: Stat::DEFAULT_RANGE).count
     rdv_danger_badge(unknown_past_rdvs)
   end
 
   def unknown_past_agent_rdvs_danger_bage
-    unknown_past_rdvs = current_organisation.rdvs.joins(:agents).where(agents: { id: current_agent }).status('unknown_past').where(created_at: Stat::DEFAULT_RANGE).count
+    unknown_past_rdvs = current_organisation.rdvs.joins(:agents).where(agents: { id: current_agent }).status("unknown_past").where(created_at: Stat::DEFAULT_RANGE).count
     rdv_danger_badge(unknown_past_rdvs)
   end
 
   def rdv_danger_badge(count)
-    content_tag(:span, count, class: 'badge badge-danger') if count.positive?
+    content_tag(:span, count, class: "badge badge-danger") if count.positive?
   end
 
   def rdv_danger_icon(count)
     content_tag(:i, nil, class: "fa fa-exclamation-circle text-danger") if count.positive? && !stats_path?
   end
 
-  def link_to_rdvs(status, clasz: 'btn-outline-white')
-    link_to 'Voir', stats_rdv_path(status), class: "btn #{clasz}" unless stats_path?
+  def link_to_rdvs(status, clasz: "btn-outline-white")
+    link_to "Voir", stats_rdv_path(status), class: "btn #{clasz}" unless stats_path?
   end
 
   def rdv_status_value(status)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -6,7 +6,7 @@ module UsersHelper
   end
 
   def relative_tag(user)
-    user.relative? ? content_tag(:span, 'Proche', class: 'badge badge-info') : nil
+    user.relative? ? content_tag(:span, "Proche", class: "badge badge-info") : nil
   end
 
   def full_name_and_birthdate(user)

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -6,19 +6,19 @@ module WelcomeHelper
   end
 
   def sign_up_agent_button
-    link_to 'Je m\'inscris', new_agent_registration_path, class: 'btn btn-primary'
+    link_to "Je m'inscris", new_agent_registration_path, class: "btn btn-primary"
   end
 
   def sign_in_agent_button
-    link_to "Se connecter en tant qu'agent", new_agent_session_path, class: 'btn btn-outline-white'
+    link_to "Se connecter en tant qu'agent", new_agent_session_path, class: "btn btn-outline-white"
   end
 
   def sign_in_user_button
-    link_to 'Se connecter', new_user_session_path, class: 'btn btn-white'
+    link_to "Se connecter", new_user_session_path, class: "btn btn-white"
   end
 
   def contact_us_button
-    mail_to "contact@rdv-solidarites.fr", "Contactez-nous", class: 'btn btn-tertiary'
+    mail_to "contact@rdv-solidarites.fr", "Contactez-nous", class: "btn btn-tertiary"
   end
 
   def urgency_quote
@@ -29,25 +29,25 @@ module WelcomeHelper
     return nil unless urgency_number_raw.present?
 
     human, raw = urgency_number_raw
-    link_to human, "tel:#{raw}", class: 'urgency-number'
+    link_to human, "tel:#{raw}", class: "urgency-number"
   end
 
   def urgency_number_raw
     {
-      '14' => ['02 31 57 14 14', "+33231571414"],
-      '22' => ['02.96.60.86.86', "+33296608686"],
-      '55' => ['03.29.80.32.34', "+33329803234"],
-      '64' => ['05.59.69.34.11', "+33559693411"],
-      '77' => ['01.64.14.77.77', "+33164147777"],
-      '78' => ['01 30 836 836', "+33130836836"],
-      '80' => ['03.22.71.80.80', "+33322718080"],
-      '92' => ['01.55.48.03.30', "+33155480330"],
-      '95' => ['01 34 25 30 30', "+33134253030"]
+      "14" => ["02 31 57 14 14", "+33231571414"],
+      "22" => ["02.96.60.86.86", "+33296608686"],
+      "55" => ["03.29.80.32.34", "+33329803234"],
+      "64" => ["05.59.69.34.11", "+33559693411"],
+      "77" => ["01.64.14.77.77", "+33164147777"],
+      "78" => ["01 30 836 836", "+33130836836"],
+      "80" => ["03.22.71.80.80", "+33322718080"],
+      "92" => ["01.55.48.03.30", "+33155480330"],
+      "95" => ["01 34 25 30 30", "+33134253030"]
     }[departement_params]
   end
 
   def departement_params
-    (controller_name == 'welcome' && params[:departement]) || (params[:search] && params[:search][:departement])
+    (controller_name == "welcome" && params[:departement]) || (params[:search] && params[:search][:departement])
   end
 
   def sectorisation_hint(zone, organisations, departement)

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -7,8 +7,8 @@ class WebhookJob < ApplicationJob
     Typhoeus.post(
       webhook_endpoint.target_url,
       headers: {
-        'Content-Type' => 'application/json; charset=utf-8',
-        'X-Lapin-Signature' => OpenSSL::HMAC.hexdigest("SHA256", webhook_endpoint.secret, payload),
+        "Content-Type" => "application/json; charset=utf-8",
+        "X-Lapin-Signature" => OpenSSL::HMAC.hexdigest("SHA256", webhook_endpoint.secret, payload),
       },
       body: payload,
       timeout: TIMEOUT

--- a/app/lib/csv_or_xls_reader.rb
+++ b/app/lib/csv_or_xls_reader.rb
@@ -1,10 +1,10 @@
-require 'csv'
+require "csv"
 
 module CsvOrXlsReader
   class Importer
     def initialize(form_file)
       @form_file = form_file
-      @extension = File.extname(@form_file.original_filename)&.tr('.', '')&.downcase&.to_sym
+      @extension = File.extname(@form_file.original_filename)&.tr(".", "")&.downcase&.to_sym
 
       if @extension == :csv
         extend CsvImporter

--- a/app/lib/sectorisation_utils.rb
+++ b/app/lib/sectorisation_utils.rb
@@ -1,5 +1,5 @@
 module SectorisationUtils
   def sectorisation_enabled?(departement)
-    ENV['SECTORISATION_ENABLED_DEPARTMENT_LIST']&.split&.include?(departement)
+    ENV["SECTORISATION_ENABLED_DEPARTMENT_LIST"]&.split&.include?(departement)
   end
 end

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -3,12 +3,12 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
     @plage_ouverture = plage_ouverture
     ics = PlageOuverture::Ics.new(plage_ouverture: @plage_ouverture)
     attachments["invite.ics"] = {
-      mime_type: 'application/ics',
+      mime_type: "application/ics",
       content: Base64.encode64(ics.to_ical),
       encoding: "base64", # seems necessary for attachments
     }
     m = mail(
-      from: 'secretariat-auto@rdv-solidarites.fr',
+      from: "secretariat-auto@rdv-solidarites.fr",
       to: plage_ouverture.agent.email,
       subject: "#{BRAND} #{plage_ouverture.title} - Plage d'ouverture"
     )

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'contact@rdv-solidarites.fr'
-  append_view_path Rails.root.join('app', 'views', 'mailers')
-  layout 'mailer'
+  default from: "contact@rdv-solidarites.fr"
+  append_view_path Rails.root.join("app", "views", "mailers")
+  layout "mailer"
 end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -7,7 +7,7 @@ class Users::RdvMailer < ApplicationMailer
     @user = user
     ics = Rdv::Ics.new(rdv: @rdv)
     attachments[ics.name] = {
-      mime_type: 'text/calendar',
+      mime_type: "text/calendar",
       content: ics.to_ical_for(user),
       encoding: "8bit", # fixes encoding issues in ICS
     }

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -26,8 +26,8 @@ class Agent < ApplicationRecord
 
   scope :complete, -> { where.not(first_name: nil).where.not(last_name: nil) }
   scope :active, -> { where(deleted_at: nil) }
-  scope :order_by_last_name, -> { order(Arel.sql('LOWER(last_name)')) }
-  scope :secretariat, -> { joins(:service).where(services: { name: 'Secrétariat'.freeze }) }
+  scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
+  scope :secretariat, -> { joins(:service).where(services: { name: "Secrétariat".freeze }) }
   scope :can_perform_motif, lambda { |motif|
     motif.for_secretariat ? joins(:service).where(service: motif.service).or(secretariat) : where(service: motif.service)
   }
@@ -43,7 +43,7 @@ class Agent < ApplicationRecord
   end
 
   def from_safe_domain?
-    return false if ENV['SAFE_DOMAIN_LIST'].blank?
+    return false if ENV["SAFE_DOMAIN_LIST"].blank?
 
     pattern = "@(#{ENV['SAFE_DOMAIN_LIST'].split&.join('|')})$"
     regex = Regexp.new(pattern)
@@ -69,7 +69,7 @@ class Agent < ApplicationRecord
   end
 
   def add_organisation(organisation)
-    errors.add(:email, 'existe déjà dans cette organisation') && return if organisation_ids.include?(organisation.id)
+    errors.add(:email, "existe déjà dans cette organisation") && return if organisation_ids.include?(organisation.id)
     organisations << organisation
   end
 end

--- a/app/models/concerns/account_normalizer_concern.rb
+++ b/app/models/concerns/account_normalizer_concern.rb
@@ -3,7 +3,7 @@ module AccountNormalizerConcern
 
   def normalize_account
     email&.downcase!
-    self.first_name = first_name.split('-').map(&:capitalize).join('-') if first_name
+    self.first_name = first_name.split("-").map(&:capitalize).join("-") if first_name
     last_name&.upcase!
     birth_name&.upcase! if defined?(birth_name)
   end

--- a/app/models/concerns/user/searchable_concern.rb
+++ b/app/models/concerns/user/searchable_concern.rb
@@ -11,7 +11,7 @@ module User::SearchableConcern
           {
             using: { tsearch: { prefix: true } },
             against: [:phone_number_formatted],
-            query: query.sub(/^0/, '+33').gsub(/\s/, '')
+            query: query.sub(/^0/, "+33").gsub(/\s/, "")
           }
         else
           {

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -6,7 +6,7 @@ class FileAttente < ApplicationRecord
   NO_MORE_NOTIFICATIONS = 7.days
   MAX_NOTIFICATIONS = 3
 
-  scope :active, -> { joins(:rdv).where('rdvs.starts_at > ?', NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
+  scope :active, -> { joins(:rdv).where("rdvs.starts_at > ?", NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
 
   def self.send_notifications
     FileAttente.active.each do |fa|

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -22,7 +22,7 @@ class Motif < ApplicationRecord
   scope :for_secretariat, -> { where(for_secretariat: true) }
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
     available_motifs = agent.service.secretariat? ? for_secretariat : where(service: agent.service)
-    available_motifs.where(organisation_id: organisation.id).active.order(Arel.sql('LOWER(name)'))
+    available_motifs.where(organisation_id: organisation.id).active.order(Arel.sql("LOWER(name)"))
   }
 
   def self.searchable(organisations, service: nil)

--- a/app/models/motif_libelle.rb
+++ b/app/models/motif_libelle.rb
@@ -3,5 +3,5 @@ class MotifLibelle < ApplicationRecord
 
   default_scope { order("LOWER(name)") }
 
-  VISITE_PROCHE = 'Visite d\'un proche'.freeze
+  VISITE_PROCHE = "Visite d'un proche".freeze
 end

--- a/app/models/plage_ouverture/ics.rb
+++ b/app/models/plage_ouverture/ics.rb
@@ -6,8 +6,8 @@ class PlageOuverture::Ics
   TZID = "Europe/Paris".freeze
 
   def to_ical
-    require 'icalendar'
-    require 'icalendar/tzinfo'
+    require "icalendar"
+    require "icalendar/tzinfo"
 
     cal = Icalendar::Calendar.new
 
@@ -18,8 +18,8 @@ class PlageOuverture::Ics
 
     cal.event do |e|
       e.uid         = plage_ouverture.ical_uid
-      e.dtstart     = Icalendar::Values::DateTime.new(plage_ouverture.starts_at, 'tzid' => TZID)
-      e.dtend       = Icalendar::Values::DateTime.new(plage_ouverture.ends_at, 'tzid' => TZID)
+      e.dtstart     = Icalendar::Values::DateTime.new(plage_ouverture.starts_at, "tzid" => TZID)
+      e.dtend       = Icalendar::Values::DateTime.new(plage_ouverture.ends_at, "tzid" => TZID)
       e.summary     = "#{BRAND} #{plage_ouverture.title}"
       e.description = ""
       e.location    = plage_ouverture.lieu.address
@@ -71,7 +71,7 @@ class PlageOuverture::Ics
     if on.is_a?(String)
       on[0, 2].upcase
     else
-      on.map { |d| d[0, 2].upcase }.join(',')
+      on.map { |d| d[0, 2].upcase }.join(",")
     end
   end
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -24,16 +24,16 @@ class Rdv < ApplicationRecord
   validates :lieu, presence: true, if: :public_office?
 
   scope :active, -> { where(cancelled_at: nil) }
-  scope :past, -> { where('starts_at < ?', Time.zone.now) }
-  scope :future, -> { where('starts_at > ?', Time.zone.now) }
+  scope :past, -> { where("starts_at < ?", Time.zone.now) }
+  scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :tomorrow, -> { where(starts_at: DateTime.tomorrow...DateTime.tomorrow + 1.day) }
   scope :day_after_tomorrow, -> { where(starts_at: DateTime.tomorrow + 1.day...DateTime.tomorrow + 2.day) }
-  scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where('users.id IN (?)', [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten) }
+  scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where("users.id IN (?)", [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten) }
   scope :status, lambda { |status|
-    if status == 'unknown_past'
-      past.where(status: ['unknown', 'waiting'])
-    elsif status == 'unknown_future'
-      future.where(status: ['unknown', 'waiting'])
+    if status == "unknown_past"
+      past.where(status: ["unknown", "waiting"])
+    elsif status == "unknown_future"
+      future.where(status: ["unknown", "waiting"])
     else
       where(status: status)
     end
@@ -155,6 +155,6 @@ class Rdv < ApplicationRecord
 
   def reload_uuid
     # https://github.com/rails/rails/issues/17605
-    self[:uuid] = self.class.where(id: id).pluck(:uuid).first if attributes.key? 'uuid'
+    self[:uuid] = self.class.where(id: id).pluck(:uuid).first if attributes.key? "uuid"
   end
 end

--- a/app/models/rdv/ics.rb
+++ b/app/models/rdv/ics.rb
@@ -7,8 +7,8 @@ class Rdv::Ics
   validates :rdv, presence: true
 
   def to_ical_for(user)
-    require 'icalendar'
-    require 'icalendar/tzinfo'
+    require "icalendar"
+    require "icalendar/tzinfo"
 
     cal = Icalendar::Calendar.new
 
@@ -19,8 +19,8 @@ class Rdv::Ics
     cal.prodid = BRAND
 
     cal.event do |e|
-      e.dtstart     = Icalendar::Values::DateTime.new(rdv.starts_at, 'tzid' => tzid)
-      e.dtend       = Icalendar::Values::DateTime.new(rdv.ends_at, 'tzid' => tzid)
+      e.dtstart     = Icalendar::Values::DateTime.new(rdv.starts_at, "tzid" => tzid)
+      e.dtend       = Icalendar::Values::DateTime.new(rdv.ends_at, "tzid" => tzid)
       e.summary     = "RDV #{rdv_title_for_user(rdv, user)}"
       e.description = description
       e.location    = rdv.address unless rdv.motif.phone?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -3,8 +3,8 @@ class Service < ApplicationRecord
   has_many :motifs, dependent: :destroy
   has_many :motif_libelles, dependent: :destroy
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
-  SECRETARIAT = 'Secrétariat'.freeze
-  SERVICE_SOCIAL = 'Service social'.freeze
+  SECRETARIAT = "Secrétariat".freeze
+  SERVICE_SOCIAL = "Service social".freeze
 
   scope :with_motifs, -> { where.not(name: SECRETARIAT) }
   scope :secretariat, -> { where(name: SECRETARIAT).first }

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -2,8 +2,8 @@ class Stat
   include ActiveModel::Model
   attr_accessor :agents, :organisations, :users, :rdvs
 
-  DEFAULT_RANGE = (Date.strptime('01/02/2020', '%d/%m/%Y').beginning_of_day..Time.zone.now.end_of_day).freeze
-  DEFAULT_FORMAT = '%d/%m/%Y'.freeze
+  DEFAULT_RANGE = (Date.strptime("01/02/2020", "%d/%m/%Y").beginning_of_day..Time.zone.now.end_of_day).freeze
+  DEFAULT_FORMAT = "%d/%m/%Y".freeze
 
   def rdvs_for_default_range
     rdvs.where(created_at: DEFAULT_RANGE)
@@ -14,7 +14,7 @@ class Stat
   end
 
   def users_group_by_week
-    users.active.group_by_week('users.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
+    users.active.group_by_week("users.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
   end
 
   def organisations_for_default_range
@@ -22,7 +22,7 @@ class Stat
   end
 
   def organisations_group_by_week
-    organisations.group_by_week('organisations.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
+    organisations.group_by_week("organisations.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
   end
 
   def agents_for_default_range
@@ -30,23 +30,23 @@ class Stat
   end
 
   def agents_group_by_week
-    agents.active.group_by_week('agents.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
+    agents.active.group_by_week("agents.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
   end
 
   def rdvs_group_by_week
-    rdvs.group(:created_by).group_by_week('rdvs.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
+    rdvs.group(:created_by).group_by_week("rdvs.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
   end
 
   def rdvs_group_by_type
-    rdvs.joins(:motif).group('motifs.location_type').group_by_week('rdvs.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count.transform_keys { |key| [I18n.t(Motif.location_types.invert[key[0]]), key[1]] }
+    rdvs.joins(:motif).group("motifs.location_type").group_by_week("rdvs.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count.transform_keys { |key| [I18n.t(Motif.location_types.invert[key[0]]), key[1]] }
   end
 
   def rdvs_group_by_departement
-    rdvs.joins(:organisation).group('organisations.departement').group_by_week('rdvs.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
+    rdvs.joins(:organisation).group("organisations.departement").group_by_week("rdvs.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
   end
 
   def rdvs_group_by_service
-    rdvs.joins(motif: :service).group('services.name').group_by_week('rdvs.created_at', range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
+    rdvs.joins(motif: :service).group("services.name").group_by_week("rdvs.created_at", range: DEFAULT_RANGE, format: DEFAULT_FORMAT).count
   end
 
   def rdvs_group_by_week_fr

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :user_profiles
 
   scope :active, -> { where(deleted_at: nil) }
-  scope :order_by_last_name, -> { order(Arel.sql('LOWER(last_name)')) }
+  scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
   scope :responsible, -> { where(responsible_id: nil) }
 
   after_commit :send_invite_if_checked, on: :create
@@ -83,7 +83,7 @@ class User < ApplicationRecord
   end
 
   def available_users_for_rdv
-    User.where(responsible_id: id).or(User.where(id: id)).order('responsible_id DESC NULLS FIRST', first_name: :asc).active
+    User.where(responsible_id: id).or(User.where(id: id)).order("responsible_id DESC NULLS FIRST", first_name: :asc).active
   end
 
   def family

--- a/app/presenters/paper_trail_augmented_version.rb
+++ b/app/presenters/paper_trail_augmented_version.rb
@@ -19,7 +19,7 @@ class PaperTrailAugmentedVersion
 
   def changes
     @changes ||= begin
-      c = @version.changeset.except('updated_at').to_h.merge(virtual_changes)
+      c = @version.changeset.except("updated_at").to_h.merge(virtual_changes)
       c = c.slice(*@attributes_whitelist) unless @attributes_whitelist.nil?
       c
     end

--- a/app/services/duplicate_user_finder_service.rb
+++ b/app/services/duplicate_user_finder_service.rb
@@ -26,7 +26,7 @@ class DuplicateUserFinderService < BaseService
       first_name: @user.first_name.capitalize,
       last_name: @user.last_name.upcase,
       birth_date: @user.birth_date
-    ).left_joins(:rdvs).group(:id).order('COUNT(rdvs.id) DESC').first
+    ).left_joins(:rdvs).group(:id).order("COUNT(rdvs.id) DESC").first
     return nil unless similar_user.present?
 
     OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: similar_user)
@@ -35,7 +35,7 @@ class DuplicateUserFinderService < BaseService
   def check_phone_number
     return nil unless @user.phone_number.present?
 
-    similar_user = users_in_scope.where(phone_number: @user.phone_number).left_joins(:rdvs).group(:id).order('COUNT(rdvs.id) DESC').first
+    similar_user = users_in_scope.where(phone_number: @user.phone_number).left_joins(:rdvs).group(:id).order("COUNT(rdvs.id) DESC").first
     return nil unless similar_user.present?
 
     OpenStruct.new(severity: :warning, attributes: [:phone_number], user: similar_user)

--- a/app/services/import_zone_rows_service.rb
+++ b/app/services/import_zone_rows_service.rb
@@ -126,7 +126,7 @@ class ImportZoneRowsService < BaseService
   end
 
   def build_zone(row)
-    unique_attributes = { level: 'city', city_code: row["city_code"] }
+    unique_attributes = { level: "city", city_code: row["city_code"] }
     extra_attributes = {
       organisation: find_organisation(row["organisation_id"]),
       city_name: row["city_name"]

--- a/app/services/rdv_exporter_service.rb
+++ b/app/services/rdv_exporter_service.rb
@@ -1,7 +1,7 @@
 class RdvExporterService < BaseService
   TYPE = { "user" => "Usager", "agent" => "Agent", "file_attente" => "File d'attente" }.freeze
-  HourFormat = Spreadsheet::Format.new(number_format: 'hh:mm')
-  DateFormat = Spreadsheet::Format.new(number_format: 'DD/MM/YYYY')
+  HourFormat = Spreadsheet::Format.new(number_format: "hh:mm")
+  DateFormat = Spreadsheet::Format.new(number_format: "DD/MM/YYYY")
   HEADER = [
     "année",
     "date prise rdv",
@@ -17,7 +17,7 @@ class RdvExporterService < BaseService
   ].freeze
 
   def initialize(rdvs, file)
-    Spreadsheet.client_encoding = 'UTF-8'
+    Spreadsheet.client_encoding = "UTF-8"
     @rdvs = rdvs
     @file = file
   end

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -8,7 +8,7 @@ class SendTransactionalSmsService < BaseService
     @user = user
     @rdv = rdv
     @options = options
-    @from = 'RdvSoli'
+    @from = "RdvSoli"
   end
 
   def perform
@@ -19,7 +19,7 @@ class SendTransactionalSmsService < BaseService
       sender: @from,
       recipient: @user.phone_number_formatted,
       content: replace_special_chars(body),
-      tag: [ENV['APP'], @rdv.organisation.id, @type].join(" ")
+      tag: [ENV["APP"], @rdv.organisation.id, @type].join(" ")
     )
     sib_instance.send_transac_sms(transac_sms)
   end
@@ -27,7 +27,7 @@ class SendTransactionalSmsService < BaseService
   private
 
   def replace_special_chars(body)
-    body.tr('áâãëẽêíïîĩóôõúûũçÀÁÂÃÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ', 'aaaeeeiiiiooouuucAAAAEEEEIIIIIOOOOUUUU')
+    body.tr("áâãëẽêíïîĩóôõúûũçÀÁÂÃÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ", "aaaeeeiiiiooouuucAAAAEEEEIIIIIOOOOUUUU")
   end
 
   def sms_footer

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 # explode rails/all to be able to exclude sprockets
 require "active_record/railtie"
@@ -28,22 +28,22 @@ module Lapin
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    config.time_zone = 'Paris'
+    config.time_zone = "Paris"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.available_locales = [:fr, :en]
     config.i18n.default_locale = :fr
     config.action_view.raise_on_missing_translations = true
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
     config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
 
     # Devise layout
     config.to_prepare do
       [Devise::RegistrationsController, Devise::SessionsController, Devise::ConfirmationsController, Devise::PasswordsController, Devise::InvitationsController].each do |controller|
-        controller.layout 'registration'
+        controller.layout "registration"
       end
-      Devise::Mailer.layout 'mailer'
+      Devise::Mailer.layout "mailer"
     end
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,12 +14,12 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}",
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'localhost:5000', utm_source: 'dev', utm_medium: 'email', utm_campaign: 'default' }
+  config.action_mailer.default_url_options = { host: "localhost:5000", utm_source: "dev", utm_medium: "email", utm_campaign: "default" }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :letter_opener

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
@@ -62,14 +62,14 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { protocol: 'https', host: ENV["HOST"].sub(%r{^https?:\/\/}, ""), utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
+  config.action_mailer.default_url_options = { protocol: "https", host: ENV["HOST"].sub(%r{^https?:\/\/}, ""), utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
   config.action_mailer.smtp_settings = {
-    address:        'smtp-relay.sendinblue.com',
-    port:           '587',
+    address:        "smtp-relay.sendinblue.com",
+    port:           "587",
     authentication: :plain,
     user_name:      ENV["SENDINBLUE_USERNAME"],
     password:       ENV["SENDINBLUE_PASSWORD"],
-    domain:         'rdv-solidarites.fr',
+    domain:         "rdv-solidarites.fr",
   }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.asset_host = ENV["HOST"]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}",
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.
@@ -32,8 +32,8 @@ Rails.application.configure do
   config.active_storage.service = :test
   config.active_job.queue_adapter = :inline
 
-  port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
-  config.action_mailer.default_url_options = { host: "localhost:#{port}", utm_source: 'test', utm_medium: 'email', utm_campaign: 'default' }
+  port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
+  config.action_mailer.default_url_options = { host: "localhost:#{port}", utm_source: "test", utm_medium: "email", utm_campaign: "default" }
   config.action_mailer.perform_caching = false
 
   config.assets.compile = true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,9 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,14 +10,14 @@ unless Rails.env.test?
     policy.font_src    :self, :data, "https://fonts.gstatic.com", "github.com"
     policy.img_src     :self, :data, "stats.data.gouv.fr", "*.gstatic.com", "*.google.com", "voxusagers.numerique.gouv.fr"
     policy.object_src  :none
-    policy.style_src   :self, :unsafe_inline, "fonts.googleapis.com", "*.bootstrapcdn.com", "cdnjs.cloudflare.com", 'api.mapbox.com'
+    policy.style_src   :self, :unsafe_inline, "fonts.googleapis.com", "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
 
     if Rails.env.development?
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net", "tags.clickintext.net", "api.mapbox.com", "blob:"
-      policy.connect_src :self, "api-adresse.data.gouv.fr", "sentry.io", "localhost:3035", "ws://localhost:3035", 'etalab-tiles.fr'
+      policy.connect_src :self, "api-adresse.data.gouv.fr", "sentry.io", "localhost:3035", "ws://localhost:3035", "etalab-tiles.fr"
     else
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "data1.gryplex.com", "lb.apicit.net", "tags.clickintext.net", "api.mapbox.com", "blob:"
-      policy.connect_src :self, "api-adresse.data.gouv.fr", "sentry.io", "cdnjs.cloudflare.com", 'etalab-tiles.fr'
+      policy.connect_src :self, "api-adresse.data.gouv.fr", "sentry.io", "cdnjs.cloudflare.com", "etalab-tiles.fr"
     end
 
     # Specify URI for violation reports

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'contact@rdv-solidarites.fr'
+  config.mailer_sender = "contact@rdv-solidarites.fr"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -30,7 +30,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -309,7 +309,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :github, ENV["GITHUB_APP_ID"], ENV["GITHUB_APP_SECRET"], scope: 'user:email'
+  config.omniauth :github, ENV["GITHUB_APP_ID"], ENV["GITHUB_APP_SECRET"], scope: "user:email"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -4,7 +4,7 @@
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.irregular 'lieu', 'lieux'
+  inflect.irregular "lieu", "lieux"
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,17 +1,17 @@
-if ENV['SENTRY_DSN_RAILS'].present?
-  require 'raven'
+if ENV["SENTRY_DSN_RAILS"].present?
+  require "raven"
 
   Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN_RAILS']
-    config.environments = ['production', 'staging']
+    config.dsn = ENV["SENTRY_DSN_RAILS"]
+    config.environments = ["production", "staging"]
     config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 
     config.excluded_exceptions = [
-      'ActionController::InvalidAuthenticityToken',
-      'ActiveRecord::RecordNotFound',
-      'CGI::Session::CookieStore::TamperedWithCookie',
-      'Sinatra::NotFound',
-      'ActiveJob::DeserializationError',
+      "ActionController::InvalidAuthenticityToken",
+      "ActiveRecord::RecordNotFound",
+      "CGI::Session::CookieStore::TamperedWithCookie",
+      "Sinatra::NotFound",
+      "ActiveJob::DeserializationError",
     ]
   end
 end

--- a/config/initializers/sendinblue.rb
+++ b/config/initializers/sendinblue.rb
@@ -1,3 +1,3 @@
 SibApiV3Sdk.configure do |config|
-  config.api_key['api-key'] = ENV['SENDINBLUE_SMS_API_KEY']
+  config.api_key["api-key"] = ENV["SENDINBLUE_SMS_API_KEY"]
 end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -75,7 +75,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :nested
 
   # Default class for buttons
-  config.button_class = 'btn'
+  config.button_class = "btn"
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -86,7 +86,7 @@ SimpleForm.setup do |config|
   config.error_notification_tag = :div
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = 'error_notification'
+  config.error_notification_class = "error_notification"
 
   # Series of attempts to detect a default label method for collection.
   # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
@@ -165,7 +165,7 @@ SimpleForm.setup do |config|
   # config.input_class = nil
 
   # Define the default class of the input wrapper of the boolean input.
-  config.boolean_label_class = 'checkbox'
+  config.boolean_label_class = "checkbox"
 
   # Defines if the default input wrapper class should be included in radio
   # collection wrappers.

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -15,10 +15,10 @@
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Default class for buttons
-  config.button_class = 'btn btn-primary'
+  config.button_class = "btn btn-primary"
 
   # Define the default class of the input wrapper of the boolean input.
-  config.boolean_label_class = 'form-check-label'
+  config.boolean_label_class = "form-check-label"
 
   # How the label text should be generated altogether with the required text.
   config.label_text = ->(label, required, _explicit_label) { "#{label} #{required}" }
@@ -34,7 +34,7 @@ SimpleForm.setup do |config|
   config.include_default_input_wrapper_class = false
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = 'alert alert-danger'
+  config.error_notification_class = "alert alert-danger"
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -42,13 +42,13 @@ SimpleForm.setup do |config|
   config.error_method = :to_sentence
 
   # add validation classes to `input_field`
-  config.input_field_error_class = 'is-invalid'
-  config.input_field_valid_class = 'is-valid'
+  config.input_field_error_class = "is-invalid"
+  config.input_field_valid_class = "is-valid"
 
   # vertical forms
   #
   # vertical default_wrapper
-  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_form, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -56,89 +56,89 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'form-control-label'
-    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "form-control-label"
+    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # vertical input for boolean
-  config.wrappers :vertical_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_boolean, tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
-      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      bb.use :label, class: 'form-check-label'
-      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.wrapper :form_check_wrapper, tag: "div", class: "form-check" do |bb|
+      bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+      bb.use :label, class: "form-check-label"
+      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # vertical input for radio buttons and check boxes
-  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_collection, item_wrapper_class: "form-check", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
       ba.use :label_text
     end
-    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # vertical input for inline radio buttons and check boxes
-  config.wrappers :vertical_collection_inline, item_wrapper_class: 'form-check form-check-inline', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_collection_inline, item_wrapper_class: "form-check form-check-inline", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
       ba.use :label_text
     end
-    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # vertical file input
-  config.wrappers :vertical_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_file, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
     b.use :label
-    b.use :input, class: 'form-control-file', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-control-file", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # vertical multi select
-  config.wrappers :vertical_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_multi_select, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: 'form-control-label'
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: "form-control-label"
+    b.wrapper tag: "div", class: "d-flex flex-row justify-content-between align-items-center" do |ba|
+      ba.use :input, class: "form-control mx-1", error_class: "is-invalid", valid_class: "is-valid"
     end
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # vertical range input
-  config.wrappers :vertical_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :vertical_range, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
     b.use :label
-    b.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-control-range", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # horizontal forms
   #
   # horizontal default_wrapper
-  config.wrappers :horizontal_form, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_form, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -146,102 +146,102 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'col-sm-3 col-form-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "col-sm-3 col-form-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # horizontal input for boolean
-  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_boolean, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper tag: 'label', class: 'col-sm-3' do |ba|
+    b.wrapper tag: "label", class: "col-sm-3" do |ba|
       ba.use :label_text
     end
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |wr|
-      wr.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
-        bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-        bb.use :label, class: 'form-check-label'
-        bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-        bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |wr|
+      wr.wrapper :form_check_wrapper, tag: "div", class: "form-check" do |bb|
+        bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+        bb.use :label, class: "form-check-label"
+        bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+        bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
       end
     end
   end
 
   # horizontal input for radio buttons and check boxes
-  config.wrappers :horizontal_collection, item_wrapper_class: 'form-check', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_collection, item_wrapper_class: "form-check", tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: 'col-sm-3 form-control-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # horizontal input for inline radio buttons and check boxes
-  config.wrappers :horizontal_collection_inline, item_wrapper_class: 'form-check form-check-inline', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_collection_inline, item_wrapper_class: "form-check form-check-inline", tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: 'col-sm-3 form-control-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # horizontal file input
-  config.wrappers :horizontal_file, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_file, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
-    b.use :label, class: 'col-sm-3 form-control-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # horizontal multi select
-  config.wrappers :horizontal_multi_select, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_multi_select, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: 'col-sm-3 control-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
-        bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: "col-sm-3 control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.wrapper tag: "div", class: "d-flex flex-row justify-content-between align-items-center" do |bb|
+        bb.use :input, class: "form-control mx-1", error_class: "is-invalid", valid_class: "is-valid"
       end
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # horizontal range input
-  config.wrappers :horizontal_range, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :horizontal_range, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
-    b.use :label, class: 'col-sm-3 form-control-label'
-    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-control-range", error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # inline forms
   #
   # inline default_wrapper
-  config.wrappers :inline_form, tag: 'span', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :inline_form, tag: "span", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -249,115 +249,115 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'sr-only'
+    b.use :label, class: "sr-only"
 
-    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.optional :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # inline input for boolean
-  config.wrappers :inline_boolean, tag: 'span', class: 'form-check flex-wrap justify-content-start mr-sm-2', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :inline_boolean, tag: "span", class: "form-check flex-wrap justify-content-start mr-sm-2", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :label, class: 'form-check-label'
-    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :label, class: "form-check-label"
+    b.use :error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.optional :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # bootstrap custom forms
   #
   # custom input for boolean
-  config.wrappers :custom_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_boolean, tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-checkbox' do |bb|
-      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      bb.use :label, class: 'custom-control-label'
-      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.wrapper :form_check_wrapper, tag: "div", class: "custom-control custom-checkbox" do |bb|
+      bb.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: "is-valid"
+      bb.use :label, class: "custom-control-label"
+      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
-  config.wrappers :custom_boolean_switch, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_boolean_switch, tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-checkbox-switch' do |bb|
-      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      bb.use :label, class: 'custom-control-label'
-      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.wrapper :form_check_wrapper, tag: "div", class: "custom-control custom-checkbox-switch" do |bb|
+      bb.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: "is-valid"
+      bb.use :label, class: "custom-control-label"
+      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
   # custom input for radio buttons and check boxes
-  config.wrappers :custom_collection, item_wrapper_class: 'custom-control', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_collection, item_wrapper_class: "custom-control", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
       ba.use :label_text
     end
-    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # custom input for inline radio buttons and check boxes
-  config.wrappers :custom_collection_inline, item_wrapper_class: 'custom-control custom-control-inline', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_collection_inline, item_wrapper_class: "custom-control custom-control-inline", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
       ba.use :label_text
     end
-    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # custom file input
-  config.wrappers :custom_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_file, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
     b.optional :minlength
     b.optional :readonly
-    b.use :label, class: 'form-control-label'
-    b.wrapper :custom_file_wrapper, tag: 'div', class: 'custom-file' do |ba|
-      ba.use :input, class: 'custom-file-input', error_class: 'is-invalid', valid_class: 'is-valid'
-      ba.use :label, class: 'custom-file-label'
-      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :label, class: "form-control-label"
+    b.wrapper :custom_file_wrapper, tag: "div", class: "custom-file" do |ba|
+      ba.use :input, class: "custom-file-input", error_class: "is-invalid", valid_class: "is-valid"
+      ba.use :label, class: "custom-file-label"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
     end
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # custom multi select
-  config.wrappers :custom_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_multi_select, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: 'form-control-label'
-    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
-      ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: "form-control-label"
+    b.wrapper tag: "div", class: "d-flex flex-row justify-content-between align-items-center" do |ba|
+      ba.use :input, class: "custom-select mx-1", error_class: "is-invalid", valid_class: "is-valid"
     end
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # custom range input
-  config.wrappers :custom_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :custom_range, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly
     b.optional :step
-    b.use :label, class: 'form-control-label'
-    b.use :input, class: 'custom-range', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :label, class: "form-control-label"
+    b.use :input, class: "custom-range", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # Input Group - custom component
   # see example app and config at https://github.com/rafaelfranca/simple_form-bootstrap
-  config.wrappers :input_group, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :input_group, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -365,20 +365,20 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: 'form-control-label'
-    b.wrapper :input_group_tag, tag: 'div', class: 'input-group' do |ba|
+    b.use :label, class: "form-control-label"
+    b.wrapper :input_group_tag, tag: "div", class: "input-group" do |ba|
       ba.optional :prepend
-      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
       ba.optional :append
     end
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # Floating Labels form
   #
   # floating labels default_wrapper
-  config.wrappers :floating_labels_form, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :floating_labels_form, tag: "div", class: "form-label-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -386,20 +386,20 @@ SimpleForm.setup do |config|
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :label, class: 'form-control-label'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :label, class: "form-control-label"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # custom multi select
-  config.wrappers :floating_labels_select, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  config.wrappers :floating_labels_select, tag: "div", class: "form-label-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :input, class: 'custom-select custom-select-lg', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :label, class: 'form-control-label'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    b.use :input, class: "custom-select custom-select-lg", error_class: "is-invalid", valid_class: "is-valid"
+    b.use :label, class: "form-control-label"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
   # The default wrapper to be used by the FormBuilder.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   ## ADMIN ##
-  devise_for :super_admins, controllers: { omniauth_callbacks: 'super_admins/omniauth_callbacks' }
+  devise_for :super_admins, controllers: { omniauth_callbacks: "super_admins/omniauth_callbacks" }
 
-  delete 'admin/sign_out' => 'super_admins/sessions#destroy'
+  delete "admin/sign_out" => "super_admins/sessions#destroy"
 
   namespace :admin do
     resources :agents do
-      get 'sign_in_as', on: :member
+      get "sign_in_as", on: :member
       post :invite, on: :member
     end
     resources :super_admins
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     resources :services
     resources :motifs
     resources :users do
-      get 'sign_in_as', on: :member
+      get "sign_in_as", on: :member
     end
     resources :rdvs
     resources :plage_ouvertures
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   end
 
   ## APP ##
-  devise_for :users, controllers: { registrations: 'users/registrations', sessions: 'users/sessions', passwords: 'users/passwords', confirmations: 'users/confirmations' }
+  devise_for :users, controllers: { registrations: "users/registrations", sessions: "users/sessions", passwords: "users/passwords", confirmations: "users/confirmations" }
 
   namespace :users do
     resource :rdv_wizard_step, only: [:new, :create]
@@ -39,53 +39,53 @@ Rails.application.routes.draw do
       put :cancel
     end
     resources :creneaux, only: [:index, :edit, :update], param: :rdv_id
-    post 'file_attente', to: 'file_attentes#create_or_delete'
+    post "file_attente", to: "file_attentes#create_or_delete"
   end
   resources :stats, only: :index
-  get 'stats/agents', to: "stats#agents", as: "agents_stats"
-  get 'stats/organisations', to: "stats#organisations", as: "organisations_stats"
-  get 'stats/rdvs', to: "stats#rdvs", as: "rdvs_stats"
-  get 'stats/users', to: "stats#users", as: "users_stats"
-  get 'stats/:departement', to: "stats#index", as: "departement_stats"
+  get "stats/agents", to: "stats#agents", as: "agents_stats"
+  get "stats/organisations", to: "stats#organisations", as: "organisations_stats"
+  get "stats/rdvs", to: "stats#rdvs", as: "rdvs_stats"
+  get "stats/users", to: "stats#users", as: "users_stats"
+  get "stats/:departement", to: "stats#index", as: "departement_stats"
 
   authenticate :user do
-    get "/users/informations", to: 'users/users#edit'
-    patch "users/informations", to: 'users/users#update'
+    get "/users/informations", to: "users/users#edit"
+    patch "users/informations", to: "users/users#update"
     resources :relatives, except: [:index], controller: "users/relatives"
   end
   authenticated :user do
-    get "/users/rdvs", to: 'users/rdvs#index', as: :authenticated_user_root
+    get "/users/rdvs", to: "users/rdvs#index", as: :authenticated_user_root
   end
 
   devise_for :agents, controllers: {
-    invitations: 'agents/invitations',
-    sessions: 'agents/sessions',
-    passwords: 'agents/passwords'
+    invitations: "agents/invitations",
+    sessions: "agents/sessions",
+    passwords: "agents/passwords"
   }
 
   as :agent do
-    get 'agents/edit' => 'agents/registrations#edit', as: 'edit_agent_registration'
-    put 'agents' => 'agents/registrations#update', as: 'agent_registration'
-    delete 'agents' => 'agents/registrations#destroy', as: 'delete_agent_registration'
+    get "agents/edit" => "agents/registrations#edit", as: "edit_agent_registration"
+    put "agents" => "agents/registrations#update", as: "agent_registration"
+    delete "agents" => "agents/registrations#destroy", as: "delete_agent_registration"
   end
 
   resources :organisations, only: [:new, :create]
 
   authenticate :agent do
-    scope module: 'agents' do
+    scope module: "agents" do
       resources :departements, only: [] do
-        scope module: 'departements' do
+        scope module: "departements" do
           resources :zone_imports, only: [:new, :create]
           resource :organisations, only: [:show, :update] # note the singular
           resources :zones
-          delete '/zones' => 'zones#destroy_multiple'
+          delete "/zones" => "zones#destroy_multiple"
           resource :setup_checklist, only: [:show]
         end
       end
       resources :organisations, except: [:destroy, :new, :create] do
         resources :lieux, except: :show
         resources :motifs
-        scope module: 'organisations' do
+        scope module: "organisations" do
           resource :setup_checklist, only: [:show]
           resources :rdvs, only: :index
           resources :stats, only: :index do
@@ -143,21 +143,21 @@ Rails.application.routes.draw do
     end
   end
   authenticated :agent do
-    root to: 'agents/organisations#index', as: :authenticated_agent_root
+    root to: "agents/organisations#index", as: :authenticated_agent_root
   end
 
-  { disclaimer: 'mentions_legales', terms: 'cgv', mds: 'mds' }.each do |k, v|
+  { disclaimer: "mentions_legales", terms: "cgv", mds: "mds" }.each do |k, v|
     get v => "static_pages##{k}"
   end
 
-  get 'r', to: redirect('users/rdvs', status: 301), as: "rdvs_shorten"
-  get 'accueil_mds' => "welcome#welcome_agent"
-  post '/' => "welcome#search"
-  get 'departement/:departement', to: "welcome#welcome_departement", as: "welcome_departement"
-  post 'departement/:departement' => "welcome#search_departement"
-  get 'departement/:departement/:service', to: "welcome#welcome_service", as: "welcome_service"
-  get 'departement/:departement/:service/:motif', to: "welcome#welcome_motif", as: "welcome_motif"
+  get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_shorten"
+  get "accueil_mds" => "welcome#welcome_agent"
+  post "/" => "welcome#search"
+  get "departement/:departement", to: "welcome#welcome_departement", as: "welcome_departement"
+  post "departement/:departement" => "welcome#search_departement"
+  get "departement/:departement/:service", to: "welcome#welcome_service", as: "welcome_service"
+  get "departement/:departement/:service/:motif", to: "welcome#welcome_motif", as: "welcome_motif"
   resources :lieux, only: [:index, :show]
   resources :motif_libelles, only: :index
-  root 'welcome#index'
+  root "welcome#index"
 end

--- a/db/migrate/20200728074728_add_phone_number_formatted_to_users.rb
+++ b/db/migrate/20200728074728_add_phone_number_formatted_to_users.rb
@@ -2,7 +2,7 @@ class AddPhoneNumberFormattedToUsers < ActiveRecord::Migration[6.0]
   def up
     add_column :users, :phone_number_formatted, :string
 
-    User.where.not(phone_number: nil).where.not(phone_number: '').each do |user|
+    User.where.not(phone_number: nil).where.not(phone_number: "").each do |user|
       user.update_columns(phone_number_formatted: Phonelib.parse(user.phone_number).e164)
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-require 'csv'
+require "csv"
 
 # TODO: when trying to create models using direct associations like
 # `organisation: org_paris_nord` instead of `organisation_id: org_paris_nord.id`
@@ -42,8 +42,8 @@ organisations_by_human_id = [
     Organisation.create!(phone_number: "0123456789", departement: "62", **attributes)
   ]
 end.to_h
-org_arques = organisations_by_human_id['1030']
-org_bapaume = organisations_by_human_id['1034']
+org_arques = organisations_by_human_id["1030"]
+org_bapaume = organisations_by_human_id["1034"]
 Organisation.set_callback(:create, :after, :notify_admin_organisation_created)
 
 # SERVICES
@@ -67,7 +67,7 @@ libelle_social_droits = MotifLibelle.create!(service: service_social, name: "Dro
 
 motif_org_paris_nord_pmi_rappel = Motif.create!(
   name: libelle_pmi_rappel.name,
-  color: '#FF7C00',
+  color: "#FF7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   reservable_online: true,
@@ -75,7 +75,7 @@ motif_org_paris_nord_pmi_rappel = Motif.create!(
 )
 motif_org_paris_nord_pmi_gyneco = Motif.create!(
   name: libelle_pmi_gyneco.name,
-  color: '#FF7C00',
+  color: "#FF7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   reservable_online: false,
@@ -83,7 +83,7 @@ motif_org_paris_nord_pmi_gyneco = Motif.create!(
 )
 motif_org_paris_nord_pmi_prenatale = Motif.create!(
   name: libelle_pmi_prenatale.name,
-  color: '#CC7C00',
+  color: "#CC7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   reservable_online: true,
@@ -91,7 +91,7 @@ motif_org_paris_nord_pmi_prenatale = Motif.create!(
 )
 motif_org_paris_nord_pmi_suivi = Motif.create!(
   name: libelle_pmi_suivi.name,
-  color: '#00FC60',
+  color: "#00FC60",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   reservable_online: true,
@@ -100,7 +100,7 @@ motif_org_paris_nord_pmi_suivi = Motif.create!(
 )
 motif_org_paris_nord_pmi_securite = Motif.create!(
   name: libelle_pmi_securite.name,
-  color: '#1010FF',
+  color: "#1010FF",
   organisation_id: org_paris_nord.id,
   service_id: service_pmi.id,
   reservable_online: true,
@@ -108,7 +108,7 @@ motif_org_paris_nord_pmi_securite = Motif.create!(
 )
 _motif_org_paris_nord_social_rappel = Motif.create!(
   name: libelle_social_rappel.name,
-  color: '#FF7C00',
+  color: "#FF7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   reservable_online: true,
@@ -116,7 +116,7 @@ _motif_org_paris_nord_social_rappel = Motif.create!(
 )
 _motif_org_paris_nord_social_suivi = Motif.create!(
   name: libelle_social_suivi.name,
-  color: '#CC7C00',
+  color: "#CC7C00",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   reservable_online: true,
@@ -125,7 +125,7 @@ _motif_org_paris_nord_social_suivi = Motif.create!(
 )
 _motif_org_paris_nord_social_droits = Motif.create!(
   name: libelle_social_droits.name,
-  color: '#00FC60',
+  color: "#00FC60",
   organisation_id: org_paris_nord.id,
   service_id: service_social.id,
   reservable_online: true,
@@ -139,7 +139,7 @@ motifs = {}
   motifs[seed_id] ||= {}
   motifs[seed_id][:pmi_rappel] = Motif.create!(
     name: libelle_pmi_rappel.name,
-    color: '#10FF10',
+    color: "#10FF10",
     organisation_id: org.id,
     service_id: service_pmi.id,
     reservable_online: true,
@@ -147,7 +147,7 @@ motifs = {}
   )
   motifs[seed_id][:pmi_prenatale] = Motif.create!(
     name: libelle_pmi_prenatale.name,
-    color: '#FF1010',
+    color: "#FF1010",
     organisation_id: org.id,
     service_id: service_pmi.id,
     reservable_online: true,
@@ -187,13 +187,13 @@ lieu_bapaume_est = Lieu.create!(
 )
 
 ## ZONES
-zones_csv_path = File.join(Rails.root, 'db', 'seeds', 'zones_62.csv')
+zones_csv_path = File.join(Rails.root, "db", "seeds", "zones_62.csv")
 CSV.read(zones_csv_path, headers: :first_row).each do |att|
   Zone.create!(
-    level: 'city',
-    organisation: organisations_by_human_id[att['organisation_id']],
-    city_code: att['city_code'],
-    city_name: att['city_name']
+    level: "city",
+    organisation: organisations_by_human_id[att["organisation_id"]],
+    city_code: att["city_code"],
+    city_name: att["city_name"]
   )
 end
 
@@ -204,7 +204,7 @@ user_org_paris_nord_patricia = User.new(
   last_name: "Duroy",
   email: "patricia_duroy@demo.rdv-solidarites.fr",
   birth_date: Date.parse("20/06/1975"),
-  password: '123456',
+  password: "123456",
   organisation_ids: [org_paris_nord.id]
 )
 
@@ -217,7 +217,7 @@ user_org_paris_nord_lea = User.new(
   last_name: "Dupont",
   email: "lea_dupont@demo.rdv-solidarites.fr",
   birth_date: Date.parse("01/12/1982"),
-  password: '123456',
+  password: "123456",
   organisation_ids: [org_paris_nord.id]
 )
 
@@ -230,7 +230,7 @@ user_org_paris_nord_jean = User.new(
   last_name: "Moustache",
   email: "jean_moustache@demo.rdv-solidarites.fr",
   birth_date: Date.parse("10/01/1973"),
-  password: '123456',
+  password: "123456",
   organisation_ids: [org_paris_nord.id]
 )
 
@@ -241,11 +241,11 @@ user_org_paris_nord_jean.profile_for(org_paris_nord).update!(notes: "des notes d
 # AGENTS
 
 agent_org_paris_nord_pmi_martine = Agent.new(
-  email: 'martine@demo.rdv-solidarites.fr',
+  email: "martine@demo.rdv-solidarites.fr",
   role: :admin,
-  first_name: 'Martine',
-  last_name: 'Validay',
-  password: '123456',
+  first_name: "Martine",
+  last_name: "Validay",
+  password: "123456",
   service_id: service_pmi.id,
   organisation_ids: [org_paris_nord.id]
 )
@@ -253,11 +253,11 @@ agent_org_paris_nord_pmi_martine.skip_confirmation!
 agent_org_paris_nord_pmi_martine.save!
 
 agent_org_paris_nord_pmi_marco = Agent.new(
-  email: 'marco@demo.rdv-solidarites.fr',
+  email: "marco@demo.rdv-solidarites.fr",
   role: :user,
-  first_name: 'Marco',
-  last_name: 'Durand',
-  password: '123456',
+  first_name: "Marco",
+  last_name: "Durand",
+  password: "123456",
   service_id: service_pmi.id,
   organisation_ids: [org_paris_nord.id]
 )
@@ -265,11 +265,11 @@ agent_org_paris_nord_pmi_marco.skip_confirmation!
 agent_org_paris_nord_pmi_marco.save!
 
 agent_org_paris_nord_social_polo = Agent.new(
-  email: 'polo@demo.rdv-solidarites.fr',
+  email: "polo@demo.rdv-solidarites.fr",
   role: :user,
-  first_name: 'Polo',
-  last_name: 'Durant',
-  password: '123456',
+  first_name: "Polo",
+  last_name: "Durant",
+  password: "123456",
   service_id: service_social.id,
   organisation_ids: [org_paris_nord.id]
 )
@@ -277,23 +277,23 @@ agent_org_paris_nord_social_polo.skip_confirmation!
 agent_org_paris_nord_social_polo.save!
 
 org_arques_pmi_maya = Agent.new(
-  email: 'maya@demo.rdv-solidarites.fr',
+  email: "maya@demo.rdv-solidarites.fr",
   role: :admin,
-  first_name: 'Maya',
-  last_name: 'Patrick',
-  password: '123456',
+  first_name: "Maya",
+  last_name: "Patrick",
+  password: "123456",
   service_id: service_pmi.id,
-  organisation_ids: Organisation.where(departement: '62').pluck(:id)
+  organisation_ids: Organisation.where(departement: "62").pluck(:id)
 )
 org_arques_pmi_maya.skip_confirmation!
 org_arques_pmi_maya.save!
 
 org_bapaume_pmi_bruno = Agent.new(
-  email: 'bruno@demo.rdv-solidarites.fr',
+  email: "bruno@demo.rdv-solidarites.fr",
   role: :admin,
-  first_name: 'Bruno',
-  last_name: 'Frangi',
-  password: '123456',
+  first_name: "Bruno",
+  last_name: "Frangi",
+  password: "123456",
   service_id: service_pmi.id,
   organisation_ids: [org_bapaume.id]
 )
@@ -304,7 +304,7 @@ org_bapaume_pmi_bruno.save!
 
 PlageOuverture.skip_callback(:create, :after, :plage_ouverture_created)
 _plage_ouverture_org_paris_nord_martine_classique = PlageOuverture.create!(
-  title: 'Permanence classique',
+  title: "Permanence classique",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,
   lieu_id: lieu_org_paris_nord_sud.id,
@@ -315,7 +315,7 @@ _plage_ouverture_org_paris_nord_martine_classique = PlageOuverture.create!(
   recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, on: [:monday, :tuesday, :thursday, :friday])
 )
 _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
-  title: 'Permanence enfant',
+  title: "Permanence enfant",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,
   lieu_id: lieu_org_paris_nord_sud.id,
@@ -326,7 +326,7 @@ _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
   recurrence: Montrose.every(:week, on: [:wednesday], interval: 1)
 )
 _plage_ouverture_org_paris_nord_martine_exceptionnelle = PlageOuverture.create!(
-  title: 'Aprem PMI exptn',
+  title: "Aprem PMI exptn",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,
   lieu_id: lieu_org_paris_nord_sud.id,
@@ -336,7 +336,7 @@ _plage_ouverture_org_paris_nord_martine_exceptionnelle = PlageOuverture.create!(
   end_time: Tod::TimeOfDay.new(18)
 )
 _plage_ouverture_org_paris_nord_marco_perm = PlageOuverture.create!(
-  title: 'Perm.',
+  title: "Perm.",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_marco.id,
   lieu_id: lieu_org_paris_nord_nord.id,
@@ -347,7 +347,7 @@ _plage_ouverture_org_paris_nord_marco_perm = PlageOuverture.create!(
   recurrence: Montrose.every(:week, interval: 1)
 )
 _plage_ouverture_org_arques_maya_tradi = PlageOuverture.create!(
-  title: 'Perm. tradi',
+  title: "Perm. tradi",
   organisation_id: org_arques.id,
   agent_id: org_arques_pmi_maya.id,
   lieu_id: lieu_arques_nord.id,
@@ -358,7 +358,7 @@ _plage_ouverture_org_arques_maya_tradi = PlageOuverture.create!(
   recurrence: Montrose.every(:week, interval: 1)
 )
 _plage_ouverture_org_bapaume_bruno_classique = PlageOuverture.create!(
-  title: 'Perm. classique',
+  title: "Perm. classique",
   organisation_id: org_bapaume.id,
   agent_id: org_bapaume_pmi_bruno.id,
   lieu_id: lieu_bapaume_est.id,

--- a/lib/tasks/dev/generate_rdv.rake
+++ b/lib/tasks/dev/generate_rdv.rake
@@ -10,7 +10,7 @@ namespace :dev do
           break unless user
 
           Rdv.skip_callback(:create, :after, :send_notifications_to_users)
-          Rdv.create!(user_ids: [user.id], motif_id: motif.id, duration_in_min: motif.default_duration_in_min, starts_at: starts_at, organisation_id: organisation.id, agent_ids: organisation.agents.pluck(:id)) if ['Saturday', 'Sunday'].exclude?(starts_at.strftime('%A'))
+          Rdv.create!(user_ids: [user.id], motif_id: motif.id, duration_in_min: motif.default_duration_in_min, starts_at: starts_at, organisation_id: organisation.id, agent_ids: organisation.agents.pluck(:id)) if ["Saturday", "Sunday"].exclude?(starts_at.strftime("%A"))
           Rdv.set_callback(:create, :after, :send_notifications_to_users)
         end
       end

--- a/lib/tasks/matomo.rake
+++ b/lib/tasks/matomo.rake
@@ -4,7 +4,7 @@ namespace :matomo do
     # if you update that list
     params_to_filter = %w[address /.*_name/ affiliation_number /.*latitude.*/ /.*longitude.*/ /.*where.*/ /.*_token/]
 
-    unless ENV['MATOMO_AUTH_TOKEN']
+    unless ENV["MATOMO_AUTH_TOKEN"]
       raise "A MATOMO_AUTH_TOKEN envvar is required to run that script.
         Such token is available at: https://stats.data.gouv.fr/index.php?module=UsersManager&action=userSettings"
     end
@@ -12,18 +12,18 @@ namespace :matomo do
     # Production and Demo sites
     id_sites = %w[123 124]
     id_sites.each do |id_site|
-      token_auth = ENV['MATOMO_AUTH_TOKEN']
+      token_auth = ENV["MATOMO_AUTH_TOKEN"]
       # https://developer.matomo.org/api-reference/reporting-api
-      url = 'https://stats.data.gouv.fr/index.php?method=SitesManager.updateSite&module=API&format=JSON2'
+      url = "https://stats.data.gouv.fr/index.php?method=SitesManager.updateSite&module=API&format=JSON2"
       payload = {
         idSite: id_site,
         token_auth: token_auth,
-        excludedQueryParameters: params_to_filter.join(','),
+        excludedQueryParameters: params_to_filter.join(","),
       }
       response = Typhoeus.post(url, body: payload)
       result = JSON.parse(response.body)
 
-      raise result['message'] unless result['result'] == 'success'
+      raise result["message"] unless result["result"] == "success"
     end
   end
 end

--- a/scripts/get_deployed_changes.rb
+++ b/scripts/get_deployed_changes.rb
@@ -7,8 +7,8 @@
 
 # ruby scripts/get_deployed_changes.rb
 
-require 'dotenv/load'
-require 'trello'
+require "dotenv/load"
+require "trello"
 
 Trello.configure do |config|
   config.developer_public_key = ENV["TRELLO_DEVELOPER_PUBLIC_KEY"]

--- a/spec/controllers/agents/absences_controller_spec.rb
+++ b/spec/controllers/agents/absences_controller_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe Agents::AbsencesController, type: :controller do
   end
 
   context "admin can CRUD on an agent's absences" do
-    let(:admin) { create(:agent, role: 'admin') }
+    let(:admin) { create(:agent, role: "admin") }
 
     before { sign_in admin }
 

--- a/spec/controllers/agents/invitations_controller_spec.rb
+++ b/spec/controllers/agents/invitations_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Agents::InvitationsController, type: :controller do
         {
           email: "michel@lapin.com",
           organisation_id: organisation_id,
-          role: 'user',
+          role: "user",
           service_id: service_id,
         }
       end
@@ -64,7 +64,7 @@ RSpec.describe Agents::InvitationsController, type: :controller do
         {
           email: "aa@hhh",
           organisation_id: organisation_id,
-          role: 'user',
+          role: "user",
           service_id: service_id,
         }
       end
@@ -89,7 +89,7 @@ RSpec.describe Agents::InvitationsController, type: :controller do
         {
           email: agent_2.email,
           organisation_id: organisation_id,
-          role: 'user',
+          role: "user",
           service_id: service_id,
         }
       end
@@ -127,7 +127,7 @@ RSpec.describe Agents::InvitationsController, type: :controller do
         {
           email: "MARCO@demo.rdv-solidarites.fr",
           organisation_id: organisation_id,
-          role: 'user',
+          role: "user",
           service_id: service_id,
         }
       end

--- a/spec/controllers/agents/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/agents/plage_ouvertures_controller_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe Agents::PlageOuverturesController, type: :controller do
   end
 
   context "admin CRUD on an agent's plage ouverture" do
-    let(:admin) { create(:agent, role: 'admin') }
+    let(:admin) { create(:agent, role: "admin") }
 
     before { sign_in admin }
 

--- a/spec/controllers/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/agents/rdvs_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Agents::RdvsController, type: :controller do
 
   describe "PUT #update" do
     let(:referer_path) { organisation_agent_path(organisation.id, agent.id) }
-    before { request.headers['HTTP_REFERER'] = referer_path }
+    before { request.headers["HTTP_REFERER"] = referer_path }
 
     subject do
       put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Users::RdvsController, type: :controller do
       sign_in signed_in_user
     end
 
-    context 'when user belongs to rdv' do
+    context "when user belongs to rdv" do
       let(:signed_in_user) { rdv.users.first }
 
       it { expect { subject }.to change(rdv, :cancelled_at).from(nil).to(now) }

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Users::RelativesController, type: :controller do
   end
 
   describe "POST #create" do
-    before { request.headers['HTTP_REFERER'] = users_informations_path }
+    before { request.headers["HTTP_REFERER"] = users_informations_path }
     subject { post :create, params: attributes }
 
     context "with valid params" do

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     email { generate(:agent_email) }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    password { 'password' }
+    password { "password" }
     organisations { [Organisation.first || create(:organisation)] }
     confirmed_at { 1.day.ago }
     service { Service.first || create(:service) }

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     end
     trait :excused do
       cancelled_at { 2.days.ago }
-      status { 'excused' }
+      status { "excused" }
     end
   end
 end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
   factory :service do
     name { generate(:service_name) }
     trait :secretariat do
-      name { 'Secrétariat' }
+      name { "Secrétariat" }
     end
     trait :pmi do
-      name { 'PMI' }
+      name { "PMI" }
     end
 
     after(:build) do |service|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  require 'faker'
+  require "faker"
 
   sequence(:user_email) { |n| "usager_#{n}@lapin.fr" }
 
@@ -7,15 +7,15 @@ FactoryBot.define do
     email { generate(:user_email) }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name.upcase }
-    phone_number { Faker::Base.numerify('06 ## ## ## ##') }
+    phone_number { Faker::Base.numerify("06 ## ## ## ##") }
     birth_date { Faker::Date.between(from: 80.years.ago, to: Date.today) }
     address { "20 avenue de Ségur, Paris" }
     password { "12345678" }
     password_confirmation { "12345678" }
     confirmed_at { Time.zone.now }
-    caisse_affiliation { 'caf' }
-    affiliation_number { '39012093812038' }
-    family_situation { 'divorced' }
+    caisse_affiliation { "caf" }
+    affiliation_number { "39012093812038" }
+    family_situation { "divorced" }
     number_of_children { 12 }
     responsible { nil }
     trait :unconfirmed do

--- a/spec/factories/zone.rb
+++ b/spec/factories/zone.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   sequence(:city_code) { |n| (62001 + n).to_s }
 
   factory :zone do
-    level { 'city' }
+    level { "city" }
     city_code { generate(:city_code) }
-    city_name { 'ARQUES' }
-    organisation { build(:organisation, departement: '62') }
+    city_name { "ARQUES" }
+    organisation { build(:organisation, departement: "62") }
   end
 end

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -1,6 +1,6 @@
 describe "Admin can configure the organisation" do
-  let!(:pmi) { create(:service, name: 'PMI') }
-  let!(:service_social) { create(:service, name: 'Service social') }
+  let!(:pmi) { create(:service, name: "PMI") }
+  let!(:service_social) { create(:service, name: "Service social") }
   let!(:agent_admin) { create(:agent, :admin, service: pmi) }
   let!(:agent_user) { create(:agent) }
   let!(:motif_libelle) { create(:motif_libelle, name: "Motif 1") }
@@ -26,25 +26,25 @@ describe "Admin can configure the organisation" do
 
     click_link lieu.name
     expect_page_title("Modifier le lieu")
-    fill_in 'Nom', with: 'Le nouveau lieu'
-    click_button('Modifier')
+    fill_in "Nom", with: "Le nouveau lieu"
+    click_button("Modifier")
 
     expect_page_title("Vos lieux de consultation")
-    click_link 'Le nouveau lieu'
+    click_link "Le nouveau lieu"
 
-    click_link('Supprimer')
+    click_link("Supprimer")
 
     expect_page_title("Vos lieux de consultation")
     expect_page_with_no_record_text("Vous n'avez pas encore ajouté de lieu de consultation.")
 
-    click_link 'Ajouter un lieu', match: :first
+    click_link "Ajouter un lieu", match: :first
 
     expect_page_title("Nouveau lieu")
-    fill_in 'Nom', with: le_nouveau_lieu.name
-    fill_in 'Adresse', with: le_nouveau_lieu.address
-    first('input#lieu_latitude', visible: false).set(32)
-    first('input#lieu_longitude', visible: false).set(2)
-    click_button 'Créer'
+    fill_in "Nom", with: le_nouveau_lieu.name
+    fill_in "Adresse", with: le_nouveau_lieu.address
+    first("input#lieu_latitude", visible: false).set(32)
+    first("input#lieu_longitude", visible: false).set(2)
+    click_button "Créer"
     expect_page_title("Vos lieux de consultation")
     click_link le_nouveau_lieu.name
   end
@@ -56,37 +56,37 @@ describe "Admin can configure the organisation" do
     click_link agent_user.full_name
     expect_page_title("Modifier le professionnel")
     choose :agent_permission_role_admin
-    click_button('Modifier')
+    click_button("Modifier")
 
     expect_page_title("Vos agents")
-    expect(page).to have_selector('span.badge.badge-danger', count: 2)
+    expect(page).to have_selector("span.badge.badge-danger", count: 2)
 
     click_link agent_user.full_name
-    click_link('Supprimer')
+    click_link("Supprimer")
 
     expect_page_title("Vos agents")
     expect(page).to have_no_content(agent_user.full_name)
 
-    click_link 'Inviter un professionnel', match: :first
-    fill_in 'Email', with: 'jean@paul.com'
-    click_button 'Envoyer une invitation'
+    click_link "Inviter un professionnel", match: :first
+    fill_in "Email", with: "jean@paul.com"
+    click_button "Envoyer une invitation"
 
     expect_page_title("Vos agents")
-    expect(page).to have_content('jean@paul.com')
+    expect(page).to have_content("jean@paul.com")
 
-    open_email('jean@paul.com')
+    open_email("jean@paul.com")
     expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")
   end
 
   scenario "Update organisation" do
     click_link "Votre organisation"
-    click_link 'Modifier'
-    fill_in 'Nom', with: la_nouvelle_org.name
-    fill_in 'Téléphone', with: la_nouvelle_org.phone_number
-    fill_in 'Horaires', with: la_nouvelle_org.horaires
-    click_button 'Modifier'
+    click_link "Modifier"
+    fill_in "Nom", with: la_nouvelle_org.name
+    fill_in "Téléphone", with: la_nouvelle_org.phone_number
+    fill_in "Horaires", with: la_nouvelle_org.horaires
+    click_button "Modifier"
 
-    expect(page).to have_content('L\'organisation a été modifiée.')
+    expect(page).to have_content("L'organisation a été modifiée.")
   end
 
   scenario "CRUD on motifs", js: true do
@@ -95,38 +95,38 @@ describe "Admin can configure the organisation" do
 
     click_link motif.name
     expect(page).to have_content(motif.name)
-    click_link 'Modifier'
+    click_link "Modifier"
 
     expect(page).to have_content("Modifier le motif")
-    expect(page.find_by_id('motif_name')).to have_content(motif.name)
+    expect(page.find_by_id("motif_name")).to have_content(motif.name)
     select(motif_libelle2.name, from: :motif_name)
     page.execute_script "$('.slimscroll-menu').scrollTop(10000)"
-    click_button('Modifier')
+    click_button("Modifier")
     expect(page).to have_content(motif_libelle2.name)
     expect_page_title("Vos motifs")
 
     click_link le_nouveau_motif.name
     expect(page).to have_content(le_nouveau_motif.name)
-    click_link('Supprimer')
+    click_link("Supprimer")
     begin
       page.driver.browser.switch_to.alert.accept
     rescue Selenium::WebDriver::Error::NoSuchAlertError
-      click_link('Supprimer')
+      click_link("Supprimer")
       retry
     end
 
     expect_page_title("Vos motifs")
     expect_page_with_no_record_text("Vous n'avez pas encore créé de motif.")
 
-    click_link 'Créer un motif', match: :first
+    click_link "Créer un motif", match: :first
     expect(page).to have_content("Nouveau motif")
     ## Check secretariat is unavailable
-    expect(page.all('select#motif_service_id option').map(&:value)).to match_array ["", pmi.id.to_s, service_social.id.to_s]
+    expect(page.all("select#motif_service_id option").map(&:value)).to match_array ["", pmi.id.to_s, service_social.id.to_s]
     select(service_social.name, from: :motif_service_id)
-    expect(page).to have_select('motif[name]', with_options: ['', motif_libelle3.name], wait: 10)
+    expect(page).to have_select("motif[name]", with_options: ["", motif_libelle3.name], wait: 10)
     select(motif_libelle3.name, from: :motif_name)
-    fill_in 'Couleur', with: le_nouveau_motif.color
-    click_button 'Créer'
+    fill_in "Couleur", with: le_nouveau_motif.color
+    click_button "Créer"
     expect(page).to have_link(motif_libelle3.name)
   end
 end

--- a/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
+++ b/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
@@ -9,9 +9,9 @@ describe "Admin can configure the organisation" do
   shared_examples "a stats page" do
     it "displays all the stats" do
       click_link "Statistiques de l'organisation"
-      expect(page).to have_content('Statistiques')
-      expect(page).to have_content('RDV créés')
-      expect(page).to have_content('Usagers créés')
+      expect(page).to have_content("Statistiques")
+      expect(page).to have_content("RDV créés")
+      expect(page).to have_content("Usagers créés")
     end
   end
 

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -18,7 +18,7 @@ describe "Agent can create a Rdv with creneau search" do
     visit organisation_agent_path(agent.organisations.first, agent)
 
     expect(user.rdvs.count).to eq(0)
-    click_link('Trouver un créneau')
+    click_link("Trouver un créneau")
   end
 
   after { travel_back }
@@ -26,7 +26,7 @@ describe "Agent can create a Rdv with creneau search" do
   scenario "default", js: true do
     expect_page_title("Choisir un créneau")
     select(motif.name, from: "creneau_agent_search_motif_id")
-    click_button('Afficher les créneaux')
+    click_button("Afficher les créneaux")
 
     # Display results for both lieux
     expect(page).to have_content(plage_ouverture.lieu.address)
@@ -36,19 +36,19 @@ describe "Agent can create a Rdv with creneau search" do
 
     # Add a filter on lieu
     select(lieu.name, from: "creneau_agent_search_lieu_ids")
-    click_button('Afficher les créneaux')
+    click_button("Afficher les créneaux")
     expect(page).to have_content(plage_ouverture.lieu.address)
     expect(page).not_to have_content(plage_ouverture2.lieu.address)
 
     # Add an agent filter
     select(agent.full_name, from: "creneau_agent_search_agent_ids")
-    click_button('Afficher les créneaux')
+    click_button("Afficher les créneaux")
     expect(page).to have_content(plage_ouverture.agent.short_name)
     expect(page).not_to have_content(plage_ouverture2.agent.short_name)
 
     # Click to change to next week
     first(:link, ">>").click
-    expect(page).to have_content('<<', wait: 5)
+    expect(page).to have_content("<<", wait: 5)
 
     expect(page).to have_content(plage_ouverture.agent.short_name)
     expect(page).not_to have_content(plage_ouverture2.agent.short_name)
@@ -60,13 +60,13 @@ describe "Agent can create a Rdv with creneau search" do
     # Step 2
     expect_page_title("Choisir le ou les usagers")
     select_user(user)
-    click_button('Continuer')
+    click_button("Continuer")
 
     # Step 3
     expect_page_title("Choisir la durée et la date")
     expect_checked("Motif : #{motif.name}")
-    expect(find_field('rdv[lieu_id]').value).to eq(lieu.id.to_s)
-    click_button('Créer RDV')
+    expect(find_field("rdv[lieu_id]").value).to eq(lieu.id.to_s)
+    click_button("Créer RDV")
 
     expect(user.rdvs.count).to eq(1)
     rdv = user.rdvs.first

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -20,15 +20,15 @@ describe "Agent can create a Rdv with wizard" do
     expect_page_title("Choisir le motif")
 
     select(motif.name, from: "rdv_motif_id")
-    click_button('Continuer')
+    click_button("Continuer")
 
     # Step 2
     expect_page_title("Choisir le ou les usagers")
     expect_checked("Motif : #{motif.name}")
     select_user(user)
-    click_link('Ajouter un autre usager')
-    expect(page).to have_link('Créer un usager')
-    click_link('Créer un usager')
+    click_link("Ajouter un autre usager")
+    expect(page).to have_link("Créer un usager")
+    click_link("Créer un usager")
 
     # create user with mail
     expect(find("#modal-holder")).to have_content("Nouvel usager")
@@ -37,33 +37,33 @@ describe "Agent can create a Rdv with wizard" do
     fill_in :user_email, with: "jporvoir@bidule.com"
     sleep(1) # wait for scroll to not interfere with form input
     page.execute_script "$('#mainModal').scrollTop(1000)"
-    click_button('Créer usager')
+    click_button("Créer usager")
     sleep(1) # wait for modal to hide completely
 
     # create user without email
-    click_link('Ajouter un autre usager')
-    click_link('Créer un usager')
+    click_link("Ajouter un autre usager")
+    click_link("Créer un usager")
     fill_in :user_first_name, with: "Jean-Marie"
     fill_in :user_last_name, with: "Lapin"
     sleep(1) # wait for scroll to not interfere with form input
     page.execute_script "$('#mainModal').scrollTop(1000)"
-    click_button('Créer usager')
+    click_button("Créer usager")
     sleep(1) # wait for modal to hide completely
 
     fill_in :rdv_notes, with: "RDV très spécial"
-    click_button('Continuer')
+    click_button("Continuer")
 
     # Step 3
     expect_page_title("Choisir la durée et la date")
     expect_checked(motif.name)
     expect(page).to have_selector("input#rdv_duration_in_min[value='#{motif.default_duration_in_min}']")
-    select(lieu.full_name, from: 'rdv_lieu_id')
-    fill_in 'Durée en minutes', with: '35'
-    fill_in 'Commence à', with: '11/10/2019 14:15'
+    select(lieu.full_name, from: "rdv_lieu_id")
+    fill_in "Durée en minutes", with: "35"
+    fill_in "Commence à", with: "11/10/2019 14:15"
 
     select_agent(agent)
     select_agent(agent2)
-    click_button('Créer RDV')
+    click_button("Créer RDV")
 
     expect(user.rdvs.count).to eq(1)
     rdv = user.rdvs.first
@@ -80,7 +80,7 @@ describe "Agent can create a Rdv with wizard" do
   end
 
   def select_agent(agent)
-    select(agent.full_name_and_service, from: 'rdv_agent_ids')
+    select(agent.full_name_and_service, from: "rdv_agent_ids")
   end
 
   def expect_checked(text)

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -10,13 +10,13 @@ describe "Agent can CRUD absences" do
     click_link "Absences"
   end
 
-  context 'for an agent' do
+  context "for an agent" do
     scenario "default" do
       crud_absence(agent, agent)
     end
   end
 
-  context 'for an other agent calendar' do
+  context "for an other agent calendar" do
     let!(:absence) { create(:absence, agent: other_agent) }
 
     scenario "can crud a absence" do
@@ -33,24 +33,24 @@ describe "Agent can CRUD absences" do
     click_link absence.title
 
     expect_page_title("Modifier l'absence")
-    fill_in 'Description', with: 'La belle absence'
-    click_button('Modifier')
+    fill_in "Description", with: "La belle absence"
+    click_button("Modifier")
 
     expect_page_title(title)
-    click_link 'La belle absence'
+    click_link "La belle absence"
 
-    click_link('Supprimer')
+    click_link("Supprimer")
     expect_page_title(title)
     empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé d'absence" : "#{agent_crud.full_name} n'a pas encore créé d'absence"
     expect_page_with_no_record_text(empty_text)
 
-    click_link 'Créer une absence', match: :first
+    click_link "Créer une absence", match: :first
 
     expect_page_title("Nouvelle absence")
-    fill_in 'Description', with: new_absence.title
+    fill_in "Description", with: new_absence.title
     fill_in "absence[first_day]", with: new_absence.first_day
     fill_in "absence[end_day]", with: new_absence.first_day + 1.day
-    click_button 'Créer'
+    click_button "Créer"
 
     expect_page_title(title)
     click_link new_absence.title

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -10,22 +10,22 @@ describe "Agent can CRUD plage d'ouverture" do
     click_link "Plages d'ouverture"
   end
 
-  context 'for an agent' do
+  context "for an agent" do
     scenario "default" do
       crud_plage_ouverture(agent, agent)
     end
   end
 
-  context 'for a secretaire' do
+  context "for a secretaire" do
     let(:agent) { create(:agent, :secretaire) }
 
     scenario "cannot create plage_ouverture" do
       expect_page_title("Vos plages d'ouverture")
-      click_link 'Créer une plage d\'ouverture', match: :first
+      click_link "Créer une plage d'ouverture", match: :first
       expect(page).to have_content("Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.")
     end
 
-    context 'with motif for_secretariat' do
+    context "with motif for_secretariat" do
       let!(:motif) { create(:motif, :for_secretariat) }
       let(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif]) }
 
@@ -35,7 +35,7 @@ describe "Agent can CRUD plage d'ouverture" do
     end
   end
 
-  context 'for an other agent calendar' do
+  context "for an other agent calendar" do
     let!(:plage_ouverture) { create(:plage_ouverture, agent: other_agent) }
 
     scenario "can crud a plage_ouverture" do
@@ -52,23 +52,23 @@ describe "Agent can CRUD plage d'ouverture" do
     click_link plage_ouverture.title
 
     expect_page_title("Modifier la plage d'ouverture")
-    fill_in 'Description', with: 'La belle plage'
-    click_button('Modifier')
+    fill_in "Description", with: "La belle plage"
+    click_button("Modifier")
 
     expect_page_title("Modifier la plage d'ouverture")
     expect(page).to have_content("La belle plage")
 
-    click_link('Supprimer')
+    click_link("Supprimer")
     expect_page_title(title)
     empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé de plage d'ouverture" : "#{agent_crud.full_name} n'a pas encore créé de plage d'ouverture"
     expect_page_with_no_record_text(empty_text)
 
-    click_link 'Créer une plage d\'ouverture', match: :first
+    click_link "Créer une plage d'ouverture", match: :first
 
     expect_page_title("Nouvelle plage d'ouverture")
-    fill_in 'Description', with: new_plage_ouverture.title
+    fill_in "Description", with: new_plage_ouverture.title
     check plage_ouverture.motifs.first.name
-    click_button 'Créer'
+    click_button "Créer"
 
     expect_page_title(title)
     click_link new_plage_ouverture.title

--- a/spec/features/agents/agent_can_initiate_rdv_from_calendar.rb
+++ b/spec/features/agents/agent_can_initiate_rdv_from_calendar.rb
@@ -19,7 +19,7 @@ describe "Agent can initiate a Rdv from calendar" do
   end
 
   scenario "for an other agent", js: true do
-    select(agent2.full_name, from: 'id')
+    select(agent2.full_name, from: "id")
     expect_page_title("Agenda de #{agent2.full_name_and_service}")
 
     initiate_rdv(agent2)
@@ -27,20 +27,20 @@ describe "Agent can initiate a Rdv from calendar" do
 
   def initiate_rdv(agent)
     # Step 1
-    find('.fc-bgevent', match: :first).click
+    find(".fc-bgevent", match: :first).click
 
     # Step 2
     select(motif.name, from: "rdv_motif_id")
-    click_button('Continuer')
+    click_button("Continuer")
 
     # Step 3
     expect(find(".select2")).to have_content(agent.full_name_and_service)
-    click_button('Continuer')
+    click_button("Continuer")
 
     # Step 4
     select_user(user)
     expect(page).to have_content(full_name_and_birthdate(user))
-    click_button('Continuer')
+    click_button("Continuer")
 
     # Step 5
     expect(page).to have_content("Le rendez-vous a été créé.")

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture.rb
@@ -24,7 +24,7 @@ describe "Agent can manage recurrence on plage d'ouverture" do
     check("recurrence_on_saturday")
     fill_in("recurrence-until", with: "30/12/2019")
 
-    click_button('Modifier')
+    click_button("Modifier")
 
     # check if everything is ok in db
     expect(plage_ouverture.reload.recurrence.to_hash).to eq(
@@ -44,16 +44,16 @@ describe "Agent can manage recurrence on plage d'ouverture" do
     expect_checked("recurrence_on_thursday")
     expect_checked("recurrence_on_friday")
     expect_checked("recurrence_on_saturday")
-    expect(find_field('recurrence-until').value).to eq '2019-12-30'
+    expect(find_field("recurrence-until").value).to eq "2019-12-30"
 
     visit edit_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
     select("mois", from: "recurrence_every")
-    expect(page).not_to have_text('Répéter les')
-    expect(page).to have_text('Tous les 1er mardi du mois')
+    expect(page).not_to have_text("Répéter les")
+    expect(page).to have_text("Tous les 1er mardi du mois")
     fill_in("recurrence-source", with: "11/12/2019")
     select("1", from: "recurrence_interval")
-    expect(page).to have_text('Tous les 2ème mercredi du mois')
-    click_button('Modifier')
+    expect(page).to have_text("Tous les 2ème mercredi du mois")
+    click_button("Modifier")
 
     # check if everything is ok in db
     expect(plage_ouverture.reload.recurrence.to_hash).to eq(
@@ -66,10 +66,10 @@ describe "Agent can manage recurrence on plage d'ouverture" do
     # reload page to check if form is filled correctly
     visit edit_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
     expect_checked("recurrence_has_recurrence")
-    expect(page).to have_select('recurrence_every', selected: 'mois')
-    expect(page).to have_select('recurrence_interval', selected: '1')
-    expect(page).to have_text('Tous les 2ème mercredi du mois')
-    expect(find_field('recurrence-until').value).to eq '2019-12-30'
+    expect(page).to have_select("recurrence_every", selected: "mois")
+    expect(page).to have_select("recurrence_interval", selected: "1")
+    expect(page).to have_text("Tous les 2ème mercredi du mois")
+    expect(find_field("recurrence-until").value).to eq "2019-12-30"
   end
 
   def expect_checked(element_selector)

--- a/spec/features/agents/agent_can_see_his_stats_spec.rb
+++ b/spec/features/agents/agent_can_see_his_stats_spec.rb
@@ -8,9 +8,9 @@ describe "Agent can see his stats" do
 
   shared_examples "a stats page" do
     it "displays all the stats" do
-      click_link 'Vos statistiques'
-      expect(page).to have_content('Statistiques')
-      expect(page).to have_content('RDV créés')
+      click_link "Vos statistiques"
+      expect(page).to have_content("Statistiques")
+      expect(page).to have_content("RDV créés")
     end
   end
 

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -5,26 +5,26 @@ describe "can see users' RDV" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link 'Vos usagers'
+    click_link "Vos usagers"
   end
 
-  context 'with no RDV' do
+  context "with no RDV" do
     before { click_link user.full_name }
     it do
       expect(page).to have_content("0\nÀ venir")
-      click_link 'Voir tous les RDV'
-      expect_page_title('Liste des RDV')
+      click_link "Voir tous les RDV"
+      expect_page_title("Liste des RDV")
       expect_page_with_no_record_text("Aucun RDV")
     end
   end
 
-  context 'with one RDV' do
+  context "with one RDV" do
     let!(:rdv) { create :rdv, :future, users: [user] }
     before { click_link user.full_name }
     it do
       expect(page).to have_content("1\nÀ venir")
-      click_link 'Voir tous les RDV'
-      expect_page_title('Liste des RDV')
+      click_link "Voir tous les RDV"
+      expect_page_title("Liste des RDV")
       expect(page).to have_content(rdv_title_spec(rdv))
     end
   end

--- a/spec/features/agents/relatives/agent_can_create_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_create_relative_spec.rb
@@ -13,7 +13,7 @@ describe "Agent can create a relative" do
   end
 
   it "should work" do
-    expect(page).to have_content('Aucun proche')
+    expect(page).to have_content("Aucun proche")
     click_link "Ajouter un proche"
     fill_in :user_first_name, with: "Loulou"
     fill_in :user_last_name, with: "Legende"
@@ -22,6 +22,6 @@ describe "Agent can create a relative" do
     click_button "Créer usager"
     expect_page_title("Loulou LEGENDE")
     expect(page).to have_content("L'usager a été créé")
-    expect(page).not_to have_content('Aucun proche')
+    expect(page).not_to have_content("Aucun proche")
   end
 end

--- a/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
@@ -16,10 +16,10 @@ describe "Agent can delete a relative" do
   end
 
   it "should work", js: true do
-    click_link('Supprimer')
+    click_link("Supprimer")
     page.driver.browser.switch_to.alert.accept
     expect_page_title "Fiona LEGENDE"
     expect(page).to have_content("L'usager a été supprimé")
-    expect(page).to have_content('Aucun proche')
+    expect(page).to have_content("Aucun proche")
   end
 end

--- a/spec/features/agents/relatives/agent_can_update_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_update_relative_spec.rb
@@ -25,9 +25,9 @@ describe "Agent can update a relative" do
     click_button "Modifier"
     expect_page_title "Michelle MYTHE"
     expect(page).to have_content("L'usager a été modifié")
-    expect(find('#spec-primary-user-card')).to have_content('Informations de votre proche')
-    expect(find('#spec-primary-user-card')).to have_content('fougue ultime')
-    expect(find('#spec-secondary-user-card')).to have_content("Informations sur l'usager en charge")
-    expect(find('#spec-secondary-user-card')).to have_content('tenebres')
+    expect(find("#spec-primary-user-card")).to have_content("Informations de votre proche")
+    expect(find("#spec-primary-user-card")).to have_content("fougue ultime")
+    expect(find("#spec-secondary-user-card")).to have_content("Informations sur l'usager en charge")
+    expect(find("#spec-secondary-user-card")).to have_content("tenebres")
   end
 end

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -9,20 +9,20 @@ describe "Agent can create user" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
-    click_link 'Créer un usager', match: :first
+    click_link "Créer un usager", match: :first
     expect_page_title("Nouvel usager")
   end
 
   it "should work" do
     fill_in :user_first_name, with: "Marco"
     fill_in :user_last_name, with: "Lebreton"
-    click_button 'Créer'
+    click_button "Créer"
     expect_page_title("Marco LEBRETON")
-    expect(page).to have_no_content('Inviter')
-    click_link 'Modifier'
-    fill_in 'Email', with: "marco@lebreton.bzh"
-    click_button 'Modifier'
-    click_link 'Inviter'
+    expect(page).to have_no_content("Inviter")
+    click_link "Modifier"
+    fill_in "Email", with: "marco@lebreton.bzh"
+    click_button "Modifier"
+    click_link "Inviter"
     open_email("marco@lebreton.bzh")
     expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")
   end
@@ -36,7 +36,7 @@ describe "Agent can create user" do
       fill_in :user_first_name, with: "Cee-Lo"
       fill_in :user_last_name, with: "Green"
       fill_in :user_email, with: "ceelo@green.com"
-      click_button 'Créer'
+      click_button "Créer"
       expect(page).to have_content("Un usager avec le même email existe déjà dans une autre organisation")
       click_link "Associer cet usager à l'organisation MDS des Champs"
       expect_page_title("Cee-Lo GREEN")

--- a/spec/features/agents/users/agent_can_delete_user_spec.rb
+++ b/spec/features/agents/users/agent_can_delete_user_spec.rb
@@ -11,7 +11,7 @@ describe "Agent can delete user" do
   end
 
   scenario "delete user", js: true do
-    click_link('Supprimer')
+    click_link("Supprimer")
     page.driver.browser.switch_to.alert.accept
     expect_page_title("Vos usagers")
     expect_page_with_no_record_text("Vous n'avez pas encore ajouté d'usager.")

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -12,19 +12,19 @@ describe "Agent can update user" do
     expect_page_title("Vos usagers")
     click_link "Jean LEGENDE"
     expect_page_title("Jean LEGENDE")
-    click_link 'Modifier'
+    click_link "Modifier"
   end
 
   scenario "update existing user's email" do
     fill_in :user_first_name, with: "jeanne"
     fill_in :user_last_name, with: "reynolds"
-    fill_in 'Email', with: 'jeanne@reynolds.com'
-    click_button 'Modifier'
+    fill_in "Email", with: "jeanne@reynolds.com"
+    click_button "Modifier"
     # When the user has already a pwd, changing email send a confirmation email
-    open_email('jeanne@reynolds.com')
+    open_email("jeanne@reynolds.com")
     expect(current_email.subject).to eq I18n.t("devise.mailer.confirmation_instructions.subject")
     expect_page_title("Jeanne REYNOLDS")
-    expect(page).to have_content('En attente de confirmation pour jeanne@reynolds.com')
+    expect(page).to have_content("En attente de confirmation pour jeanne@reynolds.com")
   end
 
   context "unregistered user" do
@@ -33,9 +33,9 @@ describe "Agent can update user" do
     end
 
     scenario "add email to existing user", js: true do
-      fill_in 'Email', with: "jean@legende.com"
-      click_button 'Modifier'
-      click_link 'Inviter'
+      fill_in "Email", with: "jean@legende.com"
+      click_button "Modifier"
+      click_link "Inviter"
       open_email("jean@legende.com")
       expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")
     end

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -5,10 +5,10 @@ describe "Anybody can see stats" do
 
   shared_examples "a stats page" do
     it "displays all the stats" do
-      click_link 'Statistiques'
-      expect(page).to have_content('Statistiques')
-      expect(page).to have_content('RDV créés')
-      expect(page).to have_content('Usagers créés')
+      click_link "Statistiques"
+      expect(page).to have_content("Statistiques")
+      expect(page).to have_content("RDV créés")
+      expect(page).to have_content("Usagers créés")
     end
   end
 

--- a/spec/features/super_admin/super_admin_sets_up_an_organisation_spec.rb
+++ b/spec/features/super_admin/super_admin_sets_up_an_organisation_spec.rb
@@ -10,30 +10,30 @@ describe "Super admin can configure an account" do
   end
 
   scenario "Create organisation and invite a agent" do
-    click_link 'Organisation'
-    click_link 'Création organisation'
-    fill_in 'Nom', with: organisation.name
-    fill_in 'Département', with: organisation.departement
-    click_button 'Créer'
+    click_link "Organisation"
+    click_link "Création organisation"
+    fill_in "Nom", with: organisation.name
+    fill_in "Département", with: organisation.departement
+    click_button "Créer"
     click_link organisation.name
 
-    click_link 'Agent'
-    click_link 'Création agent'
-    fill_in 'Email', with: agent.email
-    fill_in 'Prénom', with: agent.first_name
-    fill_in 'Nom', with: agent.last_name
-    select organisation.name, from: 'Organisation'
-    select Service.first.name, from: 'Service'
-    click_button 'Créer'
+    click_link "Agent"
+    click_link "Création agent"
+    fill_in "Email", with: agent.email
+    fill_in "Prénom", with: agent.first_name
+    fill_in "Nom", with: agent.last_name
+    select organisation.name, from: "Organisation"
+    select Service.first.name, from: "Service"
+    click_button "Créer"
     click_link agent.email
-    click_link 'Inviter'
-    click_link 'Se déconnecter'
+    click_link "Inviter"
+    click_link "Se déconnecter"
 
     open_email(agent.email)
     expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")
   end
 
-  shared_examples 'an administrate resource' do
+  shared_examples "an administrate resource" do
     it do
       class_name = resource.class.model_name.human
       click_link class_name
@@ -46,7 +46,7 @@ describe "Super admin can configure an account" do
       click_link "Création #{resource.class.name.titleize.downcase}"
       expect_page_title("Création #{class_name.titleize}")
 
-      click_link 'Précédent'
+      click_link "Précédent"
       expect_page_title(class_name)
     end
   end
@@ -54,11 +54,11 @@ describe "Super admin can configure an account" do
   [:agent, :user, :super_admin, :lieu, :service, :motif, :rdv, :plage_ouverture, :absence, :motif_libelle].each do |resource|
     context resource do
       let!(:resource) { create resource }
-      it_behaves_like 'an administrate resource'
+      it_behaves_like "an administrate resource"
     end
   end
 
   def expect_page_title(expected_title)
-    expect(page).to have_selector('h1.main-content__page-title', text: expected_title)
+    expect(page).to have_selector("h1.main-content__page-title", text: expected_title)
   end
 end

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -15,7 +15,7 @@ describe "User can manage their rdvs" do
       click_link("Annuler le RDV")
       expect(page).to have_content("Confirmation")
       click_link("Oui, annuler le RDV")
-      expect(page).to have_selector('.badge', text: "Annulé")
+      expect(page).to have_selector(".badge", text: "Annulé")
     end
   end
 
@@ -24,8 +24,8 @@ describe "User can manage their rdvs" do
 
     scenario "default", js: true do
       expect(page).to have_content(rdv.motif.name)
-      expect(page).not_to have_selector('li', text: "Annuler le RDV")
-      expect(page).to have_selector('p.font-italic', text: "Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne.")
+      expect(page).not_to have_selector("li", text: "Annuler le RDV")
+      expect(page).to have_selector("p.font-italic", text: "Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne.")
     end
   end
 
@@ -33,9 +33,9 @@ describe "User can manage their rdvs" do
     let(:starts_at) { 15.days.from_now }
     scenario "default", js: true do
       expect(page).to have_content("Je souhaite être prévenu si un créneau se libère.")
-      check 'Je souhaite être prévenu si un créneau se libère.'
+      check "Je souhaite être prévenu si un créneau se libère."
       expect(page).to have_content("Vous êtes à présent sur la liste d'attente")
-      uncheck 'Je souhaite être prévenu si un créneau se libère.'
+      uncheck "Je souhaite être prévenu si un créneau se libère."
       expect(page).to have_content("Vous n'êtes plus sur la liste d'attente")
     end
   end

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -14,7 +14,7 @@ describe "User can search for rdvs" do
     scenario "default", js: true do
       # Step 1
       expect_page_h1("Prenez rendez-vous en ligne\navec votre département")
-      fill_in('search_where', with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
+      fill_in("search_where", with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
 
       # fake algolia autocomplete to pass on Circle ci
       page.execute_script("document.querySelector('#search_departement').value = '92'")
@@ -24,12 +24,12 @@ describe "User can search for rdvs" do
 
       # Step 2
       expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
-      select(motif.service.name, from: 'search_service')
+      select(motif.service.name, from: "search_service")
       click_button("Choisir ce service")
 
       # Step 3
       expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
-      select(motif.name, from: 'search_motif_name')
+      select(motif.name, from: "search_motif_name")
       click_button("Choisir ce motif")
 
       # Step 4
@@ -54,30 +54,30 @@ describe "User can search for rdvs" do
       expect(page).to have_content("Inscription")
       fill_in(:user_first_name, with: "Michel")
       fill_in(:user_last_name, with: "Lapin")
-      fill_in('Email', with: "michel@lapin.fr")
+      fill_in("Email", with: "michel@lapin.fr")
       fill_in(:password, with: "12345678")
       click_button("Je m'inscris")
 
       # Confirmation email
-      open_email('michel@lapin.fr')
+      open_email("michel@lapin.fr")
       expect(current_email).to have_content("Merci pour votre inscription")
       current_email.click_link("Confirmer mon compte")
 
       # Login page
       expect(page).to have_content("Se connecter")
-      fill_in('Email', with: "michel@lapin.fr")
+      fill_in("Email", with: "michel@lapin.fr")
       fill_in(:password, with: "12345678")
       click_button("Se connecter")
 
       # Step 4
       expect(page).to have_content("Vos informations")
-      fill_in('Date de naissance', with: Date.tomorrow.strftime("%d/%m/%Y"))
-      click_button('Continuer')
+      fill_in("Date de naissance", with: Date.tomorrow.strftime("%d/%m/%Y"))
+      click_button("Continuer")
       expect(page).to have_content("Date de naissance est invalide")
-      fill_in('Date de naissance', with: DateTime.yesterday.strftime("%d/%m/%Y"))
-      fill_in('Nom de naissance', with: "Lapinou")
-      expect(page).to have_field('Adresse', with: '79 Rue de Plaisance, 92250 La Garenne-Colombes')
-      click_button('Continuer')
+      fill_in("Date de naissance", with: DateTime.yesterday.strftime("%d/%m/%Y"))
+      fill_in("Nom de naissance", with: "Lapinou")
+      expect(page).to have_field("Adresse", with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
+      click_button("Continuer")
 
       # Step 5
       expect(page).to have_content("Vaccination")
@@ -85,19 +85,19 @@ describe "User can search for rdvs" do
 
       # Add relative
       click_link("Ajouter un proche")
-      expect(page).to have_selector('h4', text: "Ajouter un proche")
-      fill_in('Prénom', with: "Mathieu")
-      fill_in('Nom', with: "Lapin")
-      fill_in('Date de naissance', with: Date.yesterday)
-      click_button('Créer')
+      expect(page).to have_selector("h4", text: "Ajouter un proche")
+      fill_in("Prénom", with: "Mathieu")
+      fill_in("Nom", with: "Lapin")
+      fill_in("Date de naissance", with: Date.yesterday)
+      click_button("Créer")
       expect(page).to have_content("Mathieu LAPIN")
 
-      click_button('Continuer')
+      click_button("Continuer")
 
       # Step 6
       expect(page).to have_content("Informations de contact")
       expect(page).to have_content("Mathieu LAPIN")
-      click_link('Confirmer mon RDV')
+      click_link("Confirmer mon RDV")
 
       # Step 7
       expect(page).to have_content("Vos rendez-vous")
@@ -126,9 +126,9 @@ describe "User can search for rdvs" do
 
       choose(relative.full_name)
 
-      click_button('Continuer')
+      click_button("Continuer")
 
-      click_link('Confirmer mon RDV')
+      click_link("Confirmer mon RDV")
 
       # Step 6
       expect(page).to have_content(relative.full_name)
@@ -136,6 +136,6 @@ describe "User can search for rdvs" do
   end
 
   def expect_page_h1(title)
-    expect(page).to have_selector('h1', text: title)
+    expect(page).to have_selector("h1", text: title)
   end
 end

--- a/spec/features/users/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/user_signs_up_and_signs_in_spec.rb
@@ -1,50 +1,50 @@
-feature 'User signs up and signs in' do
+feature "User signs up and signs in" do
   let(:user) { build(:user) }
   let(:invited_user) { create(:user, :unconfirmed) }
 
-  context 'through home page' do
+  context "through home page" do
     before { visit root_path }
 
-    scenario '.sign_up, .confirm, .sign_in and then signs out' do
-      click_link 'Se connecter'
-      click_link 'Je m\'inscris'
+    scenario ".sign_up, .confirm, .sign_in and then signs out" do
+      click_link "Se connecter"
+      click_link "Je m'inscris"
       sign_up(user)
       expect(current_path).to eq(new_user_session_path)
       expect_flash_info(I18n.t("devise.registrations.signed_up_but_unconfirmed"))
       open_email(user.email)
-      current_email.click_link 'Confirmer mon compte'
+      current_email.click_link "Confirmer mon compte"
       expect_flash_info(I18n.t("devise.confirmations.confirmed"))
       sign_in(user)
       expect(current_path).to eq(authenticated_user_root_path)
       expect_flash_info(I18n.t("devise.sessions.signed_in"))
       click_link user.first_name
-      click_link 'Se déconnecter'
+      click_link "Se déconnecter"
       expect(current_path).to eq(root_path)
     end
 
-    scenario '.sign_up, .invite!, accept_invite and then signs out' do
-      click_link 'Se connecter'
-      click_link 'Je m\'inscris'
+    scenario ".sign_up, .invite!, accept_invite and then signs out" do
+      click_link "Se connecter"
+      click_link "Je m'inscris"
       sign_up(invited_user)
       expect(current_path).to eq(new_user_session_path)
       expect_flash_info(I18n.t("devise.registrations.signed_up_but_unconfirmed"))
       open_email(invited_user.email)
       current_email.click_link "Accepter l'invitation"
-      expect(page).to have_content('Inscription')
+      expect(page).to have_content("Inscription")
       fill_in :password, with: "123456"
       click_on "Enregistrer"
       expect(current_path).to eq(root_path)
       expect_flash_info(I18n.t("devise.invitations.updated"))
       click_link invited_user.first_name
-      click_link 'Se déconnecter'
+      click_link "Se déconnecter"
       expect(current_path).to eq(root_path)
     end
 
-    context 'if agent goes wrong' do
+    context "if agent goes wrong" do
       let!(:agent) { create(:agent, password: "123456") }
 
-      scenario '.sign_in as user and be signed in as agent' do
-        click_link 'Se connecter'
+      scenario ".sign_in as user and be signed in as agent" do
+        click_link "Se connecter"
         fill_in :user_email, with: agent.email
         fill_in :password, with: agent.password
         click_on "Se connecter"
@@ -62,6 +62,6 @@ feature 'User signs up and signs in' do
   end
 
   def expect_flash_info(message)
-    expect(page).to have_selector('.alert.alert-info', text: message)
+    expect(page).to have_selector(".alert.alert-info", text: message)
   end
 end

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -7,26 +7,26 @@ describe "User views his rdv" do
     click_link "Vos rendez-vous"
   end
 
-  context 'with no rdv' do
+  context "with no rdv" do
     it { expect_page_with_no_record_text("Vous n'avez pas de RDV à venir.") }
   end
 
-  context 'with future rdv' do
+  context "with future rdv" do
     let!(:rdv) { create(:rdv, :future) }
     before { click_link "Vos rendez-vous" }
     it do
       expect(page).to have_content(rdv_title_spec(rdv))
-      click_link 'Voir vos RDV passés'
+      click_link "Voir vos RDV passés"
       expect_page_with_no_record_text("Vous n'avez pas de RDV passé.")
     end
   end
 
-  context 'with past rdv' do
+  context "with past rdv" do
     let!(:rdv) { create(:rdv, :past) }
     before { click_link "Vos rendez-vous" }
     it do
       expect_page_with_no_record_text("Vous n'avez pas de RDV à venir.")
-      click_link 'Voir vos RDV passés'
+      click_link "Voir vos RDV passés"
       expect(page).to have_content(rdv_title_spec(rdv))
     end
   end

--- a/spec/form_models/agent_rdv_wizard_spec.rb
+++ b/spec/form_models/agent_rdv_wizard_spec.rb
@@ -2,20 +2,20 @@ describe AgentRdvWizard do
   let(:organisation) { build(:organisation) }
   let!(:agent) { create(:agent) }
   let!(:user) { create(:user) }
-  let(:rdv_attributes) { { user_ids: [user.id], notes: 'test' } }
+  let(:rdv_attributes) { { user_ids: [user.id], notes: "test" } }
 
   describe "#new" do
     it "should work" do
       rdv_wizard = AgentRdvWizard::Step1.new(agent, organisation, rdv_attributes)
       expect(rdv_wizard.rdv.user_ids).to eq [user.id]
       expect(rdv_wizard.agents.to_a).to eq [agent]
-      expect(rdv_wizard.notes).to eq 'test'
+      expect(rdv_wizard.notes).to eq "test"
     end
 
     describe "motif default behaviour" do
       context "linked to a motif" do
         let!(:motif) { create(:motif, default_duration_in_min: 25) }
-        let(:rdv_attributes) { { user_ids: [user.id], motif_id: motif.id, notes: 'test' } }
+        let(:rdv_attributes) { { user_ids: [user.id], motif_id: motif.id, notes: "test" } }
 
         context "no duration passed explicitly" do
           it "should use motif default duration" do

--- a/spec/jobs/file_attente_job_spec.rb
+++ b/spec/jobs/file_attente_job_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe FileAttenteJob, type: :job do
-  describe '#perform' do
+  describe "#perform" do
     let(:now) { DateTime.parse("01-01-2019 09:00") }
     let(:plage_ouverture) { create(:plage_ouverture, first_day: 2.weeks.from_now, start_time: Tod::TimeOfDay.new(9)) }
     let(:rdv) { create(:rdv, starts_at: 2.weeks.from_now) }
@@ -12,7 +12,7 @@ RSpec.describe FileAttenteJob, type: :job do
 
     after { FileAttenteJob.perform_now }
 
-    it 'should call send_notifications' do
+    it "should call send_notifications" do
       expect(FileAttente).to receive(:send_notifications)
     end
   end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1,6 +1,6 @@
 describe Agent, type: :model do
-  describe '#soft_delete' do
-    context 'with many remaining organisations' do
+  describe "#soft_delete" do
+    context "with many remaining organisations" do
       before { agent.soft_delete deleted_org }
       let(:agent) { create(:agent, :with_multiple_organisations) }
       let(:deleted_org) { agent.organisations.first }
@@ -8,15 +8,15 @@ describe Agent, type: :model do
       it { expect(agent.deleted_at).to be_nil }
     end
 
-    context 'with one remaining organisations' do
+    context "with one remaining organisations" do
       let!(:agent) { create(:agent) }
       let(:deleted_org) { agent.organisations.first }
 
-      context 'without rdv' do
+      context "without rdv" do
         it { expect { agent.soft_delete deleted_org }.to change(Agent, :count).by(-1) }
       end
 
-      context 'with rdv' do
+      context "with rdv" do
         let!(:rdv) { create(:rdv, agent_ids: [agent.id]) }
         before { agent.soft_delete deleted_org }
 
@@ -24,7 +24,7 @@ describe Agent, type: :model do
       end
     end
 
-    context 'with no organisation given' do
+    context "with no organisation given" do
       let!(:agent) { create(:agent, :with_multiple_organisations) }
       let(:deleted_org) { nil }
 

--- a/spec/models/creneau/agent_search_spec.rb
+++ b/spec/models/creneau/agent_search_spec.rb
@@ -6,7 +6,7 @@ describe Creneau::AgentSearch, type: :model do
   let(:lieu_ids) { [] }
   let(:agent_ids) { [] }
 
-  describe '#lieux' do
+  describe "#lieux" do
     subject { agent_search.lieux }
 
     let(:motif) { plage_ouverture.motifs.first }

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -1,5 +1,5 @@
 describe FileAttente, type: :model do
-  describe '#send_notifications' do
+  describe "#send_notifications" do
     let(:now) { DateTime.parse("01-01-2019 09:00 +0100") }
     let!(:lieu) { create(:lieu) }
     let!(:plage_ouverture) { create(:plage_ouverture, first_day: now + 2.weeks, start_time: Tod::TimeOfDay.new(10)) }
@@ -19,18 +19,18 @@ describe FileAttente, type: :model do
     context "with availabilities before rdv" do
       let!(:plage_ouverture_2) { create(:plage_ouverture, first_day: 1.day.from_now, start_time: Tod::TimeOfDay.new(9)) }
 
-      it 'should increment notifications_sent' do
+      it "should increment notifications_sent" do
         expect { subject }.to change(file_attente, :notifications_sent).from(0).to(1)
       end
-      it 'should save last creneau sent' do
+      it "should save last creneau sent" do
         expect { subject }.to change(file_attente, :last_creneau_sent_at).from(nil).to(now)
       end
-      it 'should send an sms' do
+      it "should send an sms" do
         expect(SendTransactionalSmsJob).to receive(:perform_later)
         subject
       end
 
-      it 'should send an email' do
+      it "should send an email" do
         expect(Users::FileAttenteMailer).to receive(:new_creneau_available).with(rdv, rdv.users.first).and_return(double(deliver_later: nil))
         subject
       end
@@ -39,7 +39,7 @@ describe FileAttente, type: :model do
     context "without availabilities before rdv" do
       let!(:plage_ouverture_2) { create(:plage_ouverture, first_day: Date.yesterday) }
 
-      it 'should not send notification' do
+      it "should not send notification" do
         subject
         expect(SendTransactionalSmsJob).not_to receive(:perform_later)
         expect(Users::FileAttenteMailer).not_to receive(:new_creneau_available)
@@ -49,7 +49,7 @@ describe FileAttente, type: :model do
     context "when creneau was already sent" do
       let!(:plage_ouverture_2) { create(:plage_ouverture, first_day: 1.day.from_now, start_time: Tod::TimeOfDay.new(9)) }
 
-      it 'should not send notification' do
+      it "should not send notification" do
         file_attente.update(last_creneau_sent_at: now)
         file_attente.reload
         subject
@@ -61,7 +61,7 @@ describe FileAttente, type: :model do
     context "when creneau is too close to RDV" do
       let!(:plage_ouverture_2) { create(:plage_ouverture, first_day: 2.weeks.from_now - 1.day) }
 
-      it 'should not send notification' do
+      it "should not send notification" do
         expect { subject }.not_to change(file_attente, :notifications_sent).from(0)
       end
     end

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -89,7 +89,7 @@ describe Lieu, type: :model do
     end
   end
 
-  describe '.distance' do
+  describe ".distance" do
     let!(:lieu_lille) { create(:lieu, latitude: 50.63, longitude: 3.053) }
     let(:paris_loc) { { latitude: 48.83, longitude: 2.37 } }
     let(:reservable_online) { true }

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -4,14 +4,14 @@ describe Rdv, type: :model do
   let(:secretariat) { create(:service, :secretariat) }
   let(:motif_with_rdv) { create(:motif, :with_rdvs) }
 
-  describe '.create when associated with secretariat' do
+  describe ".create when associated with secretariat" do
     let(:motif) { build(:motif, service: secretariat) }
     it {
       expect(motif.valid?).to be false
     }
   end
 
-  describe '#soft_delete' do
+  describe "#soft_delete" do
     before do
       freeze_time
       @delation_time = Time.current

--- a/spec/models/plage_ouverture/ics_spec.rb
+++ b/spec/models/plage_ouverture/ics_spec.rb
@@ -2,7 +2,7 @@ describe PlageOuverture::Ics, type: :model do
   let(:plage_ouverture) { create(:plage_ouverture, first_day: Date.new(2019, 7, 22)) }
   let(:ics) { PlageOuverture::Ics.new(plage_ouverture: plage_ouverture) }
 
-  describe '#to_ical' do
+  describe "#to_ical" do
     subject { ics.to_ical }
 
     it do

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -1,5 +1,5 @@
 describe PlageOuverture, type: :model do
-  describe '#end_after_start' do
+  describe "#end_after_start" do
     let(:plage_ouverture) { build(:plage_ouverture, start_time: start_time, end_time: end_time) }
 
     context "start_time < end_time" do

--- a/spec/models/rdv/ics_spec.rb
+++ b/spec/models/rdv/ics_spec.rb
@@ -1,5 +1,5 @@
 describe Rdv::Ics, type: :model do
-  describe '#to_ical_for' do
+  describe "#to_ical_for" do
     let(:motif) { create(:motif, name: "Consultation initiale") }
     let(:user) { create(:user, first_name: "elisa", last_name: "simon", email: "elisa@simon.fr") }
     let(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes") }
@@ -20,7 +20,7 @@ describe Rdv::Ics, type: :model do
       is_expected.to include("METHOD:REQUEST")
     end
 
-    context 'when the motif is by_phone' do
+    context "when the motif is by_phone" do
       # TODO: this does not test for RDVs by phone at all.
       it { is_expected.to include("LOCATION:") }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,38 +1,38 @@
 describe User, type: :model do
-  describe '#age' do
+  describe "#age" do
     let(:user) { build(:user, birth_date: birth_date) }
 
-    context 'born 4 years ago' do
+    context "born 4 years ago" do
       let(:birth_date) { 4.years.ago }
 
       it { expect(user.age).to eq("4 ans") }
     end
 
-    context 'born 4 years + 1 day ago' do
+    context "born 4 years + 1 day ago" do
       let(:birth_date) { 4.years.ago + 1.day }
 
       it { expect(user.age).to eq("3 ans") }
     end
 
-    context 'born 2 months ago' do
+    context "born 2 months ago" do
       let(:birth_date) { 2.months.ago }
 
       it { expect(user.age).to eq("2 mois") }
     end
 
-    context 'born 23 months ago' do
+    context "born 23 months ago" do
       let(:birth_date) { 23.months.ago }
 
       it { expect(user.age).to eq("23 mois") }
     end
 
-    context 'born 24 months ago' do
+    context "born 24 months ago" do
       let(:birth_date) { 24.months.ago }
 
       it { expect(user.age).to eq("2 ans") }
     end
 
-    context 'born 20 days ago' do
+    context "born 20 days ago" do
       let(:birth_date) { 20.days.ago }
 
       it { expect(user.age).to eq("20 jours") }
@@ -133,7 +133,7 @@ describe User, type: :model do
       user.reload
     end
 
-    context 'belongs to multiple organisations and with organisation given' do
+    context "belongs to multiple organisations and with organisation given" do
       let(:user) { create(:user, :with_multiple_organisations, email: "jean@valjean.fr") }
       let(:deleted_org) { user.organisations.first }
       it { expect(user.organisations).not_to include(deleted_org) }
@@ -146,16 +146,16 @@ describe User, type: :model do
       it { expect(user.email).to eq "jean@valjean.fr" }
     end
 
-    context 'belongs to one organisation and with organisation given' do
+    context "belongs to one organisation and with organisation given" do
       let(:user) { create(:user, email: "jean@valjean.fr", organisations: [create(:organisation)]) }
       let(:deleted_org) { user.organisations.first }
       it { expect(user.deleted_at).to eq(now) }
-      it { expect(user.email).to end_with('deleted.rdv-solidarites.fr') }
-      it { expect(user.email_original).to eq('jean@valjean.fr') }
+      it { expect(user.email).to end_with("deleted.rdv-solidarites.fr") }
+      it { expect(user.email_original).to eq("jean@valjean.fr") }
       it { expect(user.organisations).to be_empty }
     end
 
-    context 'with no organisation given' do
+    context "with no organisation given" do
       let(:user) { create(:user, :with_multiple_organisations) }
       let(:deleted_org) { nil }
       it { expect(user.organisations).to be_empty }
@@ -259,16 +259,16 @@ describe User, type: :model do
         it { should eq(nil) }
       end
       context "blank phone number" do
-        let!(:user) { create(:user, phone_number: '') }
+        let!(:user) { create(:user, phone_number: "") }
         it { should eq(nil) }
       end
       context "valid phone number" do
-        let!(:user) { create(:user, phone_number: '01 30 30 40 40') }
-        it { should eq('+33130304040') }
+        let!(:user) { create(:user, phone_number: "01 30 30 40 40") }
+        it { should eq("+33130304040") }
       end
       context "invalid phone number" do
         it "should not save" do
-          user = build(:user, phone_number: '01 30 20')
+          user = build(:user, phone_number: "01 30 20")
           expect(user.save).to be false
         end
       end
@@ -277,11 +277,11 @@ describe User, type: :model do
     context "on update" do
       context "previous phone number" do
         it "should update it" do
-          user = create(:user, phone_number: '01 30 30 40 40')
-          expect(user.phone_number_formatted).to eq('+33130304040')
-          user.update!(phone_number: '04 300 32020')
-          expect(user.phone_number_formatted).to eq('+33430032020')
-          user.update!(phone_number: '')
+          user = create(:user, phone_number: "01 30 30 40 40")
+          expect(user.phone_number_formatted).to eq("+33130304040")
+          user.update!(phone_number: "04 300 32020")
+          expect(user.phone_number_formatted).to eq("+33430032020")
+          user.update!(phone_number: "")
           expect(user.phone_number_formatted).to eq(nil)
         end
       end
@@ -291,7 +291,7 @@ describe User, type: :model do
   describe "#search_by_text" do
     let!(:user_jean) { create(:user, first_name: "jean", last_name: "moustache", email: "jean@moustache.fr", phone_number: "01 30 30 04 04") }
     let!(:user_patricia) { create(:user, first_name: "patricia", last_name: "duroy", email: "patoche@duroy.fr", phone_number: nil) }
-    let!(:user_maurice) { create(:user, first_name: "maurice", last_name: "rhey", email: "mo@mo.lo", phone_number: '0152424242') }
+    let!(:user_maurice) { create(:user, first_name: "maurice", last_name: "rhey", email: "mo@mo.lo", phone_number: "0152424242") }
     subject { User.search_by_text(query) }
 
     context "name query" do

--- a/spec/models/webhook_deliverable_spec.rb
+++ b/spec/models/webhook_deliverable_spec.rb
@@ -10,30 +10,30 @@ describe WebhookDeliverable, type: :concern do
   RSpec::Matchers.define :json_payload_with_meta do |key, value|
     match do |actual|
       content = ActiveSupport::JSON.decode(actual)
-      content['meta'][key] == value
+      content["meta"][key] == value
     end
   end
 
-  describe '#send_web_hook' do
+  describe "#send_web_hook" do
     let(:rdv) { create(:rdv) }
 
-    it 'notifies on creation' do
-      expect(WebhookJob).to receive(:perform_later).with(json_payload_with_meta('event', 'created'), webhook_endpoint.id)
+    it "notifies on creation" do
+      expect(WebhookJob).to receive(:perform_later).with(json_payload_with_meta("event", "created"), webhook_endpoint.id)
       rdv.reload
     end
 
-    it 'notifies on update' do
+    it "notifies on update" do
       rdv.reload
 
-      expect(WebhookJob).to receive(:perform_later).with(json_payload_with_meta('event', 'updated'), webhook_endpoint.id)
+      expect(WebhookJob).to receive(:perform_later).with(json_payload_with_meta("event", "updated"), webhook_endpoint.id)
       rdv.status = :excused
       rdv.save
     end
 
-    it 'notifies on deletion' do
+    it "notifies on deletion" do
       rdv.reload
 
-      expect(WebhookJob).to receive(:perform_later).with(json_payload_with_meta('event', 'destroyed'), webhook_endpoint.id)
+      expect(WebhookJob).to receive(:perform_later).with(json_payload_with_meta("event", "destroyed"), webhook_endpoint.id)
       rdv.destroy
     end
   end

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -1,16 +1,16 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Zone, type: :model do
-  let(:organisation) { build(:organisation, departement: '75') }
+  let(:organisation) { build(:organisation, departement: "75") }
 
   describe "uniqueness" do
     context "city zone" do
       let(:zone_attributes) do
         {
           organisation: organisation,
-          level: 'city',
-          city_name: 'Paris XXe',
-          city_code: '75120'
+          level: "city",
+          city_name: "Paris XXe",
+          city_code: "75120"
         }
       end
 
@@ -24,9 +24,9 @@ RSpec.describe Zone, type: :model do
         Zone.create!(zone_attributes)
         duplicate_zone = Zone.new(
           organisation: build(:organisation),
-          level: 'city',
-          city_name: 'Paris 20e',
-          city_code: '75120'
+          level: "city",
+          city_name: "Paris 20e",
+          city_code: "75120"
         )
         expect(duplicate_zone.valid?).to eq false
         expect(duplicate_zone.errors.keys).to include(:city_code)
@@ -34,13 +34,13 @@ RSpec.describe Zone, type: :model do
     end
   end
 
-  describe 'incoherent departement and city code' do
+  describe "incoherent departement and city code" do
     it "should be invalid" do
       zone = Zone.new(
-        organisation: build(:organisation, departement: '75'),
-        level: 'city',
-        city_name: 'Paris XXe',
-        city_code: '62120'
+        organisation: build(:organisation, departement: "75"),
+        level: "city",
+        city_name: "Paris XXe",
+        city_code: "62120"
       )
       expect(zone.valid?).to eq false
       expect(zone.errors.keys).to eq([:city_code])

--- a/spec/presenters/paper_trail_augmented_version_spec.rb
+++ b/spec/presenters/paper_trail_augmented_version_spec.rb
@@ -3,9 +3,9 @@ describe PaperTrailAugmentedVersion do
     context "no previous version" do
       it "should work with only object_changes" do
         version = instance_double(PaperTrail::Version)
-        prepare_version_double(version, object_changes: { 'title' => ['foo', 'bar'] })
+        prepare_version_double(version, object_changes: { "title" => ["foo", "bar"] })
         expect(PaperTrailAugmentedVersion.new(version, nil).changes).to eq(
-          { 'title' => ['foo', 'bar'] }
+          { "title" => ["foo", "bar"] }
         )
       end
 
@@ -13,12 +13,12 @@ describe PaperTrailAugmentedVersion do
         version = instance_double(PaperTrail::Version)
         prepare_version_double(
           version,
-          object_changes: { 'title' => ['foo', 'bar'] },
+          object_changes: { "title" => ["foo", "bar"] },
           virtual_attributes: { "user_ids" => [1, 2] }
         )
         expect(PaperTrailAugmentedVersion.new(version, nil).changes).to eq(
           {
-            'title' => ['foo', 'bar'],
+            "title" => ["foo", "bar"],
             "user_ids" => [nil, [1, 2]],
           }
         )
@@ -31,12 +31,12 @@ describe PaperTrailAugmentedVersion do
       before do
         prepare_version_double(
           version,
-          object_changes: { 'title' => ['foo', 'bar'] },
+          object_changes: { "title" => ["foo", "bar"] },
           virtual_attributes: { "user_ids" => [1, 2], "agent_ids" => [3] }
         )
         prepare_version_double(
           previous_version,
-          object_changes: { 'title' => ['baz', 'foo'] },
+          object_changes: { "title" => ["baz", "foo"] },
           virtual_attributes: { "user_ids" => [1], "agent_ids" => [3] }
         )
       end
@@ -46,7 +46,7 @@ describe PaperTrailAugmentedVersion do
           PaperTrailAugmentedVersion.new(version, previous_version).changes
         ).to eq(
           {
-            'title' => ['foo', 'bar'],
+            "title" => ["foo", "bar"],
             "user_ids" => [[1], [1, 2]],
             # agent_ids has not changed so it does not appear here
           }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -20,8 +20,8 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
-Dir[Rails.root.join('spec', 'factories', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "factories", "**", "*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/services/duplicate_user_finder_service_spec.rb
+++ b/spec/services/duplicate_user_finder_service_spec.rb
@@ -1,6 +1,6 @@
 describe DuplicateUserFinderService, type: :service do
   describe ".perform" do
-    let(:user) { build(:user, first_name: "Mathieu", last_name: "Lapin", email: "lapin@beta.fr", birth_date: '21/10/2000', phone_number: '0658032518') }
+    let(:user) { build(:user, first_name: "Mathieu", last_name: "Lapin", email: "lapin@beta.fr", birth_date: "21/10/2000", phone_number: "0658032518") }
 
     subject { DuplicateUserFinderService.new(user).perform }
 
@@ -31,7 +31,7 @@ describe DuplicateUserFinderService, type: :service do
       end
 
       context "same main first_name, last_name, birth_date" do
-        let!(:duplicated_user) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: '21/10/2000') }
+        let!(:duplicated_user) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: "21/10/2000") }
         it { should eq(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user)) }
 
         context "but soft deleted" do
@@ -41,7 +41,7 @@ describe DuplicateUserFinderService, type: :service do
       end
 
       context "same phone_number" do
-        let!(:duplicated_user) { create(:user, phone_number: '0658032518') }
+        let!(:duplicated_user) { create(:user, phone_number: "0658032518") }
         it { should eq(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user)) }
 
         context "but soft deleted" do
@@ -57,8 +57,8 @@ describe DuplicateUserFinderService, type: :service do
       end
 
       context "multiple account" do
-        let!(:duplicated_user_1) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: '21/10/2000') }
-        let!(:duplicated_user_2) { create(:user, phone_number: '0658032518') }
+        let!(:duplicated_user_1) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: "21/10/2000") }
+        let!(:duplicated_user_2) { create(:user, phone_number: "0658032518") }
         let!(:rdv) { create(:rdv, users: [duplicated_user_1]) }
         it { should eq(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user_1)) }
 

--- a/spec/services/import_zone_rows_service_spec.rb
+++ b/spec/services/import_zone_rows_service_spec.rb
@@ -1,6 +1,6 @@
 describe ImportZoneRowsService, type: :service do
-  let!(:orga_arques) { create(:organisation, human_id: "arques", departement: '62') }
-  let!(:orga_arras_sud) { create(:organisation, human_id: "arras-sud", departement: '62') }
+  let!(:orga_arques) { create(:organisation, human_id: "arques", departement: "62") }
+  let!(:orga_arras_sud) { create(:organisation, human_id: "arras-sud", departement: "62") }
   let!(:agent) { create(:agent, :admin, organisation_ids: [orga_arques.id, orga_arras_sud.id]) }
 
   context "valid rows" do
@@ -13,7 +13,7 @@ describe ImportZoneRowsService, type: :service do
     end
 
     it "should be valid and import zones" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(true)
       expect(res[:counts][:imported_new]["arques"]).to eq(2)
       expect(res[:counts][:imported_new]["arras-sud"]).to eq(1)
@@ -25,7 +25,7 @@ describe ImportZoneRowsService, type: :service do
 
     context "dry_run" do
       it "should return counters but not actually import" do
-        res = ImportZoneRowsService.perform_with(rows, '62', agent, dry_run: true)
+        res = ImportZoneRowsService.perform_with(rows, "62", agent, dry_run: true)
         expect(res[:valid]).to eq(true)
         expect(res[:counts][:imported_new]["arques"]).to eq(2)
         expect(res[:counts][:imported_new]["arras-sud"]).to eq(1)
@@ -38,7 +38,7 @@ describe ImportZoneRowsService, type: :service do
   context "no lines" do
     let(:rows) { [] }
     it "should be invalid" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:errors][0]).to eq("Aucune ligne")
     end
@@ -53,7 +53,7 @@ describe ImportZoneRowsService, type: :service do
       ]
     end
     it "should be invalid" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:errors][0]).to eq("Colonne(s) city_code absente(s)")
     end
@@ -68,7 +68,7 @@ describe ImportZoneRowsService, type: :service do
       ]
     end
     it "should be invalid" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:row_errors][1]).to eq("Champ(s) city_code manquant(s)")
     end
@@ -82,7 +82,7 @@ describe ImportZoneRowsService, type: :service do
       ]
     end
     it "should be invalid" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:row_errors][1]).to eq("Champ(s) organisation_id manquant(s)")
     end
@@ -96,7 +96,7 @@ describe ImportZoneRowsService, type: :service do
       ]
     end
     it "should not import anything" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:row_errors][0]).to include("Aucune organisation trouvée pour l'identifiant arras-nord")
       expect(Zone.count).to eq(0)
@@ -110,7 +110,7 @@ describe ImportZoneRowsService, type: :service do
       ]
     end
     it "should not import anything" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:row_errors][0]).to include("doit commencer par le département de l'organisation")
       expect(Zone.count).to eq(0)
@@ -126,7 +126,7 @@ describe ImportZoneRowsService, type: :service do
     end
 
     it "should not import anything" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:errors][0]).to eq("Le code commune 62040 apparaît 2 fois")
       expect(Zone.count).to eq(0)
@@ -143,32 +143,32 @@ describe ImportZoneRowsService, type: :service do
     end
     context "without override option" do
       it "should not import anything" do
-        res = ImportZoneRowsService.perform_with(rows, '62', agent)
+        res = ImportZoneRowsService.perform_with(rows, "62", agent)
         expect(res[:valid]).to eq(false)
         expect(res[:counts][:imported]).to be_empty
         expect(res[:row_errors][0]).to eq("Code de la commune (Code INSEE) est déjà utilisé")
         expect(Zone.count).to eq(1)
-        expect(Zone.first.city_code).to eq('62040')
+        expect(Zone.first.city_code).to eq("62040")
         expect(Zone.first.organisation).to eq(orga_arras_sud) # unchanged
       end
     end
     context "with override option" do
       it "should not import anything" do
-        res = ImportZoneRowsService.perform_with(rows, '62', agent, override_conflicts: true)
+        res = ImportZoneRowsService.perform_with(rows, "62", agent, override_conflicts: true)
         expect(res[:row_errors]).to be_empty
         expect(res[:valid]).to eq(true)
         expect(res[:counts][:imported]["arques"]).to eq(2)
         expect(res[:counts][:imported_override]["arques"]).to eq(1)
         expect(res[:counts][:imported_new]["arques"]).to eq(1)
         expect(Zone.count).to eq(2)
-        expect(Zone.find_by(city_code: '62040').organisation).to eq(orga_arques)
-        expect(Zone.find_by(city_code: '62004').organisation).to eq(orga_arques)
+        expect(Zone.find_by(city_code: "62040").organisation).to eq(orga_arques)
+        expect(Zone.find_by(city_code: "62004").organisation).to eq(orga_arques)
       end
     end
   end
 
   context "organisation exists in same departement, but agent unauthorized" do
-    let!(:orga_arras_nord) { create(:organisation, human_id: "arras-nord", departement: '62') }
+    let!(:orga_arras_nord) { create(:organisation, human_id: "arras-nord", departement: "62") }
 
     let(:rows) do
       [
@@ -178,7 +178,7 @@ describe ImportZoneRowsService, type: :service do
     end
 
     it "should not import anything" do
-      res = ImportZoneRowsService.perform_with(rows, '62', agent)
+      res = ImportZoneRowsService.perform_with(rows, "62", agent)
       expect(res[:valid]).to eq(false)
       expect(res[:row_errors][1]).to include("Pas les droits nécessaires")
       expect(Zone.count).to eq(0)

--- a/spec/services/notifications/rdv/rdv_upcoming_reminder_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_upcoming_reminder_service_spec.rb
@@ -4,7 +4,7 @@ describe Notifications::Rdv::RdvUpcomingReminderService, type: :service do
   let(:user1) { build(:user) }
   let(:rdv) { create(:rdv, starts_at: 2.days.from_now, users: [user1]) }
 
-  it 'should send an sms and an email' do
+  it "should send an sms and an email" do
     expect(Users::RdvMailer).to receive(:rdv_upcoming_reminder)
       .with(rdv, user1)
       .and_return(double(deliver_later: nil))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,21 +13,21 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'database_cleaner'
-require 'capybara/rspec'
-require 'capybara/email/rspec'
-require 'webdrivers'
-require 'capybara-screenshot/rspec'
+require "database_cleaner"
+require "capybara/rspec"
+require "capybara/email/rspec"
+require "webdrivers"
+require "capybara-screenshot/rspec"
 
 Capybara.register_driver :selenium do |app|
   # these args seem to reduce test flakyness
   # w3c false required for logs cf https://github.com/SeleniumHQ/selenium/issues/7270
   chrome_options = { args: %w[headless no-sandbox disable-gpu window-size=1500,1000], w3c: false }
-  chrome_bin = ENV.fetch('GOOGLE_CHROME_SHIM', nil)
+  chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
   chrome_options[:binary] = chrome_bin if chrome_bin
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: chrome_options,
-    "goog:loggingPrefs" => { browser: 'ALL' }
+    "goog:loggingPrefs" => { browser: "ALL" }
   )
   Capybara::Selenium::Driver.new(
     app,
@@ -37,7 +37,7 @@ Capybara.register_driver :selenium do |app|
 end
 
 Capybara.configure do |config|
-  port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
+  port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
   config.app_host = "http://localhost:#{port}"
   # config.asset_host = "http://localhost:#{port}"  # for screenshots
   config.server_host = "localhost"
@@ -152,7 +152,7 @@ RSpec.configure do |config|
     [:browser, :driver].each do |source|
       errors = Capybara.page.driver.browser.manage.logs.get(source)
       fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"
-      File.open(fp, 'w') do |f|
+      File.open(fp, "w") do |f|
         f << "// empty logs" if errors.empty?
         errors.each do |e|
           f << "#{e.timestamp} [#{e.level}]: #{e.message}"

--- a/spec/support/page_spec_helper.rb
+++ b/spec/support/page_spec_helper.rb
@@ -1,10 +1,10 @@
 module PageSpecHelper
   def expect_page_title(title)
-    expect(page).to have_selector('h4.page-title', text: title)
+    expect(page).to have_selector("h4.page-title", text: title)
   end
 
   def expect_page_with_no_record_text(text)
-    expect(page).to have_selector('.card .card-body p.lead', text: text)
+    expect(page).to have_selector(".card .card-body p.lead", text: text)
   end
 
   def rdv_title_spec(rdv)

--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -2,6 +2,6 @@ module Select2SpecHelper
   def select_user(user)
     find(".select2-selection").click
     find(".select2-results li.select2-results__option", text: user.full_name).click
-    expect(page).to have_content('Modifier')
+    expect(page).to have_content("Modifier")
   end
 end


### PR DESCRIPTION
followup to https://github.com/betagouv/rdv-solidarites.fr/pull/805

as discussed with @stephanyan : 
- we are enforcing double quotes everywhere, no matter whether interpolation is used
- we used rubocop to autocorrect all occurrences
- no files are excluded, neither schema.rb