### PR TITLE
monitor CRON jobs running : RDV reminders and file attente notifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ rake send_reminder
 
 # Envoi des sms/email lorsque des créneaux se libèrent
 rake file_attente
+
+# Envoi d'un mail quotidien de monitoring des notifs a l'equipe
+rake rdv_events_stats_mail
 ```
 
 ### Organisation du développement et processus de déploiement

--- a/app/controllers/admin/mailer_previews_controller.rb
+++ b/app/controllers/admin/mailer_previews_controller.rb
@@ -26,8 +26,9 @@ module Admin
         part_type = Mime::Type.lookup(params[:part])
 
         if (part = find_part(part_type))
-          return response.content_type = part_type &&
-                                         render(plain: part.respond_to?(:decoded) ? part.decoded : part)
+          response.content_type = part_type.to_s
+          render(plain: part.respond_to?(:decoded) ? part.decoded : part)
+          return
         end
         raise AbstractController::ActionNotFound, "Email part '#{part_type}' not found in #{@preview.name}##{@email_action}"
       else

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,0 +1,5 @@
+class HealthChecksController < ApplicationController
+  def rdv_events_stats
+    render json: RdvEvent.date_stats
+  end
+end

--- a/app/jobs/send_rdv_events_stats_mail_job.rb
+++ b/app/jobs/send_rdv_events_stats_mail_job.rb
@@ -1,0 +1,5 @@
+class SendRdvEventsStatsMailJob < ApplicationJob
+  def perform
+    Admins::SystemMailer.rdv_events_stats.deliver_later
+  end
+end

--- a/app/mailers/admins/system_mailer.rb
+++ b/app/mailers/admins/system_mailer.rb
@@ -1,0 +1,7 @@
+class Admins::SystemMailer < ApplicationMailer
+  def rdv_events_stats
+    @today_stats = RdvEvent.date_stats(Date.today)
+    @yesterday_stats = RdvEvent.date_stats(Date.yesterday)
+    mail(to: "contact@rdv-solidarites.fr", subject: "[monitoring] Notifications Stats")
+  end
+end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -12,6 +12,7 @@ class Rdv < ApplicationRecord
   has_many :agents, through: :agents_rdvs
   has_many :rdvs_users, validate: false, inverse_of: :rdv, dependent: :destroy
   has_many :users, through: :rdvs_users, validate: false
+  has_many :events, class_name: "RdvEvent"
 
   has_many :webhook_endpoints, through: :organisation
 

--- a/app/models/rdv_event.rb
+++ b/app/models/rdv_event.rb
@@ -5,4 +5,15 @@ class RdvEvent < ApplicationRecord
   validates :event_type, inclusion: { in: [TYPE_NOTIFICATION_SMS, TYPE_NOTIFICATION_MAIL] }
 
   belongs_to :rdv
+
+  def self.date_stats(date = Date.today)
+    [TYPE_NOTIFICATION_SMS, TYPE_NOTIFICATION_MAIL].map do |event_type|
+      events_by_name = RdvEvent
+        .where(event_type: event_type)
+        .where("date(created_at) = ?", date)
+        .group(:event_name)
+        .count
+      [event_type, events_by_name.merge("total" => events_by_name.values.sum)]
+    end.to_h
+  end
 end

--- a/app/models/rdv_event.rb
+++ b/app/models/rdv_event.rb
@@ -1,0 +1,8 @@
+class RdvEvent < ApplicationRecord
+  TYPE_NOTIFICATION_SMS = "notification_sms".freeze
+  TYPE_NOTIFICATION_MAIL = "notification_mail".freeze
+
+  validates :event_type, inclusion: { in: [TYPE_NOTIFICATION_SMS, TYPE_NOTIFICATION_MAIL] }
+
+  belongs_to :rdv
+end

--- a/app/services/notifications/rdv/base_service_concern.rb
+++ b/app/services/notifications/rdv/base_service_concern.rb
@@ -8,8 +8,12 @@ module Notifications::Rdv::BaseServiceConcern
   def perform
     return false if @rdv.starts_at < Time.zone.now || @rdv.motif.disable_notifications_for_users
 
-    if methods.include?(:notify_user)
-      @rdv.users.map(&:user_to_notify).uniq.each { notify_user(_1) }
+    if methods.include?(:notify_user_by_mail)
+      users_to_notify.select { _1.email.present? }.each { notify_user_by_mail(_1) }
+    end
+
+    if methods.include?(:notify_user_by_sms)
+      users_to_notify.select { _1.phone_number_formatted.present? }.each { notify_user_by_sms(_1) }
     end
 
     if methods.include?(:notify_agent)
@@ -17,5 +21,9 @@ module Notifications::Rdv::BaseServiceConcern
     end
 
     true
+  end
+
+  def users_to_notify
+    @rdv.users.map(&:user_to_notify).uniq
   end
 end

--- a/app/services/notifications/rdv/rdv_cancelled_by_agent_service.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_by_agent_service.rb
@@ -3,8 +3,13 @@ class Notifications::Rdv::RdvCancelledByAgentService < ::BaseService
 
   protected
 
-  def notify_user(user)
-    Users::RdvMailer.rdv_cancelled_by_agent(@rdv, user).deliver_later if user.email.present?
-    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.id, user.id) if user.phone_number_formatted
+  def notify_user_by_mail(user)
+    Users::RdvMailer.rdv_cancelled_by_agent(@rdv, user).deliver_later
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :cancelled_by_agent)
+  end
+
+  def notify_user_by_sms(user)
+    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.id, user.id)
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :cancelled_by_agent)
   end
 end

--- a/app/services/notifications/rdv/rdv_created_service.rb
+++ b/app/services/notifications/rdv/rdv_created_service.rb
@@ -3,9 +3,14 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
 
   protected
 
-  def notify_user(user)
-    Users::RdvMailer.rdv_created(@rdv, user).deliver_later if user.email.present?
-    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.id, user.id) if user.phone_number_formatted
+  def notify_user_by_mail(user)
+    Users::RdvMailer.rdv_created(@rdv, user).deliver_later
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :created)
+  end
+
+  def notify_user_by_sms(user)
+    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.id, user.id)
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :created)
   end
 
   def notify_agent(agent)

--- a/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
+++ b/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
@@ -3,8 +3,13 @@ class Notifications::Rdv::RdvUpcomingReminderService < ::BaseService
 
   protected
 
-  def notify_user(user)
-    Users::RdvMailer.rdv_upcoming_reminder(@rdv, user).deliver_later if user.email.present?
-    SendTransactionalSmsJob.perform_later(:reminder, @rdv.id, user.id) if user.phone_number_formatted
+  def notify_user_by_mail(user)
+    Users::RdvMailer.rdv_upcoming_reminder(@rdv, user).deliver_later
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :upcoming_reminder)
+  end
+
+  def notify_user_by_sms(user)
+    SendTransactionalSmsJob.perform_later(:reminder, @rdv.id, user.id)
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :upcoming_reminder)
   end
 end

--- a/app/services/notifications/rdv/rdv_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_updated_service.rb
@@ -3,9 +3,15 @@ class Notifications::Rdv::RdvUpdatedService < ::BaseService
 
   protected
 
-  def notify_user(user)
-    # TODO : it's weird that it uses the exact same notifications as for creations
-    Users::RdvMailer.rdv_created(@rdv, user).deliver_later if user.email.present?
-    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.id, user.id) if user.phone_number_formatted
+  # TODO : it's weird that it uses the exact same notifications as for creations
+
+  def notify_user_by_mail(user)
+    Users::RdvMailer.rdv_created(@rdv, user).deliver_later
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :updated)
+  end
+
+  def notify_user_by_sms(user)
+    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.id, user.id)
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :updated)
   end
 end

--- a/app/views/mailers/admins/system_mailer/rdv_events_stats.html.slim
+++ b/app/views/mailers/admins/system_mailer/rdv_events_stats.html.slim
@@ -1,0 +1,19 @@
+h1 Notification Stats
+
+- @today_stats.each do |event_type, stats|
+  h3= "Today #{event_type}"
+  table
+    - stats.each do |event_name, count|
+      tr
+        td[style='text-align: right;']= event_name
+        td[style='padding-left: 10px;']= count
+
+hr
+
+- @today_stats.each do |event_type, stats|
+  h3= "Yesterday #{event_type}"
+  table
+    - stats.each do |event_name, count|
+      tr
+        td[style='text-align: right;']= event_name
+        td[style='padding-left: 10px;']= count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,5 +159,6 @@ Rails.application.routes.draw do
   get "departement/:departement/:service/:motif", to: "welcome#welcome_motif", as: "welcome_motif"
   resources :lieux, only: [:index, :show]
   resources :motif_libelles, only: :index
+  get "health_checks/rdv_events_stats", to: "health_checks#rdv_events_stats"
   root "welcome#index"
 end

--- a/db/migrate/20200730084038_create_rdv_events.rb
+++ b/db/migrate/20200730084038_create_rdv_events.rb
@@ -1,0 +1,10 @@
+class CreateRdvEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :rdv_events do |t|
+      t.references :rdv, null: false, foreign_key: true
+      t.string :event_type
+      t.string :event_name
+      t.datetime :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_093918) do
+ActiveRecord::Schema.define(version: 2020_07_30_084038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -223,6 +223,14 @@ ActiveRecord::Schema.define(version: 2020_07_29_093918) do
     t.index ["organisation_id"], name: "index_plage_ouvertures_on_organisation_id"
   end
 
+  create_table "rdv_events", force: :cascade do |t|
+    t.bigint "rdv_id", null: false
+    t.string "event_type"
+    t.string "event_name"
+    t.datetime "created_at"
+    t.index ["rdv_id"], name: "index_rdv_events_on_rdv_id"
+  end
+
   create_table "rdvs", force: :cascade do |t|
     t.integer "duration_in_min", null: false
     t.datetime "starts_at", null: false
@@ -364,6 +372,7 @@ ActiveRecord::Schema.define(version: 2020_07_29_093918) do
   add_foreign_key "plage_ouvertures", "agents"
   add_foreign_key "plage_ouvertures", "lieux"
   add_foreign_key "plage_ouvertures", "organisations"
+  add_foreign_key "rdv_events", "rdvs"
   add_foreign_key "rdvs", "lieux"
   add_foreign_key "rdvs", "motifs"
   add_foreign_key "rdvs", "organisations"

--- a/lib/tasks/rdv_events_stats_mail.rake
+++ b/lib/tasks/rdv_events_stats_mail.rake
@@ -1,0 +1,3 @@
+task rdv_events_stats_mail: :environment do
+  SendRdvEventsStatsMailJob.set(cron: "0 12 * * *").perform_later
+end

--- a/spec/mailers/previews/admins/system_mailer_preview.rb
+++ b/spec/mailers/previews/admins/system_mailer_preview.rb
@@ -1,0 +1,5 @@
+class Admins::SystemMailerPreview < ActionMailer::Preview
+  def rdv_events_stats
+    Admins::SystemMailer.rdv_events_stats
+  end
+end

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -28,11 +28,13 @@ describe FileAttente, type: :model do
       it "should send an sms" do
         expect(SendTransactionalSmsJob).to receive(:perform_later)
         subject
+        expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "file_attente_creneaux_available").count).to eq 1
       end
 
       it "should send an email" do
         expect(Users::FileAttenteMailer).to receive(:new_creneau_available).with(rdv, rdv.users.first).and_return(double(deliver_later: nil))
         subject
+        expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "file_attente_creneaux_available").count).to eq 1
       end
     end
 

--- a/spec/models/rdv_event_spec.rb
+++ b/spec/models/rdv_event_spec.rb
@@ -1,0 +1,12 @@
+describe RdvEvent, type: :model do
+  let(:rdv) { build(:rdv) }
+
+  it "requires a RDV" do
+    expect(RdvEvent.new(event_type: RdvEvent::TYPE_NOTIFICATION_SMS).valid?).to eq false
+  end
+
+  it "validates type" do
+    expect(RdvEvent.new(rdv: rdv, event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "reminder").valid?).to eq true
+    expect(RdvEvent.new(rdv: rdv, event_type: "whatev", event_name: "reminder").valid?).to eq false
+  end
+end

--- a/spec/services/notifications/rdv/rdv_cancelled_by_agent_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_by_agent_service_spec.rb
@@ -3,16 +3,18 @@ describe Notifications::Rdv::RdvCancelledByAgentService, type: :service do
   let(:user1) { build(:user) }
   let(:rdv) { create(:rdv, starts_at: 3.days.from_now, users: [user1]) }
 
-  it "calls RdvMailer to send email to user" do
+  it "sends an email" do
     expect(Users::RdvMailer).to receive(:rdv_cancelled_by_agent)
       .with(rdv, user1)
       .and_return(double(deliver_later: nil))
     subject
+    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
   end
 
-  it "calls RdvMailer to send email to user" do
+  it "sends a SMS" do
     expect(SendTransactionalSmsJob).to receive(:perform_later)
       .with(:rdv_cancelled, rdv.id, user1.id)
     subject
+    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "cancelled_by_agent").count).to eq 1
   end
 end

--- a/spec/services/notifications/rdv/rdv_created_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_created_service_spec.rb
@@ -5,8 +5,16 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
   let(:agent1) { build(:agent) }
   let(:agent2) { build(:agent) }
 
+  def create_rdv_skip_notify(**kwargs)
+    rdv = build(:rdv, **kwargs)
+    # HACK: skip callback on single object
+    def rdv.notify_rdv_created; end
+    rdv.save!
+    rdv
+  end
+
   context "starts in more than 2 days" do
-    let(:rdv) { create(:rdv, starts_at: 3.days.from_now, users: [user1, user2], agents: [agent1, agent2]) }
+    let(:rdv) { create_rdv_skip_notify(starts_at: 3.days.from_now, users: [user1, user2], agents: [agent1, agent2]) }
     # create is necessary for serialization reasons (?)
 
     it "triggers sending mail to users but not to agents" do
@@ -14,12 +22,12 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
       expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2).and_return(double(deliver_later: nil))
       expect(Agents::RdvMailer).not_to receive(:rdv_starting_soon_created)
       subject
+      expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "created").count).to eq 2
     end
   end
 
   context "starts today or tomorrow" do
-    let(:rdv) { create(:rdv, starts_at: 2.hours.from_now, users: [user1, user2], agents: [agent1, agent2]) }
-    # create is necessary for serialization reasons (?)
+    let(:rdv) { create_rdv_skip_notify(starts_at: 2.hours.from_now, users: [user1, user2], agents: [agent1, agent2]) }
 
     it "triggers sending mails to both user and agents" do
       expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1).and_return(double(deliver_later: nil))
@@ -32,7 +40,7 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
 
   context "motif with users notifications disabled" do
     let(:motif) { build(:motif, :no_notification) }
-    let(:rdv) { create(:rdv, motif: motif, starts_at: 3.days.from_now, users: [user1, user2]) }
+    let(:rdv) { create_rdv_skip_notify(motif: motif, starts_at: 3.days.from_now, users: [user1, user2]) }
 
     it "should not be called" do
       expect(Users::RdvMailer).not_to receive(:rdv_created)
@@ -44,7 +52,7 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
     # TODO: this is actually testing the users#user_to_notify method, move it
     let(:responsible) { create(:user) }
     let(:relative) { create(:user, responsible_id: responsible.id) }
-    let(:rdv) { create(:rdv, users: [relative], starts_at: 3.days.from_now) }
+    let(:rdv) { create_rdv_skip_notify(users: [relative], starts_at: 3.days.from_now) }
 
     it "calls RdvMailer to send email to responsible" do
       expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, responsible).and_return(double(deliver_later: nil))

--- a/spec/services/notifications/rdv/rdv_upcoming_reminder_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_upcoming_reminder_service_spec.rb
@@ -12,5 +12,7 @@ describe Notifications::Rdv::RdvUpcomingReminderService, type: :service do
       .with(:reminder, rdv.id, user1.id)
     # .and_call_original
     subject
+    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "upcoming_reminder").count).to eq 1
+    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "upcoming_reminder").count).to eq 1
   end
 end


### PR DESCRIPTION
https://trello.com/c/FKue0DWU/971-monitor-cron-jobs-reminders-file-attente

- new table `RdvEvents` : `rdv_id event_type event_name`
- store event on each mail + sms notifs
- new public endpoint to expose RdvEvent today stats (to setup an external monitoring alert)
- daily mail sent with RdvEvents stats for manual monitoring in the first days/weeks