### PR TITLE
fix user soft_delete with RDVs

### DIFF
--- a/app/controllers/agents/rdvs_controller.rb
+++ b/app/controllers/agents/rdvs_controller.rb
@@ -86,7 +86,7 @@ class Agents::RdvsController < AgentAuthController
   end
 
   def rdvs_list(agent, form)
-    rdvs = agent.rdvs.where(organisation: current_organisation)
+    rdvs = agent.rdvs.active.where(organisation: current_organisation)
     rdvs = rdvs.default_stats_period if form.default_period.present?
     rdvs = rdvs.status(form.status) if form.status.present?
     if form.date_range_params.present?

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -88,7 +88,7 @@ class Agents::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if Rdv.future.not_cancelled.where(users: @user.family.pluck(:id), organisation: current_organisation).empty?
+    if Rdv.future.not_cancelled.where(users: @user.self_and_relatives.pluck(:id), organisation: current_organisation).empty?
       @user.soft_delete(current_organisation)
       flash[:notice] = "L'usager a été supprimé."
     else

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -88,11 +88,11 @@ class Agents::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if Rdv.future.not_cancelled.where(users: @user.self_and_relatives.pluck(:id), organisation: current_organisation).empty?
+    if @user.can_be_soft_deleted_from_organisation?(current_organisation)
       @user.soft_delete(current_organisation)
       flash[:notice] = "L'usager a été supprimé."
     else
-      flash[:error] = "L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer."
+      flash[:error] = I18n.t("users.can_not_delete_because_has_future_rdvs")
     end
 
     if @user.relative?

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -88,7 +88,7 @@ class Agents::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if Rdv.future.active.where(users: @user.family.pluck(:id), organisation: current_organisation).empty?
+    if Rdv.future.not_cancelled.where(users: @user.family.pluck(:id), organisation: current_organisation).empty?
       @user.soft_delete(current_organisation)
       flash[:notice] = "L'usager a été supprimé."
     else

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -34,12 +34,12 @@ class StatsController < ApplicationController
   def scope_rdv_to_departement
     @departement = params[:departement]
     if @departement.present?
-      @rdvs = Rdv.joins(:organisation).where(organisations: { departement: @departement })
+      @rdvs = Rdv.active.joins(:organisation).where(organisations: { departement: @departement })
       @users = User.joins(:organisations).where(organisations: { departement: @departement })
       @agents = Agent.joins(:organisations).where(organisations: { departement: @departement })
       @organisations = Organisation.where(organisations: { departement: @departement })
     else
-      @rdvs = Rdv.all
+      @rdvs = Rdv.active
       @users = User.all
       @agents = Agent.all
       @organisations = Organisation.all

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -26,6 +26,14 @@ module UsersHelper
       else
         "⚠️ Cet usager a #{user.relatives.active.count} proches qui seront aussi supprimés"
       end,
+      case Rdv.with_user_in(user.self_and_relatives).active.count
+      when 0
+        nil
+      when 1
+        "⚠️ Cet usager (ou un proche) a un RDV qui sera aussi supprimé"
+      else
+        "⚠️ Cet usager (ou un proche) a #{Rdv.with_user_in(user.self_and_relatives).active.count} RDVs qui seront aussi supprimés"
+      end,
     ].compact.join("\n\n")
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -18,23 +18,9 @@ module UsersHelper
   def user_soft_delete_confirm_message(user)
     [
       "Confirmez-vous la suppression de cet usager ?",
-      case user.relatives.active.count
-      when 0
-        nil
-      when 1
-        "⚠️ Cet usager a un proche qui sera aussi supprimé"
-      else
-        "⚠️ Cet usager a #{user.relatives.active.count} proches qui seront aussi supprimés"
-      end,
-      case Rdv.with_user_in(user.self_and_relatives).active.count
-      when 0
-        nil
-      when 1
-        "⚠️ Cet usager (ou un proche) a un RDV qui sera aussi supprimé"
-      else
-        "⚠️ Cet usager (ou un proche) a #{Rdv.with_user_in(user.self_and_relatives).active.count} RDVs qui seront aussi supprimés"
-      end,
-    ].compact.join("\n\n")
+      I18n.t("users.soft_delete_confirm_message.relatives", count: user.relatives.active.count),
+      I18n.t("users.soft_delete_confirm_message.rdvs", count: Rdv.with_user_in(user.self_and_relatives).active.count),
+    ].select(&:present?).join("\n\n")
   end
 end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -14,6 +14,20 @@ module UsersHelper
     label += " - #{birth_date_and_age(user)}" if user.birth_date
     label
   end
+
+  def user_soft_delete_confirm_message(user)
+    [
+      "Confirmez-vous la suppression de cet usager ?",
+      case user.relatives.active.count
+      when 0
+        nil
+      when 1
+        "⚠️ Cet usager a un proche qui sera aussi supprimé"
+      else
+        "⚠️ Cet usager a #{user.relatives.active.count} proches qui seront aussi supprimés"
+      end,
+    ].compact.join("\n\n")
+  end
 end
 
 class DisplayableUser

--- a/app/jobs/reminder_job.rb
+++ b/app/jobs/reminder_job.rb
@@ -2,7 +2,7 @@ class ReminderJob < ApplicationJob
   queue_as :cron
 
   def perform(*_args)
-    Rdv.not_cancelled.day_after_tomorrow.each do |rdv|
+    Rdv.active.not_cancelled.day_after_tomorrow.each do |rdv|
       Notifications::Rdv::RdvUpcomingReminderService.perform_with(rdv)
     end
   end

--- a/app/jobs/reminder_job.rb
+++ b/app/jobs/reminder_job.rb
@@ -2,7 +2,7 @@ class ReminderJob < ApplicationJob
   queue_as :cron
 
   def perform(*_args)
-    Rdv.active.day_after_tomorrow.each do |rdv|
+    Rdv.not_cancelled.day_after_tomorrow.each do |rdv|
       Notifications::Rdv::RdvUpcomingReminderService.perform_with(rdv)
     end
   end

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -29,7 +29,7 @@ class Creneau
       end
       next unless occurence_match_creneau
 
-      rdvs = p.agent.rdvs.where(starts_at: date_range).active
+      rdvs = p.agent.rdvs.where(starts_at: date_range).not_cancelled
       absences_occurrences = p.agent.absences.flat_map { |a| a.occurences_for(date_range) }
       overlapping_rdvs_or_absences(rdvs.to_a + absences_occurrences.to_a).empty?
     end

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -29,7 +29,7 @@ class Creneau
       end
       next unless occurence_match_creneau
 
-      rdvs = p.agent.rdvs.where(starts_at: date_range).not_cancelled
+      rdvs = p.agent.rdvs.where(starts_at: date_range).active.not_cancelled
       absences_occurrences = p.agent.absences.flat_map { |a| a.occurences_for(date_range) }
       overlapping_rdvs_or_absences(rdvs.to_a + absences_occurrences.to_a).empty?
     end

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -6,10 +6,10 @@ class FileAttente < ApplicationRecord
   NO_MORE_NOTIFICATIONS = 7.days
   MAX_NOTIFICATIONS = 3
 
-  scope :active, -> { joins(:rdv).where("rdvs.starts_at > ?", NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
+  scope :with_upcoming_rdvs, -> { joins(:rdv).where("rdvs.starts_at > ?", NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
 
   def self.send_notifications
-    FileAttente.active.each do |fa|
+    FileAttente.with_upcoming_rdvs.each do |fa|
       next if fa.rdv.motif.phone?
 
       end_time = fa.rdv.starts_at - 2.day

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -41,6 +41,7 @@ class Rdv < ApplicationRecord
   }
   scope :default_stats_period, -> { where(created_at: Stat.default_date_range) }
   scope :with_agent, ->(agent) { joins(:agents).where(agents: { id: agent.id }) }
+  scope :with_user_in, ->(users) { joins(:rdvs_users).where(rdvs_users: { user_id: users.pluck(:id) }).distinct }
 
   after_commit :reload_uuid, on: :create
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -24,7 +24,7 @@ class Rdv < ApplicationRecord
   validates :users, :organisation, :motif, :starts_at, :duration_in_min, :agents, presence: true
   validates :lieu, presence: true, if: :public_office?
 
-  scope :active, -> { where(cancelled_at: nil) }
+  scope :not_cancelled, -> { where(cancelled_at: nil) }
   scope :past, -> { where("starts_at < ?", Time.zone.now) }
   scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :tomorrow, -> { where(starts_at: DateTime.tomorrow...DateTime.tomorrow + 1.day) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,6 +153,12 @@ class User < ApplicationRecord
     duplicate_user
   end
 
+  def can_be_soft_deleted_from_organisation?(organisation)
+    Rdv.future.not_cancelled
+      .where(users: @user.self_and_relatives.pluck(:id), organisation: organisation)
+      .empty?
+  end
+
   protected
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,22 +73,25 @@ class User < ApplicationRecord
   end
 
   def add_organisation(organisation)
-    family.each do |u|
+    self_and_relatives_and_responsible.each do |u|
       u.organisations << organisation if u.organisation_ids.exclude?(organisation.id)
     end
   end
 
   def soft_delete(organisation = nil)
-    [self, relatives].flatten.each { _1.do_soft_delete(organisation) }
+    self_and_relatives.each { _1.do_soft_delete(organisation) }
   end
 
   def available_users_for_rdv
     User.where(responsible_id: id).or(User.where(id: id)).order("responsible_id DESC NULLS FIRST", first_name: :asc).active
   end
 
-  def family
-    user_id = relative? ? responsible.id : id
-    User.active.where("responsible_id = ? OR id = ?", user_id, user_id)
+  def self_and_relatives
+    [self, relatives].flatten
+  end
+
+  def self_and_relatives_and_responsible
+    [self, relatives, responsible].compact.flatten
   end
 
   def invitable?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,9 +154,8 @@ class User < ApplicationRecord
   end
 
   def can_be_soft_deleted_from_organisation?(organisation)
-    Rdv.future.not_cancelled
-      .where(users: @user.self_and_relatives.pluck(:id), organisation: organisation)
-      .empty?
+    Rdv.with_user_in(self_and_relatives_and_responsible)
+      .active.not_cancelled.future.where(organisation: organisation).empty?
   end
 
   protected

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -6,9 +6,9 @@ class Agent::RdvPolicy < DefaultAgentPolicy
   class Scope < Scope
     def resolve
       if @context.agent.can_access_others_planning?
-        scope.where(organisation_id: @context.organisation.id)
+        scope.active.where(organisation_id: @context.organisation.id)
       else
-        scope.joins(:agents).where(organisation_id: @context.organisation.id, agents: { id: @context.agent.id })
+        scope.active.joins(:agents).where(organisation_id: @context.organisation.id, agents: { id: @context.agent.id })
       end
     end
   end

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -88,7 +88,7 @@ class CreneauxBuilderForDate < BaseService
   end
 
   def rdvs
-    @rdvs ||= @plage_ouverture.agent.rdvs.where(starts_at: inclusive_datetime_range).active.to_a
+    @rdvs ||= @plage_ouverture.agent.rdvs.where(starts_at: inclusive_datetime_range).not_cancelled.to_a
   end
 
   def absences_occurrences

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -88,7 +88,8 @@ class CreneauxBuilderForDate < BaseService
   end
 
   def rdvs
-    @rdvs ||= @plage_ouverture.agent.rdvs.where(starts_at: inclusive_datetime_range).not_cancelled.to_a
+    @rdvs ||= @plage_ouverture.agent.rdvs
+      .where(starts_at: inclusive_datetime_range).active.not_cancelled.to_a
   end
 
   def absences_occurrences

--- a/app/views/agents/users/show.html.slim
+++ b/app/views/agents/users/show.html.slim
@@ -57,7 +57,7 @@
   .col-md-6
     .card
       .card-body
-        = render 'stats/rdv_counters', rdvs: @user.rdvs.where(organisation_id: current_organisation)
+        = render 'stats/rdv_counters', rdvs: @user.rdvs.active.where(organisation_id: current_organisation)
         .text-right
           = link_to 'Voir tous les RDV', organisation_user_rdvs_path(current_organisation, @user), class: 'btn btn-outline-primary'
 

--- a/app/views/agents/users/show.html.slim
+++ b/app/views/agents/users/show.html.slim
@@ -41,7 +41,10 @@
 
         .row.mt-3
           .col.text-left
-            = link_to "Supprimer", organisation_user_path(current_organisation, @user), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de cet usager ?"}
+            - if @user.can_be_soft_deleted_from_organisation?(current_organisation)
+              = link_to "Supprimer", organisation_user_path(current_organisation, @user), method: :delete, class: "btn btn-outline-danger", data: { confirm: user_soft_delete_confirm_message(@user)}
+            - else
+              = link_to "Supprimer", "#", class: "btn btn-outline-danger", onclick: "alert(this.dataset.message)", data: { message: I18n.t("users.can_not_delete_because_has_future_rdvs") }
           .col.text-right
             = link_to "Modifier", edit_organisation_user_path(current_organisation, @user), class: "btn btn-primary"
 

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -1,3 +1,12 @@
 fr:
   users:
     can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.
+    soft_delete_confirm_message:
+      relatives:
+        zero:
+        one: ⚠️ Cet usager a un proche qui sera aussi supprimé
+        other: ⚠️ Cet usager a %{count} proches qui seront aussi supprimés
+      rdvs:
+        zero:
+        one: ⚠️ Cet usager (ou un proche) a un RDV qui sera aussi supprimé
+        other: ⚠️ Cet usager (ou un proche) a %{count} RDVs qui seront aussi supprimés

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -1,0 +1,3 @@
+fr:
+  users:
+    can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.

--- a/db/migrate/20200803093615_add_deleted_at_to_rdvs.rb
+++ b/db/migrate/20200803093615_add_deleted_at_to_rdvs.rb
@@ -1,0 +1,12 @@
+class AddDeletedAtToRdvs < ActiveRecord::Migration[6.0]
+  def up
+    add_column :rdvs, :deleted_at, :datetime
+    User.where.not(deleted_at: nil).each do |user|
+      user.rdvs.active.each { |rdv| rdv.soft_delete_for_user(user) }
+    end
+  end
+
+  def down
+    remove_column :rdvs, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_084038) do
+ActiveRecord::Schema.define(version: 2020_08_03_093615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -246,6 +246,7 @@ ActiveRecord::Schema.define(version: 2020_07_30_084038) do
     t.integer "created_by", default: 0
     t.text "notes"
     t.bigint "lieu_id"
+    t.datetime "deleted_at"
     t.index ["created_by"], name: "index_rdvs_on_created_by"
     t.index ["lieu_id"], name: "index_rdvs_on_lieu_id"
     t.index ["motif_id"], name: "index_rdvs_on_motif_id"

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -1,6 +1,6 @@
 class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_starting_soon_created
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.active.not_cancelled.last
     rdv.starts_at = 2.hours.from_now
     Agents::RdvMailer.rdv_starting_soon_created(rdv, rdv.agents.first)
   end

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -1,6 +1,6 @@
 class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_starting_soon_created
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     rdv.starts_at = 2.hours.from_now
     Agents::RdvMailer.rdv_starting_soon_created(rdv, rdv.agents.first)
   end

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -4,40 +4,40 @@ class Users::RdvMailerPreview < ActionMailer::Preview
   # it's pretty hacky but avoids overriding rails email templates
 
   def rdv_created
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_visite_a_domicile
-    rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :home }).last
+    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_phone
-    rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :phone }).last
+    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_public_office
-    rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :public_office }).last
+    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_cancelled_by_agent
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_cancelled_by_agent(rdv, rdv.users.first)
   end
 
   def rdv_upcoming_reminder
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     Users::RdvMailer.rdv_upcoming_reminder(rdv, rdv.users.first)
   end
 

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -4,40 +4,40 @@ class Users::RdvMailerPreview < ActionMailer::Preview
   # it's pretty hacky but avoids overriding rails email templates
 
   def rdv_created
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.active.not_cancelled.last
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_visite_a_domicile
-    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
+    rdv = Rdv.active.not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_phone
-    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
+    rdv = Rdv.active.not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_public_office
-    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
+    rdv = Rdv.active.not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_cancelled_by_agent
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.active.not_cancelled.last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_cancelled_by_agent(rdv, rdv.users.first)
   end
 
   def rdv_upcoming_reminder
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.active.not_cancelled.last
     Users::RdvMailer.rdv_upcoming_reminder(rdv, rdv.users.first)
   end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -163,4 +163,20 @@ describe Rdv, type: :model do
       expect { rdv.destroy }.to change { Rdv.count }.by(-1)
     end
   end
+
+  describe "Rdv.with_user_in" do
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:user3) { create(:user) }
+    let!(:rdv1) { create(:rdv, users: [user1, user2]) }
+    let!(:rdv2) { create(:rdv, users: [user2]) }
+    let!(:rdv3) { create(:rdv, users: [user3]) }
+
+    it "should retrieve rdv, contrarily to where(users:)" do
+      expect(Rdv.where(users: [user1, user2])).to be_empty
+      expect(Rdv.with_user_in([user1, user2])).to include(rdv1)
+      expect(Rdv.with_user_in([user1, user2])).to include(rdv2)
+      expect(Rdv.with_user_in([user1, user2])).not_to include(rdv3)
+    end
+  end
 end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -164,6 +164,31 @@ describe Rdv, type: :model do
     end
   end
 
+  describe "#soft_delete_for_user" do
+    context "rdv with multiple users" do
+      let(:user1) { create(:user) }
+      let(:user2) { create(:user) }
+      let(:rdv) { create(:rdv, users: [user1, user2]) }
+
+      it "should just remove user, not mark rdv as soft deleted" do
+        rdv.soft_delete_for_user(user1)
+        expect(rdv.deleted_at).to be_nil
+        expect(rdv.users).to eq([user2])
+      end
+    end
+
+    context "rdv with single user" do
+      let(:user1) { create(:user) }
+      let(:rdv) { create(:rdv, users: [user1]) }
+
+      it "should mark rdv as soft_deleted but leave user" do
+        rdv.soft_delete_for_user(user1)
+        expect(rdv.deleted_at).not_to be_nil
+        expect(rdv.users).to eq([user1])
+      end
+    end
+  end
+
   describe "Rdv.with_user_in" do
     let!(:user1) { create(:user) }
     let!(:user2) { create(:user) }


### PR DESCRIPTION
https://trello.com/c/aUoAmzuL/986-usersoftdelete-devrait-soccuper-des-rdvs

there was actually already a protection to avoid deleting users with RDVs but it was broken (cf commit 5) and incomplete (only dealt with future RDVs)

ℹ️ this PR should be read commit by commit 

## 1. refactor: simplify user#soft_delete specs

remove freeze time and complicated dependencies

## 2. refactor: harmonize active scope meaning in all models

the `active` scope means 'not deleted' in most models except `FileAttente` and
`Rdv` where it has a different meaning. This commit changes these 2 scopes names.

## 3. refactor: rename User#family to User#self_and_relatives_and_responsible

`family` feels bad: I don't know what kind of objects it will return, and it's
unclear what it's going to include.

## 4. refactor: extract user#can_be_soft_deleted_from_organisation? method

preliminary iso-refactor

## 5. fix user#can_be_soft_deleted_from_organisation? method

The current implementation is half broken: it will only check for RDVs with 
strictly rdv.users == user.family. It will not match RDVs where only one member
of the family is part of the RDV, whereas it should.

## 6. improve user soft delete alert message

- prevents beforehands actually trying to delete a user that cannot be deleted
- adds warning information when you're about to delete a user that has relatives

## 7. user#soft_delete now soft_deletes rdvs in cascade

The actual feature: 

- adds a `rdvs.deleted_at` column + fill for existing RDVs for deleted users
- adds a `Rdv.active` scope + uses it almost everywhere in the app
- `User#soft_delete` now calls `Rdv#soft_delete_for_user` for all linked RDVs.
- improves warning messages


