### PR TITLE
refactor specs to use more stable determined past dates to avoid flakiness

### DIFF
--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     password { "password" }
     organisations { [Organisation.first || create(:organisation)] }
-    confirmed_at { 1.day.ago }
+    confirmed_at { DateTime.parse("2020-07-30 10:30").in_time_zone }
     service { Service.first || create(:service) }
     trait :admin do
       role { "admin" }

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :rdv do
     duration_in_min { 45 }
-    starts_at { Time.zone.now }
+    starts_at { DateTime.parse("2020-06-15 10:30").in_time_zone }
     lieu { build(:lieu) }
     organisation { Organisation.first || create(:organisation) }
     motif { Motif.first || build(:motif) }
@@ -33,14 +33,14 @@ FactoryBot.define do
       starts_at { 2.days.since }
     end
     trait :past do
-      starts_at { 2.days.ago }
+      starts_at { DateTime.parse("2020-01-15 10:30").in_time_zone }
     end
     trait :at_home do
       motif { build(:motif, :at_home) }
       lieu { nil }
     end
     trait :excused do
-      cancelled_at { 2.days.ago }
+      cancelled_at { DateTime.parse("2020-01-15 10:30").in_time_zone }
       status { "excused" }
     end
   end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -13,7 +13,21 @@ FactoryBot.define do
       lieu { nil }
     end
     trait :random_start do
-      starts_at { Faker::Time.between(from: 10.days.ago, to: 3.month.since) }
+      sequence :starts_at do |n|
+        d = [
+          "2020-03-01 10:30",
+          "2019-02-10 15:05",
+          "2020-06-17 10:00",
+          "2020-12-01 07:30",
+          "2021-10-01 11:30",
+          "2020-07-10 12:45",
+          "2020-01-13 09:10",
+          "2020-08-03 17:30",
+          "2020-11-20 16:05",
+          "2020-04-01 15:35",
+        ][n % 10]
+        DateTime.parse(d).in_time_zone
+      end
     end
     trait :future do
       starts_at { 2.days.since }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name.upcase }
     phone_number { Faker::Base.numerify("06 ## ## ## ##") }
-    birth_date { Faker::Date.between(from: 80.years.ago, to: Date.today) }
+    birth_date { Date.parse("1985-07-20") }
     address { "20 avenue de Ségur, Paris" }
     password { "12345678" }
     password_confirmation { "12345678" }

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -140,7 +140,7 @@ describe Creneau, type: :model do
       it { should eq([]) }
 
       describe "which is cancelled" do
-        let!(:rdv) { build(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30, cancelled_at: 2.days.ago) }
+        let!(:rdv) { build(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30, cancelled_at: DateTime.parse("2020-07-30 10:30").in_time_zone) }
 
         it { should contain_exactly(plage_ouverture) }
       end

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -40,7 +40,7 @@ describe Lieu, type: :model do
 
     context "with a plage_ouverture with no recurrence and closed" do
       let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: 2.days.ago) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: Date.parse("2020-07-30")) }
 
       it { expect(subject).to contain_exactly(lieu) }
     end
@@ -77,7 +77,7 @@ describe Lieu, type: :model do
 
     context "with a plage_ouverture with no recurrence and closed" do
       let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: 2.days.ago) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: Date.parse("2020-07-30")) }
 
       it { expect(subject).to contain_exactly(lieu) }
     end

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -81,7 +81,7 @@ describe PlageOuverture, type: :model do
 
     context "with exceptionnelles plages" do
       describe "when first_day is in past" do
-        let(:plage_ouverture) { create(:plage_ouverture, :no_recurrence, first_day: 2.days.ago) }
+        let(:plage_ouverture) { create(:plage_ouverture, :no_recurrence, first_day: Date.parse("2020-07-30")) }
 
         it { should be true }
       end
@@ -101,7 +101,7 @@ describe PlageOuverture, type: :model do
 
     context "with plages regulières" do
       describe "when until is in past" do
-        let(:plage_ouverture) { create(:plage_ouverture, recurrence: Montrose.every(:week, until: 2.days.ago).to_json) }
+        let(:plage_ouverture) { create(:plage_ouverture, recurrence: Montrose.every(:week, until: DateTime.parse("2020-07-30 10:30").in_time_zone).to_json) }
 
         it { should be true }
       end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -49,7 +49,7 @@ describe Rdv, type: :model do
       it { expect(subject).to eq(true) }
 
       context "but is already cancelled" do
-        let(:rdv) { create(:rdv, cancelled_at: 1.hour.ago, starts_at: 5.hours.from_now) }
+        let(:rdv) { create(:rdv, cancelled_at: DateTime.parse("2020-07-30 10:30").in_time_zone, starts_at: 5.hours.from_now) }
 
         it { expect(subject).to eq(false) }
       end


### PR DESCRIPTION
I only dealt with past dates because for the ones in the future it's not as easy (we don't want to have to come back and postpone the dates every so often)