### PR TITLE
Improve users soft deletion behaviour with RDVs

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -88,7 +88,7 @@ class Agents::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if Rdv.future.not_cancelled.where(users: @user.family.pluck(:id), organisation: current_organisation).empty?
+    if Rdv.future.not_cancelled.where(users: @user.self_and_relatives.pluck(:id), organisation: current_organisation).empty?
       @user.soft_delete(current_organisation)
       flash[:notice] = "L'usager a été supprimé."
     else

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -88,11 +88,11 @@ class Agents::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if Rdv.future.not_cancelled.where(users: @user.self_and_relatives.pluck(:id), organisation: current_organisation).empty?
+    if @user.can_be_soft_deleted_from_organisation?(current_organisation)
       @user.soft_delete(current_organisation)
       flash[:notice] = "L'usager a été supprimé."
     else
-      flash[:error] = "L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer."
+      flash[:error] = I18n.t("users.can_not_delete_because_has_future_rdvs")
     end
 
     if @user.relative?

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -88,7 +88,7 @@ class Agents::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if Rdv.future.active.where(users: @user.family.pluck(:id), organisation: current_organisation).empty?
+    if Rdv.future.not_cancelled.where(users: @user.family.pluck(:id), organisation: current_organisation).empty?
       @user.soft_delete(current_organisation)
       flash[:notice] = "L'usager a été supprimé."
     else

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -21,13 +21,15 @@ module RdvsHelper
   end
 
   def users_to_links(rdv)
-    safe_join(rdv.users.order_by_last_name.map do |user|
-      if user.organisations.include?(current_organisation)
-        link_to user.full_name, organisation_user_path(current_organisation, user)
-      else
-        "#{user.full_name} - l'usager a été supprimé"
-      end
-    end, ", ")
+    safe_join(rdv.users.order_by_last_name.map { user_to_link(_1) }, ", ")
+  end
+
+  def user_to_link(user)
+    if user.organisations.include?(current_organisation)
+      link_to user.full_name, organisation_user_path(current_organisation, user)
+    else
+      "#{user.full_name} - l'usager a été supprimé"
+    end
   end
 
   def users_to_sentence(rdv)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -18,7 +18,7 @@ module UsersHelper
   def user_soft_delete_confirm_message(user)
     [
       "Confirmez-vous la suppression de cet usager ?",
-      I18n.t("users.soft_delete_confirm_message.relatives", count: user.relatives.active.count),
+      (I18n.t("users.soft_delete_confirm_message.relatives", count: user.relatives.active.count) if user.relatives.active.any?),
     ].select(&:present?).join("\n\n")
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -56,6 +56,8 @@ class DisplayableUser
   end
 
   def logement
+    return nil unless @user_profile.present?
+
     UserProfile.human_enum_name(:logement, @user_profile.logement)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -14,6 +14,13 @@ module UsersHelper
     label += " - #{birth_date_and_age(user)}" if user.birth_date
     label
   end
+
+  def user_soft_delete_confirm_message(user)
+    [
+      "Confirmez-vous la suppression de cet usager ?",
+      I18n.t("users.soft_delete_confirm_message.relatives", count: user.relatives.active.count),
+    ].select(&:present?).join("\n\n")
+  end
 end
 
 class DisplayableUser

--- a/app/jobs/reminder_job.rb
+++ b/app/jobs/reminder_job.rb
@@ -2,7 +2,7 @@ class ReminderJob < ApplicationJob
   queue_as :cron
 
   def perform(*_args)
-    Rdv.active.day_after_tomorrow.each do |rdv|
+    Rdv.not_cancelled.day_after_tomorrow.each do |rdv|
       Notifications::Rdv::RdvUpcomingReminderService.perform_with(rdv)
     end
   end

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -29,7 +29,7 @@ class Creneau
       end
       next unless occurence_match_creneau
 
-      rdvs = p.agent.rdvs.where(starts_at: date_range).active
+      rdvs = p.agent.rdvs.where(starts_at: date_range).not_cancelled
       absences_occurrences = p.agent.absences.flat_map { |a| a.occurences_for(date_range) }
       overlapping_rdvs_or_absences(rdvs.to_a + absences_occurrences.to_a).empty?
     end

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -6,10 +6,10 @@ class FileAttente < ApplicationRecord
   NO_MORE_NOTIFICATIONS = 7.days
   MAX_NOTIFICATIONS = 3
 
-  scope :active, -> { joins(:rdv).where("rdvs.starts_at > ?", NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
+  scope :with_upcoming_rdvs, -> { joins(:rdv).where("rdvs.starts_at > ?", NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
 
   def self.send_notifications
-    FileAttente.active.each do |fa|
+    FileAttente.with_upcoming_rdvs.each do |fa|
       next if fa.rdv.motif.phone?
 
       end_time = fa.rdv.starts_at - 2.day

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -41,6 +41,7 @@ class Rdv < ApplicationRecord
   }
   scope :default_stats_period, -> { where(created_at: Stat.default_date_range) }
   scope :with_agent, ->(agent) { joins(:agents).where(agents: { id: agent.id }) }
+  scope :with_user_in, ->(users) { joins(:rdvs_users).where(rdvs_users: { user_id: users.pluck(:id) }).distinct }
 
   after_commit :reload_uuid, on: :create
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -24,7 +24,7 @@ class Rdv < ApplicationRecord
   validates :users, :organisation, :motif, :starts_at, :duration_in_min, :agents, presence: true
   validates :lieu, presence: true, if: :public_office?
 
-  scope :active, -> { where(cancelled_at: nil) }
+  scope :not_cancelled, -> { where(cancelled_at: nil) }
   scope :past, -> { where("starts_at < ?", Time.zone.now) }
   scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :tomorrow, -> { where(starts_at: DateTime.tomorrow...DateTime.tomorrow + 1.day) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,8 +154,9 @@ class User < ApplicationRecord
   end
 
   def can_be_soft_deleted_from_organisation?(organisation)
-    Rdv.future.not_cancelled
-      .where(users: @user.self_and_relatives.pluck(:id), organisation: organisation)
+    Rdv.not_cancelled.future
+      .with_user_in(self_and_relatives_and_responsible)
+      .where(organisation: organisation)
       .empty?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,6 +153,12 @@ class User < ApplicationRecord
     duplicate_user
   end
 
+  def can_be_soft_deleted_from_organisation?(organisation)
+    Rdv.future.not_cancelled
+      .where(users: @user.self_and_relatives.pluck(:id), organisation: organisation)
+      .empty?
+  end
+
   protected
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,22 +73,25 @@ class User < ApplicationRecord
   end
 
   def add_organisation(organisation)
-    family.each do |u|
+    self_and_relatives_and_responsible.each do |u|
       u.organisations << organisation if u.organisation_ids.exclude?(organisation.id)
     end
   end
 
   def soft_delete(organisation = nil)
-    [self, relatives].flatten.each { _1.do_soft_delete(organisation) }
+    self_and_relatives.each { _1.do_soft_delete(organisation) }
   end
 
   def available_users_for_rdv
     User.where(responsible_id: id).or(User.where(id: id)).order("responsible_id DESC NULLS FIRST", first_name: :asc).active
   end
 
-  def family
-    user_id = relative? ? responsible.id : id
-    User.active.where("responsible_id = ? OR id = ?", user_id, user_id)
+  def self_and_relatives
+    [self, relatives].flatten
+  end
+
+  def self_and_relatives_and_responsible
+    [self, relatives, responsible].compact.flatten
   end
 
   def invitable?

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -88,7 +88,7 @@ class CreneauxBuilderForDate < BaseService
   end
 
   def rdvs
-    @rdvs ||= @plage_ouverture.agent.rdvs.where(starts_at: inclusive_datetime_range).active.to_a
+    @rdvs ||= @plage_ouverture.agent.rdvs.where(starts_at: inclusive_datetime_range).not_cancelled.to_a
   end
 
   def absences_occurrences

--- a/app/views/agents/rdvs/_rdv.html.slim
+++ b/app/views/agents/rdvs/_rdv.html.slim
@@ -15,10 +15,10 @@
             .pl-2.pt-1
               - rdv.users.order_by_last_name.each do |user|
                 div
-                  = link_to organisation_user_path(current_organisation, user) do
-                    b> #{user.full_name}
-                  - if user.responsible.present?
-                    | (proche de #{link_to(user.responsible.full_name, organisation_user_path(current_organisation, user.responsible))})
+                  b= user_to_link(user)
+                - if user.responsible.present?
+                  div= "proche de #{user_to_link(user.responsible)}".html_safe
+                div
                   ul.list-unstyled
                     - [:birth_date, :phone_number, :address, :email].each do |attr_name|
                       li= render "common/user_attribute", user: user, attribute_name: attr_name

--- a/app/views/agents/users/show.html.slim
+++ b/app/views/agents/users/show.html.slim
@@ -41,7 +41,10 @@
 
         .row.mt-3
           .col.text-left
-            = link_to "Supprimer", organisation_user_path(current_organisation, @user), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de cet usager ?"}
+            - if @user.can_be_soft_deleted_from_organisation?(current_organisation)
+              = link_to "Supprimer", organisation_user_path(current_organisation, @user), method: :delete, class: "btn btn-outline-danger", data: { confirm: user_soft_delete_confirm_message(@user)}
+            - else
+              = link_to "Supprimer", "#", class: "btn btn-outline-danger", onclick: "alert(this.dataset.message)", data: { message: I18n.t("users.can_not_delete_because_has_future_rdvs") }
           .col.text-right
             = link_to "Modifier", edit_organisation_user_path(current_organisation, @user), class: "btn btn-primary"
 

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -1,3 +1,8 @@
 fr:
   users:
     can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.
+    soft_delete_confirm_message:
+      relatives:
+        zero:
+        one: ⚠️ Cet usager a un proche qui sera aussi supprimé
+        other: ⚠️ Cet usager a %{count} proches qui seront aussi supprimés

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -3,6 +3,5 @@ fr:
     can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.
     soft_delete_confirm_message:
       relatives:
-        zero:
         one: ⚠️ Cet usager a un proche qui sera aussi supprimé
         other: ⚠️ Cet usager a %{count} proches qui seront aussi supprimés

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -1,0 +1,3 @@
+fr:
+  users:
+    can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -1,6 +1,6 @@
 class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_starting_soon_created
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     rdv.starts_at = 2.hours.from_now
     Agents::RdvMailer.rdv_starting_soon_created(rdv, rdv.agents.first)
   end

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -4,40 +4,40 @@ class Users::RdvMailerPreview < ActionMailer::Preview
   # it's pretty hacky but avoids overriding rails email templates
 
   def rdv_created
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_visite_a_domicile
-    rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :home }).last
+    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_phone
-    rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :phone }).last
+    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_public_office
-    rdv = Rdv.active.joins(:motif).where(motifs: { location_type: :public_office }).last
+    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_cancelled_by_agent
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     raise ActiveRecord::RecordNotFound unless rdv
 
     Users::RdvMailer.rdv_cancelled_by_agent(rdv, rdv.users.first)
   end
 
   def rdv_upcoming_reminder
-    rdv = Rdv.active.last
+    rdv = Rdv.not_cancelled.last
     Users::RdvMailer.rdv_upcoming_reminder(rdv, rdv.users.first)
   end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -163,4 +163,20 @@ describe Rdv, type: :model do
       expect { rdv.destroy }.to change { Rdv.count }.by(-1)
     end
   end
+
+  describe "Rdv.with_user_in" do
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:user3) { create(:user) }
+    let!(:rdv1) { create(:rdv, users: [user1, user2]) }
+    let!(:rdv2) { create(:rdv, users: [user2]) }
+    let!(:rdv3) { create(:rdv, users: [user3]) }
+
+    it "should retrieve rdv, contrarily to where(users:)" do
+      expect(Rdv.where(users: [user1, user2])).to be_empty
+      expect(Rdv.with_user_in([user1, user2])).to include(rdv1)
+      expect(Rdv.with_user_in([user1, user2])).to include(rdv2)
+      expect(Rdv.with_user_in([user1, user2])).not_to include(rdv3)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/aUoAmzuL/986-usersoftdelete-devrait-soccuper-des-rdvs

alternative version for #815

there was actually already a protection to avoid deleting users with RDVs but it was broken (cf commit 5) and incomplete (only dealt with future RDVs)

ℹ️ this PR should be read commit by commit 

## 1. refactor: simplify user#soft_delete specs

remove freeze time and complicated dependencies

## 2. refactor: harmonize active scope meaning in all models

the `active` scope means 'not deleted' in most models except `FileAttente` and
`Rdv` where it has a different meaning. This commit changes these 2 scopes names.

## 3. refactor: rename User#family to User#self_and_relatives_and_responsible

`family` feels bad: I don't know what kind of objects it will return, and it's
unclear what it's going to include.

## 4. refactor: extract user#can_be_soft_deleted_from_organisation? method

preliminary iso-refactor

## 5. fix user#can_be_soft_deleted_from_organisation? method

The current implementation is half broken: it will only check for RDVs with 
strictly rdv.users == user.family. It will not match RDVs where only one member
of the family is part of the RDV, whereas it should.

## 6. improve user soft delete alert message

- prevents beforehands actually trying to delete a user that cannot be deleted
- adds warning information when you're about to delete a user that has relatives

<img width="719" alt="Screenshot_2020-08-05_at_14 43 53" src="https://user-images.githubusercontent.com/883348/89418206-09245700-d730-11ea-871b-6e7ba1a164ab.png">


## 7. Fix Rdv List

- stop showing links to deleted users in RDV list 
- fix trying to display logement for deleted users for RDVs in service social

<img width="1206" alt="Screenshot_2020-08-05_at_15 26 10" src="https://user-images.githubusercontent.com/883348/89418191-06296680-d730-11ea-9ebe-2ad75708ab70.png">
