### PR TITLE
[agent] fix active users scope in users index

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -18,12 +18,12 @@ class Agents::UsersController < AgentAuthController
   }.freeze
 
   def index
-    @users = policy_scope(User).order_by_last_name.page(params[:page])
+    @users = policy_scope(User).active.order_by_last_name.page(params[:page])
     filter_users if params[:user] && params[:user][:search]
   end
 
   def search
-    @users = policy_scope(User).where.not(id: params[:exclude_ids]).order_by_last_name.limit(10)
+    @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.order_by_last_name.limit(10)
     @users = @users.search_by_text(search_params) if search_params
     skip_authorization
   end

--- a/app/models/concerns/user/responsability_concern.rb
+++ b/app/models/concerns/user/responsability_concern.rb
@@ -4,6 +4,7 @@ module User::ResponsabilityConcern
   included do
     before_save :set_organisation_ids_from_responsible, if: :responsible_id_changed?
     accepts_nested_attributes_for :responsible
+    validate :cannot_be_responsible_of_self
   end
 
   def responsability_type
@@ -53,5 +54,9 @@ module User::ResponsabilityConcern
   def organisations_mismatch?
     responsible &&
       responsible.user_profiles.map(&:organisation_id).sort != user_profiles.map(&:organisation_id).sort
+  end
+
+  def cannot_be_responsible_of_self
+    errors.add(:responsible_id, "ne peut pas être l'usager lui même") if responsible_id.present? && responsible_id == id
   end
 end


### PR DESCRIPTION
PR très discutable ! 

pendant que je bossais sur la fusion des usagers, j'ai fait des manips interdites et me suis retrouvé dans des états incohérents. Ces deux petits changements m'ont paru utiles à ce moment, mais ce sont en fait des sécurités redondantes avec ce qui existe déjà. On peut considérer ça comme du code "en trop", ou des sécurités utiles, je ne suis pas hyper sûr.

1. filtrer sur les usagers `active` (càd pas soft deleted) dans les listes d'usagers coté agent. c'est deja fait indirectement via le filtre du Policy Scope des users qui filtre les usagers appartenant a l'orga courante. ca ne devrait pas se produire qu'un usager soit soft deleted mais continue a appartenir a une orga, donc c'est redondant mais quand meme plus securisant

2. validation sur les users que `responsible_id != id`. ne devrait pas se produire non plus, mais quand ca se produit pour une raison ou une autre c'est le gros bazar avec des boucles infinies, donc sympa a eviter :)