### PR TITLE
[agent] merge users interface

### DIFF
--- a/app/controllers/agents/merge_users_controller.rb
+++ b/app/controllers/agents/merge_users_controller.rb
@@ -1,0 +1,29 @@
+class Agents::MergeUsersController < AgentAuthController
+  before_action :set_organisation
+
+  def new
+    user1 = policy_scope(User).find(params[:user1_id]) if params[:user1_id].present?
+    user2 = policy_scope(User).find(params[:user2_id]) if params[:user2_id].present?
+    @merge_users_form = MergeUsersForm.new(current_organisation, user1: user1, user2: user2)
+    skip_authorization
+  end
+
+  def create
+    user1 = policy_scope(User).find(params[:merge_users_form][:user1_id])
+    user2 = policy_scope(User).find(params[:merge_users_form][:user2_id])
+    authorize(user1)
+    authorize(user2)
+    @merge_users_form = MergeUsersForm.new(current_organisation, user1: user1, user2: user2, **merge_users_params)
+    if @merge_users_form.save
+      redirect_to organisation_user_path(current_organisation, @merge_users_form.user_target), flash: { success: "Les usagers ont été fusionnés" }
+    else
+      render :new
+    end
+  end
+
+  protected
+
+  def merge_users_params
+    params.require(:merge_users_form).permit(MergeUsersForm::ATTRIBUTES)
+  end
+end

--- a/app/controllers/agents/merge_users_controller.rb
+++ b/app/controllers/agents/merge_users_controller.rb
@@ -5,14 +5,16 @@ class Agents::MergeUsersController < AgentAuthController
     user1 = policy_scope(User).find(params[:user1_id]) if params[:user1_id].present?
     user2 = policy_scope(User).find(params[:user2_id]) if params[:user2_id].present?
     @merge_users_form = MergeUsersForm.new(current_organisation, user1: user1, user2: user2)
-    skip_authorization
+    authorize(user1, :update?) if user1.present?
+    authorize(user2, :update?) if user2.present?
+    skip_authorization if user1.nil? && user2.nil?
   end
 
   def create
     user1 = policy_scope(User).find(params[:merge_users_form][:user1_id])
     user2 = policy_scope(User).find(params[:merge_users_form][:user2_id])
-    authorize(user1)
-    authorize(user2)
+    authorize(user1, :update?)
+    authorize(user2, :update?)
     @merge_users_form = MergeUsersForm.new(current_organisation, user1: user1, user2: user2, **merge_users_params)
     if @merge_users_form.save
       redirect_to organisation_user_path(current_organisation, @merge_users_form.user_target), flash: { success: "Les usagers ont été fusionnés" }

--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -1,0 +1,108 @@
+class MergeUsersForm
+  include ActiveModel::Model
+
+  ATTRIBUTES = [
+    :email,
+    :first_name, :last_name, :birth_name, :birth_date, :phone_number,
+    :address, :caisse_affiliation, :affiliation_number, :family_situation,
+    :number_of_children,
+    :logement
+  ].freeze
+
+  attr_accessor :user1, :user2, :change_user1_id, :change_user2_id, *ATTRIBUTES
+
+  validates_presence_of :user1, :user2
+  validate :different_users?
+
+  def initialize(organisation, **kwargs)
+    @organisation = organisation
+    super(**kwargs)
+  end
+
+  def user1_id
+    user1&.id
+  end
+
+  def user2_id
+    user2&.id
+  end
+
+  def save
+    return false unless valid?
+
+    MergeUsersService.perform_with(user_target, user_to_merge, attributes_to_merge, @organisation)
+  end
+
+  def available_attributes
+    return [:first_name, :last_name, :birth_date] if user1&.relative? || user2&.relative?
+
+    ATTRIBUTES
+  end
+
+  def attribute_comparison(attribute)
+    return nil if user1.nil? || user2.nil?
+
+    value1, value2 = values_for(attribute)
+    return :identical_na if value1.blank? && value2.blank?
+
+    return :identical if value1 == value2
+
+    :different
+  end
+
+  def user_target
+    number_to_user(user_target_number)
+  end
+
+  protected
+
+  def number_to_user(number)
+    { "1" => user1, "2" => user2 }[number]
+  end
+
+  def user_target_number
+    if user2.relative?
+      "1"
+    elsif user1.relative? && user2.responsible?
+      "2"
+    else
+      email || "1"
+    end
+  end
+
+  def user_to_merge_number
+    { "1" => "2", "2" => "1" }[user_target_number]
+  end
+
+  def user_to_merge
+    number_to_user(user_to_merge_number)
+  end
+
+  def attributes_to_merge
+    ATTRIBUTES
+      .select { send(_1) == user_to_merge_number }
+      .without(:email) # email cannot be in this list, only to be explicit
+  end
+
+  def user1_profile
+    user1&.profile_for(@organisation)
+  end
+
+  def user2_profile
+    user2&.profile_for(@organisation)
+  end
+
+  def values_for(attribute)
+    if [:logement].include?(attribute)
+      [user1_profile&.send(attribute), user2_profile&.send(attribute)]
+    else
+      [user1&.send(attribute), user2&.send(attribute)]
+    end
+  end
+
+  def different_users?
+    return true if user1.nil? || user2.nil?
+
+    errors.add(:base, "Mauvaise sélection d'usagers") if user1.id == user2.id
+  end
+end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -31,6 +31,9 @@ class Agent < ApplicationRecord
   scope :can_perform_motif, lambda { |motif|
     motif.for_secretariat ? joins(:service).where(service: motif.service).or(secretariat) : where(service: motif.service)
   }
+  scope :within_organisation, lambda { |organisation|
+    joins(:organisations).where(organisations: { id: organisation.id })
+  }
 
   before_save :normalize_account
 

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -7,6 +7,9 @@ class FileAttente < ApplicationRecord
   MAX_NOTIFICATIONS = 3
 
   scope :with_upcoming_rdvs, -> { joins(:rdv).where("rdvs.starts_at > ?", NO_MORE_NOTIFICATIONS.from_now).order(created_at: :desc) }
+  scope :for_organisation, lambda { |organisation|
+    joins(:rdv).where(rdvs: { organisation: organisation })
+  }
 
   def self.send_notifications
     FileAttente.with_upcoming_rdvs.each do |fa|

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -1,0 +1,93 @@
+class MergeUsersService < BaseService
+  def initialize(user_target, user_to_merge, attributes_to_merge, organisation)
+    @user_target = user_target
+    @user_to_merge = user_to_merge
+    @attributes_to_merge = attributes_to_merge
+    @organisation = organisation
+  end
+
+  def perform
+    User.transaction do
+      merge_user_attributes
+      merge_rdvs
+      merge_relatives
+      merge_user_profiles
+      merge_file_attentes
+      merge_agents
+      merge_user_notes
+      @user_to_merge.reload.soft_delete(@organisation) # ! reload refreshes associations to delete
+    end
+  end
+
+  private
+
+  def merge_user_attributes
+    user_attributes_to_merge.each do |attribute|
+      @user_target.send("#{attribute}=", @user_to_merge.send(attribute))
+    end
+    @user_target.save!
+  end
+
+  def merge_rdvs
+    @user_to_merge.rdvs.where(organisation: @organisation).each do |rdv|
+      users = rdv.users.to_a
+      users.delete(@user_to_merge)
+      users.append(@user_target) unless users.include?(@user_target)
+      rdv.users.replace(users)
+    end
+  end
+
+  def merge_relatives
+    @user_to_merge.relatives.each do |user_relative|
+      user_relative.responsible = @user_target
+      user_relative.save!
+    end
+  end
+
+  def merge_user_profiles
+    user_profile_to_merge = @user_to_merge.profile_for(@organisation)
+    user_profile_target = @user_target.profile_for(@organisation)
+    raise if user_profile_target.nil? || user_profile_to_merge.nil?
+
+    user_profile_attributes_to_merge.each do |attribute|
+      user_profile_target.send("#{attribute}=", user_profile_to_merge.send(attribute))
+    end
+    user_profile_target.save!
+  end
+
+  def merge_file_attentes
+    @user_to_merge.file_attentes.for_organisation(@organisation).each do |file_attente_to_merge|
+      file_attente_target = @user_target.file_attentes.find_by(rdv: file_attente_to_merge.rdv)
+      if file_attente_target
+        file_attente_to_merge.destroy
+      else
+        file_attente_to_merge.update!(user: @user_target)
+      end
+    end
+  end
+
+  def merge_agents
+    return unless @user_to_merge.agents.within_organisation(@organisation).any?
+
+    agents = (
+      @user_target.agents.to_a +
+      @user_to_merge.agents.within_organisation(@organisation).to_a
+    ).uniq
+    @user_target.update!(agents: agents)
+  end
+
+  def merge_user_notes
+    @user_to_merge.notes_for(@organisation).each do |user_note|
+      user_note.update_columns(user_id: @user_target.id)
+      # skip validation because of migrated notes without agent
+    end
+  end
+
+  def user_attributes_to_merge
+    @attributes_to_merge.without(:logement)
+  end
+
+  def user_profile_attributes_to_merge
+    @attributes_to_merge.select{ [:logement].include?(_1) }
+  end
+end

--- a/app/views/agents/merge_users/_user_agents.html.slim
+++ b/app/views/agents/merge_users/_user_agents.html.slim
@@ -1,0 +1,5 @@
+- agents = user&.agents&.within_organisation(current_organisation)
+- if agents.present?
+  = agents.map(&:full_name).to_sentence
+- else
+  i.text-muted Aucun agent responsable

--- a/app/views/agents/merge_users/_user_notes.html.slim
+++ b/app/views/agents/merge_users/_user_notes.html.slim
@@ -1,0 +1,5 @@
+- notes = user&.notes_for(current_organisation)
+- if notes.present?
+  = "#{notes.count} notes"
+- else
+  i.text-muted Aucune note

--- a/app/views/agents/merge_users/_user_rdvs.html.slim
+++ b/app/views/agents/merge_users/_user_rdvs.html.slim
@@ -1,0 +1,7 @@
+- rdvs = user&.rdvs&.where(organisation: current_organisation)
+- if rdvs.present?
+  div>= "#{rdvs.count} RDVs"
+  div>= "dont #{rdvs.future.not_cancelled.count} à venir"
+  div>= "et dont #{rdvs.count} en file d'attente"
+- else
+  i.text-muted Aucun RDV

--- a/app/views/agents/merge_users/_user_relatives.html.slim
+++ b/app/views/agents/merge_users/_user_relatives.html.slim
@@ -1,0 +1,5 @@
+- relatives = user&.relatives&.active
+- if relatives.present?
+  = "#{relatives.count} proches"
+- else
+  i.text-muted Aucun proche

--- a/app/views/agents/merge_users/_user_selection.html.slim
+++ b/app/views/agents/merge_users/_user_selection.html.slim
@@ -1,0 +1,35 @@
+.js-merge-users-user-wrapper
+  - if user.present?
+    .collapse.show.js-merge-users-collapse-user class="collapse-#{attribute}"
+      div
+        b>= user.full_name
+        span>= relative_tag(user)
+        = link_to "changer...", ".collapse-#{attribute}", data: { toggle: "collapse" }
+
+    = f.input attribute, as: :hidden, input_html: { id: attribute }, wrapper: false
+
+  .collapse class="collapse-#{attribute}" class=('show' unless user.present?)
+    - url_opts = local_assigns[:other_user_id].present? ? { exclude_ids: [other_user_id] } : {}
+    = f.input "change_#{attribute}", \
+      as: :select, \
+      collection: policy_scope(User).order_by_last_name, \
+      label_method: -> { full_name_and_birthdate(_1) },
+      include_blank: "Sélectionner un usager", \
+      required: true, \
+      label: false, \
+      disabled: user.present?, \
+      wrapper_html: { class: "mb-0" }, \
+      input_html: { \
+        id: attribute, \
+        class: "select2-input js-merge-users-user-select js-selectable", \
+        data: { \
+          "select-options": { \
+            ajax: { \
+              url: search_organisation_users_path(current_organisation, **url_opts), \
+              dataType: 'json', \
+              delay: 250, \
+            } \
+          }, \
+          "field-name": attribute \
+        } \
+      }

--- a/app/views/agents/merge_users/new.html.slim
+++ b/app/views/agents/merge_users/new.html.slim
@@ -1,0 +1,74 @@
+- content_for :title do
+  | Fusionner deux usagers
+
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to 'Vos usagers', organisation_users_path(current_organisation)
+    li.breadcrumb-item.active Fusionner
+
+= simple_form_for @merge_users_form, url: organisation_merge_users_path(current_organisation), method: "POST" do |f|
+  = render partial: 'layouts/model_errors', locals: { model: @merge_users_form }
+  .card
+    table.table.table-bordered.merge-users-table[style="table-layout:fixed"]
+      tr.text-center
+        th[style="width:20%"]
+        th[style="width:40%"]
+          i.fa.fa-user>
+          | Usager A
+        th[style="width:40%"]
+          i.fa.fa-user>
+          | Usager B
+      tr.text-center
+        td
+        td= render "user_selection", user: @merge_users_form.user1, attribute: "user1_id", f: f, other_user_id: @merge_users_form.user2&.id
+        td= render "user_selection", user: @merge_users_form.user2, attribute: "user2_id", f: f, other_user_id: @merge_users_form.user1&.id
+      - @merge_users_form.available_attributes.each do |attribute|
+        tr class=@merge_users_form.attribute_comparison(attribute)
+          - if [:logement].include?(attribute)
+            td= I18n.t("activerecord.attributes.user_profile.#{attribute}")
+          - else
+            td= I18n.t("activerecord.attributes.user.#{attribute}")
+
+          td.text-right
+            - if @merge_users_form.user1
+              div.pr-2
+                label for="merge_users_form_#{attribute}_1"
+                  - value = DisplayableUser.new(@merge_users_form.user1, current_organisation).send(attribute)
+                  - if value&.present?
+                    = value
+                  - else
+                    i.text-muted N/A
+                  - if @merge_users_form.attribute_comparison(attribute) == :different
+                    span.ml-2= f.radio_button attribute, "1", required: true
+          td.text-left.pl-3
+            - if @merge_users_form.user2
+              label for="merge_users_form_#{attribute}_2"
+                - if @merge_users_form.attribute_comparison(attribute) == :different
+                  span.mr-2= f.radio_button attribute, "2", required: true
+                - value = DisplayableUser.new(@merge_users_form.user2, current_organisation).send(attribute)
+                - if value&.present?
+                  = value
+                - else
+                  i.text-muted N/A
+      tr
+        td= "🔒 RDVs"
+        td.text-right= render "user_rdvs", user: @merge_users_form.user1
+        td.text-left= render "user_rdvs", user: @merge_users_form.user2
+      tr
+        td= "🔒 Notes"
+        td.text-right= render "user_notes", user: @merge_users_form.user1
+        td.text-left= render "user_notes", user: @merge_users_form.user2
+
+      - unless @merge_users_form.user1&.relative? && @merge_users_form.user2&.relative?
+        tr
+          td= "🔒 Agents Responsables"
+          td.text-right= render "user_agents", user: @merge_users_form.user1
+          td.text-left= render "user_agents", user: @merge_users_form.user2
+        tr
+          td= "🔒 Proches"
+          td.text-right= render "user_relatives", user: @merge_users_form.user1
+          td.text-left= render "user_relatives", user: @merge_users_form.user2
+    .row.pr-3.pb-3
+      .col.text-right
+        = f.button :submit, value: "Fusionner", data: { confirm: "Êtes-vous certain(e) de vouloir fusionner ces deux usagers ? Cette action est définitive" }

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -35,14 +35,21 @@
               = link_to 'Absences', \
                 organisation_agent_absences_path(current_organisation, current_agent), \
                 data: { route: "agents/absences#index" }
+
         li.side-nav-item
-          = link_to( \
-            organisation_users_path(current_organisation), \
-            class: 'side-nav-link', \
-            data: { route: "agents/users#index" } \
-          ) do
+          = link_to '#', class: 'side-nav-link' do
             i.fa.fa-user
             span Vos usagers
+            i.fa.fa-angle-right.menu-arrow.mt-1
+          ul.side-nav-second-level aria-expanded="false"
+            li
+              = link_to "Usagers", \
+                organisation_users_path(current_organisation), \
+                data: { route: "agents/users#index" }
+            li
+              = link_to "Fusionner", \
+                new_organisation_merge_users_path(current_organisation), \
+                data: { route: "agents/merge_users#new" }
         li.side-nav-item
           = link_to( \
             organisation_agent_stats_path(current_organisation, current_agent), \

--- a/app/webpacker/components/merge-users-form.js
+++ b/app/webpacker/components/merge-users-form.js
@@ -1,0 +1,20 @@
+class MergeUsersForm {
+  constructor() {
+    // have to use jQuery here because of select2
+    $(".js-merge-users-user-select").on("change", this.userSelected)
+    $(".js-merge-users-collapse-user").on("click", this.toggleDisabledUserFields)
+  }
+
+  userSelected = (event) => {
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    urlSearchParams.set(event.currentTarget.dataset.fieldName, event.currentTarget.value)
+    window.location = `${window.location.pathname}?${urlSearchParams}`
+  }
+
+  toggleDisabledUserFields = (evt) => {
+    const parentElt = $(evt.currentTarget).closest(".js-merge-users-user-wrapper")
+    parentElt.find("select.js-selectable").removeAttr("disabled")
+  }
+}
+
+export { MergeUsersForm }

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -29,6 +29,7 @@ import { AgentsCreneaux } from 'components/agents_creneaux.js'
 import { AgentUserForm } from 'components/agent-user-form.js'
 import { RecordVersions } from 'components/record-versions.js'
 import { RecurrenceForm } from 'components/recurrence-form.js'
+import { MergeUsersForm } from 'components/merge-users-form.js'
 import 'components/calendar';
 import 'components/select2';
 import 'components/tooltip';
@@ -116,4 +117,6 @@ $(document).on('turbolinks:load', function() {
   new RecordVersions();
 
   new RecurrenceForm();
+
+  new MergeUsersForm();
 });

--- a/app/webpacker/stylesheets/components/_forms.scss
+++ b/app/webpacker/stylesheets/components/_forms.scss
@@ -54,3 +54,57 @@ select.form-control-sm {
 .form-check-inline .collection_radio_buttons {
   margin-bottom: 0;
 }
+
+.merge-users-table {
+  label {
+    display: block;
+    cursor: pointer;
+    margin-bottom: 0;
+  }
+
+  tr.identical {
+    td:not(:first-child) {
+      background-color: #DDFFEB;
+      color: #39C06E;
+    }
+
+    td:nth-child(2) > div{
+      position: relative;
+
+      &::before {
+        content: '=';
+        display: block;
+        position: absolute;
+        right: -27px;
+        background-color: #39C06E;
+        color: #FFF;
+        padding: 0 6px;
+        border-radius: 10px;
+        font-size: 20px;
+      }
+    }
+  }
+
+  tr.different {
+    td:not(:first-child) {
+      background-color: #FEF9CB;
+      color: #FE8810;
+    }
+
+    td:nth-child(2) > div{
+      position: relative;
+
+      &::before {
+        content: '≠';
+        display: block;
+        position: absolute;
+        right: -27px;
+        background-color: #FE8810;
+        color: #FFF;
+        padding: 0 6px;
+        border-radius: 10px;
+        font-size: 20px;
+      }
+    }
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
         end
 
         resource :rdv_wizard_step, only: [:new, :create]
+        resource :merge_users, only: [:new, :create]
       end
       resources :jours_feries, only: [:index]
     end

--- a/spec/factories/user_profile.rb
+++ b/spec/factories/user_profile.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :user_profile do
     user
     organisation
-    logement { UserProfile.locataire }
+    logement { :locataire }
   end
 end

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -7,6 +7,7 @@ describe "can see users' RDV" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
   end
 
   context "with no RDV" do

--- a/spec/features/agents/relatives/agent_can_create_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_create_relative_spec.rb
@@ -9,6 +9,7 @@ describe "Agent can create a relative" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
     click_link "Fiona LEGENDE"
   end
 

--- a/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
@@ -12,6 +12,7 @@ describe "Agent can delete a relative" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
     click_link "Mimi LEGENDE"
   end
 

--- a/spec/features/agents/relatives/agent_can_update_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_update_relative_spec.rb
@@ -13,6 +13,7 @@ describe "Agent can update a relative" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
     click_link "Mimi LEGENDE"
     click_link "Modifier"
   end

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -9,6 +9,7 @@ describe "Agent can create user" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
     click_link "Créer un usager", match: :first
     expect_page_title("Nouvel usager")
   end

--- a/spec/features/agents/users/agent_can_delete_user_spec.rb
+++ b/spec/features/agents/users/agent_can_delete_user_spec.rb
@@ -7,6 +7,7 @@ describe "Agent can delete user" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
     click_link "Lala LAND"
   end
 

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -1,0 +1,52 @@
+describe "Agent can delete user" do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:user1) do
+    create(
+      :user,
+      email: "aalyah@damn.com",
+      first_name: "Aalyah",
+      last_name: "SWAN",
+      birth_date: nil,
+      phone_number: "01 02 03 04 05",
+      organisations: [organisation]
+    )
+  end
+  let!(:user2) do
+    create(
+      :user,
+      email: nil,
+      first_name: "Anna",
+      last_name: "SWAN",
+      birth_date: nil,
+      phone_number: "01 09 09 09 09",
+      organisations: [organisation]
+    )
+  end
+
+  scenario "normal", js: true do
+    login_as(agent, scope: :agent)
+    visit authenticated_agent_root_path
+    click_link "Vos usagers"
+    click_link "Fusionner"
+    find("#select2-user1_id-container").click
+    find(".select2-results__option") { _1.text == "Aalyah SWAN" }.click
+    find("#select2-user2_id-container").click
+    find(".select2-results__option") { _1.text == "Anna SWAN" }.click
+    choose "aalyah@damn.com"
+    choose "Anna"
+    # forget to check phone number
+    find("input[type=submit]").click
+    page.driver.browser.switch_to.alert.accept
+    message = page.find("#merge_users_form_phone_number_1").native.attribute("validationMessage") # cf https://stackoverflow.com/a/48206413
+    expect(message).to eq "Please select one of these options."
+
+    choose "01 02 03 04 05"
+    find("input[type=submit]").click
+    page.driver.browser.switch_to.alert.accept
+
+    expect_page_title("Anna SWAN")
+    expect(page).to have_content("Les usagers ont été fusionnés")
+    expect(page).to have_content("aalyah@damn.com")
+  end
+end

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -9,6 +9,7 @@ describe "Agent can update user" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Vos usagers"
+    click_link "Usagers"
     expect_page_title("Vos usagers")
     click_link "Jean LEGENDE"
     expect_page_title("Jean LEGENDE")

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -1,0 +1,261 @@
+describe MergeUsersService, type: :service do
+  subject { MergeUsersService.perform_with(user_target, user_to_merge, attributes_to_merge, organisation) }
+
+  # defaults
+  let!(:organisation) { create(:organisation) }
+  let(:attributes_to_merge) { [] }
+  let(:user_target) { create(:user, organisations: [organisation]) }
+  let(:user_to_merge) { create(:user, organisations: [organisation]) }
+
+  context "simply merge first_name" do
+    let(:user_target) { create(:user, first_name: "Jean", last_name: "PAUL", email: "jean@paul.fr", organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, first_name: "Francis", last_name: "DUTRONC", email: "francis@dutronc.fr", organisations: [organisation]) }
+    let(:attributes_to_merge) { [:first_name] }
+
+    it "should merge attributes" do
+      subject
+      user_target.reload
+      expect(user_target.first_name).to eq("Francis")
+      expect(user_target.last_name).to eq("PAUL")
+      expect(user_target.email).to eq("jean@paul.fr")
+      expect(user_to_merge.reload.deleted_at).to be_within(3.seconds).of(Time.now)
+    end
+  end
+
+  context "with rdvs in the same orga" do
+    let(:user_target) { create(:user, organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, organisations: [organisation]) }
+    let!(:rdv1) { create(:rdv, users: [user_target], organisation: organisation) }
+    let!(:rdv2) { create(:rdv, users: [user_target], organisation: organisation) }
+    let!(:rdv3) { create(:rdv, users: [user_to_merge], organisation: organisation) }
+    let!(:rdv4) { create(:rdv, users: [user_to_merge], organisation: organisation) }
+
+    it "should move RDVs to target user" do
+      subject
+      expect(rdv1.reload.users).to contain_exactly(user_target)
+      expect(rdv2.reload.users).to contain_exactly(user_target)
+      expect(rdv3.reload.users).to contain_exactly(user_target)
+      expect(rdv4.reload.users).to contain_exactly(user_target)
+      expect(user_to_merge.deleted_at).not_to be_nil
+    end
+  end
+
+  context "with rdvs in different organisations" do
+    let!(:organisation2) { create(:organisation) }
+    let(:user_target) { create(:user, organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, organisations: [organisation, organisation2]) }
+    let!(:rdv1) { create(:rdv, users: [user_target], organisation: organisation) }
+    let!(:rdv2) { create(:rdv, users: [user_to_merge], organisation: organisation) }
+    let!(:rdv3) { create(:rdv, users: [user_to_merge], organisation: organisation2) }
+
+    it "should move RDVs to target user" do
+      subject
+      expect(rdv1.reload.users).to contain_exactly(user_target)
+      expect(rdv2.reload.users).to contain_exactly(user_target)
+      expect(rdv3.reload.users).to contain_exactly(user_to_merge)
+      expect(user_to_merge.deleted_at).to be_nil
+    end
+  end
+
+  context "with a rdv with both users already" do
+    let!(:rdv) { create(:rdv, users: [user_target, user_to_merge], organisation: organisation) }
+
+    it "should just remove user_to_merge from rdv" do
+      subject
+      expect(rdv.reload.users).to contain_exactly(user_target)
+    end
+  end
+
+  context "with relatives" do
+    let!(:relative1) { create(:user, responsible: user_target, organisations: [organisation]) }
+    let!(:relative2) { create(:user, responsible: user_target, organisations: [organisation]) }
+    let!(:relative3) { create(:user, responsible: user_to_merge, organisations: [organisation]) }
+    let!(:relative4) { create(:user, responsible: user_to_merge, organisations: [organisation]) }
+
+    it "should move relatives" do
+      subject
+      expect(user_target.relatives.count).to eq 4
+      expect(relative1.reload.responsible).to eq user_target
+      expect(relative2.reload.responsible).to eq user_target
+      expect(relative3.reload.responsible).to eq user_target
+      expect(relative4.reload.responsible).to eq user_target
+    end
+  end
+
+  context "user profiles existing for same orga" do
+    let(:user_target) { create(:user) }
+    let(:user_to_merge) { create(:user) }
+    let!(:user_profile_target) { create(:user_profile, user: user_target, organisation: organisation, logement: :locataire) }
+    let!(:user_profile_to_merge) { create(:user_profile, user: user_to_merge, organisation: organisation, logement: :proprietaire) }
+
+    context "merging logement" do
+      let(:attributes_to_merge) { [:logement] }
+
+      it "should just destroy the merged user profile" do
+        expect(UserProfile.count).to eq 2
+        subject
+        expect(UserProfile.count).to eq 1
+        expect(user_target.profile_for(organisation).logement).to eq("proprietaire")
+      end
+    end
+
+    context "not merging logement" do
+      it "should move the logement" do
+        expect(UserProfile.count).to eq 2
+        subject
+        expect(UserProfile.count).to eq 1
+        expect(user_target.profile_for(organisation).logement).to eq("locataire")
+      end
+    end
+  end
+
+  context "user profiles for different organisations" do
+    let!(:organisation2) { create(:organisation) }
+    let(:user_target) { create(:user) }
+    let(:user_to_merge) { create(:user) }
+    let!(:user_profile_target) { create(:user_profile, user: user_target, organisation: organisation, logement: :locataire) }
+    let!(:user_profile_to_merge_same_orga) { create(:user_profile, user: user_to_merge, organisation: organisation, logement: :proprietaire) }
+    let!(:user_profile_to_merge) { create(:user_profile, user: user_to_merge, organisation: organisation2, logement: :proprietaire) }
+
+    it "should not import other profile" do
+      expect(UserProfile.count).to eq 3
+      subject
+      expect(UserProfile.count).to eq 2
+      expect(user_target.user_profiles.count).to eq 1
+      expect(user_target.profile_for(organisation).logement).to eq "locataire"
+      expect(user_target.profile_for(organisation2)).to be_nil
+      expect(user_to_merge.profile_for(organisation)).to be_nil
+      expect(user_to_merge.profile_for(organisation2)).not_to be_nil
+    end
+  end
+
+  context "with file attentes for different rdvs" do
+    let!(:rdv1) { create(:rdv, users: [user_target], organisation: organisation) }
+    let!(:file_attente1) { create(:file_attente, user: user_target, rdv: rdv1) }
+    let!(:rdv2) { create(:rdv, users: [user_to_merge], organisation: organisation) }
+    let!(:file_attente2) { create(:file_attente, user: user_to_merge, rdv: rdv2) }
+
+    it "should move file attente" do
+      expect(FileAttente.count).to eq 2
+      subject
+      expect(FileAttente.count).to eq 2
+      expect(user_target.file_attentes.count).to eq 2
+      expect(file_attente2.reload.user).to eq user_target
+      expect(file_attente2.reload.rdv.users).to contain_exactly(user_target)
+    end
+  end
+
+  context "with file attentes for different orgas" do
+    let!(:organisation2) { create(:organisation) }
+    let!(:rdv1) { create(:rdv, users: [user_target], organisation: organisation) }
+    let!(:file_attente1) { create(:file_attente, user: user_target, rdv: rdv1) }
+    let!(:rdv2) { create(:rdv, users: [user_to_merge], organisation: organisation2) }
+    let!(:file_attente2) { create(:file_attente, user: user_to_merge, rdv: rdv2) }
+
+    it "should not move file attente from other orga" do
+      expect(FileAttente.count).to eq 2
+      subject
+      expect(FileAttente.count).to eq 2
+      expect(user_target.reload.file_attentes.count).to eq 1
+      expect(user_to_merge.reload.file_attentes.count).to eq 1
+      expect(file_attente2.reload.user).to eq user_to_merge
+    end
+  end
+
+  context "with file attentes for the same rdvs" do
+    let!(:rdv) { create(:rdv, users: [user_target], organisation: organisation) }
+    let!(:file_attente1) { create(:file_attente, user: user_target, rdv: rdv) }
+    let!(:file_attente2) { create(:file_attente, user: user_to_merge, rdv: rdv) }
+
+    it "should move file attente" do
+      expect(FileAttente.count).to eq 2
+      subject
+      expect(FileAttente.count).to eq 1
+      expect(user_target.file_attentes.count).to eq 1
+      expect(user_target.file_attentes.first.rdv).to eq rdv
+    end
+  end
+
+  context "with different agents from same orga attached" do
+    let!(:agent1) { create(:agent, organisations: [organisation]) }
+    let(:user_target) { create(:user, agents: [agent1], organisations: [organisation]) }
+    let!(:agent2) { create(:agent, organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, agents: [agent2], organisations: [organisation]) }
+
+    it "should append agents" do
+      subject
+      expect(user_target.agents).to contain_exactly(agent1, agent2)
+    end
+  end
+
+  context "with same agents" do
+    let!(:agent1) { create(:agent, organisations: [organisation]) }
+    let!(:agent2) { create(:agent, organisations: [organisation]) }
+    let(:user_target) { create(:user, agents: [agent1, agent2], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, agents: [agent1, agent2], organisations: [organisation]) }
+
+    it "should not do anything" do
+      subject
+      expect(user_target.agents).to contain_exactly(agent1, agent2)
+    end
+  end
+
+  context "target user doesn't have any agents yet" do
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let(:user_target) { create(:user, agents: [], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, agents: [agent], organisations: [organisation]) }
+
+    it "should set agent" do
+      subject
+      expect(user_target.agents).to contain_exactly(agent)
+    end
+  end
+
+  context "merged user doesn't have any agents yet" do
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let(:user_target) { create(:user, agents: [agent], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, agents: [], organisations: [organisation]) }
+
+    it "should not do anything" do
+      subject
+      expect(user_target.agents).to contain_exactly(agent)
+    end
+  end
+
+  context "merged user has an agent from another orga" do
+    let!(:organisation2) { create(:organisation) }
+    let!(:agent1) { create(:agent, organisations: [organisation]) }
+    let!(:agent2) { create(:agent, organisations: [organisation2]) }
+    let(:user_target) { create(:user, agents: [agent1], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, agents: [agent2], organisations: [organisation, organisation2]) }
+
+    it "should not move the agent from the other orga anything" do
+      subject
+      expect(user_target.reload.agents).to contain_exactly(agent1)
+      expect(user_to_merge.reload.agents).to contain_exactly(agent2)
+    end
+  end
+
+  context "user has notes" do
+    let!(:note1) { create(:user_note, organisation: organisation, user: user_target) }
+    let!(:note2) { create(:user_note, organisation: organisation, user: user_to_merge) }
+    let!(:note3) { create(:user_note, organisation: organisation, user: user_to_merge) }
+
+    it "should move notes" do
+      subject
+      expect(user_target.notes_for(organisation)).to contain_exactly(note1, note2, note3)
+    end
+  end
+
+  context "user has notes in other orga" do
+    let!(:organisation2) { create(:organisation) }
+    let!(:note1) { create(:user_note, organisation: organisation, user: user_target) }
+    let!(:note2) { create(:user_note, organisation: organisation, user: user_to_merge) }
+    let!(:note3) { create(:user_note, organisation: organisation2, user: user_to_merge) }
+
+    it "should move only same orga notes" do
+      subject
+      expect(user_target.notes_for(organisation)).to contain_exactly(note1, note2)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Yv0CMWtJ/942-agent-doublon-fusion-des-fiches-usagers

ℹ️ followup to #829 , rebased on master

This PR only includes the merge users interface and service, not the duplicate users list suggestion. This last part may come as a later separate PR.

![Screenshot_2020-08-11 RDV Solidarités](https://user-images.githubusercontent.com/883348/89868192-b117a580-dbb2-11ea-9f6a-f0e8f4835c9c.png)


Features:
- lets you pick 2 active users (relative or responsible or mixed)
- when there are conflicting values for attributes, lets you pick which one to preserve
- merges all associations of the users within the current organisation 
- automatically decides which should be the target and which should be merged into the target