### PR TITLE
[agent] fix active links in sidebar menu for nested routes

### DIFF
--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -30,11 +30,14 @@
             li
               = link_to "Plages d'ouverture", \
                 organisation_agent_plage_ouvertures_path(current_organisation, current_agent), \
-                data: { route: "agents/plage_ouvertures#index" }
+                data: { \
+                  route: "agents/plage_ouvertures#index", \
+                  controller: "agents/plage_ouvertures" \
+                }
             li
               = link_to 'Absences', \
                 organisation_agent_absences_path(current_organisation, current_agent), \
-                data: { route: "agents/absences#index" }
+                data: { route: "agents/absences#index", controller: "agents/absences" }
 
         li.side-nav-item
           = link_to '#', class: 'side-nav-link' do
@@ -45,7 +48,7 @@
             li
               = link_to "Usagers", \
                 organisation_users_path(current_organisation), \
-                data: { route: "agents/users#index" }
+                data: { route: "agents/users#index", controller: "agents/users" }
             li
               = link_to "Fusionner", \
                 new_organisation_merge_users_path(current_organisation), \
@@ -81,7 +84,7 @@
               li
                 = link_to 'Vos motifs', \
                   organisation_motifs_path(current_organisation), \
-                  data: { route: 'agents/motifs#index' }
+                  data: { route: 'agents/motifs#index', controller: "agents/motifs" }
               - if current_agent.admin? && policy_scope(Organisation).count == 1
                 li
                   = link_to "Sectorisation #{current_organisation.departement}", departement_setup_checklist_path(current_organisation.departement)

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -28,3 +28,4 @@ html lang="fr"
       = yield :popin
     = render "common/footer"
     input type='hidden' name='js-current-route' id="js-current-route" value=current_route_for_js
+    input type='hidden' name='js-current-controller' id="js-current-controller" value=controller_path

--- a/app/views/layouts/application_agent_departement.html.slim
+++ b/app/views/layouts/application_agent_departement.html.slim
@@ -11,7 +11,10 @@
       = link_to \
         departement_zones_path(current_departement), \
         class: 'side-nav-link', \
-        data: { route: 'agents/departements/zones#index' } \
+        data: { \
+          route: 'agents/departements/zones#index', \
+          controller: 'agents/departements/zones' \
+        } \
       do
         i.fa.fa-table
         | Zones

--- a/app/webpacker/components/menu.js
+++ b/app/webpacker/components/menu.js
@@ -78,23 +78,32 @@ class Menu {
   }
 
   _initMenuItemActive = () => {
-    document.querySelectorAll(".side-nav a").forEach(elt => {
-      if (!this.isCurrentRoute(elt)) return
+    const sideNavLinks = Array.from(document.querySelectorAll(".side-nav a"))
+    const currentNavLink = sideNavLinks.find(this.isCurrentRoute) ||
+      sideNavLinks.find(this.isCurrentController)
+    if (!currentNavLink) return
 
-      const $elt = $(elt)
-      $elt.addClass("active");
-      $elt.closest("li").addClass("active")
-      $elt.closest("ul").addClass("in")
-      const $topItemElt = $elt.closest(".side-nav-item")
-      $topItemElt.addClass("active");
-      $topItemElt.find(">.side-nav-link").addClass("active");
-    });
+    const $elt = $(currentNavLink)
+    $elt.addClass("active");
+    $elt.closest("li").addClass("active")
+    $elt.closest("ul").addClass("in")
+    const $topItemElt = $elt.closest(".side-nav-item")
+    $topItemElt.addClass("active");
+    $topItemElt.find(">.side-nav-link").addClass("active");
   }
 
-  isCurrentRoute = (elt) => {
+  isCurrentRoute = (elt) => this.getCurrentRoute() === elt.getAttribute("data-route")
+
+  isCurrentController = (elt) => this.getCurrentController() === elt.getAttribute("data-controller")
+
+  getCurrentRoute = () => {
     const currentRouteElt = document.getElementById("js-current-route")
-    const currentRoute = currentRouteElt && currentRouteElt.value;
-    return (!currentRoute || currentRoute === elt.getAttribute("data-route"))
+    return currentRouteElt && currentRouteElt.value
+  }
+
+  getCurrentController = () => {
+    const currentControllerElt = document.getElementById("js-current-controller")
+    return currentControllerElt && currentControllerElt.value
   }
 
   _initNavbarToggle(){


### PR DESCRIPTION
https://trello.com/c/fhCtioEr/1034-agent-reparer-ouverture-menu-lateral-pour-usersshow-et-plageouverturenew

Cette PR répare un petit souci : la selection et le depliement des elements du menu lateral des agents pour certaines routes. Notamment : les formulaires d'edition d'usagers, de motifs et de plages d'ouvertures

Pour ce faire, j'ai modifié le JS pour qu'il cherche d'abord un match sur base de la route exacte et en fallback sur base du controlleur

<img width="3104" alt="stitched_2020_08_11-11_43_49" src="https://user-images.githubusercontent.com/883348/89883147-0dd18b00-dbc8-11ea-9510-abea953facf2.png">
