### PR TITLE
[agent] fix placeholder for date format in date inputs, prevent submission of empty dates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,6 +42,7 @@ module ApplicationHelper
         value: form.object&.send(field)&.strftime("%d/%m/%Y"),
         data: { behaviour: "datepicker" },
         autocomplete: "off",
+        placeholder: "__/__/___"
       }.deep_merge(input_html),
       **kwargs
     )

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -5,7 +5,7 @@ class Absence < ApplicationRecord
   belongs_to :organisation
 
   before_validation :set_end_day
-  validates :agent, :organisation, :end_day, presence: true
+  validates :agent, :organisation, :first_day, presence: true
   validate :ends_at_should_be_after_starts_at
 
   default_scope -> { order(first_day: :desc, start_time: :desc) }
@@ -27,6 +27,8 @@ class Absence < ApplicationRecord
   end
 
   def ends_at_should_be_after_starts_at
+    return if starts_at.blank? || ends_at.blank?
+
     errors.add(:ends_time, "doit être après le début.") if starts_at >= ends_at
   end
 end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -17,10 +17,14 @@ module RecurrenceConcern
   end
 
   def starts_at
+    return nil if start_time.blank? || first_day.blank?
+
     start_time&.on(first_day)
   end
 
   def ends_at
+    return nil if end_time.blank? || (first_day.blank? && (!defined(end_day) || end_day.blank?))
+
     if defined?(end_day) && end_day.present?
       end_time.on(end_day)
     else

--- a/app/webpacker/components/datetimepicker.js
+++ b/app/webpacker/components/datetimepicker.js
@@ -8,7 +8,7 @@ class Datetimepicker {
     $("[data-behaviour='datepicker']").datetimepicker({
       format:'d/m/Y',
       timepicker:false,
-      mask: true,
+      mask: false,
       scrollMonth: false,
       scrollInput: false,
       dayOfWeekStart: 1,


### PR DESCRIPTION
https://trello.com/c/6JeDpvVn/1036-investiguer-probleme-datepicker-sur-les-absences

- remplace l'utilisation de l'option `mask` du plugin jquery de datepicker par un simple placeholder. le `mask` mettait en fait une valeur dans l'input, donc il etait envoyable tel quel alors qu'il contenait `__/__/____`. ce n'est pas le cas avec le placeholder, l'input est considéré vide.

- ameliore les absences et le RecurrenceConcern pour ne pas exploser mais donner une erreur claire lorsqu'on soumet une valeur incorrecte (ce qui ne devrait pas arriver). L'erreur est en double mais c'est mieux qu'une 500 et je n'ai pas trop envie de hacker pour empecher ca (c'est du au fait que c'est divisé en temps et date)

<img width="1552" alt="Screenshot_2020-08-11_at_12 04 53" src="https://user-images.githubusercontent.com/883348/89885823-ebda0780-dbcb-11ea-8e6c-fe5250ab94bd.png">
