### PR TITLE
[agent] duplicate users suggestions service and interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "sib-api-v3-sdk"
 gem "blueprinter"
 gem "typhoeus"
 
+# Other
+gem "damerau-levenshtein"
+
 # Ops
 gem "sentry-raven"
 gem "skylight"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     css_parser (1.7.1)
       addressable
     daemons (1.3.1)
+    damerau-levenshtein (1.3.3)
     database_cleaner (1.8.2)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
@@ -507,6 +508,7 @@ DEPENDENCIES
   capybara-selenium
   chartkick (~> 3.3.0)
   daemons
+  damerau-levenshtein
   database_cleaner
   delayed_cron_job
   delayed_job_active_record (~> 4.1.4)

--- a/app/controllers/agents/duplicate_users_suggestions_controller.rb
+++ b/app/controllers/agents/duplicate_users_suggestions_controller.rb
@@ -1,0 +1,34 @@
+class Agents::DuplicateUsersSuggestionsController < AgentAuthController
+  before_action :set_organisation
+
+  SLICE_SIZE = 50000
+
+  def index
+    @page = params[:page]&.to_i || 1
+    slice_start = (@page - 1) * SLICE_SIZE
+    slice = [slice_start, slice_start + SLICE_SIZE]
+    result = FindDuplicateUsersSuggestionsService
+      .perform_with(
+        current_organisation,
+        slice: slice,
+        hydrate_users: true,
+        users_scope: policy_scope(User)
+      )
+    @duplicate_users_suggestions = result.hits
+    @paginatable_combinations = Kaminari
+      .paginate_array([], total_count: result.combinations_count)
+      .page(@page)
+      .per(SLICE_SIZE)
+    @pages_left = @paginatable_combinations.total_pages - @page
+
+    return unless request.xhr?
+
+    render(
+      partial: "agents/duplicate_users_suggestions/suggestions",
+      locals: {
+        suggestions: @duplicate_users_suggestions,
+        paginatable_combinations: @paginatable_combinations
+      }
+    )
+  end
+end

--- a/app/services/find_duplicate_users_suggestions_service.rb
+++ b/app/services/find_duplicate_users_suggestions_service.rb
@@ -1,0 +1,89 @@
+class FindDuplicateUsersSuggestionsService < BaseService
+  SCORE_THRESHOLD = 0.8
+
+  def initialize(organisation, slice: nil, hydrate_users: false, users_scope: nil)
+    @organisation = organisation
+    @hydrate_users = hydrate_users
+    @slice = slice
+    @users_scope = users_scope || User.all
+  end
+
+  def perform
+    OpenStruct.new(hits: hits, combinations_count: all_combinations.count)
+  end
+
+  protected
+
+  def hits
+    raw_hits.map { @hydrate_users ? hydrate_hit(_1) : _1 }
+  end
+
+  def raw_hits
+    @raw_hits ||= combinations
+      .map { compute_raw_hits(_1, _2) }
+      .compact
+      .flatten(1)
+      .sort_by(&:score)
+      .reverse
+  end
+
+  def combinations
+    @combinations ||= \
+      if @slice.present?
+        all_combinations.to_a[(@slice.first)..(@slice.second)]
+      else
+        all_combinations
+      end
+  end
+
+  def all_combinations
+    @all_combinations ||= users_names.combination(2)
+  end
+
+  def compute_raw_hits(name1, name2)
+    score = 1 - (
+      DamerauLevenshtein.distance(name1, name2).to_f / [name1.length, name2.length].max
+    )
+    return nil if score < SCORE_THRESHOLD
+
+    (user_ids_by_names[name1] + user_ids_by_names[name2])
+      .sort.combination(2).map { OpenStruct.new(score: score, user_ids: _1) }
+  end
+
+  def users
+    @users ||= @organisation.users.active.order(:id).select(:id, :first_name, :last_name)
+  end
+
+  def user_ids_by_names
+    @user_ids_by_names ||= users
+      .group_by { format_user_name(_1) }
+      .map { [_1, _2.pluck(:id)] }
+      .to_h
+  end
+
+  def format_user_name(user)
+    "#{user.first_name} #{user.last_name}"
+      .parameterize
+      .gsub(/(monsieur\-|madame\-|mr\-|mme\-|m\-|mlle\-)/, "")
+      .gsub("-", " ")
+      .strip
+  end
+
+  def users_names
+    @users_names ||= user_ids_by_names.keys
+  end
+
+  def hydrate_hit(hit)
+    OpenStruct.new(users: hit.user_ids.map { hits_users_by_ids[_1] }, **hit.to_h)
+  end
+
+  def hits_users_by_ids
+    @hits_users_by_ids ||= @users_scope
+      .where(id: raw_hits.map(&:user_ids).flatten)
+      .select(:id, :first_name, :last_name, :birth_name)
+      .to_a
+      .group_by(&:id)
+      .transform_values { _1.first } # group_by returns arrays but we expect one
+      .to_h
+  end
+end

--- a/app/views/agents/duplicate_users_suggestions/_suggestions.html.slim
+++ b/app/views/agents/duplicate_users_suggestions/_suggestions.html.slim
@@ -1,0 +1,37 @@
+- if suggestions.empty?
+  p.my-1
+    i.text-muted Aucune suggestion d'usagers doublons
+
+- suggestions.each_with_index do |suggestion, idx|
+  .row.mb-1.pb-1.border-bottom.border-light
+    .col-sm-9
+      .row
+        .col-sm-6.text-right.py-1= user_to_link(suggestion.users.first)
+        .col-sm-6.text-left.py-1= user_to_link(suggestion.users.second)
+    .col-sm-3.text-right
+      = link_to( \
+        'Fusionner…', \
+        new_organisation_merge_users_path(\
+          current_organisation, \
+          user1_id: suggestion.users.first.id, \
+          user2_id: suggestion.users.second \
+        ), \
+        class: 'btn btn-primary' \
+      )
+
+.js-load-more-duplicate-users-target
+  .text-center.mt-3
+    .js-load-more-collapse.collapse
+      .spinner.spinner-border
+    .js-load-more-collapse.collapse.show
+      div= link_to_next_page \
+        paginatable_combinations, \
+        "Voir d'autres suggestions", \
+        class: 'btn btn-primary js-load-more-duplicate-users-suggestions', \
+        remote: true, \
+        data: { \
+          toggle: "collapse", \
+          target: ".js-load-more-collapse" \
+        }
+      - if paginatable_combinations.next_page.present?
+        i.text-muted= "encore #{@pages_left} pages"

--- a/app/views/agents/duplicate_users_suggestions/index.html.slim
+++ b/app/views/agents/duplicate_users_suggestions/index.html.slim
@@ -1,0 +1,22 @@
+- content_for :title do
+  | Suggestions d'usagers doublons
+
+- content_for :breadcrumb do
+  = add_button 'Fusionner deux usagers', new_organisation_merge_users_path(current_organisation), header: true
+
+.row.justify-content-md-center
+  .col-md-6
+    .card
+      .card-body
+        - if @duplicate_users_suggestions.any? || @paginatable_combinations.next_page.present?
+          .js-load-more-duplicate-users-target
+            = render "suggestions", suggestions: @duplicate_users_suggestions, paginatable_combinations: @paginatable_combinations
+
+        - else
+          .row.justify-content-md-center
+            .col-md-6.text-center.my-5
+              p.mb-2.lead Aucun doublon détécté
+              p L'algorithme de détection de doublons de RDV-Solidarités se base principalement sur le prénom et le nom, il se peut qu'il rate des doublons.
+
+          .text-center
+            = add_button 'Fusionner deux usagers', new_organisation_merge_users_path(current_organisation)

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -47,6 +47,10 @@
                 organisation_users_path(current_organisation), \
                 data: { route: "agents/users#index" }
             li
+              = link_to "Doublons", \
+                organisation_duplicate_users_suggestions_path(current_organisation), \
+                data: { route: "agents/duplicate_users_suggestions#index" }
+            li
               = link_to "Fusionner", \
                 new_organisation_merge_users_path(current_organisation), \
                 data: { route: "agents/merge_users#new" }

--- a/app/webpacker/components/duplicate-users-suggestions.js
+++ b/app/webpacker/components/duplicate-users-suggestions.js
@@ -1,0 +1,23 @@
+class DuplicateUsersSuggestions {
+  constructor() {
+    const $button = $(".js-load-more-duplicate-users-suggestions")
+    if (!$button) return
+
+    this.bindHandlers()
+  }
+
+  bindHandlers = () => {
+    $(".js-load-more-duplicate-users-suggestions")
+      .on("ajax:success", this.displayResults)
+  }
+
+  displayResults = (event) => {
+    const [_data, _status, xhr] = event.detail;
+    $(event.currentTarget).
+      closest(".js-load-more-duplicate-users-target").
+      html(xhr.responseText)
+    this.bindHandlers()
+  }
+}
+
+export { DuplicateUsersSuggestions }

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -30,6 +30,7 @@ import { AgentUserForm } from 'components/agent-user-form.js'
 import { RecordVersions } from 'components/record-versions.js'
 import { RecurrenceForm } from 'components/recurrence-form.js'
 import { MergeUsersForm } from 'components/merge-users-form.js'
+import { DuplicateUsersSuggestions } from "components/duplicate-users-suggestions"
 import 'components/calendar';
 import 'components/select2';
 import 'components/tooltip';
@@ -119,4 +120,6 @@ $(document).on('turbolinks:load', function() {
   new RecurrenceForm();
 
   new MergeUsersForm();
+
+  new DuplicateUsersSuggestions();
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
         end
 
         resource :rdv_wizard_step, only: [:new, :create]
+        resources :duplicate_users_suggestions, only: [:index]
         resource :merge_users, only: [:new, :create]
       end
       resources :jours_feries, only: [:index]

--- a/scripts/list_duplicate_users_suggestions.rb
+++ b/scripts/list_duplicate_users_suggestions.rb
@@ -1,0 +1,69 @@
+# rails runner scripts/list_duplicate_users_suggestions.rb
+
+ActiveRecord::Base.logger = nil # disable SQL output
+
+class Stats
+  def initialize(print_suggestions: "all")
+    @results_by_organisation = {}
+    @print_suggestions = print_suggestions
+  end
+
+  def perform
+    puts "will go through #{Organisation.count} organisations...\n"
+    Organisation.order(:departement).each { treat_organisation(_1) }
+    puts "\n--- TOTALS ---\n"
+    @results_by_organisation = @results_by_organisation.sort_by { _2.suggestions.count }
+    @results_by_organisation.reverse.each { print_organisatio_result_row(_1, _2) }
+
+    return unless @print_suggestions.present?
+
+    puts "\n--- Suggestions by orga ---\n"
+    @results_by_organisation.each { print_suggestions(_1, _2.suggestions) }
+  end
+
+  protected
+
+  def treat_organisation(organisation)
+    suggestions = nil
+    time_ms = Benchmark.ms do
+      suggestions = FindDuplicateUsersSuggestionsService
+        .perform_with(organisation, hydrate_users: true)
+    end
+
+    @results_by_organisation[organisation] = \
+      OpenStruct.new(suggestions: suggestions, time_ms: time_ms)
+  end
+
+  def orga_name_with_dpt(organisation)
+    "#{organisation.departement} #{organisation.name}"
+  end
+
+  def print_organisatio_result_row(organisation, result)
+    total_users = organisation.users.active.count
+    percentage = ((result.suggestions.count.to_f / total_users) * 100).round if total_users.positive?
+    cols = [
+      orga_name_with_dpt(organisation)[0..15].ljust(16, " "),
+      "#{result.suggestions.count.to_s.ljust(5, ' ')} suggestions",
+      "out of #{total_users.to_s.ljust(5, ' ')} users",
+      percentage ? "#{percentage} %" : "",
+      "~#{result.time_ms.round} ms"
+    ]
+    puts cols.join("\t|\t")
+  end
+
+  def print_suggestions(organisation, suggestions)
+    puts "\n--- Organisation #{orga_name_with_dpt(organisation)}  ---"
+    puts "found #{suggestions.count} duplicate users suggestions"
+    suggestions.each do |suggestion|
+      users = suggestion.users.map(&:full_name).join(" - ")
+      puts "#{suggestion.score.round(2)}: #{users}"
+    end
+  end
+end
+
+Stats.new.perform
+
+# StackProf.run(mode: :cpu, out: "tmp/stackprof-duplicate-users.dump") do
+#   FindDuplicateUsersSuggestionsService
+#     .perform_with(Organisation.find_by_name("MDS Lens 2"), hydrate_users: true)
+# end

--- a/spec/services/find_duplicate_users_suggestions_service_spec.rb
+++ b/spec/services/find_duplicate_users_suggestions_service_spec.rb
@@ -1,0 +1,60 @@
+describe FindDuplicateUsersSuggestionsService, type: :service do
+  subject { FindDuplicateUsersSuggestionsService.perform_with(organisation).hits }
+  let!(:organisation) { create(:organisation) }
+
+  context "a duplicate on the same name" do
+    let!(:user1) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUES") }
+    let!(:user2) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "PATRICK") }
+    let!(:user3) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUS") }
+
+    it "should find the duplicate pair" do
+      suggestions = subject
+      expect(suggestions.count).to eq 1
+      expect(suggestions.first.user_ids).to eq([user1.id, user3.id])
+    end
+  end
+
+  context "multiple duplicates on the same name" do
+    let!(:user1) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUES") }
+    let!(:user2) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "PATRICK") }
+    let!(:user3) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUE") }
+    let!(:user4) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUSS") }
+
+    it "should find multiple duplicate pairs" do
+      suggestions = subject
+      expect(suggestions.count).to eq 3
+      user_ids_pairs = suggestions.map(&:user_ids)
+      expect(user_ids_pairs).to include([user1.id, user3.id])
+      expect(user_ids_pairs).to include([user1.id, user4.id])
+      expect(user_ids_pairs).to include([user3.id, user4.id])
+    end
+  end
+
+  context "hydrate_users option" do
+    let!(:user1) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUES") }
+    let!(:user2) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "PATRICK") }
+    let!(:user3) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUE") }
+    let!(:user4) { create(:user, organisations: [organisation], first_name: "Jean", last_name: "JACQUSS") }
+
+    it "should find multiple duplicate pairs" do
+      suggestions = FindDuplicateUsersSuggestionsService.perform_with(organisation, hydrate_users: true).hits
+      expect(suggestions.count).to eq 3
+      user_ids_pairs = suggestions.map(&:users)
+      expect(user_ids_pairs).to include([user1, user3])
+      expect(user_ids_pairs).to include([user1, user4])
+      expect(user_ids_pairs).to include([user3, user4])
+    end
+  end
+
+  context "Monsieur or Madame words in names" do
+    let!(:user1) { create(:user, organisations: [organisation], first_name: "Monsieur / Madame Jean", last_name: "JACQUES") }
+    let!(:user2) { create(:user, organisations: [organisation], first_name: "Monsieur / Madame Jean", last_name: "JANY") }
+    let!(:user3) { create(:user, organisations: [organisation], first_name: "Monsieur / Madame Jean", last_name: "JACQUS") }
+
+    it "should ignore monsieur and madame in matches" do
+      user_ids_pairs = subject.map(&:user_ids)
+      expect(user_ids_pairs).to include([user1.id, user3.id])
+      expect(user_ids_pairs).not_to include([user1.id, user2.id])
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Jvs9g9Zp/1035-agent-suggestions-dusagers-doublons

algo très simpliste pour détecter les doublons : on parcourt toutes les combinaisons d'usagers possibles au sein de l'orga courante, on caclule la distance de Levenshtein, et on applique un threshold.

Le calcul est malheureusment trop lent sur les données de prod pour certaines orgas pour le faire en temps réel lors de l'affichage de la page : 

<img width="1045" alt="Screenshot_2020-08-12_at_10 46 05" src="https://user-images.githubusercontent.com/883348/90020265-e81fb100-dcaf-11ea-9004-a019b3dec370.png">

L'option la plus fiable et évolutive serait de calculer en asynchrone, et stocker les suggestions dans la DB. Cela permettrait aussi de laisser les agents cacher des suggestions. Cependant cela serait nettement plus compliqué : 
- nouvelle table et modèle
- jobs CRON pour calculer automatiquement tous les jours
- rafraîchissement rapide lors des CRUD usagers pour avoir des données à peu près à jour

En version hacky alternative, j'ai fait une interface style "afficher plus" qui pagine les combinaisons à tester, et permet de découper le travail. L'UX n'est pas parfaite, mais ça me semble suffisant pour tester que la fonctionnalité a un intérêt avant d'y investir plus de temps. 

j'ai seedé la review app avec des données de la gem Faker, ca fait beaucoup de doublons suspectés par rapport aux données de prod.