### PR TITLE
bash script to export all data from one organisation

### DIFF
--- a/scripts/full_orga_sql_dump.sh
+++ b/scripts/full_orga_sql_dump.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # ./scripts/full_orga_sql_dump.sh 83 postgresql://localhost/rdv-sol-prod-dump
+# ./scripts/full_orga_sql_dump.sh ORGANISATION_ID $DATABASE_URL
 
 set -e  # will exit upon failure
 

--- a/scripts/full_orga_sql_dump.sh
+++ b/scripts/full_orga_sql_dump.sh
@@ -2,6 +2,8 @@
 
 # ./scripts/full_orga_sql_dump.sh 83 postgresql://localhost/rdv-sol-prod-dump
 
+set -e  # will exit upon failure
+
 ORGANISATION_ID=$1
 SOURCE_DB_URL=$2
 
@@ -13,24 +15,24 @@ TEMP_DB_URL=postgresql://localhost/$TEMP_DB_NAME
 mkdir -p $OUTPUT_PATH
 
 echo "exporting db schema..."
-pg_dump --schema-only --file $OUTPUT_PATH/schema.pg_dump $SOURCE_DB_URL || exit 1
+pg_dump --schema-only --file $OUTPUT_PATH/schema.pg_dump $SOURCE_DB_URL
 
 echo "exporting all data from organisation $ORGANISATION_ID from DB to CSV files..."
 
 # common data
-psql $SOURCE_DB_URL -c "COPY motif_libelles TO '$OUTPUT_PATH/motif_libelles.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY services TO '$OUTPUT_PATH/services.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY motif_libelles TO '$OUTPUT_PATH/motif_libelles.csv';"
+psql $SOURCE_DB_URL -c "COPY services TO '$OUTPUT_PATH/services.csv';"
 
 # direct links
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM organisations WHERE id=$ORGANISATION_ID) TO '$OUTPUT_PATH/organisations.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM absences              WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/absences.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM agents_organisations  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/agents_organisations.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM lieux                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/lieux.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM motifs                WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/motifs.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM plage_ouvertures      WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/plage_ouvertures.csv';" || exit 1
-# psql $SOURCE_DB_URL -c "COPY (SELECT * FROM rdvs                  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/rdvs.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM user_profiles         WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/user_profiles.csv';" || exit 1
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM zones                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/zones.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM organisations WHERE id=$ORGANISATION_ID) TO '$OUTPUT_PATH/organisations.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM absences              WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/absences.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM agents_organisations  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/agents_organisations.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM lieux                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/lieux.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM motifs                WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/motifs.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM plage_ouvertures      WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/plage_ouvertures.csv';"
+# psql $SOURCE_DB_URL -c "COPY (SELECT * FROM rdvs                  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/rdvs.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM user_profiles         WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/user_profiles.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM zones                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/zones.csv';"
 
 # special case for RDVS because of https://metabase-rdv-solidarites.osc-fr1.scalingo.io/question/6
 
@@ -38,7 +40,7 @@ psql $SOURCE_DB_URL -c "COPY (
   SELECT rdvs.* FROM rdvs
   LEFT JOIN lieux ON lieux.id = rdvs.lieu_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID AND lieux.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/rdvs.csv';" || exit 1
+) TO '$OUTPUT_PATH/rdvs.csv';"
 
 # joined links
 
@@ -46,37 +48,37 @@ psql $SOURCE_DB_URL -c "COPY (
   SELECT agents.* FROM agents
   LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents.id
   WHERE agents_organisations.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/agents.csv';" || exit 1
+) TO '$OUTPUT_PATH/agents.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT agents_rdvs.* FROM agents_rdvs
   LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents_rdvs.agent_id
   WHERE agents_organisations.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/agents_rdvs.csv';" || exit 1
+) TO '$OUTPUT_PATH/agents_rdvs.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT agents_users.* FROM agents_users
   LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents_users.agent_id
   WHERE agents_organisations.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/agents_users.csv';" || exit 1
+) TO '$OUTPUT_PATH/agents_users.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT file_attentes.* FROM file_attentes
   LEFT JOIN rdvs ON rdvs.id = file_attentes.rdv_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/file_attentes.csv';" || exit 1
+) TO '$OUTPUT_PATH/file_attentes.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT motifs_plage_ouvertures.* FROM motifs_plage_ouvertures
   LEFT JOIN motifs ON motifs.id = motifs_plage_ouvertures.motif_id
   WHERE motifs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/motifs_plage_ouvertures.csv';" || exit 1
+) TO '$OUTPUT_PATH/motifs_plage_ouvertures.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT rdv_events.* FROM rdv_events
   LEFT JOIN rdvs ON rdvs.id = rdv_events.rdv_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/rdv_events.csv';" || exit 1
+) TO '$OUTPUT_PATH/rdv_events.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT rdvs_users.* FROM rdvs_users
   LEFT JOIN rdvs ON rdvs.id = rdvs_users.rdv_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/rdvs_users.csv';" || exit 1
+) TO '$OUTPUT_PATH/rdvs_users.csv';"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT * FROM users WHERE id IN (
     (
@@ -90,50 +92,50 @@ psql $SOURCE_DB_URL -c "COPY (
       WHERE user_profiles.organisation_id=$ORGANISATION_ID
     )
   ) ORDER BY responsible_id
-) TO '$OUTPUT_PATH/users.csv';" || exit 1
+) TO '$OUTPUT_PATH/users.csv';"
 # psql $SOURCE_DB_URL -c "COPY (
 #   SELECT * FROM users WHERE id IN (
 #     SELECT users.responsible_id FROM users
 #     LEFT JOIN user_profiles ON user_profiles.user_id = users.id
 #     WHERE user_profiles.organisation_id=$ORGANISATION_ID
 #   )
-# ) TO '$OUTPUT_PATH/users_responsibles.csv';" || exit 1
+# ) TO '$OUTPUT_PATH/users_responsibles.csv';"
 
 # version
 echo "creating temporary PostgreSQL database $TEMP_DB_NAME..."
-createdb $TEMP_DB_NAME || exit 1
+createdb $TEMP_DB_NAME
 
 echo "loading schema..."
-cat $OUTPUT_PATH/schema.pg_dump | psql $TEMP_DB_URL || exit 1
+cat $OUTPUT_PATH/schema.pg_dump | psql $TEMP_DB_URL
 
 echo "importing data into tmp db..."
 # note that the order is important to respect FKs
-psql $TEMP_DB_URL -c "COPY services FROM '$OUTPUT_PATH/services.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY motif_libelles FROM '$OUTPUT_PATH/motif_libelles.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY organisations FROM '$OUTPUT_PATH/organisations.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY agents FROM '$OUTPUT_PATH/agents.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY absences FROM '$OUTPUT_PATH/absences.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY agents_organisations FROM '$OUTPUT_PATH/agents_organisations.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY lieux FROM '$OUTPUT_PATH/lieux.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY motifs FROM '$OUTPUT_PATH/motifs.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY plage_ouvertures FROM '$OUTPUT_PATH/plage_ouvertures.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY rdvs FROM '$OUTPUT_PATH/rdvs.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY user_profiles FROM '$OUTPUT_PATH/user_profiles.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY zones FROM '$OUTPUT_PATH/zones.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY agents_rdvs FROM '$OUTPUT_PATH/agents_rdvs.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY agents_users FROM '$OUTPUT_PATH/agents_users.csv';" || exit 1
-# psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY motifs_plage_ouvertures FROM '$OUTPUT_PATH/motifs_plage_ouvertures.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY rdv_events FROM '$OUTPUT_PATH/rdv_events.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY rdvs_users FROM '$OUTPUT_PATH/rdvs_users.csv';" || exit 1
-# psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users_responsibles.csv';" || exit 1
-psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY services FROM '$OUTPUT_PATH/services.csv';"
+psql $TEMP_DB_URL -c "COPY motif_libelles FROM '$OUTPUT_PATH/motif_libelles.csv';"
+psql $TEMP_DB_URL -c "COPY organisations FROM '$OUTPUT_PATH/organisations.csv';"
+psql $TEMP_DB_URL -c "COPY agents FROM '$OUTPUT_PATH/agents.csv';"
+psql $TEMP_DB_URL -c "COPY absences FROM '$OUTPUT_PATH/absences.csv';"
+psql $TEMP_DB_URL -c "COPY agents_organisations FROM '$OUTPUT_PATH/agents_organisations.csv';"
+psql $TEMP_DB_URL -c "COPY lieux FROM '$OUTPUT_PATH/lieux.csv';"
+psql $TEMP_DB_URL -c "COPY motifs FROM '$OUTPUT_PATH/motifs.csv';"
+psql $TEMP_DB_URL -c "COPY plage_ouvertures FROM '$OUTPUT_PATH/plage_ouvertures.csv';"
+psql $TEMP_DB_URL -c "COPY rdvs FROM '$OUTPUT_PATH/rdvs.csv';"
+psql $TEMP_DB_URL -c "COPY user_profiles FROM '$OUTPUT_PATH/user_profiles.csv';"
+psql $TEMP_DB_URL -c "COPY zones FROM '$OUTPUT_PATH/zones.csv';"
+psql $TEMP_DB_URL -c "COPY agents_rdvs FROM '$OUTPUT_PATH/agents_rdvs.csv';"
+psql $TEMP_DB_URL -c "COPY agents_users FROM '$OUTPUT_PATH/agents_users.csv';"
+# psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv';"
+psql $TEMP_DB_URL -c "COPY motifs_plage_ouvertures FROM '$OUTPUT_PATH/motifs_plage_ouvertures.csv';"
+psql $TEMP_DB_URL -c "COPY rdv_events FROM '$OUTPUT_PATH/rdv_events.csv';"
+psql $TEMP_DB_URL -c "COPY rdvs_users FROM '$OUTPUT_PATH/rdvs_users.csv';"
+# psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users_responsibles.csv';"
+psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users.csv';"
 
 
 echo "exporting SQL dump"
-pg_dump --clean --no-owner --no-privileges --file $OUTPUT_PATH/full_dump_organisation_$ORGANISATION_ID.sql $TEMP_DB_NAME || exit 1
+pg_dump --clean --no-owner --no-privileges --file $OUTPUT_PATH/full_dump_organisation_$ORGANISATION_ID.sql $TEMP_DB_NAME
 
 echo "dropping temporary db..."
-dropdb $TEMP_DB_NAME || exit 1
+dropdb $TEMP_DB_NAME
 
 echo "Done, all files are in $OUTPUT_PATH"

--- a/scripts/full_orga_sql_dump.sh
+++ b/scripts/full_orga_sql_dump.sh
@@ -93,13 +93,6 @@ psql $SOURCE_DB_URL -c "COPY (
     )
   ) ORDER BY responsible_id
 ) TO '$OUTPUT_PATH/users.csv';"
-# psql $SOURCE_DB_URL -c "COPY (
-#   SELECT * FROM users WHERE id IN (
-#     SELECT users.responsible_id FROM users
-#     LEFT JOIN user_profiles ON user_profiles.user_id = users.id
-#     WHERE user_profiles.organisation_id=$ORGANISATION_ID
-#   )
-# ) TO '$OUTPUT_PATH/users_responsibles.csv';"
 
 # version
 echo "creating temporary PostgreSQL database $TEMP_DB_NAME..."
@@ -124,13 +117,11 @@ psql $TEMP_DB_URL -c "COPY user_profiles FROM '$OUTPUT_PATH/user_profiles.csv';"
 psql $TEMP_DB_URL -c "COPY zones FROM '$OUTPUT_PATH/zones.csv';"
 psql $TEMP_DB_URL -c "COPY agents_rdvs FROM '$OUTPUT_PATH/agents_rdvs.csv';"
 psql $TEMP_DB_URL -c "COPY agents_users FROM '$OUTPUT_PATH/agents_users.csv';"
-# psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv';"
 psql $TEMP_DB_URL -c "COPY motifs_plage_ouvertures FROM '$OUTPUT_PATH/motifs_plage_ouvertures.csv';"
 psql $TEMP_DB_URL -c "COPY rdv_events FROM '$OUTPUT_PATH/rdv_events.csv';"
 psql $TEMP_DB_URL -c "COPY rdvs_users FROM '$OUTPUT_PATH/rdvs_users.csv';"
-# psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users_responsibles.csv';"
 psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users.csv';"
-
+psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv';"
 
 echo "exporting SQL dump"
 pg_dump --clean --no-owner --no-privileges --file $OUTPUT_PATH/full_dump_organisation_$ORGANISATION_ID.sql $TEMP_DB_NAME

--- a/scripts/full_orga_sql_dump.sh
+++ b/scripts/full_orga_sql_dump.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+# ./scripts/full_orga_sql_dump.sh 83 postgresql://localhost/rdv-sol-prod-dump
+
+ORGANISATION_ID=$1
+SOURCE_DB_URL=$2
+
+DUMP_ID=$ORGANISATION_ID-`date +"%Y_%m_%d_%HH%M"`
+OUTPUT_PATH=$(pwd)/tmp/dump_organisation_$DUMP_ID
+TEMP_DB_NAME=rdv-solidarites-dump-$DUMP_ID
+TEMP_DB_URL=postgresql://localhost/$TEMP_DB_NAME
+
+mkdir -p $OUTPUT_PATH
+
+echo "exporting db schema..."
+pg_dump --schema-only --file $OUTPUT_PATH/schema.pg_dump $SOURCE_DB_URL || exit 1
+
+echo "exporting all data from organisation $ORGANISATION_ID from DB to CSV files..."
+
+# common data
+psql $SOURCE_DB_URL -c "COPY motif_libelles TO '$OUTPUT_PATH/motif_libelles.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY services TO '$OUTPUT_PATH/services.csv';" || exit 1
+
+# direct links
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM organisations WHERE id=$ORGANISATION_ID) TO '$OUTPUT_PATH/organisations.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM absences              WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/absences.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM agents_organisations  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/agents_organisations.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM lieux                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/lieux.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM motifs                WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/motifs.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM plage_ouvertures      WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/plage_ouvertures.csv';" || exit 1
+# psql $SOURCE_DB_URL -c "COPY (SELECT * FROM rdvs                  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/rdvs.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM user_profiles         WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/user_profiles.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM zones                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/zones.csv';" || exit 1
+
+# special case for RDVS because of https://metabase-rdv-solidarites.osc-fr1.scalingo.io/question/6
+
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT rdvs.* FROM rdvs
+  LEFT JOIN lieux ON lieux.id = rdvs.lieu_id
+  WHERE rdvs.organisation_id=$ORGANISATION_ID AND lieux.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/rdvs.csv';" || exit 1
+
+# joined links
+
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT agents.* FROM agents
+  LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents.id
+  WHERE agents_organisations.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/agents.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT agents_rdvs.* FROM agents_rdvs
+  LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents_rdvs.agent_id
+  WHERE agents_organisations.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/agents_rdvs.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT agents_users.* FROM agents_users
+  LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents_users.agent_id
+  WHERE agents_organisations.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/agents_users.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT file_attentes.* FROM file_attentes
+  LEFT JOIN rdvs ON rdvs.id = file_attentes.rdv_id
+  WHERE rdvs.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/file_attentes.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT motifs_plage_ouvertures.* FROM motifs_plage_ouvertures
+  LEFT JOIN motifs ON motifs.id = motifs_plage_ouvertures.motif_id
+  WHERE motifs.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/motifs_plage_ouvertures.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT rdv_events.* FROM rdv_events
+  LEFT JOIN rdvs ON rdvs.id = rdv_events.rdv_id
+  WHERE rdvs.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/rdv_events.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT rdvs_users.* FROM rdvs_users
+  LEFT JOIN rdvs ON rdvs.id = rdvs_users.rdv_id
+  WHERE rdvs.organisation_id=$ORGANISATION_ID
+) TO '$OUTPUT_PATH/rdvs_users.csv';" || exit 1
+psql $SOURCE_DB_URL -c "COPY (
+  SELECT * FROM users WHERE id IN (
+    (
+      SELECT users.responsible_id FROM users
+      LEFT JOIN user_profiles ON user_profiles.user_id = users.id
+      WHERE user_profiles.organisation_id=$ORGANISATION_ID
+    )
+    UNION ALL (
+      SELECT users.id FROM users
+      LEFT JOIN user_profiles ON user_profiles.user_id = users.id
+      WHERE user_profiles.organisation_id=$ORGANISATION_ID
+    )
+  ) ORDER BY responsible_id
+) TO '$OUTPUT_PATH/users.csv';" || exit 1
+# psql $SOURCE_DB_URL -c "COPY (
+#   SELECT * FROM users WHERE id IN (
+#     SELECT users.responsible_id FROM users
+#     LEFT JOIN user_profiles ON user_profiles.user_id = users.id
+#     WHERE user_profiles.organisation_id=$ORGANISATION_ID
+#   )
+# ) TO '$OUTPUT_PATH/users_responsibles.csv';" || exit 1
+
+# version
+echo "creating temporary PostgreSQL database $TEMP_DB_NAME..."
+createdb $TEMP_DB_NAME || exit 1
+
+echo "loading schema..."
+cat $OUTPUT_PATH/schema.pg_dump | psql $TEMP_DB_URL || exit 1
+
+echo "importing data into tmp db..."
+# note that the order is important to respect FKs
+psql $TEMP_DB_URL -c "COPY services FROM '$OUTPUT_PATH/services.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY motif_libelles FROM '$OUTPUT_PATH/motif_libelles.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY organisations FROM '$OUTPUT_PATH/organisations.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY agents FROM '$OUTPUT_PATH/agents.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY absences FROM '$OUTPUT_PATH/absences.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY agents_organisations FROM '$OUTPUT_PATH/agents_organisations.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY lieux FROM '$OUTPUT_PATH/lieux.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY motifs FROM '$OUTPUT_PATH/motifs.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY plage_ouvertures FROM '$OUTPUT_PATH/plage_ouvertures.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY rdvs FROM '$OUTPUT_PATH/rdvs.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY user_profiles FROM '$OUTPUT_PATH/user_profiles.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY zones FROM '$OUTPUT_PATH/zones.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY agents_rdvs FROM '$OUTPUT_PATH/agents_rdvs.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY agents_users FROM '$OUTPUT_PATH/agents_users.csv';" || exit 1
+# psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY motifs_plage_ouvertures FROM '$OUTPUT_PATH/motifs_plage_ouvertures.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY rdv_events FROM '$OUTPUT_PATH/rdv_events.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY rdvs_users FROM '$OUTPUT_PATH/rdvs_users.csv';" || exit 1
+# psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users_responsibles.csv';" || exit 1
+psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users.csv';" || exit 1
+
+
+echo "exporting SQL dump"
+pg_dump --clean --no-owner --no-privileges --file $OUTPUT_PATH/full_dump_organisation_$ORGANISATION_ID.sql $TEMP_DB_NAME || exit 1
+
+echo "dropping temporary db..."
+dropdb $TEMP_DB_NAME || exit 1
+
+echo "Done, all files are in $OUTPUT_PATH"

--- a/scripts/full_orga_sql_dump.sh
+++ b/scripts/full_orga_sql_dump.sh
@@ -20,19 +20,19 @@ pg_dump --schema-only --file $OUTPUT_PATH/schema.pg_dump $SOURCE_DB_URL
 echo "exporting all data from organisation $ORGANISATION_ID from DB to CSV files..."
 
 # common data
-psql $SOURCE_DB_URL -c "COPY motif_libelles TO '$OUTPUT_PATH/motif_libelles.csv';"
-psql $SOURCE_DB_URL -c "COPY services TO '$OUTPUT_PATH/services.csv';"
+psql $SOURCE_DB_URL -c "COPY motif_libelles TO '$OUTPUT_PATH/motif_libelles.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY services TO '$OUTPUT_PATH/services.csv' CSV HEADER;"
 
 # direct links
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM organisations WHERE id=$ORGANISATION_ID) TO '$OUTPUT_PATH/organisations.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM absences              WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/absences.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM agents_organisations  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/agents_organisations.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM lieux                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/lieux.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM motifs                WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/motifs.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM plage_ouvertures      WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/plage_ouvertures.csv';"
-# psql $SOURCE_DB_URL -c "COPY (SELECT * FROM rdvs                  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/rdvs.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM user_profiles         WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/user_profiles.csv';"
-psql $SOURCE_DB_URL -c "COPY (SELECT * FROM zones                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/zones.csv';"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM organisations WHERE id=$ORGANISATION_ID) TO '$OUTPUT_PATH/organisations.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM absences              WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/absences.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM agents_organisations  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/agents_organisations.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM lieux                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/lieux.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM motifs                WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/motifs.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM plage_ouvertures      WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/plage_ouvertures.csv' CSV HEADER;"
+# psql $SOURCE_DB_URL -c "COPY (SELECT * FROM rdvs                  WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/rdvs.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM user_profiles         WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/user_profiles.csv' CSV HEADER;"
+psql $SOURCE_DB_URL -c "COPY (SELECT * FROM zones                 WHERE organisation_id=$ORGANISATION_ID) TO '$OUTPUT_PATH/zones.csv' CSV HEADER;"
 
 # special case for RDVS because of https://metabase-rdv-solidarites.osc-fr1.scalingo.io/question/6
 
@@ -40,7 +40,7 @@ psql $SOURCE_DB_URL -c "COPY (
   SELECT rdvs.* FROM rdvs
   LEFT JOIN lieux ON lieux.id = rdvs.lieu_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID AND lieux.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/rdvs.csv';"
+) TO '$OUTPUT_PATH/rdvs.csv' CSV HEADER;"
 
 # joined links
 
@@ -48,37 +48,37 @@ psql $SOURCE_DB_URL -c "COPY (
   SELECT agents.* FROM agents
   LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents.id
   WHERE agents_organisations.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/agents.csv';"
+) TO '$OUTPUT_PATH/agents.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT agents_rdvs.* FROM agents_rdvs
   LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents_rdvs.agent_id
   WHERE agents_organisations.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/agents_rdvs.csv';"
+) TO '$OUTPUT_PATH/agents_rdvs.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT agents_users.* FROM agents_users
   LEFT JOIN agents_organisations ON agents_organisations.agent_id = agents_users.agent_id
   WHERE agents_organisations.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/agents_users.csv';"
+) TO '$OUTPUT_PATH/agents_users.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT file_attentes.* FROM file_attentes
   LEFT JOIN rdvs ON rdvs.id = file_attentes.rdv_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/file_attentes.csv';"
+) TO '$OUTPUT_PATH/file_attentes.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT motifs_plage_ouvertures.* FROM motifs_plage_ouvertures
   LEFT JOIN motifs ON motifs.id = motifs_plage_ouvertures.motif_id
   WHERE motifs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/motifs_plage_ouvertures.csv';"
+) TO '$OUTPUT_PATH/motifs_plage_ouvertures.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT rdv_events.* FROM rdv_events
   LEFT JOIN rdvs ON rdvs.id = rdv_events.rdv_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/rdv_events.csv';"
+) TO '$OUTPUT_PATH/rdv_events.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT rdvs_users.* FROM rdvs_users
   LEFT JOIN rdvs ON rdvs.id = rdvs_users.rdv_id
   WHERE rdvs.organisation_id=$ORGANISATION_ID
-) TO '$OUTPUT_PATH/rdvs_users.csv';"
+) TO '$OUTPUT_PATH/rdvs_users.csv' CSV HEADER;"
 psql $SOURCE_DB_URL -c "COPY (
   SELECT * FROM users WHERE id IN (
     (
@@ -92,7 +92,7 @@ psql $SOURCE_DB_URL -c "COPY (
       WHERE user_profiles.organisation_id=$ORGANISATION_ID
     )
   ) ORDER BY responsible_id
-) TO '$OUTPUT_PATH/users.csv';"
+) TO '$OUTPUT_PATH/users.csv' CSV HEADER;"
 
 # version
 echo "creating temporary PostgreSQL database $TEMP_DB_NAME..."
@@ -103,25 +103,25 @@ cat $OUTPUT_PATH/schema.pg_dump | psql $TEMP_DB_URL
 
 echo "importing data into tmp db..."
 # note that the order is important to respect FKs
-psql $TEMP_DB_URL -c "COPY services FROM '$OUTPUT_PATH/services.csv';"
-psql $TEMP_DB_URL -c "COPY motif_libelles FROM '$OUTPUT_PATH/motif_libelles.csv';"
-psql $TEMP_DB_URL -c "COPY organisations FROM '$OUTPUT_PATH/organisations.csv';"
-psql $TEMP_DB_URL -c "COPY agents FROM '$OUTPUT_PATH/agents.csv';"
-psql $TEMP_DB_URL -c "COPY absences FROM '$OUTPUT_PATH/absences.csv';"
-psql $TEMP_DB_URL -c "COPY agents_organisations FROM '$OUTPUT_PATH/agents_organisations.csv';"
-psql $TEMP_DB_URL -c "COPY lieux FROM '$OUTPUT_PATH/lieux.csv';"
-psql $TEMP_DB_URL -c "COPY motifs FROM '$OUTPUT_PATH/motifs.csv';"
-psql $TEMP_DB_URL -c "COPY plage_ouvertures FROM '$OUTPUT_PATH/plage_ouvertures.csv';"
-psql $TEMP_DB_URL -c "COPY rdvs FROM '$OUTPUT_PATH/rdvs.csv';"
-psql $TEMP_DB_URL -c "COPY user_profiles FROM '$OUTPUT_PATH/user_profiles.csv';"
-psql $TEMP_DB_URL -c "COPY zones FROM '$OUTPUT_PATH/zones.csv';"
-psql $TEMP_DB_URL -c "COPY agents_rdvs FROM '$OUTPUT_PATH/agents_rdvs.csv';"
-psql $TEMP_DB_URL -c "COPY agents_users FROM '$OUTPUT_PATH/agents_users.csv';"
-psql $TEMP_DB_URL -c "COPY motifs_plage_ouvertures FROM '$OUTPUT_PATH/motifs_plage_ouvertures.csv';"
-psql $TEMP_DB_URL -c "COPY rdv_events FROM '$OUTPUT_PATH/rdv_events.csv';"
-psql $TEMP_DB_URL -c "COPY rdvs_users FROM '$OUTPUT_PATH/rdvs_users.csv';"
-psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users.csv';"
-psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv';"
+psql $TEMP_DB_URL -c "COPY services FROM '$OUTPUT_PATH/services.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY motif_libelles FROM '$OUTPUT_PATH/motif_libelles.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY organisations FROM '$OUTPUT_PATH/organisations.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY agents FROM '$OUTPUT_PATH/agents.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY absences FROM '$OUTPUT_PATH/absences.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY agents_organisations FROM '$OUTPUT_PATH/agents_organisations.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY lieux FROM '$OUTPUT_PATH/lieux.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY motifs FROM '$OUTPUT_PATH/motifs.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY plage_ouvertures FROM '$OUTPUT_PATH/plage_ouvertures.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY rdvs FROM '$OUTPUT_PATH/rdvs.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY user_profiles FROM '$OUTPUT_PATH/user_profiles.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY zones FROM '$OUTPUT_PATH/zones.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY agents_rdvs FROM '$OUTPUT_PATH/agents_rdvs.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY agents_users FROM '$OUTPUT_PATH/agents_users.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY motifs_plage_ouvertures FROM '$OUTPUT_PATH/motifs_plage_ouvertures.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY rdv_events FROM '$OUTPUT_PATH/rdv_events.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY rdvs_users FROM '$OUTPUT_PATH/rdvs_users.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY users FROM '$OUTPUT_PATH/users.csv' CSV HEADER;"
+psql $TEMP_DB_URL -c "COPY file_attentes FROM '$OUTPUT_PATH/file_attentes.csv' CSV HEADER;"
 
 echo "exporting SQL dump"
 pg_dump --clean --no-owner --no-privileges --file $OUTPUT_PATH/full_dump_organisation_$ORGANISATION_ID.sql $TEMP_DB_NAME


### PR DESCRIPTION
https://trello.com/c/NVvX8hOR/1030-dump-complet-des-donn%C3%A9es-par-organisation

new version of #822 , pure bash script without gem dependency and ruby script

`./scripts/full_orga_sql_dump.sh 83 postgresql://localhost/rdv-sol-prod-dump` 

- outputs one CSV file per table
- outputs one global `full_dump_organisation_XX.sql` file that contains both the schema and data.

in order to do it, the script creates a temporary postgres db on the local machine, but it's dropped before the end of the script

@guillett this is not my most beautiful looking code , sorry. I'm far from being a bash expert 😨 so it's a lot of hacks.

there are a few tricky workarounds to deal with weird cases in the prod db where there's some incoherent data, and also some twists so that foreign keys constraints are respected when the csv files are imported back into a temporary db.

TODO : 
- [ ] export the versions table
- [ ] double check that it's exhaustive and doesn't leak data