### PR TITLE
supprimer une lib inutilisé

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "rails-erb-loader": "^5.5.2",
     "select2": "^4.0.8",
     "select2-bootstrap4-theme": "^1.0.0",
-    "serialize-javascript": "^2.1.1",
     "turbolinks": "^5.2.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6619,7 +6619,7 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^2.1.1, serialize-javascript@^2.1.2:
+serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==


### PR DESCRIPTION
Le robot de surveillance à suggérer la mise à jour d'un paquet js : serialize-javascript (https://github.com/betagouv/rdv-solidarites.fr/pull/839).

En regardant un peu ce que faisait cette mise à jour et ce paquet, j'ai l'impression que nous ne nous en servons pas.

```bash
grep -ri "serialize" app/webpacker/
```
ne renvoie rien.