### PR TITLE
Affiche la proposition invitation

### DIFF
--- a/app/views/agents/users/_responsible_form_fields.html.slim
+++ b/app/views/agents/users/_responsible_form_fields.html.slim
@@ -16,14 +16,10 @@
     as: :boolean, \
     label: "Inviter l'utilisateur à se créer un compte sur RDV-solidarites.", \
     wrapper_html: { \
-      class:"align-items-baseline ml-0 d-none js-invite-row",
+      class:"align-items-baseline ml-0",
     }, \
     **input_opts, \
   )
-
-- elsif user.pending_reconfirmation?
-  .form-text.text-muted.mb-2
-    | En attente de confirmation pour #{user.unconfirmed_email}
 
 = f.input :phone_number, as: :tel, **input_opts
 

--- a/app/webpacker/components/agent-user-form.js
+++ b/app/webpacker/components/agent-user-form.js
@@ -28,16 +28,6 @@ class AgentUserForm {
         this.refreshVisibleFields()
       })
     )
-    this.formElt.querySelectorAll("input[type=email]").forEach(elt => {
-      elt.addEventListener("change", this.onEmailChangeHandler);
-      elt.dispatchEvent(new CustomEvent("change"));
-    })
-  }
-
-  onEmailChangeHandler = (evt) => {
-    const inviteRow = evt.currentTarget.parentElement.parentElement.querySelector(".js-invite-row");
-    if (!inviteRow) return
-    inviteRow.classList.toggle("d-none", !evt.currentTarget.value)
   }
 
   refreshVisibleFields = () => {

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -39,7 +39,7 @@ describe "Agent can delete user" do
     find("input[type=submit]").click
     page.driver.browser.switch_to.alert.accept
     message = page.find("#merge_users_form_phone_number_1").native.attribute("validationMessage") # cf https://stackoverflow.com/a/48206413
-    expect(message).to eq "Please select one of these options."
+    expect(message).to eq("Please select one of these options.").or(eq("Veuillez sélectionner l'une de ces options."))
 
     choose "01 02 03 04 05"
     find("input[type=submit]").click


### PR DESCRIPTION
En plus de clarifier le formularie usager, cette PR permet d'avoir des tests qui passent sur la PR https://github.com/betagouv/rdv-solidarites.fr/pull/832.

De plus 
- je pense que la règle 12.14 du RGAA est moyennement respecté (https://references.modernisation.gouv.fr/rgaa-accessibilite/criteres.html#crit-12-14);
- je me dit qu'en plus, ça fait beaucoup de javascript pour un gain UX qui me semble assez discutable;
- le `elsif user.pending_reconfirmation?`, vis à vis du message de  n'est jamais appelé (je n'ai pas reproduit le cas où ça s'affiche;

Moins de code, moins de bug.