### PR TITLE
espace-avec-un-blanc

### DIFF
--- a/app/views/agents/rdvs/show.html.slim
+++ b/app/views/agents/rdvs/show.html.slim
@@ -17,7 +17,7 @@
         p.card-text
           i.fa.fa-fw.fa-calendar>
           = rdv_time_and_duration(@rdv)
-          |>
+          |&nbsp;
           = link_to "voir dans l'agenda", organisation_agent_path(current_organisation, @rdv.agents.first, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date)
         = render 'rdv_details', rdv: @rdv, display_links_to_users: false
         .row


### PR DESCRIPTION
découverte d'un caractère `>` dans la fiche RDV. C'est une erreur. Je vais remettre un `&nbsp;` à la place puisque ça ne semble pas être faisable autrement.