### PR TITLE
reintroduce RDVs old_notes as context

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -1,7 +1,7 @@
 class RdvBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :uuid, :status, :duration_in_min, :starts_at, :address
+  fields :uuid, :status, :duration_in_min, :starts_at, :address, :context
 
   association :organisation, blueprint: OrganisationBlueprint
   association :motif, blueprint: MotifBlueprint

--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -2,7 +2,7 @@ class Admin::RdvWizardStepsController < AgentAuthController
   before_action :set_agent
 
   PERMITTED_PARAMS = [
-    :motif_id, :duration_in_min, :starts_at, :lieu_id,
+    :motif_id, :duration_in_min, :starts_at, :lieu_id, :context,
     :organisation_id, agent_ids: [], user_ids: []
   ].freeze
 

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -74,7 +74,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def rdv_params
-    params.require(:rdv).permit(:motif_id, :lieu_id, :duration_in_min, :starts_at, agent_ids: [], user_ids: [])
+    params.require(:rdv).permit(:motif_id, :lieu_id, :duration_in_min, :starts_at, :context, agent_ids: [], user_ids: [])
   end
 
   def status_params

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -1,5 +1,5 @@
 class Users::RdvWizardStepsController < UserAuthController
-  RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, user_ids: []].freeze
+  RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, user_ids: []].freeze
   EXTRA_PERMITTED_PARAMS = [:lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code].freeze
 
   def new

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -64,6 +64,6 @@ class Users::RdvsController < UserAuthController
   end
 
   def rdv_params
-    params.permit(:starts_at, :motif_id, user_ids: [])
+    params.permit(:starts_at, :motif_id, :context, user_ids: [])
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -81,6 +81,7 @@ class Rdv < ApplicationRecord
       starts_at: starts_at&.to_s,
       user_ids: users&.map(&:id),
       agent_ids: agents&.map(&:id),
+      context: context
     }
   end
 

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -52,6 +52,8 @@
               | L'usager n'existe pas ?&nbsp;
               = link_to 'Créer un usager', new_admin_organisation_user_path(current_organisation, modal: true), data: { modal: true }
 
+          .mt-3= f.input :context, input_html: { rows: 4 }
+
           = f.input_field :motif_id, as: :hidden
           = f.input_field :starts_at, as: :hidden
           = f.input_field :lieu_id, as: :hidden

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -20,6 +20,7 @@
         = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
         = simple_form_for(@rdv, url: admin_organisation_rdvs_path(current_organisation)) do |f|
           = f.association :motif, as: :hidden,  wrapper_html: { class: 'm-0' }
+          = f.input :context, as: :hidden, wrapper_html: { class: 'm-0' }
           .form-row
             .col-md-6= datetime_input(f, :starts_at)
             .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"

--- a/app/views/admin/rdvs/_form.html.slim
+++ b/app/views/admin/rdvs/_form.html.slim
@@ -1,6 +1,7 @@
 = simple_form_for([:admin, rdv.organisation, rdv], remote: request.xhr?, data: { rightbar: true }) do |f|
   = render partial: 'layouts/model_errors', locals: { model: rdv }
   = f.association :motif, disabled: true
+  = f.input :context, input_html: { rows: 3 }
   .form-row
     .col-md-6= datetime_input(f, :starts_at)
     .col-md-6= f.input :duration_in_min

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -3,8 +3,18 @@
     i.fa.fa-fw.fa-at>
     | RDV pris sur Internet
 p.card-text
-  i.fa.fa-fw.fa-info-circle>
-  = rdv.motif.name
+  .d-flex
+    div.mr-1
+      i.fa.fa-fw.fa-info-circle>
+    div
+      = rdv.motif.name
+      div
+        - if rdv.context.blank?
+          .text-muted  Pas de contexte renseigné
+        - else
+          .text-muted Contexte :
+          .border-left.pl-2= simple_format(rdv.context)
+
 - if rdv.phone?
   p.card-text
     i.fa.fa-fw.fa-phone>

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -48,10 +48,6 @@
             = display_value_or_na_placeholder(user.email)
 
           h5.cart-title.mb-2.mt-4 Notes
-          = simple_form_for(UserNote.new, url: admin_organisation_user_notes_path(current_organisation, user)) do |f|
-            = f.input :text, label: false, mandatory: true
-            = f.button :submit, "Enregistrer"
-          hr
           = render "common/user_notes", user: user, extra_link_params: { rdv_id: @rdv.id }
 
     .card
@@ -70,7 +66,7 @@
           href="#history"
           data-text-close="🕵️‍♂️ Cacher l'historique des actions ˄"
           data-text-open="🕵️‍♂️ Afficher l'historique des actions ⌄"
-          data-versions-url=admin_organisation_rdv_versions_path(@rdv.organisation, @rdv, only: ['user_ids', 'agent_ids', 'duration_in_min', 'status', 'starts_at', 'lieu_id', 'notes', 'location'])
+          data-versions-url=admin_organisation_rdv_versions_path(@rdv.organisation, @rdv, only: ['user_ids', 'agent_ids', 'duration_in_min', 'status', 'starts_at', 'lieu_id', 'notes', 'location', 'context'])
         ]
           | 🕵️‍♂️ Afficher l'historique des actions ⌄
       .js-record-versions-body#history.collapse class=(@uncollapsed_section == 'history' ? "show" : "")

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -13,7 +13,7 @@ fr:
         starts_at: Commence à
         duration_in_min: Durée en minutes
         status: Statut
-        notes: Notes libres
+        context: Contexte
         statuses:
           unknown: Indéterminé
           waiting: En salle d'attente

--- a/db/migrate/20200903072742_restore_rdv_context.rb
+++ b/db/migrate/20200903072742_restore_rdv_context.rb
@@ -1,0 +1,56 @@
+# prod run: :user_note_destroyed=>3509, :context_cleaned=>42
+
+class RestoreRdvContext < ActiveRecord::Migration[6.0]
+  def up
+    rename_column :rdvs, :old_notes, :context
+    puts "will verify #{rdvs_to_migrate.count} rdvs with a context"
+    counters = { user_note_destroyed: 0, context_cleaned: 0 }
+
+    # disable AR logging, it's quite intense
+    old_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = nil
+
+    rdvs_to_migrate.each do |rdv|
+      res = migrate_rdv(rdv)
+      counters[res] += 1
+    end
+
+    ActiveRecord::Base.logger = old_logger
+    puts "finished ! totals: #{counters}"
+  end
+
+  def down
+    rename_column :rdvs, :context, :old_notes
+  end
+
+  private
+
+  def rdvs_to_migrate
+    @rdvs_to_migrate = Rdv.includes(:organisation).where.not(context: [nil, ""])
+  end
+
+  def migrate_rdv(rdv)
+    user_note = find_rdv_matching_user_note(rdv)
+    if user_note.present?
+      puts "destroying user_note!"
+      user_note.destroy!
+      :user_note_destroyed
+    else
+      puts "user_note disappeared, cleaning context..."
+      rdv.update_columns(context: nil)
+      :context_cleaned
+    end
+  end
+
+  def find_rdv_matching_user_note(rdv)
+    target_user = rdv.users.responsible.first || rdv.users.first
+    return nil unless target_user.present?
+
+    UserNote.find_by(
+      user: target_user,
+      organisation: rdv.organisation,
+      agent: nil,
+      text: rdv.context
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_03_164154) do
+ActiveRecord::Schema.define(version: 2020_09_03_072742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -244,7 +244,7 @@ ActiveRecord::Schema.define(version: 2020_08_03_164154) do
     t.integer "status", default: 0
     t.string "location"
     t.integer "created_by", default: 0
-    t.text "old_notes"
+    t.text "context"
     t.bigint "lieu_id"
     t.index ["created_by"], name: "index_rdvs_on_created_by"
     t.index ["lieu_id"], name: "index_rdvs_on_lieu_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -388,7 +388,8 @@ rdv1 = Rdv.new(
   lieu: lieu_org_paris_nord_sud,
   organisation_id: org_paris_nord.id,
   agent_ids: [agent_org_paris_nord_pmi_martine.id],
-  user_ids: [user_org_paris_nord_patricia.id]
+  user_ids: [user_org_paris_nord_patricia.id],
+  context: "Visite de courtoisie"
 )
 rdv1.save!
 Rdv.set_callback(:create, :after, :notify_rdv_created)

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
 
     duration_in_min { 45 }
     starts_at { DateTime.parse("2020-06-15 10:30").in_time_zone }
+    context { "Vient en taxi depuis Lille" }
+
     trait :by_phone do
       motif { build(:motif, :by_phone, organisation: organisation) }
       lieu { nil }

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -51,7 +51,7 @@ describe "Agent can create a Rdv with wizard" do
     page.execute_script "$('#mainModal').scrollTop(1000)"
     click_button("Créer usager")
     sleep(1) # wait for modal to hide completely
-
+    fill_in :rdv_context, with: "RDV très spécial"
     click_button("Continuer")
 
     # Step 3
@@ -73,6 +73,7 @@ describe "Agent can create a Rdv with wizard" do
     expect(rdv.duration_in_min).to eq(35)
     expect(rdv.starts_at).to eq(Time.zone.local(2019, 10, 11, 14, 15))
     expect(rdv.created_by_agent?).to be(true)
+    expect(rdv.context).to eq("RDV très spécial")
 
     expect(page).to have_current_path(admin_organisation_rdv_path(organisation, rdv))
     expect(page).to have_content("Le rendez-vous a été créé.")


### PR DESCRIPTION
https://trello.com/c/bATaTRzd/1046-contexte-du-rendez-vous

# Notes

- j'ai pris l'initative de modifier l'affichage et l'édition du contexte pour être plus proche du Motif 
- j'ai rajouté le `context` dans le blueprint pour qu'il soit envoyé dans les webhooks outgoing. @guillett est-ce que ca te parait logique ? faut-il prévenir les utilisateurs des webhooks?
- j'ai lancé la migration sur un dump de la prod : `user_note_destroyed=>3509, :context_cleaned=>42` et ca a duré ~1m

# Screenshots

<img width="598" alt="Screenshot_2020-09-03_at_12 01 45" src="https://user-images.githubusercontent.com/883348/92102242-a4b3f080-edde-11ea-8a75-e737a9425cda.png">
<img width="579" alt="Screenshot_2020-09-03_at_12 03 36" src="https://user-images.githubusercontent.com/883348/92102281-b0071c00-edde-11ea-8c28-2456b37b1cdd.png">
<img width="582" alt="Screenshot_2020-09-03_at_12 04 29" src="https://user-images.githubusercontent.com/883348/92102294-b4cbd000-edde-11ea-833d-30d0928ce262.png">
<img width="697" alt="Screenshot_2020-09-03_at_12 04 58" src="https://user-images.githubusercontent.com/883348/92102302-b72e2a00-edde-11ea-9abb-dc6d18fe3ed6.png">
<img width="600" alt="Screenshot_2020-09-03_at_12 05 34" src="https://user-images.githubusercontent.com/883348/92102324-bdbca180-edde-11ea-85de-15518fd34060.png">
<img width="1079" alt="Screenshot_2020-09-03_at_12 09 33" src="https://user-images.githubusercontent.com/883348/92102337-c01efb80-edde-11ea-8d10-42f84e5cf811.png">
