### PR TITLE
improve registration layout for connected agents

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,7 +70,7 @@ module ApplicationHelper
   end
 
   def agent_path?
-    request.path =~ /(agents)/
+    request.path =~ /(agents|admin)/ || (request.path == "/" && current_agent.present?)
   end
 
   def agents_or_users_body_class

--- a/app/views/admin/organisations/index.html.slim
+++ b/app/views/admin/organisations/index.html.slim
@@ -1,5 +1,5 @@
-.text-center.m-auto
-  h4.text-dark-50.text-center.mt-0.font-weight-bold.mb-4 Choisissez une organisation
+- content_for :title, "Choisissez une organisation"
+
 - @organisations_by_departement.each do |departement, organisations|
   .card
     .card-header

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -15,11 +15,23 @@ html lang="fr"
         = link_logo
         .align-items-center.d-flex.h-100
           .p-3.flex-grow-1
-            = image_pack_tag 'welcome/agent.svg', class: 'agent-profile mx-auto mb-5', alt: ""
-            - if agent_path?
+            = image_pack_tag 'welcome/agent.svg', class: 'agent-profile mx-auto mb-4', alt: ""
+            - if agent_path? && current_agent.nil?
               h4.mb-3 Terminé l'agenda papier, moins de temps perdu.
               p.lead
                 | Digitalisez votre prise de RDV !
+            - elsif agent_path? && current_agent.present?
+              h4.mb-3
+                i.far.fa-id-card>
+                = current_agent.full_name_and_service
+              .d-flex.flex-row.justify-content-center
+                ul.list-unstyled.text-left
+                  li
+                    h5= link_to "Mon compte", edit_agent_registration_path
+                  li
+                    h5= link_to "Mes organisations", admin_organisations_path
+                  li
+                    h5= link_to "Se déconnecter", destroy_agent_session_path, method: :delete
             - else
               h4.mb-3 Prenez RDV en ligne avec votre département !
 

--- a/app/webpacker/stylesheets/structure/_authentication.scss
+++ b/app/webpacker/stylesheets/structure/_authentication.scss
@@ -44,6 +44,7 @@ body.authentication-bg {
     position: relative;
     color: $white;
     background-color: $primary;
+    max-height: 100vh;
 
     body.agents & {
       background-color: $turquoise;


### PR DESCRIPTION
https://trello.com/c/KXykCVie/1059-agent-am%C3%A9liorer-le-message-affich%C3%A9-sur-la-gauche-des-pages-listes-des-organisations-et-editer-mon-compte

remplace PR #857

# Changements

- repare detection users ou agents sur la liste des orgas pour le message de gauche
- change message generique par un menu pour les agents connectés (visible sur liste des orgas et sur editer compte donc)
- ajoute max height 100vh

ce n'est pas très beau mais ca me parait quand meme mieux que l'existant

# Avant-Après pour la liste orgas :

<img width="3104" alt="stitched_2020_09_02-15_30_59" src="https://user-images.githubusercontent.com/883348/91989900-5ac10100-ed31-11ea-9140-4b049f4d7e61.png">


# Avant-Après pour la page editer compte :
<img width="3104" alt="stitched_2020_09_02-15_27_47" src="https://user-images.githubusercontent.com/883348/91989602-faca5a80-ed30-11ea-8fdb-2c4dd18daa0d.png">