### PR TITLE
add optional banner for degraded service cases

### DIFF
--- a/app/views/layouts/_degraded_service.html.slim
+++ b/app/views/layouts/_degraded_service.html.slim
@@ -1,0 +1,6 @@
+- if message.present?
+  .row
+    .col-md-12
+      .d-print-none.alert.fade.show.main-alert.alert-warning.m-0.text-center
+        span> ⚠️
+        = message

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,6 +3,7 @@ html lang="fr"
   head
     = render 'common/head'
   body class="#{agents_or_users_body_class}"
+    = render 'layouts/degraded_service', message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
     div class="#{ params[:controller].include?('users/') ? '' : 'bg-primary'}"
       - if current_user.present?
         = render "common/header_user_logged"

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -5,6 +5,7 @@ html lang="fr"
     = render 'common/head_agent'
   body
     .wrapper
+      = render 'layouts/degraded_service', message: ENV["DEGRADED_SERVICE_MESSAGE_AGENTS"]
       = render "layouts/left_menu"
       .content-page
         .content


### PR DESCRIPTION
https://trello.com/c/s77YlZQG/1060-banni%C3%A8re-pour-service-d%C3%A9grad%C3%A9

<img width="1552" alt="Screenshot_2020-09-03_at_11 49 25" src="https://user-images.githubusercontent.com/883348/92100283-e55e3a80-eddb-11ea-8f08-973b20813536.png">

<img width="1552" alt="Screenshot_2020-09-03_at_11 49 28" src="https://user-images.githubusercontent.com/883348/92100294-e8592b00-eddb-11ea-9e85-016faab24e10.png">

messages optionnels indépendants pour agents et usagers définis par des variables d'env

testable sur la review app en togglant les vars d'env sur https://my.osc-fr1.scalingo.com/apps/demo-rdv-solidarites-pr860/variables

`DEGRADED_SERVICE_MESSAGE_AGENTS`

and

`DEGRADED_SERVICE_MESSAGE_USERS`