### PR TITLE
fix selecting current_organisation in admin organisations controller

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -45,6 +45,15 @@ class Admin::OrganisationsController < AgentAuthController
 
   private
 
+  def current_organisation
+    # overrides AgentAuthController's because here it's params[:id]
+    if params[:id].present?
+      current_agent.organisations.find(params[:id])
+    else
+      current_agent.organisations.first # necessary for pundit but should not
+    end
+  end
+
   def organisation_params
     params.require(:organisation).permit(:name, :horaires, :phone_number, :human_id)
   end

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -39,10 +39,7 @@ class AgentAuthController < ApplicationController
   end
 
   def current_organisation
-    id = params[:controller] == "agents/organisations" ? params[:id] : params[:organisation_id]
-    id ? current_agent.organisations.find(id) : current_agent.organisations.first
-  rescue ActiveRecord::RecordNotFound
-    raise Pundit::NotAuthorizedError
+    current_agent.organisations.find(params[:organisation_id])
   end
 
   def from_modal?


### PR DESCRIPTION
Corrige un bug qui fait changer d'orga sans raison quand on visite la page admin/organisations#show et qu'on a accès à plusieurs orgas.

bug introduit par le changement de namespace du controller `agents/organisations` vers `admin/organisations`

j'ai corrigé en arrêtant de faire la comparaison sur base du nom du namespace, mais plutot en overridant la fonction dans le controlleur héritant. j'ai mis des commentaires expliquant un peu ce bout de code mystique.