### PR TITLE
Redirige agent vers agenda après la prise d'un RDV

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -60,7 +60,7 @@ class Admin::RdvsController < AgentAuthController
     @rdv.organisation = current_organisation
     authorize(@rdv)
     if @rdv.save
-      redirect_to admin_organisation_rdv_path(current_organisation, @rdv), notice: "Le rendez-vous a été créé."
+      redirect_to admin_organisation_agent_path(current_organisation, current_agent), notice: "Le rendez-vous a été créé."
     else
       @rdv_wizard = AgentRdvWizard::Step3.new(current_agent, current_organisation, @rdv.attributes)
       render "admin/rdv_wizard_steps/step3"

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -60,7 +60,7 @@ class Admin::RdvsController < AgentAuthController
     @rdv.organisation = current_organisation
     authorize(@rdv)
     if @rdv.save
-      redirect_to admin_organisation_agent_path(current_organisation, current_agent), notice: "Le rendez-vous a été créé."
+      redirect_to admin_organisation_agent_path(current_organisation, current_agent, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date), notice: "Le rendez-vous a été créé."
     else
       @rdv_wizard = AgentRdvWizard::Step3.new(current_agent, current_organisation, @rdv.attributes)
       render "admin/rdv_wizard_steps/step3"

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -80,9 +80,9 @@ describe "Agent can create a Rdv with creneau search" do
     expect(rdv.duration_in_min).to eq(motif.default_duration_in_min)
     expect(rdv.created_by_agent?).to be(true)
 
-    expect(page).to have_current_path(admin_organisation_rdv_path(organisation, rdv))
+    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent))
     expect(page).to have_content("Le rendez-vous a été créé.")
-    expect(page).to have_content("lundi 29 juillet 2019")
+    expect(page).to have_content("Votre agenda")
   end
 
   def expect_checked(text)

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -80,7 +80,7 @@ describe "Agent can create a Rdv with creneau search" do
     expect(rdv.duration_in_min).to eq(motif.default_duration_in_min)
     expect(rdv.created_by_agent?).to be(true)
 
-    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent))
+    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
     expect(page).to have_content("Le rendez-vous a été créé.")
     expect(page).to have_content("Votre agenda")
   end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -75,7 +75,7 @@ describe "Agent can create a Rdv with wizard" do
     expect(rdv.created_by_agent?).to be(true)
     expect(rdv.context).to eq("RDV très spécial")
 
-    expect(page).to have_current_path(admin_organisation_rdv_path(organisation, rdv))
+    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent))
     expect(page).to have_content("Le rendez-vous a été créé.")
     sleep(0.5) # wait for ajax request
   end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -75,7 +75,7 @@ describe "Agent can create a Rdv with wizard" do
     expect(rdv.created_by_agent?).to be(true)
     expect(rdv.context).to eq("RDV très spécial")
 
-    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent))
+    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
     expect(page).to have_content("Le rendez-vous a été créé.")
     sleep(0.5) # wait for ajax request
   end


### PR DESCRIPTION
https://trello.com/c/lOBN6DfA/1047-sassurer-que-le-rendez-vous-est-bien-enregistr%C3%A9-dans-lagenda

Maintenant qu'une zone de texte est disponible dans le tunnel de prise de rendez-vous pour préciser l'objet, nous pouvons remettre la redirection vers l'agenda en fin de tunnel.

Ça rassure les agents de voir le rendez-vous positionné.