### PR TITLE
Tri les rdv par ordre chronologique

### DIFF
--- a/app/views/admin/rdvs/_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_rdvs_list.html.slim
@@ -1,7 +1,7 @@
 - if rdvs.any?
   = render( \
     partial: 'admin/rdvs/rdv', \
-    collection: rdvs, \
+    collection: rdvs.sort_by(&:starts_at), \
     locals: local_assigns.slice(:date_format, :show_user_details) \
   )
   .d-flex.justify-content-center= paginate rdvs, theme: 'twitter-bootstrap-4'


### PR DESCRIPTION
https://trello.com/c/PMmIQ65G/1050-liste-des-rdv-de-la-journ%C3%A9e-tri%C3%A9s-par-ordre-chronologique

Afin d'avoir la liste des rendez-vous de la journée dans le même ordre que le déroulement de la journée, la les des rdvs est trié par ordre chronologique.