### PR TITLE
order agents, lieux and motifs in trouver un creneau interface

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -7,9 +7,9 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     respond_to do |format|
       format.html do
         @organisation = current_organisation
-        @motifs = @organisation.motifs.active
-        @agents = @organisation.agents.complete.active
-        @lieux = @organisation.lieux
+        @motifs = policy_scope(Motif).active.ordered_by_name
+        @agents = policy_scope(Agent).complete.active.order_by_last_name
+        @lieux = policy_scope(Lieu).ordered_by_name
       end
       format.js do
         @agent_search = Creneau::AgentSearch.new(filter_params)

--- a/app/controllers/admin/lieux_controller.rb
+++ b/app/controllers/admin/lieux_controller.rb
@@ -2,7 +2,7 @@ class Admin::LieuxController < AgentAuthController
   respond_to :html, :json
 
   def index
-    @lieux = policy_scope(Lieu).includes(:organisation).order(Arel.sql("LOWER(name)")).page(params[:page])
+    @lieux = policy_scope(Lieu).includes(:organisation).ordered_by_name.page(params[:page])
   end
 
   def new

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -5,7 +5,7 @@ class Admin::MotifsController < AgentAuthController
   before_action :set_motif, only: [:show, :edit, :update, :destroy]
 
   def index
-    @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).order(Arel.sql("LOWER(name)")).page(params[:page])
+    @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page])
   end
 
   def new

--- a/app/models/creneau/agent_search.rb
+++ b/app/models/creneau/agent_search.rb
@@ -28,9 +28,9 @@ class Creneau::AgentSearch
 
   def lieux
     filtered_lieux = if lieu_ids.any?
-                       organisation.lieux.where(id: lieu_ids)
+                       organisation.lieux.where(id: lieu_ids).ordered_by_name
                      else
-                       organisation.lieux.for_motif(motif)
+                       organisation.lieux.for_motif(motif).ordered_by_name
                      end
     filtered_lieux = filtered_lieux.where(id: PlageOuverture.where(agent_id: agent_ids).pluck(:lieu_id)) if agent_ids.any?
     filtered_lieux

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -36,6 +36,8 @@ class Lieu < ApplicationRecord
     )
   }
 
+  scope :ordered_by_name, -> { order(Arel.sql("LOWER(name)")) }
+
   def full_name
     "#{name} (#{address})"
   end

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -36,7 +36,7 @@ class Lieu < ApplicationRecord
     )
   }
 
-  scope :ordered_by_name, -> { order(Arel.sql("LOWER(name)")) }
+  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
 
   def full_name
     "#{name} (#{address})"

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -20,7 +20,7 @@ class Motif < ApplicationRecord
   scope :reservable_online, -> { where(reservable_online: true) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
   scope :for_secretariat, -> { where(for_secretariat: true) }
-  scope :ordered_by_name, -> { order(Arel.sql("LOWER(name)")) }
+  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
     available_motifs = agent.service.secretariat? ? for_secretariat : where(service: agent.service)
     available_motifs.where(organisation_id: organisation.id).active.ordered_by_name
@@ -51,6 +51,7 @@ class Motif < ApplicationRecord
       .complete
       .active
       .where(service: authorized_services)
+      .order_by_last_name
   end
 
   def authorized_services

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -20,9 +20,10 @@ class Motif < ApplicationRecord
   scope :reservable_online, -> { where(reservable_online: true) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
   scope :for_secretariat, -> { where(for_secretariat: true) }
+  scope :ordered_by_name, -> { order(Arel.sql("LOWER(name)")) }
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
     available_motifs = agent.service.secretariat? ? for_secretariat : where(service: agent.service)
-    available_motifs.where(organisation_id: organisation.id).active.order(Arel.sql("LOWER(name)"))
+    available_motifs.where(organisation_id: organisation.id).active.ordered_by_name
   }
 
   def self.searchable(organisations, service: nil)

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -1,2 +1,11 @@
 class Agent::MotifPolicy < Agent::AdminPolicy
+  class Scope < Scope
+    def resolve
+      if @context.agent.can_access_others_planning?
+        scope.where(organisation: @context.organisation)
+      else
+        scope.where(organisation: @context.organisation, service: @context.agent.service)
+      end
+    end
+  end
 end

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -3,7 +3,7 @@
     = render partial: 'layouts/model_errors', locals: { model: plage_ouverture }
     = f.hidden_field :agent_id
     = f.input :title, hint: 'Uniquement visible en interne', placeholder: 'Ex: Permanence PMI exceptionnelle'
-    = f.association :lieu, collection: policy_scope(Lieu), label_method: :full_name, include_blank: false
+    = f.association :lieu, collection: policy_scope(Lieu).ordered_by_name, label_method: :full_name, include_blank: false
     = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_badges(_1) }, as: :check_boxes
 
     hr

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -27,7 +27,7 @@
             .col-md-12
               - if @rdv.public_office?
                 = f.association :lieu, \
-                  collection: policy_scope(Lieu), \
+                  collection: policy_scope(Lieu).ordered_by_name, \
                   label_method: :full_name, \
                   include_blank: true,
                   required: true,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,37 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
+      "fingerprint": "29e444edecbb24dca14f234041519278e4d627e960dc2df4de112e59ce0098e9",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/admin/lieux/index.html.slim",
+      "line": 18,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => policy_scope(Lieu).includes(:organisation).ordered_by_name.page(params[:page]), {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::LieuxController",
+          "method": "index",
+          "line": 6,
+          "file": "app/controllers/admin/lieux_controller.rb",
+          "rendered": {
+            "name": "admin/lieux/index",
+            "file": "app/views/admin/lieux/index.html.slim"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/lieux/index"
+      },
+      "user_input": "params[:page]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
       "fingerprint": "5dac0e77a1407c8fe48311e85004875de6856a785512abf2ef6e27ebc3f4a376",
       "check_name": "Render",
       "message": "Render path contains parameter value",
@@ -81,8 +112,39 @@
       "user_input": ":role",
       "confidence": "Medium",
       "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "d73171480d9871ed50cc113b6a9bfc457a0c694d2f085d7537447509b41509e0",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/admin/motifs/index.html.slim",
+      "line": 24,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page]), {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Admin::MotifsController",
+          "method": "index",
+          "line": 9,
+          "file": "app/controllers/admin/motifs_controller.rb",
+          "rendered": {
+            "name": "admin/motifs/index",
+            "file": "app/views/admin/motifs/index.html.slim"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "admin/motifs/index"
+      },
+      "user_input": "params[:page]",
+      "confidence": "Weak",
+      "note": ""
     }
   ],
-  "updated": "2020-09-01 11:44:39 +0200",
+  "updated": "2020-09-09 10:21:07 +0200",
   "brakeman_version": "4.7.2"
 }


### PR DESCRIPTION
https://trello.com/c/qYU7hDhW/516-agents-lieux-et-motifs-trop-longue-dans-les-listes-de-recherche-de-cr%C3%A9neaux

# Notes
- j'en ai profité pour corriger un bug de permissions : on ne filtrait pas du tout les agents ni les motifs proposés dans l'interface trouver un créneau. Un agent non admin et non secretaire ne devrait voir que les agents de son propre service. ce n'était pas le cas avant.
- j'ai essayé d'harmoniser les tris de ces trois ressources Agent Lieux et Motifs sur l'ensembe de l'admin
- j'ai utilisé la fonction pg `unaccent` qui permet de faire des comparaisons en ignorant les accents. utile pour le motif 'Être rappelé par la PMI'
- je n'ai rien fait pour aider à la découverte de l'autocomplete dans les champs sur la vue trouver un créneau car je n'ai pas trop d'idée 
- j'ai tenté d'utiliser des default_scope pour que ce soit toujours trié mais malheureusement ca rentre en conflit avec d'autres clauses comme include? et distinct cf https://piechowski.io/post/why-is-default-scope-bad-rails/