### PR TITLE
new chart for rdvs by statuses on public stats pages

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -13,6 +13,8 @@ class StatsController < ApplicationController
               stats.rdvs_group_by_service
             elsif params[:by_location_type].present?
               stats.rdvs_group_by_type
+            elsif params[:by_status].present?
+              stats.rdvs_group_by_status
             else
               stats.rdvs_group_by_week_fr
             end

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -48,6 +48,11 @@
 
       .card.mb-5
         .card-body
+          h4.card-title.mb-3 RDV par statut (#{@stats.rdvs_for_default_range.count})
+          = column_chart add_query_string_params_to_url(rdvs_stats_path, by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%"
+
+      .card.mb-5
+        .card-body
           h4.card-title.mb-3 Usagers créés (#{@stats.users_for_default_range.count})
           = column_chart add_query_string_params_to_url(users_stats_path, departement: @departement)
 

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -48,7 +48,7 @@
 
       .card.mb-5
         .card-body
-          h4.card-title.mb-3 RDV par statut (#{@stats.rdvs_for_default_range.count})
+          h4.card-title.mb-3 RDV par statut
           = column_chart add_query_string_params_to_url(rdvs_stats_path, by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%"
 
       .card.mb-5


### PR DESCRIPTION
https://trello.com/c/EXxWdesz/1052-ajouter-un-graphique-sur-la-page-stats-avec-les-statuts-des-rdvs

# Screenshot (with prod dump)

<img width="600" alt="Screenshot_2020-09-09_at_18 18 34" src="https://user-images.githubusercontent.com/883348/92625444-ee15ab80-f2c8-11ea-80e7-4aed0b252930.png">


slightly tricky because we're using chartkick + chart.js which doesn't let us use `stacked: :relative` option [cf doc](https://github.com/ankane/chartkick.js?files=1#options), so I used some ruby ninja-fu but it's not incredibly readable 🤷 

thanks for the very precise specs @guillett  👍 I decided to filter out `waiting` rdvs because I think it only makes it harder to read without giving any additional infos as it's a very transient state so they'll ever be a maximum of a few rdvs in that state at a time