### PR TITLE
display user relative tag in rdvs#show and rdvs lists

### DIFF
--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -14,7 +14,7 @@
         li.list-group-item
           i.fa.fa-check.fa-fw.mr-1.text-success
           | Usager(s) :&nbsp;
-          = users_to_sentence(@rdv.users)
+          = users_inline_list_for_agents(@rdv.users)
 
       .card-body
         = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -33,7 +33,4 @@ p.card-text
 - if local_assigns.fetch(:show_users, true)
   p.card-text
     strong> Usager(s) :
-    - if local_assigns.fetch(:display_links_to_users, true)
-      = users_to_links(rdv.users)
-    - else
-      = users_to_sentence(rdv.users)
+    = users_inline_list_for_agents(rdv.users, display_links_to_users: local_assigns.fetch(:display_links_to_users, true))

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -48,7 +48,9 @@
       .card
         .card-header
           .d-flex.justify-content-between
-            .mt-1 = user.full_name
+            .mt-1
+              = user.full_name
+              = relative_tag(user)
             = link_to "Voir la fiche usager", admin_organisation_user_path(current_organisation, user), class: "btn btn-outline-primary small"
 
         .card-body

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -213,6 +213,15 @@ user_org_paris_nord_patricia.skip_confirmation!
 user_org_paris_nord_patricia.save!
 user_org_paris_nord_patricia.profile_for(org_paris_nord).update!(logement: 2)
 
+user_org_paris_nord_josephine = User.new(
+  first_name: "Joséphine",
+  last_name: "Duroy",
+  birth_date: Date.parse("01/03/2018"),
+  responsible: user_org_paris_nord_patricia,
+  organisation_ids: [org_paris_nord.id]
+)
+user_org_paris_nord_josephine.save!
+
 user_org_paris_nord_lea = User.new(
   first_name: "Léa",
   last_name: "Dupont",
@@ -392,6 +401,17 @@ rdv1 = Rdv.new(
   context: "Visite de courtoisie"
 )
 rdv1.save!
+rdv2 = Rdv.new(
+  duration_in_min: 30,
+  starts_at: Date.today + 4.days + 15.hours,
+  motif_id: motif_org_paris_nord_pmi_suivi.id,
+  lieu: lieu_org_paris_nord_nord,
+  organisation_id: org_paris_nord.id,
+  agent_ids: [agent_org_paris_nord_pmi_martine.id],
+  user_ids: [user_org_paris_nord_josephine.id],
+  context: "Suivi vaccins"
+)
+rdv2.save!
 Rdv.set_callback(:create, :after, :notify_rdv_created)
 
 # User Notes


### PR DESCRIPTION
https://trello.com/c/oz2KGEWU/1065-afficher-linfo-du-responsable-proche-sur-la-fiche-rdv

- en passant j'ai corrigé le tri pour qu'il soit sur le nom de famille et pas le prenom
- dans le code j'ai découpé en deux helpers, un utilisé coté admin et un utilisé coté users. jusqu'ici il y avait un seul helper qui testait la présence de `current_agent` pour distinguer

<img width="1000" alt="stitched_2020_09_10-16_39_30" src="https://user-images.githubusercontent.com/883348/92747373-6b522680-f384-11ea-86c2-4fbc30c4aeee.png">

<img width="1000" alt="stitched_2020_09_10-16_41_52" src="https://user-images.githubusercontent.com/883348/92747621-ab190e00-f384-11ea-93e6-d77f4ac99577.png">

cf https://demo-rdv-solidarites-pr873.osc-fr1.scalingo.io/admin/organisations/1/rdvs/2
