### PR TITLE
reposition email confirmation pending message in admin/users#show

### DIFF
--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -1,10 +1,12 @@
 ul.list-unstyled.mb-5
-  - [:first_name, :last_name, :birth_name, :birth_date, :phone_number, :address, :email, :notes].each do |attr_name|
+  - [:first_name, :last_name, :birth_name, :birth_date, :phone_number, :address, :email].each do |attr_name|
     li.mb-2= render "common/user_attribute", user: user, attribute_name: attr_name
 
   - if user.pending_reconfirmation?
     .text-muted.mb-2
       | En attente de confirmation pour #{user.unconfirmed_email}
+
+  li.mb-2= render "common/user_attribute", user: user, attribute_name: :notes
 
 h4.card-title.mb-3 Informations sociales
 ul.list-unstyled.mb-5


### PR DESCRIPTION
https://trello.com/c/DsiOqZ2d/1069-repositionner-message-dattente-confirmation-mail

<img width="1000" alt="stitched_2020_09_10-17_22_42" src="https://user-images.githubusercontent.com/883348/92753613-56789180-f38a-11ea-82ff-1aa59fb94a6f.png">

cf https://demo-rdv-solidarites-pr874.osc-fr1.scalingo.io/admin/organisations/1/users/1