### PR TITLE
better agent context visibility in admin/absences and admin/plage_ouvertures + remove right bar from absences

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -16,32 +16,42 @@ class Admin::AbsencesController < AgentAuthController
     @agent = policy_scope(Agent).find(params[:agent_id])
     @absence = Absence.new(organisation: current_organisation, agent: @agent)
     authorize(@absence)
-    respond_right_bar_with @absence
   end
 
   def edit
     authorize(@absence)
-    respond_right_bar_with @absence
   end
 
   def create
     @absence = Absence.new(absence_params)
     @absence.organisation = current_organisation
     authorize(@absence)
-    flash[:notice] = "L'absence a été créée." if @absence.save
-    respond_right_bar_with @absence, location: admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
+    if @absence.save
+      flash[:notice] = "L'absence a été créée."
+      redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
+    else
+      render :edit
+    end
   end
 
   def update
     authorize(@absence)
-    flash[:notice] = "L'absence a été modifiée." if @absence.update(absence_params)
-    respond_right_bar_with @absence, location: admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
+    if @absence.update(absence_params)
+      flash[:notice] = "L'absence a été modifiée."
+      redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
+    else
+      render :edit
+    end
   end
 
   def destroy
     authorize(@absence)
-    flash[:notice] = "L'absence a été supprimée." if @absence.destroy
-    redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
+    if @absence.destroy
+      flash[:notice] = "L'absence a été supprimée."
+      redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -1,6 +1,6 @@
 tr
   td
-    = link_to absence.title_or_default, edit_admin_organisation_absence_path(absence.organisation, absence), data: { rightbar: true }
+    = link_to absence.title_or_default, edit_admin_organisation_absence_path(absence.organisation, absence)
     = absence_tag(absence)
   td
     | Du #{l(absence.starts_at, format: :human)} au #{l(absence.ends_at, format: :human)}

--- a/app/views/admin/absences/_form.html.slim
+++ b/app/views/admin/absences/_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for [:admin, absence.organisation, absence], remote: request.xhr?, data: { rightbar: true } do |f|
+= simple_form_for [:admin, absence.organisation, absence] do |f|
   = render partial: 'layouts/model_errors', locals: { model: absence }
   = f.hidden_field :agent_id
   = f.input :title, hint:'Uniquement visible en interne', placeholder: 'Ex: Absence pour formation premiers secours'

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -1,6 +1,24 @@
 - content_for(:menu_item) { 'menu-absences' }
 
 - content_for :title do
-  | Modifier l'absence
+  - if @absence.agent == current_agent
+    | Modifier votre absence
+  - else
+    | Modifier l'absence de #{@agent.full_name}
 
-= render 'form', absence: @absence, agent: @agent
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to admin_organisation_agent_absences_path(@absence.organisation, @absence.agent) do
+        - if @absence.agent == current_agent
+          | Vos Absences
+        - else
+          | Absences de #{@absence.agent.full_name}
+    li.breadcrumb-item.active
+      = truncate(@absence.title, length: 20)
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = render 'form', absence: @absence, agent: @agent

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -4,7 +4,7 @@
   - if @absence.agent == current_agent
     | Modifier votre absence
   - else
-    | Modifier l'absence de #{@agent.full_name}
+    | Modifier l'absence de #{@absence.agent.full_name}
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -11,31 +11,34 @@
     .d-inline-block.mr-2
       = select_tag :id, options_for_select(policy_scope(Agent).complete.active.order_by_last_name.map { |agent| [agent.full_name, agent.id, { 'data-url': admin_organisation_agent_absences_path(current_organisation, agent.id)}]}, selected: @agent.id), class: "select2-input", onchange: "window.location.href = $('.select2-input option:selected').attr('data-url')"
 
-  = link_to 'Créer une absence', new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-outline-white align-bottom", data: { rightbar: true }
-.card
-  .card-body
-    - if @absences.any?
-      table.table
-        thead
-          tr
-            th Description
-            th
-        tbody
-          = render @absences
-      .d-flex.justify-content-center
-        = paginate @absences, theme: 'twitter-bootstrap-4'
+  = link_to 'Créer une absence', new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-outline-white align-bottom"
+.card.pb-3
+  - if @absences.any?
+    table.table
+      thead
+        tr
+          th Description
+          th Dates
+      tbody
+        = render @absences
+    .d-flex.justify-content-center
+      = paginate @absences, theme: 'twitter-bootstrap-4'
 
-    - else
-      .row.justify-content-md-center
-        .col-md-6.text-center.my-5
-          p.mb-2.lead
-            - if current_agent == @agent
-              | Vous n'avez pas encore créé d'absence.
-            - else
-              | #{@agent.full_name} n'a pas encore créé d'absence.
-          p Les absences sont des exceptions aux Plages d'Ouvertures. Vous pouvez les utiliser pour les congés ou les fermetures. Les Absences peuvent être récurrentes (par exemple pour les temps partiels).
-          span.fa-stack.fa-4x
-            i.fa.fa-circle.fa-stack-2x.text-primary
-            i.far.fa-calendar.fa-stack-1x.text-white
-    .text-center
-      = add_button 'Créer une absence', new_admin_organisation_agent_absence_path(current_organisation, @agent.id)
+  - else
+    .row.justify-content-md-center.p-2.mt-3
+      .col-md-6.text-center.mb-2
+        p.mb-2.lead
+          - if current_agent == @agent
+            | Vous n'avez pas encore créé d'absence.
+          - else
+            | #{@agent.full_name} n'a pas encore créé d'absence.
+        p Les absences sont des exceptions aux Plages d'Ouvertures. Vous pouvez les utiliser pour les congés ou les fermetures. Les Absences peuvent être récurrentes (par exemple pour les temps partiels).
+        span.fa-stack.fa-4x
+          i.fa.fa-circle.fa-stack-2x.text-primary
+          i.far.fa-calendar.fa-stack-1x.text-white
+  .text-center.py-2
+    = link_to new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: 'btn btn-primary' do
+      - if @agent == current_agent
+        | Créer une absence
+      - else
+        | Créer une absence pour #{@agent.full_name}

--- a/app/views/admin/absences/new.html.slim
+++ b/app/views/admin/absences/new.html.slim
@@ -1,6 +1,24 @@
 - content_for(:menu_item) { 'menu-absences' }
 
 - content_for :title do
-  | Nouvelle absence
+  - if @absence.agent == current_agent
+    | Nouvelle absence
+  - else
+    | Nouvelle absence pour #{@agent.full_name}
 
-= render 'form', absence: @absence, agent: @agent
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to admin_organisation_agent_absences_path(@absence.organisation, @absence.agent) do
+        - if @absence.agent == current_agent
+          | Vos Absences
+        - else
+          | Absences de #{@absence.agent.full_name}
+    li.breadcrumb-item.active
+      | Nouvelle absence
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = render 'form', absence: @absence, agent: @agent

--- a/app/views/admin/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/plage_ouvertures/edit.html.slim
@@ -1,12 +1,19 @@
 - content_for(:menu_item) { 'menu-plages-ouvertures' }
 
 - content_for :title do
-  | Modifier la plage d'ouverture
+  - if @plage_ouverture.agent == current_agent
+    | Modifier votre plage d'ouverture
+  - else
+    | Modifier la plage d'ouverture de #{@plage_ouverture.agent.full_name}
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
-      = link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)
+      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
+        - if @plage_ouverture.agent == current_agent
+          | Vos plages d'ouverture
+        - else
+          | Plages d'ouverture de #{@plage_ouverture.agent.full_name}
     li.breadcrumb-item.active
       = truncate(@plage_ouverture.title, length: 20)
 

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -13,7 +13,7 @@
 
   = link_to 'Créer une plage d\'ouverture', new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-outline-white align-bottom"
 
-.card
+.card.pb-3
   - if @display_tabs
     ul.nav.nav-tabs.px-2.mt-2
       li.nav-item
@@ -35,19 +35,21 @@
     .d-flex.justify-content-center
       = paginate @plage_ouvertures, theme: 'twitter-bootstrap-4'
   - else
-    .card-body
-      .row.justify-content-md-center
-        .col-md-6.text-center.my-5
-          p.mb-2.lead
-            - if current_agent == @agent
-              | Vous n'avez pas encore créé de plage d'ouverture.
-            - else
-              | #{@agent.full_name} n'a pas encore créé de plage d'ouverture.
-          p Les plages d'ouvertures affichent votre disponibilité à la prise de RDV, qu'elle soit faite par l'usager lui même (en ligne) ou par un autre agent de votre organisation. Chaque agent a ses propres plages d'ouvertures et peut y associer des motifs et un lieu. Les plages peuvent être récurrentes.
-          span.fa-stack.fa-4x
-            i.fa.fa-circle.fa-stack-2x.text-primary
-            i.far.fa-calendar.fa-stack-1x.text-white
+    .row.justify-content-md-center.p-2.mt-3
+      .col-md-6.text-center.mb-2
+        p.mb-2.lead
+          - if current_agent == @agent
+            | Vous n'avez pas encore créé de plage d'ouverture.
+          - else
+            | #{@agent.full_name} n'a pas encore créé de plage d'ouverture.
+        p Les plages d'ouvertures affichent votre disponibilité à la prise de RDV, qu'elle soit faite par l'usager lui même (en ligne) ou par un autre agent de votre organisation. Chaque agent a ses propres plages d'ouvertures et peut y associer des motifs et un lieu. Les plages peuvent être récurrentes.
+        span.fa-stack.fa-4x
+          i.fa.fa-circle.fa-stack-2x.text-primary
+          i.far.fa-calendar.fa-stack-1x.text-white
 
-  .card-body
-    .text-center
-      = link_to 'Créer une plage d\'ouverture', new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-primary"
+  .text-center.py-2
+    = link_to new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-primary" do
+      - if current_agent == @agent
+        | Créer une plage d'ouverture
+      - else
+        | Créer une plage d'ouverture pour #{@agent.full_name}

--- a/app/views/admin/plage_ouvertures/new.html.slim
+++ b/app/views/admin/plage_ouvertures/new.html.slim
@@ -1,12 +1,19 @@
 - content_for(:menu_item) { 'menu-plages-ouvertures' }
 
 - content_for :title do
-  | Nouvelle plage d'ouverture
+  - if @plage_ouverture.agent == current_agent
+    | Nouvelle plage d'ouverture
+  - else
+    | Nouvelle plage d'ouverture pour #{@plage_ouverture.agent.full_name}
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
-      = link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)
+      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
+      - if @plage_ouverture.agent == current_agent
+        | Vos plages d'ouverture
+      - else
+        | Plages d'ouverture de #{@plage_ouverture.agent.full_name}
     li.breadcrumb-item.active
       | Nouvelle plage
 

--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Admin::AbsencesController, type: :controller do
 
     describe "GET #edit" do
       it "returns a success response" do
-        get :edit, params: { organisation_id: organisation.id, id: absence.to_param }
+        get :edit, params: { organisation_id: organisation.id, agent_id: agent.id, id: absence.to_param }
         expect(response).to be_successful
       end
     end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -1,7 +1,6 @@
 describe "Agent can CRUD absences" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, :admin, organisations: [organisation]) }
-  let!(:other_agent) { create(:agent, organisations: [organisation]) }
   let!(:absence) { create(:absence, agent: agent, organisation: organisation) }
   let!(:new_absence) { build(:absence, agent: agent, organisation: organisation) }
 
@@ -13,47 +12,64 @@ describe "Agent can CRUD absences" do
 
   context "for an agent" do
     scenario "default" do
-      crud_absence(agent, agent)
+      expect_page_title("Vos absences")
+      click_link absence.title
+
+      expect_page_title("Modifier votre absence")
+      fill_in "Description", with: "La belle absence"
+      click_button("Modifier")
+
+      expect_page_title("Vos absences")
+      click_link "La belle absence"
+
+      click_link("Supprimer")
+      expect_page_title("Vos absences")
+      expect(page).to have_content("Vous n'avez pas encore créé d'absence")
+
+      click_link "Créer une absence", match: :first
+
+      expect_page_title("Nouvelle absence")
+      fill_in "Description", with: new_absence.title
+      fill_in "absence[first_day]", with: new_absence.first_day
+      fill_in "absence[end_day]", with: new_absence.first_day + 1.day
+      click_button "Créer"
+
+      expect_page_title("Vos absences")
+      click_link new_absence.title
     end
   end
 
   context "for an other agent calendar" do
+    let!(:service) { create(:service, name: "PMI") }
+    let!(:other_agent) { create(:agent, first_name: "Jane", last_name: "FAROU", service: service, organisations: [organisation]) }
     let!(:absence) { create(:absence, agent: other_agent, organisation: organisation) }
 
     scenario "can crud a absence" do
-      # select(other_agent.full_name, from: :id)
       visit admin_organisation_agent_absences_path(organisation, other_agent.id)
-      crud_absence(agent, other_agent)
+      expect_page_title("Absences de Jane FAROU (PMI)")
+      click_link absence.title
+
+      expect_page_title("Modifier l'absence de Jane FAROU")
+      fill_in "Description", with: "La belle absence"
+      click_button("Modifier")
+
+      expect_page_title("Absences de Jane FAROU (PMI)")
+      click_link "La belle absence"
+
+      click_link("Supprimer")
+      expect_page_title("Absences de Jane FAROU (PMI)")
+      expect(page).to have_content("Jane FAROU n'a pas encore créé d'absence")
+
+      click_link "Créer une absence", match: :first
+
+      expect_page_title("Nouvelle absence")
+      fill_in "Description", with: new_absence.title
+      fill_in "absence[first_day]", with: new_absence.first_day
+      fill_in "absence[end_day]", with: new_absence.first_day + 1.day
+      click_button "Créer"
+
+      expect_page_title("Absences de Jane FAROU (PMI)")
+      click_link new_absence.title
     end
-  end
-
-  def crud_absence(current_agent, agent_crud)
-    title = agent_crud == current_agent ? "Vos absences" : "Absences de #{agent_crud.full_name_and_service}"
-
-    expect_page_title(title)
-    click_link absence.title
-
-    expect_page_title("Modifier l'absence")
-    fill_in "Description", with: "La belle absence"
-    click_button("Modifier")
-
-    expect_page_title(title)
-    click_link "La belle absence"
-
-    click_link("Supprimer")
-    expect_page_title(title)
-    empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé d'absence" : "#{agent_crud.full_name} n'a pas encore créé d'absence"
-    expect_page_with_no_record_text(empty_text)
-
-    click_link "Créer une absence", match: :first
-
-    expect_page_title("Nouvelle absence")
-    fill_in "Description", with: new_absence.title
-    fill_in "absence[first_day]", with: new_absence.first_day
-    fill_in "absence[end_day]", with: new_absence.first_day + 1.day
-    click_button "Créer"
-
-    expect_page_title(title)
-    click_link new_absence.title
   end
 end

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -1,9 +1,8 @@
 describe "Agent can CRUD plage d'ouverture" do
   let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
+  let!(:service) { create(:service, name: "PMI") }
   let!(:motif) { create(:motif, name: "Suivi bonjour", service: service, organisation: organisation) }
   let!(:agent) { create(:agent, :admin, service: service, organisations: [organisation]) }
-  let!(:other_agent) { create(:agent, service: service, organisations: [organisation]) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, agent: agent, organisation: organisation) }
   let(:new_plage_ouverture) { build(:plage_ouverture, lieu: lieu, agent: agent, organisation: organisation) }
@@ -14,10 +13,36 @@ describe "Agent can CRUD plage d'ouverture" do
     click_link "Plages d'ouverture"
   end
 
-  context "for an agent" do
-    scenario "default" do
-      crud_plage_ouverture(agent, agent)
+  shared_examples "can crud own plage ouvertures" do
+    it "works" do
+      expect_page_title("Vos plages d'ouverture")
+      click_link plage_ouverture.title
+
+      expect_page_title("Modifier votre plage d'ouverture")
+      fill_in "Description", with: "La belle plage"
+      click_button("Modifier")
+
+      expect_page_title("Modifier votre plage d'ouverture")
+      expect(page).to have_content("La belle plage")
+
+      click_link("Supprimer")
+      expect_page_title("Vos plages d'ouverture")
+      expect(page).to have_content("Vous n'avez pas encore créé de plage d'ouverture")
+
+      click_link "Créer une plage d'ouverture", match: :first
+
+      expect_page_title("Nouvelle plage d'ouverture")
+      fill_in "Description", with: new_plage_ouverture.title
+      check "Suivi bonjour"
+      click_button "Créer"
+
+      expect_page_title("Vos plages d'ouverture")
+      click_link new_plage_ouverture.title
     end
+  end
+
+  context "for an agent" do
+    it_behaves_like "can crud own plage ouvertures"
   end
 
   context "for a secretaire" do
@@ -32,49 +57,40 @@ describe "Agent can CRUD plage d'ouverture" do
     context "with motif for_secretariat" do
       let!(:motif) { create(:motif, :for_secretariat, name: "Suivi bonjour", service: service, organisation: organisation) }
       let(:plage_ouverture) { create(:plage_ouverture, lieu: lieu, agent: agent, motifs: [motif], organisation: organisation) }
-
-      scenario "can crud a plage_ouverture" do
-        crud_plage_ouverture(agent, agent)
-      end
+      it_behaves_like "can crud own plage ouvertures"
     end
   end
 
   context "for an other agent calendar" do
+    let!(:other_agent) { create(:agent, first_name: "Jane", last_name: "FAROU", service: service, organisations: [organisation]) }
     let!(:plage_ouverture) { create(:plage_ouverture, lieu: lieu, agent: other_agent, organisation: organisation) }
 
     scenario "can crud a plage_ouverture" do
-      # select(other_agent.full_name, from: :id)
       visit admin_organisation_agent_plage_ouvertures_path(organisation, other_agent.id)
-      crud_plage_ouverture(agent, other_agent)
+
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      click_link plage_ouverture.title
+
+      expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
+      fill_in "Description", with: "La belle plage"
+      click_button("Modifier")
+
+      expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
+      expect(page).to have_content("La belle plage")
+
+      click_link("Supprimer")
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
+
+      click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
+
+      expect_page_title("Nouvelle plage d'ouverture")
+      fill_in "Description", with: new_plage_ouverture.title
+      check "Suivi bonjour"
+      click_button "Créer"
+
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      click_link new_plage_ouverture.title
     end
-  end
-
-  def crud_plage_ouverture(current_agent, agent_crud)
-    title =  agent_crud == current_agent ? "Vos plages d'ouverture" : "Plages d'ouverture de #{agent_crud.full_name_and_service}"
-
-    expect_page_title(title)
-    click_link plage_ouverture.title
-
-    expect_page_title("Modifier la plage d'ouverture")
-    fill_in "Description", with: "La belle plage"
-    click_button("Modifier")
-
-    expect_page_title("Modifier la plage d'ouverture")
-    expect(page).to have_content("La belle plage")
-
-    click_link("Supprimer")
-    expect_page_title(title)
-    empty_text = agent_crud == current_agent ? "Vous n'avez pas encore créé de plage d'ouverture" : "#{agent_crud.full_name} n'a pas encore créé de plage d'ouverture"
-    expect_page_with_no_record_text(empty_text)
-
-    click_link "Créer une plage d'ouverture", match: :first
-
-    expect_page_title("Nouvelle plage d'ouverture")
-    fill_in "Description", with: new_plage_ouverture.title
-    check "Suivi bonjour"
-    click_button "Créer"
-
-    expect_page_title(title)
-    click_link new_plage_ouverture.title
   end
 end


### PR DESCRIPTION
https://trello.com/c/gCzhgs3J/1070-pr%C3%A9ciser-agent-cible-dans-les-formulaires-de-plage-douverture-et-dabsences

<img width="2776" alt="stitched_2020_09_10-18_08_43" src="https://user-images.githubusercontent.com/883348/92760168-b7a36380-f390-11ea-9c2c-9f4bed52e3db.png">

<img width="1000" alt="stitched_2020_09_10-18_08_00" src="https://user-images.githubusercontent.com/883348/92760189-ba05bd80-f390-11ea-9333-7506cad13e07.png">
