### PR TITLE
ajoute brakemane au make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## Run the tests and rubocop
-	bundle exec rubocop -a && bundle exec rspec --profile 3
+	bundle exec rubocop -a && bundle exec rspec --profile 3 && bundle exec brakeman
 
 install: ## Install or update dependencies
 	bundle install && yarn install && bundle exec rails db:migrate


### PR DESCRIPTION
Pas de carte Trello.

J'ai découvert que nous avons accès à la gem [Brakeman](https://brakemanscanner.org/) un outil de scan de sécurité.

Je ne sais pas encore m'en servir, mais j'aimerais qu'il soit exécuté le plus souvent possible. Je l'ajoute donc dans le make test.