### PR TITLE
handle error when user searches for a lieu that doesn't have associated motifs

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -80,6 +80,7 @@ class LieuxController < ApplicationController
     @zone = Zone.in_address_sector(@city_code)
     @organisations = Organisation.in_zone_or_departement(@zone, @departement)
     searchable_motifs = Motif.searchable(@organisations, service: @service)
+    redirect_to root_path, flash: { error: "Une erreur s'est produite, veuillez recommencer votre recherche" } if searchable_motifs.empty?
     @motif_names = searchable_motifs.pluck(:name).uniq
     @matching_motifs = searchable_motifs.where(name: @motif_name)
     @latitude = search_params[:latitude]


### PR DESCRIPTION
https://trello.com/c/P07xCD4Q/1081-corriger-bug-pendant-recherche-usager-quand-un-motif-a-disparu-pour-le-lieu-courant

https://sentry.io/organizations/rdv-solidarites/issues/1756911462/?environment=production&project=1811205&query=is%3Aunresolved

testable sur la review app via ce lien : 
https://demo-rdv-solidarites-pr878.osc-fr1.scalingo.io/lieux/5?date=2020-09-14+11%3A00%3A00+%2B0200&search%5Bcity_code%5D=75056&search%5Bdepartement%5D=75&search%5Blatitude%5D=48.845&search%5Blongitude%5D=2.3752&search%5Bmotif_name%5D=Consultation+pr%C3%A9natale&search%5Bservice%5D=1&search%5Bwhere%5D=Paris%2C+75001%2C+75%2C+Paris%2C+%C3%8Ele-de-France

(j'ai accédé a cette recherche puis j'ai supprimé toutes les plages d'ouvertures de l'orga)
