### PR TITLE
Autorise tous les motifs pour l'admin

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -22,10 +22,10 @@ class Motif < ApplicationRecord
   scope :for_secretariat, -> { where(for_secretariat: true) }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
-    available_motifs = if agent.service.secretariat?
-                         for_secretariat
-                       elsif agent.admin?
+    available_motifs = if agent.admin?
                          all
+                       elsif agent.service.secretariat?
+                         for_secretariat
                        else
                          where(service: agent.service)
                        end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -22,7 +22,13 @@ class Motif < ApplicationRecord
   scope :for_secretariat, -> { where(for_secretariat: true) }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
-    available_motifs = agent.service.secretariat? ? for_secretariat : where(service: agent.service)
+    available_motifs = if agent.service.secretariat?
+                         for_secretariat
+                       elsif agent.admin?
+                         all
+                       else
+                         where(service: agent.service)
+                       end
     available_motifs.where(organisation_id: organisation.id).active.ordered_by_name
   }
 

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -51,6 +51,11 @@ describe Rdv, type: :model do
       let(:agent) { create(:agent, :admin, organisations: [organisation]) }
       it { is_expected.to contain_exactly(motif, motif2, motif3, motif5) }
     end
+
+    describe "for secretary admin" do
+      let(:agent) { create(:agent, :secretaire, :admin, organisations: [organisation]) }
+      it { is_expected.to contain_exactly(motif, motif2, motif3, motif5) }
+    end
   end
 
   describe "#authorized_agents" do

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -31,6 +31,7 @@ describe Rdv, type: :model do
     let!(:motif2) { create(:motif, service: service, organisation: organisation) }
     let!(:motif3) { create(:motif, :for_secretariat, service: service, organisation: organisation) }
     let!(:motif4) { create(:motif, service: service, organisation: create(:organisation)) }
+    let!(:motif5) { create(:motif, service: create(:service), organisation: organisation) }
     let(:plage_ouverture) { build(:plage_ouverture, agent: agent, organisation: organisation) }
 
     subject { Motif.available_motifs_for_organisation_and_agent(motif.organisation, agent) }
@@ -45,6 +46,11 @@ describe Rdv, type: :model do
 
       it { is_expected.to contain_exactly(motif, motif2, motif3) }
     end
+
+    describe "for admin" do
+      let(:agent) { create(:agent, :admin, organisations: [organisation]) }
+      it { is_expected.to contain_exactly(motif, motif2, motif3, motif5) }
+    end
   end
 
   describe "#authorized_agents" do
@@ -55,6 +61,7 @@ describe Rdv, type: :model do
     let!(:agent_pmi2) { create(:agent, organisations: [org1], service: service_pmi) }
     let!(:agent_secretariat1) { create(:agent, organisations: [org1], service: service_secretariat) }
     let!(:motif) { create(:motif, service: service_pmi, organisation: org1) }
+
     subject { motif.authorized_agents.to_a }
 
     it { should match_array([agent_pmi1, agent_pmi2]) }


### PR DESCRIPTION
https://trello.com/c/rMGykJTv/1071-tous-les-motifs-de-lorganisation-pour-un-admin

Élargir la liste des motifs quand on est sur la prise d'un rendez-vous par une personne ayant les droit administrateur (et donc une visibilité sur tout les motifs).