### PR TITLE
improve forgotten password visibility for users signin

### DIFF
--- a/app/views/common/_session_form.html.slim
+++ b/app/views/common/_session_form.html.slim
@@ -4,11 +4,11 @@
     = f.label :email
     = f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'nom.prenom@email.com'
   .form-group
-    = link_to new_password_path(resource_name), class: 'text-muted float-right' do
-      small Mot de passe oublié ?
     = f.label :password
     = f.password_field :password, autocomplete: "off", required: true, class: 'form-control ', placeholder: 'Votre mot de passe', id: "password"
     span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
+
+    .mt-1.mb-3= link_to "Mot de passe oublié ?", new_password_path(resource_name)
 
   .form-group.mb-3
     .custom-control.custom-checkbox


### PR DESCRIPTION
https://trello.com/c/wgO4USIk/1078-rendre-mot-de-passe-oubli%C3%A9-plus-visible

<img width="600" alt="stitched_2020_09_14-17_50_43" src="https://user-images.githubusercontent.com/883348/93108374-01eb5400-f6b3-11ea-82d5-78209137c8e0.png">

aussi visible sur le formulaire agents

qu'en penses-tu @yaf ?

cf https://demo-rdv-solidarites-pr885.osc-fr1.scalingo.io/users/sign_in