### PR TITLE
fix pundit authentication in departement level controllers

### DIFF
--- a/app/controllers/agent_departement_auth_controller.rb
+++ b/app/controllers/agent_departement_auth_controller.rb
@@ -7,6 +7,11 @@ class AgentDepartementAuthController < AgentAuthController
   end
   helper_method :current_departement
 
+  def current_organisation
+    # TODO: remove and fix pundit policies for departement-level routes
+    current_agent.organisations.where(departement: current_departement.to_s).first
+  end
+
   private
 
   def set_departement


### PR DESCRIPTION
https://trello.com/c/4pdDmnK7/1083-r%C3%A9parer-authentification-partie-sectorisation

broken in https://github.com/betagouv/rdv-solidarites.fr/commit/d087e7a1e73c01a53e4c3857b8ac145ce7196522

it's surprising no tests failed but that part is under-tested. it may be acceptable because sectorisation is almost unused