### PR TITLE
Affiche les changements récent dans l'application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,481 @@
+## Jeudi 17 septembre 2020
+
+- [Ajout de la notion "sur place" sur les motifs](https://trello.com/c/aSs1am9j/917-ajout-de-la-notion-sur-place-sur-les-motifs)
+- [amélioration du tunnel d'inscription : décaler la définition du mot de passe après la confirmation + fusionner mot de passe oublié et renvoyer mail de confirmation](https://trello.com/c/hbPQO0e2/1079-am%C3%A9lioration-du-tunnel-dinscription-d%C3%A9caler-la-d%C3%A9finition-du-mot-de-passe-apr%C3%A8s-la-confirmation-fusionner-mot-de-passe-oubli%C3%A9-et)
+
+
+
+## Mercredi 16 septembre 2020
+
+- [correction bug : usager proche apparait après suppression](https://trello.com/c/rxp0FbGL)
+- [réparer authentification partie sectorisation](https://trello.com/c/4pdDmnK7)
+- [Créer des motifs avec le même libellé dans des services différents](https://trello.com/c/3ZJT9exS)
+- [corriger bug vue RDV avec usager supprimé](https://trello.com/c/7C2lbUU5)
+- [[agent] Afficher les 5 derniers rdvs dans les vues RDV et usager](https://trello.com/c/9z5bv0jw)
+
+## Mardi 15 septembre 2020
+
+- [Rendre "mot de passe oublié" plus visible](https://trello.com/c/wgO4USIk/1078-rendre-mot-de-passe-oubli%C3%A9-plus-visible)
+- [Afficher tous les motifs de l'organisation pour les admin dans le tunnel de prise de RDV](https://trello.com/c/rMGykJTv/1071-afficher-tous-les-motifs-de-lorganisation-pour-les-admin-dans-le-tunnel-de-prise-de-rdv)
+- [Simplifier la sélection d'agent dans le tunnel de prise de rdv](https://trello.com/c/rsX31ZB5/1075-simplifier-la-s%C3%A9lection-dagent)
+
+## Lundi 14 septembre 2020
+
+- [préciser agent cible dans les formulaires de plage d'ouverture et d'absences](https://trello.com/c/gCzhgs3J/1070-pr%C3%A9ciser-agent-cible-dans-les-formulaires-de-plage-douverture-et-dabsences)
+- [Correction d'un bug sur la recherche usager quand un motif a disparu pour le lieu courant](https://trello.com/c/P07xCD4Q/1081-corriger-bug-pendant-recherche-usager-quand-un-motif-a-disparu-pour-le-lieu-courant)
+
+## Vendredi 11 septembre 2020
+
+- [Améliorer l'UI du menu latéral](https://trello.com/c/oRwiQaLW/1062-am%C3%A9liorer-lui-du-menu-lat%C3%A9ral)
+- [Afficher l'info du responsable / proche sur la fiche rdv](https://trello.com/c/oz2KGEWU/1065-afficher-linfo-du-responsable-proche-sur-la-fiche-rdv)
+- [repositionner message d'attente confirmation mail](https://trello.com/c/DsiOqZ2d/1069-repositionner-message-dattente-confirmation-mail)
+
+## Jeudi 10 septembre 2020
+
+- [Ajouter un graphique sur la page stats avec les statuts des RDVs](https://trello.com/c/EXxWdesz)
+- [trier les listes de motifs, lieux et d'agents dans 'trouver un créneau' + corriger les filtres appliqués selon le rôle de l'agent](https://trello.com/c/qYU7hDhW)
+- [Avertir de l'impossibilité de suppression d'un lieu qui a des RDVs attachés](https://trello.com/c/PwQGYNum)
+- [[Agent] Pouvoir chercher un agent dans la liste "vos agents"](https://trello.com/c/hoyaICEM)
+
+## Mercredi 9 septembre 2020
+
+- [bug redirection agenda quand creation de rdv pour un autre agent](https://trello.com/c/P3GFQqz2)
+
+## Mardi 8 septembre 2020
+
+- [transformer le journal de notes des usagers en un seul champ de notes](https://trello.com/c/kna783GZ)
+- [Supprimer les anciennes notes](https://trello.com/c/Z0vnbwks/1027-supprimer-les-anciennes-notes)
+- [Masquer les plages d'ouvertures passées](https://trello.com/c/P8Hmx11j/1066-bug-r%C3%A9partition-plages-douvertures-actuelles-et-pass%C3%A9es)
+- [Changer le statut d'un rdv](https://trello.com/c/QMqq2ljQ/1001-changer-le-statut-dun-rdv)
+
+## Lundi 7 septembre 2020
+
+- [Liste des RDV de la journée triés par ordre chronologique](https://trello.com/c/PMmIQ65G/1050-liste-des-rdv-de-la-journ%C3%A9e-tri%C3%A9s-par-ordre-chronologique)
+- [correction d'un bug sur le calcul de créneaux nocturnes à cause d'une absence finissant tard](https://trello.com/c/RRAODoeY/1063-corriger-bug-cr%C3%A9neaux-nocturnes-%C3%A0-cause-dune-absence-finissant-tard)
+- [S'assurer que le rendez-vous est bien enregistré dans l'agenda](https://trello.com/c/lOBN6DfA/1047-sassurer-que-le-rendez-vous-est-bien-enregistr%C3%A9-dans-lagenda)
+
+## Jeudi 3 septembre 2020
+
+- [[agents] Savoir dans quelle organisation je suis](https://trello.com/c/xqzrST3B/1039-agents-savoir-dans-quelle-organisation-je-suis)
+- [[agent] améliorer le message affiché sur la gauche des pages "listes des organisations" et "editer mon compte"](https://trello.com/c/KXykCVie/1059-agent-am%C3%A9liorer-le-message-affich%C3%A9-sur-la-gauche-des-pages-listes-des-organisations-et-editer-mon-compte)
+- [réparer bug changement d'orga involontaire](https://trello.com/c/7Tf15YXi/1061-r%C3%A9parer-bug-changement-dorga-involontaire)
+- [bannière pour service dégradé](https://trello.com/c/s77YlZQG/1060-banni%C3%A8re-pour-service-d%C3%A9grad%C3%A9)
+- [Contexte du rendez-vous](https://trello.com/c/bATaTRzd/1046-contexte-du-rendez-vous)
+
+## Mercredi 2 septembre 2020
+
+- [isoler les URLs de l'espace agent](https://trello.com/c/vvPZpGHL)
+- [Dump complet des données par organisation](https://trello.com/c/NVvX8hOR)
+
+## Mardi 1 septembre 2020
+
+- [[agent][usager] bloc agent référent](https://trello.com/c/3mU13t9s)
+- [permettre la création d'une nouvelle organisation par un agent déjà existant dans une autre organisation](https://trello.com/c/axi8ALDy)
+
+## Lundi 31 août 2020
+
+- [renommer admin en super_admin](https://trello.com/c/cg0CIpk8/1056-renommer-admin-en-superadmin)
+- [[Fiche usager] Afficher l'âge de l'enfant en mois jusqu'aux 36 mois](https://trello.com/c/eIqnMJaq/1045-fiche-usager-afficher-l%C3%A2ge-de-lenfant-en-mois-jusquaux-36-mois)
+
+## Jeudi 27 août 2020
+
+- [mise en place d'une alerte en cas de peu de mails envoyés le matin](https://trello.com/c/iQ07hFf3/1044-mettre-en-place-une-alerte-en-cas-de-peu-de-mails-envoy%C3%A9s-le-matin)
+
+## Mardi 25 août 2020
+
+- [[agent] Corriger orthographe : "Aucune note pour cet usager"](https://trello.com/c/TVtfXOLb/1042-agent-corriger-orthographe-aucune-note-pour-cet-usager)
+
+
+## Vendredi 21 août 2020
+
+- [[agents] afficher le rendez-vous en dernière page de prise de rendez-vous](https://trello.com/c/yQlhcOdi/1040-agents-afficher-le-rendez-vous-en-derni%C3%A8re-page-de-prise-de-rendez-vous)
+
+## Lundi 17 août 2020
+
+- [[agents][rdvs] ajout d'un lien explicite pour revenir à l'agenda](https://trello.com/c/G4YqIQeF/1038-agentsrdvs-ajout-dun-lien-explicite-pour-revenir-%C3%A0-lagenda)
+- [[agents] utilise le même champ date partout](https://trello.com/c/m2Qv3ZCB/1037-agents-utilise-le-m%C3%AAme-champ-date-partout)
+
+## Mercredi 12 août 2020
+
+- [investiguer probleme datepicker sur les absences](https://trello.com/c/6JeDpvVn)
+- [[agent] reparer ouverture menu lateral pour users#show et plage_ouverture#new](https://trello.com/c/fhCtioEr)
+
+## Mardi 11 août 2020
+
+- [[Agent ][doublon] fusion des fiches usagers](https://trello.com/c/Yv0CMWtJ/942-agent-doublon-fusion-des-fiches-usagers)
+- [avoir un journal de notes](https://trello.com/c/JfCbBd7j/992-avoir-un-journal-de-notes)
+
+## Jeudi 6 août 2020
+
+- [bump skylight + remove dev warning](https://trello.com/c/nRFadSy5)
+- [rendre les associations dans les tests plus deterministes (plus de .first)](https://trello.com/c/gJMG0HBY)
+- [upgrade devise](https://trello.com/c/lOCByOyS)
+
+## Mercredi 5 août 2020
+
+- [[Agent][rdv flow] clarifier le libellé du bouton de choix d'un usager existant](https://trello.com/c/KtgcJanE)
+- [incoherence des filtres entre compteur RDV a venir et liste](https://trello.com/c/hCDhZfkF)
+- [user.soft_delete devrait s'occuper des RDVs](https://trello.com/c/aUoAmzuL)
+
+## Mardi 4 août 2020
+
+- [remove selectize JS package dependency](https://trello.com/c/2vDHjGJ5)
+- [investigate flaky specs](https://trello.com/c/BxD7Om8R)
+- [Interconnexion rdv-sol vers Outlook (RDV) ajouter le type de RDV](https://trello.com/c/5w87iDZw)
+- [Interconnexion rdv-sol vers Outlook (RDV) ajouter le numéro de tél](https://trello.com/c/njHdVPIy)
+
+## Lundi 3 août 2020
+
+- [fix rdv deletion](https://trello.com/c/mPYYhcXM/1020-fix-rdv-deletion)
+- [enable policy content actual blocking](https://trello.com/c/UusjcXAQ/1013-enable-policy-content-actual-blocking)
+- [fix remove from dom JS IE11](https://trello.com/c/tCv0o8RX/1022-fix-remove-from-dom-js-ie11)
+- [IE11 dispatchEvent change is broken](https://trello.com/c/5NPOAv7d/1021-ie11-dispatchevent-change-is-broken)
+- [[Stats] réparer la fraîcheur des statistiques](https://trello.com/c/oL31Kv20/983-stats-r%C3%A9parer-la-fra%C3%AEcheur-des-statistiques)
+- [[Usager] Retirer les mentions "MDS"](https://trello.com/c/jZTIrLG2/981-usager-retirer-les-mentions-mds)
+
+## Jeudi 30 juillet 2020
+
+- [Monitor CRON jobs : reminders + file attente](https://trello.com/c/FKue0DWU)
+
+## Mercredi 29 juillet 2020
+
+- [[agent] warning usagers avec meme numero](https://trello.com/c/aoyln2ag/1016-agent-warning-usagers-avec-meme-numero)
+- [[agent] ajuster les créneaux proposés](https://trello.com/c/AGzPGXNf/959-agent-ajuster-les-cr%C3%A9neaux-propos%C3%A9s)
+- [remove flipflop](https://trello.com/c/ycCzzv6Q/908-remove-flipflop)
+- [[agent] permettre la création d'un usager avec un numéro de tél doublon + ameliorer UI de comparaison](https://trello.com/c/zpU6r5K8/934-agent-permettre-la-cr%C3%A9ation-dun-usager-avec-un-num%C3%A9ro-de-t%C3%A9l-doublon-ameliorer-ui-de-comparaison)
+
+## Mardi 28 juillet 2020
+
+- [[agent] recherche usager par telephone](https://trello.com/c/RaPfbIeL)
+
+## Lundi 27 juillet 2020
+
+- [[agent][tunnel rdv] Créer un proche à la volée](https://trello.com/c/PAFufC3w)
+- [fix closest usage in motif-form](https://trello.com/c/aIIrOQaZ)
+- [remove stimulus](https://trello.com/c/uKwbGhtx)
+- [corriger test qui faile aleatoirement](https://trello.com/c/lUcnCKnZ)
+- [remove actiontext](https://trello.com/c/nBlS5ETP)
+- [[Agent][tunnel de prise de RDV] pouvoir créer un usager existant dans une autre orga](https://trello.com/c/oe7D3fSt)
+- [envoyer ICS plage ouverture depuis une autre adresse](https://trello.com/c/ZuBCaH2U)
+
+## Jeudi 23 juillet 2020
+
+- [Creation de plage ouverture: jour de fin pas pris en compte](https://trello.com/c/vXYTvvDg)
+- [forcer premier jour a lundi dans les datepickers](https://trello.com/c/Y4yDu6Kz)
+- [Creation de plage ouverture: jour de debut pas pris en compte](https://trello.com/c/ywpNNFsy)
+- [Creation de plage d'ouverture : la barre latérale se ferme lorsqu'on cherche une date de fin de récurrence](https://trello.com/c/b08geApC)
+- [[Agent] Améliorer l'affichage et le tri des plages d'ouverture](https://trello.com/c/V1tOsi0r)
+
+## Jeudi 16 juillet 2020
+
+- [[agent][trouver un créneau] ajouter la même fonctionnalité que côté usager => affichage de la prochaine disponibilité](https://trello.com/c/vp8fSFwU/417-agenttrouver-un-cr%C3%A9neau-ajouter-la-m%C3%AAme-fonctionnalit%C3%A9-que-c%C3%B4t%C3%A9-usager-affichage-de-la-prochaine-disponibilit%C3%A9)
+
+## Vendredi 10 juillet 2020
+
+- [[Usager] Etape vérifier mes informations => le champ logement apparaît 2 fois](https://trello.com/c/PpjN4DMc/984-usager-etape-v%C3%A9rifier-mes-informations-le-champ-logement-appara%C3%AEt-2-fois)
+- [[agents] garder la sélection de l'usager](https://trello.com/c/boJA0l8c/996-agents-garder-la-s%C3%A9lection-du-user)
+
+## Jeudi 9 juillet 2020
+
+- [[Agent] harmoniser interface sélection dates dans les champs (datepicker)](https://trello.com/c/Cpb7njXc/967-agent-harmoniser-interface-s%C3%A9lection-dates-dans-les-champs-datepicker)
+- [[usager] supprimer le numéro de tel du 62](https://trello.com/c/p1jB3VWn/993-usager-supprimer-le-num%C3%A9ro-de-tel-du-62)
+
+## Lundi 6 juillet 2020
+
+- [[agent][sectorisation] rendre plus visible le fait que c'est un code INSEE et pas un code postal](https://trello.com/c/0g389RKW)
+- [Impossible de recréer un usager supprimé](https://trello.com/c/MbRWv7GQ)
+- [[agent][calendrier] lorsqu'un onglet est laissé ouvert longtemps, il y a plein d'alertes lorsqu'on revient](https://trello.com/c/Fpw2RY9R)
+
+## Jeudi 2 juillet 2020
+
+- [[agent][stats] export des statistiques de l'organisation](https://trello.com/c/wJlbVY9G/940-agentstats-export-des-statistiques-de-lorganisation)
+- [[Agent][ plages d'ouverture] permettre la création successive de plages d'ouvertures pour une même activité sans récurrence de date](https://trello.com/c/etIgH5un/957-agent-plages-douverture-permettre-la-cr%C3%A9ation-successive-de-plages-douvertures-pour-une-m%C3%AAme-activit%C3%A9-sans-r%C3%A9currence-de-date)
+- [[Usager][inscription] Ajouter lien "mot de passe oublié" lorsque l'email est déjà utilisé](https://trello.com/c/6dNrculW/943-usagerinscription-ajouter-lien-mot-de-passe-oubli%C3%A9-lorsque-lemail-est-d%C3%A9j%C3%A0-utilis%C3%A9)
+- [[usager][inscription] renvoyer mail d'invitation plutot que confirmation pour demander MDP](https://trello.com/c/5ZCBnIuH/977-usagerinscription-renvoyer-mail-dinvitation-plutot-que-confirmation-pour-demander-mdp)
+
+## Mercredi 1 juillet 2020
+
+- [[agent] réparer affichage logement dans liste de RDVs](https://trello.com/c/PMkqNIDR)
+- [[Agent] Completer les descriptions des pages vides](https://trello.com/c/vBdHTRxc)
+- [[Usager] ajouter les numéros de telephone du Calvados/ Val d'Oise/yvelines](https://trello.com/c/ObK4QDGs)
+- [[agent] arreter de selectionner un lieu par défaut dans le formulaire de creation de RDV](https://trello.com/c/UN83Anmb)
+- [[agent] lien sectorisation dans menu dépasse en responsive](https://trello.com/c/wQTXdPd0)
+- [[agent] déplacer le lien Sectorisation dans Paramètres](https://trello.com/c/S4oO0Vrh)
+
+## Mardi 30 juin 2020
+
+- [[agent][usager] oeil pour visualiser le mot de passe ne fonctionne plus](https://trello.com/c/rbTL0OwO)
+- [[agent][agenda] rend visible les créneaux de tres courte durée](https://trello.com/c/ZJxUjkxI)
+- [[Home] Bandeau Navigateur obsolète](https://trello.com/c/iVY5eZTe)
+
+## vendredi 26 juin 2020
+
+- [Bug- création des proches](https://trello.com/c/l1c77Ug2/961-bug-cr%C3%A9ation-des-proches)
+
+## Jeudi 25 juin 2020
+
+- [agent- Impression des RDVS - niveau de détail que l'on souhaite voir apparaître](https://trello.com/c/DlPqZorv/948-agent-impression-des-rdvs-niveau-de-d%C3%A9tail-que-lon-souhaite-voir-appara%C3%AEtre)
+- [[agent] Les notes libres et le champ logement ne doivent pas être partagés entre organisations](https://trello.com/c/uqSvS3iM/585-agent-les-notes-libres-et-le-champ-logement-ne-doivent-pas-%C3%AAtre-partag%C3%A9s-entre-organisations)
+- [[Usager] COVID Lever le bouclier de la prise de RDV en ligne et le bandeau "la prise de RDV en ligne est momentanément limitée à certains rendez-vous pendant la durée de l'urgence "](https://trello.com/c/fZG0ZRLs/944-usager-covid-lever-le-bouclier-de-la-prise-de-rdv-en-ligne-et-le-bandeau-la-prise-de-rdv-en-ligne-est-momentan%C3%A9ment-limit%C3%A9e-%C3%A0-ce)
+
+
+## Mercredi 24 juin 2020
+
+- [sectorisation par Site a l'echelle de la commune entiere](https://trello.com/c/3poo0MxG)
+- [Envoyer les SMS avec SendInBlue](https://trello.com/c/ZQAIcRcq)
+- [[usager] changer le numéro de téléphone de la Somme sur la home page](https://trello.com/c/2Z2kIPzs)
+- [Bug tooltips persistentes sur l'agenda](https://trello.com/c/7dEhr6Wu)
+- [[où ?] Ne pas afficher le numéro de tel s'il n'y en a pas dans le departement](https://trello.com/c/USRqtFtw)
+- [réparer lieux créés avec coordonnées inversées](https://trello.com/c/xkqlACCY)
+- [[usager][recherche] bug clic 'modifier service'](https://trello.com/c/BwuMXjmA)
+- [[Agent] lors de la creation et edition de RDV, permettre recherche autocomplétée des lieux](https://trello.com/c/MbrzvSYo)
+- [[agent] réparer exports de RDVs de l'agent courant : limiter RDVs](https://trello.com/c/Jf6G6373)
+
+## Mardi 23 juin 2020
+
+- [[usager] [inscription] labels formulaires pas traduits](https://trello.com/c/MDclzKuB/923-bug-usager-inscription)
+- [Utiliser IP dédiée pour les mails SIB](https://trello.com/c/ro91EkYk/889-utiliser-ip-d%C3%A9di%C3%A9e-pour-les-mails-sib)
+- [[investigation] Problème distance recherche Christelle Cufay](https://trello.com/c/XnqTAzbl/947-investigation-probl%C3%A8me-distance-recherche-christelle-cufay)
+
+## Lundi 22 juin 2020
+
+- [[usager][prise de RDV en ligne] éviter que l'usager reste sans réponse](https://trello.com/c/UEYEErDt)
+- [[usager] Recueil des avis avec « Je Donne Mon Avis »](https://trello.com/c/8lG42wnh)
+- [agent + user Réparer support IE 11 / Edge 18 : closest + toggleAttribute](https://trello.com/c/bR6ukPkS)
+- [[Agent][Agenda] Sélection automatique de la semaine ou du jour courant lors du changement de vue](https://trello.com/c/7a7kCxz3)
+
+## Jeudi 18 juin 2020
+
+- [Réparer les ICS de plages d'ouvertures pour le 64](https://trello.com/c/zg0MQfk2)
+- [réparer ICS pour zimbra](https://trello.com/c/4RIwsw9A)
+
+## Lundi 15 juin 2020
+
+- [Passer à ruby 2.7.1](https://trello.com/c/FNxfNb6H/906-passer-%C3%A0-ruby-271)
+- [Supprimer les migrations d'avant mars](https://trello.com/c/1KsaDinl/893-supprimer-les-migrations-davant-mars)
+- [[agent] [vos agents ] mise à jour de la description des rôles](https://trello.com/c/wEqCO6p7/907-agent-vos-agents-mise-%C3%A0-jour-de-la-description-des-r%C3%B4les)
+- [[Agent][tunnel de prise de RDV] rendre le remplissage du "lieu" obligatoire](https://trello.com/c/heKmUaHP/886-agenttunnel-de-prise-de-rdv-rendre-le-remplissage-du-lieu-obligatoire)
+- [[agent] erreur 404 sur clic usager depuis vue RDV](https://trello.com/c/tXTF18UG/915-agent-erreur-404-sur-clic-usager-depuis-vue-rdv)
+- [bug BAN nom commune](https://trello.com/c/gTCPwLIu/930-bug-ban-nom-commune)
+
+## Jeudi 11 juin 2020
+
+- [Permettre la création d'une organisation depuis le site internet et proposer un tutoriel de base pour la configuration](https://trello.com/c/qz6bRKye/877-permettre-la-cr%C3%A9ation-dune-organisation-depuis-le-site-internet-et-proposer-un-tutoriel-de-base-pour-la-configuration)
+
+## Mardi 9 juin 2020
+
+- [utiliser BAN plutot qu'Algolia](https://trello.com/c/yRRlTxAN/912-utiliser-ban-plutot-qualgolia)
+- [[Agent] extraction stats : impossible d'ouvrir le fichier](https://trello.com/c/MjwC5deL/897-agent-extraction-stats-impossible-douvrir-le-fichier)
+
+## Lundi 8 juin 2020
+
+- [[agent][historique des actions] les modifications sur les notes libres n'apparaissent pas](https://trello.com/c/fD1aSsjR)
+- [[Usager] Sur la phrase de description de la Homepage ajouter le service social](https://trello.com/c/ynAdlEAM)
+
+## Vendredi 5 juin 2020
+
+- [[agent] erreur invitation email différence de capitalisation](https://trello.com/c/ZCoXalEx/902-agent-erreur-invitation-email-diff%C3%A9rence-de-capitalisation)
+- [[Usager][notification] Lorsqu'un RDV est modifié, l'usager reçoit un mail de confirmations mais plus de SMS](https://trello.com/c/F2nEwFc9/903-usagernotification-lorsquun-rdv-est-modifi%C3%A9-lusager-re%C3%A7oit-un-mail-de-confirmations-mais-plus-de-sms)
+- [L'agent devrait pouvoir annuler un RDV qui a lieu dans tres peu de temps](https://trello.com/c/nAhf9nW3/892-lagent-devrait-pouvoir-annuler-un-rdv-qui-a-lieu-dans-tres-peu-de-temps)
+
+## Jeudi 4 juin 2020
+
+- [[Agent] Bouton "Trouver un creneau" ne s'affiche plus sur la fiche usager responsable](https://trello.com/c/YGOAMoPY)
+
+## Mercredi 3 juin 2020
+
+- [[Bug] 404 apres demande re-envoi verification mail](https://trello.com/c/MmSvkVJU/883-bug-404-apres-demande-re-envoi-verification-mail)
+
+## Mardi 2 juin 2020
+
+- [[notification] retirer notre domaine d'envoi des blacklists de spam depuis SIB](https://trello.com/c/VDwIx6Yq/884-notification-retirer-notre-domaine-denvoi-des-blacklists-de-spam-depuis-sib)
+- [[agent] [Outlook] la plage d'ouverture envoyée de rdv-solidarités vers Outlook n'apparaît pas dans l'outlook (soit erreur à l'ouverture de la PJ/ soit ne s’intègre pas à l'Outlook)](https://trello.com/c/wmYVeX4z/568-agent-outlook-la-plage-douverture-envoy%C3%A9e-de-rdv-solidarit%C3%A9s-vers-outlook-nappara%C3%AEt-pas-dans-loutlook-soit-erreur-%C3%A0-louverture-d)
+- [[agent][stat] export stats](https://trello.com/c/SrIAnvuR/882-agentstat-export-stats)
+- [[agent][agenda] affichage des statuts de RDV](https://trello.com/c/d0RVVlVk/453-agentagenda-affichage-des-statuts-de-rdv)
+- [[Bug] Refresh agenda](https://trello.com/c/p6UeX5eV/879-bug-refresh-agenda)
+- [[agent] cacher le pin de geolocalisation partout](https://trello.com/c/kt8ywN07/874-agent-cacher-le-pin-de-geolocalisation-partout)
+- [[usager][prise de rdv] toujours passer par la liste de lieux](https://trello.com/c/ojjMVtjb/872-usagerprise-de-rdv-toujours-passer-par-la-liste-de-lieux)
+
+## Vendredi 29 mai 2020
+
+- [[usager] bug marges dans la selection usager dans la prise rdv](https://trello.com/c/R7tUmMdh/887-usager-bug-marges-dans-la-selection-usager-dans-la-prise-rdv)
+- [[usager] modifier bandeau covid pour la Somme](https://trello.com/c/FIPlIYe8/888-usager-modifier-bandeau-covid-pour-la-somme)
+
+## Mercredi 27 mai 2020
+
+- [[Agent] Pouvoir imprimer la liste et les notes des RDV du jour](https://trello.com/c/uNz3uw6C)
+
+## Mardi 26 mai 2020
+
+- [[agent][détails du RDV] Rendre plus visible le champ "Notes libres'](https://trello.com/c/4uwkCJ40/869-agentd%C3%A9tails-du-rdv-rendre-plus-visible-le-champ-notes-libres)
+
+## Mercredi 20 mai 2020
+
+- [[Agent][agenda] Perte du contexte lorsque l'on fait une action pour un autre agent](https://trello.com/c/cn1iSHNI)
+- [[usager] [tunnel de prise de RDV] modifier l'emplacement des consignes](https://trello.com/c/cb7CgZj2)
+- [re-corriger le graph de stats de RDV par types](https://trello.com/c/X1XAHAOu)
+
+## Mardi 19 mai 2020
+
+- [[Usager][Prise de RDV] Adresse de la recherche / Adresse de l'usager](https://trello.com/c/A85ziBYW/875-usagerprise-de-rdv-adresse-de-la-recherche-adresse-de-lusager)
+- [[Agent][Fiche usager] Libellés différents pour le champ "référent"](https://trello.com/c/k2XeEyJe/868-agentfiche-usager-libell%C3%A9s-diff%C3%A9rents-pour-le-champ-r%C3%A9f%C3%A9rent)
+- [[RDV suivi] Configuration du motif + rdv usager](https://trello.com/c/EVZ1Ov7Q/648-rdv-suivi-configuration-du-motif-rdv-usager)
+- [[usager] supprimer les bandeaux Corona](https://trello.com/c/Wrm8ou0v/873-usager-supprimer-les-bandeaux-corona)
+
+## Lundi 18 mai 2020
+
+- [[Usager][prise de rdv] ajouter étape de vérification des informations de l'usager](https://trello.com/c/HGKPddEc/258-usagerprise-de-rdv-ajouter-%C3%A9tape-de-v%C3%A9rification-des-informations-de-lusager)
+
+## Jeudi 14 mai 2020
+
+- [[Bug][Agent] Sign in links](https://trello.com/c/7FNzIql7/866-bugagent-sign-in-links)
+- [Réparere les accents dans les fichiers iCal](https://trello.com/c/EoXzM9kK/826-r%C3%A9parere-les-accents-dans-les-fichiers-ical)
+- [[Usager] Enlever le bouton de géolocalisation buggé](https://trello.com/c/I8Dxdjxy/855-usager-enlever-le-bouton-de-g%C3%A9olocalisation-bugg%C3%A9)
+
+## Mercredi 13 mai 2020
+
+- [[agent] bug rechargement lors du flow de prise rdv](https://trello.com/c/gfYBPsdQ/864-agent-bug-rechargement-lors-du-flow-de-prise-rdv)
+- [[Agent][vos statistiques globales] les données contenus dans les histogrammes ne sont plus lisibles](https://trello.com/c/P1Tx7LoI/837-agentvos-statistiques-globales-les-donn%C3%A9es-contenus-dans-les-histogrammes-ne-sont-plus-lisibles)
+- [Améliorer le support des vieux navigateurs (Chrome 49, Firefox 48)](https://trello.com/c/TtroIl05/865-am%C3%A9liorer-le-support-des-vieux-navigateurs-chrome-49-firefox-48)
+
+## Mardi 12 mai 2020
+
+- [[Agent] Affichage de l'historique des modifications d'un RDV](https://trello.com/c/Of8YVaXo/469-agent-affichage-de-lhistorique-des-modifications-dun-rdv)
+- [[agent] enlever consignes rdv dans mail rdv_created_starts_soon](https://trello.com/c/zj9U9Bl5/858-agent-enlever-consignes-rdv-dans-mail-rdvcreatedstartssoon)
+- [Bug [agent] prise de RDV => les notes libres ne s'enregistrent pas](https://trello.com/c/AVAA7q9I/854-bug-agent-prise-de-rdv-les-notes-libres-ne-senregistrent-pas)
+
+## Lundi 11 mai 2020
+
+- [[Agent][agenda] alerte mails des RDV créés au dernier moment](https://trello.com/c/dseR7A0F/844-agentagenda-alerte-mails-des-rdv-cr%C3%A9%C3%A9s-au-dernier-moment)
+- [[agent][prise de rdv] selection agents referent dans la modale d'edition usager dans le flow prise de rdv](https://trello.com/c/z3I45YZ1/856-agentprise-de-rdv-selection-agents-referent-dans-la-modale-dedition-usager-dans-le-flow-prise-de-rdv)
+
+## Mercredi 6 mai 2020
+
+- [[Agent] bugfix echec de creation de RDV](https://trello.com/c/hD9aYaAw/853-agent-bugfix-echec-de-creation-de-rdv)
+- [[Agent][Wizard] Retours sur le wizard](https://trello.com/c/vVzUt5G2/850-agentwizard-retours-sur-le-wizard)
+- [[Usager] clarifier les boutons lors de l'annulation](https://trello.com/c/r7wveFpO/834-usager-clarifier-les-boutons-lors-de-lannulation)
+- [Bug [agent] [usager] pb à la création d'un proche](https://trello.com/c/rxQr4zzV/852-bug-agent-usager-pb-%C3%A0-la-cr%C3%A9ation-dun-proche)
+
+## Mardi 5 mai 2020
+
+- [[Agent][Agenda] rafraîchissement automatique](https://trello.com/c/jmKnXLdZ/849-agentagenda-rafra%C3%AEchissement-automatique)
+- [[Agent][améliorer la prise du RDV] afficher/modifier la fiche usager dans le tunnel de prise de RDV](https://trello.com/c/868Uso0M/679-agentam%C3%A9liorer-la-prise-du-rdv-afficher-modifier-la-fiche-usager-dans-le-tunnel-de-prise-de-rdv)
+- [[RDV suivi] Lier l'usager à un agent](https://trello.com/c/gm9X6IN1/658-rdv-suivi-lier-lusager-%C3%A0-un-agent)
+
+## Jeudi 30 avril 2020
+
+- [[agent] Calendrier en double apres retour](https://trello.com/c/HtWCNUBJ/839-agent-calendrier-en-double-apres-retour)
+- [ne pas afficher les créneaux passés dans "trouver un creneau" (ceux du matin du jour meme)](https://trello.com/c/nb3LeyAY/833-ne-pas-afficher-les-cr%C3%A9neaux-pass%C3%A9s-dans-trouver-un-creneau-ceux-du-matin-du-jour-meme)
+
+## Mercredi 29 avril 2020
+
+- [[usager] dans le tunnel de prise de RDV, auto-sélectionner le proche nouvellement créé](https://trello.com/c/E0ngGLpB/840-usager-dans-le-tunnel-de-prise-de-rdv-auto-s%C3%A9lectionner-le-proche-nouvellement-cr%C3%A9%C3%A9)
+
+## Mardi 28 avril 2020
+
+- [Bug [usager] le bouton "annuler" ou fermer la fenêtre ne fonctionne pas depuis la page "ajouter un proche"](https://trello.com/c/tw6BL4rZ/676-bug-usager-le-bouton-annuler-ou-fermer-la-fen%C3%AAtre-ne-fonctionne-pas-depuis-la-page-ajouter-un-proche)
+- [Parcours EHPAD](https://trello.com/c/A6NRbYsz/831-parcours-ehpad)
+- [Bug [usager] le bouton "annuler" ou fermer la fenêtre ne fonctionne pas depuis la page "ajouter un proche"](https://trello.com/c/tw6BL4rZ/676-bug-usager-le-bouton-annuler-ou-fermer-la-fen%C3%AAtre-ne-fonctionne-pas-depuis-la-page-ajouter-un-proche)
+- [Parcours EHPAD](https://trello.com/c/A6NRbYsz/831-parcours-ehpad)
+
+## Lundi 27 avril 2020
+
+- [[Perf] Optimiser LieuxController#index](https://trello.com/c/D1FkScBO/564-perf-optimiser-lieuxcontrollerindex)
+- [[Agenda] Clic sur un jour ferié](https://trello.com/c/ytxQaCIi/657-agenda-clic-sur-un-jour-feri%C3%A9)
+- [matomo update V2](https://trello.com/c/3UBcDxUd/830-matomo-update-v2)
+- [[Annulation] supprimer les notifs (de confirmation) pour les RDV passés](https://trello.com/c/nDvnpBQd/546-annulation-supprimer-les-notifs-de-confirmation-pour-les-rdv-pass%C3%A9s)
+- [[Agent][Trouver un créneau] rendre le délai mini et maxi inactif côté agent](https://trello.com/c/zc0mkTqD/682-agenttrouver-un-cr%C3%A9neau-rendre-le-d%C3%A9lai-mini-et-maxi-inactif-c%C3%B4t%C3%A9-agent)
+- [Notifications pour les plages d'ouverture](https://trello.com/c/uBIfj7y5/695-notifications-pour-les-plages-douverture)
+- [matomo update V1](https://trello.com/c/eo2NN34t/829-matomo-update-v1)
+
+
+## Jeudi 23 avril 2020
+
+- [Ajout d'un champ UID dans les fichiers iCal des plages d'ouverture](https://trello.com/c/1NK90kS3/696-ajout-dun-champ-uid-dans-les-fichiers-ical-des-plages-douverture)
+- [[VAD] etiquette "a domicile" manquante dans les plages d'ouvertures](https://trello.com/c/2ncVyWrq/684-vad-etiquette-a-domicile-manquante-dans-les-plages-douvertures)
+- [[Agent] Créer un motif ou faire une erreur si un motif existe déjà avec ce nom](https://trello.com/c/dC6NiD9C/699-agent-retirer-le-comportement-createorupdate-%C3%A0-la-cr%C3%A9ation-de-motif)
+- [Gestion des messages COVID en listant les départements désactivés](https://trello.com/c/XTTJ25C2/827-gestion-des-messages-covid-en-listant-les-d%C3%A9partements-d%C3%A9sactiv%C3%A9s)
+- [[Agent][VAD] Permettre la création de motifs de même libellés mais de types de RDV différents](https://trello.com/c/PqADEs7M/689-agentvad-permettre-la-cr%C3%A9ation-de-motifs-de-m%C3%AAme-libell%C3%A9s-mais-de-types-de-rdv-diff%C3%A9rents)
+
+## Mercredi 22 avril 2020
+
+- [[Notification][mail] enlever le motif dans les mails de confirmation et de rappels et file d'attente de RDV](https://trello.com/c/giRALVx0/643-notificationmail-enlever-le-motif-dans-les-mails-de-confirmation-et-de-rappels-et-file-dattente-de-rdv)
+- [réparer les recherches pour des motifs devenus indisponibles à la réservation en ligne.](https://trello.com/c/PHIBzZko/690-r%C3%A9parer-les-recherches-pour-des-motifs-devenus-indisponibles-%C3%A0-la-r%C3%A9servation-en-ligne)
+- [[VAD][Notifications] Heure pas affichée dans le mail de confirmation de RDV VAD](https://trello.com/c/E9Hfq5L2/678-vadnotifications-heure-pas-affich%C3%A9e-dans-le-mail-de-confirmation-de-rdv-vad)
+- [[API]Notifications des RDVs pris](https://trello.com/c/26WZzTNS/656-apinotifications-des-rdvs-pris)
+- [[Tech] Add mailer previews on admin interface](https://trello.com/c/Nm0jS75O/694-tech-add-mailer-previews-on-admin-interface)
+
+## Mardi 21 avril 2020
+
+- [[Agent] Retour annulation](https://trello.com/c/g7EA7qqC/683-agent-retour-annulation)
+- [[FIX] randomly failing feature specs](https://trello.com/c/yibIcLXq/601-fix-randomly-failing-feature-specs)
+- [Déplacer le bouton « trouver un créneau » en haut dans la fiche usage](https://trello.com/c/AalrVNVt/685-d%C3%A9placer-le-bouton-trouver-un-cr%C3%A9neau-en-haut-dans-la-fiche-usage)
+- [Pourvoir poser un rendez-vous à partir de la ficher d'un proche usager](https://trello.com/c/GrEOzbyb/686-pourvoir-poser-un-rendez-vous-%C3%A0-partir-de-la-ficher-dun-proche-usager)
+
+## Lundi 20 avril 2020
+
+- [[Annulation] supprimer les notifs (de confirmation) pour les RDV passés](https://trello.com/c/nDvnpBQd/546-annulation-supprimer-les-motifs-de-confirmation-pour-les-rdv-pass%C3%A9s)
+
+## Vendredi 17 avril 2020
+
+- [Exclure des données envoyer à piwik](https://trello.com/c/B7nx3xh6/659-exclure-des-donn%C3%A9es-envoyer-%C3%A0-piwik)
+- [[VAD][notification] Défaut d'affichage adresse dans le mail](https://trello.com/c/YCt2zJFe/663-vadnotification-d%C3%A9faut-daffichage-adresse-dans-le-mail)
+- [move all assets from sprockets to webpack](https://trello.com/c/dDfurz2o/628-remove-sprockets)
+- [[Agent][Usager] Trouver un creneau à partir de la fiche usager](https://trello.com/c/foss6CCl/616-agentusager-trouver-un-creneau-%C3%A0-partir-de-la-fiche-usager)
+
+## Jeudi 16 avril 2020
+
+- [[Doublons] Détecter les doublons](https://trello.com/c/jzam61J0/506-doublons-d%C3%A9tecter-les-doublons)
+- [[Bug][Secretariat] Problème de modification du RDV](https://trello.com/c/BAvwNF4Y/651-bugsecretariat-probl%C3%A8me-de-modification-du-rdv)
+- [[Annulation] Annulation d'un RDV](https://trello.com/c/lIel31TM/178-annulation-annulation-dun-rdv)
+- [[VAD] desactiver file d'attente](https://trello.com/c/fKtt6Kzz/667-vad-desactiver-file-dattente)
+- [[Tech] enlever flipper file d'attente](https://trello.com/c/YAwXQrXh/664-enlever-flipper-file-dattente)
+
+## Mercredi 15 avril 2020
+
+- [open phone rdv for 64](https://trello.com/c/ir3Q238O/665-open-phone-rdv-for-64)
+- [[VAD] Notifications Création / Modification / Rappel](https://trello.com/c/qv8HrKtL/593-vad-notifications-cr%C3%A9ation-modification-rappel)
+
+## Mardi 14 avril 2020
+
+- [[VAD] Pose d'un RDV sur l'agenda](https://trello.com/c/SbLo91uF/594-vad-pose-dun-rdv-sur-lagenda)
+- [[VAD] Metrics](https://trello.com/c/cCnoo8XZ/607-vad-metrics)
+
+## Vendredi 10 avril 2020
+
+- [[covid] Bandeau d'annonce différente pour les départements avec rdv téléphoniques secrétariat ouvert en ligne](https://trello.com/c/0pSdYGc8/641-covid-bandeau-dannonce-diff%C3%A9rente-pour-les-d%C3%A9partements-avec-rdv-t%C3%A9l%C3%A9phoniques-secr%C3%A9tariat-ouvert-en-ligne)
+- [Bug le RDv posé dans l'agenda d'un autre agent n’apparaît pas](https://trello.com/c/gSPz8rZ2/647-bug-le-rdv-pos%C3%A9-dans-lagenda-dun-autre-agent-nappara%C3%AEt-pas)
+
+## Jeudi 9 avril 2020
+
+- [reenable rdvs for 62](https://trello.com/c/iI5LMdQy/645-reenable-rdvs-for-62)
+- [[Administrate] Ajouter la liste des Rdvs aux Usagers + Agents](https://trello.com/c/1JguKvoE/615-administrate-ajouter-la-liste-des-rdvs-aux-usagers-agents)
+
+## Mercredi 8 avril 2020
+
+- [[Agent][pose du RDV] l'agent n'arrive pas à poser un RDV à un autre agent](https://trello.com/c/3UCedl13/631-agentpose-du-rdv-lagent-narrive-pas-%C3%A0-poser-un-rdv-%C3%A0-un-autre-agent)
+- [[Notifications] Migrer le compte Sendgrid d'Heroku](https://trello.com/c/FGO1vuZx/545-notifications-migrer-le-compte-sendgrid-dheroku)
+- [[Notifications Slack] Ajouter les notifications d'updown.io](https://trello.com/c/3P5aqcER/612-notifications-slack-ajouter-les-notifications-dupdownio)
+
+## Mardi 7 avril 2020
+
+- [[Notifications] Push sentry to #startup-lapin-dev - waiting for first occurence to validate](https://trello.com/c/slFz54Gi/239-notifications-push-sentry-to-startup-lapin-dev-waiting-for-first-occurence-to-validate)
+- [[VAD][Agent] Identifier les RDV à domicile](https://trello.com/c/T9BNYXUH/595-vadagent-identifier-les-rdv-%C3%A0-domicile)
+- [[VAD][Usager] Détail du RDV](https://trello.com/c/GZrPb6jh/596-vadusager-d%C3%A9tail-du-rdv)
+- [[Metrics] Changement GGL analytics > Matomo](https://trello.com/c/iULCDVl2/611-metrics-changement-ggl-analytics-matomo)
+- [[File d'attente] Metrics](https://trello.com/c/gz3o619p/608-file-dattente-metrics)
+- [[Scalingo] Migration](https://trello.com/c/1t8AcUyh/605-scalingo-migration)
+
+## Lundi 6 avril 2020
+
+- [[vad] desactiver secretariat dans la config du motif](https://trello.com/c/2IYnahvU/627-vad-desactiver-secretariat-dans-la-config-du-motif)
+- [[Social] Faire évoluer "ajouter un enfant" en "ajouter un proche"](https://trello.com/c/rAaQGgB2/574-social-faire-%C3%A9voluer-ajouter-un-enfant-en-ajouter-un-proche)
+- [[Social] Metrics](https://trello.com/c/wiX7vkJF/606-social-metrics)
+- [[Tech] Security Alerts](https://trello.com/c/Y5CfcCHz/614-tech-security-alerts)
+
+## Vendredi 3 avril 2020
+
+- Feature: Ajout de la visite à domicile dans la configuration du motif (caché derrière un flipper)
+- Bug: URL du logo de la page de la maintenance corrigé
+- Bug: Correction d'une faille de sécurité lors du login Agent
+

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ gem "jbuilder", "~> 2.5"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
 gem "spreadsheet"
+gem "redcarpet"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,6 +358,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     regexp_parser (1.6.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -540,6 +541,7 @@ DEPENDENCIES
   pundit (~> 2.0)
   rails (~> 6.0)
   rails-controller-testing
+  redcarpet
   rspec-rails (>= 4.0.0.beta)
   rspec_junit_formatter
   rubocop

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,20 @@
+# frozen_string_literal: true
+
+require "redcarpet"
+require "redcarpet/render_strip"
+
 class StaticPagesController < ApplicationController
   def disclaimer; end
 
   def terms; end
 
   def mds; end
+
+  def changelog
+    fichier = File.join(Rails.root, "CHANGELOG.md")
+    renderer = Redcarpet::Render::HTML.new(hard_wrap: true)
+    markdown = Redcarpet::Markdown.new(renderer, {})
+    contenue = markdown.render(File.read(fichier)).to_s
+    @html_changelog = contenue.html_safe
+  end
 end

--- a/app/views/common/_footer.html.slim
+++ b/app/views/common/_footer.html.slim
@@ -6,6 +6,7 @@
           | © RDV Solidarités #{Time.zone.today.year}
         .col-md-6
           .text-md-right.footer-links.d-none.d-md-block
+            = link_to 'Changements récents', changelog_path
             = link_to 'Mentions légales', mentions_legales_path
             = mail_to "contact@rdv-solidarites.fr", 'Contact'
 

--- a/app/views/static_pages/changelog.html.slim
+++ b/app/views/static_pages/changelog.html.slim
@@ -1,0 +1,9 @@
+- content_for :title do
+  h1 Changements récents
+
+.container.mt-3
+  .row
+    .col-md-12
+      .card.mb-3
+        .card-body
+          = @html_changelog

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,7 +150,7 @@ Rails.application.routes.draw do
     root to: "admin/organisations#index", as: :authenticated_agent_root, defaults: { follow_unique: "1" }
   end
 
-  { disclaimer: "mentions_legales", terms: "cgv", mds: "mds" }.each do |k, v|
+  { disclaimer: "mentions_legales", changelog: "changelog", terms: "cgv", mds: "mds" }.each do |k, v|
     get v => "static_pages##{k}"
   end
 


### PR DESCRIPTION
https://trello.com/c/TOWGxXSw/1095-affiche-les-changements-r%C3%A9cents-dans-lapplication
(ticket ajouté par moi même pour garder une trace si nous acceptons d'inclure cette modification)

Je pense que ça nous permettrais de gagner du temps sur la réunion référent, et de communiquer plus largement et plus facilement sur ce qui a été livré.

Pour le moment, ce n'est accessible que pour les agents. C'est peut-être à ajouter coté usager également ?

![Capture d’écran de 2020-09-18 13-18-02](https://user-images.githubusercontent.com/42057/93591909-84289080-f9b1-11ea-9a8f-aad192a87238.png)


![Capture d’écran de 2020-09-18 13-17-02](https://user-images.githubusercontent.com/42057/93591764-41ff4f00-f9b1-11ea-83fb-dd8378b88c87.png)



Ajout de la gem Redcarpet pour le traitement du markdown -> HTML. Je pense que ça pourrait servir à l'avenir dans l'application.

Nous pourrions mettre à jour le fichier changelog chaque soir, directement dans master.


