### PR TITLE
invite l'usager depuis le controller

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,7 +9,7 @@ class Admin::UsersController < AgentAuthController
     :first_name, :last_name, :birth_name, :email, :phone_number,
     :birth_date, :address, :caisse_affiliation, :affiliation_number,
     :family_situation, :number_of_children,
-    :invite_on_create, :skip_duplicate_warnings
+    :skip_duplicate_warnings
   ].freeze
 
   PERMITTED_NESTED_ATTRIBUTES = {
@@ -43,6 +43,8 @@ class Admin::UsersController < AgentAuthController
     @duplicate_user_result = DuplicateUserFinderService.perform_with(@user)
     @user.skip_confirmation_notification!
     user_persisted = @user.save
+
+    @user.invite! if invite_user?(@user, params)
     prepare_new unless user_persisted
 
     if from_modal?
@@ -110,6 +112,10 @@ class Admin::UsersController < AgentAuthController
   end
 
   private
+
+  def invite_user?(user, params)
+    user.persisted? && user.email.present? && (params[:user][:invite_on_create] == "1")
+  end
 
   def prepare_new
     return unless @user.responsible.nil?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -114,7 +114,7 @@ class Admin::UsersController < AgentAuthController
   private
 
   def invite_user?(user, params)
-    user.persisted? && user.email.present? && (params[:user][:invite_on_create] == "1")
+    user.persisted? && user.email.present? && (params[:invite_on_create] == "1")
   end
 
   def prepare_new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,8 +38,6 @@ class User < ApplicationRecord
     joins(:organisations).where(organisations: { id: organisation.id })
   }
 
-  after_commit :send_invite_if_checked, on: :create
-
   before_save :set_email_to_null_if_blank
   before_save :normalize_account
   before_save :format_phone_number
@@ -82,14 +80,6 @@ class User < ApplicationRecord
 
   def user_to_notify
     relative? ? responsible : self
-  end
-
-  def invite_on_create?
-    invite_on_create == "true"
-  end
-
-  def send_invite_if_checked
-    invite! if invite_on_create? && email.present?
   end
 
   def profile_for(organisation)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   include AccountNormalizerConcern
   include User::SearchableConcern
 
-  attr_accessor :invite_on_create, :skip_duplicate_warnings
+  attr_accessor :skip_duplicate_warnings
 
   devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable, :async

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -11,15 +11,12 @@
 = f.input(:email, as: :email, **input_opts)
 
 - if user.new_record?
-  = f.input( \
-    :invite_on_create, \
-    as: :boolean, \
-    label: "Inviter l'utilisateur à se créer un compte sur RDV-solidarites.", \
-    wrapper_html: { \
-      class:"align-items-baseline ml-0",
-    }, \
-    **input_opts, \
-  )
+  label
+    = check_box_tag :invite_on_create, \
+      1, \
+      false, \
+      class:"align-items-baseline ml-0"
+    |&nbsp; Inviter l'utilisateur à se créer un compte sur RDV-solidarites.
 
 = f.input :phone_number, as: :tel, **input_opts
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Admin::UsersController, type: :controller do
         {
           first_name: "Michel",
           last_name: "Lapin",
-          invite_on_create: "true",
           user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
         }
       end
@@ -40,7 +39,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       it { expect { subject }.to change(User, :count).by(1) }
 
       it "should not send an invite" do
-        subject
+        post :create, params: { organisation_id: organisation.id, user: attributes, invite_on_create: 0}
         expect(assigns(:user).invitation_sent_at).to be_nil
       end
 
@@ -70,7 +69,6 @@ RSpec.describe Admin::UsersController, type: :controller do
       let(:attributes) do
         {
           first_name: "Michel",
-          invite_on_create: "true",
           user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
         }
       end
@@ -95,7 +93,6 @@ RSpec.describe Admin::UsersController, type: :controller do
             first_name: "Michel",
             last_name: "Lapin",
             email: "michel@lapin.com",
-            invite_on_create: "1",
             user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
           }
         end
@@ -103,7 +100,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
         it "should send an invite" do
           expect_any_instance_of(User).to receive(:invite!)
-          subject
+          post :create, params: { organisation_id: organisation.id, user: attributes, invite_on_create: "1"}
         end
       end
     end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       it { expect { subject }.to change(User, :count).by(1) }
 
       it "should not send an invite" do
-        post :create, params: { organisation_id: organisation.id, user: attributes, invite_on_create: 0}
+        post :create, params: { organisation_id: organisation.id, user: attributes, invite_on_create: 0 }
         expect(assigns(:user).invitation_sent_at).to be_nil
       end
 
@@ -100,7 +100,7 @@ RSpec.describe Admin::UsersController, type: :controller do
 
         it "should send an invite" do
           expect_any_instance_of(User).to receive(:invite!)
-          post :create, params: { organisation_id: organisation.id, user: attributes, invite_on_create: "1"}
+          post :create, params: { organisation_id: organisation.id, user: attributes, invite_on_create: "1" }
         end
       end
     end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -9,48 +9,6 @@ RSpec.describe Admin::UsersController, type: :controller do
     sign_in agent
   end
 
-  shared_examples "with valid email" do |format|
-    let(:attributes) do
-      {
-        first_name: "Michel",
-        last_name: "Lapin",
-        email: "michel@lapin.com",
-        invite_on_create: "true",
-        user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
-      }
-    end
-    let(:format) { format }
-
-    it "should send an invite" do
-      subject
-      expect(assigns(:user).invitation_sent_at).not_to be_nil
-    end
-  end
-
-  shared_examples "with invalid params" do
-    let(:attributes) do
-      {
-        first_name: "Michel",
-        invite_on_create: "true",
-        user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
-      }
-    end
-    let(:format) { :html }
-
-    it { expect { subject }.not_to change(User, :count) }
-    it { expect(subject).to render_template(:new) }
-
-    it do
-      subject
-      expect(assigns(:user_to_compare)).to be_nil
-    end
-
-    it "should not send an invite" do
-      subject
-      expect(assigns(:user).invitation_sent_at).to be_nil
-    end
-  end
-
   describe "DELETE destroy" do
     it "removes user from organisation" do
       expect do
@@ -108,7 +66,46 @@ RSpec.describe Admin::UsersController, type: :controller do
       it { expect(subject).to render_template(:new) }
     end
 
-    it_behaves_like "with invalid params"
-    it_behaves_like "with valid email", :html
+    context "with invalid params" do
+      let(:attributes) do
+        {
+          first_name: "Michel",
+          invite_on_create: "true",
+          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
+        }
+      end
+      let(:format) { :html }
+
+      it { expect { subject }.not_to change(User, :count) }
+      it { expect(subject).to render_template(:new) }
+
+      it do
+        subject
+        expect(assigns(:user_to_compare)).to be_nil
+      end
+
+      it "should not send an invite" do
+        subject
+        expect(assigns(:user).invitation_sent_at).to be_nil
+      end
+
+      context "with valid email" do
+        let(:attributes) do
+          {
+            first_name: "Michel",
+            last_name: "Lapin",
+            email: "michel@lapin.com",
+            invite_on_create: "1",
+            user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
+          }
+        end
+        let(:format) { format }
+
+        it "should send an invite" do
+          expect_any_instance_of(User).to receive(:invite!)
+          subject
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/KDZt9wA2/1093-reparer-la-case-%C3%A0-cocher-envoyer-une-invitation-sur-la-fiche-usager

J'ai déplacé l'invitation dans le controller. Ça me semble plus approprié. Nous utilisons devise pour faire le boulot, pas la peine de surcharger nos modèles en plus.

