### PR TITLE
fix service permission leaks in admin by introducing Agent::ServicePo…

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -19,6 +19,10 @@ class Admin::InvitationsController < Devise::InvitationsController
 
   protected
 
+  def pundit_user
+    AgentContext.new(current_agent)
+  end
+
   def organisation_id
     devise_parameter_sanitizer.sanitize(:invite)[:organisation_id]
   end

--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -1,0 +1,17 @@
+class Agent::ServicePolicy < Agent::AdminPolicy
+  class Scope < Scope
+    def resolve
+      return scope.all if @context.agent.admin? || @context.agent.service.secretariat?
+
+      scope.where(id: @context.agent.service_id)
+    end
+  end
+
+  class AdminScope < Scope
+    def resolve
+      return scope.all if @context.agent.admin?
+
+      scope.where(id: @context.agent.service_id)
+    end
+  end
+end

--- a/app/views/admin/invitations/new.html.slim
+++ b/app/views/admin/invitations/new.html.slim
@@ -6,7 +6,7 @@
 = simple_form_for [:admin, resource], as: resource_name, url: invitation_path(resource_name), remote: request.xhr?, html: { method: :post, data: { rightbar: true } } do |f|
   = devise_error_messages!
   = f.input :email, placeholder: 'votre_nom@votre_entreprise.com', input_html: { autocomplete: 'off'}
-  = f.association :service, collection: Service.all, include_blank: false
+  = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, include_blank: false
   - organisation_id = params[:agent] ? params.require(:agent).permit(:organisation_id)[:organisation_id] : params[:organisation_id]
   = f.input :organisation_id, as: :hidden, input_html: { value: organisation_id }
   = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons

--- a/app/views/admin/permissions/edit.html.slim
+++ b/app/views/admin/permissions/edit.html.slim
@@ -3,7 +3,7 @@
 
 = simple_form_for [:admin, @permission], url: admin_organisation_permission_path(current_organisation, @permission), remote: request.xhr?, html: { data: { rightbar: true } } do |f|
   = render partial: 'layouts/model_errors', locals: { model: @permission }
-  = f.input :service_id, collection: Service.all, as: :select, label: 'Service'
+  = f.input :service_id, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, as: :select, label: 'Service'
   = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons, label: "Rôle de #{@permission.agent.full_name}"
 
   .row

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -9,7 +9,7 @@
 
   = f.input :first_name, placeholder: 'Prénom'
   = f.input :last_name, placeholder: 'Nom'
-  = f.association :service, collection: Service.all
+  = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve
 
   = f.input :password, placeholder: 'Votre mot de passe (au moins 6 caractères)'
   .form-text.text-muted.mb-2


### PR DESCRIPTION
https://trello.com/c/xctbAFtI/1099-emp%C3%AAcher-agents-non-admin-de-sauto-changer-de-service

L'introduction de la policy sur les permissions permet de limiter les vues selon que l'agent est admin ou secretaire ou aucun des deux.

Il faut aussi faire une sous-distinction : sur certaines vues (ex: la création de RDV) les secretaires et les admin voient tous les services mais sur d'autres pages (ex : l'édition de son propre compte) seuls les admins voient tous les services. Sinon les secrétaires peuvent s'auto-changer de service.

détail technique: j'ai utilisé `Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve` plutôt que `policy_scope(Service, policy_scope_class: Agent::ServicePolicy::AdminScope)` qui est suggéré sur la doc de pundit, parce que ca ne marche pas, pour une raison qui m'échappe. je ne trouve pas ça particulièrement plus parlant ceci dit donc je pense que c'est OK