### PR TITLE
new service filter for motifs in admin/agent_searches#index and admin/rdv_wizard#step1

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -8,6 +8,8 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       if (params[:commit].present? || request.format.js?) && @form.valid?
     respond_to do |format|
       format.html do
+        @services = policy_scope(Service).ordered_by_name
+        @form.service_id = @services.first.id if @services.count == 1
         @motifs = policy_scope(Motif).active.ordered_by_name
         @agents = policy_scope(Agent).complete.active.order_by_last_name
         @lieux = policy_scope(Lieu).ordered_by_name
@@ -23,6 +25,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   def build_agent_creneaux_search_form
     AgentCreneauxSearchForm.new(
       organisation_id: current_organisation.id,
+      service_id: params[:service_id],
       motif_id: params[:motif_id],
       from_date: params[:from_date],
       user_id: params[:user_id].presence,

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -8,9 +8,11 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       if (params[:commit].present? || request.format.js?) && @form.valid?
     respond_to do |format|
       format.html do
-        @services = policy_scope(Service).ordered_by_name
-        @form.service_id = @services.first.id if @services.count == 1
         @motifs = policy_scope(Motif).active.ordered_by_name
+        @services = policy_scope(Service)
+          .where(id: @motifs.pluck(:service_id).uniq)
+          .ordered_by_name
+        @form.service_id = @services.first.id if @services.count == 1
         @agents = policy_scope(Agent).complete.active.order_by_last_name
         @lieux = policy_scope(Lieu).ordered_by_name
       end

--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -1,7 +1,7 @@
 class AgentCreneauxSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :motif_id, :agent_ids, :user_id, :lieu_ids
+  attr_accessor :organisation_id, :service_id, :motif_id, :agent_ids, :user_id, :lieu_ids
   attr_writer :from_date
 
   validates :organisation_id, :motif_id, presence: true

--- a/app/form_models/agent_rdv_wizard.rb
+++ b/app/form_models/agent_rdv_wizard.rb
@@ -6,14 +6,14 @@ module AgentRdvWizard
   class Base
     include ActiveModel::Model
 
-    attr_accessor :rdv
+    attr_accessor :rdv, :service_id
 
     # delegates all getters and setters to rdv
     delegate(*::Rdv.attribute_names, to: :rdv)
-    delegate :motif, :organisation, :agents, :users, :to_query, to: :rdv
+    delegate :motif, :organisation, :agents, :users, to: :rdv
 
     def initialize(agent, organisation, attributes)
-      rdv_attributes = attributes.to_h.symbolize_keys
+      rdv_attributes = attributes.to_h.symbolize_keys.except(:service_id)
       rdv_defaults = {
         agent_ids: [agent.id],
         organisation_id: organisation.id,
@@ -21,6 +21,11 @@ module AgentRdvWizard
       }
       @rdv = ::Rdv.new(rdv_defaults.merge(rdv_attributes))
       @rdv.duration_in_min ||= @rdv.motif.default_duration_in_min if @rdv.motif.present?
+      @service_id = attributes.to_h.symbolize_keys[:service_id]
+    end
+
+    def to_query
+      @rdv.to_query.merge(service_id: service_id)
     end
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,6 +8,7 @@ class Service < ApplicationRecord
 
   scope :with_motifs, -> { where.not(name: SECRETARIAT) }
   scope :secretariat, -> { where(name: SECRETARIAT).first }
+  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
 
   scope :searchable, lambda { |organisations|
     where(id: Motif.searchable(organisations).pluck(:service_id).uniq)

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -13,11 +13,32 @@
       - if @user
         = hidden_field_tag :user_id, @user.id
       .row
-        .col-md-3
-          = f.input :motif_id, collection: @motifs, label_method: -> { motif_name_with_location_type(_1) }, required: true, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' }
-        .col-md-2
-          = date_input(f, :from_date, label = "À partir du")
-        .col-md-3
+        .col-md-4
+          = f.input :service_id, \
+            collection: @services, \
+            input_html: { \
+              class: 'select2-input js-service-filter', \
+              data: { \
+                placeholder: "Sélectionnez un service pour filtrer les motifs", \
+                "select-options": { disableSearch: true } \
+              } \
+            }
+        .col-md-4
+          = f.input :motif_id, \
+            required: true, \
+            include_blank: true, \
+            collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
+            as: :grouped_select, \
+            group_method: :last,
+            label_method: -> { motif_name_with_location_type(_1) }, \
+            input_html: { \
+              data: { placeholder: "Sélectionnez un motif" }, \
+              class: 'js-filtered-motifs' \
+            }
+        .col-md-4
+          = date_input(f, :from_date, label = "À partir du", required: true)
+      .row
+        .col-md-4
           = f.input :agent_ids, collection: @agents, label: "Agent(s)", label_method: :full_name, input_html: { multiple: true, class: 'select2-input' }
         .col-md-4
           = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: 'select2-input' }

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -14,14 +14,32 @@
               = "Commence le : #{l(@rdv.starts_at, format: :human)}"
       .card-body
         = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
-        = simple_form_for(@rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|
+        = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|
           = f.input_field :starts_at, as: :hidden
           = f.input_field :lieu_id, as: :hidden
           - @rdv.agents.each do |p|
             / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
             = f.hidden_field "agent_ids][", value: p.id
-
-          = f.association(:motif, collection: policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent), label_method: -> { motif_name_with_location_type(_1) }, include_blank: "Sélectionnez un motif", input_html: { class: 'select2-input' })
+          = f.input :service_id, \
+            collection: @services.ordered_by_name, \
+            input_html: { \
+              class: 'select2-input js-service-filter', \
+              data: { \
+                placeholder: "Sélectionnez un service pour filtrer les motifs", \
+                "select-options": { disableSearch: true } \
+              } \
+            }
+          = f.input :motif_id, \
+            required: true, \
+            include_blank: true, \
+            collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
+            as: :grouped_select, \
+            group_method: :last,
+            label_method: -> { motif_name_with_location_type(_1) }, \
+            input_html: { \
+              data: { placeholder: "Sélectionnez un motif" },
+              class: 'js-filtered-motifs' \
+            }
           .row
             .col.text-left
               = link_to 'Revenir en arrière', admin_organisation_agent_path(current_organisation, @agent), class: 'btn btn-link'

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -23,7 +23,7 @@
           label Usagers
           .js-users-spinner.spinner-border.d-none &nbsp;
 
-        = simple_form_for(@rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation, step: 2)) do |f|
+        = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation, step: 2)) do |f|
           - @rdv.users.each do |user|
             / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
             = f.hidden_field "user_ids][", value: user.id
@@ -52,11 +52,12 @@
               | L'usager n'existe pas ?&nbsp;
               = link_to 'Créer un usager', new_admin_organisation_user_path(current_organisation, modal: true), data: { modal: true }
 
-          .mt-3= f.input :context, input_html: { rows: 4 }
+          .mt-3= f.input :context, as: :text, label: t("activerecord.attributes.rdv.context"), input_html: { rows: 4 }
 
           = f.input_field :motif_id, as: :hidden
           = f.input_field :starts_at, as: :hidden
           = f.input_field :lieu_id, as: :hidden
+          = f.input_field :service_id, as: :hidden
 
           - @rdv.agents.each do |p|
             / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field

--- a/app/webpacker/components/service-filter-for-motifs-selects.js
+++ b/app/webpacker/components/service-filter-for-motifs-selects.js
@@ -1,0 +1,62 @@
+class ServiceFilterForMotifsSelects {
+  // jQuery is required to interact with select2
+
+  constructor() {
+    $(document).on("turbolinks:load", this.initFilter)
+    $(document).on("turbolinks:before-cache", this.destroyFilter)
+  }
+
+  initFilter = () => {
+    this.serviceSelect = document.querySelector(".js-service-filter")
+    this.motifSelect = document.querySelector('.js-filtered-motifs')
+    if (!this.serviceSelect || !this.motifSelect) return
+
+    this.initialGroupedOptions = this.getInitialGroupedOptions()
+    $(this.serviceSelect).on("change", () => this.refreshData())
+    $(this.serviceSelect).trigger("change")
+  }
+
+  destroyFilter = () => {
+    this.motifSelect = document.querySelector('.js-filtered-motifs')
+    if (!this.motifSelect) return
+
+    this.motifSelect.dataset.valueBeforeDestroy = $(this.motifSelect).val()
+    $(this.motifSelect).select2("destroy")
+  }
+
+  // select2 expects format {groupname: [{id: "optvalue", text: "opttext"}, ...]}
+  getInitialGroupedOptions = () =>
+    Array.
+      from(this.motifSelect.querySelectorAll("optgroup")).
+      map(this.formatOptgroup)
+
+  formatOptgroup = (g) => ({ text: g.label, children: this.optgroupChildren(g) })
+
+  optgroupChildren = optgroup =>
+    Array.
+      from(optgroup.querySelectorAll("option")).
+      map(this.formatOption)
+
+  formatOption = (option) => ({id: option.value, text: option.innerHTML})
+
+  refreshData = () => {
+    const currentServiceName = this.serviceSelect.options[this.serviceSelect.selectedIndex].text
+    const filteredOptions = this.getFilteredGroupedOptions(currentServiceName)
+    const motifValue = $(this.motifSelect).val() || this.motifSelect.dataset.valueBeforeDestroy
+    const filteredOptionsWithSelected = this.tagSelectedOption(filteredOptions, motifValue)
+    const filteredOptionsWithBlank = [{id: "", text: ""}].concat(filteredOptionsWithSelected)
+    $(this.motifSelect).html("") // otherwise it doesn't clear previous options
+    $(this.motifSelect).select2({ data: filteredOptionsWithBlank })
+  }
+
+  getFilteredGroupedOptions = (serviceName) =>
+    serviceName ? this.initialGroupedOptions.filter(g => g.text == serviceName) : this.initialGroupedOptions
+
+  tagSelectedOption = (optgroups, value) =>
+    optgroups.map(optgroup => ({
+      ...optgroup,
+      children: optgroup.children.map(opt => ({ selected: opt.id == value, ...opt })),
+    }))
+}
+
+export { ServiceFilterForMotifsSelects }

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -20,6 +20,7 @@ import { Layout } from 'components/layout';
 import { Modal } from 'components/modal';
 import { Rightbar } from 'components/rightbar';
 import { PopulateLibelle } from 'components/populate-libelle';
+import { ServiceFilterForMotifsSelects } from 'components/service-filter-for-motifs-selects';
 import 'components/analytic.js';
 import { PlacesInputs } from 'components/places-inputs.js';
 import { RdvWizardStep2 } from 'components/rdv_wizard_step2.js';
@@ -48,6 +49,7 @@ $.fn.select2.defaults.set("language", "fr");
 new Modal();
 new Rightbar();
 new Select2Inputs();
+new ServiceFilterForMotifsSelects();
 
 global.$ = require('jquery');
 

--- a/app/webpacker/stylesheets/components/_select2.scss
+++ b/app/webpacker/stylesheets/components/_select2.scss
@@ -14,3 +14,7 @@
   background-color: $tertiary;
   color: $dark;
 }
+
+.select2-container--bootstrap4 .select2-results__group {
+  font-size: initial;
+}


### PR DESCRIPTION
https://trello.com/c/dQzWcy1m/597-ajouter-un-filtre-par-service-dans-la-vue-trouver-un-cr%C3%A9neau

<img width="3639" alt="trouver-creneau" src="https://user-images.githubusercontent.com/883348/94132295-62228880-fe5f-11ea-9525-7ec4d9e31ad8.png">
<img width="1500" alt="rdv_wizard" src="https://user-images.githubusercontent.com/883348/94132304-651d7900-fe5f-11ea-9d8a-c58a95342ba3.png">


J'ai envisagé trois solutions différentes : 
1. a chaque changement de service, faire une requete AJAX JSON sur `/motifs?service_id=x` et rafraichir la liste des options dispos dans le select du motif (comme le `populate-libelle.js` existant) 
2. a chaque changement de service, rafraichir la page automatiquement avec le parametre get `service_id=x` et peupler le select de motifs avec la liste filtrée dans la vue directement
3. a chaque changement de service, filtrer la liste des options dispos dans le select des motifs purement en JS - sans requête AJAX

J'ai fini par choisir **3** pour plusieurs raisons : 
- La requête AJAX est superflue et offre une moins bonne UX (plus lente + plus instable) que le pur filtre JS. on peut tout à fait charger tous les motifs initialement et les filtrer ensuite, il n'y a pas de soucis de perfs pour ce genre de petit volume de données
- la **2.** est attirante mais après avoir essayé, c'est peu délicat à mettre en place à la fois dans "trouver un créneau" et dans le rdv wizard step 1. ça pose aussi pas mal de questionnements vis-à-vis du remplissage auto de ce champ quand un motif est sélectionné, et comment gérer les soumissions de formulaire avec service , sans service mais avec motif etc..  L'UX est légèrement moins bonne aussi puisque ça implique un refresh de la page.

Finalement 3. me paraît pertinente car ce n'est pas vraiment un champ qu'on rajoute au formulaire, mais juste une aide pour sélectionner le champ important : le motif. ça me va assez bien de voir ça comme purement de la vue. L'UX est assez bonne comme ça. 

J'ai donc : 
- dans le select de motifs, groupé les options par services dans des `optgroup`. L'avantage c'est que meme sans filtrer a l'aide du select de services, le choix est déja plus aisé. et ca fonctionne sans JS :) 
- rajouté du JS pour que lorsqu'on change la selection dans le dropdown de service ca filtre les options dans le select de motif. malheureusement ça fait beaucoup de JS, plus que je n'aurais aimé. 
- géré le cas particulier ou il n'y a qu'un seul service dispo (qui va arriver souvent) pour auto-selectionner ce service. 

Le JS est principalement compliqué à cause de deux choses : 
- l'API de select2 pour changer les options n'est vraiment pas très agréable, il faut reformatter les options du DOM dans un format précis. Et il faut retagger manuellement l'option selected + rajouter manuellement l'option vide
- gérer turbolinks est relou (par exemple si tu avances puis recules, il faut bien sélectionner le motif)