### PR TITLE
allow toggling password visibility on password reset page

### DIFF
--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -7,7 +7,10 @@
 = simple_form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put } do |f|
   = devise_error_messages!
   = f.input :reset_password_token, as: :hidden
-  = f.input :password, as: :password, label: 'Mot de passe'
+  .form-group
+    = f.password_field :password, as: :password, label: 'Mot de passe', class: 'form-control', autocomplete: "off", required: true, id: "password"
+    span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
+
   - if @minimum_password_length
     .form-text.text-muted.mb-2
       | #{@minimum_password_length} caractères minimum

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -65,7 +65,7 @@ describe "User can search for rdvs" do
       # Password reset page after confirmation
       expect(page).to have_content("Votre compte a été validé")
       expect(page).to have_content("Définir mon mot de passe")
-      fill_in(:user_password, with: "12345678")
+      fill_in(:password, with: "12345678")
       click_button("Enregistrer")
 
       # Step 4

--- a/spec/features/users/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/user_signs_up_and_signs_in_spec.rb
@@ -18,7 +18,7 @@ feature "User signs up and signs in" do
         current_email.click_link "Confirmer mon compte"
         expect_flash_info(I18n.t("devise.confirmations.confirmed"))
         expect(page).to have_content("Définir mon mot de passe")
-        fill_in :user_password, with: user.password
+        fill_in :password, with: user.password
         click_on "Enregistrer"
         expect_flash_info(I18n.t("devise.passwords.updated")) # auto-connected
         click_link user.first_name


### PR DESCRIPTION
https://trello.com/c/VoV38htD/1092-ajouter-oeil-pour-visualiser-mot-de-passe-sur-la-page-de-reset-password

<img width="1177" alt="Screenshot_2020-09-24_at_15 37 44" src="https://user-images.githubusercontent.com/883348/94152515-f4388a00-fe7b-11ea-8dde-8da63723d872.png">
