### PR TITLE
UI improvements in user_registration layout

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,5 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  layout "user_registration"
+  layout :user_devise_layout
 
   def create
     return invite_and_redirect if User.find_by(email: sign_up_params[:email], confirmed_at: nil)
@@ -27,7 +27,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def user_devise_layout
-    user_signed_in? ? "application" : "registration"
+    user_signed_in? ? "application" : "user_registration"
   end
 
   def after_inactive_sign_up_path_for(resource)

--- a/app/views/layouts/user_registration.html.slim
+++ b/app/views/layouts/user_registration.html.slim
@@ -6,16 +6,15 @@ html lang="fr"
     = render 'layouts/degraded_service', message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
     .bg-primary
       = render 'common/header'
-
-      .container
-        = render 'layouts/flash'
-        - if content_for :title
-          .row
-            .col-md-12.d-flex.justify-content-between.align-items-center
-              .my-4= yield :title
       = yield :header
     .container
-      = yield
+      .row
+        .col-md-12
+          = render 'layouts/flash'
+        .col-md-6.m-auto.pt-3
+          - if content_for :title
+            h1.mb-3= yield :title
+          = yield
 
     #modal-holder
     = render 'common/footer'

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -1,23 +1,19 @@
-- content_for :title
-  h1 Définir mon mot de passe
+- content_for :title, "Définir mon mot de passe"
 
-.container.mt-3
-  .card
-    .card-body
+.card
+  .card-body
+    - if @from_confirmation
+      p.text-muted Pour finaliser votre inscription, veuillez définir un mot de passe.
 
-      - if @from_confirmation
-        p.text-muted Pour finaliser votre inscription, veuillez définir un mot de passe.
+    = simple_form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put } do |f|
+      = devise_error_messages!
+      = f.input :reset_password_token, as: :hidden
+      .form-group
+        = f.password_field :password, as: :password, label: 'Mot de passe', class: 'form-control', autocomplete: "off", required: true, id: "password"
+        span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
 
-      = simple_form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put } do |f|
-        = devise_error_messages!
-        = f.input :reset_password_token, as: :hidden
-        .form-group
-          = f.password_field :password, as: :password, label: 'Mot de passe', class: 'form-control', autocomplete: "off", required: true, id: "password"
-          span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
-
-        - if @minimum_password_length
-          .form-text.text-muted.mb-2
-            | #{@minimum_password_length} caractères minimum
-        .text-center
-          = f.submit 'Enregistrer', class: 'btn btn btn-primary'
-
+      - if @minimum_password_length
+        .form-text.text-muted.mb-2
+          | #{@minimum_password_length} caractères minimum
+      .text-center
+        = f.submit 'Enregistrer', class: 'btn btn btn-primary'

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,26 +1,23 @@
-- content_for :title
-  h1 Mot de passe oublié ?
+- content_for :title, "Mot de passe oublié ?"
 
-.container.mt-3
-  .card
-    .card-body
-      = form_for resource, as: resource_name, url: password_path(resource_name) do |f|
-        .text-center.w-75.m-auto
-        = devise_error_messages!
-        .form-group
-          = f.email_field :email, autofocus: true, required: true, placeholder: "nom.prenom@email.com", class: 'form-control'
-        .form-group.mb-0.text-center
-          = f.submit 'Envoyer', class: 'btn btn btn-primary'
+.card
+  .card-body
+    = form_for resource, as: resource_name, url: password_path(resource_name) do |f|
+      .text-center.w-75.m-auto
+      = devise_error_messages!
+      .form-group
+        = f.email_field :email, autofocus: true, required: true, placeholder: "nom.prenom@email.com", class: 'form-control'
+      .form-group.mb-0.text-center
+        = f.submit 'Envoyer', class: 'btn btn btn-primary'
 
-      hr
-      .text-center
-        p.text-muted
-          | Vous avez un compte ?&nbsp;
-          = link_to new_session_path(resource_name) do
-            b Se connecter
+    hr
+    .text-center
+      p.text-muted
+        | Vous avez un compte ?&nbsp;
+        = link_to new_session_path(resource_name) do
+          b Se connecter
 
-        p.text-muted
-          | Vous n'avez pas de compte ?&nbsp;
-          = link_to new_registration_path(resource_name) do
-            b Je m'inscris
-
+      p.text-muted
+        | Vous n'avez pas de compte ?&nbsp;
+        = link_to new_registration_path(resource_name) do
+          b Je m'inscris

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -1,13 +1,12 @@
 .row.justify-content-md-center
   .col-md-6
+    h1.text-dark.my-3 Votre compte
     .card.mt-3
       .card-body
-        h4.card-title.mb-4  Votre compte
-
         = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put, data: {rightbar: true} }) do |f|
           = devise_error_messages!
           = f.input :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: 'nom.prenom@email.com'
-          - if devise_mapping.confirmable? && resource.pending_reconfirmation? 
+          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
             .form-text.text-muted.mb-2
               | En attente de confirmation pour #{resource.unconfirmed_email}
           = f.input :password, placeholder: 'Votre mot de passe (au moins 6 caractères)'
@@ -19,8 +18,5 @@
           .text-right= f.submit "Modifier", class: 'btn btn-primary'
           .mt-5.text-center
             hr
-            p.font-13 Vous souhaitez supprimer votre compte ? 
+            p.font-13 Vous souhaitez supprimer votre compte ?
             = link_to 'Supprimer', user_registration_path, data:{confirm: "Êtes-vous sûr de vouloir supprimer votre compte ?"}, method: :delete, class: 'btn btn-outline-danger btn-sm'
-
-
-

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,32 +1,28 @@
-- content_for :title
-  h1 Inscription
+- content_for :title, "Inscription"
 
+.card
+  .card-body
+    = simple_form_for resource, as: :user, url: registration_path(resource_name) do |f|
+      = devise_error_messages!
+      - if resource.errors[:email]&.include?(I18n.t('errors.messages.taken'))
+        .mb-3= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email)
+      .form-row
+        .col-6= f.input :first_name, label: t('activerecord.attributes.user.first_name'), required: true
+        .col-6= f.input :last_name, label: t('activerecord.attributes.user.last_name'), required: true
+      = f.input :email, as: :email, placeholder: 'nom.prenom@email.com', required: true, label: t('activerecord.attributes.user.email')
+      = f.input :phone_number, as: :tel, placeholder: '061010101010', hint: 'Vous recevrez les rappels et les informations du RDV sur ce numéro.', label: t('activerecord.attributes.user.phone_number')
 
-.container.mt-3
-  .card
-    .card-body
-      = simple_form_for resource, as: :user, url: registration_path(resource_name) do |f|
-        = devise_error_messages!
-        - if resource.errors[:email]&.include?(I18n.t('errors.messages.taken'))
-          .mb-3= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email)
-        .form-row
-          .col-6= f.input :first_name, label: t('activerecord.attributes.user.first_name'), required: true
-          .col-6= f.input :last_name, label: t('activerecord.attributes.user.last_name'), required: true
-        = f.input :email, as: :email, placeholder: 'nom.prenom@email.com', required: true, label: t('activerecord.attributes.user.email')
-        = f.input :phone_number, as: :tel, placeholder: '061010101010', hint: 'Vous recevrez les rappels et les informations du RDV sur ce numéro.', label: t('activerecord.attributes.user.phone_number')
+      .form-group
+        small
+        | En vous inscrivant, vous acceptez les
+        = link_to 'conditions générales d\'utilisation', cgv_path
 
-        .form-group
-          small
-          | En vous inscrivant, vous acceptez les
-          = link_to 'conditions générales d\'utilisation', cgv_path
+      .form-group.mb-0.text-center
+        = f.button :submit, 'Je m\'inscris'
 
-        .form-group.mb-0.text-center
-          = f.button :submit, 'Je m\'inscris'
-
-      hr
-      .text-center
-        p.text-muted
-          | Vous avez un compte ?&nbsp;
-          = link_to new_session_path(resource_name) do
-            b Se connecter
-
+    hr
+    .text-center
+      p.text-muted
+        | Vous avez un compte ?&nbsp;
+        = link_to new_session_path(resource_name) do
+          b Se connecter

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -14,7 +14,7 @@
 
       .form-group
         small
-        | En vous inscrivant, vous acceptez les
+        span> En vous inscrivant, vous acceptez les
         = link_to 'conditions générales d\'utilisation', cgv_path
 
       .form-group.mb-0.text-center

--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -1,4 +1,4 @@
-.card.mt-3
+.card
   .card-body
     p Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé
     .text-center

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -1,15 +1,12 @@
-- content_for :title do
-  h1 Connexion
+- content_for :title, "Connexion"
 
-.container.mt-3
-  .card
-    .card-body
-      = render "common/session_form", resource: resource, resource_name: resource_name
+.card
+  .card-body
+    = render "common/session_form", resource: resource, resource_name: resource_name
 
-      hr
-      .text-center
-        p.text-muted
-          | Vous n'avez pas de compte ?&nbsp;
-          = link_to new_registration_path(resource_name) do
-            b Je m'inscris
-
+    hr
+    .text-center
+      p.text-muted
+        | Vous n'avez pas de compte ?&nbsp;
+        = link_to new_registration_path(resource_name) do
+          b Je m'inscris

--- a/app/webpacker/stylesheets/structure/_general.scss
+++ b/app/webpacker/stylesheets/structure/_general.scss
@@ -7,3 +7,7 @@ body {
   padding-bottom: 60px;
   overflow-x: hidden;
 }
+
+body.user h1 {
+  color: black;
+}


### PR DESCRIPTION
https://trello.com/c/l3DQkHUm/1112-am%C3%A9liorations-ui-dans-nouveau-layout-userregistration

## Modifs 

harmonisation avec le tunnel de prise de RDV : 

- titre et flash descendus du header (fond bleu) dans le corps (fond blanc)
- colonne md-6 réduite et centrée plutôt que largeur complète car le contenu est court 

Correction : 

- sur la page editer les infos de mon compte (`user_registrations#edit`)  il ne faut pas utiliser le nouveau layout `user_registration` mais plutot le layout normal `application` qui affiche l'info de connexion de l'usager dans le header.

## Screenshots Avant / Après 

<img width="1440" alt="Screenshot_2020-10-05_at_09 08 19" src="https://user-images.githubusercontent.com/883348/95050755-64e96d00-06ec-11eb-8fa3-d85de0cf6594.png">
<img width="1440" alt="Screenshot_2020-10-05_at_09 08 32" src="https://user-images.githubusercontent.com/883348/95050761-69158a80-06ec-11eb-912d-32238df69558.png">
<img width="1440" alt="Screenshot_2020-10-05_at_09 08 43" src="https://user-images.githubusercontent.com/883348/95050763-69ae2100-06ec-11eb-91b8-7b6ec96ff6e6.png">
<img width="1440" alt="Screenshot_2020-10-05_at_09 11 50" src="https://user-images.githubusercontent.com/883348/95050768-6adf4e00-06ec-11eb-8732-6b0219fa05d8.png">
<img width="1440" alt="Screenshot_2020-10-05_at_09 12 08" src="https://user-images.githubusercontent.com/883348/95050776-6c107b00-06ec-11eb-9d80-2337a188b0c9.png">
<img width="1440" alt="Screenshot_2020-10-05_at_09 17 35" src="https://user-images.githubusercontent.com/883348/95050779-6ca91180-06ec-11eb-9f7d-a03329730acc.png">
<img width="1437" alt="Screenshot_2020-10-05_at_09 19 55" src="https://user-images.githubusercontent.com/883348/95050785-6dda3e80-06ec-11eb-99e1-f4acb5f6952d.png">






