### PR TITLE
Reorganisation du menu Usager

### DIFF
--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -4,7 +4,7 @@
   | Vos usagers
 
 - content_for :breadcrumb do
-  = link_to 'Fusionner des fiches', new_admin_organisation_merge_users_path(current_organisation), class: "btn btn-outline-white mr-2"
+  = link_to 'Fusionner deux usagers', new_admin_organisation_merge_users_path(current_organisation), class: "btn btn-outline-white mr-2"
   = link_to 'Créer un usager', new_admin_organisation_user_path(current_organisation), class: "btn btn-outline-white"
 
 .card

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -4,6 +4,7 @@
   | Vos usagers
 
 - content_for :breadcrumb do
+  = link_to 'Fusionner des fiches', new_admin_organisation_merge_users_path(current_organisation), class: "btn btn-outline-white mr-2"
   = link_to 'Créer un usager', new_admin_organisation_user_path(current_organisation), class: "btn btn-outline-white"
 
 .card

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -61,7 +61,7 @@
               id: "menu-users" \
               ) do
                 i.fa.fa-user
-                span Vos usagers
+                span Usagers
         li.side-nav-item
           = link_to( \
             admin_organisation_agent_stats_path(current_organisation, current_agent), \

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -55,19 +55,13 @@
                 id: "menu-absences"
 
         li.side-nav-item
-          = link_to '#', class: 'side-nav-link' do
-            i.fa.fa-user
-            span Vos usagers
-            i.fa.fa-angle-right.menu-arrow.mt-1
-          ul.side-nav-second-level aria-expanded="false"
-            li
-              = link_to "Usagers", \
-                admin_organisation_users_path(current_organisation), \
-                id: "menu-users"
-            li
-              = link_to "Fusionner", \
-                new_admin_organisation_merge_users_path(current_organisation), \
-                id: "menu-merge-users"
+          = link_to( \
+              admin_organisation_users_path(current_organisation), \
+              class: 'side-nav-link', \
+              id: "menu-users" \
+              ) do
+                i.fa.fa-user
+                span Vos usagers
         li.side-nav-item
           = link_to( \
             admin_organisation_agent_stats_path(current_organisation, current_agent), \

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -6,7 +6,6 @@ describe "can see users' RDV" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
   end
 

--- a/spec/features/agents/relatives/agent_can_create_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_create_relative_spec.rb
@@ -8,7 +8,6 @@ describe "Agent can create a relative" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
     click_link "Fiona LEGENDE"
   end

--- a/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
@@ -11,7 +11,6 @@ describe "Agent can delete a relative" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
     click_link "Mimi LEGENDE"
   end

--- a/spec/features/agents/relatives/agent_can_update_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_update_relative_spec.rb
@@ -12,7 +12,6 @@ describe "Agent can update a relative" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
     click_link "Mimi LEGENDE"
     click_link "Modifier"

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -8,7 +8,6 @@ describe "Agent can create user" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
     click_link "Créer un usager", match: :first
     expect_page_title("Nouvel usager")

--- a/spec/features/agents/users/agent_can_delete_user_spec.rb
+++ b/spec/features/agents/users/agent_can_delete_user_spec.rb
@@ -6,7 +6,6 @@ describe "Agent can delete user" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
     click_link "Lala LAND"
   end

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -28,7 +28,7 @@ describe "Agent can delete user" do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
     click_link "Usagers"
-    click_link "Fusionner des fiches"
+    click_link "Fusionner deux usagers"
     find("#select2-user1_id-container").click
     find(".select2-results__option") { _1.text == "Aalyah SWAN" }.click
     find("#select2-user2_id-container").click

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -27,8 +27,8 @@ describe "Agent can delete user" do
   scenario "normal", js: true do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
-    click_link "Fusionner"
+    click_link "Usagers"
+    click_link "Fusionner des fiches"
     find("#select2-user1_id-container").click
     find(".select2-results__option") { _1.text == "Aalyah SWAN" }.click
     find("#select2-user2_id-container").click

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -8,7 +8,6 @@ describe "Agent can update user" do
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Vos usagers"
     click_link "Usagers"
     expect_page_title("Vos usagers")
     click_link "Jean LEGENDE"


### PR DESCRIPTION
https://trello.com/c/jpQlZ7pV/1106-modifier-menu-usager

Pour simplifier la navigation dans l'application, nous avons déplacé l'entrée de menu « fusionner des fiches usagers » dans la page qui liste les usagers.

Ça nous permet de placer l'accès aux usagers en un click dans le menu de gauche.
