### PR TITLE
Ensure HTTP errors in web hook logic are reported

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -1,11 +1,14 @@
+class OutgoingWebhookError < StandardError; end
+
 class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
   def perform(payload, webhook_endpoint_id)
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 
-    Typhoeus.post(
+    request = Typhoeus::Request.new(
       webhook_endpoint.target_url,
+      method: :post,
       headers: {
         "Content-Type" => "application/json; charset=utf-8",
         "X-Lapin-Signature" => OpenSSL::HMAC.hexdigest("SHA256", webhook_endpoint.secret, payload),
@@ -13,5 +16,11 @@ class WebhookJob < ApplicationJob
       body: payload,
       timeout: TIMEOUT
     )
+
+    request.on_complete do |response|
+      raise OutgoingWebhookError, "Webhook failed with status code #{response.code} and body #{response.body[0...1000]}" unless response.success?
+    end
+
+    request.run
   end
 end


### PR DESCRIPTION
- Lien vers Trello Sentry
https://trello.com/c/sgoKsOHT/1119-remonter-les-erreurs-en-cas-de-probl%C3%A8mes-dans-les-notifications
- Des requêtes en direction du SI du Pas de Calais sont en échec. Aujourd'hui nous n'avons pas de visibilité là dessus. Avec ce dev, les notifications ayant échouées, ie celle dont la requête HTTP ne retournant pas un statut sans erreur, seront en erreur dans les _delayed_jobs_ avec la réponse HTTP reçue pour faciliter la résolution du problème.

Dans le cas du Pas de Calais, les requêtes en erreur renvoyaient précédemment un code 200 (ie pas d'erreur). Aujourd'hui, nous recevons une 403 mais celui est pour le moment ignoré.
  
Je suis preneur de [reformulation de l'erreur remontée](https://github.com/betagouv/rdv-solidarites.fr/compare/feature/clean-webhook-failure?expand=1#diff-c78664700e440ef77afd7f389fe993d8R19).

- checklist avant review: 
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [ ] Attendre que les tests soient verts sur la CI
