### PR TITLE
Ensure HTTP errors in web hook logic are reported 

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -1,11 +1,14 @@
+class OutgoingWebhookError < StandardError; end
+
 class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
   def perform(payload, webhook_endpoint_id)
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 
-    Typhoeus.post(
+    request = Typhoeus::Request.new(
       webhook_endpoint.target_url,
+      method: :post,
       headers: {
         "Content-Type" => "application/json; charset=utf-8",
         "X-Lapin-Signature" => OpenSSL::HMAC.hexdigest("SHA256", webhook_endpoint.secret, payload),
@@ -13,5 +16,11 @@ class WebhookJob < ApplicationJob
       body: payload,
       timeout: TIMEOUT
     )
+
+    request.on_complete do |response|
+      raise OutgoingWebhookError, "Webhook failed with status code #{response.code} and body #{response.body[0...1000]}" unless response.success?
+    end
+
+    request.run
   end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -18,7 +18,7 @@ class WebhookJob < ApplicationJob
     )
 
     request.on_complete do |response|
-      raise OutgoingWebhookError, "Webhook failed with status code #{response.code} and body #{response.body[0...1000]}" unless response.success?
+      raise OutgoingWebhookError, "Webhook failed with status code #{response.code} and body #{response.body.force_encoding('UTF-8')[0...1000]}" unless response.success?
     end
 
     request.run


### PR DESCRIPTION
followup to #913 @guillett 

we need to fix sentry integration weird encoding pb


Bogus response payload:
> OutgoingWebhookError (Webhook failed with status code 500 and body {"Signature":true,"Erreur":"Une exception a été levée par l'initialiseur de type pour 'Cd62.Fwk.Fondamentaux.Ldap.Dal.ActiveDirectory.Impl.Helpers'."})