### PR TITLE
Supprime le symbole Copyright de notre application

### DIFF
--- a/app/views/common/_footer.html.slim
+++ b/app/views/common/_footer.html.slim
@@ -3,7 +3,7 @@
     .container-fluid
       .row
         .col-md-6
-          | © RDV Solidarités #{Time.zone.today.year}
+          | RDV Solidarités #{Time.zone.today.year}
         .col-md-6
           .text-md-right.footer-links.d-none.d-md-block
             = link_to 'Mentions légales', mentions_legales_path
@@ -23,4 +23,4 @@
             li.list-inline-item.mr-5= link_to "Espace professionel", accueil_mds_path
             li.list-inline-item.mr-5= link_to "Les solidarités dans votre département", mds_path
             li.list-inline-item.mr-5= link_to "Mentions Légales", mentions_legales_path
-            li.list-inline-item RDV Solidarités © #{Time.zone.today.year}
+            li.list-inline-item RDV Solidarités #{Time.zone.today.year}

--- a/app/views/common/_footer.html.slim
+++ b/app/views/common/_footer.html.slim
@@ -2,9 +2,7 @@
   footer.footer
     .container-fluid
       .row
-        .col-md-6
-          | RDV Solidarités #{Time.zone.today.year}
-        .col-md-6
+        .col-md-12
           .text-md-right.footer-links.d-none.d-md-block
             = link_to 'Mentions légales', mentions_legales_path
             = mail_to "contact@rdv-solidarites.fr", 'Contact'
@@ -23,4 +21,3 @@
             li.list-inline-item.mr-5= link_to "Espace professionel", accueil_mds_path
             li.list-inline-item.mr-5= link_to "Les solidarités dans votre département", mds_path
             li.list-inline-item.mr-5= link_to "Mentions Légales", mentions_legales_path
-            li.list-inline-item RDV Solidarités #{Time.zone.today.year}

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -23,5 +23,5 @@ html
               table width="100%"
                 tr
                   td.aligncenter.content-block
-                    = "© RDV Solidarités #{Time.zone.today.year} | "
+                    = "RDV Solidarités #{Time.zone.today.year} | "
                     = link_to 'Mentions légales', mentions_legales_url

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -23,5 +23,4 @@ html
               table width="100%"
                 tr
                   td.aligncenter.content-block
-                    = "RDV Solidarités #{Time.zone.today.year} | "
                     = link_to 'Mentions légales', mentions_legales_url

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -59,4 +59,4 @@ html lang="fr"
                 .mt-3.text-center
                   = yield :footer
           footer.footer.footer-alt
-            | © RDV Solidarités #{Time.zone.today.year}
+            | RDV Solidarités #{Time.zone.today.year}

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -58,5 +58,3 @@ html lang="fr"
                 - if content_for :footer
                 .mt-3.text-center
                   = yield :footer
-          footer.footer.footer-alt
-            | RDV Solidarités #{Time.zone.today.year}


### PR DESCRIPTION
C'est quelque chose par défaut dans un projet RoR je crois. Cela n'a pas de sens dans notre contexte.

https://trello.com/c/uLf2AKId/1122-supprimer-les-copyrights-de-lapplication