### PR TITLE
in agent_searches, filter on motifs.location_type

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -34,21 +34,14 @@ class PlageOuverture < ApplicationRecord
     time_shift.duration / 60
   end
 
-  def self.for_motif_and_lieu_from_date_range(motif_name, lieu, inclusive_date_range, agent_ids = nil)
-    motifs_ids = Motif.where(name: motif_name, organisation_id: lieu.organisation_id)
-    results = PlageOuverture
+  def self.for_motif_and_lieu_from_date_range(motif_name, lieu, inclusive_date_range)
+    PlageOuverture
       .includes(:motifs_plageouvertures)
       .where(lieu: lieu)
       .where("plage_ouvertures.first_day <= ?", inclusive_date_range.end)
       .joins(:motifs)
-      .where(motifs: { id: motifs_ids })
+      .where(motifs: { name: motif_name, organisation_id: lieu.organisation_id })
       .includes(:motifs, agent: :absences)
-
-    if agent_ids.present?
-      results = results.where(agent_id: agent_ids)
-    end
-
-    results.uniq
   end
 
   def expired?

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -7,6 +7,7 @@ class CreneauxBuilderService < BaseService
     @for_agents = options.fetch(:for_agents, false)
     @agent_ids = options.fetch(:agent_ids, nil)
     @agent_name = options.fetch(:agent_name, false)
+    @motif_location_type = options.fetch(:motif_location_type, nil)
   end
 
   def perform
@@ -19,7 +20,10 @@ class CreneauxBuilderService < BaseService
   private
 
   def plages_ouvertures
-    @plages_ouvertures ||= PlageOuverture.for_motif_and_lieu_from_date_range(@motif_name, @lieu, @inclusive_date_range, @agent_ids)
+    @plages_ouvertures ||= PlageOuverture
+      .for_motif_and_lieu_from_date_range(@motif_name, @lieu, @inclusive_date_range)
+      .where(({ agent_id: @agent_ids } if @agent_ids.present?))
+      .where(({ motifs: { location_type: @motif_location_type } } if @motif_location_type.present?))
   end
 
   def motifs_for_plage_ouverture(plage_ouverture)

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -17,14 +17,16 @@ class SearchCreneauxForAgentsService < BaseService
         lieu,
         Date.today,
         for_agents: true,
-        agent_ids: @form.agent_ids
+        agent_ids: @form.agent_ids,
+        motif_location_type: @form.motif.location_type
       ),
       creneaux: CreneauxBuilderService.perform_with(
         @form.motif.name,
         lieu,
         @form.date_range,
         for_agents: true,
-        agent_ids: @form.agent_ids
+        agent_ids: @form.agent_ids,
+        motif_location_type: @form.motif.location_type
       )
     )
   end

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -8,7 +8,7 @@ tr
   td
     ul.pl-2
       - plage_ouverture.motifs.each do |motif|
-        li= motif.name
+        li= motif_name_with_location_type_and_badges(motif)
   td
     = plage_ouverture.lieu.name
     br

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -39,9 +39,8 @@ describe PlageOuverture, type: :model do
     let(:agent2) { create(:agent, service: service, organisations: [organisation]) }
     let(:agent3) { create(:agent, service: service, organisations: [organisation]) }
     let!(:plage_ouverture) { create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), organisation: organisation) }
-    let(:agent_ids) { nil }
 
-    subject { PlageOuverture.for_motif_and_lieu_from_date_range(motif.name, lieu, today..six_days_later, agent_ids) }
+    subject { PlageOuverture.for_motif_and_lieu_from_date_range(motif.name, lieu, today..six_days_later) }
 
     it { expect(subject).to contain_exactly(plage_ouverture) }
 
@@ -61,24 +60,6 @@ describe PlageOuverture, type: :model do
       let!(:plage_ouverture) { create(:plage_ouverture, :weekly, motifs: [motif], lieu: lieu, first_day: today + 8.days, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), organisation: organisation) }
 
       it { expect(subject.count).to eq(0) }
-    end
-
-    describe "when agent_ids is passed to filter" do
-      let(:agent_ids) { [agent.id] }
-
-      it { expect(subject).to contain_exactly(plage_ouverture) }
-
-      describe "and plage_ouverture.agent_id is not passed" do
-        let(:agent_ids) { [agent2.id, agent3.id] }
-
-        it { expect(subject.count).to eq(0) }
-      end
-
-      describe "and there is another plage_ouverture" do
-        let!(:plage_ouverture2) { create(:plage_ouverture, :weekly, motifs: [motif], lieu: lieu, first_day: today, agent: create(:agent), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), organisation: organisation) }
-
-        it { expect(subject).to contain_exactly(plage_ouverture) }
-      end
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/rKf95VMz/1121-trouver-un-cr%C3%A9neau-affiche-toutes-les-dispos-dun-m%C3%AAme-motif-par-t%C3%A9l-%C3%A0-domicile-et-sur-place

Le problème vient du fait qu'on utilise le meme service pour la recherche coté usager (seulement sur base du nom du motif) et coté agent (ou le filtre distingue les motifs par types : sur place, a domicile, par tel).

testable sur la review app avec le motif "**Suivi Après Naissance**" : 

- Martine a une plage d'ouverture les lundis pour le motif **Sur place**
- Martine a une plage d'ouverture les mardis pour le motif **Par téléphone**
- Marco a une plage d'ouverture les mercredis pour le motif **Sur place**

<img width="1750" alt="stitched_2020_10_07-14_55_51" src="https://user-images.githubusercontent.com/883348/95333649-572f1580-08ad-11eb-8efa-39f21f9afe2d.png">

https://demo-rdv-solidarites-pr918.osc-secnum-fr1.scalingo.io/admin/organisations/1/agent_searches?service_id=1&motif_id=15&from_date=07%2F10%2F2020&agent_ids%5B%5D=&lieu_ids%5B%5D=&commit=Afficher+les+cr%C3%A9neaux

et coté usager c'est inchangé, tous les créneaux apparaissent :

<img width="1029" alt="Screenshot_2020-10-07_at_14 57 59" src="https://user-images.githubusercontent.com/883348/95333816-92314900-08ad-11eb-8fd2-9d83f6ecd355.png">

https://demo-rdv-solidarites-pr918.osc-secnum-fr1.scalingo.io/lieux/2?date=2020-10-12+09%3A00%3A00+%2B0200&search%5Bcity_code%5D=75056&search%5Bdepartement%5D=75&search%5Blatitude%5D=48.845&search%5Blongitude%5D=2.3752&search%5Bmotif_name%5D=Suivi+apr%C3%A8s+naissance&search%5Bservice%5D=1&search%5Bwhere%5D=Paris%2C+75001%2C+75%2C+Paris%2C+%C3%8Ele-de-France
