### PR TITLE
add duplicate link on admin/rdvs#show to the wizard prefilled

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -28,6 +28,18 @@ module AgentsHelper
     params
   end
 
+  def duplicate_rdv_wizard_path(rdv)
+    new_admin_organisation_rdv_wizard_step_path(
+      step: 1,
+      service_id: rdv.motif.service_id,
+      agent_ids: rdv.agent_ids,
+      user_ids: rdv.user_ids,
+      **rdv.attributes.symbolize_keys.slice(
+        :starts_at, :motif_id, :lieu_id, :organisation_id, :duration_in_min, :context
+      )
+    )
+  end
+
   def display_meta_note(note)
     meta = content_tag(:span, "le #{l(note.created_at.to_date)}", title: l(note.created_at))
     meta += " par #{note.agent.full_name_and_service}"

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -17,8 +17,11 @@
         = simple_form_for(@rdv_wizard, as: :rdv, url: admin_organisation_rdv_wizard_step_path(current_organisation, step: 1)) do |f|
           = f.input_field :starts_at, as: :hidden
           = f.input_field :lieu_id, as: :hidden
-          - @rdv.agents.each do |p|
+          = f.input_field :context, as: :hidden
+          - @rdv.users.each do |p|
             / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
+            = f.hidden_field "user_ids][", value: p.id
+          - @rdv.agents.each do |p|
             = f.hidden_field "agent_ids][", value: p.id
           = f.input :service_id, \
             collection: @services.ordered_by_name, \

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -9,6 +9,9 @@
       - if @rdv.cancelled?
         span.badge.badge-danger
 
+- content_for :breadcrumb do
+  = link_to "Dupliquer…", duplicate_rdv_wizard_path(@rdv), class: "btn btn-outline-white"
+
 .row
   .col-md-6.mb-3
     .card
@@ -84,4 +87,3 @@
       .js-record-versions-body#history.collapse class=(@uncollapsed_section == 'history' ? "show" : "")
         .text-center.py-4
           .spinner.spinner-border
-


### PR DESCRIPTION
https://trello.com/c/3cQqvxLA/422-copier-un-rdv-et-son-contexte

simple lien qui renvoie au wizard avec les valeurs pré remplies via les params get.

Il manquait quelques champs cachés dans la step1 car on n'arrivait jamais a la step1 avec ces params pour l'instant.