### PR TITLE
annule le rdv en changeant de status

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -22,6 +22,9 @@ class Admin::RdvsController < AgentAuthController
   def update
     authorize(@rdv)
     @rdv.updated_at = Time.zone.now
+    # TODO: replace this manual touch. It forces creating a version when an
+    # agent or a user is removed from the RDV. the touch: true option on the
+    # association does not do it for some reason I could not figure out
     @rdv.cancelled_at = nil
     if params[:rdv][:status] == "excused"
       CancelRdvByAgentService.new(@rdv).perform

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -22,26 +22,14 @@ class Admin::RdvsController < AgentAuthController
   def update
     authorize(@rdv)
     @rdv.updated_at = Time.zone.now
-    # TODO: replace this manual touch. It forces creating a version when an
-    # agent or a user is removed from the RDV. the touch: true option on the
-    # association does not do it for some reason I could not figure out
-    if params[:status] == "excused"
+    @rdv.cancelled_at = nil
+    if params[:rdv][:status] == "excused"
       CancelRdvByAgentService.new(@rdv).perform
       flash[:notice] = "Le rendez-vous a été annulé."
     elsif @rdv.update(rdv_params)
       flash[:notice] = "Le rendez-vous a été modifié."
     end
     respond_right_bar_with @rdv, location: request.referer
-  end
-
-  def status
-    # TODO: remove this route and use #update
-    authorize(@rdv)
-    cancelled_at = ["unknown", "waiting", "seen"].include?(status_params[:status]) ? nil : Time.zone.now
-    @rdv.update(status: status_params[:status], cancelled_at: cancelled_at)
-    @rdv.file_attentes.delete_all
-    flash[:notice] = "Le statut du RDV a été modifié"
-    redirect_to admin_organisation_rdv_path(@rdv.organisation, @rdv)
   end
 
   def destroy

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -36,7 +36,7 @@ class Users::RdvsController < UserAuthController
 
   def cancel
     authorize(@rdv)
-    if @rdv.cancel
+    if @rdv.cancel!
       @rdv.file_attentes.destroy_all
       flash[:notice] = "Le RDV a bien été annulé."
     else

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -79,7 +79,7 @@ class Rdv < ApplicationRecord
     cancelled_at.present?
   end
 
-  def cancel
+  def cancel!
     update(cancelled_at: Time.zone.now, status: :excused)
   end
 

--- a/app/services/cancel_rdv_by_agent_service.rb
+++ b/app/services/cancel_rdv_by_agent_service.rb
@@ -4,7 +4,7 @@ class CancelRdvByAgentService
   end
 
   def perform
-    @rdv.update!(status: :excused, cancelled_at: Time.now)
+    @rdv.cancel!
     Notifications::Rdv::RdvCancelledByAgentService.perform_with(@rdv)
   end
 end

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -35,7 +35,7 @@
         .row
           .col
             - if !@rdv.past? && !@rdv.cancelled?
-              = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, status: :excused), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
+              = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, rdv: {status: :excused}), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
               | ou
             = link_to "Supprimer ❌", admin_organisation_rdv_path(@rdv.organisation, @rdv), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,7 +94,6 @@ Rails.application.routes.draw do
         resources :lieux, except: :show
         resources :motifs, except: :show
         resources :rdvs, except: [:index, :new] do
-          patch :status, on: :member
           resources :versions, only: [:index]
         end
         scope module: "organisations" do

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
       end
 
       it "set cancelled_at to nil when change status from cancel to other" do
-        rdv.cancel
+        rdv.cancel!
         put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "waiting" } }
         expect(rdv.reload.cancelled_at).to eq(nil)
         expect(rdv.reload.status).to eq("waiting")

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe Admin::RdvsController, type: :controller do
     before { request.headers["HTTP_REFERER"] = referer_path }
 
     context "with valid params" do
-
       it "updates the requested rdv" do
         lieu = create(:lieu, organisation: organisation)
         put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { lieu_id: lieu.id } }
@@ -88,11 +87,9 @@ RSpec.describe Admin::RdvsController, type: :controller do
         put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { lieu_id: lieu.id } }
         expect(response).to redirect_to(referer_path)
       end
-
     end
 
     context "with invalid params" do
-
       it "returns a success response (i.e. to display the 'edit' template)" do
         new_attributes = { duration_in_min: nil }
         put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
@@ -101,9 +98,9 @@ RSpec.describe Admin::RdvsController, type: :controller do
 
       it "does not change rdv" do
         new_attributes = { duration_in_min: nil }
-        expect {
+        expect do
           put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
-        }.not_to change(rdv, :duration_in_min)
+        end.not_to change(rdv, :duration_in_min)
       end
     end
   end

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -63,43 +63,47 @@ RSpec.describe Admin::RdvsController, type: :controller do
     let(:referer_path) { admin_organisation_agent_path(organisation.id, agent.id) }
     before { request.headers["HTTP_REFERER"] = referer_path }
 
-    subject do
-      put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
-      rdv.reload
-    end
-
     context "with valid params" do
-      let(:lieu) { create(:lieu, organisation: organisation) }
-      let(:new_attributes) do
-        {
-          lieu_id: lieu.id,
-        }
-      end
 
       it "updates the requested rdv" do
-        expect { subject }.to change(rdv, :lieu_id).to(lieu.id)
+        lieu = create(:lieu, organisation: organisation)
+        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { lieu_id: lieu.id } }
+        expect(rdv.reload.lieu).to eq(lieu)
+      end
+
+      it "updates the requested rdv status" do
+        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "waiting" } }
+        expect(rdv.reload.status).to eq("waiting")
+      end
+
+      it "set cancelled_at to nil when change status from cancel to other" do
+        rdv.cancel
+        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "waiting" } }
+        expect(rdv.reload.cancelled_at).to eq(nil)
+        expect(rdv.reload.status).to eq("waiting")
       end
 
       it "redirects to the agenda" do
-        subject
+        lieu = create(:lieu, organisation: organisation)
+        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { lieu_id: lieu.id } }
         expect(response).to redirect_to(referer_path)
       end
+
     end
 
     context "with invalid params" do
-      let(:new_attributes) do
-        {
-          duration_in_min: nil,
-        }
-      end
 
       it "returns a success response (i.e. to display the 'edit' template)" do
-        subject
+        new_attributes = { duration_in_min: nil }
+        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
         expect(response).to be_successful
       end
 
       it "does not change rdv" do
-        expect { subject }.not_to change(rdv, :duration_in_min)
+        new_attributes = { duration_in_min: nil }
+        expect {
+          put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
+        }.not_to change(rdv, :duration_in_min)
       end
     end
   end
@@ -108,22 +112,6 @@ RSpec.describe Admin::RdvsController, type: :controller do
     it "returns a success response" do
       get :show, params: { organisation_id: organisation.id, id: rdv.id }
       expect(response).to be_successful
-    end
-  end
-
-  describe "POST #status" do
-    subject do
-      post :status, params: { organisation_id: organisation.id, id: rdv.id, rdv: { status: "waiting" }, format: "js" }
-      rdv.reload
-    end
-
-    it "returns a success response" do
-      subject
-      expect(response).to redirect_to(admin_organisation_rdv_path(rdv.organisation, rdv))
-    end
-
-    it "changes status" do
-      expect { subject }.to change(rdv, :status).from("unknown").to("waiting")
     end
   end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -36,11 +36,11 @@ describe Rdv, type: :model do
     end
   end
 
-  describe "#cancel" do
+  describe "#cancel!" do
     let(:rdv) { create(:rdv) }
     let(:now) { Time.current }
 
-    subject { rdv.cancel }
+    subject { rdv.cancel! }
 
     before { freeze_time }
     after { travel_back }


### PR DESCRIPTION
https://trello.com/c/IvGqFbiQ/1118-lib%C3%A9rer-le-cr%C3%A9neau-quand-on-passe-au-statut-absent-excus%C3%A9-sans-annuler

Le changement de status pour une « absence excusée » ne faisait pas le boulot nécessaire d'annulation... Cette PR vise à faire ce qu'il faut.