### PR TITLE
Agent level Sector Attributions : Migration + Admin UI + Search

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -31,7 +31,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       from_date: params[:from_date],
       user_ids: params[:user_ids].presence || [],
       context: params[:context].presence,
-      agent_ids: params[:agent_ids]&.reject(&:blank?) || [],
+      agent_ids: params[:agent_ids]&.reject(&:blank?)&.presence,
       lieu_ids: params[:lieu_ids]&.reject(&:blank?) || []
     )
   end

--- a/app/controllers/admin/departements/sector_attributions_controller.rb
+++ b/app/controllers/admin/departements/sector_attributions_controller.rb
@@ -1,13 +1,20 @@
 class Admin::Departements::SectorAttributionsController < AgentDepartementAuthController
   before_action :set_sector
 
+  def new
+    @sector_attribution = SectorAttribution.new(**sector_attribution_params_get, sector: @sector)
+    prepare_available_organisations_and_agents
+    authorize(@sector_attribution)
+  end
+
   def create
     @sector_attribution = SectorAttribution.new(**sector_attribution_params, sector: @sector)
     authorize(@sector_attribution)
     if @sector_attribution.save
-      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { success: "Attribution créée" }
+      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { success: "Attribution ajoutée" }
     else
-      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { error: "Erreur lors de la création de l'attribution: #{@sector_attribution.errors.full_messages.join(', ')}" }
+      prepare_available_organisations_and_agents
+      render :new
     end
   end
 
@@ -15,19 +22,46 @@ class Admin::Departements::SectorAttributionsController < AgentDepartementAuthCo
     sector_attribution = SectorAttribution.find(params[:id])
     authorize(sector_attribution)
     if sector_attribution.destroy
-      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { success: "Attribution supprimée" }
+      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { success: "Attribution retirée" }
     else
-      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { error: "Erreur lors de la suppression" }
+      redirect_to admin_departement_sector_path(current_departement, @sector), flash: { error: "Erreur lors du retrait de l'attribution" }
     end
   end
 
   private
+
+  def prepare_available_organisations_and_agents
+    @available_organisations = policy_scope(Organisation)
+      .where(departement: current_departement.number)
+      .where.not(id: excluded_organisation_ids)
+    return if @sector_attribution.level_organisation? || @sector_attribution.organisation.blank?
+
+    existing_agent_attributions = @sector
+      .attributions
+      .level_agent
+      .where(organisation: @sector_attribution.organisation)
+    @available_agents = policy_scope(Agent)
+      .within_organisation(@sector_attribution.organisation)
+      .where.not(id: existing_agent_attributions.pluck(:agent_id))
+  end
+
+  def excluded_organisation_ids
+    if @sector_attribution.level_organisation?
+      @sector.attributions
+    elsif @sector_attribution.level_agent?
+      @sector.attributions.level_organisation
+    end&.pluck(:organisation_id)
+  end
 
   def set_sector
     @sector = policy_scope(Sector).find(params[:sector_id])
   end
 
   def sector_attribution_params
-    params.require(:sector_attribution).permit(:level, :organisation_id)
+    params.require(:sector_attribution).permit(:level, :organisation_id, :agent_id)
+  end
+
+  def sector_attribution_params_get
+    params.permit(:level, :organisation_id, :agent_id)
   end
 end

--- a/app/controllers/admin/departements/sectors_controller.rb
+++ b/app/controllers/admin/departements/sectors_controller.rb
@@ -26,7 +26,6 @@ class Admin::Departements::SectorsController < AgentDepartementAuthController
 
   def show
     @sector = Sector.find(params[:id])
-    @new_sector_attribution = SectorAttribution.new(sector: @sector)
     authorize(@sector)
     @zones = @sector.zones.page(params[:page])
   end

--- a/app/controllers/agent_departement_auth_controller.rb
+++ b/app/controllers/agent_departement_auth_controller.rb
@@ -7,6 +7,10 @@ class AgentDepartementAuthController < AgentAuthController
   end
   helper_method :current_departement
 
+  def pundit_user
+    AgentContext.new(current_agent, nil)
+  end
+
   def current_organisation
     # TODO: remove and fix pundit policies for departement-level routes
     current_agent.organisations.where(departement: current_departement.to_s).first

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -59,7 +59,13 @@ class LieuxController < ApplicationController
   end
 
   def creneaux_search_for(lieu, date_range)
-    Users::CreneauxSearch.new(user: current_user, motifs: @matching_motifs, lieu: lieu, date_range: date_range)
+    Users::CreneauxSearch.new(
+      user: current_user,
+      motifs: @matching_motifs,
+      lieu: lieu,
+      date_range: date_range,
+      geo_search: @geo_search
+    )
   end
 
   def search_params

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -1,5 +1,6 @@
 class Users::RdvsController < UserAuthController
   before_action :set_rdv, only: [:cancel]
+  before_action :set_geo_search, only: [:create]
 
   def index
     @rdvs = policy_scope(Rdv).includes(:motif, :rdvs_users, :users)
@@ -14,7 +15,8 @@ class Users::RdvsController < UserAuthController
         user: current_user,
         starts_at: DateTime.parse(rdv_params[:starts_at]),
         motif: motif,
-        lieu: Lieu.find(new_rdv_extra_params[:lieu_id])
+        lieu: Lieu.find(new_rdv_extra_params[:lieu_id]),
+        geo_search: @geo_search
       )
       if @creneau.present?
         @rdv = build_rdv_from_creneau(@creneau)
@@ -48,6 +50,11 @@ class Users::RdvsController < UserAuthController
 
   def set_rdv
     @rdv = policy_scope(Rdv).find(params[:rdv_id])
+  end
+
+  def set_geo_search
+    @geo_search = Users::GeoSearch
+      .new(departement: params[:departement], city_code: params[:city_code])
   end
 
   def build_rdv_from_creneau(creneau)

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -17,11 +17,13 @@ module UserRdvWizard
           .merge(motif: @motif)
           .merge(@attributes.slice(:starts_at, :user_ids, :motif_id))
       )
+      @geo_search = Users::GeoSearch.new(**@attributes.slice(:departement, :city_code))
       @creneau = Users::CreneauSearch.creneau_for(
         user: @user,
         motif: @rdv.motif,
         lieu: Lieu.find(@attributes[:lieu_id]),
-        starts_at: @rdv.starts_at
+        starts_at: @rdv.starts_at,
+        geo_search: @geo_search
       )
     end
 

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -45,11 +45,13 @@ module WelcomeHelper
   end
 
   def sectorisation_hint(geo_search)
-    return nil if !geo_search.departement_sectorisation_enabled? || geo_search.attributed_organisations.empty?
+    return nil if !geo_search.departement_sectorisation_enabled? || geo_search.empty_attributions?
 
     explanations = geo_search.matching_zones.map do |zone|
       "#{zone.city_name} → " +
-        zone.sector.attributions.map { _1.organisation.name }.join(", ")
+        zone.sector.attributions.to_a.group_by(&:organisation).map do |organisation, attributions|
+          organisation.name + (attributions.all?(&:level_agent?) ? " (certains agents)" : "")
+        end.join(", ")
     end
     content_tag(:div, class: "d-flex") do
       content_tag(:div, "Sectorisation :", class: "mr-1") +

--- a/app/models/sector_attribution.rb
+++ b/app/models/sector_attribution.rb
@@ -1,11 +1,24 @@
 class SectorAttribution < ApplicationRecord
   LEVEL_ORGANISATION = "organisation".freeze
+  LEVEL_AGENT = "agent".freeze
+  LEVELS = [LEVEL_ORGANISATION, LEVEL_AGENT].freeze
 
   belongs_to :organisation
   belongs_to :sector
+  belongs_to :agent, optional: true
 
+  validates :level, inclusion: { in: LEVELS }
   validates :organisation, :sector, :level, presence: true
-  validates :level, inclusion: { in: [LEVEL_ORGANISATION] }
+  validates :agent, presence: true, if: :level_agent?
 
+  scope :level_agent, -> { where(level: LEVEL_AGENT) }
   scope :level_organisation, -> { where(level: LEVEL_ORGANISATION) }
+
+  def level_agent?
+    level == LEVEL_AGENT
+  end
+
+  def level_organisation?
+    level == LEVEL_ORGANISATION
+  end
 end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -21,7 +21,9 @@ class Agent::AgentPolicy < Agent::AdminPolicy
 
   class Scope < Scope
     def resolve
-      if @context.agent.can_access_others_planning?
+      if @context.organisation.nil? && @context.agent.can_access_others_planning?
+        scope.joins(:organisations).where(organisations: { id: @context.agent.organisation_ids })
+      elsif @context.agent.can_access_others_planning?
         scope.joins(:organisations).where(organisations: { id: @context.organisation.id })
       else
         scope.joins(:organisations).where(organisations: { id: @context.organisation.id }, service_id: @context.agent.service_id)

--- a/app/policies/agent/sector_attribution_policy.rb
+++ b/app/policies/agent/sector_attribution_policy.rb
@@ -1,4 +1,8 @@
 class Agent::SectorAttributionPolicy < DefaultAgentPolicy
+  def new?
+    orga_admin?
+  end
+
   def create?
     orga_admin?
   end

--- a/app/service_models/users/creneau_search.rb
+++ b/app/service_models/users/creneau_search.rb
@@ -1,11 +1,12 @@
 class Users::CreneauSearch
   include Users::CreneauxSearchConcern
 
-  def initialize(user:, motif:, lieu:, starts_at:)
+  def initialize(user:, motif:, lieu:, starts_at:, geo_search: nil)
     @user = user
     @motif = motif
     @lieu = lieu
     @starts_at = starts_at
+    @geo_search = geo_search
   end
 
   def creneau

--- a/app/service_models/users/creneaux_search.rb
+++ b/app/service_models/users/creneaux_search.rb
@@ -3,11 +3,12 @@ class Users::CreneauxSearch
 
   attr_reader :motifs, :date_range
 
-  def initialize(user:, motifs:, lieu:, date_range:)
+  def initialize(user:, motifs:, lieu:, date_range:, geo_search: nil)
     @user = user
     @motifs = motifs
     @lieu = lieu
     @date_range = date_range
+    @geo_search = geo_search
   end
 
   protected

--- a/app/service_models/users/geo_search.rb
+++ b/app/service_models/users/geo_search.rb
@@ -17,6 +17,16 @@ class Users::GeoSearch
       end
   end
 
+  def attributed_agents_by_organisation
+    return {} unless departement_sectorisation_enabled?
+
+    @attributed_agents_by_organisation ||= matching_sectors
+      .map { |sector| sector.attributions.level_agent.includes(:agent).to_a }
+      .flatten
+      .group_by(&:organisation)
+      .transform_values { |attributions| attributions.map(&:agent) }
+  end
+
   def matching_zones
     return nil if !departement_sectorisation_enabled? || @city_code.nil?
 
@@ -34,6 +44,41 @@ class Users::GeoSearch
   end
 
   def available_motifs
-    @available_motifs ||= Motif.reservable_online.active.joins(:organisation, :plage_ouvertures).where(organisations: { id: attributed_organisations.pluck(:id) })
+    @available_motifs ||= available_motifs_arels.reduce(:or)
+  end
+
+  def empty_attributions?
+    attributed_organisations.empty? && attributed_agents_by_organisation.empty?
+  end
+
+  private
+
+  def available_motifs_arels
+    [available_motifs_from_attributed_organisations_arel] +
+      available_motifs_from_attributed_agents_arels
+  end
+
+  def available_motifs_from_attributed_organisations_arel
+    @available_motifs_from_attributed_organisations_arel ||= available_motifs_base
+      .where(organisations: { id: attributed_organisations.pluck(:id) })
+  end
+
+  def available_motifs_from_attributed_agents_arels
+    @available_motifs_from_attributed_agents_arels ||= attributed_agents_by_organisation
+      .map do |organisation, agents|
+        agents.map { available_motifs_from_attributed_agent_arel(_1, organisation) }
+      end
+      .flatten(1)
+  end
+
+  def available_motifs_from_attributed_agent_arel(agent, organisation)
+    available_motifs_base.where(
+      organisations: { id: organisation.id },
+      plage_ouvertures: { agent_id: agent.id }
+    )
+  end
+
+  def available_motifs_base
+    Motif.reservable_online.active.joins(:organisation, :plage_ouvertures)
   end
 end

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -22,7 +22,7 @@ class CreneauxBuilderService < BaseService
   def plages_ouvertures
     @plages_ouvertures ||= PlageOuverture
       .for_motif_and_lieu_from_date_range(@motif_name, @lieu, @inclusive_date_range)
-      .where(({ agent_id: @agent_ids } if @agent_ids.present?))
+      .where(({ agent_id: @agent_ids } unless @agent_ids.nil?))
       .where(({ motifs: { location_type: @motif_location_type } } if @motif_location_type.present?))
   end
 

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -43,7 +43,7 @@ class SearchCreneauxForAgentsService < BaseService
       else
         @lieux.for_motif(@form.motif)
       end
-    @lieux = @lieux.where(id: PlageOuverture.where(agent_id: @form.agent_ids).pluck(:lieu_id)) if @form.agent_ids.any?
+    @lieux = @lieux.where(id: PlageOuverture.where(agent_id: @form.agent_ids).pluck(:lieu_id)) if @form.agent_ids.present?
     @lieux = @lieux.ordered_by_name
     @lieux
   end

--- a/app/views/admin/departements/sector_attributions/_form.html.slim
+++ b/app/views/admin/departements/sector_attributions/_form.html.slim
@@ -1,0 +1,56 @@
+= simple_form_for \
+  sector_attribution, \
+  url: admin_departement_sector_attributions_path(current_departement, ), \
+  html: { class: "js-sector-attribution-form" } \
+do |f|
+
+  = f.input_field :level, \
+    label: false, \
+    collection: SectorAttribution::LEVELS, \
+    label_method: -> { "&nbsp;&nbsp;".html_safe + SectorAttribution.human_enum_name(:level, _1) }, \
+    as: :radio_buttons, \
+    wrapper: :vertical_collection_inline
+  .d-flex.align-items-center.mb-3.mt-1.text-muted
+    i.fa.fa-info
+    div.pl-2
+    - if sector_attribution.level_organisation?
+      | Toutes les disponibilités de l'organisation seront proposées aux usagers dans ce ce secteur
+    - elsif sector_attribution.level_agent?
+      | Seules les disponibilités des agents choisis dans l'organisation seront proposées aux usagers dans ce ce secteur
+
+  - if available_organisations.any?
+    = f.input :organisation_id, \
+      collection: available_organisations, \
+      include_blank: true, \
+      required: true, \
+      input_html: { class: "select2-input" }
+  - else
+    = f.input :organisation_id, \
+      collection: [], \
+      required: true, \
+      disabled: true, \
+      input_html: { class: "select2-input" }
+
+  - if sector_attribution.level_agent?
+    = f.input :agent_id, \
+      collection: available_agents || [], \
+      include_blank: true, \
+      required: true, \
+      disabled: available_agents.blank?, \
+      label_method: :full_name_and_service,
+      input_html: { class: "select2-input" }
+
+  = f.submit \
+    value: "Ajouter", \
+    class: "btn btn-primary w-100", \
+    disabled: available_organisations.blank? || (sector_attribution.level_agent? && available_agents.blank?)
+
+  - if available_organisations.blank?
+    .alert.alert-warning.mt-2
+      | Impossible de rajouter une attribution à une organisation entière car les organisations dont vous êtes administrateur sont déjà attribuées à ce Secteur.
+  - elsif sector_attribution.level_agent? && available_agents&.empty?
+    .alert.alert-warning.mt-2
+      - if sector.attributions.level_agent.where(organisation: sector_attribution.organisation).any?
+        | Tous les agents de l'organisation #{sector_attribution.organisation.name} sont déjà attribués à ce secteur.
+      - else
+        | Aucun agent de l'organisation #{sector_attribution.organisation.name} n'est disponible pour être attribué à ce secteur.

--- a/app/views/admin/departements/sector_attributions/new.html.slim
+++ b/app/views/admin/departements/sector_attributions/new.html.slim
@@ -1,0 +1,26 @@
+- content_for(:menu_item) { 'menu-departement-sectors' }
+
+- content_for :title do
+  | Nouvelle attribution pour le secteur #{@sector.name}
+
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to "Secteurs", admin_departement_sectors_path(current_departement)
+    li.breadcrumb-item
+      = link_to truncate(@sector.name, length: 20), admin_departement_sector_path(current_departement, @sector)
+    li.breadcrumb-item.active
+      | Nouvelle attribution
+
+.row.justify-content-center
+  .col-md-6
+    .card[style="position: relative;"]
+      .card-overlay-spinner.js-spinner-overlay.d-none
+        .spinner.spinner-border
+      .card-body
+        = render partial: 'layouts/model_errors', locals: { model: @sector_attribution }
+        = render "form", \
+          sector_attribution: @sector_attribution, \
+          sector: @sector, \
+          available_organisations: @available_organisations, \
+          available_agents: @available_agents

--- a/app/views/admin/departements/sectors/index.html.slim
+++ b/app/views/admin/departements/sectors/index.html.slim
@@ -34,11 +34,18 @@
               td= "#{sector.zones.count} communes"
               td
                 - if sector.attributions.any?
-                  ul
-                    - sector.attributions.each do |attribution|
-                      li= "Organisation #{attribution.organisation.name}"
+                  ul.pl-2.mb-0
+                    - sector.attributions.to_a.group_by(&:organisation).each do |organisation, attributions|
+                      - if attributions.count == 1 && attributions.all?(&:level_organisation?)
+                        li= "Organisation entière #{organisation.name}"
+                      - if attributions.all?(&:level_agent?)
+                        li
+                          = "Agents de l'organisation #{organisation.name}:"
+                          ul.pl-2
+                            - attributions.each do |attribution|
+                              li= attribution.agent.full_name_and_service
                 - else
-                  | Aucune attribution
+                  .text-muted Aucune attribution
               td
                 .d-flex
                   - if policy([:agent, sector]).show?

--- a/app/views/admin/departements/sectors/show.html.slim
+++ b/app/views/admin/departements/sectors/show.html.slim
@@ -120,7 +120,7 @@
           i.fa.fa-plus>
           | Attribuer une organisation ou un agent
       .card-footer
-        .text-muted Lorsqu'un usager cherche une adresse couverte par ce secteur, les disponibilités des organisations et-ou des agents attribués lui seront proposées
+        .text-muted Lorsqu'un usager cherche une adresse couverte par ce secteur, les disponibilités des organisations ou des agents attribués lui seront proposées
 
     .card
       #zones-map.small[

--- a/app/views/admin/departements/sectors/show.html.slim
+++ b/app/views/admin/departements/sectors/show.html.slim
@@ -82,42 +82,45 @@
     .card
       .card-header
         .card-title
-          h5 Organisations attribuées
+          h5 Organisations & Agents attribués
       .card-body
         - if @sector.attributions.any?
-          .mb-3
-            - @sector.attributions.each do |attribution|
-              .d-flex.justify-content-between.mb-1
-                div>= "Organisation #{attribution.organisation.name}"
-                div.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attribution), method: :delete
+          ul.mb-3.pl-2
+            - @sector.attributions.to_a.group_by(&:organisation).each do |organisation, attributions|
+              - if attributions.count == 1 && attributions.first.level_organisation?
+                li
+                  .d-flex.justify-content-between.mb-2
+                    div= "Organisation entière #{organisation.name}"
+                    div.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attributions.first), method: :delete
+              - elsif attributions.all?(&:level_agent?)
+                li.mb-2
+                  div.mb-1= "Agents dans l'organisation #{organisation.name} :"
+                  ul.pl-2
+                    - attributions.each do |attribution|
+                      li
+                        .d-flex.justify-content-between.mb-1
+                          div= attribution.agent.full_name_and_service
+                          div.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attribution), method: :delete
+                    li.mb-3= link_to \
+                      "Attribuer un autre agent de #{organisation.name.truncate(10)}", \
+                      new_admin_departement_sector_attribution_path( \
+                        current_departement, \
+                        @sector, \
+                        level: "agent", \
+                        organisation_id: organisation.id \
+                    )
+
         - else
           .alert.alert-warning.d-flex.align-items-center
             div.mr-2.h4 ⚠️
             div
-              .mb-1 Aucune organisation attribuée
-              div Ce secteur ne renverra aucune disponibilité
-        = link_to ".new-sector-organisation-form-collapse", \
-          class: "btn btn-primary w-100 new-sector-organisation-form-collapse collapse show", \
-          data: { toggle: "collapse" } do
+              .mb-1 Aucune organisation ni agent attribués
+              div Ce secteur ne renvoie pas de disponibilités
+        = link_to new_admin_departement_sector_attribution_path(current_departement, @sector, level: "organisation"), class: "btn btn-primary w-100" do
           i.fa.fa-plus>
-          | Ajouter une organisation
-        .new-sector-organisation-form-collapse.collapse
-          = simple_form_for \
-            @new_sector_attribution, \
-            url: admin_departement_sector_attributions_path(current_departement, @sector) \
-          do |f|
-            = f.input :level, \
-              collection: [SectorAttribution::LEVEL_ORGANISATION], \
-              include_blank: false, \
-              input_html: { class: "select2-input" }
-            = f.input :organisation_id, \
-              collection: policy_scope(Organisation).where.not(id: @sector.attributions.pluck(:organisation_id)).where(departement: current_departement.number), \
-              include_blank: true, \
-              required: true, \
-              input_html: { class: "select2-input" }
-            = f.submit value: "Ajouter", class: "btn btn-primary w-100"
+          | Attribuer une organisation ou un agent
       .card-footer
-        .text-muted Lorsqu'un usager cherche une adresse couverte par ce secteur, les disponibilités des organisations attribuées lui seront proposées
+        .text-muted Lorsqu'un usager cherche une adresse couverte par ce secteur, les disponibilités des organisations et-ou des agents attribués lui seront proposées
 
     .card
       #zones-map.small[

--- a/app/views/admin/departements/setup_checklists/show.slim
+++ b/app/views/admin/departements/setup_checklists/show.slim
@@ -17,9 +17,7 @@
           span.text-muted La possibilité de définir un secteur à l'échelle de rues sera bientôt développée
 
         p.mt-3
-          | Chaque <b>Secteur</b> est attribué à une ou plusieurs <b>Organisations</b>.
-          br
-          span.text-muted Les attributions au niveau d'un <b>Agent</b> seront bientôt développées.
+          | Un <b>Secteur</b> est attribué à une ou plusieurs <b>Organisations</b> entières ou bien à un ou plusieurs <b>Agents</b> spécifiques désignés.
 
         p.mt-3 Seuls les <b>Agents</b> avec le rôle Administrateur peuvent configurer la sectorisation des organisations qu’ils administrent. Néanmoins, ils ont la visibilité sur l’ensemble des <b>Secteurs</b> du Département.
         p.d-flex.justify-content-between.align-items-center
@@ -41,7 +39,7 @@
             span
               .badge.badge-success Activée
             div.ml-1
-              p L’usager est orienté vers l’organisation dont il dépend en fonction de l'adresse saisie lors de sa prise de RDV en ligne
+              p L’usager est orienté vers les organisations ou les agents dont il dépend en fonction de l'adresse saisie lors de sa prise de RDV en ligne
           p Lors de la prise de RDV en ligne, les communes ou adresses non attachées à une organisation ne renvoient à aucun résultat.
           hr
           h5 Désactivation
@@ -60,8 +58,8 @@
           p
             span> Une fois la sectorisation activée :
             ul
-              li L’usager sera orienté vers l’organisation dont il dépend en fonction de l'adresse saisie lors de sa prise de RDV en ligne
-              li Les communes ou adresses non attachées à une organisation ne renverront plus aucun résultat
+              li L’usager sera orienté vers les rganisations ou les agents dont il dépend en fonction de l'adresse saisie lors de sa prise de RDV en ligne
+              li Les communes ou adresses non attachées à une organisation ou un agent ne renverront plus aucun résultat
           p
             span> Pour activer la sectorisation, veuillez nous écrire sur
             a[href='mailto:dev@rdv-solidarites.fr'] dev@rdv-solidarites.fr

--- a/app/views/lieux/index.html.slim
+++ b/app/views/lieux/index.html.slim
@@ -9,7 +9,7 @@
       - if @lieux.empty?
           h3.font-weight-bold Nous n'avons pas trouvé de créneaux pour votre motif.
           p.font-weight-bold Voici les organisations disponibles dans votre département.
-          = render @organisations
+          = render @geo_search.attributed_organisations
       - else
         h3.font-weight-bold Résultats de votre recherche
         p.font-weight-bold= "#{@lieux.size.to_s} lieux sont disponibles"

--- a/app/webpacker/components/sector-attribution-form.js
+++ b/app/webpacker/components/sector-attribution-form.js
@@ -1,0 +1,38 @@
+class SectorAttributionForm {
+  constructor() {
+    this.formElt = document.querySelector('.js-sector-attribution-form')
+    if (!this.formElt) return
+
+    this.spinnerOverlayElt = document.querySelector(".js-spinner-overlay")
+    this.$organisationSelect = $(this.formElt).find('select[name="sector_attribution[organisation_id]"]')
+
+    this.formElt.
+      querySelectorAll('input[name="sector_attribution[level]"]').
+      forEach(i => i.addEventListener("change", this.onLevelChange))
+    this.$organisationSelect.on("change", this.onOrganisationChange)
+  }
+
+  onLevelChange = (event) =>
+    this.changeGetParamAndRefresh("level", event.currentTarget.value)
+
+  onOrganisationChange = (event) => {
+    if (this.getSelectedLevel() == "agent")
+      this.changeGetParamAndRefresh("organisation_id", this.$organisationSelect.val())
+  }
+
+  changeGetParamAndRefresh = (name, value) => {
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    urlSearchParams.set(name, value)
+    this.displaySpinner()
+    window.location = `${window.location.pathname}?${urlSearchParams}`
+  }
+
+  getSelectedLevel = () =>
+    this.formElt.
+      querySelector('input[name="sector_attribution[level]"]:checked').
+      value
+
+  displaySpinner = () => this.spinnerOverlayElt.classList.remove("d-none")
+}
+
+export { SectorAttributionForm };

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -31,6 +31,7 @@ import { AgentUserForm } from 'components/agent-user-form.js'
 import { RecordVersions } from 'components/record-versions.js'
 import { RecurrenceForm } from 'components/recurrence-form.js'
 import { MergeUsersForm } from 'components/merge-users-form.js'
+import { SectorAttributionForm } from 'components/sector-attribution-form.js'
 import { Select2Inputs } from 'components/select2-inputs';
 import 'components/calendar';
 import 'components/tooltip';
@@ -122,4 +123,6 @@ $(document).on('turbolinks:load', function() {
   new RecurrenceForm();
 
   new MergeUsersForm();
+
+  new SectorAttributionForm();
 });

--- a/app/webpacker/stylesheets/components/_forms.scss
+++ b/app/webpacker/stylesheets/components/_forms.scss
@@ -108,3 +108,14 @@ select.form-control-sm {
     }
   }
 }
+
+.card-overlay-spinner {
+  position: absolute;
+  width: 100%;
+  background: rgba(0,0,0,0.3);
+  height: 100%;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/config/locales/models/sector_attribution.fr.yml
+++ b/config/locales/models/sector_attribution.fr.yml
@@ -7,3 +7,6 @@ fr:
         level: Niveau
         organisation_id: Organisation
         sector_id: Secteur
+        levels:
+          organisation: Organisation entière
+          agent: Agent désigné

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,9 +82,9 @@ Rails.application.routes.draw do
         scope module: "departements" do
           resources :zone_imports, only: [:new, :create]
           resources :sectors do
-            resources :zones, only: [:new, :create, :destroy]
+            resources :zones, except: [:index]
+            resources :sector_attributions, only: [:new, :create, :destroy], as: :attributions
             delete "/zones" => "zones#destroy_multiple"
-            resources :sector_attributions, only: [:create, :destroy], as: :attributions
           end
           resource :setup_checklist, only: [:show]
         end

--- a/db/migrate/20201007134333_add_agent_id_to_sector_attributions.rb
+++ b/db/migrate/20201007134333_add_agent_id_to_sector_attributions.rb
@@ -1,0 +1,5 @@
+class AddAgentIdToSectorAttributions < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :sector_attributions, :agent, null: true, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_094454) do
+ActiveRecord::Schema.define(version: 2020_10_07_134333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -264,6 +264,8 @@ ActiveRecord::Schema.define(version: 2020_10_05_094454) do
     t.bigint "sector_id", null: false
     t.bigint "organisation_id", null: false
     t.string "level", null: false
+    t.bigint "agent_id"
+    t.index ["agent_id"], name: "index_sector_attributions_on_agent_id"
     t.index ["organisation_id"], name: "index_sector_attributions_on_organisation_id"
     t.index ["sector_id"], name: "index_sector_attributions_on_sector_id"
   end
@@ -406,6 +408,7 @@ ActiveRecord::Schema.define(version: 2020_10_05_094454) do
   add_foreign_key "rdvs", "lieux"
   add_foreign_key "rdvs", "motifs"
   add_foreign_key "rdvs", "organisations"
+  add_foreign_key "sector_attributions", "agents"
   add_foreign_key "user_notes", "agents"
   add_foreign_key "user_notes", "organisations"
   add_foreign_key "user_notes", "users"

--- a/spec/controllers/lieux_controller_spec.rb
+++ b/spec/controllers/lieux_controller_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe LieuxController, type: :controller do
           user: nil,
           motifs: [motif],
           lieu: lieu,
-          date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 28))
+          date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 28)),
+          geo_search: mock_geo_search
         ).and_return(mock_creneaux_search)
         subject
       end
@@ -98,7 +99,8 @@ RSpec.describe LieuxController, type: :controller do
             user: user,
             motifs: [motif],
             lieu: lieu,
-            date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 28))
+            date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 28)),
+            geo_search: mock_geo_search
           ).and_return(mock_creneaux_search)
           subject
         end
@@ -162,7 +164,8 @@ RSpec.describe LieuxController, type: :controller do
           user: nil,
           motifs: [motif],
           lieu: lieu,
-          date_range: (Date.new(2019, 7, 15)..Date.new(2019, 7, 22))
+          date_range: (Date.new(2019, 7, 15)..Date.new(2019, 7, 22)),
+          geo_search: mock_geo_search
         )
         .and_return(
           instance_double(
@@ -178,7 +181,8 @@ RSpec.describe LieuxController, type: :controller do
           user: nil,
           motifs: [motif],
           lieu: lieu2,
-          date_range: (Date.new(2019, 7, 15)..Date.new(2019, 7, 22))
+          date_range: (Date.new(2019, 7, 15)..Date.new(2019, 7, 22)),
+          geo_search: mock_geo_search
         )
         .and_return(
           instance_double(

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -7,14 +7,18 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:motif) { create(:motif, organisation: organisation) }
     let(:lieu) { create(:lieu, organisation: organisation) }
     let(:starts_at) { DateTime.parse("2020-10-20 10h30") }
+    let(:mock_geo_search) { instance_double(Users::GeoSearch) }
 
-    subject { post :create, params: { organisation_id: organisation.id, lieu_id: lieu.id, departement: "12", where: "1 rue de la, ville 12345", motif_id: motif.id, starts_at: starts_at } }
+    subject { post :create, params: { organisation_id: organisation.id, lieu_id: lieu.id, departement: "12", city_code: "12100", where: "1 rue de la, ville 12345", motif_id: motif.id, starts_at: starts_at } }
 
     before do
       travel_to(Time.zone.local(2019, 7, 20))
       sign_in user
+      expect(Users::GeoSearch).to receive(:new)
+        .with(departement: "12", city_code: "12100")
+        .and_return(mock_geo_search)
       expect(Users::CreneauSearch).to receive(:creneau_for)
-        .with(user: user, starts_at: starts_at, motif: motif, lieu: lieu)
+        .with(user: user, starts_at: starts_at, motif: motif, lieu: lieu, geo_search: mock_geo_search)
         .and_return(mock_creneau)
       subject
     end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -6,29 +6,36 @@ describe UserRdvWizard do
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: DateTime.parse("2020-10-20 09h30")) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
+  let(:mock_geo_search) { instance_double(Users::GeoSearch) }
 
-  let(:rdv_attributes) do
+  let(:attributes) do
     {
       starts_at: creneau.starts_at,
       motif_id: motif.id,
       lieu_id: lieu.id,
       user_ids: [user_for_rdv.id],
+      departement: "62",
+      city_code: "62100"
     }
   end
   let(:returned_creneau) { Creneau.new }
 
   before do
+    expect(Users::GeoSearch).to receive(:new)
+      .with(departement: "62", city_code: "62100")
+      .and_return(mock_geo_search)
     expect(Users::CreneauSearch).to receive(:creneau_for).with(
       user: user,
       motif: motif,
       lieu: lieu,
-      starts_at: DateTime.parse("2020-10-20 09h30")
+      starts_at: DateTime.parse("2020-10-20 09h30"),
+      geo_search: mock_geo_search
     ).and_return(returned_creneau)
   end
 
   describe "#new" do
     it "should work" do
-      rdv_wizard = UserRdvWizard::Step1.new(user, rdv_attributes)
+      rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
       expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
       expect(rdv_wizard.creneau).to eq returned_creneau
     end

--- a/spec/service_models/users/creneaux_search_spec.rb
+++ b/spec/service_models/users/creneaux_search_spec.rb
@@ -1,61 +1,135 @@
 describe Users::CreneauxSearch, type: :service do
-  describe "#creneaux" do
-    let(:user) { create(:user) }
-    let(:organisation) { create(:organisation) }
-    let(:lieu) { create(:lieu, organisation: organisation) }
-    let(:motif1) { create(:motif, name: "Coucou", organisation: organisation) }
-    let(:motif2) { create(:motif, name: "Coucou", organisation: organisation) }
-    let(:date_range) { (Date.parse("2020-10-20")..Date.parse("2020-10-23")) }
+  let(:user) { create(:user) }
+  let(:organisation) { create(:organisation) }
+  let(:lieu) { create(:lieu, organisation: organisation) }
+  let(:motif1) { create(:motif, name: "Coucou", organisation: organisation) }
+  let(:motif2) { create(:motif, name: "Coucou", organisation: organisation) }
+  let(:date_range) { (Date.parse("2020-10-20")..Date.parse("2020-10-23")) }
 
+  subject do
+    Users::CreneauxSearch
+      .new(user: user, motifs: [motif1, motif2], lieu: lieu, date_range: date_range)
+      .creneaux
+  end
+
+  it "call builder without special options" do
+    expect(CreneauxBuilderService).to receive(:perform_with)
+      .with("Coucou", lieu, date_range)
+    subject
+  end
+
+  context "follow_up motif" do
+    let(:motif) { create(:motif, name: "Coucou", follow_up: true, organisation: organisation) }
     subject do
       Users::CreneauxSearch
-        .new(user: user, motifs: [motif1, motif2], lieu: lieu, date_range: date_range)
+        .new(user: user, motifs: [motif], lieu: lieu, date_range: date_range)
         .creneaux
     end
 
-    it "call builder without special options" do
-      expect(CreneauxBuilderService).to receive(:perform_with)
-        .with("Coucou", lieu, date_range)
-      subject
-    end
+    context "logged in user" do
+      context "with referents" do
+        let!(:agent) { create(:agent, organisations: [organisation]) }
+        let(:user) { create(:user, organisations: [organisation], agents: [agent]) }
 
-    context "follow_up motif" do
-      let(:motif) { create(:motif, name: "Coucou", follow_up: true, organisation: organisation) }
-      subject do
-        Users::CreneauxSearch
-          .new(user: user, motifs: [motif], lieu: lieu, date_range: date_range)
-          .creneaux
+        it "should call builder with agent options" do
+          expect(CreneauxBuilderService).to receive(:perform_with)
+            .with("Coucou", lieu, date_range, agent_ids: [agent.id], agent_name: true)
+          subject
+        end
       end
 
-      context "logged in user" do
-        context "with referents" do
-          let!(:agent) { create(:agent, organisations: [organisation]) }
-          let(:user) { create(:user, organisations: [organisation], agents: [agent]) }
+      context "without referents" do
+        let(:user) { create(:user, agents: []) }
 
-          it "should call builder with agent options" do
+        it "should call builder with agent options" do
+          expect(CreneauxBuilderService).to receive(:perform_with)
+            .with("Coucou", lieu, date_range, agent_ids: [], agent_name: true)
+          subject
+        end
+      end
+    end
+
+    context "offline user" do
+      let(:user) { nil }
+      it "should call builder without agent options" do
+        expect(CreneauxBuilderService).to receive(:perform_with)
+          .with("Coucou", lieu, date_range)
+        subject
+      end
+    end
+  end
+
+  context "with geo search" do
+    let(:mock_geo_search) { instance_double(Users::GeoSearch, attributed_agents_by_organisation: attributed_agents_by_organisation) }
+
+    subject do
+      Users::CreneauxSearch
+        .new(user: user, motifs: [motif1], lieu: lieu, date_range: date_range, geo_search: mock_geo_search)
+        .creneaux
+    end
+
+    context "organisation is not within attributed_agents_by_organisation" do
+      let(:attributed_agents_by_organisation) { {} }
+
+      it "calls builder without agent_ids params" do
+        expect(CreneauxBuilderService).to receive(:perform_with)
+          .with("Coucou", lieu, date_range)
+        subject
+      end
+    end
+
+    context "no attributed agents" do
+      let(:attributed_agents_by_organisation) { { organisation => Agent.none } }
+
+      it "calls builder with empty agent_ids" do
+        expect(CreneauxBuilderService).to receive(:perform_with)
+          .with("Coucou", lieu, date_range, agent_ids: [])
+        subject
+      end
+    end
+
+    context "some attributed agents" do
+      let!(:agent1) { create(:agent, organisations: [organisation]) }
+      let!(:agent2) { create(:agent, organisations: [organisation]) }
+      let(:attributed_agents_by_organisation) { { organisation => Agent.where(id: [agent1.id, agent2.id]) } }
+
+      it "calls builder with these agents ids" do
+        expect(CreneauxBuilderService).to receive(:perform_with)
+          .with("Coucou", lieu, date_range, agent_ids: array_including(agent1.id, agent2.id))
+        subject
+      end
+
+      context "follow_up motif" do
+        let(:motif1) { create(:motif, name: "Coucou", follow_up: true, organisation: organisation) }
+
+        context "user has agent1 as referent" do
+          let(:user) { create(:user, organisations: [organisation], agents: [agent1]) }
+
+          it "should call builder with agent1 id" do
             expect(CreneauxBuilderService).to receive(:perform_with)
-              .with("Coucou", lieu, date_range, agent_ids: [agent.id], agent_name: true)
+              .with("Coucou", lieu, date_range, agent_ids: [agent1.id], agent_name: true)
             subject
           end
         end
 
-        context "without referents" do
-          let(:user) { create(:user, agents: []) }
+        context "user has both agents as referents" do
+          let(:user) { create(:user, organisations: [organisation], agents: [agent1, agent2]) }
 
-          it "should call builder with agent options" do
+          it "should call builder with both agents ids" do
+            expect(CreneauxBuilderService).to receive(:perform_with)
+              .with("Coucou", lieu, date_range, agent_ids: array_including(agent1.id, agent2.id), agent_name: true)
+            subject
+          end
+        end
+
+        context "user has no referent agents" do
+          let(:user) { create(:user, organisations: [organisation], agents: []) }
+
+          it "should call builder with both agents ids" do
             expect(CreneauxBuilderService).to receive(:perform_with)
               .with("Coucou", lieu, date_range, agent_ids: [], agent_name: true)
             subject
           end
-        end
-      end
-
-      context "offline user" do
-        let(:user) { nil }
-        it "should call builder without agent options" do
-          expect(CreneauxBuilderService).to receive(:perform_with)
-            .with("Coucou", lieu, date_range)
-          subject
         end
       end
     end

--- a/spec/services/creneaux_builder_service_spec.rb
+++ b/spec/services/creneaux_builder_service_spec.rb
@@ -225,6 +225,16 @@ describe CreneauxBuilderService, type: :service do
         end
       end
 
+      context "when the result is filtered with an empty agents set" do
+        let(:options) { { agent_ids: [] } }
+        it { should be_empty }
+      end
+
+      context "when the result is filtered with an empty agents set, for agents" do
+        let(:options) { { for_agents: true, agent_ids: [] } }
+        it { should be_empty }
+      end
+
       context "when there is another motif with the same name but a different location_type" do
         let!(:motif_home) { create(:motif, name: "Vaccination", default_duration_in_min: 30, organisation: organisation, location_type: :home) }
         let!(:plage_ouverture_home) { create(:plage_ouverture, motifs: [motif_home], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(14) + 35.minutes, agent: agent, organisation: organisation) }


### PR DESCRIPTION
https://trello.com/c/ah4YO3LK/1109-secto-support-des-r%C3%A8gles-de-niveau-agent

followup to #919 rebased on master

## Migration de la DB

![image](https://user-images.githubusercontent.com/883348/95356769-51462e00-08c7-11eb-9932-86946fefb8ff.png)

## Screencast

Nouvelle Page séparée pour la création d'une `SectorAttribution`

![sect](https://user-images.githubusercontent.com/883348/96478717-4f218f00-1238-11eb-9f5a-9ff98328ccbd.gif)

Ce formulaire est relativement interactif et force la page à se recharger au changement de certains paramètres pour limiter la quantité de JS à écrire. Le but est de donner des indications contextualisées à la personne qui configure le formulaire : pourquoi certaines orgas ou agents ne sont pas disponibles etc.

## Détails techniques

- j'ai refacto et complexifié le service `SectoriseAddressService`. Il est maintenant responsable de renvoyer les motifs et services disponibles en plus des agents et orgas attribuées
- Le code pour trouver les motifs disponibles a la recherche est pas mal complexifié par l'introduction de cette fonctionnalité. Il faut joindre les plages d'ouvertures des agents des orgas entières attribués + des agents individuellement attribués. Je l'ai fait avec des requêtes ActiveRecord (AREL) groupées par des `.or`
- j'ai transformé ce service avec une signature `#perform` unique en un PORO (Plain Old Ruby Object) `Users::GeolocalisedSearch` avec plusieurs methodes publiques `#matching_zones`, `#available_motifs` etc. Je ne trouvais pas de maniere coherente de le faire en Service classique. J'ai mis ce nouvel objet un peu unique dans un repertoire `/app/service_models` , tres tres discutable. 