### PR TITLE
fix filtering available creneaux in user RDV tunnel

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -1,22 +1,19 @@
 class LieuxController < ApplicationController
-  before_action :set_lieu_variables, only: [:index, :show]
+  before_action \
+    :set_lieu_variables,
+    :redirect_if_user_offline_and_motif_follow_up,
+    :redirect_if_no_matching_motifs
 
   def index
-    @lieux = Lieu.with_open_slots_for_motifs(@matching_motifs)
-    return redirect_to new_user_session_path, flash: { alert: I18n.t("motifs.follow_up_need_signed_user", motif_name: @motif_name) } if follow_up_rdv_and_offline_user?
-
-    @next_availability_by_lieux = {}
-    @lieux.each do |lieu|
-      # TODO: au lieux de current_user.agents, il faudrait sans doute filtrer sur les agents du service lie au motif, de la meme organisation
-      @next_availability_by_lieux[lieu.id] = FindAvailabilityService.perform_with(@motif_name, lieu, Date.today, **options_to_build_creneaux)
-    end
-
-    @lieux = @lieux.sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
-
-    return unless @organisations.empty?
-
-    flash.now[:notice] = "La prise de RDV n’est pas encore disponible dans ce département"
-    render "welcome/index"
+    @lieux = Lieu
+      .with_open_slots_for_motifs(@matching_motifs)
+      .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
+    @next_availability_by_lieux = @lieux.map do |lieu|
+      [
+        lieu.id,
+        creneaux_search_for(lieu, (1.week.ago.to_date..Date.today)).next_availability
+      ]
+    end.to_h
   end
 
   def show
@@ -24,18 +21,15 @@ class LieuxController < ApplicationController
     @date_range = start_date..(start_date + 6.days)
     @lieu = Lieu.find(params[:id])
     @query.merge!(lieu_id: @lieu.id)
-
-    # TODO: revoir les contraintes d'unicitees completes (il manque :location_type dans le where) ou bien revoir la notion de motif.
-    return redirect_to new_user_session_path, flash: { notice: I18n.t("motifs.follow_up_need_signed_user", motif_name: @motif_name) } if follow_up_rdv_and_offline_user?
-
     @next_availability = nil
 
-    if follow_up_rdv_without_referent?
+    if follow_up_motif? && current_user && current_user.agents.empty?
       @referent_missing = "Vous ne semblez pas bénéficier d’un accompagnement ou d’un suivi, merci de choisir un autre motif ou de contacter votre département au #{@lieu.organisation.phone_number}".html_safe
       @creneaux = []
     else
-      @creneaux = CreneauxBuilderService.perform_with(@motif_name, @lieu, @date_range, **options_to_build_creneaux)
-      @next_availability = FindAvailabilityService.perform_with(@motif_name, @lieu, @date_range.end, **options_to_build_creneaux) if @creneaux.empty?
+      creneaux_search = creneaux_search_for(@lieu, @date_range)
+      @creneaux = creneaux_search.creneaux
+      @next_availability = creneaux_search.next_availability if @creneaux.empty?
     end
 
     @max_booking_delay = @matching_motifs.maximum("max_booking_delay")
@@ -48,21 +42,24 @@ class LieuxController < ApplicationController
 
   private
 
-  def options_to_build_creneaux
-    @options_to_build_creneaux ||= follow_up_rdv_and_online_user? ? { agent_ids: current_user.agent_ids, agent_name: true } : {}
+  def redirect_if_user_offline_and_motif_follow_up
+    return if !follow_up_motif? || current_user.present?
+
+    redirect_to new_user_session_path, flash: { notice: I18n.t("motifs.follow_up_need_signed_user", motif_name: @motif_name) }
   end
 
-  def follow_up_rdv_without_referent?
-    # TODO: au lieux de current_user.agents, il faudrait sans doute filtrer sur les agents du service lie au motif, de la meme organisation
-    @matching_motifs.first&.follow_up? && current_user && current_user.agents.empty?
+  def redirect_if_no_matching_motifs
+    return if @matching_motifs.any?
+
+    redirect_to root_path, flash: { error: "Une erreur s'est produite, veuillez recommencer votre recherche" }
   end
 
-  def follow_up_rdv_and_online_user?
-    current_user && @matching_motifs.first&.follow_up?
+  def follow_up_motif?
+    @matching_motifs.first&.follow_up?
   end
 
-  def follow_up_rdv_and_offline_user?
-    !current_user && @matching_motifs.first&.follow_up?
+  def creneaux_search_for(lieu, date_range)
+    Users::CreneauxSearch.new(user: current_user, motifs: @matching_motifs, lieu: lieu, date_range: date_range)
   end
 
   def search_params

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -6,7 +6,7 @@ class Users::RdvWizardStepsController < UserAuthController
     @rdv_wizard = rdv_wizard_for(current_user, query_params)
     @rdv = @rdv_wizard.rdv
     authorize(@rdv)
-    if @rdv_wizard.creneau.available?
+    if @rdv_wizard.creneau.present?
       render current_step
     else
       flash[:error] = "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre."

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -17,10 +17,11 @@ module UserRdvWizard
           .merge(motif: @motif)
           .merge(@attributes.slice(:starts_at, :user_ids, :motif_id))
       )
-      @creneau = Creneau.new(
-        lieu_id: @attributes[:lieu_id],
-        starts_at: @rdv.starts_at,
-        motif: @rdv.motif
+      @creneau = Users::CreneauSearch.creneau_for(
+        user: @user,
+        motif: @rdv.motif,
+        lieu: Lieu.find(@attributes[:lieu_id]),
+        starts_at: @rdv.starts_at
       )
     end
 

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -25,6 +25,7 @@ class Lieu < ApplicationRecord
     where(id: lieux_ids)
   }
 
+  # TODO: remove this method in favor of CreneauBuilderService usage
   scope :with_open_slots_for_motifs, lambda { |motifs|
     where(
       id: PlageOuverture

--- a/app/service_models/concerns/users/creneaux_search_concern.rb
+++ b/app/service_models/concerns/users/creneaux_search_concern.rb
@@ -1,0 +1,42 @@
+module Users::CreneauxSearchConcern
+  extend ActiveSupport::Concern
+
+  def next_availability
+    FindAvailabilityService.perform_with(motif_name, @lieu, date_range.end, **options)
+  end
+
+  def creneaux
+    CreneauxBuilderService.perform_with(motif_name, @lieu, date_range, **options)
+  end
+
+  def follow_up_motif?
+    # TODO : repair motifs modelisation to remove this hack
+    motifs.first&.follow_up?
+  end
+
+  protected
+
+  def motif_name
+    @motif_name ||= begin
+      raise unless motifs.pluck(:name).uniq.count == 1 # safety net
+
+      motifs.first.name
+    end
+  end
+
+  def options
+    @options ||= {
+      agent_ids: agent_ids,
+      agent_name: follow_up_rdv_and_online_user? || nil,
+      motif_location_type: motif_location_type
+    }.compact
+  end
+
+  def agent_ids
+    @agent_ids ||= follow_up_rdv_and_online_user? ? @user.agent_ids : nil
+  end
+
+  def follow_up_rdv_and_online_user?
+    @user && follow_up_motif?
+  end
+end

--- a/app/service_models/users/creneau_search.rb
+++ b/app/service_models/users/creneau_search.rb
@@ -1,0 +1,36 @@
+class Users::CreneauSearch
+  include Users::CreneauxSearchConcern
+
+  def initialize(user:, motif:, lieu:, starts_at:)
+    @user = user
+    @motif = motif
+    @lieu = lieu
+    @starts_at = starts_at
+  end
+
+  def creneau
+    creneaux.select { _1.starts_at == @starts_at }.sample
+  end
+
+  def next_availability
+    nil
+  end
+
+  def self.creneau_for(*args, **kwargs)
+    new(*args, **kwargs).creneau # simplifies testing
+  end
+
+  protected
+
+  def motifs
+    [@motif]
+  end
+
+  def motif_location_type
+    @motif.location_type
+  end
+
+  def date_range
+    (@starts_at.to_date..(@starts_at + 1.day).to_date)
+  end
+end

--- a/app/service_models/users/creneaux_search.rb
+++ b/app/service_models/users/creneaux_search.rb
@@ -1,0 +1,18 @@
+class Users::CreneauxSearch
+  include Users::CreneauxSearchConcern
+
+  attr_reader :motifs, :date_range
+
+  def initialize(user:, motifs:, lieu:, date_range:)
+    @user = user
+    @motifs = motifs
+    @lieu = lieu
+    @date_range = date_range
+  end
+
+  protected
+
+  def motif_location_type
+    nil
+  end
+end

--- a/app/services/creneaux_builder_for_date_service.rb
+++ b/app/services/creneaux_builder_for_date_service.rb
@@ -40,7 +40,7 @@ class CreneauxBuilderForDateService < BaseService
       starts_at: @next_starts_at,
       lieu_id: @lieu.id,
       motif: @motif,
-      agent_id: (@plage_ouverture.agent_id if @for_agents),
+      agent_id: @plage_ouverture.agent_id,
       agent_name: (@plage_ouverture.agent.short_name if @for_agents || @agent_name)
     )
   end

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -1,51 +1,42 @@
 describe Users::RdvWizardStepsController, type: :controller do
-  describe "GET new html format" do
+  describe "#new" do
     let!(:organisation) { create(:organisation) }
     let!(:user) { create(:user) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, organisation: organisation) }
-    let!(:creneau) do
-      build(
-        :creneau,
-        motif: motif,
-        starts_at: Date.parse("2020-03-03").in_time_zone + 10.hours
-      )
-    end
+    let(:starts_at) { DateTime.parse("2020-03-03 10h00") }
+    let!(:mock_creneau) { instance_double(::Creneau) }
+    let!(:mock_rdv) { build(:rdv, starts_at: starts_at, users: [user]) } # cannot use instance_double because it breaks pundit inferrence
+    let(:mock_user_rdv_wizard) { instance_double(UserRdvWizard::Step2, creneau: mock_creneau, rdv: mock_rdv) }
 
     before { travel_to Date.parse("2020-03-01").in_time_zone + 8.hours }
 
-    let(:params) do
-      {
-        step: 2,
-        motif_id: motif.id,
-        lieu_id: lieu.id,
-        starts_at: creneau.starts_at,
-      }
-    end
-
-    context "with logged user" do
+    context "logged in user" do
       before { sign_in user }
 
+      before do
+        expect(UserRdvWizard::Step2).to \
+          receive(:new).with(
+            user,
+            hash_including(
+              "motif_id" => motif.id.to_s,
+              "lieu_id" => lieu.id.to_s,
+              "starts_at" => starts_at.to_s
+            )
+          ).and_return(mock_user_rdv_wizard)
+      end
+
       it "return success" do
-        get :new, params: params
+        get :new, params: { step: 2, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at }
         expect(response).to have_http_status(:success)
-      end
-
-      it "assigns RDV with users" do
-        get :new, params: params
         expect(assigns(:rdv).users).to eq([user])
-      end
-
-      it "render template rdv_wizard_steps/step2" do
-        get :new, params: params
         expect(response).to render_template("users/rdv_wizard_steps/step2")
       end
     end
 
     context "without logged user" do
-      it "redirect to new use session path" do
-        get :new, params: params
+      it "redirects to sign_in path" do
+        get :new, params: { step: 2, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at }
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -1,25 +1,36 @@
 describe UserRdvWizard do
+  let!(:organisation) { create(:organisation) }
   let!(:user) { create(:user) }
   let!(:user_for_rdv) { create(:user) }
-  let!(:motif) { create(:motif) }
-  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif) }
-  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif]) }
+  let!(:motif) { create(:motif, organisation: organisation) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: DateTime.parse("2020-10-20 09h30")) }
+  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
 
   let(:rdv_attributes) do
     {
       starts_at: creneau.starts_at,
       motif_id: motif.id,
-      lieu_id: plage_ouverture.lieu.id,
+      lieu_id: lieu.id,
       user_ids: [user_for_rdv.id],
     }
+  end
+  let(:returned_creneau) { Creneau.new }
+
+  before do
+    expect(Users::CreneauSearch).to receive(:creneau_for).with(
+      user: user,
+      motif: motif,
+      lieu: lieu,
+      starts_at: DateTime.parse("2020-10-20 09h30")
+    ).and_return(returned_creneau)
   end
 
   describe "#new" do
     it "should work" do
       rdv_wizard = UserRdvWizard::Step1.new(user, rdv_attributes)
       expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
-      expect(rdv_wizard.creneau.starts_at).to eq creneau.starts_at
-      expect(rdv_wizard.creneau.motif).to eq motif
+      expect(rdv_wizard.creneau).to eq returned_creneau
     end
   end
 end

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -109,45 +109,6 @@ describe Creneau, type: :model do
     end
   end
 
-  describe "#available_plages_ouverture" do
-    let(:creneau) { Creneau.new(starts_at: Time.zone.local(2019, 9, 19, 9, 0), lieu_id: lieu.id, motif: motif) }
-
-    subject { creneau.available_plages_ouverture }
-
-    it { should contain_exactly(plage_ouverture) }
-
-    describe "with an other plage_ouverture for this motif" do
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), organisation: organisation) }
-
-      it { should contain_exactly(plage_ouverture, plage_ouverture2) }
-    end
-
-    describe "with an other plage_ouverture with another motif" do
-      let(:motif2) { build(:motif, name: "Visite 12 mois", default_duration_in_min: 60, reservable_online: reservable_online, organisation: organisation) }
-      let!(:plage_ouverture3) { create(:plage_ouverture, title: "Permanence visite 12 mois", motifs: [motif2], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), organisation: organisation) }
-
-      it { should contain_exactly(plage_ouverture) }
-    end
-
-    describe "with an other plage_ouverture but not opened the right time" do
-      let!(:plage_ouverture4) { build(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(18), organisation: organisation) }
-
-      it { should contain_exactly(plage_ouverture) }
-    end
-
-    describe "with a rdv" do
-      let!(:rdv) { create(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30, organisation: organisation) }
-
-      it { should eq([]) }
-
-      describe "which is cancelled" do
-        let!(:rdv) { build(:rdv, agents: [plage_ouverture.agent], starts_at: creneau.starts_at, duration_in_min: 30, cancelled_at: DateTime.parse("2020-07-30 10:30").in_time_zone, organisation: organisation) }
-
-        it { should contain_exactly(plage_ouverture) }
-      end
-    end
-  end
-
   describe "#respects_min_booking_delay?" do
     subject { creneau.respects_min_booking_delay? }
 

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -97,4 +97,26 @@ describe Lieu, type: :model do
     it { expect(lieu_lille.distance(paris_loc[:latitude], paris_loc[:longitude])).to be_a_kind_of(Float) }
     it { expect(lieu_lille.distance(paris_loc[:latitude], paris_loc[:longitude])).to be_within(10000).of(204000) }
   end
+
+  describe "#with_open_slots_for_motifs" do
+    subject { Lieu.with_open_slots_for_motifs([motif]) }
+
+    context "motif has current plage ouvertures" do
+      let!(:motif) { create(:motif, name: "Vaccination") }
+      let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu) }
+      it { should include(lieu) }
+    end
+
+    context "motif has finished plage ouverture" do
+      let!(:motif) { create(:motif, name: "Vaccination") }
+      let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, first_day: 2.days.ago, recurrence: nil) }
+      it { should_not include(lieu) }
+    end
+
+    context "motif has no plage ouvertures" do
+      let!(:motif) { create(:motif, name: "Vaccination") }
+      let(:plage_ouverture) { nil }
+      it { should_not include(lieu) }
+    end
+  end
 end

--- a/spec/service_models/users/creneau_search_spec.rb
+++ b/spec/service_models/users/creneau_search_spec.rb
@@ -1,0 +1,54 @@
+describe Users::CreneauSearch do
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:user) }
+  let(:motif) { create(:motif, name: "Coucou", location_type: :home, organisation: organisation) }
+  let(:lieu) { create(:lieu, organisation: organisation) }
+  let(:starts_at) { DateTime.parse("2020-10-20 09h30") }
+
+  describe ".creneau_for" do
+    subject do
+      Users::CreneauSearch.creneau_for(
+        user: user,
+        motif: motif,
+        lieu: lieu,
+        starts_at: starts_at
+      )
+    end
+
+    before do
+      expect(CreneauxBuilderService).to receive(:perform_with).with(
+        "Coucou",
+        lieu,
+        (Date.parse("2020-10-20")..Date.parse("2020-10-21")),
+        motif_location_type: "home"
+      ).and_return(mock_creneaux)
+    end
+
+    context "some matching creneaux" do
+      let(:mock_creneaux) do
+        [
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 09h30")),
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30"))
+        ]
+      end
+      it { should eq(mock_creneaux[0]) }
+    end
+
+    context "no matching creneaux" do
+      let(:mock_creneaux) do
+        [
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 11h30"))
+        ]
+      end
+      it { should be_nil }
+    end
+
+    context "no creneaux built at all" do
+      let(:mock_creneaux) { [] }
+      it { should be_nil }
+    end
+  end
+end

--- a/spec/service_models/users/creneaux_search_spec.rb
+++ b/spec/service_models/users/creneaux_search_spec.rb
@@ -1,0 +1,63 @@
+describe Users::CreneauxSearch, type: :service do
+  describe "#creneaux" do
+    let(:user) { create(:user) }
+    let(:organisation) { create(:organisation) }
+    let(:lieu) { create(:lieu, organisation: organisation) }
+    let(:motif1) { create(:motif, name: "Coucou", organisation: organisation) }
+    let(:motif2) { create(:motif, name: "Coucou", organisation: organisation) }
+    let(:date_range) { (Date.parse("2020-10-20")..Date.parse("2020-10-23")) }
+
+    subject do
+      Users::CreneauxSearch
+        .new(user: user, motifs: [motif1, motif2], lieu: lieu, date_range: date_range)
+        .creneaux
+    end
+
+    it "call builder without special options" do
+      expect(CreneauxBuilderService).to receive(:perform_with)
+        .with("Coucou", lieu, date_range)
+      subject
+    end
+
+    context "follow_up motif" do
+      let(:motif) { create(:motif, name: "Coucou", follow_up: true, organisation: organisation) }
+      subject do
+        Users::CreneauxSearch
+          .new(user: user, motifs: [motif], lieu: lieu, date_range: date_range)
+          .creneaux
+      end
+
+      context "logged in user" do
+        context "with referents" do
+          let!(:agent) { create(:agent, organisations: [organisation]) }
+          let(:user) { create(:user, organisations: [organisation], agents: [agent]) }
+
+          it "should call builder with agent options" do
+            expect(CreneauxBuilderService).to receive(:perform_with)
+              .with("Coucou", lieu, date_range, agent_ids: [agent.id], agent_name: true)
+            subject
+          end
+        end
+
+        context "without referents" do
+          let(:user) { create(:user, agents: []) }
+
+          it "should call builder with agent options" do
+            expect(CreneauxBuilderService).to receive(:perform_with)
+              .with("Coucou", lieu, date_range, agent_ids: [], agent_name: true)
+            subject
+          end
+        end
+      end
+
+      context "offline user" do
+        let(:user) { nil }
+        it "should call builder without agent options" do
+          expect(CreneauxBuilderService).to receive(:perform_with)
+            .with("Coucou", lieu, date_range)
+          subject
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/6ysKq39q/1130-r%C3%A9parer-coh%C3%A9rence-des-filtres-appliqu%C3%A9s-sur-les-cr%C3%A9neaux-propos%C3%A9s-cot%C3%A9-usagers-rdv-suivis-locationtype

- extract `Users::CreneauxSearch` object from `LieuxController` : not 100% necessary here, but it clears the way
- introduce a very close singular `Users::CreneauSearch` to build a single `Crenau` instead of calling directly `Creneau.new` and checking `creneau.available?`. This allows us to remove the some code in the `Creneau` model, that was duplicated with the code in `CreneauxBuilderFordateService`. 
- lieux controller specs refactored to limit testing surface : the used services are stubbed instead of being actually called. 

