### PR TITLE
remove agent calendar events min height 15px to fix overlap

### DIFF
--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -78,7 +78,6 @@ class CalendarRdvSolidarites {
           buttonText: 'Journée'
         }
       },
-      timeGridEventMinHeight: 15,
       businessHours: {
         // days of week. an array of zero-based day of week integers (0=Sunday)
         daysOfWeek: [1, 2, 3, 4, 5],


### PR DESCRIPTION
https://trello.com/c/I9NWrip0/1111-bug-probl%C3%A8me-daffichage-lorsque-les-rdvs-sencha%C3%AEnent

![Screenshot_2020-10-28_at_08 21 11](https://user-images.githubusercontent.com/883348/97404536-91149a00-18f6-11eb-88e2-1f39cbc5fc32.png)

simply removing 15px height for now