### PR TITLE
ajoute une page contact

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,5 @@ class StaticPagesController < ApplicationController
   def terms; end
 
   def mds; end
+  def contact; end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,5 +4,6 @@ class StaticPagesController < ApplicationController
   def terms; end
 
   def mds; end
+
   def contact; end
 end

--- a/app/views/common/_footer.html.slim
+++ b/app/views/common/_footer.html.slim
@@ -16,7 +16,7 @@
       .row
         .col-md-12
           ul.links.list-inline
-            li.list-inline-item.mr-5= mail_to "contact@rdv-solidarites.fr"
+            li.list-inline-item.mr-5= link_to "Contact", contact_path
             li.list-inline-item.mr-5= link_to "Statistiques", stats_path
             li.list-inline-item.mr-5= link_to "Espace professionel", accueil_mds_path
             li.list-inline-item.mr-5= link_to "Les solidarités dans votre département", mds_path

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -4,42 +4,38 @@
     | Dernière mise à jour : le 26 octobre 2020
 
 .container.mt-3
-  .row
-    .col-6.mx-auto
-      h3 Votre département
-      ul.list-group.mb-2
-        li
-          | (14) Calvados&nbsp;
-          = link_to "02 31 57 14 14", "tel:+33231571414"
-        li
-          | (22) Côte d'Armor&nbsp;
-          = link_to "02.96.60.86.86", "tel:+33296608686"
-        li
-          | (55) Meuse&nbsp;
-          = link_to "03.29.80.32.34", "tel:+33329803234"
-        li
-          | (64) Pyrénées Atlantique&nbsp;
-          = link_to "05.59.69.34.11", "tel:+33559693411"
-        li
-          | (77) Seine et marne&nbsp;
-          = link_to "01.64.14.77.77", "tel:+33164147777"
-        li
-          | (78) Yvelines&nbsp;
-          = link_to "01 30 836 836", "tel:+33130836836"
-        li
-          | (80) Somme&nbsp;
-          = link_to "03.22.71.80.80", "tel:+33322718080"
-        li
-          | (92) Hauts de seine&nbsp;
-          = link_to "0 806 00 00 92", "tel:+33806000092"
-        li
-          | (95) Val d'oise&nbsp;
-          = link_to "01 34 25 30 30", "tel:+33134253030"
-        li
-          | Autres départements, voir
-          = link_to "l'annuaire des services publiques", "https://lannuaire.service-public.fr/"
+  h3 Votre département
+  ul.list-group.mb-2
+    li
+      span> 14 - Calvados
+      = link_to "02 31 57 14 14", "tel:+33231571414"
+    li
+      span> 22 - Côte d'Armor
+      = link_to "02.96.60.86.86", "tel:+33296608686"
+    li
+      span> 55 - Meuse
+      = link_to "03.29.80.32.34", "tel:+33329803234"
+    li
+      span> 64 - Pyrénées Atlantique
+      = link_to "05.59.69.34.11", "tel:+33559693411"
+    li
+      span> 77 - Seine et marne
+      = link_to "01.64.14.77.77", "tel:+33164147777"
+    li
+      span> 78 - Yvelines
+      = link_to "01 30 836 836", "tel:+33130836836"
+    li
+      span> 80 - Somme
+      = link_to "03.22.71.80.80", "tel:+33322718080"
+    li
+      span> 92 - Hauts de seine
+      = link_to "0 806 00 00 92", "tel:+33806000092"
+    li
+      span> 95 - Val d'oise
+      = link_to "01 34 25 30 30", "tel:+33134253030"
+    li
+      span> Autres départements, voir
+      = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
 
-  .row
-    .col-6.mx-auto
-      h3 Équipe technique&nbsp;
-      = link_to "contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Depuis%20la%20page%20contact"
+  h3 Équipe technique
+  = link_to "contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Depuis%20la%20page%20contact"

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -42,4 +42,4 @@
   .row
     .col-6.mx-auto
       h3 Équipe technique&nbsp;
-      = link_to "contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr"
+      = link_to "contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Depuis%20la%20page%20contact"

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -1,0 +1,45 @@
+- content_for :title do
+  h1 Contact
+  p.text-white
+    | Dernière mise à jour : le 26 octobre 2020
+
+.container.mt-3
+  .row
+    .col-6.mx-auto
+      h3 Votre département
+      ul.list-group.mb-2
+        li
+          | (14) Calvados&nbsp;
+          = link_to "02 31 57 14 14", "tel:+33231571414"
+        li
+          | (22) Côte d'Armor&nbsp;
+          = link_to "02.96.60.86.86", "tel:+33296608686"
+        li
+          | (55) Meuse&nbsp;
+          = link_to "03.29.80.32.34", "tel:+33329803234"
+        li
+          | (64) Pyrénées Atlantique&nbsp;
+          = link_to "05.59.69.34.11", "tel:+33559693411"
+        li
+          | (77) Seine et marne&nbsp;
+          = link_to "01.64.14.77.77", "tel:+33164147777"
+        li
+          | (78) Yvelines&nbsp;
+          = link_to "01 30 836 836", "tel:+33130836836"
+        li
+          | (80) Somme&nbsp;
+          = link_to "03.22.71.80.80", "tel:+33322718080"
+        li
+          | (92) Hauts de seine&nbsp;
+          = link_to "0 806 00 00 92", "tel:+33806000092"
+        li
+          | (95) Val d'oise&nbsp;
+          = link_to "01 34 25 30 30", "tel:+33134253030"
+        li
+          | Autres départements, voir
+          = link_to "l'annuaire des services publiques", "https://lannuaire.service-public.fr/"
+
+  .row
+    .col-6.mx-auto
+      h3 Équipe technique&nbsp;
+      = link_to "contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,7 @@ Rails.application.routes.draw do
     root to: "admin/organisations#index", as: :authenticated_agent_root, defaults: { follow_unique: "1" }
   end
 
-  { disclaimer: "mentions_legales", terms: "cgv", mds: "mds" }.each do |k, v|
+  { contact: "contact", disclaimer: "mentions_legales", terms: "cgv", mds: "mds" }.each do |k, v|
     get v => "static_pages##{k}"
   end
 


### PR DESCRIPTION
https://trello.com/c/o9c4bcfq/1142-afficher-une-page-contact-avec-les-num%C3%A9ro-de-tel-des-d%C3%A9partement

Pour commencer, remplacement de l'adresse email dans le footer par une page contact qui reprends simplement les numéros de téléphone des départements qui nous l'ont donnée + l'adresse email de l'équipe.

