### PR TITLE
remove content security policies for google fonts

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,10 +7,10 @@ unless Rails.env.test?
 
   Rails.application.config.content_security_policy do |policy|
     policy.default_src :self
-    policy.font_src    :self, :data, "https://fonts.gstatic.com", "github.com"
-    policy.img_src     :self, :data, "stats.data.gouv.fr", "*.gstatic.com", "*.google.com", "voxusagers.numerique.gouv.fr"
+    policy.font_src    :self, :data, "github.com"
+    policy.img_src     :self, :data, "stats.data.gouv.fr", "voxusagers.numerique.gouv.fr"
     policy.object_src  :none
-    policy.style_src   :self, :unsafe_inline, "fonts.googleapis.com", "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
+    policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
 
     if Rails.env.development?
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net", "tags.clickintext.net", "api.mapbox.com", "blob:"


### PR DESCRIPTION
suite au retrait des google fonts, suppression de google et gstatic de nos listes de CSP