### PR TITLE
restrict before action filter to prevent double sign in to agents/sessions#new

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Agents::SessionsController < Devise::SessionsController
-  before_action :exclude_signed_in_users
+  before_action :exclude_signed_in_users, only: [:new]
 
   private
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,7 +3,7 @@ class Users::SessionsController < Devise::SessionsController
 
   include CanHaveRdvWizardContext
 
-  before_action :exclude_signed_in_agents
+  before_action :exclude_signed_in_agents, only: [:new]
 
   def create
     if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])


### PR DESCRIPTION
https://trello.com/c/jrZ94IC2/1137-corriger-bug-double-connexion-agent-et-usager

le probleme venait en partie du fait que c'etait impossible de se deconnecter lorsqu'on etait connecté aux deux en meme temps. 

Ce commit ne corrige pas le probleme a la source, mais permet de debloquer ce cas. Pour corriger la source du probleme il faudrait reussir a empecher completement devise de logger un agent et un user en meme temps, quelque soit le chemin d'entrée (sign_in, sign_up, confirmations ...). je ne sais pas comment le faire facilement