### PR TITLE
include lieu name in SMS messages

### DIFF
--- a/app/jobs/send_transactional_sms_job.rb
+++ b/app/jobs/send_transactional_sms_job.rb
@@ -2,6 +2,6 @@ class SendTransactionalSmsJob < ApplicationJob
   def perform(status, rdv_id, user_id, options = {})
     rdv = Rdv.find(rdv_id)
     user = User.find(user_id)
-    SendTransactionalSmsService.perform_with(status, rdv, user, options) if Rails.env.production?
+    SendTransactionalSmsService.perform_with(status, rdv, user, options)
   end
 end

--- a/app/views/admin/lieux/_form.html.slim
+++ b/app/views/admin/lieux/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for [:admin, lieu.organisation, lieu] do |f|
   = render partial: 'layouts/model_errors', locals: { model: lieu }
-  = f.input :name
-  = f.input :address, input_html: { class: "places-js-container" }
+  = f.input :name, hint: "Le nom apparaîtra dans les notifications mails et SMS aux usagers"
+  = f.input :address, input_html: { class: "places-js-container" }, hint: "L'adresse apparaîtra dans les notifications mails et SMS aux usagers"
   = f.input :latitude, as: :hidden
   = f.input :longitude, as: :hidden
 


### PR DESCRIPTION
https://trello.com/c/zEMWzaqC/1114-envoyer-le-nom-du-lieu-en-plus-de-ladresse-dans-les-sms-et-mails-envoy%C3%A9s-aux-usagers

<img width="321" alt="Screenshot_2020-11-09_at_14 47 56" src="https://user-images.githubusercontent.com/883348/98549101-a399b680-229a-11eb-829a-78b05a8d77e9.png">


- j'ai légèrement modifié le code de l'envoi de SMS pour voir en local les SMS qui auraient été envoyés dans les logs
- j'ai aussi rajouté des indications dans le formulaire de création de lieu pour indiquer que le nom et l'adresse apparaîtront dans les notifs

<img width="662" alt="Screenshot_2020-11-09_at_12 36 11" src="https://user-images.githubusercontent.com/883348/98536466-2c5b2700-2288-11eb-8ebf-6d978d9ea2ae.png">


voir les noms de lieux en production ici : https://pad.incubateur.net/8t63puPHTt2u1iFjSVOs_A#

- il y a des noms longs comme " Maison des Solidarités Départementales Annexe Onet Le Château"
- il y a quelques noms surprenants comme CPEF ou "Visite à domicile"
- il y a des noms qui répètent le nom de la ville comme "MEURCHIN - Centre Multi-accueil"

@yaf je vois plusieurs approches possibles : 

1. on tronque les noms
2. on fait des trucs malins pour retirer le nom de la ville des noms de lieux
3. on prévient en amont les orgas pour leur laisser une semaine pour "réparer" leurs noms de lieux avant qu'on commence à les envoyer
4. on deploie tel quel et on prévient a posteriori 

Je vote plutôt **contre** 1 et 2 pour laisser la responsabilité aux orgas de choisir leurs noms de motifs. 
et entre 3 et 4 je n'ai pas trop d'avis, je pense que 4 est acceptable je ne vois rien de scandaleux dans les noms de lieux non plus