### PR TITLE
when inviting a new agent, set uid to email

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -19,6 +19,10 @@ class Admin::InvitationsController < Devise::InvitationsController
 
   protected
 
+  def invite_resource
+    super { |agent| agent.uid = agent.email }
+  end
+
   def pundit_user
     AgentContext.new(current_agent)
   end


### PR DESCRIPTION
https://sentry.io/organizations/rdv-solidarites/issues/2018508764/?environment=production&project=1811205&referrer=alert_email

pour reproduire le bug (corrigé dans cette PR ) : inviter deux agents a la suite, sans attendre que le premier ait accepté

la gem devise_token_auth utilisee pour l'auth de l'api a ajouté plusieurs champs a agents, dont `uid` et `provider`. ces deux derniers doivent former une paire unique. pour une raison pas super claire pour moi, l'`uid` lors de l'invitation d'un nouvel agent n'etait pas setté automatiquement a la valeur de l'email. cette PR y remedie de maniere un peu brutale