### PR TITLE
improve home UI navbar alignment + smaller fonts on small devices

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,13 +4,13 @@ html lang="fr"
     = render 'common/head'
   body class="#{agents_or_users_body_class}"
     = render 'layouts/degraded_service', message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
-    div class="#{ params[:controller].include?('users/') ? '' : 'bg-primary'}"
-      - if current_user.present?
-        = render "common/header_user_logged"
-      - else
-        = render 'common/header'
-
+    .bg-primary
       .container
+        - if current_user.present?
+          = render "common/header_user_logged"
+        - else
+          = render 'common/header'
+
         = render 'layouts/flash'
         - if content_for :title
           .row

--- a/app/views/layouts/user_registration.html.slim
+++ b/app/views/layouts/user_registration.html.slim
@@ -5,8 +5,9 @@ html lang="fr"
   body class="user"
     = render 'layouts/degraded_service', message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
     .bg-primary
-      = render 'common/header'
-      = yield :header
+      .container
+        = render 'common/header'
+        = yield :header
     .container
       .row
         .col-md-12

--- a/app/views/lieux/index.html.slim
+++ b/app/views/lieux/index.html.slim
@@ -1,9 +1,7 @@
 - content_for :header
   section#hero.hero.hero-home.p-2
     .container
-      .row.justify-content-md-center
-        .col-md-10
-          = render '/common/search_form'
+      = render '/common/search_form'
   section.bg-light.p-4
     .container
       - if @lieux.empty?

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -3,15 +3,15 @@
     .container
       .row
         .col-lg-12.justify-content-md-center
-          h1.text-white.px-lg-5
+          h1.text-white
             | Prenez&nbsp;
             span.text-secondary rendez-vous en ligne
             br
             | avec votre département
-          h3.text-white.mb-4.px-lg-5 dans les services des solidarités
+          h3.text-white.mb-4 dans les services des solidarités
       .row
         .col-lg-12.justify-content-md-center
-            .mb-5.px-lg-5= render '/common/search_form'
+            .mb-5= render '/common/search_form'
       h3.text-white.text-center Comment ça marche ?
 
 = render 'welcome/how_to'

--- a/app/views/welcome/welcome_departement.html.slim
+++ b/app/views/welcome/welcome_departement.html.slim
@@ -3,15 +3,15 @@
     .container
       .row
         .col-lg-12.justify-content-md-center
-          h1.text-white.px-lg-5
+          h1.text-white
             | Prenez&nbsp;
             span.text-secondary rendez-vous en ligne
             br
             | avec votre département le&nbsp;
             span.text-secondary #{@departement}
-          h3.text-white.mb-4.px-lg-5 en PMI, CPEF, Service Social
+          h3.text-white.mb-4 en PMI, CPEF, Service Social
 
-          .mb-5.px-lg-5= render 'common/search_form'
+          .mb-5= render 'common/search_form'
       h3.text-white.text-center Comment ça marche ?
 
 = render 'how_to'

--- a/app/views/welcome/welcome_service.html.slim
+++ b/app/views/welcome/welcome_service.html.slim
@@ -3,15 +3,15 @@
     .container
       .row
         .col-lg-12.justify-content-md-center
-          h1.text-white.px-lg-5
+          h1.text-white
             | Prenez&nbsp;
             span.text-secondary rendez-vous en ligne
             br
             | avec votre département le&nbsp;
             span.text-secondary #{@departement}
-          h3.text-white.mb-4.px-lg-5 en #{@service.name}
+          h3.text-white.mb-4 en #{@service.name}
 
-          .mb-5.px-lg-5= render 'common/search_form'
+          .mb-5= render 'common/search_form'
       h3.text-white.text-center Comment ça marche ?
 
 = render 'how_to'

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
 @import "./_variables";
 @import "./fontawesome_imports";
 @import "./fonts";
@@ -39,6 +40,19 @@ h2{
   font-size: 2rem;
   padding-bottom: 1rem;
 }
+
+@include media-breakpoint-only(xs) {
+  h1 {
+    font-size: 2rem;
+  }
+  h2 {
+    font-size: 1.5rem;
+  }
+  h3 {
+    font-size: 1.3rem;
+  }
+}
+
 
 a {
   transition: all 0.3s;
@@ -91,6 +105,9 @@ section header {
 nav.navbar {
   background: none;
   transition: all 0.5s;
+  padding-left: 0;
+  padding-right: 0;
+
   .navbar-brand {
     font-weight: 800;
     font-size: 1.7rem;
@@ -140,12 +157,6 @@ nav.navbar {
   }
 }
 
-@media (min-width: 992px) {
-  nav.navbar {
-    padding-left: 3rem;
-    padding-right: 3rem;
-  }
-}
 
 /*
 * ==========================================================


### PR DESCRIPTION
- force la navbar a respecter la largeur max du container, ca aligne avec le reste
- enleve les paddings horizontaux sur le hero et le search form de la home et des differentes etapes de recherche, aussi pour aligner avec les limites verticales.
- diminue la font-size des titres du hero pour que ca rentre sur un iPhone 5/SE (~ a peu pres le plus petit smartphone encore pas mal utilisé)

## Screenshots smartphone 4"

<img width="400" alt="stitched_2020_11_11-09_13_43" src="https://user-images.githubusercontent.com/883348/98786464-64847600-23fe-11eb-9858-7017626ebbe4.png">

## Screenshots laptop

<img width="700" alt="stitched_2020_11_11-09_16_08" src="https://user-images.githubusercontent.com/883348/98786574-93025100-23fe-11eb-8d00-71055f4be0e4.png">

