### PR TITLE
Remove disable notifications for users from motifs 

### DIFF
--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -22,7 +22,6 @@ fr:
         for_secretariat: Motif accessible au secrétariat
         default_duration_in_min: Durée par défaut en minutes
         default_duration: Durée par défaut
-        disable_notifications_for_users: Désactiver les notifications pour l'usager
         min_booking_delay: Délai minimum de réservation
         max_booking_delay: Délai maximum de réservation
         restriction_for_rdv: Instructions à accepter avant la prise du rendez-vous

--- a/db/migrate/20201112164609_remove_disable_notifications_for_users_from_motifs.rb
+++ b/db/migrate/20201112164609_remove_disable_notifications_for_users_from_motifs.rb
@@ -1,0 +1,5 @@
+class RemoveDisableNotificationsForUsersFromMotifs < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :motifs, :disable_notifications_for_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_102708) do
+ActiveRecord::Schema.define(version: 2020_11_12_164609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -184,7 +184,6 @@ ActiveRecord::Schema.define(version: 2020_11_12_102708) do
     t.integer "max_booking_delay", default: 7889238
     t.datetime "deleted_at"
     t.bigint "service_id"
-    t.boolean "disable_notifications_for_users", default: false
     t.text "restriction_for_rdv"
     t.text "instruction_for_rdv"
     t.boolean "for_secretariat", default: false


### PR DESCRIPTION
Supprime le champs `disable_notifications_for_users` de la table `motifs` puisque devenu inutile

Est-ce qu'on attends la semaine prochaine pour passer cette migration ?