### PR TITLE
ramène le vos statistique chez vous

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -49,6 +49,7 @@ module AgentsHelper
       "menu-motifs" => "settings",
       "menu-organisation" => "settings",
       "menu-organisation-stats" => "settings",
+      "menu-stats" => "account",
       "men-department-sectors" => "",
       "men-department-zones" => "",
       "men-department-setup-checklist" => "",

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -11,7 +11,11 @@
   - else
     ul.side-nav.list-unstyled#menu-agent.pb-3.mb-0
       li.side-nav-item.connected-agent.mb-3.pl-3.pr-2.py-2
-        a data-toggle="collapse" href=".left-submenu-account" aria-expanded="false"
+        a[
+          data-toggle="collapse"
+          href=".left-submenu-account"
+          aria-expanded=(menu_top_level_item == "account" ? "true" : "false")
+        ]
           .d-flex.justify-content-between.w-100
             div.d-flex.align-items-center
               div.mr-2.small
@@ -23,13 +27,19 @@
                 span= current_organisation.name
             div.d-flex.align-items-center
               i.fa.fa-angle-right.menu-arrow.mt-1
-        ul.list-unstyled.ml-3.left-submenu-account.collapse
+        ul.list-unstyled.ml-3.left-submenu-account.collapse[
+          class=("show" if menu_top_level_item == "account")
+        ]
           li.my-2
             = link_to "Mon compte", edit_agent_registration_path
           li.my-2
             = link_to "Mes organisations", admin_organisations_path
           li.my-2
-            = link_to "Mes statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
+            = link_to( \
+              "Mes statistiques", \
+              admin_organisation_agent_stats_path(current_organisation, current_agent), \
+              class: ("active" if content_for(:menu_item) == "menu-stats") \
+            )
             = unknown_past_agent_rdvs_danger_bage
           li.my-2
             = link_to destroy_agent_session_path, method: :delete do

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -29,7 +29,7 @@
           li.my-2
             = link_to "Mes organisations", admin_organisations_path
           li.my-2
-            = link_to "Vos statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
+            = link_to "Mes statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
             = unknown_past_agent_rdvs_danger_bage
 
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -31,13 +31,10 @@
           li.my-2
             = link_to "Mes statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
             = unknown_past_agent_rdvs_danger_bage
-
-
           li.my-2
             = link_to destroy_agent_session_path, method: :delete do
               i.fa.fa-sign-out
               span Me déconnecter
-
 
       - if current_organisation.recent?
         li.side-nav-item.mb-4.pl-3.pr-2

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -29,9 +29,15 @@
           li.my-2
             = link_to "Mes organisations", admin_organisations_path
           li.my-2
+            = link_to "Vos statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
+            = unknown_past_agent_rdvs_danger_bage
+
+
+          li.my-2
             = link_to destroy_agent_session_path, method: :delete do
               i.fa.fa-sign-out
               span Me déconnecter
+
 
       - if current_organisation.recent?
         li.side-nav-item.mb-4.pl-3.pr-2
@@ -84,15 +90,6 @@
             ) do
               i.fa.fa-user>
               span.ml-1 Usagers
-
-      li.side-nav-item.mb-4.pl-3.pr-2
-        = link_to( \
-          admin_organisation_agent_stats_path(current_organisation, current_agent), \
-          class: ("active" if content_for(:menu_item) == "menu-stats") \
-        ) do
-          i.fa.fa-chart-bar>
-          span.ml-1 Vos statistiques
-          = unknown_past_agent_rdvs_danger_bage
 
       li.side-nav-item.mb-4.pl-3.pr-2
         = link_to \

--- a/spec/features/agents/agent_can_see_his_stats_spec.rb
+++ b/spec/features/agents/agent_can_see_his_stats_spec.rb
@@ -8,7 +8,7 @@ describe "Agent can see his stats" do
 
   shared_examples "a stats page" do
     it "displays all the stats" do
-      click_link "Vos statistiques"
+      click_link "Mes statistiques"
       expect(page).to have_content("Statistiques")
       expect(page).to have_content("RDV créés")
     end


### PR DESCRIPTION
https://trello.com/c/9VJOUdJ5/1163-ramener-vos-statistiques-dans-votre-espace-de-menu

Dans la ligné des travaux sur le menu, je propos de déplacer « vos statistiques » à coté de « mes organisations » dans la zone de menu personnel

![Capture d’écran de 2020-11-12 22-16-39](https://user-images.githubusercontent.com/42057/98997422-c47d3880-2534-11eb-8b7e-9ef88ea4104c.png)

au lieu de 

![Capture d’écran de 2020-11-12 22-13-07](https://user-images.githubusercontent.com/42057/98997434-c8a95600-2534-11eb-9065-7e6923d1fea9.png)
