### PR TITLE
tri les motifs coté usagers

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -40,7 +40,7 @@ class WelcomeController < ApplicationController
   def welcome_service
     @services = @geo_search.available_services
     @organisations_departement = Organisation.where(departement: @departement)
-    @motif_names = @geo_search.available_motifs.where(service: @service).pluck(:name).uniq
+    @motif_names = @geo_search.available_motifs.where(service: @service).ordered_by_name.pluck(:name).uniq
   end
 
   def set_lieu_variables

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -27,7 +27,7 @@ class Motif < ApplicationRecord
   scope :reservable_online, -> { where(reservable_online: true) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
   scope :for_secretariat, -> { where(for_secretariat: true) }
-  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
+  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(motifs.name))")) }
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
     available_motifs = if agent.admin?
                          all


### PR DESCRIPTION
https://trello.com/c/taHQshk8/1155-trier-la-liste-de-motifs-par-ordre-alphab%C3%A9tique-dans-la-recherche-usager

J'ai du préciser la table `motifs` dans le scope `ordered_by_name` pour éviter la confusion lors de jointure avec une table contenant également un `name`. Un peu comme ici où dans la requête, nous faisons une jointure sur le service du motif.