### PR TITLE
Add overlapping Plage Ouvertures warnings 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "daemons"
 gem "simple_form", "~> 5.0"
 gem "image_processing", "~> 1.8"
 gem "phonelib"
+gem "activemodel-caution", github: "rdv-solidarites/activemodel-caution", branch: "feature/generization"
 
 # Front
 gem "chartkick", "~> 3.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,18 @@ GIT
       rails (>= 4.2.0, < 6.1)
 
 GIT
+  remote: https://github.com/rdv-solidarites/activemodel-caution.git
+  revision: 6b2b0ca5bc302cac1971fb474b707ebb0fb55a81
+  branch: feature/generization
+  specs:
+    activemodel-caution (6.0.3.3.0)
+      actionpack (= 6.0.3.3)
+      activemodel (= 6.0.3.3)
+      activerecord (= 6.0.3.3)
+      activesupport (= 6.0.3.3)
+      railties (= 6.0.3.3)
+
+GIT
   remote: https://github.com/thoughtbot/administrate.git
   revision: eb9b1b158d3529e7d6cedd9ee5bbee88244edbc3
   branch: master
@@ -500,6 +512,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activemodel-caution!
   administrate!
   administrate-field-belongs_to_search (~> 0.7)
   better_errors

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -53,6 +53,7 @@ class Admin::PlageOuverturesController < AgentAuthController
       flash[:notice] = "Plage d'ouverture créée"
       redirect_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)
     else
+      @overlapping_plages_ouvertures = policy_scope(PlageOuverture).merge(@plage_ouverture.overlapping_plages_ouvertures)
       render :new
     end
   end
@@ -60,6 +61,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   def update
     authorize(@plage_ouverture)
     flash[:notice] = "La plage d'ouverture a été modifiée." if @plage_ouverture.update(plage_ouverture_params)
+    @overlapping_plages_ouvertures = policy_scope(PlageOuverture).merge(@plage_ouverture.overlapping_plages_ouvertures)
     render :edit
   end
 
@@ -76,7 +78,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   end
 
   def plage_ouverture_params
-    params.require(:plage_ouverture).permit(:title, :agent_id, :first_day, :start_time, :end_time, :lieu_id, :recurrence, motif_ids: [])
+    params.require(:plage_ouverture).permit(:title, :agent_id, :first_day, :start_time, :end_time, :lieu_id, :recurrence, :active_warnings_confirm_decision, motif_ids: [])
   end
 
   def date_range_params

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -46,7 +46,7 @@ module PlageOuverturesHelper
   end
 
   def display_time_range(plage_ouverture)
-    "de #{l(plage_ouverture.starts_at, format: "%H:%M")} à #{l(plage_ouverture.ends_at, format: "%H:%M")}"
+    "de #{l(plage_ouverture.start_time, format: "%H:%M")} à #{l(plage_ouverture.end_time, format: "%H:%M")}"
   end
 
   def display_recurrence_range(plage_ouverture)

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -18,7 +18,7 @@ class Absence < ApplicationRecord
   end
 
   def in_progress?
-    starts_at.past? && ends_at.future?
+    starts_at.past? && first_occurence_ends_at.future?
   end
 
   def ical_uid

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -68,7 +68,18 @@ class PlageOuverture < ApplicationRecord
     PlageOuvertureOverlap.new(self, other).exists?
   end
 
+  def overlapping_plages_ouvertures?
+    overlapping_plages_ouvertures_candidates.any? { overlaps?(_1) }
+  end
+
   def overlapping_plages_ouvertures
+    @overlapping_plages_ouvertures ||= overlapping_plages_ouvertures_candidates
+      .select { overlaps?(_1) }
+  end
+
+  private
+
+  def overlapping_plages_ouvertures_candidates
     return [] unless valid_date_and_times?
 
     candidate_pos = PlageOuverture.where(agent: agent).where.not(id: id)
@@ -77,10 +88,8 @@ class PlageOuverture < ApplicationRecord
       candidate_pos = candidate_pos.where("first_day <= ?", first_day)
     end
     # we could further restrict this query if perfs are an issue
-    @overlapping_plages_ouvertures ||= candidate_pos.select { overlaps?(_1) }
+    candidate_pos
   end
-
-  private
 
   def valid_date_and_times?
     [first_day, start_time, end_time].all?(&:present?)

--- a/app/models/plage_ouverture/ics.rb
+++ b/app/models/plage_ouverture/ics.rb
@@ -19,7 +19,7 @@ class PlageOuverture::Ics
     cal.event do |e|
       e.uid         = plage_ouverture.ical_uid
       e.dtstart     = Icalendar::Values::DateTime.new(plage_ouverture.starts_at, "tzid" => TZID)
-      e.dtend       = Icalendar::Values::DateTime.new(plage_ouverture.ends_at, "tzid" => TZID)
+      e.dtend       = Icalendar::Values::DateTime.new(plage_ouverture.first_occurence_ends_at, "tzid" => TZID)
       e.summary     = "#{BRAND} #{plage_ouverture.title}"
       e.description = ""
       e.location    = plage_ouverture.lieu.address

--- a/app/models/recurrence/occurrence.rb
+++ b/app/models/recurrence/occurrence.rb
@@ -7,4 +7,8 @@ class Recurrence::Occurrence
   def <=>(other)
     starts_at <=> other.starts_at
   end
+
+  def to_date
+    starts_at.to_date
+  end
 end

--- a/app/policies/agent/plage_ouverture_policy.rb
+++ b/app/policies/agent/plage_ouverture_policy.rb
@@ -8,4 +8,16 @@ class Agent::PlageOuverturePolicy < DefaultAgentPolicy
       end
     end
   end
+
+  class DepartementScope < Scope
+    def resolve
+      if @context.agent.can_access_others_planning?
+        scope.where(organisation_id: @context.agent.organisations.pluck(:id))
+      else
+        scope.joins(:agent)
+          .where(organisation_id: @context.agent.organisations.pluck(:id))
+          .where(agents: { service_id: @context.agent.service_id })
+      end
+    end
+  end
 end

--- a/app/service_models/plage_ouverture_overlap.rb
+++ b/app/service_models/plage_ouverture_overlap.rb
@@ -1,0 +1,61 @@
+class PlageOuvertureOverlap
+  attr_reader :po1, :po2
+
+  def initialize(po1, po2)
+    @po1 = po1
+    @po2 = po2
+  end
+
+  def exists?
+    return false if po1.agent != po2.agent
+
+    if po1.exceptionnelle? && po2.exceptionnelle?
+      both_exceptionnelles_overlap?
+    else
+      !po1_ends_before_po2? &&
+        !po2_ends_before_po1? &&
+        times_of_day_overlap? &&
+        po1_occurences_dates.any? { po2_occurrences_dates.include?(_1) }
+    end
+  end
+
+  private
+
+  def both_exceptionnelles_overlap?
+    po1.starts_at < po2.ends_at && po1.ends_at > po2.starts_at
+  end
+
+  def po1_ends_before_po2?
+    po1.ends_at && po1.ends_at < po2.starts_at
+  end
+
+  def po2_ends_before_po1?
+    po2.ends_at && po2.ends_at < po1.starts_at
+  end
+
+  def times_of_day_overlap?
+    po1.start_time < po2.end_time && po1.end_time > po2.start_time
+  end
+
+  def po1_occurences_dates
+    @po1_occurences_dates ||= po1.occurences_for(occurences_date_range).map(&:to_date)
+  end
+
+  def po2_occurrences_dates
+    @po2_occurrences_dates ||= po2.occurences_for(occurences_date_range).map(&:to_date)
+  end
+
+  def occurences_date_range
+    @occurences_date_range ||= begin
+      if po1.exceptionnelle?
+        po1.first_day.past? ? nil : (po1.first_day..po1.first_day)
+      elsif po2.exceptionnelle?
+        po2.first_day.past? ? nil : (po2.first_day..po2.first_day)
+      else
+        min = [[po1.first_day, po2.first_day].min, Date.today].max
+        max = [po1.recurrence_until, po2.recurrence_until, 6.months.from_now].compact.min
+        (min..max)
+      end
+    end
+  end
+end

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -3,7 +3,7 @@ tr
     = link_to absence.title_or_default, edit_admin_organisation_absence_path(absence.organisation, absence)
     = absence_tag(absence)
   td
-    | Du #{l(absence.starts_at, format: :human)} au #{l(absence.ends_at, format: :human)}
+    | Du #{l(absence.starts_at, format: :human)} au #{l(absence.first_occurence_ends_at, format: :human)}
 
     - if absence.recurrence.present?
       br

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -4,19 +4,10 @@
     = render partial: 'layouts/model_errors', locals: { model: plage_ouverture }
 
     - if plage_ouverture.warnings_need_confirmation?
-      - if @overlapping_plages_ouvertures.any?
-        ul
-          - @overlapping_plages_ouvertures.each do |overlapping_plage_ouverture|
-            li.mb-1
-              span>= link_to("Plage d'ouverture #{overlapping_plage_ouverture.id}", edit_admin_organisation_plage_ouverture_path(overlapping_plage_ouverture.organisation, overlapping_plage_ouverture))
-              span> à #{overlapping_plage_ouverture.lieu.name}
-              - if overlapping_plage_ouverture.recurring?
-                span>= display_recurrence(overlapping_plage_ouverture).join(" ")
-              - else
-                span>= l(overlapping_plage_ouverture.first_day, format: :human)
-                span>= display_time_range(overlapping_plage_ouverture)
-              - if overlapping_plage_ouverture.organisation != current_organisation
-                span>= "(Organisation #{organisation.name})"
+      ul.pl-3
+        = render "overlapping_plage_ouvertures", \
+          overlapping_plages_ouvertures: @overlapping_plages_ouvertures, \
+          overlapping_plages_ouvertures_out_of_scope_count: @overlapping_plages_ouvertures_out_of_scope_count
 
       .collapse.show.js-collapse-warning-confirmation
         .text-muted Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
@@ -46,9 +37,10 @@
       = render partial: 'common/recurrence', locals: { f: f, model: plage_ouverture }
 
       .row
-        - if plage_ouverture.persisted?
-          .col.text-left
-            = link_to "Supprimer", admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"}
+        .col.text-left
+          = link_to "Annuler", \
+            plage_ouverture.persisted? ? admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture) : admin_organisation_plage_ouvertures_path(current_organisation), \
+            class: "btn btn-link"
         .col.text-right
           = f.button :submit
 - else

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -1,20 +1,55 @@
 - if plage_ouverture.available_motifs.any?
   = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture] do |f|
+
     = render partial: 'layouts/model_errors', locals: { model: plage_ouverture }
-    = f.hidden_field :agent_id
-    = f.input :title, hint: 'Uniquement visible en interne', placeholder: 'Ex: Permanence PMI exceptionnelle'
-    = f.association :lieu, collection: policy_scope(Lieu).ordered_by_name, label_method: :full_name, include_blank: false
-    = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes
 
-    hr
+    - if plage_ouverture.warnings_need_confirmation?
+      - if @overlapping_plages_ouvertures.any?
+        ul
+          - @overlapping_plages_ouvertures.each do |overlapping_plage_ouverture|
+            li.mb-1
+              span>= link_to("Plage d'ouverture #{overlapping_plage_ouverture.id}", edit_admin_organisation_plage_ouverture_path(overlapping_plage_ouverture.organisation, overlapping_plage_ouverture))
+              span> à #{overlapping_plage_ouverture.lieu.name}
+              - if overlapping_plage_ouverture.recurring?
+                span>= display_recurrence(overlapping_plage_ouverture).join(" ")
+              - else
+                span>= l(overlapping_plage_ouverture.first_day, format: :human)
+                span>= display_time_range(overlapping_plage_ouverture)
+              - if overlapping_plage_ouverture.organisation != current_organisation
+                span>= "(Organisation #{organisation.name})"
 
-    = render partial: 'common/recurrence', locals: { f: f, model: plage_ouverture }
+      .collapse.show.js-collapse-warning-confirmation
+        .text-muted Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
+        = f.input :active_warnings_confirm_decision, as: :hidden, input_html: {class: "js-warning-confirm-input", value: "1" }
+        .d-flex.justify-content-between
+          div
+            a.btn.btn-outline-dark[
+              data-toggle="collapse"
+              data-target=".js-collapse-warning-confirmation"
+              href="#"
+              onclick="document.querySelector('.js-warning-confirm-input').setAttribute('disabled', 'disabled');"
+            ] Annuler et modifier
+          div= f.submit "Confirmer", class: "btn btn-warning"
+        hr
 
-    .row
-      - if plage_ouverture.persisted?
-        .col.text-left
-          = link_to "Supprimer", admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"}
-      .col.text-right
-        = f.button :submit
+    .form-collapsable-fields-wrapper.collapse.js-collapse-warning-confirmation[
+      class=(plage_ouverture.warnings_need_confirmation? ? "" : "show")
+      aria-expanded=(plage_ouverture.warnings_need_confirmation? ? "false" : "true")
+    ]
+      = f.hidden_field :agent_id
+      = f.input :title, hint: 'Uniquement visible en interne', placeholder: 'Ex: Permanence PMI exceptionnelle'
+      = f.association :lieu, collection: policy_scope(Lieu).ordered_by_name, label_method: :full_name, include_blank: false
+      = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes
+
+      hr
+
+      = render partial: 'common/recurrence', locals: { f: f, model: plage_ouverture }
+
+      .row
+        - if plage_ouverture.persisted?
+          .col.text-left
+            = link_to "Supprimer", admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"}
+        .col.text-right
+          = f.button :submit
 - else
   | Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,0 +1,15 @@
+- overlapping_plages_ouvertures.each do |overlapping_plage_ouverture|
+  li.mb-1
+    span>= link_to("Plage d'ouverture #{overlapping_plage_ouverture.id}", edit_admin_organisation_plage_ouverture_path(overlapping_plage_ouverture.organisation, overlapping_plage_ouverture))
+    span> à #{overlapping_plage_ouverture.lieu.name}
+    - if overlapping_plage_ouverture.recurring?
+      span>= display_recurrence(overlapping_plage_ouverture).join(" ")
+    - else
+      span>= l(overlapping_plage_ouverture.first_day, format: :human)
+      span>= display_time_range(overlapping_plage_ouverture)
+    - if overlapping_plage_ouverture.organisation != current_organisation
+      span>= "(Organisation #{overlapping_plage_ouverture.organisation.name})"
+
+- if overlapping_plages_ouvertures_out_of_scope_count == 1
+  li.mb-1
+    = t("plage_ouvertures.overlapping_out_of_scope", count: overlapping_plages_ouvertures_out_of_scope_count)

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -29,3 +29,10 @@ tr
           duplicate_plage_ouverture_id: plage_ouverture.id \
         ) \
       )
+    div
+      = link_to( \
+        "Supprimer", \
+        admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture), \
+        method: :delete, \
+        data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"} \
+      )

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -1,6 +1,6 @@
 tr
   td
-    = link_to plage_ouverture.title, edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
+    = link_to plage_ouverture.title, admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
     = po_exceptionnelle_tag(plage_ouverture)
     br
     small
@@ -18,21 +18,19 @@ tr
       = sanitize(display_recurrence(plage_ouverture).join("<br/>"))
     - else
       | Le #{l(plage_ouverture.first_day, format: :human)} #{display_time_range(plage_ouverture)}
+    - if plage_ouverture.overlapping_plages_ouvertures?
+      .alert.alert-warning.py-1.px-2.mt-1 ⚠️ Conflit de dates
   td
-    div= link_to "Éditer", edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
+    div
+      = link_to admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture) do
+        i.fa.fa-eye
+    div
+      = link_to edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture) do
+        i.fa.fa-pencil-alt
     div
       = link_to( \
-        "Dupliquer", \
-        new_admin_organisation_agent_plage_ouverture_path( \
-          current_organisation, \
-          @agent.id, \
-          duplicate_plage_ouverture_id: plage_ouverture.id \
-        ) \
-      )
-    div
-      = link_to( \
-        "Supprimer", \
         admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture), \
         method: :delete, \
         data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"} \
-      )
+      ) do
+        i.fa.fa-trash

--- a/app/views/admin/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/plage_ouvertures/edit.html.slim
@@ -15,7 +15,7 @@
         - else
           | Plages d'ouverture de #{@plage_ouverture.agent.full_name}
     li.breadcrumb-item.active
-      = truncate(@plage_ouverture.title, length: 20)
+      = link_to truncate(@plage_ouverture.title, length: 20), admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -1,0 +1,79 @@
+- content_for :title do
+  = truncate(@plage_ouverture.title, length: 40)
+
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0.p-0
+    li.breadcrumb-item
+      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
+        - if @plage_ouverture.agent == current_agent
+          | Vos plages d'ouverture
+        - else
+          | Plages d'ouverture de #{@plage_ouverture.agent.full_name}
+    li.breadcrumb-item.active
+      = truncate(@plage_ouverture.title, length: 20)
+
+.row.justify-content-center
+  .col-md-6.mb-3
+    .card
+      .card-header
+        b Plage d'ouverture ##{@plage_ouverture.id}
+      .card-body
+        div.mt-2.d-flex
+          .flex-shrink-0.mr-1.font-weight-bold Description :
+          span= @plage_ouverture.title
+        div.mt-2.d-flex
+          .flex-shrink-0.mr-1.font-weight-bold Professionnel :
+          span= @plage_ouverture.agent.full_name
+        div.mt-2.d-flex
+          .flex-shrink-0.mr-1.font-weight-bold Lieu :
+          span= "#{@plage_ouverture.lieu.name} (#{@plage_ouverture.lieu.address})"
+        div.mt-2.d-flex
+          .flex-shrink-0.mr-1.font-weight-bold Motifs :
+          ul.pl-3.mb-0
+            - @plage_ouverture.motifs.each do |motif|
+              li= motif_name_with_location_type_and_badges(motif)
+        div.mt-2.d-flex
+          .flex-shrink-0.mr-1.font-weight-bold Répétition :
+          span= @plage_ouverture.recurring? ? "Récurrente" : po_exceptionnelle_tag(@plage_ouverture)
+        div.mt-2.d-flex
+          .flex-shrink-0.mr-1.font-weight-bold Dates :
+          - if @plage_ouverture.recurring?
+            = sanitize(display_recurrence(@plage_ouverture).join(" "))
+          - else
+            | Le #{l(@plage_ouverture.first_day, format: :human)} #{display_time_range(@plage_ouverture)}
+        div.mt-3.text-muted.text-right
+          | modifiée le #{l(@plage_ouverture.updated_at, format: :short)}
+        - if @plage_ouverture.overlapping_plages_ouvertures?
+          div.mt-3
+            .alert.alert-warning.mt-1.mb-0
+              | Conflit de dates et d'horaires avec d'autres plages d'ouvertures
+            .border-left.border-right.border-bottom.rounded.border-warning
+              ul.pl-3.py-2.mb-0
+                = render "overlapping_plage_ouvertures", \
+                  overlapping_plages_ouvertures: @overlapping_plages_ouvertures, \
+                  overlapping_plages_ouvertures_out_of_scope_count: @overlapping_plages_ouvertures_out_of_scope_count
+
+      .card-footer.d-flex.justify-content-between
+        div
+          = link_to( \
+            "Supprimer", \
+            admin_organisation_plage_ouverture_path(current_organisation, @plage_ouverture), \
+            method: :delete, \
+            data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"}, \
+            class: "btn btn-danger" \
+          )
+        div
+          = link_to( \
+            "Dupliquer", \
+            new_admin_organisation_agent_plage_ouverture_path( \
+              current_organisation, \
+              @plage_ouverture.agent.id, \
+              duplicate_plage_ouverture_id: @plage_ouverture.id \
+            ), \
+            class: "btn btn-link" \
+          )
+          = link_to( \
+            "Modifier", \
+            edit_admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture), \
+            class: "btn btn-primary" \
+          )

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -13,7 +13,7 @@
     .col
       = f.input :end_time, as: :select, collection: time_collections, selected: model.end_time&.strftime("%H:%M"), include_blank: false
 
-  = f.input :recurrence, as: :hidden, input_html: { value: model.recurrence.as_json.to_json, "data-target": "recurrence.recurrenceComputed", class: 'js-recurrence-computed' }
+  = f.input :recurrence, as: :hidden, input_html: { value: model.recurrence ? model.recurrence.as_json.to_json : "", "data-target": "recurrence.recurrenceComputed", class: 'js-recurrence-computed' }
 
   = simple_fields_for :recurrence do |n|
     = n.input :has_recurrence, as: :boolean, label: "Répéter...", input_html: { data: { target: "recurrence.hasRecurrence", action: "recurrence#updateRecurrence" }, class: 'js-recurrence-toggle js-recurrence-input' }

--- a/app/views/layouts/_model_errors.html.slim
+++ b/app/views/layouts/_model_errors.html.slim
@@ -1,7 +1,13 @@
-- if model.errors.any?
-  .alert.alert-danger.alert-dismissible.fade.show
-    a.close(href="#" data-dismiss="alert")
-      i.fa.fa-times
+- if model.respond_to?(:warnings_need_confirmation?) &&  model.warnings_need_confirmation?
+  / warnings only appear if there are no other errors
+  .mb-1 Avertissements :
+  .alert.alert-warning.show
+    ul.pl-1
+      - model.warnings.each do |key, msg|
+        li= msg
+
+- elsif model.errors.any?
+  .alert.alert-danger.fade.show
     ul.m-0
       - errors_full_messages(model).each do |msg|
-        li=msg
+        li= msg

--- a/app/views/layouts/_model_errors.html.slim
+++ b/app/views/layouts/_model_errors.html.slim
@@ -2,7 +2,7 @@
   / warnings only appear if there are no other errors
   .mb-1 Avertissements :
   .alert.alert-warning.show
-    ul.pl-1
+    ul.m-0.pl-1
       - model.warnings.each do |key, msg|
         li= msg
 

--- a/app/webpacker/components/recurrence-form.js
+++ b/app/webpacker/components/recurrence-form.js
@@ -51,6 +51,8 @@ class RecurrenceForm {
   }
 
   getRecurrenceComputed = () => {
+    if (this.recurrenceComputedTarget.value === "")
+      return null
     return JSON.parse(this.recurrenceComputedTarget.value);
   }
 

--- a/app/webpacker/stylesheets/components/_forms.scss
+++ b/app/webpacker/stylesheets/components/_forms.scss
@@ -119,3 +119,22 @@ select.form-control-sm {
   align-items: center;
   justify-content: center;
 }
+
+.form-collapsable-fields-wrapper {
+  position: relative;
+
+  &:not(.show) {
+    display: block !important;
+
+    &::before {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      content: "";
+      background: rgba(255,255,255,0.5);
+      z-index: 1000;
+    }
+  }
+}

--- a/config/locales/plage_ouvertures.yml
+++ b/config/locales/plage_ouvertures.yml
@@ -1,0 +1,5 @@
+fr:
+  plage_ouvertures:
+    overlapping_out_of_scope:
+      one: "%{count} plage d'ouverture dans une organisation à laquelle vous n'avez pas accès"
+      other: "%{count} plages d'ouvertures dans des organisations auxquelles vous n'avez pas accès"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
       end
 
       resources :organisations do
-        resources :plage_ouvertures, except: [:index, :show, :new]
+        resources :plage_ouvertures, except: [:index, :new]
         resources :agent_searches, only: :index, module: "creneaux"
         resources :lieux, except: :show
         resources :motifs, except: :show

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -2,105 +2,118 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
   render_views
 
   let!(:organisation) { create(:organisation) }
-  let!(:agent) { create(:agent, organisations: [organisation]) }
-  let!(:motif) { create(:motif, organisation: organisation) }
+  let!(:service) { create(:service) }
+  let!(:agent) { create(:agent, organisations: [organisation], service: service) }
+  let!(:motif) { create(:motif, organisation: organisation, service: service) }
   let!(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Sud", address: "10 rue Belsunce") }
-  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu1, organisation: organisation, agent: agent) }
 
   shared_examples "agent can CRUD plage ouverture" do
     describe "GET #index" do
+      let!(:plage_ouverture) do
+        create(
+          :plage_ouverture,
+          first_day: Date.new(2020, 11, 16),
+          start_time: Tod::TimeOfDay(9),
+          end_time: Tod::TimeOfDay(12),
+          motifs: [motif],
+          lieu: lieu1,
+          organisation: organisation,
+          agent: agent
+        )
+      end
       it "returns a success response" do
         get :index, params: { organisation_id: organisation.id, agent_id: agent.id }
         expect(response).to be_successful
+        # TODO : includes plage ouverture
+      end
+    end
+
+    describe "GET #index.json" do
+      let(:agent) { create(:agent, organisations: [organisation]) }
+      let!(:plage_ouverture) { create(:plage_ouverture, :weekly_by_2, title: "Une semaine sur deux les mercredis à partir du 17/07", first_day: Date.new(2019, 7, 17), lieu: lieu1, agent: agent, organisation: organisation) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, :weekly, title: "Tous les lundis à partir du 22/07", first_day: Date.new(2019, 7, 22), lieu: lieu1, agent: agent, organisation: organisation) }
+      let!(:plage_ouverture3) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation) }
+      let!(:plage_ouverture4) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation) }
+
+      before do
+        sign_in agent
       end
 
-      describe "format json" do
-        let(:agent) { create(:agent, organisations: [organisation]) }
-        let!(:plage_ouverture) { create(:plage_ouverture, :weekly_by_2, title: "Une semaine sur deux les mercredis à partir du 17/07", first_day: Date.new(2019, 7, 17), lieu: lieu1, agent: agent, organisation: organisation) }
-        let!(:plage_ouverture2) { create(:plage_ouverture, :weekly, title: "Tous les lundis à partir du 22/07", first_day: Date.new(2019, 7, 22), lieu: lieu1, agent: agent, organisation: organisation) }
-        let!(:plage_ouverture3) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation) }
-        let!(:plage_ouverture4) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, recurrence: Montrose::Recurrence.new, organisation: organisation) }
+      subject { get :index, params: { format: "json", organisation_id: organisation.id, agent_id: agent.id, start: start_date, end: end_date } }
 
-        before do
-          sign_in agent
+      before do
+        subject
+        @parsed_response = JSON.parse(response.body)
+      end
+
+      context "from 08/07/2019 to 14/07/2019" do
+        let(:start_date) { Date.new(2019, 7, 8) }
+        let(:end_date) { Date.new(2019, 7, 14) }
+
+        it { expect(response).to have_http_status(:ok) }
+        it { expect(response.body).to eq("[]") }
+      end
+
+      context "from 22/07/2019 to 28/07/2019" do
+        let(:start_date) { Date.new(2019, 7, 22) }
+        let(:end_date) { Date.new(2019, 7, 28) }
+
+        it "should return 3 occurences from plage_ouverture2 3 and 4" do
+          expect(@parsed_response.size).to eq(3)
+
+          first = @parsed_response[0]
+          expect(first.size).to eq(6)
+          expect(first["title"]).to eq(plage_ouverture2.title)
+          expect(first["start"]).to eq(plage_ouverture2.starts_at.as_json)
+          expect(first["end"]).to eq(plage_ouverture2.first_occurence_ends_at.as_json)
+          expect(first["backgroundColor"]).to eq("#6fceff80")
+          expect(first["rendering"]).to eq("background")
+          expect(first["extendedProps"]).to eq({ lieu: "MDS Sud", location: "10 rue Belsunce" }.as_json)
+
+          second = @parsed_response[1]
+          expect(second.size).to eq(6)
+          expect(second["title"]).to eq(plage_ouverture3.title)
+          expect(second["start"]).to eq("2019-07-24T08:00:00.000+02:00")
+          expect(second["end"]).to eq("2019-07-24T12:00:00.000+02:00")
+          expect(second["backgroundColor"]).to eq("#6fceff80")
+          expect(second["rendering"]).to eq("background")
+          expect(second["extendedProps"]).to eq({ lieu: "MDS Sud", location: "10 rue Belsunce" }.as_json)
+
+          third = @parsed_response[2]
+          expect(third.size).to eq(6)
+          expect(third["title"]).to eq(plage_ouverture4.title)
+          expect(third["start"]).to eq("2019-07-24T08:00:00.000+02:00")
+          expect(third["end"]).to eq("2019-07-24T12:00:00.000+02:00")
+          expect(third["backgroundColor"]).to eq("#6fceff80")
+          expect(third["rendering"]).to eq("background")
+          expect(third["extendedProps"]).to eq({ lieu: "MDS Sud", location: "10 rue Belsunce" }.as_json)
         end
+      end
 
-        subject { get :index, params: { format: "json", organisation_id: organisation.id, agent_id: agent.id, start: start_date, end: end_date } }
+      context "from 29/07/2019 to 04/08/2019" do
+        let(:start_date) { Date.new(2019, 7, 29) }
+        let(:end_date) { Date.new(2019, 8, 4) }
 
-        before do
-          subject
-          @parsed_response = JSON.parse(response.body)
-        end
+        it "should return two occurences one from plage_ouverture and one from plage_ouverture2" do
+          expect(@parsed_response.size).to eq(2)
 
-        context "from 08/07/2019 to 14/07/2019" do
-          let(:start_date) { Date.new(2019, 7, 8) }
-          let(:end_date) { Date.new(2019, 7, 14) }
+          first = @parsed_response[0]
+          expect(first.size).to eq(6)
+          expect(first["title"]).to eq(plage_ouverture2.title)
+          expect(first["start"]).to eq("2019-07-29T08:00:00.000+02:00")
+          expect(first["end"]).to eq("2019-07-29T12:00:00.000+02:00")
+          expect(first["backgroundColor"]).to eq("#6fceff80")
+          expect(first["rendering"]).to eq("background")
+          expect(first["extendedProps"]).to eq({ lieu: plage_ouverture2.lieu.name, location: plage_ouverture2.lieu.address }.as_json)
 
-          it { expect(response).to have_http_status(:ok) }
-          it { expect(response.body).to eq("[]") }
-        end
-
-        context "from 22/07/2019 to 28/07/2019" do
-          let(:start_date) { Date.new(2019, 7, 22) }
-          let(:end_date) { Date.new(2019, 7, 28) }
-
-          it "should return 3 occurences from plage_ouverture2 3 and 4" do
-            expect(@parsed_response.size).to eq(3)
-
-            first = @parsed_response[0]
-            expect(first.size).to eq(6)
-            expect(first["title"]).to eq(plage_ouverture2.title)
-            expect(first["start"]).to eq(plage_ouverture2.starts_at.as_json)
-            expect(first["end"]).to eq(plage_ouverture2.first_occurence_ends_at.as_json)
-            expect(first["backgroundColor"]).to eq("#6fceff80")
-            expect(first["rendering"]).to eq("background")
-            expect(first["extendedProps"]).to eq({ lieu: "MDS Sud", location: "10 rue Belsunce" }.as_json)
-
-            second = @parsed_response[1]
-            expect(second.size).to eq(6)
-            expect(second["title"]).to eq(plage_ouverture3.title)
-            expect(second["start"]).to eq("2019-07-24T08:00:00.000+02:00")
-            expect(second["end"]).to eq("2019-07-24T12:00:00.000+02:00")
-            expect(second["backgroundColor"]).to eq("#6fceff80")
-            expect(second["rendering"]).to eq("background")
-            expect(second["extendedProps"]).to eq({ lieu: "MDS Sud", location: "10 rue Belsunce" }.as_json)
-
-            third = @parsed_response[2]
-            expect(third.size).to eq(6)
-            expect(third["title"]).to eq(plage_ouverture4.title)
-            expect(third["start"]).to eq("2019-07-24T08:00:00.000+02:00")
-            expect(third["end"]).to eq("2019-07-24T12:00:00.000+02:00")
-            expect(third["backgroundColor"]).to eq("#6fceff80")
-            expect(third["rendering"]).to eq("background")
-            expect(third["extendedProps"]).to eq({ lieu: "MDS Sud", location: "10 rue Belsunce" }.as_json)
-          end
-        end
-
-        context "from 29/07/2019 to 04/08/2019" do
-          let(:start_date) { Date.new(2019, 7, 29) }
-          let(:end_date) { Date.new(2019, 8, 4) }
-
-          it "should return two occurences one from plage_ouverture and one from plage_ouverture2" do
-            expect(@parsed_response.size).to eq(2)
-
-            first = @parsed_response[0]
-            expect(first.size).to eq(6)
-            expect(first["title"]).to eq(plage_ouverture2.title)
-            expect(first["start"]).to eq("2019-07-29T08:00:00.000+02:00")
-            expect(first["end"]).to eq("2019-07-29T12:00:00.000+02:00")
-            expect(first["backgroundColor"]).to eq("#6fceff80")
-            expect(first["rendering"]).to eq("background")
-            expect(first["extendedProps"]).to eq({ lieu: plage_ouverture2.lieu.name, location: plage_ouverture2.lieu.address }.as_json)
-
-            second = @parsed_response[1]
-            expect(second.size).to eq(6)
-            expect(second["title"]).to eq(plage_ouverture.title)
-            expect(second["start"]).to eq("2019-07-31T08:00:00.000+02:00")
-            expect(second["end"]).to eq("2019-07-31T12:00:00.000+02:00")
-            expect(second["backgroundColor"]).to eq("#6fceff80")
-            expect(second["rendering"]).to eq("background")
-            expect(second["extendedProps"]).to eq({ lieu: plage_ouverture.lieu.name, location: plage_ouverture.lieu.address }.as_json)
-          end
+          second = @parsed_response[1]
+          expect(second.size).to eq(6)
+          expect(second["title"]).to eq(plage_ouverture.title)
+          expect(second["start"]).to eq("2019-07-31T08:00:00.000+02:00")
+          expect(second["end"]).to eq("2019-07-31T12:00:00.000+02:00")
+          expect(second["backgroundColor"]).to eq("#6fceff80")
+          expect(second["rendering"]).to eq("background")
+          expect(second["extendedProps"]).to eq({ lieu: plage_ouverture.lieu.name, location: plage_ouverture.lieu.address }.as_json)
         end
       end
     end
@@ -113,6 +126,18 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
     end
 
     describe "GET #edit" do
+      let!(:plage_ouverture) do
+        create(
+          :plage_ouverture,
+          first_day: Date.new(2020, 11, 16),
+          start_time: Tod::TimeOfDay(9),
+          end_time: Tod::TimeOfDay(12),
+          motifs: [motif],
+          lieu: lieu1,
+          organisation: organisation,
+          agent: agent
+        )
+      end
       it "returns a success response" do
         get :edit, params: { organisation_id: organisation.id, id: plage_ouverture.to_param }
         expect(response).to be_successful
@@ -120,6 +145,20 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
     end
 
     describe "POST #create" do
+      let!(:plage_ouverture) do
+        create(
+          :plage_ouverture,
+          :weekly,
+          first_day: Date.new(2020, 11, 16),
+          start_time: Tod::TimeOfDay(9),
+          end_time: Tod::TimeOfDay(12),
+          motifs: [motif],
+          lieu: lieu1,
+          organisation: organisation,
+          agent: agent
+        )
+      end
+
       context "with valid params for non-overlapping exceptional PO" do
         it "creates it and redirects to the index" do
           post(
@@ -166,53 +205,56 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
     end
 
     describe "PUT #update" do
-      subject { put :update, params: { organisation_id: organisation.id, id: plage_ouverture.to_param, plage_ouverture: new_attributes } }
-
-      before { subject }
+      let!(:plage_ouverture) do
+        create(
+          :plage_ouverture,
+          first_day: Date.new(2020, 11, 16),
+          start_time: Tod::TimeOfDay(9),
+          end_time: Tod::TimeOfDay(12),
+          motifs: [motif],
+          lieu: lieu1,
+          organisation: organisation,
+          agent: agent
+        )
+      end
 
       context "with valid params" do
-        let(:new_attributes) do
-          {
-            title: "Le nouveau nom",
-          }
-        end
-
         it "updates the requested plage_ouverture" do
+          put :update, params: { organisation_id: organisation.id, id: plage_ouverture.to_param, plage_ouverture: { title: "Le nouveau nom" } }
           expect(response.status).to eq(200)
           plage_ouverture.reload
           expect(plage_ouverture.title).to eq("Le nouveau nom")
         end
       end
 
-      context "with invalid params" do
-        let(:new_attributes) do
-          {
-            start_time: "09:00",
-            end_time: "07:00",
-          }
-        end
-
-        it "returns a success response (i.e. to display the 'edit' template)" do
+      context "with invalid params (end_time before start_time)" do
+        it "returns a success response (i.e. to display the 'edit' template) and does not update" do
+          put :update, params: { organisation_id: organisation.id, id: plage_ouverture.to_param, plage_ouverture: { start_time: "10:00", end_time: "07:00" } }
           expect(response).to be_successful
-        end
-
-        it "does not change plage_ouverture start_time and end_time" do
           plage_ouverture.reload
-          expect(plage_ouverture.start_time.to_s).not_to eq("09:00:00")
+          expect(plage_ouverture.start_time.to_s).not_to eq("10:00:00")
           expect(plage_ouverture.end_time.to_s).not_to eq("07:00:00")
         end
       end
     end
 
     describe "DELETE #destroy" do
-      it "destroys the requested plage_ouverture" do
-        expect do
-          delete :destroy, params: { organisation_id: organisation.id, id: plage_ouverture.to_param }
-        end.to change(PlageOuverture, :count).by(-1)
+      let!(:plage_ouverture) do
+        create(
+          :plage_ouverture,
+          first_day: Date.new(2020, 11, 16),
+          start_time: Tod::TimeOfDay(9),
+          end_time: Tod::TimeOfDay(12),
+          motifs: [motif],
+          lieu: lieu1,
+          organisation: organisation,
+          agent: agent
+        )
       end
 
-      it "redirects to the plage_ouvertures list" do
-        delete :destroy, params: { organisation_id: organisation.id, id: plage_ouverture.to_param }
+      it "destroys the requested plage_ouverture" do
+        delete :destroy, params: { organisation_id: organisation.id, id: plage_ouverture.id }
+        expect(agent.plage_ouvertures.count).to eq(0)
         expect(response).to redirect_to(admin_organisation_agent_plage_ouvertures_path(organisation, plage_ouverture.agent_id))
       end
     end

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
 
     describe "GET #index.json" do
       let(:agent) { create(:agent, organisations: [organisation]) }
-      let!(:plage_ouverture) { create(:plage_ouverture, :weekly_by_2, title: "Une semaine sur deux les mercredis à partir du 17/07", first_day: Date.new(2019, 7, 17), lieu: lieu1, agent: agent, organisation: organisation) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, :weekly, title: "Tous les lundis à partir du 22/07", first_day: Date.new(2019, 7, 22), lieu: lieu1, agent: agent, organisation: organisation) }
-      let!(:plage_ouverture3) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation) }
-      let!(:plage_ouverture4) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation) }
+      let!(:plage_ouverture) { create(:plage_ouverture, :weekly_by_2, title: "Une semaine sur deux les mercredis à partir du 17/07", first_day: Date.new(2019, 7, 17), lieu: lieu1, agent: agent, organisation: organisation, active_warnings_confirm_decision: true) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, :weekly, title: "Tous les lundis à partir du 22/07", first_day: Date.new(2019, 7, 22), lieu: lieu1, agent: agent, organisation: organisation, active_warnings_confirm_decision: true) }
+      let!(:plage_ouverture3) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation, active_warnings_confirm_decision: true) }
+      let!(:plage_ouverture4) { create(:plage_ouverture, title: "Une seule fois le 24/07", first_day: Date.new(2019, 7, 24), lieu: lieu1, agent: agent, organisation: organisation, active_warnings_confirm_decision: true) }
 
       before do
         sign_in agent

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -8,6 +8,27 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
   let!(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Sud", address: "10 rue Belsunce") }
 
   shared_examples "agent can CRUD plage ouverture" do
+    describe "GET #show" do
+      let!(:plage_ouverture) do
+        create(
+          :plage_ouverture,
+          title: "Permanence",
+          first_day: Date.new(2020, 11, 16),
+          start_time: Tod::TimeOfDay(9),
+          end_time: Tod::TimeOfDay(12),
+          motifs: [motif],
+          lieu: lieu1,
+          organisation: organisation,
+          agent: agent
+        )
+      end
+      it "should display the PO" do
+        get :show, params: { organisation_id: organisation.id, id: plage_ouverture.id }
+        expect(response).to be_successful
+        expect(response.body).to include("Permanence")
+      end
+    end
+
     describe "GET #index" do
       let!(:plage_ouverture) do
         create(
@@ -177,7 +198,7 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
               }
             }
           )
-          expect(response).to redirect_to(admin_organisation_agent_plage_ouvertures_path(organisation, PlageOuverture.last.agent_id))
+          expect(response).to redirect_to(admin_organisation_plage_ouverture_path(organisation, PlageOuverture.last))
           expect(agent.plage_ouvertures.count).to eq 2
         end
       end
@@ -221,9 +242,7 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
       context "with valid params" do
         it "updates the requested plage_ouverture" do
           put :update, params: { organisation_id: organisation.id, id: plage_ouverture.to_param, plage_ouverture: { title: "Le nouveau nom" } }
-          expect(response.status).to eq(200)
-          plage_ouverture.reload
-          expect(plage_ouverture.title).to eq("Le nouveau nom")
+          expect(response).to redirect_to(admin_organisation_plage_ouverture_path(organisation, plage_ouverture))
         end
       end
 

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :weekly do
-      recurrence { Montrose.weekly.on(:monday).to_json }
+      recurrence { Montrose.weekly.on([:monday]).to_json }
     end
 
     trait :monthly do

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -4,7 +4,7 @@ describe "Agent can CRUD plage d'ouverture" do
   let!(:motif) { create(:motif, name: "Suivi bonjour", service: service, organisation: organisation) }
   let!(:agent) { create(:agent, :admin, service: service, organisations: [organisation]) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, agent: agent, organisation: organisation) }
+  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, agent: agent, organisation: organisation, title: "Permanence") }
   let(:new_plage_ouverture) { build(:plage_ouverture, lieu: lieu, agent: agent, organisation: organisation) }
 
   before do
@@ -16,28 +16,30 @@ describe "Agent can CRUD plage d'ouverture" do
   shared_examples "can crud own plage ouvertures" do
     it "works" do
       expect_page_title("Vos plages d'ouverture")
-      click_link plage_ouverture.title
+      click_link "Permanence"
+
+      expect_page_title("Permanence")
+      click_link "Modifier"
 
       expect_page_title("Modifier votre plage d'ouverture")
       fill_in "Description", with: "La belle plage"
       click_button("Modifier")
 
-      expect_page_title("Modifier votre plage d'ouverture")
-      expect(page).to have_content("La belle plage")
-
+      expect_page_title("La belle plage")
       click_link("Supprimer")
+
       expect_page_title("Vos plages d'ouverture")
       expect(page).to have_content("Vous n'avez pas encore créé de plage d'ouverture")
 
       click_link "Créer une plage d'ouverture", match: :first
 
       expect_page_title("Nouvelle plage d'ouverture")
-      fill_in "Description", with: new_plage_ouverture.title
+      fill_in "Description", with: "Accueil"
       check "Suivi bonjour"
       click_button "Créer"
 
-      expect_page_title("Vos plages d'ouverture")
-      click_link new_plage_ouverture.title
+      expect_page_title("Accueil")
+      click_link "Modifier"
     end
   end
 
@@ -56,41 +58,43 @@ describe "Agent can CRUD plage d'ouverture" do
 
     context "with motif for_secretariat" do
       let!(:motif) { create(:motif, :for_secretariat, name: "Suivi bonjour", service: service, organisation: organisation) }
-      let(:plage_ouverture) { create(:plage_ouverture, lieu: lieu, agent: agent, motifs: [motif], organisation: organisation) }
+      let!(:plage_ouverture) { create(:plage_ouverture, lieu: lieu, agent: agent, motifs: [motif], organisation: organisation, title: "Permanence") }
       it_behaves_like "can crud own plage ouvertures"
     end
   end
 
   context "for an other agent calendar" do
     let!(:other_agent) { create(:agent, first_name: "Jane", last_name: "FAROU", service: service, organisations: [organisation]) }
-    let!(:plage_ouverture) { create(:plage_ouverture, lieu: lieu, agent: other_agent, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, agent: other_agent, organisation: organisation, title: "Permanence") }
 
     scenario "can crud a plage_ouverture" do
       visit admin_organisation_agent_plage_ouvertures_path(organisation, other_agent.id)
 
       expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
-      click_link plage_ouverture.title
+      click_link "Permanence"
+
+      expect_page_title("Permanence")
+      click_link "Modifier"
 
       expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
       fill_in "Description", with: "La belle plage"
       click_button("Modifier")
 
-      expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
-      expect(page).to have_content("La belle plage")
-
+      expect_page_title("La belle plage")
       click_link("Supprimer")
+
       expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
 
       click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
 
       expect_page_title("Nouvelle plage d'ouverture")
-      fill_in "Description", with: new_plage_ouverture.title
+      fill_in "Description", with: "Accueil"
       check "Suivi bonjour"
       click_button "Créer"
 
-      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
-      click_link new_plage_ouverture.title
+      expect_page_title("Accueil")
+      click_link "Modifier"
     end
   end
 end

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -12,7 +12,7 @@ describe Absence, type: :model do
       it do
         expect(subject.size).to eq 1
         expect(subject.first.starts_at).to eq absence.starts_at
-        expect(subject.first.ends_at).to eq absence.ends_at
+        expect(subject.first.ends_at).to eq absence.first_occurence_ends_at
       end
 
       context "if the abence has many occurrences in range" do
@@ -22,9 +22,9 @@ describe Absence, type: :model do
         it do
           expect(subject.size).to eq 2
           expect(subject.first.starts_at).to eq(absence.starts_at + 1.weeks) # first one ends in range
-          expect(subject.first.ends_at).to eq(absence.ends_at + 1.weeks) # first one ends in range
+          expect(subject.first.ends_at).to eq(absence.first_occurence_ends_at + 1.weeks) # first one ends in range
           expect(subject.second.starts_at).to eq(absence.starts_at + 2.weeks) # second one starts in range
-          expect(subject.second.ends_at).to eq(absence.ends_at + 2.weeks) # second one starts in range
+          expect(subject.second.ends_at).to eq(absence.first_occurence_ends_at + 2.weeks) # second one starts in range
         end
       end
     end

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -5,7 +5,7 @@ shared_examples_for "recurrence" do
   describe "#starts_at" do
     subject { model_instance.starts_at }
 
-    context "for a plage" do
+    context "exceptionnelle" do
       let(:model_instance) { create(model_symbol, first_day: Date.new(2019, 7, 22), start_time: Tod::TimeOfDay.new(9)) }
 
       it { is_expected.to eq(Time.zone.local(2019, 7, 22, 9)) }
@@ -15,10 +15,19 @@ shared_examples_for "recurrence" do
   describe "#ends_at" do
     subject { model_instance.ends_at }
 
-    context "for a plage" do
+    context "exceptionnelle" do
       let(:model_instance) { create(model_symbol, first_day: Date.new(2019, 7, 22), end_time: Tod::TimeOfDay.new(12)) }
-
       it { is_expected.to eq(Time.zone.local(2019, 7, 22, 12)) }
+    end
+
+    context "recurring without end date" do
+      let(:model_instance) { create(model_symbol, first_day: Date.new(2019, 7, 22), end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.weekly.on(:tuesday).to_json) }
+      it { is_expected.to be_nil }
+    end
+
+    context "recurring with end date" do
+      let(:model_instance) { create(model_symbol, first_day: Date.new(2020, 11, 17), end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], until: Date.new(2020, 11, 25)).to_json) }
+      it { is_expected.to eq(Time.zone.local(2020, 11, 25, 12)) }
     end
   end
 
@@ -33,7 +42,7 @@ shared_examples_for "recurrence" do
       it do
         expect(subject.size).to eq 1
         expect(subject.first.starts_at).to eq model_instance.starts_at
-        expect(subject.first.ends_at).to eq model_instance.ends_at
+        expect(subject.first.ends_at).to eq model_instance.first_occurence_ends_at
       end
 
       context "and the first_day is the last of the range" do
@@ -42,7 +51,7 @@ shared_examples_for "recurrence" do
         it do
           expect(subject.size).to eq 1
           expect(subject.first.starts_at).to eq model_instance.starts_at
-          expect(subject.first.ends_at).to eq model_instance.ends_at
+          expect(subject.first.ends_at).to eq model_instance.first_occurence_ends_at
         end
       end
     end
@@ -54,19 +63,19 @@ shared_examples_for "recurrence" do
       it do
         expect(subject.size).to eq 7
         expect(subject[0].starts_at).to eq(model_instance.starts_at)
-        expect(subject[0].ends_at).to eq(model_instance.ends_at)
+        expect(subject[0].ends_at).to eq(model_instance.first_occurence_ends_at)
         expect(subject[1].starts_at).to eq(model_instance.starts_at + 1.day)
-        expect(subject[1].ends_at).to eq(model_instance.ends_at + 1.day)
+        expect(subject[1].ends_at).to eq(model_instance.first_occurence_ends_at + 1.day)
         expect(subject[2].starts_at).to eq(model_instance.starts_at + 2.day)
-        expect(subject[2].ends_at).to eq(model_instance.ends_at + 2.day)
+        expect(subject[2].ends_at).to eq(model_instance.first_occurence_ends_at + 2.day)
         expect(subject[3].starts_at).to eq(model_instance.starts_at + 3.day)
-        expect(subject[3].ends_at).to eq(model_instance.ends_at + 3.day)
+        expect(subject[3].ends_at).to eq(model_instance.first_occurence_ends_at + 3.day)
         expect(subject[4].starts_at).to eq(model_instance.starts_at + 4.day)
-        expect(subject[4].ends_at).to eq(model_instance.ends_at + 4.day)
+        expect(subject[4].ends_at).to eq(model_instance.first_occurence_ends_at + 4.day)
         expect(subject[5].starts_at).to eq(model_instance.starts_at + 5.day)
-        expect(subject[5].ends_at).to eq(model_instance.ends_at + 5.day)
+        expect(subject[5].ends_at).to eq(model_instance.first_occurence_ends_at + 5.day)
         expect(subject[6].starts_at).to eq(model_instance.starts_at + 6.day)
-        expect(subject[6].ends_at).to eq(model_instance.ends_at + 6.day)
+        expect(subject[6].ends_at).to eq(model_instance.first_occurence_ends_at + 6.day)
       end
     end
 
@@ -77,11 +86,11 @@ shared_examples_for "recurrence" do
       it do
         expect(subject.size).to eq 3
         expect(subject[0].starts_at).to eq(model_instance.starts_at)
-        expect(subject[0].ends_at).to eq(model_instance.ends_at)
+        expect(subject[0].ends_at).to eq(model_instance.first_occurence_ends_at)
         expect(subject[1].starts_at).to eq(model_instance.starts_at + 1.week)
-        expect(subject[1].ends_at).to eq(model_instance.ends_at + 1.week)
+        expect(subject[1].ends_at).to eq(model_instance.first_occurence_ends_at + 1.week)
         expect(subject[2].starts_at).to eq(model_instance.starts_at + 2.weeks)
-        expect(subject[2].ends_at).to eq(model_instance.ends_at + 2.weeks)
+        expect(subject[2].ends_at).to eq(model_instance.first_occurence_ends_at + 2.weeks)
       end
     end
 
@@ -92,9 +101,9 @@ shared_examples_for "recurrence" do
       it do
         expect(subject.size).to eq 2
         expect(subject[0].starts_at).to eq(model_instance.starts_at)
-        expect(subject[0].ends_at).to eq(model_instance.ends_at)
+        expect(subject[0].ends_at).to eq(model_instance.first_occurence_ends_at)
         expect(subject[1].starts_at).to eq(model_instance.starts_at + 2.weeks)
-        expect(subject[1].ends_at).to eq(model_instance.ends_at + 2.weeks)
+        expect(subject[1].ends_at).to eq(model_instance.first_occurence_ends_at + 2.weeks)
       end
     end
 

--- a/spec/service_models/plage_ouverture_overlap_spec.rb
+++ b/spec/service_models/plage_ouverture_overlap_spec.rb
@@ -1,0 +1,222 @@
+describe PlageOuvertureOverlap do
+  let(:organisation) { build(:organisation) }
+  let(:agent) { build(:agent, organisations: [organisation]) }
+  let(:monday) { Date.today.next_week(:monday) }
+
+  def build_po(first_day, start_hour, end_hour, recurrence = nil)
+    build(
+      :plage_ouverture,
+      agent: agent,
+      first_day: first_day,
+      start_time: Tod::TimeOfDay.new(start_hour),
+      end_time: Tod::TimeOfDay.new(end_hour),
+      **(recurrence ? { recurrence: recurrence.to_json } : {})
+    )
+  end
+
+  shared_examples "plage ouvertures overlap" do
+    it "overlaps" do
+      expect(PlageOuvertureOverlap.new(po1, po2).exists?).to eq true
+      expect(PlageOuvertureOverlap.new(po2, po1).exists?).to eq true
+    end
+  end
+
+  shared_examples "plage ouvertures do not overlap" do
+    it "does not overlap" do
+      expect(PlageOuvertureOverlap.new(po1, po2).exists?).to eq false
+      expect(PlageOuvertureOverlap.new(po2, po1).exists?).to eq false
+    end
+  end
+
+  # both exceptionnelles
+
+  context "po1 and po2 exceptionnelles, exactly overlapping" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday, 14, 18) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 exceptionnelles, included in other" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday, 15, 16) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 exceptionnelles, includes other" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday, 8, 20) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 exceptionnelles, partially overlapping start" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday, 8, 16) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 exceptionnelles, partially overlapping end" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday, 16, 20) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 exceptionnelles, non overlapping same day" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday, 8, 12) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 exceptionnelles, non overlapping other day" do
+    let(:po1) { build_po(monday, 14, 18) }
+    let(:po2) { build_po(monday + 1.day, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  # po1 recurring, po2 exceptionnelle
+
+  context "po1 recurring without end date, po2 exceptionnelle before recurring" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday - 7.days, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring without end date, po2 exceptionnelle on other day same week" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 3.days, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring without end date, po2 exceptionnelle on other day next week" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 3.days, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring without end date, po2 exceptionnelle on same day but times don't overlap" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 8.days, 8, 10) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring without end date, po2 exceptionnelle on same day and times overlap" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 8.days, 15, 20) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 6 weeks after" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks).on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 6.weeks, 14, 18) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 4 weeks after" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks).on([:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 4.weeks, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring with end date, po2 exceptionnelle before recurring" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday - 7.days, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring with end date, po2 exceptionnelle same weekday before po1 end date" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 recurring with end date, po2 exceptionnelle other weekday before po1 end date" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday - 10.days, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring with end date, po2 exceptionnelle same weekday after po1 end date" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 14, 18) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  ## both recurring
+
+  context "po1 and po2 recurring without end date, different weekdays" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday])) }
+    let(:po2) { build_po(monday, 14, 18, Montrose.every(:week, on: [:wednesday, :thursday])) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring without end date, overlapping weekdays" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday])) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 recurring without end date, overlapping weekdays but different times" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday])) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring without end date, non-overlapping alternative weeks" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 2)) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring without end date, overlapping weeks" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 3)) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 recurring with end date, po2 recurring without end date, po2 starts before po1 ends, with weekdays overlap" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 recurring with end date, po2 recurring without end date, po2 starts before po1 ends, without weekdays overlap" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:wednesday, :thursday])) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 recurring with end date, po2 recurring without end date, po2 starts after po1 ends" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring with end date, overlap" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 1.weeks, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], until: monday + 5.weeks)) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 recurring with end date, non-overlapping alternative weeks" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, until: monday + 10.weeks)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 2, until: monday + 10.weeks)) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring with end date, overlapping weeks" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, until: monday + 10.weeks)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 3, until: monday + 10.weeks)) }
+    it_behaves_like "plage ouvertures overlap"
+  end
+
+  context "po1 and po2 recurring with end date, po2 starts after po1 ends" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: [:tuesday, :wednesday], until: monday + 6.weeks)) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring with end date, overlap but weekdays mismatch" do
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: [:wednesday, :thursday], until: monday + 6.weeks)) }
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+end


### PR DESCRIPTION
https://trello.com/c/QEzwN6e0/1087-alerter-lors-de-la-cr%C3%A9ation-de-rdvs-ou-de-plages-douvertures-en-conflit-avec-dautres-plages-douvertures-potentiellement-dautres

⚠️ lire les commits un par un

⚠️ Cette PR a été sacrément longue et un peu dure à écrire 😓  elle est longue, mais relativement bien découpée, et il y a peut être la moitié de lignes de test

## Visuel

![overlap1](https://user-images.githubusercontent.com/883348/99534604-f44e9500-29a7-11eb-9daa-1afa78b2aae4.gif)

![overlap2](https://user-images.githubusercontent.com/883348/99534609-f9134900-29a7-11eb-9fad-8c2729424ea5.gif)


## Détails des 3 premiers commits de refactos préliminaires

- renommer le `RecurrenceConcern#ends_at` actuel en `first_occurence_ends_at`. Cette méthode est en effet très perturbante actuellement car elle renvoie le ends_at de la première occurence pour les plages d'ouvertures ou absences récurrentes. On s'attend bien plus à ce qu'elle renvoie la date de fin éventuelle de la récurrence. La nouvelle méthode `ends_at` renvoie donc bien cette valeur de fin d'occurence ou nil s'il n'y a pas de fin (récurrence infinie)
- correction du bout formulaire pour la récurrence qui envoyait `recurrence="null"` au lieu d'une chaine vide. Cela devenait problématique car je m'appuie plus qu'avant sur la présence de `recurrence` pour décider si une plage est effectivement récurrente ou non.
- ajout d'un lien pour supprimer les plages d'ouvertures depuis l'index (plus simple pour faire plein de tests)

## Détail du dernier commit d'implémentation de la fonctionnalité

- l'interface s'appuie sur la gem https://github.com/rdv-solidarites/activemodel-caution (forkée juste pour changer la version de rails compatible)
- je n'ai pas beaucoup optimisé la requête SQL pour détecter les plages d'ouvertures en conflit pour l'instant, j'attends de voir si c'est problématique ou non.
- j'ai rajouté les avertissements de recoupement dans la vue index. Cependant, ça me gênait d'afficher un avertissement sans permettre aux agents de voir le détail : avec quelles plages ça recoupait. Je ne voulais pas rajouter ce détail sur la vue #edit, ça n'a pas trop de sens. Donc j'ai créé la vue #show qui n'existait pas encore. 
- La vue show permet de simplifier un peu l'interface index : j'ai enlevé le lien "dupliquer", qui est maintenant uniquement sur la vue #show. J'ai hésité à enlever complètement les liens supprimer et éditer de l'index, pour harmoniser avec les autres ressources où il faut toujours passer par le show et il n'y a pas de raccourcis. Pour l'instant je les ai laissés mais j'ai réduit la place qu'ils prennent en utilisant des icônes (oeil, stylo, poubelle). je sais que ce n'est pas très parlant mais c'est uniquement des raccourcis pour les power users. Les usagers normaux passeront par le show et tout sera très clair à mon avis (plus qu'avant).