### PR TITLE
Destroy plage ouvertures and absences when removing agent from orga

### DIFF
--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -1,17 +1,17 @@
 class Admin::PermissionsController < AgentAuthController
-  respond_to :html, :json
-
   def edit
     @permission = Agent::Permission.new(agent: Agent.find(params[:id]))
     authorize(@permission)
-    respond_right_bar_with @permission
   end
 
   def update
     @permission = Agent::Permission.new(agent: Agent.find(params[:id]))
     authorize(@permission)
-    flash[:notice] = "Agent mis à jour" if @permission.update(permission_params)
-    respond_right_bar_with @permission, location: admin_organisation_agents_path(current_organisation)
+    if @permission.update(permission_params)
+      redirect_to admin_organisation_agents_path(current_organisation), success: "Les permissions de l'agent ont été mises à jour"
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/agents/registrations_controller.rb
+++ b/app/controllers/agents/registrations_controller.rb
@@ -1,5 +1,6 @@
 class Agents::RegistrationsController < Devise::RegistrationsController
   respond_to :html, :json
+  before_action :prevent_if_upcoming_rdvs, only: [:destroy]
 
   def pundit_user
     AgentContext.new(current_agent)
@@ -26,14 +27,23 @@ class Agents::RegistrationsController < Devise::RegistrationsController
   end
 
   def destroy
-    current_agent.soft_delete
     flash[:notice] = "Votre compte a été supprimé."
+    current_agent.organisations.each { AgentRemoval.new(@agent, _1).remove! }
+    current_agent.soft_delete
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     redirect_to root_path
   end
 
 
   private
+
+  def prevent_if_upcoming_rdvs
+    org_with_upcoming_rdvs = current_agent.organisations.all.find { AgentRemoval.new(@agent, _1).upcoming_rdvs? }
+    return unless org_with_upcoming_rdvs
+
+    flash[:error] = "Impossible de supprimer votre compte car vous avez des RDVs à venir dans l'organisation #{org_with_upcoming_rdvs.name}. Veuillez les supprimer ou les réaffecter avant de supprimer votre compte."
+    redirect_to edit_agent_registration_path
+  end
 
   def after_inactive_sign_up_path_for(_)
     new_agent_session_path

--- a/app/service_models/agent_removal.rb
+++ b/app/service_models/agent_removal.rb
@@ -1,0 +1,21 @@
+class AgentRemoval
+  def initialize(agent, organisation)
+    @agent = agent
+    @organisation = organisation
+  end
+
+  def remove!
+    return false if upcoming_rdvs?
+
+    Agent.transaction do
+      @agent.organisations.delete(@organisation)
+      @agent.absences.where(organisation: @organisation).each(&:destroy!)
+      @agent.plage_ouvertures.where(organisation: @organisation).each(&:destroy!)
+      true
+    end
+  end
+
+  def upcoming_rdvs?
+    @upcoming_rdvs ||= @agent.rdvs.where(organisation: @organisation).future.not_cancelled.any?
+  end
+end

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -1,7 +1,7 @@
 tr id="agent_#{agent.id}"
   td
     - if agent.complete?
-      = link_to agent.full_name, edit_admin_organisation_permission_path(current_organisation, agent), class: "mr-2", data: { rightbar: true }
+      = link_to agent.full_name, edit_admin_organisation_permission_path(current_organisation, agent), class: "mr-2"
       = admin_tag(agent)
       = me_tag(agent)
   td.word-break-all

--- a/app/views/admin/permissions/edit.html.slim
+++ b/app/views/admin/permissions/edit.html.slim
@@ -1,5 +1,5 @@
 - content_for :title do
-  | Modifier l'agent #{@permission.agent.full_name}
+  | Modifier le professionnel #{@permission.agent.full_name}
 
 
 - content_for :breadcrumb do
@@ -20,6 +20,10 @@
 
           .row
             .col.text-left
-              = link_to 'Supprimer', admin_organisation_agent_path(current_organisation, @permission.agent), data: { confirm: "Êtes-vous sûr de vouloir supprimer cet utilisateur ?" }, method: :delete, class: 'btn btn-outline-danger'
+              = link_to "Retirer de l'organisation", \
+                admin_organisation_agent_path(current_organisation, @permission.agent), \
+                data: { confirm: "Êtes-vous sûr de vouloir retirer cet agent de l'organisation #{current_organisation.name} ?\n\nToutes ses absences et ses plages d'ouvertures seront supprimées de manière irréversible." }, \
+                method: :delete, \
+                class: 'btn btn-outline-danger'
             .col.text-right
               = f.button :submit

--- a/app/views/admin/permissions/edit.html.slim
+++ b/app/views/admin/permissions/edit.html.slim
@@ -1,13 +1,25 @@
 - content_for :title do
-  | Modifier le professionnel
+  | Modifier l'agent #{@permission.agent.full_name}
 
-= simple_form_for [:admin, @permission], url: admin_organisation_permission_path(current_organisation, @permission), remote: request.xhr?, html: { data: { rightbar: true } } do |f|
-  = render partial: 'layouts/model_errors', locals: { model: @permission }
-  = f.input :service_id, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, as: :select, label: 'Service'
-  = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons, label: "Rôle de #{@permission.agent.full_name}"
 
-  .row
-    .col.text-left
-      = link_to 'Supprimer', admin_organisation_agent_path(current_organisation, @permission.agent), data: { confirm: "Êtes-vous sûr de vouloir supprimer cet utilisateur ?" }, method: :delete, class: 'btn btn-outline-danger'
-    .col.text-right
-      = f.button :submit
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to "Vos agents", admin_organisation_agents_path(current_organisation)
+    li.breadcrumb-item.active
+      = @permission.agent.full_name
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = simple_form_for [:admin, @permission], url: admin_organisation_permission_path(current_organisation, @permission), remote: request.xhr?, html: { data: { rightbar: true } } do |f|
+          = render partial: 'layouts/model_errors', locals: { model: @permission }
+          = f.input :service_id, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, as: :select, label: 'Service'
+          = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons, label: "Rôle de #{@permission.agent.full_name}"
+
+          .row
+            .col.text-left
+              = link_to 'Supprimer', admin_organisation_agent_path(current_organisation, @permission.agent), data: { confirm: "Êtes-vous sûr de vouloir supprimer cet utilisateur ?" }, method: :delete, class: 'btn btn-outline-danger'
+            .col.text-right
+              = f.button :submit

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -23,4 +23,8 @@
   .mt-5.text-center
     hr
     p.font-13 Vous souhaitez supprimer votre compte ?
-    = link_to 'Supprimer', delete_agent_registration_path, data:{confirm: "Êtes-vous sûr de vouloir supprimer votre compte ?"}, method: :delete, class: 'btn btn-outline-danger btn-sm'
+    = link_to 'Supprimer', \
+      delete_agent_registration_path, \
+      data: { confirm: "Êtes-vous sûr de vouloir supprimer votre compte ? Toutes vos absences et vos plages d'ouvertures seront supprimées de manière irréversible." }, \
+      method: :delete, \
+      class: 'btn btn-outline-danger btn-sm'

--- a/db/migrate/20201118161148_remove_deprecated_absences_and_plages_ouvertures.rb
+++ b/db/migrate/20201118161148_remove_deprecated_absences_and_plages_ouvertures.rb
@@ -1,0 +1,26 @@
+class RemoveDeprecatedAbsencesAndPlagesOuvertures < ActiveRecord::Migration[6.0]
+  def up
+    ActiveRecord::Base.logger = nil # disable AR logs
+
+    Agent.where.not(deleted_at: nil).includes(:organisations).each do |agent|
+      agent.organisations.each do |organisation|
+        puts "delete_agent;#{agent.full_name};#{organisation.name}"
+        AgentRemoval.new(agent, organisation).remove!
+      end
+    end
+
+    PlageOuverture.all.each do |plage_ouverture|
+      next if plage_ouverture.agent.organisation_ids.include?(plage_ouverture.organisation_id)
+
+      puts "delete_plage_ouverture;#{plage_ouverture.id};#{plage_ouverture.agent.full_name};#{plage_ouverture.organisation.name}"
+      plage_ouverture.destroy!
+    end
+
+    Absence.all.each do |absence|
+      next if absence.agent.organisation_ids.include?(absence.organisation_id)
+
+      puts "delete_absence;#{absence.id};#{absence.agent.full_name};#{absence.organisation.name}"
+      absence.destroy!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_164609) do
+ActiveRecord::Schema.define(version: 2020_11_18_161148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Admin::AgentsController, type: :controller do
   describe "DELETE #destroy" do
     subject { delete :destroy, params: { organisation_id: organisation.id, id: agent1.id } }
     it "destroys the requested agent" do
-      expect { subject }.to change(Agent, :count).by(-1)
+      subject
+      expect(agent1.reload.organisations).not_to include(organisation)
     end
 
     it "redirects to the agents list" do

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -2,8 +2,8 @@ describe "Admin can configure the organisation" do
   let!(:organisation) { create(:organisation) }
   let!(:pmi) { create(:service, name: "PMI") }
   let!(:service_social) { create(:service, name: "Service social") }
-  let!(:agent_admin) { create(:agent, :admin, service: pmi, organisations: [organisation]) }
-  let!(:agent_user) { create(:agent, service: pmi, organisations: [organisation]) }
+  let!(:agent_admin) { create(:agent, :admin, first_name: "Jeanne", last_name: "Dupont", email: "jeanne.dupont@love.fr", service: pmi, organisations: [organisation]) }
+  let!(:agent_user) { create(:agent, first_name: "Tony", last_name: "Patrick", email: "tony@patrick.fr", service: pmi, organisations: [organisation]) }
   let!(:motif_libelle) { create(:motif_libelle, service: pmi, name: "Motif 1") }
   let!(:motif_libelle2) { create(:motif_libelle, service: pmi, name: "Motif 2") }
   let!(:motif_libelle3) { create(:motif_libelle, service: service_social, name: "Motif 3") }
@@ -53,19 +53,19 @@ describe "Admin can configure the organisation" do
     click_link "Vos agents"
     expect_page_title("Vos agents")
 
-    click_link agent_user.full_name
-    expect_page_title("Modifier le professionnel")
+    click_link "Tony PATRICK"
+    expect_page_title("Modifier le professionnel Tony PATRICK")
     choose :agent_permission_role_admin
     click_button("Modifier")
 
     expect_page_title("Vos agents")
     expect(page).to have_selector("span.badge.badge-danger", count: 2)
 
-    click_link agent_user.full_name
-    click_link("Supprimer")
+    click_link "Tony PATRICK"
+    click_link("Retirer de l'organisation")
 
     expect_page_title("Vos agents")
-    expect(page).to have_no_content(agent_user.full_name)
+    expect(page).to have_no_content("Tony PATRICK")
 
     click_link "Inviter un professionnel", match: :first
     fill_in "Email", with: "jean@paul.com"

--- a/spec/service_models/agent_removal_spec.rb
+++ b/spec/service_models/agent_removal_spec.rb
@@ -1,0 +1,68 @@
+describe AgentRemoval, type: :service do
+  context "agent belongs to single organisation, with a few absences and plages ouvertures" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:plage_ouvertures) { create_list(:plage_ouverture, 2, agent: agent, organisation: organisation) }
+    let!(:absences) { create_list(:absence, 2, agent: agent, organisation: organisation) }
+
+    it "should succeed and destroy absences and plages ouvertures" do
+      result = AgentRemoval.new(agent, organisation).remove!
+      expect(result).to eq true
+      expect(agent.organisations).to be_empty
+      expect(agent.absences).to be_empty
+      expect(agent.plage_ouvertures).to be_empty
+    end
+  end
+
+  context "agent belongs to multiple organisations" do
+    let!(:organisation1) { create(:organisation) }
+    let!(:organisation2) { create(:organisation) }
+    let!(:agent) { create(:agent, organisations: [organisation1, organisation2]) }
+    let!(:plage_ouvertures1) { create_list(:plage_ouverture, 2, agent: agent, organisation: organisation1) }
+    let!(:absences1) { create_list(:absence, 2, agent: agent, organisation: organisation1) }
+    let!(:plage_ouvertures2) { create_list(:plage_ouverture, 2, agent: agent, organisation: organisation2) }
+    let!(:absences2) { create_list(:absence, 2, agent: agent, organisation: organisation2) }
+
+    it "should succeed and destroy absences and plages ouvertures" do
+      result = AgentRemoval.new(agent, organisation1).remove!
+      expect(result).to eq true
+      expect(agent.organisations).to contain_exactly(organisation2)
+      expect(agent.plage_ouvertures).to contain_exactly(*plage_ouvertures2)
+      expect(agent.absences).to contain_exactly(*absences2)
+    end
+  end
+
+  context "agent has upcoming RDVs" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:rdv) do
+      rdv = build(:rdv, agents: [agent], organisation: organisation, starts_at: Date.today.next_week(:monday) + 10.hours)
+      rdv.define_singleton_method(:notify_rdv_created) {}
+      rdv.save!
+      rdv
+    end
+
+    it "should not succeed" do
+      result = AgentRemoval.new(agent, organisation).remove!
+      expect(result).to eq false
+      expect(agent.organisations).to include(organisation)
+    end
+  end
+
+  context "agent has old RDVs" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, organisations: [organisation]) }
+    let!(:rdv) do
+      rdv = build(:rdv, agents: [agent], organisation: organisation, starts_at: Date.today.prev_week(:monday) + 10.hours)
+      rdv.define_singleton_method(:notify_rdv_created) {}
+      rdv.save!
+      rdv
+    end
+
+    it "should succeed" do
+      result = AgentRemoval.new(agent, organisation).remove!
+      expect(result).to eq true
+      expect(agent.organisations).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/c728Kj9h/1168-supprimer-les-plages-douvertures-des-agents-lorsquils-sont-retir%C3%A9s-dune-organsiation

## premier commit 

refacto préliminaire qui enlève la rightbar de la vue édition agent (en fait nommée permissions 🤷 )

## deuxième commit qui fait le job actuel 

Simplification du `Agent#soft_delete` qui ne fait plus que soft_delete effectivement, jamais destroy, ni remove orga. C'était vraiment perturbant comme méthode

Introduction d'un nouveau service `AgentRemoval` en charge de retirer un agent d'une orga. C'est dans ce service qu'on rajoute le fait de supprimer les plages d'ouvertures et absences associées

Ajout de messages preventifs dans les interfaces pour dire que l'operation de retrait d'une orga est irreversible et supprimera les POs et absences

Lorsqu'un agent veut supprimer son compte maintenant : 
- on l'en empeche s'il a des RDVs a venir
- on le retire d'abord de toutes les orgas pour declencher la suppression des ressources associées 

Un changement de comportement introduit est que quand un admin retire un agent d'une orga (et que c'est l'unique orga de l'agent), ca ne le soft_deletera plus jamais, ca ne fait que retirer l'agent de l'orga. C'est a l'agent de s'auto soft-delete s'il le souhaite. 

## Migration

La migration est destructive, j'ai fait en sorte qu'elle logge au format CSV ce qu'elle supprime. La grande majorité des POs et absences concernées sont de MOURENX. J'ai lancé la migration sur un dump de prod, et demandé a christelle Cufay de valider a vue d'oeil ce qu'on s'apprete a faire, elle a donné son GO.

csv de la simulation de run : https://pad.incubateur.net/e7aSWfWATvihJIP2AaEpAw#