### PR TITLE
fix user topbar menu layout in users/rdvs#index

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -22,7 +22,7 @@ module RdvsHelper
 
   def no_rdv_for_users
     sentence = "Vous n'avez pas de RDV "
-    sentence += params[:past].present? ? "passé." : "à venir."
+    sentence += params[:past].present? ? "passés" : "à venir"
     sentence
   end
 

--- a/app/views/common/_header_user_logged.html.slim
+++ b/app/views/common/_header_user_logged.html.slim
@@ -5,18 +5,17 @@ header.header
       i.fa.fa-bars.text-white
     #navbarSupportedContent.collapse.navbar-collapse
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
+        li.list-inline-item.text-white.px-2.py-1
+          span>= current_user.first_name
         li.list-inline-item
           = link_to users_rdvs_path, class: 'btn btn-link text-white' do
-            i.far.fa-calendar
-            |  Vos rendez-vous
-        li.dropdown.topbar-right-menu
-          a.nav-link.text-white.dropdown-toggle.arrow-none.mr-0 aria-expanded="false" aria-haspopup="false" data-toggle="dropdown" href="#" role="button"
-            | #{current_user.first_name}
-          .dropdown-menu.dropdown-menu-right.dropdown-menu-animated.profile-dropdown
-            .dropdown-header.noti-title
-              h6.text-overflow.m-0 Bienvenue !
-            = link_to 'Mes informations', users_informations_path, class: 'dropdown-item'
-            = link_to  'Mon compte', edit_user_registration_path , class: 'dropdown-item'
-            = link_to destroy_user_session_path, method: :delete, class: 'dropdown-item' do
-              i.fa.fa-sign-out
-              span Se déconnecter
+            i.far.fa-calendar>
+            | Vos rendez-vous
+        li.list-inline-item
+          = link_to 'Vos informations', users_informations_path, class: 'btn btn-link text-white'
+        li.list-inline-item
+          = link_to  'Votre compte', edit_user_registration_path , class: 'btn btn-link text-white'
+        li.list-inline-item
+          = link_to destroy_user_session_path, method: :delete, class: 'btn btn-link text-white' do
+            span> Déconnexion
+            i.fa.fa-sign-out-alt>

--- a/app/views/common/_header_user_logged.html.slim
+++ b/app/views/common/_header_user_logged.html.slim
@@ -5,8 +5,6 @@ header.header
       i.fa.fa-bars.text-white
     #navbarSupportedContent.collapse.navbar-collapse
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
-        li.list-inline-item.text-white.px-2.py-1
-          span>= current_user.first_name
         li.list-inline-item
           = link_to users_rdvs_path, class: 'btn btn-link text-white' do
             i.far.fa-calendar>

--- a/app/views/users/creneaux/index.html.slim
+++ b/app/views/users/creneaux/index.html.slim
@@ -1,5 +1,6 @@
 - content_for :title do
   | Créneaux disponibles
+
 - content_for :breadcrumb do
   = link_to 'Voir vos prochains RDV', users_rdvs_path, class: 'btn btn-outline-primary'
 

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -1,46 +1,44 @@
-.card.mb-3
-  .card-body
-    ul.list-group.list-group-flush
+ul.list-group.list-group-flush
+  li.list-group-item
+    .fa.fa-calendar>
+    = rdv_title(rdv)
+    = rdv_tag(rdv)
+
+  - if rdv.home?
       li.list-group-item
-        .fa.fa-calendar>
-        = rdv_title(rdv)
-        = rdv_tag(rdv)
+      .fa.fa-home>
+      | Ce RDV se déroulera à domicile
 
-      - if rdv.home?
-         li.list-group-item
-          .fa.fa-home>
-          | Ce RDV se déroulera à domicile
+  - elsif rdv.public_office?
+    li.list-group-item
+      .fa.fa-map-marker-alt>
+      = human_location(rdv)
 
-      - elsif rdv.public_office?
-        li.list-group-item
-          .fa.fa-map-marker-alt>
-          = human_location(rdv)
+  - elsif rdv.phone?
+    li.list-group-item
+      .fa.fa-phone>
+      | RDV Téléphonique
 
-      - elsif rdv.phone?
-        li.list-group-item
-          .fa.fa-phone>
-          | RDV Téléphonique
-
-      li.list-group-item
-        .fa.fa-user>
-        = users_to_sentence(rdv.users)
-      li.list-group-item
-        i.fa.fa-info-circle>
-        = rdv.motif.name
-      - if rdv.motif.instruction_for_rdv.present?
-        li.list-group-item
-          i.fa.fa-exclamation-triangle>
-          strong Informations supplémentaires :
-          = simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1")
-      - unless defined?(hide_file_attente_infos) && hide_file_attente_infos
-        = render "/users/rdvs/file_attente", rdv: rdv
-    - unless defined?(hide_cancellation_infos) && hide_cancellation_infos
-      - if rdv.cancellable?
-        .text-right.mt-2
-          = link_to 'Annuler le RDV', "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: 'btn btn-outline-danger'
-      - elsif !rdv.past? && !rdv.cancelled?
-        p.font-italic
-          | Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne. Prenez contact avec le secrétariat.
+  li.list-group-item
+    .fa.fa-user>
+    = users_to_sentence(rdv.users)
+  li.list-group-item
+    i.fa.fa-info-circle>
+    = rdv.motif.name
+  - if rdv.motif.instruction_for_rdv.present?
+    li.list-group-item
+      i.fa.fa-exclamation-triangle>
+      strong Informations supplémentaires :
+      = simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1")
+  - unless defined?(hide_file_attente_infos) && hide_file_attente_infos
+    = render "/users/rdvs/file_attente", rdv: rdv
+- unless defined?(hide_cancellation_infos) && hide_cancellation_infos
+  - if rdv.cancellable?
+    .text-right.mt-2
+      = link_to 'Annuler le RDV', "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: 'btn btn-outline-danger'
+  - elsif !rdv.past? && !rdv.cancelled?
+    p.font-italic
+      | Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne. Prenez contact avec le secrétariat.
 
 = render( \
   "common/modal_confirmation", \

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -5,7 +5,7 @@ ul.list-group.list-group-flush
     = rdv_tag(rdv)
 
   - if rdv.home?
-      li.list-group-item
+    li.list-group-item
       .fa.fa-home>
       | Ce RDV se déroulera à domicile
 

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -1,32 +1,31 @@
-- content_for :title
-  | Vos rendez-vous
+.row.mt-3.justify-content-center
+  .col-md-6
+    h1.text-dark.mb-3 Vos rendez-vous
+    div.mb-3
+      .float-right= link_to 'Prendre un RDV', root_path, class: "btn btn-primary"
+      - if params[:past].present?
+        = link_to 'Voir vos prochains RDV', users_rdvs_path, class: 'btn btn-outline-primary'
+      - else
+        = link_to 'Voir vos RDV passés', users_rdvs_path(past: true), class: 'btn btn-outline-primary'
 
-- content_for :breadcrumb do
-  => add_button 'Prendre un RDV', root_path
-  - if params[:past].present?
-    = link_to 'Voir vos prochains RDV', users_rdvs_path, class: 'btn btn-outline-primary'
-  - else
-    = link_to 'Voir vos RDV passés', users_rdvs_path(past: true), class: 'btn btn-outline-primary'
+    - if @rdvs.any?
+          - @rdvs.each do |rdv|
+            .card
+              .card-body
+                = render 'rdv', rdv: rdv
+          .d-flex.justify-content-center= paginate @rdvs, theme: 'twitter-bootstrap-4'
+          .text-center= link_to 'Prendre un autre RDV', root_path, class: "btn btn-primary"
+    - else
+      .card
+        .card-body
+          .text-center.my-5
+            p.mb-2.lead= no_rdv_for_users
+            span.fa-stack.fa-4x
+              i.fa.fa-circle.fa-stack-2x.text-primary
+              i.far.fa-calendar.fa-stack-1x.text-white
+            .text-center.mt-2
+              = link_to 'Prendre un RDV', root_path, class: "btn btn-primary"
 
-- if @rdvs.any?
-  .row.justify-content-md-center
-    .col-md-6
-      = render partial: 'rdv', collection: @rdvs
-  .d-flex.justify-content-center= paginate @rdvs, theme: 'twitter-bootstrap-4'
-  .text-center
-    = add_button 'Prendre un RDV', root_path
-- else
-  .card
-    .card-body
-      .row.justify-content-md-center
-        .col-md-6.text-center.my-5
-          p.mb-2.lead= no_rdv_for_users
-          span.fa-stack.fa-4x
-            i.fa.fa-circle.fa-stack-2x.text-primary
-            i.far.fa-calendar.fa-stack-1x.text-white
-          .text-center.mt-2
-            = add_button 'Prendre un RDV', root_path
-
-.text-center.my-5
-  = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
-    img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"
+    .text-center.my-5
+      = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
+        img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"

--- a/spec/features/users/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/user_signs_up_and_signs_in_spec.rb
@@ -21,8 +21,7 @@ feature "User signs up and signs in" do
         fill_in :password, with: user.password
         click_on "Enregistrer"
         expect_flash_info(I18n.t("devise.passwords.updated")) # auto-connected
-        click_link user.first_name
-        click_link "Se déconnecter"
+        click_link "Déconnexion"
         expect(current_path).to eq(root_path)
       end
     end
@@ -46,8 +45,7 @@ feature "User signs up and signs in" do
         click_on "Enregistrer"
         expect(current_path).to eq(root_path)
         expect_flash_info(I18n.t("devise.invitations.updated"))
-        click_link invited_user.first_name
-        click_link "Se déconnecter"
+        click_link "Déconnexion"
         expect(current_path).to eq(root_path)
       end
     end

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -9,7 +9,7 @@ describe "User views his rdv" do
   end
 
   context "with no rdv" do
-    it { expect_page_with_no_record_text("Vous n'avez pas de RDV à venir.") }
+    it { expect_page_with_no_record_text("Vous n'avez pas de RDV à venir") }
   end
 
   context "with future rdv" do
@@ -18,7 +18,7 @@ describe "User views his rdv" do
     it do
       expect(page).to have_content(rdv_title_spec(rdv))
       click_link "Voir vos RDV passés"
-      expect_page_with_no_record_text("Vous n'avez pas de RDV passé.")
+      expect_page_with_no_record_text("Vous n'avez pas de RDV passés")
     end
   end
 
@@ -26,7 +26,7 @@ describe "User views his rdv" do
     let!(:rdv) { create(:rdv, :past, users: [user], organisation: organisation) }
     before { click_link "Vos rendez-vous" }
     it do
-      expect_page_with_no_record_text("Vous n'avez pas de RDV à venir.")
+      expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
       click_link "Voir vos RDV passés"
       expect(page).to have_content(rdv_title_spec(rdv))
     end


### PR DESCRIPTION
https://trello.com/c/hFd6rlQO/1179-reparer-menu-haut-de-la-vue-usager

j'en profite pour 

- retirer le menu dropdown qui ne sert a rien et cassait la vue responsive pour les users
- harmoniser les items de menus en "Vos"
- ameliorer le layout des rdvs sur l'index
- réparer une faute d'orthographe sur le "passés"

<img width="2181" alt="stitched_2020_11_23-12_21_37" src="https://user-images.githubusercontent.com/883348/99956531-7531d600-2d86-11eb-8a73-d42983f78696.png">
