### PR TITLE
better preserve agent context in rdvs, plage ouvertures and absences views

### DIFF
--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -2,6 +2,8 @@ class Admin::PlageOuverturesController < AgentAuthController
   respond_to :html, :json
 
   before_action :set_plage_ouverture, only: [:show, :edit, :update, :destroy]
+  before_action :build_plage_ouverture, only: [:create]
+  before_action :set_agent
 
   def show
     authorize(@plage_ouverture)
@@ -9,7 +11,6 @@ class Admin::PlageOuverturesController < AgentAuthController
   end
 
   def index
-    @agent = policy_scope(Agent).find(filter_params[:agent_id])
     plage_ouvertures = policy_scope(PlageOuverture)
       .includes(:lieu, :organisation)
       .where(agent_id: filter_params[:agent_id])
@@ -51,7 +52,6 @@ class Admin::PlageOuverturesController < AgentAuthController
   end
 
   def create
-    @plage_ouverture = PlageOuverture.new(plage_ouverture_params)
     @plage_ouverture.organisation = current_organisation
     authorize(@plage_ouverture)
     if @plage_ouverture.save
@@ -81,8 +81,16 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   private
 
+  def set_agent
+    @agent = filter_params[:agent_id].present? ? policy_scope(Agent).find(filter_params[:agent_id]) : @plage_ouverture.agent
+  end
+
   def set_plage_ouverture
     @plage_ouverture = PlageOuverture.find(params[:id])
+  end
+
+  def build_plage_ouverture
+    @plage_ouverture = PlageOuverture.new(plage_ouverture_params)
   end
 
   def plage_ouverture_params

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -1,3 +1,5 @@
+- content_for(:menu_item) { 'menu-plages-ouvertures' }
+
 - content_for :title do
   = truncate(@plage_ouverture.title, length: 40)
 

--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -18,6 +18,7 @@ ul.list-unstyled.topbar-right-menu.float-right.mb-0
               rdv.organisation, \
               rdv, \
               rdv: { status: status[1] }, \
+              agent_id: local_assigns[:agent]&.id, \
               format: local_assigns[:remote] ? 'json' : 'html' \
             ), \
             method: :put, \

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -1,5 +1,24 @@
+- content_for(:menu_item) { @agent ? 'menu-agendas' : 'menu-rdvs-list' }
+
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0.p-0
+    - if @agent
+      li.breadcrumb-item.p-0
+        - if @agent != current_agent
+          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_path(current_organisation, @agent)
+        - else
+          = link_to "Votre agenda", admin_organisation_agent_path(current_organisation, current_agent)
+    li.breadcrumb-item.p-0.ml-2
+      | RDV
+      |&nbsp;
+      = rdv_title_for_agent(@rdv)
+      - if @rdv.cancelled?
+        span.badge.badge-danger
+    li.breadcrumb-item.p-0.ml-2
+      | Modifier
+
 - content_for :title do
-  | Modifier le rendez-vous
+  | Modifier le RDV
 
 .row.justify-content-center
   .col-md-6
@@ -7,6 +26,7 @@
       .card-body
         = simple_form_for([:admin, @rdv.organisation, @rdv]) do |f|
           = render partial: 'layouts/model_errors', locals: { model: @rdv }
+          = hidden_field_tag :agent_id, @agent&.id
           = f.association :motif, disabled: true
           = f.input :context, input_html: { rows: 3 }
           .form-row

--- a/app/views/admin/rdvs/index.json.jbuilder
+++ b/app/views/admin/rdvs/index.json.jbuilder
@@ -10,6 +10,6 @@ json.array! @rdvs do |rdv|
   end
   json.start rdv.starts_at
   json.end rdv.ends_at
-  json.url admin_organisation_rdv_path(rdv.organisation, rdv)
+  json.url admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: params[:agent_id])
   json.backgroundColor rdv.motif&.color
 end

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -1,17 +1,22 @@
+- content_for(:menu_item) { @agent ? 'menu-agendas' : 'menu-rdvs-list' }
+
 - content_for :title do
   ol.breadcrumb.m-0.p-0
-    li.breadcrumb-item.p-0
-      = link_to 'Vos agendas', admin_organisation_agent_path(current_organisation, current_agent)
+    - if @agent
+      li.breadcrumb-item.p-0
+        - if @agent != current_agent
+          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_path(current_organisation, @agent)
+        - else
+          = link_to "Votre agenda", admin_organisation_agent_path(current_organisation, current_agent)
     li.breadcrumb-item.p-0.ml-2
-      | RDV
-      |&nbsp;
-      = rdv_title_for_agent(@rdv)
-      - if @rdv.cancelled?
-        span.badge.badge-danger
+      div
+        span> RDV
+        span>= rdv_title_for_agent(@rdv)
+        - if @rdv.cancelled?
+          span.badge.badge-danger
 
 - content_for :breadcrumb do
   = link_to "Dupliquer…", admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context), class: "btn btn-outline-white"
-
 
 .row
   .col-md-6.mb-3
@@ -19,7 +24,7 @@
       .card-header
         .d-flex.justify-content-between
           = l(@rdv.starts_at.to_date, format: :human )
-          = render "rdv_status_dropdown", rdv: @rdv
+          = render "rdv_status_dropdown", rdv: @rdv, agent: @agent
 
       .card-body
         p.card-text
@@ -31,12 +36,12 @@
         .row
           .col
             - if !@rdv.past? && !@rdv.cancelled?
-              = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, rdv: {status: :excused}), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
+              = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, rdv: {status: :excused}, agent_id: @agent&.id), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
               | ou
-            = link_to "Supprimer ❌", admin_organisation_rdv_path(@rdv.organisation, @rdv), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
+            = link_to "Supprimer ❌", admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
 
           .col.text-right
-            = link_to "Modifier", edit_admin_organisation_rdv_path(@rdv.organisation, @rdv), class: "btn btn-outline-primary"
+            = link_to "Modifier", edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
 
   .col-md-6.mb-3
 
@@ -72,11 +77,11 @@
       .card-header
         a.js-record-versions-toggle[
           href="#history"
-          data-text-close="🕵️‍♂️ Cacher l'historique des actions ˄"
-          data-text-open="🕵️‍♂️ Afficher l'historique des actions ⌄"
+          data-text-close="Cacher l'historique des actions ˄"
+          data-text-open="Afficher l'historique des actions ⌄"
           data-versions-url=admin_organisation_rdv_versions_path(@rdv.organisation, @rdv, only: ['user_ids', 'agent_ids', 'duration_in_min', 'status', 'starts_at', 'lieu_id', 'notes', 'location', 'context'])
         ]
-          | 🕵️‍♂️ Afficher l'historique des actions ⌄
+          | Afficher l'historique des actions ⌄
       .js-record-versions-body#history.collapse class=(@uncollapsed_section == 'history' ? "show" : "")
         .text-center.py-4
           .spinner.spinner-border

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
         expect(first["start"]).to eq(rdv1.starts_at.as_json)
         expect(first["end"]).to eq(rdv1.ends_at.as_json)
         expect(first["backgroundColor"]).to eq(rdv1.motif.color)
-        expect(first["url"]).to eq(admin_organisation_rdv_path(rdv1.organisation, rdv1))
+        expect(first["url"]).to eq(admin_organisation_rdv_path(rdv1.organisation, rdv1, agent_id: agent.id))
         expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv1.status), status: rdv1.status, motif: "Suivi", past: rdv1.past?, duration: rdv.duration_in_min }.as_json)
 
         second = @parsed_response[1]
@@ -47,7 +47,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
         expect(second["start"]).to eq(rdv2.starts_at.as_json)
         expect(second["end"]).to eq(rdv2.ends_at.as_json)
         expect(second["backgroundColor"]).to eq(rdv2.motif.color)
-        expect(second["url"]).to eq(admin_organisation_rdv_path(rdv2.organisation, rdv2))
+        expect(second["url"]).to eq(admin_organisation_rdv_path(rdv2.organisation, rdv2, agent_id: agent.id))
         expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv2.status), status: rdv2.status, motif: rdv2.motif.name, past: rdv2.past?, duration: rdv.duration_in_min }.as_json)
       end
     end


### PR DESCRIPTION
https://trello.com/c/95YCduVA/1164-perte-de-contexte-suite-%C3%A0-suppression-dun-rdv-dans-lagenda

ℹ️ lisible commit par commit
ℹ️ @yaf hésite pas à merger en mon absence, c'est assez safe

ce n'est pas parfaitement trivial de préserver le contexte de l'agent sur toutes les pages, il faut bien s'assurer de le garder partout. 

## Pages RDVs

on peut arriver depuis l'agenda mais aussi depuis la liste des RDVs, ou bien les users show. Il faut donc gérer le cas où on est dans le contexte d'un agent et le contexte sans. J'ai donc passé l'agent en param get `agent_id` et il faut bien faire attention de le passer partout et le retuiliser quand on redirige, par ex apres un create. 

## Pages Absences et POs

On peut seulement arriver depuis l'agenda (je crois), donc c'est un peu plus simple. La petite complexité réside dans le fait qu'on utilise des routes scopées différemment pour les différentes actions :  

- `http://localhost:5000/admin/organisations/1/agents/2/absences` pour la vue `index` 

mais

- `http://localhost:5000/admin/organisations/1/absences` pour la création ou la suppression

J'ai commencé à refacto tout scoper dans agent mais j'ai eu un doute que ce soit la bonne direction donc j'ai arrêté et pris la route du moindre effort.

il faut donc gérer la récupération de l'agent depuis le param ou depuis la plage d'ouverture. 

## A côtés 

J'en ai profité pour corriger quelques trucs : 

- rajouté le breadcrumb sur la page rdvs#edit
- amélioré le breadcrumb de la page rdvs#show (selon de quel agent on vient)
- retiré l'emoji espion de l'historique des actions (il ne plait pas ni ne marche tres bien selon les fonts dispos)

