### PR TITLE
add motifs.sectorisation_level to allow desectorisation

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -6,6 +6,9 @@ class Admin::MotifsController < AgentAuthController
 
   def index
     @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page])
+    @sectors_attributed_to_organisation = Sector.attributed_to_organisation(current_organisation)
+    @sectorisation_level_agent_counts_by_service = SectorAttribution.level_agent_grouped_by_service(current_organisation)
+    @display_sectorisation_level = current_organisation.motifs.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?
   end
 
   def new
@@ -57,6 +60,6 @@ class Admin::MotifsController < AgentAuthController
 
   def motif_params
     params.require(:motif)
-      .permit(:name, :service_id, :color, :default_duration_in_min, :reservable_online, :location_type, :max_booking_delay, :min_booking_delay, :visibility_type, :restriction_for_rdv, :instruction_for_rdv, :for_secretariat, :follow_up)
+      .permit(:name, :service_id, :color, :default_duration_in_min, :reservable_online, :location_type, :max_booking_delay, :min_booking_delay, :visibility_type, :restriction_for_rdv, :instruction_for_rdv, :for_secretariat, :follow_up, :sectorisation_level)
   end
 end

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -6,7 +6,7 @@ class Admin::MotifsController < AgentAuthController
 
   def index
     @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page])
-    @sectors_attributed_to_organisation = Sector.attributed_to_organisation(current_organisation)
+    @sectors_attributed_to_organisation_count = Sector.attributed_to_organisation(current_organisation).count
     @sectorisation_level_agent_counts_by_service = SectorAttribution.level_agent_grouped_by_service(current_organisation)
     @display_sectorisation_level = current_organisation.motifs.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?
   end

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -12,12 +12,12 @@ module MotifsHelper
   end
 
   def motif_badges(motif)
-    badges = [:reservable_online, :secretariat, :follow_up]
+    badges = [:secretariat, :follow_up]
     badges.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) }.join("").html_safe
   end
 
-  def build_badge_tag_for(motif)
-    content_tag(:span, I18n.t("motifs.badges.#{motif}"), class: "badge badge-motif-#{motif}")
+  def build_badge_tag_for(badge_name)
+    content_tag(:span, I18n.t("motifs.badges.#{badge_name}"), class: "badge badge-motif-#{badge_name}")
   end
 
   def min_max_delay_options

--- a/app/helpers/sectors_helper.rb
+++ b/app/helpers/sectors_helper.rb
@@ -2,8 +2,4 @@ module SectorsHelper
   def sector_zone_color(sector)
     "##{Digest::MD5.hexdigest("sector-#{sector.id}")[0..5]}"
   end
-
-  def departement_sectorisation_enabled?(departement)
-    Users::GeoSearch.new(departement: departement).departement_sectorisation_enabled?
-  end
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,6 +1,6 @@
 module WelcomeHelper
   def sectorisation_hint(geo_search)
-    return nil if !geo_search.departement_sectorisation_enabled? || geo_search.empty_attributions?
+    return nil if geo_search.empty_attributions?
 
     explanations = geo_search.matching_zones.map do |zone|
       (zone.level_street? ? "#{zone.street_name} " : "") +

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -10,9 +10,15 @@ class Motif < ApplicationRecord
   INVISIBLE = "invisible".freeze
   VISIBILITY_TYPES = [VISIBLE_AND_NOTIFIED, VISIBLE_AND_NOT_NOTIFIED, INVISIBLE].freeze
 
+  SECTORISATION_LEVEL_AGENT = "agent".freeze
+  SECTORISATION_LEVEL_ORGANISATION = "organisation".freeze
+  SECTORISATION_LEVEL_DEPARTEMENT = "departement".freeze
+  SECTORISATION_TYPES = [SECTORISATION_LEVEL_AGENT, SECTORISATION_LEVEL_ORGANISATION, SECTORISATION_LEVEL_DEPARTEMENT].freeze
+
   enum location_type: [:public_office, :phone, :home]
 
   validates :visibility_type, inclusion: { in: VISIBILITY_TYPES }
+  validates :sectorisation_level, inclusion: { in: SECTORISATION_TYPES }
   validates :name, presence: true, uniqueness: { scope: [:organisation, :location_type, :service], conditions: -> { where(deleted_at: nil) }, message: "est déjà utilisé pour un motif avec le même type de RDV" }
 
   delegate :service_social?, to: :service
@@ -45,6 +51,9 @@ class Motif < ApplicationRecord
     end.compact.first
     where(name: name, location_type: location_type)
   }
+  scope :sectorisation_level_departement, -> { where(sectorisation_level: SECTORISATION_LEVEL_DEPARTEMENT) }
+  scope :sectorisation_level_organisation, -> { where(sectorisation_level: SECTORISATION_LEVEL_ORGANISATION) }
+  scope :sectorisation_level_agent, -> { where(sectorisation_level: SECTORISATION_LEVEL_AGENT) }
 
   def soft_delete
     rdvs.any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
@@ -78,6 +87,18 @@ class Motif < ApplicationRecord
 
   def name_with_location_type
     "#{name}-#{location_type}"
+  end
+
+  def sectorisation_level_agent?
+    sectorisation_level == SECTORISATION_LEVEL_AGENT
+  end
+
+  def sectorisation_level_organisation?
+    sectorisation_level == SECTORISATION_LEVEL_ORGANISATION
+  end
+
+  def sectorisation_level_departement?
+    sectorisation_level == SECTORISATION_LEVEL_DEPARTEMENT
   end
 
   private

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -9,6 +9,11 @@ class Sector < ApplicationRecord
 
   scope :order_by_name, -> { order(Arel.sql("LOWER(name)")) }
 
+  scope :attributed_to_organisation, lambda { |organisation|
+    joins(:attributions)
+      .where(sector_attributions: { organisation_id: organisation.id, level: SectorAttribution::LEVEL_ORGANISATION })
+  }
+
   protected
 
   def coherent_city_code_departement

--- a/app/models/sector_attribution.rb
+++ b/app/models/sector_attribution.rb
@@ -21,4 +21,20 @@ class SectorAttribution < ApplicationRecord
   def level_organisation?
     level == LEVEL_ORGANISATION
   end
+
+  def self.level_agent_grouped_by_service(organisation)
+    SectorAttribution
+      .level_agent
+      .where(organisation: organisation)
+      .includes(:agent)
+      .to_a
+      .group_by { _1.agent.service_id }
+      .transform_values do |attributions|
+        {
+          sectors_count: attributions.pluck(:sector_id).uniq.count,
+          agents_count: attributions.pluck(:agent_id).uniq.count,
+          attributions: attributions
+        }
+      end
+  end
 end

--- a/app/service_models/concerns/users/creneaux_search_concern.rb
+++ b/app/service_models/concerns/users/creneaux_search_concern.rb
@@ -31,7 +31,7 @@ module Users::CreneauxSearchConcern
   end
 
   def geo_attributed_agents
-    return if @geo_search.nil?
+    return if @geo_search.nil? || !motif.sectorisation_level_agent?
 
     @geo_search.attributed_agents_by_organisation[@lieu.organisation]
   end

--- a/app/views/admin/departements/sectors/show.html.slim
+++ b/app/views/admin/departements/sectors/show.html.slim
@@ -17,7 +17,7 @@
       = truncate(@sector.name, length: 20)
 
 .row.justify-content-center
-  .col-md-7
+  .col-md-6
     .card
       .card-body.d-flex.justify-content-between
         ul.list-unstyled
@@ -83,39 +83,56 @@
               data: { confirm: "Êtes-vous sûr de vouloir retirer ces #{@zones.total_count} communes et rues ?" }, \
               class: 'btn btn-danger' \
             )
-  .col-md-5
+  .col-md-6
     .card
       .card-header
         .card-title
           h5 Organisations & Agents attribués
       .card-body
-        - if @sector.attributions.any?
-          ul.mb-3.pl-2
-            - @sector.attributions.to_a.group_by(&:organisation).each do |organisation, attributions|
-              - if attributions.count == 1 && attributions.first.level_organisation?
-                li
-                  .d-flex.justify-content-between.mb-2
-                    div= "Organisation entière #{organisation.name}"
-                    div.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attributions.first), method: :delete
-              - elsif attributions.all?(&:level_agent?)
-                li.mb-2
-                  div.mb-1= "Agents dans l'organisation #{organisation.name} :"
-                  ul.pl-2
-                    - attributions.each do |attribution|
-                      li
-                        .d-flex.justify-content-between.mb-1
-                          div= attribution.agent.full_name_and_service
-                          div.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attribution), method: :delete
-                    li.mb-3= link_to \
-                      "Attribuer un autre agent de #{organisation.name.truncate(10)}", \
-                      new_admin_departement_sector_attribution_path( \
-                        current_departement, \
-                        @sector, \
-                        level: "agent", \
-                        organisation_id: organisation.id \
-                    )
+        - @sector.attributions.level_organisation.each do |attribution|
+          div.mb-3
+            div.mb-1
+              span>= "Organisation entière #{attribution.organisation.name}"
+              span.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attribution), method: :delete
+            .pl-2.py-1.border-left
+              - orga_motifs = Motif.sectorisation_level_organisation.where(organisation: attribution.organisation)
+              .text-muted
+                = t( \
+                  "sectors.motifs_with_organisation_level_sectorisation", \
+                  count: orga_motifs.count, \
+                  organisation: attribution.organisation.name, \
+                  motifs: orga_motifs.map(&:name).to_sentence.truncate(100) \
+                )
 
-        - else
+        - @sector.attributions.level_agent.to_a.group_by(&:organisation).each do |organisation, all_attributions|
+          div.mb-1= "Organisation #{organisation.name} :"
+          .pl-2.py-1.border-left
+            - all_attributions.group_by { _1.agent.service }.each do |service, attributions|
+              span> Service #{service.short_name}
+              span.text-muted.ml-1
+                - service_motifs = Motif.sectorisation_level_agent.where(organisation: organisation, service: service)
+                = t( \
+                  "sectors.motifs_with_agent_level_sectorisation_in_service", \
+                  count: service_motifs.count, \
+                  service: service.short_name, \
+                  motifs: service_motifs.map(&:name).to_sentence.truncate(100) \
+                )
+              ul.pl-3.mb-3
+                - attributions.each do |attribution|
+                  li.mb-1
+                    span>= attribution.agent.full_name
+                    span.ml-2>= link_to "Retirer", admin_departement_sector_attribution_path(current_departement, @sector, attribution), method: :delete
+
+            .mb-3= link_to \
+              "Attribuer un autre agent de #{organisation.name.truncate(20)}", \
+              new_admin_departement_sector_attribution_path( \
+                current_departement, \
+                @sector, \
+                level: "agent", \
+                organisation_id: organisation.id \
+            )
+
+        - if @sector.attributions.empty?
           .alert.alert-warning.d-flex.align-items-center
             div.mr-2.h4 ⚠️
             div

--- a/app/views/admin/departements/setup_checklists/show.slim
+++ b/app/views/admin/departements/setup_checklists/show.slim
@@ -44,5 +44,5 @@
               .badge.badge-warning Inactive
             .ml-1.text-muted Tous les motifs de votre département sont sectorisés au niveau du département entier (par défaut)
 
-        p Il n'y a maintenant plus besoin de demander à l'équipe de RDV-Solidarités d'activer la sectorisation par département.
-        p Il vous suffit de définir le niveau de sectorisation sur chacun de vos motifs pour qu'elle soit prise en compte. Le niveau de sectorisation par défaut est le département. Vous pouvez choisir de sectoriser vos motifs individuellement soit au niveau de l'organisation entière, soit au niveau des agents spécifiques.
+        p L'activation de la sectorisation a évolué récemment : l'intervention de l'équipe technique de RDV-Solidarités n'est plus nécessaire.
+        p La sectorisation s'active maintenant au niveau des motifs. Le niveau de sectorisation par défaut d'un motif est le département entier. Vous pouvez modifier un motif pour le niveau « organisation entière » ou pour le niveau « agents spécifiques », et ce motif ne sera alors plus accessible que pour les secteurs avec un niveau correspondant.

--- a/app/views/admin/departements/setup_checklists/show.slim
+++ b/app/views/admin/departements/setup_checklists/show.slim
@@ -30,34 +30,19 @@
   .col-md-6
     .card
       .card-header
-        h4 Activation pour le #{current_departement}
+        h4 État de la sectorisation pour le #{current_departement}
       .card-body
-        - if departement_sectorisation_enabled?(departement: current_departement.number)
-          .mb-2.d-flex.align-items-top
-            span
-              .badge.badge-success Activée
-            div.ml-1
-              p L’usager est orienté vers les organisations ou les agents dont il dépend en fonction de l'adresse saisie lors de sa prise de RDV en ligne
-          p Lors de la prise de RDV en ligne, les communes ou adresses non attachées à une organisation ne renvoient à aucun résultat.
-          hr
-          h5 Désactivation
-          p En désactivant la sectorisation, les Secteurs seront ignorés et les usagers pourront faire des recherches dans l'ensemble du département
-          p
-            span> Pour désactiver la sectorisation, veuillez nous écrire sur
-            a[href='mailto:dev@rdv-solidarites.fr'] dev@rdv-solidarites.fr
-        - else
-          .mb-2.d-flex.align-items-center
-            span
-              .badge.badge-danger Désactivée
-            div.ml-1 L’usager a accès à l’ensemble des lieux de RDV configurés et accessibles à la prise de RDV en ligne dans votre Département
-          p La sectorisation est désactivée par défaut
-          hr
-          h5 Activation
-          p
-            span> Une fois la sectorisation activée :
-            ul
-              li L’usager sera orienté vers les rganisations ou les agents dont il dépend en fonction de l'adresse saisie lors de sa prise de RDV en ligne
-              li Les communes ou adresses non attachées à une organisation ou un agent ne renverront plus aucun résultat
-          p
-            span> Pour activer la sectorisation, veuillez nous écrire sur
-            a[href='mailto:dev@rdv-solidarites.fr'] dev@rdv-solidarites.fr
+        - @sectorised_motifs_count = Motif.joins(:organisation).where(organisations: { departement: current_departement.number }).where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).count
+
+        .d-flex.align-items-center.mb-2
+          - if @sectorised_motifs_count > 0
+            div
+              .badge.badge-success Active
+            .ml-1.text-muted #{@sectorised_motifs_count} motifs sont sectorisés au niveau de l'organisation ou de l'agent dans votre département
+          - else
+            div
+              .badge.badge-warning Inactive
+            .ml-1.text-muted Tous les motifs de votre département sont sectorisés au niveau du département entier (par défaut)
+
+        p Il n'y a maintenant plus besoin de demander à l'équipe de RDV-Solidarités d'activer la sectorisation par département.
+        p Il vous suffit de définir le niveau de sectorisation sur chacun de vos motifs pour qu'elle soit prise en compte. Le niveau de sectorisation par défaut est le département. Vous pouvez choisir de sectoriser vos motifs individuellement soit au niveau de l'organisation entière, soit au niveau des agents spécifiques.

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -51,7 +51,7 @@
         .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
         .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
 
-  .card
+  .card.js-sectorisation-card
     .card-body
       h5.mb-2 Sectorisation géographique
       .text-muted.mb-3

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -50,6 +50,38 @@
       .form-row
         .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
         .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
+
+  .card
+    .card-body
+      h5.mb-2 Sectorisation géographique
+      .text-muted.mb-3
+        span> Seules les recherches des usagers sont concernées par ces règles de sectorisation. Elles n'ont donc pas d'effet si le motif n'est pas réservable en ligne.
+        = link_to "https://doc.rdv-solidarites.fr/sectorisation-geographique" do
+          span> Documentation sur la sectorisation
+          i.fa.fa-external-link-alt>
+      .mb-2= label_tag do
+        = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
+        span.ml-1= "Réservable par les usagers dans l'ensemble du #{current_organisation.departement}"
+      = label_tag do
+        = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION)
+        span.ml-1= "Réservable par les usagers uniquement dans les secteurs attribués à l'organisation #{current_organisation.name}"
+        .text-muted.font-14.my-1.ml-3
+          - sectors_attributed_to_orga = Sector.attributed_to_organisation(current_organisation)
+          = t("motifs.form.sectorisation_level.sectors_attributed_to_orga", count: sectors_attributed_to_orga.count, sectors: sectors_attributed_to_orga.map(&:name).to_sentence.truncate(100), organisation: current_organisation.name)
+      = label_tag do
+        = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT)
+        span.ml-1 Réservable par les usagers uniquement dans les secteurs attribués à des agents spécifiques
+        - if motif.service.present?
+          - attributions_group = SectorAttribution.level_agent_grouped_by_service(current_organisation).fetch(motif.service_id, {agents_count: 0, attributions: []})
+          .text-muted.font-14.my-1.ml-3
+            = t( \
+              "motifs.form.sectorisation_level.sectors_attributed_to_agents", \
+              count: attributions_group[:agents_count], \
+              service: motif.service.name, \
+              sectors_count_human: t("motifs.index.sectorisation_level_organisation", count: attributions_group[:sectors_count]), \
+              sectors: attributions_group[:attributions].map { "#{_1.agent.full_name} -> #{_1.sector.name}" }.to_sentence.truncate(100) \
+            )
+
   .card
     .card-body
       h5 Visibilité usager

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -11,7 +11,7 @@ tr
       - if motif.sectorisation_level_departement?
         | Tout le #{current_organisation.departement}
       - elsif motif.sectorisation_level_organisation?
-        = t("motifs.index.sectorisation_level_organisation", count: @sectors_attributed_to_organisation.count)
+        = t("motifs.index.sectorisation_level_organisation", count: @sectors_attributed_to_organisation_count)
       - elsif motif.sectorisation_level_agent?
         - counts = @sectorisation_level_agent_counts_by_service.fetch(motif.service_id, {agents_count: 0})
         = t("motifs.index.sectorisation_level_agent", count: counts[:agents_count], sectors_count_human: \

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -4,6 +4,18 @@ tr
   td
     = link_to motif.name, edit_admin_organisation_motif_path(motif.organisation, motif)
     = motif_badges(motif)
+  td
+    = content_tag(:span, I18n.t("motifs.badges.reservable_online"), class: "badge badge-motif-reservable_online") if motif.reservable_online?
+  - if @display_sectorisation_level
+    td
+      - if motif.sectorisation_level_departement?
+        | Tout le #{current_organisation.departement}
+      - elsif motif.sectorisation_level_organisation?
+        = t("motifs.index.sectorisation_level_organisation", count: @sectors_attributed_to_organisation.count)
+      - elsif motif.sectorisation_level_agent?
+        - counts = @sectorisation_level_agent_counts_by_service.fetch(motif.service_id, {agents_count: 0})
+        = t("motifs.index.sectorisation_level_agent", count: counts[:agents_count], sectors_count_human: \
+            t("motifs.index.sectorisation_level_organisation", count: counts[:sectors_count]))
   td= motif.service.short_name
   td= Motif.human_enum_name(:location_type, motif.location_type)
   td= "#{motif.default_duration_in_min} min."

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -15,6 +15,9 @@
             tr
               th
               th= t("activerecord.attributes.motif.name")
+              th= t("activerecord.attributes.motif.reservable_online")
+              - if @display_sectorisation_level
+                th= t("activerecord.attributes.motif.sectorisation_level")
               th= t("activerecord.attributes.motif.service")
               th= t("activerecord.attributes.motif.location_type")
               th= t("activerecord.attributes.motif.default_duration")

--- a/app/views/common/_search_form.html.slim
+++ b/app/views/common/_search_form.html.slim
@@ -59,10 +59,8 @@
 
           - else
             h3.text-white
-              - if @organisations_departement.any? && departement_sectorisation_enabled?(@departement)
+              - if @organisations_departement.any?
                 span Votre adresse n'est pas disponible à la prise de RDV en ligne
-              - elsif @organisations_departement.any?
-                span> Vous ne pouvez pas prendre de rendez-vous en ligne dans votre département
               - else
                 | La prise de rendez-vous n'est pas disponible pour ce département.
               = render "common/contact", geo_search: @geo_search

--- a/app/webpacker/components/motif-form.js
+++ b/app/webpacker/components/motif-form.js
@@ -1,13 +1,12 @@
 class MotifForm {
 
-  setSecretariatEnabled() {
+  toggleSecretariat() {
     const enabled = this.secretariatShouldBeEnabled();
     if (enabled == this.secretariatEnabled) return;
 
-    const secretariatCheckbox = document.querySelector('#motif_for_secretariat')
-    if (!enabled) secretariatCheckbox.checked = false
-    secretariatCheckbox.disabled = !enabled
-    $(secretariatCheckbox).closest('.card').toggleClass('translucent', !enabled)
+    if (!enabled) this.secretariatCheckbox.checked = false
+    this.secretariatCheckbox.disabled = !enabled
+    $(this.secretariatCheckbox).closest('.card').toggleClass('translucent', !enabled)
 
     this.secretariatEnabled = enabled
   }
@@ -17,18 +16,35 @@ class MotifForm {
       !document.querySelector("#motif_follow_up:checked")
   }
 
-  constructor() {
+  toggleSectorisation = () => {
+    const enabled = !!document.querySelector("#motif_reservable_online:checked")
+    if (enabled == this.sectorisationEnabled) return;
 
-    if (!document.querySelector('#motif_for_secretariat')) return;
+    if (!enabled) {
+      document.querySelector('#motif_sectorisation_level_agent').checked = false
+      document.querySelector('#motif_sectorisation_level_organisation').checked = false
+      document.querySelector('#motif_sectorisation_level_departement').checked = true
+    }
+    document.
+      querySelectorAll('input[name="motif[sectorisation_level]"]').
+      forEach(i => i.disabled = !enabled)
+    document.querySelector(".js-sectorisation-card").classList.toggle('translucent', !enabled)
+    this.sectorisationEnabled = enabled
+  }
+
+  constructor() {
+    this.secretariatCheckbox = document.querySelector('#motif_for_secretariat')
+    this.reservableOnlineCheckbox = document.querySelector('#motif_reservable_online')
+    if (!this.secretariatCheckbox || !this.reservableOnlineCheckbox) return;
 
     const noSecretariatInputs = ["input[name=\"motif[location_type]\"]", "input[name=\"motif[follow_up]\"]"]
-    document.querySelectorAll(noSecretariatInputs).forEach(input => {
-      input.addEventListener('change', e => {
-        this.setSecretariatEnabled()
-      })
-    })
+    document.querySelectorAll(noSecretariatInputs).forEach(input =>
+      input.addEventListener('change', e => this.toggleSecretariat())
+    )
+    this.reservableOnlineCheckbox.addEventListener('change', e => this.toggleSectorisation())
 
-    this.setSecretariatEnabled();
+    this.toggleSecretariat()
+    this.toggleSectorisation()
   }
 
 }

--- a/app/webpacker/stylesheets/components/_motifs.scss
+++ b/app/webpacker/stylesheets/components/_motifs.scss
@@ -24,3 +24,7 @@
   color: $white;
 }
 
+.badge-motif-sectorisation_level_organisation,
+.badge-motif-sectorisation_level_departement {
+  border: 1px solid $gray-900;
+}

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -8,12 +8,17 @@ fr:
         service: Service
         name: Nom
         color: Couleur
-        reservable_online: RDV en ligne
+        reservable_online: Réservable
         visibility_type: Visibilité usager
         visibility_types:
           visible_and_notified: Visible et notifié
           visible_and_not_notified: Visible et non notifié
           invisible: Invisible
+        sectorisation_level: Sectorisation
+        sectorisation_levels:
+          agent: Sectorisation à l'agent
+          organisation: Sectorisation à l'organisation
+          departement: Sectorisation au département
         location_type: Type de RDV
         location_types:
           home: À domicile

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -6,4 +6,26 @@ fr:
       home: "À domicile"
       secretariat: "Secrétariat"
       follow_up: "Suivi"
+      sectorisation_level_agent: "Sectorisé à l'agent"
+      sectorisation_level_organisation: "Sectorisé à l'organisation"
+      sectorisation_level_departement: "Sectorisé au département"
     follow_up_need_signed_user: "Le RDV '%{motif_name}' est disponible uniquement pour les personnes déjà suivies. Veuillez vous connecter pour prendre ce type de RDV."
+    form:
+      sectorisation_level:
+        sectors_attributed_to_orga:
+          zero: "⚠️ Aucun secteur n'est attribué à l'organisation %{organisation}, ce motif n'apparaîtra donc dans aucune recherche usager"
+          one: "Un seul secteur est attribué à l'organisation %{organisation} : %{sectors}"
+          other: "%{count} secteurs sont attribués à l'organisation %{organisation} : %{sectors}"
+        sectors_attributed_to_agents:
+          zero: "⚠️ Aucun secteur n'est attribué à des agents du service %{service}, ce motif n'apparaîtra donc dans aucune recherche usager"
+          one: "Un seul agent du service %{service} est attribué à %{sectors_count_human} : %{sectors}"
+          other: "%{count} agents du service %{service} sont attribués à %{sectors_count_human} : %{sectors}"
+    index:
+      sectorisation_level_organisation:
+        zero: "⚠️ aucun secteur"
+        one: "1 secteur"
+        other: "%{count} secteurs"
+      sectorisation_level_agent:
+        zero: "⚠️ aucun agent"
+        one: "1 agent dans %{sectors_count_human}"
+        other: "%{count} agents dans %{sectors_count_human}"

--- a/config/locales/sectors.yml
+++ b/config/locales/sectors.yml
@@ -1,0 +1,10 @@
+fr:
+  sectors:
+    motifs_with_agent_level_sectorisation_in_service:
+      zero: "⚠️ aucun motif du service %{service} n'est sectorisé par agent"
+      one: "1 motif du service %{service} est sectorisé par agent : %{motifs}"
+      other: "%{count} motifs du service %{service} sont sectorisés par agent : %{motifs}"
+    motifs_with_organisation_level_sectorisation:
+      zero: "⚠️ aucun motif de %{organisation} n'est sectorisé à l'organisation"
+      one: "Un motif de %{organisation} est sectorisé à l'organisation : %{motifs}"
+      other: "%{count} motifs de %{organisation} sont sectorisés à l'organisation : %{motifs}"

--- a/db/migrate/20201123155850_add_sectorisation_level_to_motifs.rb
+++ b/db/migrate/20201123155850_add_sectorisation_level_to_motifs.rb
@@ -1,0 +1,18 @@
+class AddSectorisationLevelToMotifs < ActiveRecord::Migration[6.0]
+  def up
+    add_column :motifs, :sectorisation_level, :string, default: "departement"
+    enabled_departements = ENV["SECTORISATION_ENABLED_DEPARTMENT_LIST"]&.split
+    Motif
+      .joins(:organisation)
+      .where(organisations: { departement: enabled_departements })
+      .update_all(sectorisation_level: Motif::SECTORISATION_LEVEL_ORGANISATION)
+    Motif
+      .joins(:organisation)
+      .where.not(organisations: { departement: enabled_departements })
+      .update_all(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT)
+  end
+
+  def down
+    remove_column :motifs, :sectorisation_level
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_161148) do
+ActiveRecord::Schema.define(version: 2020_11_23_155850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define(version: 2020_11_18_161148) do
     t.integer "location_type", default: 0, null: false
     t.boolean "follow_up", default: false
     t.string "visibility_type", default: "visible_and_notified", null: false
+    t.string "sectorisation_level", default: "departement"
     t.index ["deleted_at"], name: "index_motifs_on_deleted_at"
     t.index ["organisation_id"], name: "index_motifs_on_organisation_id"
     t.index ["service_id"], name: "index_motifs_on_service_id"

--- a/spec/controllers/lieux_controller_spec.rb
+++ b/spec/controllers/lieux_controller_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe LieuxController, type: :controller do
   let(:lieu2) { create(:lieu, latitude: 50.72, longitude: 3.16, organisation: organisation) }
   let(:motif) { create(:motif, reservable_online: true, organisation: organisation) }
   let(:now) { Date.new(2019, 7, 22) }
-  let(:mock_geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.all, departement_sectorisation_enabled?: false) }
+  let(:mock_geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.all) }
 
   before { travel_to(now) }
   after { travel_back }
   before do
     allow(mock_geo_search).to receive(:attributed_organisations).and_return(Organisation.where(id: organisation.id))
+    allow(mock_geo_search).to receive(:empty_attributions?).and_return(true)
     expect(Users::GeoSearch).to receive(:new)
       .with(departement: "62", city_code: "62100")
       .and_return(mock_geo_search)

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -49,5 +49,17 @@ FactoryBot.define do
     trait :visible_and_not_notified do
       visibility_type { Motif::VISIBLE_AND_NOT_NOTIFIED }
     end
+
+    trait :sectorisation_level_departement do
+      sectorisation_level { Motif::SECTORISATION_LEVEL_DEPARTEMENT }
+    end
+
+    trait :sectorisation_level_organisation do
+      sectorisation_level { Motif::SECTORISATION_LEVEL_ORGANISATION }
+    end
+
+    trait :sectorisation_level_agent do
+      sectorisation_level { Motif::SECTORISATION_LEVEL_AGENT }
+    end
   end
 end

--- a/spec/factories/sector_attribution.rb
+++ b/spec/factories/sector_attribution.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :sector_attribution do
+    sector
+    organisation
+    level { SectorAttribution::LEVEL_ORGANISATION }
+
+    trait :level_organisation do
+      level { SectorAttribution::LEVEL_ORGANISATION }
+    end
+
+    trait :level_agent do
+      level { SectorAttribution::LEVEL_AGENT }
+      agent { build(:agent, organisations: [organisation]) }
+    end
+  end
+end

--- a/spec/helpers/motifs_helper_spec.rb
+++ b/spec/helpers/motifs_helper_spec.rb
@@ -1,12 +1,5 @@
 describe MotifsHelper do
   describe "#motif_badges" do
-    it "affiche le badge En ligne pour un motif `reservable_online`" do
-      motif = build(:motif, reservable_online: true, location_type: :public_office)
-      badges = motif_badges(motif)
-      expect(badges).to include("En ligne")
-      expect(badges).to include("badge-motif-reservable_online")
-    end
-
     it "affiche le badge Secrétariat pour un motif `secretariat`" do
       motif = build(:motif, reservable_online: false, for_secretariat: true)
       badges = motif_badges(motif)

--- a/spec/service_models/users/creneaux_search_spec.rb
+++ b/spec/service_models/users/creneaux_search_spec.rb
@@ -60,7 +60,7 @@ describe Users::CreneauxSearch, type: :service do
   end
 
   context "with geo search" do
-    let(:motif1) { create(:motif, name: "Coucou", organisation: organisation) }
+    let(:motif1) { create(:motif, :sectorisation_level_agent, name: "Coucou", organisation: organisation) }
     let(:mock_geo_search) { instance_double(Users::GeoSearch, attributed_agents_by_organisation: attributed_agents_by_organisation) }
 
     subject do

--- a/spec/service_models/users/geo_search_cases_spec.rb
+++ b/spec/service_models/users/geo_search_cases_spec.rb
@@ -1,7 +1,7 @@
 # this file contains ~integration specs, there is another with ~unit tests
 
 describe Users::GeoSearch, type: :service_model do
-  context "secto disabled, with a few motifs" do
+  context "with a few motifs sectorised with departement level" do
     subject { Users::GeoSearch.new(departement: "62", city_code: "62100") }
 
     let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
@@ -9,17 +9,11 @@ describe Users::GeoSearch, type: :service_model do
     let(:service1) { create(:service) }
     let(:service2) { create(:service) }
 
-    before do
-      expect(subject).to receive(:departement_sectorisation_enabled?)
-        .at_least(:once)
-        .and_return(false)
-    end
-
-    let!(:motif_ok) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-    let!(:motif_no_plage_ouverture) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-    let!(:motif_service2) { create(:motif, service: service2, reservable_online: true, organisation: organisation1) }
-    let!(:motif_orga2) { create(:motif, service: service1, reservable_online: true, organisation: organisation2) }
-    let!(:motif_offline) { create(:motif, service: service2, reservable_online: false, organisation: organisation1) }
+    let!(:motif_ok) { create(:motif, :sectorisation_level_departement, service: service1, reservable_online: true, organisation: organisation1) }
+    let!(:motif_no_plage_ouverture) { create(:motif, :sectorisation_level_departement, service: service1, reservable_online: true, organisation: organisation1) }
+    let!(:motif_service2) { create(:motif, :sectorisation_level_departement, service: service2, reservable_online: true, organisation: organisation1) }
+    let!(:motif_orga2) { create(:motif, :sectorisation_level_departement, service: service1, reservable_online: true, organisation: organisation2) }
+    let!(:motif_offline) { create(:motif, :sectorisation_level_departement, service: service2, reservable_online: false, organisation: organisation1) }
     let!(:plage_ouverture_ok) { create(:plage_ouverture, motifs: [motif_ok], organisation: organisation1) }
     let!(:plage_ouverture_service2) { create(:plage_ouverture, motifs: [motif_service2], organisation: organisation1) }
     let!(:plage_ouverture_orga2) { create(:plage_ouverture, motifs: [motif_orga2], organisation: organisation2) }
@@ -38,19 +32,13 @@ describe Users::GeoSearch, type: :service_model do
   context "overlapping matching sectors with multiple agents attributed" do
     subject { Users::GeoSearch.new(departement: "62", city_code: "62100") }
 
-    before do
-      expect(subject).to receive(:departement_sectorisation_enabled?)
-        .at_least(:once)
-        .and_return(true)
-    end
-
     let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
     let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Bapaume") }
     let(:service1) { create(:service) }
     let(:service2) { create(:service) }
 
-    let!(:motifs_orga1) { create_list(:motif, 5, service: service1, reservable_online: true, organisation: organisation1) }
-    let!(:motifs_orga2) { create_list(:motif, 2, service: service1, reservable_online: true, organisation: organisation2) }
+    let!(:motifs_orga1) { create_list(:motif, 5, :sectorisation_level_agent, service: service1, reservable_online: true, organisation: organisation1) }
+    let!(:motifs_orga2) { create_list(:motif, 2, :sectorisation_level_agent, service: service1, reservable_online: true, organisation: organisation2) }
 
     let!(:sector_arques) { create(:sector, departement: "62", name: "Arques CENTRE", human_id: "arques") }
     let!(:zone_arques) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques) }

--- a/spec/service_models/users/geo_search_cases_spec.rb
+++ b/spec/service_models/users/geo_search_cases_spec.rb
@@ -1,0 +1,178 @@
+# this file contains ~integration specs, there is another with ~unit tests
+
+describe Users::GeoSearch, type: :service_model do
+  context "secto disabled, with a few motifs" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100") }
+
+    let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
+    let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Bapaume") }
+    let(:service1) { create(:service) }
+    let(:service2) { create(:service) }
+
+    before do
+      expect(subject).to receive(:departement_sectorisation_enabled?)
+        .at_least(:once)
+        .and_return(false)
+    end
+
+    let!(:motif_ok) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
+    let!(:motif_no_plage_ouverture) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
+    let!(:motif_service2) { create(:motif, service: service2, reservable_online: true, organisation: organisation1) }
+    let!(:motif_orga2) { create(:motif, service: service1, reservable_online: true, organisation: organisation2) }
+    let!(:motif_offline) { create(:motif, service: service2, reservable_online: false, organisation: organisation1) }
+    let!(:plage_ouverture_ok) { create(:plage_ouverture, motifs: [motif_ok], organisation: organisation1) }
+    let!(:plage_ouverture_service2) { create(:plage_ouverture, motifs: [motif_service2], organisation: organisation1) }
+    let!(:plage_ouverture_orga2) { create(:plage_ouverture, motifs: [motif_orga2], organisation: organisation2) }
+    let!(:plage_ouverture_offline) { create(:plage_ouverture, motifs: [motif_offline], organisation: organisation1) }
+
+    it "should filter available motifs and services" do
+      expect(subject.available_motifs).to include(motif_ok)
+      expect(subject.available_motifs).to include(motif_service2)
+      expect(subject.available_motifs).to include(motif_orga2)
+      expect(subject.available_motifs).not_to include(motif_no_plage_ouverture)
+      expect(subject.available_motifs).not_to include(motif_offline)
+      expect(subject.available_services).to include(service1, service2)
+    end
+  end
+
+  context "overlapping matching sectors with multiple agents attributed" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100") }
+
+    before do
+      expect(subject).to receive(:departement_sectorisation_enabled?)
+        .at_least(:once)
+        .and_return(true)
+    end
+
+    let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
+    let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Bapaume") }
+    let(:service1) { create(:service) }
+    let(:service2) { create(:service) }
+
+    let!(:motifs_orga1) { create_list(:motif, 5, service: service1, reservable_online: true, organisation: organisation1) }
+    let!(:motifs_orga2) { create_list(:motif, 2, service: service1, reservable_online: true, organisation: organisation2) }
+
+    let!(:sector_arques) { create(:sector, departement: "62", name: "Arques CENTRE", human_id: "arques") }
+    let!(:zone_arques) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques) }
+    let!(:sector_ville) { create(:sector, departement: "62", name: "Ville", human_id: "ville") }
+    let!(:zone_ville) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_ville) }
+
+    # first agent : sector Arques, orga 1
+    let!(:agent_arques1) { create(:agent, organisations: [organisation1]) }
+    let!(:attribution_arques1) { SectorAttribution.create(level: "agent", sector: sector_arques, organisation: organisation1, agent: agent_arques1) }
+    let!(:plage_ouverture_arques1) { create(:plage_ouverture, agent: agent_arques1, motifs: [motifs_orga1[0], motifs_orga1[1]], organisation: organisation1) }
+    let!(:agent_arques_not_attributed) { create(:agent, organisations: [organisation1]) }
+    let!(:plage_ouverture_arques_not_attributed) { create(:plage_ouverture, agent: agent_arques_not_attributed, motifs: [motifs_orga1[2]], organisation: organisation1) }
+
+    # second agent : sector Ville, orga 1
+    let!(:agent_ville1) { create(:agent, organisations: [organisation1]) }
+    let!(:attribution_ville1) { SectorAttribution.create(level: "agent", sector: sector_ville, organisation: organisation1, agent: agent_ville1) }
+    let!(:plage_ouverture_ville1) { create(:plage_ouverture, agent: agent_ville1, motifs: [motifs_orga1[4]], organisation: organisation1) }
+
+    # third agent : sector Ville, orga 2
+    let!(:agent_ville2) { create(:agent, organisations: [organisation2]) }
+    let!(:attribution_ville2) { SectorAttribution.create(level: "agent", sector: sector_ville, organisation: organisation2, agent: agent_ville2) }
+    let!(:plage_ouverture_ville2) { create(:plage_ouverture, agent: agent_ville2, motifs: [motifs_orga2[0]], organisation: organisation2) }
+
+    it "should filter accordingly" do
+      expect(subject.attributed_organisations).to be_empty
+      expect(subject.attributed_agents_by_organisation.keys.flatten).to include(organisation1)
+      expect(subject.attributed_agents_by_organisation.keys.flatten).to include(organisation2)
+      expect(subject.attributed_agents_by_organisation[organisation1]).to include(agent_arques1)
+      expect(subject.attributed_agents_by_organisation[organisation1]).to include(agent_ville1)
+      expect(subject.attributed_agents_by_organisation[organisation1]).not_to include(agent_arques_not_attributed)
+      expect(subject.attributed_agents_by_organisation[organisation2]).to include(agent_ville2)
+      expect(subject.available_motifs).to include(motifs_orga1[0])
+      expect(subject.available_motifs).to include(motifs_orga1[1])
+      expect(subject.available_motifs).not_to include(motifs_orga1[2])
+      expect(subject.available_motifs).not_to include(motifs_orga1[3])
+      expect(subject.available_motifs).to include(motifs_orga1[4])
+      expect(subject.available_motifs).to include(motifs_orga2[0])
+      expect(subject.available_motifs).not_to include(motifs_orga2[1]) # no plage ouvertures
+      expect(subject.available_services).to include(service1)
+    end
+  end
+
+  context "2 sectors splitting a single city into street zones" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100") }
+
+    let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
+    let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Bapaume") }
+    let(:service1) { create(:service) }
+    let(:service2) { create(:service) }
+
+    let!(:sector_nord) { create(:sector, departement: "62", name: "Arques Nord", human_id: "arques-nord") }
+    let!(:zone_nord1) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue du machin vert", street_ban_id: "62100_0103", sector: sector_nord) }
+    let!(:zone_nord2) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue des étoiles", street_ban_id: "62100_2t30", sector: sector_nord) }
+    let!(:sector_sud) { create(:sector, departement: "62", name: "Arques Sud", human_id: "arques-sud") }
+    let!(:zone_sud1) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue du fond", street_ban_id: "62100_304f", sector: sector_sud) }
+    let!(:zone_sud2) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue des étoiles", street_ban_id: "62100_2t30", sector: sector_sud) }
+
+    let!(:attribution_nord) { SectorAttribution.create(level: "organisation", sector: sector_nord, organisation: organisation1) }
+    let!(:attribution_sud) { SectorAttribution.create(level: "organisation", sector: sector_sud, organisation: organisation2) }
+
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100", street_ban_id: searched_street_ban_id) }
+
+    context "searched street matched zone in sector nord" do
+      let(:searched_street_ban_id) { "62100_0103" }
+      it "should find the right sector" do
+        expect(subject.matching_zones).to contain_exactly(zone_nord1)
+        expect(subject.matching_sectors).to contain_exactly(sector_nord)
+        expect(subject.attributed_organisations).to contain_exactly(organisation1)
+      end
+    end
+
+    context "searched street matched zone in sector sud" do
+      let(:searched_street_ban_id) { "62100_304f" }
+      it "should find the right sector" do
+        expect(subject.matching_zones).to contain_exactly(zone_sud1)
+        expect(subject.matching_sectors).to contain_exactly(sector_sud)
+        expect(subject.attributed_organisations).to contain_exactly(organisation2)
+      end
+    end
+
+    context "searched street matched in both sectors" do
+      let(:searched_street_ban_id) { "62100_2t30" }
+      it "should find both sectors" do
+        expect(subject.matching_zones).to contain_exactly(zone_nord2, zone_sud2)
+        expect(subject.matching_sectors).to contain_exactly(sector_nord, sector_sud)
+        expect(subject.attributed_organisations).to contain_exactly(organisation1, organisation2)
+      end
+    end
+
+    context "searched street not matched" do
+      let(:searched_street_ban_id) { "62100_21xx" }
+      it "should find nothing" do
+        expect(subject.matching_zones).to be_empty
+        expect(subject.matching_sectors).to be_empty
+        expect(subject.attributed_organisations).to be_empty
+      end
+    end
+
+    context "with a fallback sector attributed to whole city" do
+      let!(:organisation3) { create(:organisation, departement: "62", name: "MDS Arques backup") }
+
+      let!(:sector_fallback) { create(:sector, departement: "62", name: "Arques full", human_id: "arques-fallback") }
+      let!(:zone_fallback) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_fallback) }
+      let!(:attribution_nord) { SectorAttribution.create(level: "organisation", sector: sector_fallback, organisation: organisation3) }
+
+      context "searched street matched zone in sector sud" do
+        let(:searched_street_ban_id) { "62100_304f" }
+        it "should find the right sector" do
+          expect(subject.matching_zones).to contain_exactly(zone_sud1)
+          expect(subject.matching_sectors).to contain_exactly(sector_sud)
+          expect(subject.attributed_organisations).to contain_exactly(organisation2)
+        end
+      end
+
+      context "searched street not matched" do
+        let(:searched_street_ban_id) { "62100_21xx" }
+        it "should find fallback sector" do
+          expect(subject.matching_zones).to contain_exactly(zone_fallback)
+          expect(subject.matching_sectors).to contain_exactly(sector_fallback)
+          expect(subject.attributed_organisations).to contain_exactly(organisation3)
+        end
+      end
+    end
+  end
+end

--- a/spec/service_models/users/geo_search_spec.rb
+++ b/spec/service_models/users/geo_search_spec.rb
@@ -1,276 +1,260 @@
+# this file contains ~unit tests, there is another with ~integration specs
+
 describe Users::GeoSearch, type: :service_model do
-  subject { Users::GeoSearch.new(departement: "62", city_code: searched_city_code) }
-
-  let(:searched_city_code) { "62100" }
-  let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
-  let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Bapaume") }
-
-  let(:service1) { create(:service) }
-  let(:service2) { create(:service) }
-
   before do
-    expect(subject).to receive(:departement_sectorisation_enabled?)
+    expect_any_instance_of(Users::GeoSearch).to receive(:departement_sectorisation_enabled?)
       .at_least(:once)
-      .and_return(sectorisation_enabled)
+      .and_return(true)
   end
 
-  context "sectorisation is disabled for this departement" do
-    let(:sectorisation_enabled) { false }
+  describe "#matching_zones" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100").matching_zones }
 
-    it "should return all organisations from departement" do
-      expect(subject.attributed_organisations).to contain_exactly(organisation1, organisation2)
+    context "organisation exist but no zones" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      it { should be_empty }
     end
 
-    context "there are a few motifs" do
-      let!(:motif_ok) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-      let!(:motif_no_plage_ouverture) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-      let!(:motif_service2) { create(:motif, service: service2, reservable_online: true, organisation: organisation1) }
-      let!(:motif_orga2) { create(:motif, service: service1, reservable_online: true, organisation: organisation2) }
-      let!(:motif_offline) { create(:motif, service: service2, reservable_online: false, organisation: organisation1) }
-      let!(:plage_ouverture_ok) { create(:plage_ouverture, motifs: [motif_ok], organisation: organisation1) }
-      let!(:plage_ouverture_service2) { create(:plage_ouverture, motifs: [motif_service2], organisation: organisation1) }
-      let!(:plage_ouverture_orga2) { create(:plage_ouverture, motifs: [motif_orga2], organisation: organisation2) }
-      let!(:plage_ouverture_offline) { create(:plage_ouverture, motifs: [motif_offline], organisation: organisation1) }
-
-      it "should filter available motifs and services" do
-        expect(subject.available_motifs).to include(motif_ok)
-        expect(subject.available_motifs).to include(motif_service2)
-        expect(subject.available_motifs).to include(motif_orga2)
-        expect(subject.available_motifs).not_to include(motif_no_plage_ouverture)
-        expect(subject.available_motifs).not_to include(motif_offline)
-        expect(subject.available_services).to include(service1, service2)
-      end
+    context "city-zones match" do
+      let!(:zone1) { create(:zone, level: "city", city_code: "62100", city_name: "Arques") }
+      let!(:zone2) { create(:zone, level: "city", city_code: "62100", city_name: "Arques") }
+      let!(:zone_mismatch) { create(:zone, level: "city", city_code: "62300", city_name: "Arques") }
+      it { should contain_exactly(zone1, zone2) }
     end
   end
 
-  context "sectorisation is enabled but no sectors match is attributed" do
-    let(:sectorisation_enabled) { true }
+  describe "#matching_sectors" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100").matching_sectors }
 
-    it "should return empty results" do
-      expect(subject.matching_zones).to be_empty
-      expect(subject.matching_sectors).to be_empty
-      expect(subject.attributed_organisations).to be_empty
-      expect(subject.available_services).to be_empty
-      expect(subject.available_motifs).to be_empty
+    context "organisation exist but no zones or sectors" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      it { should be_empty }
+    end
+
+    context "city-zones match" do
+      let!(:sector1) { create(:sector, departement: "62", name: "Arques 1", human_id: "arques-1") }
+      let!(:zone1) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector1) }
+      let!(:sector2) { create(:sector, departement: "62", name: "Arques 2", human_id: "arques-2") }
+      let!(:zone2) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector2) }
+      let!(:sector_mismatch) { create(:sector, departement: "62", name: "Bapaume", human_id: "bapaume") }
+      let!(:zone_mismatch) { create(:zone, level: "city", city_code: "62300", city_name: "Bapaume") }
+      it { should contain_exactly(sector1, sector2) }
     end
   end
 
-  context "sectorisation is enabled and a sector matches but without any attributions" do
-    let(:sectorisation_enabled) { true }
-    let!(:sector1) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
-    let!(:zone1) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector1) }
+  describe "#attributed_organisations" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100").attributed_organisations }
 
-    it "should return empty results" do
-      expect(subject.matching_zones).to contain_exactly(zone1)
-      expect(subject.matching_sectors).to contain_exactly(sector1)
-      expect(subject.attributed_organisations).to be_empty
-      expect(subject.available_services).to be_empty
-      expect(subject.available_motifs).to be_empty
+    context "no matching sectors" do
+      it { should be_empty }
+    end
+
+    context "matching sector attributed to orga" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(organisation) }
+    end
+
+    context "matching sector attributed to agent" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_agent, sector: sector, organisation: organisation) }
+      it { should_not contain_exactly(organisation) }
+    end
+
+    context "matching sector attributed to multiple organisations" do
+      let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques Nord") }
+      let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Arques Sud") }
+      let!(:organisation_not_attributed) { create(:organisation, departement: "62") }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution1) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation1) }
+      let!(:attribution2) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation2) }
+      it { should contain_exactly(organisation1, organisation2) }
+    end
+
+    context "matching sectors attributed to different organisations" do
+      let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques Nord") }
+      let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Arques Sud") }
+      let!(:sector1) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques-nord") }
+      let!(:sector2) { create(:sector, departement: "62", name: "Arques Sud", human_id: "arques-sud") }
+      let!(:zone1) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector1) }
+      let!(:zone2) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector2) }
+      let!(:attribution1) { create(:sector_attribution, :level_organisation, sector: sector1, organisation: organisation1) }
+      let!(:attribution2) { create(:sector_attribution, :level_organisation, sector: sector2, organisation: organisation2) }
+      it { should contain_exactly(organisation1, organisation2) }
+    end
+
+    context "edge case: one matching sector attributed to full orga, other matching sector attributed to agent in same orga" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:sector_arques_rural) { create(:sector, departement: "62", name: "Arques CENTRE", human_id: "arques") }
+      let!(:zone_arques_rural) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques_rural) }
+      let!(:sector_arques_ville) { create(:sector, departement: "62", name: "Ville", human_id: "ville") }
+      let!(:zone_arques_ville) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques_ville) }
+      let!(:agent) { create(:agent, organisations: [organisation]) }
+      let!(:attribution_organisation_arques_rural) { SectorAttribution.create(level: "organisation", sector: sector_arques_rural, organisation: organisation) }
+      let!(:attribution_agent_arques_ville) { SectorAttribution.create(level: "agent", sector: sector_arques_ville, organisation: organisation, agent: agent) }
+      it { should contain_exactly(organisation) }
     end
   end
 
-  context "sectorisation is enabled and an organisation is attributed" do
-    let(:sectorisation_enabled) { true }
-    let!(:sector1) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
-    let!(:zone1) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector1) }
-    let!(:attribution1) { SectorAttribution.create(level: "organisation", sector: sector1, organisation: organisation1) }
+  describe "#attributed_agents_by_organisation" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100").attributed_agents_by_organisation }
 
-    it "should return only organisations from matching sector" do
-      expect(subject.matching_zones).to contain_exactly(zone1)
-      expect(subject.matching_sectors).to contain_exactly(sector1)
-      expect(subject.attributed_organisations).to contain_exactly(organisation1)
+    context "one agent attributed with online motif" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:agent) { create(:agent, organisations: [organisation]) }
+      let!(:motif) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], organisation: organisation, agent: agent) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_agent, sector: sector, organisation: organisation, agent: agent) }
+      it { should eq({ organisation => [agent] }) }
     end
 
-    context "there is a single motif with a plage ouverture" do
-      let!(:motif) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif]) }
-
-      it "should return the service" do
-        expect(subject.available_motifs).to contain_exactly(motif)
-        expect(subject.available_services).to contain_exactly(service1)
-      end
-    end
-
-    context "there are 2 motifs from the same service, one has a plage ouverture, the other doesn't" do
-      let!(:motif) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-      let!(:motif2) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif]) }
-
-      it "should return only one motif" do
-        expect(subject.available_motifs).to contain_exactly(motif)
-        expect(subject.available_services).to contain_exactly(service1)
-      end
-    end
-
-    context "there is only a offline motif" do
-      let!(:motif) { create(:motif, service: service1, reservable_online: false, organisation: organisation1) }
-      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif]) }
-
-      it "should not include the service" do
-        expect(subject.available_motifs).to be_empty
-        expect(subject.available_services).to be_empty
-      end
-    end
-
-    context "there is a deleted motif" do
-      let!(:motif) { create(:motif, service: service1, reservable_online: true, deleted_at: Time.now, organisation: organisation1) }
-
-      it "should not include the service" do
-        expect(subject.available_motifs).to be_empty
-        expect(subject.available_services).to be_empty
-      end
-    end
-
-    context "no sector match" do
-      let(:searched_city_code) { "62999" }
-
-      it "should return no results" do
-        expect(subject.matching_zones).to be_empty
-        expect(subject.matching_sectors).to be_empty
-        expect(subject.attributed_organisations).to be_empty
-      end
+    context "edge case: sector attributed to full orga + other sector attributed to agent in same orga" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:sector_arques_rural) { create(:sector, departement: "62", name: "Arques CENTRE", human_id: "arques") }
+      let!(:zone_arques_rural) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques_rural) }
+      let!(:sector_arques_ville) { create(:sector, departement: "62", name: "Ville", human_id: "ville") }
+      let!(:zone_arques_ville) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques_ville) }
+      let!(:agent) { create(:agent, organisations: [organisation]) }
+      let!(:attribution_organisation_arques_rural) { SectorAttribution.create(level: "organisation", sector: sector_arques_rural, organisation: organisation) }
+      let!(:attribution_agent_arques_ville) { SectorAttribution.create(level: "agent", sector: sector_arques_ville, organisation: organisation, agent: agent) }
+      it { should be_empty } # orga match supersedes, we want no duplication
     end
   end
 
-  context "sectorisation is enabled, overlapping matching sectors with multiple agents attributed" do
-    let(:sectorisation_enabled) { true }
+  describe "#available_motifs" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100").available_motifs }
 
-    let!(:motifs_orga1) { create_list(:motif, 5, service: service1, reservable_online: true, organisation: organisation1) }
-    let!(:motifs_orga2) { create_list(:motif, 2, service: service1, reservable_online: true, organisation: organisation2) }
+    context "no organisations in departement" do
+      it { should be_empty }
+    end
 
-    let!(:sector_arques) { create(:sector, departement: "62", name: "Arques CENTRE", human_id: "arques") }
-    let!(:zone_arques) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques) }
-    let!(:sector_ville) { create(:sector, departement: "62", name: "Ville", human_id: "ville") }
-    let!(:zone_ville) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_ville) }
+    context "matching sector not attributed" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      it { should be_empty }
+    end
 
-    # first agent : sector Arques, orga 1
-    let!(:agent_arques1) { create(:agent, organisations: [organisation1]) }
-    let!(:attribution_arques1) { SectorAttribution.create(level: "agent", sector: sector_arques, organisation: organisation1, agent: agent_arques1) }
-    let!(:plage_ouverture_arques1) { create(:plage_ouverture, agent: agent_arques1, motifs: [motifs_orga1[0], motifs_orga1[1]], organisation: organisation1) }
-    let!(:agent_arques_not_attributed) { create(:agent, organisations: [organisation1]) }
-    let!(:plage_ouverture_arques_not_attributed) { create(:plage_ouverture, agent: agent_arques_not_attributed, motifs: [motifs_orga1[2]], organisation: organisation1) }
+    context "matching sector attributed to orga" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:motif) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(motif) }
+    end
 
-    # second agent : sector Ville, orga 1
-    let!(:agent_ville1) { create(:agent, organisations: [organisation1]) }
-    let!(:attribution_ville1) { SectorAttribution.create(level: "agent", sector: sector_ville, organisation: organisation1, agent: agent_ville1) }
-    let!(:plage_ouverture_ville1) { create(:plage_ouverture, agent: agent_ville1, motifs: [motifs_orga1[4]], organisation: organisation1) }
+    context "2 motifs with 2 plage ouvertures match" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:motif1) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
+      let!(:motif2) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(motif1, motif2) }
+    end
 
-    # third agent : sector Ville, orga 2
-    let!(:agent_ville2) { create(:agent, organisations: [organisation2]) }
-    let!(:attribution_ville2) { SectorAttribution.create(level: "agent", sector: sector_ville, organisation: organisation2, agent: agent_ville2) }
-    let!(:plage_ouverture_ville2) { create(:plage_ouverture, agent: agent_ville2, motifs: [motifs_orga2[0]], organisation: organisation2) }
+    context "2 motifs, one without plage ouverture" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:motif1) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
+      let!(:motif2) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(motif1) }
+    end
 
-    it "should filter accordingly" do
-      expect(subject.attributed_organisations).to be_empty
-      expect(subject.attributed_agents_by_organisation.keys.flatten).to include(organisation1)
-      expect(subject.attributed_agents_by_organisation.keys.flatten).to include(organisation2)
-      expect(subject.attributed_agents_by_organisation[organisation1]).to include(agent_arques1)
-      expect(subject.attributed_agents_by_organisation[organisation1]).to include(agent_ville1)
-      expect(subject.attributed_agents_by_organisation[organisation1]).not_to include(agent_arques_not_attributed)
-      expect(subject.attributed_agents_by_organisation[organisation2]).to include(agent_ville2)
-      expect(subject.available_motifs).to include(motifs_orga1[0])
-      expect(subject.available_motifs).to include(motifs_orga1[1])
-      expect(subject.available_motifs).not_to include(motifs_orga1[2])
-      expect(subject.available_motifs).not_to include(motifs_orga1[3])
-      expect(subject.available_motifs).to include(motifs_orga1[4])
-      expect(subject.available_motifs).to include(motifs_orga2[0])
-      expect(subject.available_motifs).not_to include(motifs_orga2[1]) # no plage ouvertures
-      expect(subject.available_services).to include(service1)
+    context "2 motifs, one offline" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:motif1) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
+      let!(:motif2) { create(:motif, reservable_online: false, organisation: organisation) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(motif1) }
+    end
+
+    context "2 motifs, one deleted" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:motif1) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
+      let!(:motif2) { create(:motif, reservable_online: true, organisation: organisation, deleted_at: 2.hours.ago) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(motif1) }
+    end
+
+    context "1 motif coming from attributed agent, 1 from attributed orga" do
+      let!(:organisation1) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:organisation2) { create(:organisation, departement: "62", name: "MDS Arras") }
+      let!(:agent) { create(:agent, organisations: [organisation2]) }
+
+      let!(:motif_organisation) { create(:motif, reservable_online: true, organisation: organisation1) }
+      let!(:motif_agent) { create(:motif, reservable_online: true, organisation: organisation2) }
+
+      let!(:plage_ouverture_organisation) { create(:plage_ouverture, motifs: [motif_organisation], organisation: organisation1) }
+      let!(:plage_ouverture_agent) { create(:plage_ouverture, motifs: [motif_agent], organisation: organisation2, agent: agent) }
+
+      let!(:sector_organisation) { create(:sector, departement: "62", name: "Arques 1", human_id: "arques-1") }
+      let!(:zone_organisation) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_organisation) }
+      let!(:attribution_organisation) { create(:sector_attribution, :level_organisation, sector: sector_organisation, organisation: organisation1) }
+
+      let!(:sector_agent) { create(:sector, departement: "62", name: "Arques 2", human_id: "arques-2") }
+      let!(:zone_agent) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_agent) }
+      let!(:attribution_agent) { create(:sector_attribution, :level_agent, sector: sector_agent, organisation: organisation2, agent: agent) }
+
+      it { should contain_exactly(motif_organisation, motif_agent) }
     end
   end
 
-  context "sectorisation is enabled, one matching sector attributed to full orga, other matching sector attributed to agent in same orga" do
-    let(:sectorisation_enabled) { true }
-    let!(:motif) { create(:motif, service: service1, reservable_online: true, organisation: organisation1) }
-    let!(:sector_arques_rural) { create(:sector, departement: "62", name: "Arques CENTRE", human_id: "arques") }
-    let!(:zone_arques_rural) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques_rural) }
-    let!(:sector_arques_ville) { create(:sector, departement: "62", name: "Ville", human_id: "ville") }
-    let!(:zone_arques_ville) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_arques_ville) }
-    let!(:agent) { create(:agent, organisations: [organisation1]) }
-    let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif], organisation: organisation1) }
-    let!(:attribution_organisation_arques_rural) { SectorAttribution.create(level: "organisation", sector: sector_arques_rural, organisation: organisation1) }
-    let!(:attribution_agent_arques_ville) { SectorAttribution.create(level: "agent", sector: sector_arques_ville, organisation: organisation1, agent: agent) }
+  describe "#available_services" do
+    subject { Users::GeoSearch.new(departement: "62", city_code: "62100").available_services }
 
-    it "should attribute only full organisation, not redundant attributed agent" do
-      expect(subject.attributed_organisations).to contain_exactly(organisation1)
-      expect(subject.attributed_agents_by_organisation).to be_empty
-    end
-  end
-
-  context "2 sectors splitting a single city into street zones" do
-    let(:sectorisation_enabled) { true }
-    let!(:sector_nord) { create(:sector, departement: "62", name: "Arques Nord", human_id: "arques-nord") }
-    let!(:zone_nord1) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue du machin vert", street_ban_id: "62100_0103", sector: sector_nord) }
-    let!(:zone_nord2) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue des étoiles", street_ban_id: "62100_2t30", sector: sector_nord) }
-    let!(:sector_sud) { create(:sector, departement: "62", name: "Arques Sud", human_id: "arques-sud") }
-    let!(:zone_sud1) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue du fond", street_ban_id: "62100_304f", sector: sector_sud) }
-    let!(:zone_sud2) { create(:zone, level: "street", city_code: "62100", city_name: "Arques", street_name: "Rue des étoiles", street_ban_id: "62100_2t30", sector: sector_sud) }
-
-    let!(:attribution_nord) { SectorAttribution.create(level: "organisation", sector: sector_nord, organisation: organisation1) }
-    let!(:attribution_sud) { SectorAttribution.create(level: "organisation", sector: sector_sud, organisation: organisation2) }
-
-    subject { Users::GeoSearch.new(departement: "62", city_code: "62100", street_ban_id: searched_street_ban_id) }
-
-    context "searched street matched zone in sector nord" do
-      let(:searched_street_ban_id) { "62100_0103" }
-      it "should find the right sector" do
-        expect(subject.matching_zones).to contain_exactly(zone_nord1)
-        expect(subject.matching_sectors).to contain_exactly(sector_nord)
-        expect(subject.attributed_organisations).to contain_exactly(organisation1)
-      end
+    context "organisation exist but no sectors" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      it { should be_empty }
     end
 
-    context "searched street matched zone in sector sud" do
-      let(:searched_street_ban_id) { "62100_304f" }
-      it "should find the right sector" do
-        expect(subject.matching_zones).to contain_exactly(zone_sud1)
-        expect(subject.matching_sectors).to contain_exactly(sector_sud)
-        expect(subject.attributed_organisations).to contain_exactly(organisation2)
-      end
+    context "matching sector with 2 motifs with POs from different services" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:service1) { create(:service) }
+      let!(:service2) { create(:service) }
+      let!(:motif1) { create(:motif, reservable_online: true, organisation: organisation, service: service1) }
+      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
+      let!(:motif2) { create(:motif, reservable_online: true, organisation: organisation, service: service2) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(service1, service2) }
     end
 
-    context "searched street matched in both sectors" do
-      let(:searched_street_ban_id) { "62100_2t30" }
-      it "should find both sectors" do
-        expect(subject.matching_zones).to contain_exactly(zone_nord2, zone_sud2)
-        expect(subject.matching_sectors).to contain_exactly(sector_nord, sector_sud)
-        expect(subject.attributed_organisations).to contain_exactly(organisation1, organisation2)
-      end
-    end
-
-    context "searched street not matched" do
-      let(:searched_street_ban_id) { "62100_21xx" }
-      it "should find nothing" do
-        expect(subject.matching_zones).to be_empty
-        expect(subject.matching_sectors).to be_empty
-        expect(subject.attributed_organisations).to be_empty
-      end
-    end
-
-    context "with a fallback sector attributed to whole city" do
-      let!(:organisation3) { create(:organisation, departement: "62", name: "MDS Arques backup") }
-
-      let!(:sector_fallback) { create(:sector, departement: "62", name: "Arques full", human_id: "arques-fallback") }
-      let!(:zone_fallback) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector_fallback) }
-      let!(:attribution_nord) { SectorAttribution.create(level: "organisation", sector: sector_fallback, organisation: organisation3) }
-
-      context "searched street matched zone in sector sud" do
-        let(:searched_street_ban_id) { "62100_304f" }
-        it "should find the right sector" do
-          expect(subject.matching_zones).to contain_exactly(zone_sud1)
-          expect(subject.matching_sectors).to contain_exactly(sector_sud)
-          expect(subject.attributed_organisations).to contain_exactly(organisation2)
-        end
-      end
-
-      context "searched street not matched" do
-        let(:searched_street_ban_id) { "62100_21xx" }
-        it "should find fallback sector" do
-          expect(subject.matching_zones).to contain_exactly(zone_fallback)
-          expect(subject.matching_sectors).to contain_exactly(sector_fallback)
-          expect(subject.attributed_organisations).to contain_exactly(organisation3)
-        end
-      end
+    context "matching sector with 2 motifs with POs from same service" do
+      let!(:organisation) { create(:organisation, departement: "62", name: "MDS Arques") }
+      let!(:service) { create(:service) }
+      let!(:motif1) { create(:motif, reservable_online: true, organisation: organisation, service: service) }
+      let!(:plage_ouverture1) { create(:plage_ouverture, motifs: [motif1], organisation: organisation) }
+      let!(:motif2) { create(:motif, reservable_online: true, organisation: organisation, service: service) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation) }
+      let!(:sector) { create(:sector, departement: "62", name: "Arques VILLE", human_id: "arques") }
+      let!(:zone) { create(:zone, level: "city", city_code: "62100", city_name: "Arques", sector: sector) }
+      let!(:attribution) { create(:sector_attribution, :level_organisation, sector: sector, organisation: organisation) }
+      it { should contain_exactly(service) } # we expect no duplicates
     end
   end
 end


### PR DESCRIPTION
# Changements

Cette PR introduit un changement conceptuel assez profond de la sectorisation.

Actuellement la secto est activée ou désactivée à l'échelle d'un département via une variable d'env. Sur les départements activés, les règles d'attribution des secteurs (à l'agent ou à l'orga) s'appliquent à tous les motifs. 

Pour rappel, **un secteur =** 
- un ensemble de communes (ou de rues) 
- attribuées à 
- un ensemble d'organisations entières OU d'agents spécifiques

Dans cette PR on introduit un `sectorisation_level` au niveau des motifs qui peut avoir trois valeurs : 

- `departement` : les créneaux proposés pour ce motif seront dispos pour tout le département
- `organisation`: les créneaux proposés pour ce motif seront dispos uniquement pour les secteurs attribués à des orgas entières
- `agent` : les créneaux proposés pour ce motif seront dispos uniquement pour les secteurs attribués à des agents spécifiques

On supprime donc le besoin de la variable d'environnement et on permet plus d'autonomie aux départements souhaitant se lancer. C'est aussi moins compliqué qu'aujourd'hui que de commencer à sectoriser, puisqu'on peut sectoriser uniquement un motif, sans que d'un coup les autres ne soient plus accessibles par défaut

# Implémentation

## Premier commit de refacto préliminaire des specs de geo_search

- split en deux fichiers . un de specs plus ou moins unitaires, un de specs d'integration avec des scenarios plus complets et plusieurs méthodes testées
- inlining de la majeure partie des contextes, ça devrait te plaire @yaf ! je commence à me convertir. 

## Contextualisations

J'ai rajouté pas mal d'infos contextuelles pour aider à la configuration : 

- dans les vues motifs#index, motifs#edit et sectors#show
- dans les vues motifs le but est d'avertir s'il existe des secteurs correspondants au niveau choisi. C'est à dire que pour un motif sectorisé niveau orga on va afficher le nombre de secteurs attribués à l'orga du motif. Pour un motif sectorisé niveau agent, on va afficher le nombre de secteurs attribués à des agents du service du motif.
- dans les vues secteurs, c'est l'opposé, on veut informer sur l'existence de motifs correspondants au secteur affiché.

## Migration

Reduction du scope :

```bash
## en prod:

irb(main):010:0> ENV["SECTORISATION_ENABLED_DEPARTMENT_LIST"].split
=> ["62", "77", "12"]

irb(main):008:0> SectorAttribution.where(organisation: Organisation.where(departement: ENV["SECTORISATION_ENABLED_DEPARTMENT_LIST"].split)).level_agent.count
=> 0

## sur demo

irb(main):002:0> ENV["SECTORISATION_ENABLED_DEPARTMENT_LIST"]&.split
=> nil
```

Donc pour bien migrer il suffit de : 

- pour les départements où la secto est desactivée : on passe tous les motifs en `sectorisation_level` = `departement`
- pour les départements où la secto est activée : on passe tous les motifs en `sectorisation_level` = `organisation` 

après simulation de migration sur la prod : 

```
pp Motif.includes(:organisation).to_a.group_by { _1.organisation.departement }.transform_values{ |motifs| motifs.group_by(&:sectorisation_level).transform_valu
es { _1.count } }; nil

{"77"=>{"organisation"=>478},
 "62"=>{"organisation"=>99},
 "12"=>{"organisation"=>34},
 "14"=>{"departement"=>32},
 "64"=>{"departement"=>89},
 "55"=>{"departement"=>34},
 "26"=>{"departement"=>37},
 "80"=>{"departement"=>255},
 "92"=>{"departement"=>32},
 "22"=>{"departement"=>52},
 "33"=>{"departement"=>1},
 "86"=>{"departement"=>40},
 "08"=>{"departement"=>1},
 "95"=>{"departement"=>2}}
```

puis j'ai testé des recherches usagers dans un  dpt sectorisé, et dans un autre non sectorisé ça correspond aux résultats en prod

## Documentation

J'ai adapté la doc : https://doc.rdv-solidarites.fr/sectorisation-geographique

# Review Apps Tests

il faut s'accrocher pour tester faut avoir le contexte bien en tete pour detecter des pbs :) 

Voici un superbe schéma de l'état sur la review app. J'ai créé et découpé paris en deux secteurs nord et sud associés à deux orgas différentes. j'ai aussi créé des sous-secteurs attribués à des agents pour quelques départements, avec certains motifs uniquement sectorisés à l'agent.

<img width="553" alt="Screenshot_2020-11-26_at_15 50 19" src="https://user-images.githubusercontent.com/883348/100365145-63a73300-2fff-11eb-984b-bd85e8cecc40.png">

On peut donc faire des recherches usagers avec ce genre d'adresses : 

- rue du louvre (2e, nord)
- rue des pyrénées (20e, nord)
- métro trocadéro (16e nord)
- pernéty (14e sud)
- place d'italie (13e sud)

je n'ai pas vu d'erreurs pour l'instant