### PR TITLE
send lieu on RDVs webhooks

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -7,4 +7,5 @@ class RdvBlueprint < Blueprinter::Base
   association :motif, blueprint: MotifBlueprint
   association :users, blueprint: UserBlueprint
   association :agents, blueprint: AgentBlueprint
+  association :lieu, blueprint: LieuBlueprint
 end


### PR DESCRIPTION
https://trello.com/c/yEE6L8rj/1180-ajouter-le-nom-du-lieu-pour-linterconnexion

encore plus simple que prévu, mais je n'ai pas ajouté de spec par contre

pour tester sur la review app https://demo-rdv-solidarites-pr978.osc-secnum-fr1.scalingo.io/ : 

- j'ai branché un webhook sur l'orga 1 vers https://webhook.site/#!/bf304f9c-5f15-49a7-b7a9-6b2ca5a90f70
- se connecter en tant que martine
- créer des RDVs de différents location_type
- vérifier : sur webhook.site : lieu est null ou bien présent pour les motifs sur place
