### PR TITLE
ajoute un lien vers la politique de confidentialité

### DIFF
--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -16,6 +16,9 @@ footer.main-footer
           = link_to "https://doc.rdv-solidarites.fr/conditions-dutilisation-de-la-plateforme-rdv-solidarites" do
             span> C.G.U.
             i.fa.fa-external-link-alt
+          = link_to "https://doc.rdv-solidarites.fr/politique-de-confidentialite" do
+            span> Politique de confidentialité
+            i.fa.fa-external-link-alt
         .footer-links.d-flex.flex-wrap.flex-gap-1em.mb-2
           span
             span> RDV-Solidarités

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -47,5 +47,8 @@ html lang="fr"
               = link_to "https://doc.rdv-solidarites.fr/conditions-dutilisation-de-la-plateforme-rdv-solidarites" do
                 span> C.G.U.
                 i.fa.fa-external-link-alt
+              = link_to "https://doc.rdv-solidarites.fr/politique-de-confidentialite" do
+                span> Politique de confidentialité
+                i.fa.fa-external-link-alt
               = mail_to "contact@rdv-solidarites.fr", 'Contact'
     input type='hidden' id="js-current-menu-item" value=content_for(:menu_item)


### PR DESCRIPTION
https://trello.com/c/ztA8YAyx/1184-ajouter-un-lien-vers-la-politique-de-confidentialit%C3%A9

Thomas me faisait remarqué qu'il manquait la Politique de Confidentialité dans les documents que nous avions mis en ligne. Ça sera chose réparé avec cette PR.