### PR TITLE
généralise l'usager de RdvUpdater

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -33,7 +33,7 @@ class Admin::RdvsController < AgentAuthController
 
   def update
     authorize(@rdv)
-    success = RdvUpdater.update(@rdv, rdv_params)
+    success = RdvUpdater.update_by_agent(@rdv, rdv_params)
     respond_to do |format|
       format.json do
         temporal_status_human = I18n.t("activerecord.attributes.rdv.statuses.#{@rdv.temporal_status}")

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -37,8 +37,7 @@ class Users::RdvsController < UserAuthController
 
   def cancel
     authorize(@rdv)
-    if @rdv.cancel
-      @rdv.file_attentes.destroy_all
+    if RdvUpdater.update(@rdv, { status: "excused" })
       flash[:notice] = "Le RDV a bien été annulé."
     else
       flash[:error] = "Impossible d'annuler le RDV."

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -37,7 +37,7 @@ class Users::RdvsController < UserAuthController
 
   def cancel
     authorize(@rdv)
-    if RdvUpdater.update(@rdv, { status: "excused" })
+    if RdvUpdater.update_by_user(@rdv, { status: "excused" })
       flash[:notice] = "Le RDV a bien été annulé."
     else
       flash[:error] = "Impossible d'annuler le RDV."

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -34,4 +34,13 @@ class Users::RdvMailer < ApplicationMailer
       subject: "RDV annulé le #{l(rdv.starts_at, format: :human)} avec #{rdv.organisation.name}"
     )
   end
+
+  def rdv_cancelled_by_user(rdv, user)
+    @rdv = rdv
+    @user = user
+    mail(
+      to: user.email,
+      subject: "RDV annulé le #{l(rdv.starts_at, format: :human)} avec #{rdv.organisation.name}"
+    )
+  end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -81,10 +81,6 @@ class Rdv < ApplicationRecord
     cancelled_at.present?
   end
 
-  def cancel
-    update(cancelled_at: Time.zone.now, status: :excused)
-  end
-
   def cancellable?
     !cancelled? && starts_at > 4.hours.from_now
   end

--- a/app/service_functions/rdv_updater.rb
+++ b/app/service_functions/rdv_updater.rb
@@ -23,11 +23,11 @@ module RdvUpdater
       return false unless rdv.update(rdv_params)
 
       rdv.file_attentes.destroy_all if cancel_status?(rdv_params[:status])
-      notify(rdv, by) if rdv_params[:status] == "excused"
+      notify_cancelled(rdv, by) if rdv_params[:status] == "excused"
       true
     end
 
-    def notify(rdv, by)
+    def notify_cancelled(rdv, by)
       send("notify_#{by}", rdv)
     end
 

--- a/app/service_functions/rdv_updater.rb
+++ b/app/service_functions/rdv_updater.rb
@@ -1,6 +1,16 @@
 module RdvUpdater
   class << self
-    def update(rdv, rdv_params)
+    def update_by_user(rdv, rdv_params)
+      update(rdv, rdv_params, :user)
+    end
+
+    def update_by_agent(rdv, rdv_params)
+      update(rdv, rdv_params, :agent)
+    end
+
+    private
+
+    def update(rdv, rdv_params, by)
       rdv.updated_at = Time.zone.now
       # TODO: replace this manual touch. It forces creating a version when an
       # agent or a user is removed from the RDV. the touch: true option on the
@@ -13,11 +23,21 @@ module RdvUpdater
       return false unless rdv.update(rdv_params)
 
       rdv.file_attentes.destroy_all if cancel_status?(rdv_params[:status])
-      Notifications::Rdv::RdvCancelledByAgentService.perform_with(rdv) if rdv_params[:status] == "excused"
+      notify(rdv, by) if rdv_params[:status] == "excused"
       true
     end
 
-    private
+    def notify(rdv, by)
+      send("notify_#{by}", rdv)
+    end
+
+    def notify_agent(rdv)
+      Notifications::Rdv::RdvCancelledByAgent.perform_with(rdv)
+    end
+
+    def notify_user(rdv)
+      Notifications::Rdv::RdvCancelledByUser.perform_with(rdv)
+    end
 
     def cancel_status?(status)
       %w[excused notexcused].include?(status)

--- a/app/service_functions/rdv_updater.rb
+++ b/app/service_functions/rdv_updater.rb
@@ -12,6 +12,7 @@ module RdvUpdater
 
       return false unless rdv.update(rdv_params)
 
+      rdv.file_attentes.destroy_all if cancel_status?(rdv_params[:status])
       Notifications::Rdv::RdvCancelledByAgentService.perform_with(rdv) if rdv_params[:status] == "excused"
       true
     end

--- a/app/services/notifications/rdv/rdv_cancelled_by_agent.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_by_agent.rb
@@ -1,4 +1,4 @@
-class Notifications::Rdv::RdvCancelledByAgentService < ::BaseService
+class Notifications::Rdv::RdvCancelledByAgent < ::BaseService
   include Notifications::Rdv::BaseServiceConcern
 
   protected

--- a/app/services/notifications/rdv/rdv_cancelled_by_user.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_by_user.rb
@@ -7,9 +7,4 @@ class Notifications::Rdv::RdvCancelledByUser < ::BaseService
     Users::RdvMailer.rdv_cancelled_by_user(@rdv, user).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :cancelled_by_user)
   end
-
-  def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.id, user.id)
-    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :cancelled_by_user)
-  end
 end

--- a/app/services/notifications/rdv/rdv_cancelled_by_user.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_by_user.rb
@@ -1,0 +1,15 @@
+class Notifications::Rdv::RdvCancelledByUser < ::BaseService
+  include Notifications::Rdv::BaseServiceConcern
+
+  protected
+
+  def notify_user_by_mail(user)
+    Users::RdvMailer.rdv_cancelled_by_user(@rdv, user).deliver_later
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :cancelled_by_user)
+  end
+
+  def notify_user_by_sms(user)
+    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.id, user.id)
+    @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :cancelled_by_user)
+  end
+end

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled_by_agent.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled_by_agent.html.slim
@@ -12,4 +12,10 @@ div
     p Trouvez un nouveau créneau en cliquant sur le lien ci-dessous.
 
     .btn-wrapper
-      = link_to 'Reprendre RDV', lieu_url(@rdv.lieu.id, search: {departement: @rdv.organisation.departement, motif: @rdv.motif.name, service: @rdv.motif.service.id, where: @rdv.address}), class:'btn btn-primary'
+      = link_to 'Reprendre RDV', lieux_url(search: { \
+        departement: @rdv.organisation.departement, \
+        motif_name_with_location_type: @rdv.motif.name_with_location_type, \
+        service: @rdv.motif.service.id, \
+        where: @rdv.address \
+      }), class:'btn btn-primary'
+

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled_by_user.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled_by_user.html.slim
@@ -6,4 +6,10 @@ div
     p Vous pouvez reprendre un rendez-vous en cliquant sur le lien ci-dessous.
 
     .btn-wrapper
-      = link_to 'Reprendre RDV', lieu_url(@rdv.lieu.id, search: {departement: @rdv.organisation.departement, motif: @rdv.motif.name, service: @rdv.motif.service.id, where: @rdv.address}), class:'btn btn-primary'
+      = link_to 'Reprendre RDV', lieux_url(search: { \
+        departement: @rdv.organisation.departement, \
+        motif_name_with_location_type: @rdv.motif.name_with_location_type, \
+        service: @rdv.motif.service.id, \
+        where: @rdv.address \
+      }), class:'btn btn-primary'
+

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled_by_user.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled_by_user.html.slim
@@ -1,0 +1,9 @@
+div
+  p Bonjour,
+  p Votre RDV #{@rdv.motif.service.name} du #{l(@rdv.starts_at, format: :human)} a bien été annulé.
+
+  - if @rdv.lieu.present? && @rdv.reservable_online?
+    p Vous pouvez reprendre un rendez-vous en cliquant sur le lien ci-dessous.
+
+    .btn-wrapper
+      = link_to 'Reprendre RDV', lieu_url(@rdv.lieu.id, search: {departement: @rdv.organisation.departement, motif: @rdv.motif.name, service: @rdv.motif.service.id, where: @rdv.address}), class:'btn btn-primary'

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Users::RdvsController, type: :controller do
       it "call RdvUpdate.update function" do
         rdv = create(:rdv, starts_at: 5.hours.from_now)
         sign_in rdv.users.first
-        expect(RdvUpdater).to receive(:update).with(rdv, { status: "excused" })
+        expect(RdvUpdater).to receive(:update_by_user).with(rdv, { status: "excused" })
         put :cancel, params: { rdv_id: rdv.id }
       end
 

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -50,41 +50,50 @@ RSpec.describe Users::RdvsController, type: :controller do
   end
 
   describe "PUT #cancel" do
-    let(:now) { "01/01/2019 14:20".to_datetime }
-    let(:rdv) { create(:rdv, starts_at: 5.hours.from_now) }
-    let!(:user) { create(:user) }
-
-    subject do
-      put :cancel, params: { rdv_id: rdv.id }
-      rdv.reload
-    end
-
-    before do
-      travel_to(now)
-      sign_in signed_in_user
-    end
-
     context "when user belongs to rdv" do
-      let(:signed_in_user) { rdv.users.first }
+      it "change cancelled_at" do
+        rdv = create(:rdv, starts_at: 5.hours.from_now)
+        now = "01/01/2019 14:20".to_datetime
 
-      it { expect { subject }.to change(rdv, :cancelled_at).from(nil).to(now) }
+        travel_to(now)
+        sign_in rdv.users.first
+
+        put :cancel, params: { rdv_id: rdv.id }
+        expect(rdv.reload.cancelled_at).to be_within(5.seconds).of(now)
+      end
+
+      it "call RdvUpdate.update function" do
+        rdv = create(:rdv, starts_at: 5.hours.from_now)
+        sign_in rdv.users.first
+        expect(RdvUpdater).to receive(:update).with(rdv, { status: "excused" })
+        put :cancel, params: { rdv_id: rdv.id }
+      end
 
       it "redirects to rdvs" do
-        subject
+        rdv = create(:rdv, starts_at: 5.hours.from_now)
+        sign_in rdv.users.first
+        put :cancel, params: { rdv_id: rdv.id }
         expect(response).to redirect_to users_rdvs_path
       end
 
-      context "when rdv is not cancellable" do
-        let(:rdv) { create(:rdv, starts_at: 3.hours.from_now) }
-
-        it { expect { subject }.not_to change(rdv, :cancelled_at) }
+      it "when rdv is not cancellable" do
+        rdv = create(:rdv, starts_at: 3.hours.from_now)
+        sign_in rdv.users.first
+        expect do
+          put :cancel, params: { rdv_id: rdv.id }
+        end.not_to change(rdv, :cancelled_at)
       end
     end
 
-    context "when user does not belongs to rdv" do
-      let(:signed_in_user) { create(:user) }
+    it "when user does not belongs to rdv" do
+      rdv = create(:rdv, starts_at: 5.hours.from_now)
+      other_user = create(:user)
 
-      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+      sign_in other_user
+
+      expect do
+        put :cancel, params: { rdv_id: rdv.id }
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -1,47 +1,7 @@
 RSpec.describe Users::RdvMailer, type: :mailer do
-  let(:rdv) { create(:rdv) }
-  let(:previous_starts_at) { nil }
-
-  shared_examples "mail with ICS" do
-    it "contains the ics" do
-      expect(mail.body.encoded).to match("UID:#{rdv.uuid}")
-      expect(mail.body.encoded).to match("STATUS:CANCELLED") if rdv.cancelled?
-    end
-  end
-
-  shared_examples "mail for rdv confirmation" do
-    it "renders the subject" do
-      expect(mail.subject).to eq("RDV confirmé le #{I18n.l(rdv.starts_at, format: :human)}")
-    end
-
-    it "renders the body" do
-      expect(mail.html_part.body.encoded).to match("Votre RDV du #{I18n.l(rdv.starts_at, format: :human)} a été confirmé")
-    end
-  end
-
-  shared_examples "mail for updated rdv" do
-    it "renders the subject" do
-      expect(mail.subject).to eq("Modification de la date de votre RDV")
-    end
-
-    it "renders the body" do
-      expect(mail.html_part.body.encoded).to match("Modification de votre RDV")
-      expect(mail.html_part.body.encoded).to match("Votre rendez-vous initialement prévu le #{I18n.l(previous_starts_at, format: :human)}")
-      expect(mail.html_part.body.encoded).to match("a été déplacé au&nbsp;<strong>#{I18n.l(rdv.starts_at, format: :human)}</strong>")
-    end
-  end
-
-  shared_examples "mail for cancelled rdv" do
-    it "renders the subject" do
-      expect(mail.subject).to eq("ANNULÉ : RDV du #{I18n.l(rdv.starts_at, format: :human)}")
-    end
-
-    it "renders the body" do
-      expect(mail.html_part.body.encoded).to match("ANNULÉ : RDV du #{I18n.l(rdv.starts_at, format: :human)}")
-    end
-  end
 
   describe "#rdv_created" do
+    let(:rdv) { create(:rdv) }
     let(:user) { rdv.users.first }
     let(:mail) { Users::RdvMailer.rdv_created(rdv, user) }
 
@@ -49,8 +9,108 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
     end
 
-    it_behaves_like "mail for rdv confirmation"
+    it "renders the subject" do
+      expect(mail.subject).to eq("RDV confirmé le #{I18n.l(rdv.starts_at, format: :human)}")
+    end
 
-    it_behaves_like "mail with ICS"
+    it "renders the body" do
+      expect(mail.html_part.body.encoded).to match("Votre RDV du #{I18n.l(rdv.starts_at, format: :human)} a été confirmé")
+    end
+
+    it "contains the ics" do
+      expect(mail.body.encoded).to match("UID:#{rdv.uuid}")
+      expect(mail.body.encoded).to match("STATUS:CANCELLED") if rdv.cancelled?
+    end
+  end
+
+  describe "#rdv_cancelled_by_user" do
+    it "send mail to user" do
+      rdv = create(:rdv)
+      user = rdv.users.first
+      mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
+
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "subject contains date of cancelled rdv" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
+
+      expect(mail.subject).to eq("RDV annulé le lundi 15 juin 2020 à 12h30 avec Orga du coin")
+    end
+
+    it "body contains cancelled confirmation with dateTime" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
+
+      expect(mail.body).to match("lundi 15 juin 2020 à 12h30")
+    end
+
+    it "body contains cancelled confirmation with motif's service name" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
+
+      expect(mail.body).to match(rdv.motif.service_name)
+    end
+
+    it "body contains link to book a new RDV" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
+
+      expected_url = lieux_url(search: { \
+        departement: rdv.organisation.departement, \
+        motif_name_with_location_type: rdv.motif.name_with_location_type, \
+        service: rdv.motif.service.id, \
+        where: rdv.address \
+      })
+
+      expect(mail.body).to have_link("Reprendre RDV", href: expected_url)
+    end
+  end
+
+  describe "#rdv_cancelled_by_agent" do
+    it "send mail to user" do
+      rdv = create(:rdv)
+      user = rdv.users.first
+      mail = Users::RdvMailer.rdv_cancelled_by_agent(rdv, user)
+
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "subject contains date of cancelled rdv" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
+
+      expect(mail.subject).to eq("RDV annulé le lundi 15 juin 2020 à 12h30 avec Orga du coin")
+    end
+
+    it "body contains cancelled confirmation with dateTime" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_agent(rdv, user)
+
+      expect(mail.body).to match("lundi 15 juin 2020 à 12h30")
+    end
+
+    it "body contains cancelled confirmation with motif's service name" do
+      organisation = build(:organisation, name: "Orga du coin")
+      user = build(:user)
+      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = Users::RdvMailer.rdv_cancelled_by_agent(rdv, user)
+
+      expect(mail.body).to match(rdv.motif.service_name)
+    end
+
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Users::RdvMailer, type: :mailer do
-
   describe "#rdv_created" do
     let(:rdv) { create(:rdv) }
     let(:user) { rdv.users.first }
@@ -66,11 +65,11 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       mail = Users::RdvMailer.rdv_cancelled_by_user(rdv, user)
 
       expected_url = lieux_url(search: { \
-        departement: rdv.organisation.departement, \
-        motif_name_with_location_type: rdv.motif.name_with_location_type, \
-        service: rdv.motif.service.id, \
-        where: rdv.address \
-      })
+                                 departement: rdv.organisation.departement, \
+                                 motif_name_with_location_type: rdv.motif.name_with_location_type, \
+                                 service: rdv.motif.service.id, \
+                                 where: rdv.address \
+                               })
 
       expect(mail.body).to have_link("Reprendre RDV", href: expected_url)
     end
@@ -111,6 +110,5 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
       expect(mail.body).to match(rdv.motif.service_name)
     end
-
   end
 end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -36,20 +36,6 @@ describe Rdv, type: :model do
     end
   end
 
-  describe "#cancel" do
-    let(:rdv) { create(:rdv) }
-    let(:now) { Time.current }
-
-    subject { rdv.cancel }
-
-    before { freeze_time }
-    after { travel_back }
-
-    it "should set cancelled_at" do
-      expect { subject }.to change { rdv.cancelled_at }.from(nil).to(now)
-    end
-  end
-
   describe "#cancellable?" do
     let(:now) { Time.current }
 

--- a/spec/service_functions/rdv_updater_spec.rb
+++ b/spec/service_functions/rdv_updater_spec.rb
@@ -13,6 +13,14 @@ describe RdvUpdater, type: :service do
       RdvUpdater.update(rdv, rdv_params)
     end
 
+    it "destroy all file_attentes" do
+      rdv = create(:rdv, agents: [create(:agent)])
+      create(:file_attente, rdv: rdv)
+      rdv_params = { status: "excused" }
+      RdvUpdater.update(rdv, rdv_params)
+      expect(rdv.reload.file_attentes).to be_empty
+    end
+
     it "return false when update fail" do
       rdv = create(:rdv, agents: [create(:agent)])
       rdv_params = { agents: [] }

--- a/spec/services/notifications/rdv/rdv_cancelled_by_agent_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_by_agent_spec.rb
@@ -1,5 +1,5 @@
-describe Notifications::Rdv::RdvCancelledByAgentService, type: :service do
-  subject { Notifications::Rdv::RdvCancelledByAgentService.perform_with(rdv) }
+describe Notifications::Rdv::RdvCancelledByAgent, type: :service do
+  subject { Notifications::Rdv::RdvCancelledByAgent.perform_with(rdv) }
   let(:user1) { build(:user) }
   let(:rdv) { create(:rdv, starts_at: 3.days.from_now, users: [user1]) }
 

--- a/spec/services/notifications/rdv/rdv_cancelled_by_user_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_by_user_spec.rb
@@ -1,0 +1,20 @@
+describe Notifications::Rdv::RdvCancelledByUser, type: :service do
+  subject { Notifications::Rdv::RdvCancelledByUser.perform_with(rdv) }
+  let(:user1) { build(:user) }
+  let(:rdv) { create(:rdv, starts_at: 3.days.from_now, users: [user1]) }
+
+  it "sends an email" do
+    expect(Users::RdvMailer).to receive(:rdv_cancelled_by_user)
+      .with(rdv, user1)
+      .and_return(double(deliver_later: nil))
+    subject
+    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_user").count).to eq 1
+  end
+
+  it "sends a SMS" do
+    expect(SendTransactionalSmsJob).to receive(:perform_later)
+      .with(:rdv_cancelled, rdv.id, user1.id)
+    subject
+    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "cancelled_by_user").count).to eq 1
+  end
+end

--- a/spec/services/notifications/rdv/rdv_cancelled_by_user_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_by_user_spec.rb
@@ -10,5 +10,4 @@ describe Notifications::Rdv::RdvCancelledByUser, type: :service do
     subject
     expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_user").count).to eq 1
   end
-
 end

--- a/spec/services/notifications/rdv/rdv_cancelled_by_user_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_by_user_spec.rb
@@ -11,10 +11,4 @@ describe Notifications::Rdv::RdvCancelledByUser, type: :service do
     expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_user").count).to eq 1
   end
 
-  it "sends a SMS" do
-    expect(SendTransactionalSmsJob).to receive(:perform_later)
-      .with(:rdv_cancelled, rdv.id, user1.id)
-    subject
-    expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "cancelled_by_user").count).to eq 1
-  end
 end


### PR DESCRIPTION
https://trello.com/c/YunxOY7K/1185-utilise-partout-la-m%C3%AAme-fa%C3%A7on-dannuler-un-rdv

L'usager ne passait pas par le RdvUpdater. Cette PR vise à corriger cela.
J'en ais profité pour supprimer la méthode `cancel` de la classe Rdv.
