### PR TITLE
Create rubocop-analysis.yml

### DIFF
--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -1,0 +1,40 @@
+# pulled from repo
+name: "Rubocop"
+
+on: push
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # If running on a self-hosted runner, check it meets the requirements
+    # listed at https://github.com/ruby/setup-ruby#using-self-hosted-runners
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    # This step is not necessary if you add the gem to your Gemfile
+    - name: Install Code Scanning integration
+      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Rubocop run
+      run: |
+        bash -c "
+          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
+          [[ $? -ne 2 ]]
+        "
+
+    - name: Upload Sarif output
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: rubocop.sarif


### PR DESCRIPTION
Github suggère depuis un moment de mettre en place un workflow 

> Code scanning alerts
> Automatically detect common vulnerability and coding errors 

Après avoir regardé de quoi il retourne, je découvre qu'il propose d'utiliser un workflow avec Rubocop. J'essai pour voir et comprendre en quoi ça ne correspond pas à ce que nous avons déjà.
