### PR TITLE
Zammad contact form, support tickets controller form and model

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,11 @@
 class StaticPagesController < ApplicationController
   def mds; end
 
-  def contact; end
+  def contact
+    @support_ticket_form = SupportTicketForm.new(
+      first_name: current_user&.first_name,
+      last_name: current_user&.last_name,
+      email: current_user&.email
+    )
+  end
 end

--- a/app/controllers/support_tickets_controller.rb
+++ b/app/controllers/support_tickets_controller.rb
@@ -1,0 +1,16 @@
+class SupportTicketsController < ApplicationController
+  def create
+    @support_ticket_form = SupportTicketForm.new(contact_params.to_h)
+    if @support_ticket_form.save
+      redirect_to contact_path(anchor: ""), flash: { success: "Votre demande a bien été reçue, nous vous répondrons rapidement par mail" }
+    else
+      render "static_pages/contact"
+    end
+  end
+
+  private
+
+  def contact_params
+    params.require(:support_ticket).permit(:subject, :first_name, :last_name, :email, :message, :departement)
+  end
+end

--- a/app/form_models/support_ticket_form.rb
+++ b/app/form_models/support_ticket_form.rb
@@ -1,0 +1,38 @@
+class SupportTicketForm
+  include ActiveModel::Model
+
+  SUBJECTS = [
+    "Je suis usager et je n'arrive pas à annuler mon RDV",
+    "Je suis usager et je n'arrive pas à accéder à mon compte",
+    "Je suis agent et je n'arrive pas à accéder à mon compte",
+    "Je suis agent et j'ai une question ou je rencontre un problème",
+    "Je suis agent ou décideur public et j'aimerais plus d'informations sur RDV-Solidarités",
+    "Autre",
+  ].freeze
+
+  attr_accessor :subject, :first_name, :last_name, :email, :message, :departement
+
+  validates :first_name, :last_name, :email, :message, :departement, presence: true
+
+  validates :subject, inclusion: { in: SUBJECTS }
+
+  def save
+    if valid?
+      success, api_result = ZammadApi.create_ticket(email, ticket_title, ticket_body)
+      errors.add(:base, api_result[:errors].to_sentence) if api_result[:errors]&.any?
+      success
+    else
+      false
+    end
+  end
+
+  private
+
+  def ticket_title
+    "#{subject} - #{departement} - #{first_name} #{last_name}"
+  end
+
+  def ticket_body
+    """Prénom: #{first_name}\nNom: #{last_name}\nDépartement: #{departement}\n\n" + message
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -111,4 +111,10 @@ module ApplicationHelper
       class: "badge badge-light text-monospace"
     )
   end
+
+  def departements_with_upcoming_rdvs
+    Organisation
+      .where(id: Rdv.where("starts_at > ?", Time.zone.now).select(:organisation_id).distinct.pluck(:organisation_id))
+      .select(:departement).distinct.pluck(:departement)
+  end
 end

--- a/app/lib/zammad_api.rb
+++ b/app/lib/zammad_api.rb
@@ -1,0 +1,33 @@
+module ZammadApi
+  class HttpError < StandardError; end
+  class RequestError < StandardError; end
+
+  class << self
+    def create_ticket(email, ticket_title, ticket_body)
+      response = Typhoeus::Request.new(
+        "https://rdv-solidarites.zammad.com/api/v1/tickets",
+        method: :post,
+        body: JSON.dump(
+          title: ticket_title,
+          group: "Users",
+          customer_id: "guess:#{email}",
+          article: { body: ticket_body }
+        ),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Token token=#{ENV['ZAMMAD_API_TOKEN']}"
+        }
+      ).run
+      if response.success?
+        [true, {}]
+      elsif response.timed_out? || response.code.zero?
+        Raven.capture_exception(HttpError.new(response.code))
+        [false, { errors: ["HTTP request failed"] }]
+      else
+        parsed_response = JSON.parse(response.body)
+        Raven.capture_exception(RequestError.new(parsed_response["error_human"]))
+        [false, { errors: [parsed_response["error_human"]] }]
+      end
+    end
+  end
+end

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -50,5 +50,5 @@ html lang="fr"
               = link_to "https://doc.rdv-solidarites.fr/politique-de-confidentialite" do
                 span> Politique de confidentialité
                 i.fa.fa-external-link-alt
-              = mail_to "contact@rdv-solidarites.fr", 'Contact'
+              = link_to 'Contact', contact_path(anchor: "tech-support")
     input type='hidden' id="js-current-menu-item" value=content_for(:menu_item)

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -37,5 +37,26 @@
       span> Autres départements, voir
       = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
 
-  h3 Équipe technique
-  = link_to "contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Depuis%20la%20page%20contact"
+  .row#tech-support
+    .col-md-6
+      h3.mt-4 Contacter l'équipe technique
+      - if @support_ticket_form.errors.empty?
+        button.btn.btn-primary.collapse.show.js-form-support-ticket[
+          data-toggle="collapse"
+          aria-expanded="false"
+          data-target=".js-form-support-ticket"
+        ]
+          | Question à l'équipe technique de RDV-Solidarités
+      .js-form-support-ticket.mt-2[
+        class=(@support_ticket_form.errors.any? ? "" : "collapse")
+      ]
+        = simple_form_for [:users, @support_ticket_form], url: support_tickets_path(anchor: "tech-support"), as: :support_ticket do |f|
+          = render partial: 'layouts/model_errors', locals: { model: @support_ticket_form }
+          = f.input :subject, label: "Sujet", collection: SupportTicketForm::SUBJECTS
+          .row
+            .col-md-6= f.input :first_name, label: "Prénom"
+            .col-md-6= f.input :last_name, label: "Nom"
+          = f.input :departement, label: "Département", collection: departements_with_upcoming_rdvs + ["Autre"], hint: "Si votre département n'est pas listé, c'est qu'il n'utilise pas la plateforme RDV-Solidarités"
+          = f.input :email, label: "Email"
+          = f.input :message, label: "Message", as: :text, hint: "Merci de ne pas inclure d'informations confidentielles vous concernant", input_html: { rows: 5 }
+          = f.button :submit, value: "Envoyer la demande à l'équipe technique", data: { disable_with: "Envoi en cours…" }

--- a/app/views/welcome/welcome_agent.html.slim
+++ b/app/views/welcome/welcome_agent.html.slim
@@ -42,7 +42,7 @@ section.py-5.bg-lightturquoise.text-primary
           p.lead Vous souhaitez en savoir plus ?
           .row.d-flex.justify-content-center
             .col-md-3.p-2.px-3.p-md-0
-              = mail_to "contact@rdv-solidarites.fr", "Contactez-nous", class: "btn btn-tertiary"
+              = link_to "Contactez-nous", contact_path(anchor: "tech-support"), class: "btn btn-tertiary"
             .col-md-3.p-2.px-3.p-md-0
               = link_to "Créez votre service", new_organisation_path, class: 'btn btn-tertiary'
             - unless demo?
@@ -106,7 +106,7 @@ section.bg-lightturquoise.py-5
         .col-md-9.m-auto
           .row.d-flex.justify-content-center
             .col-md-3.p-2.px-3.p-md-0
-              = mail_to "contact@rdv-solidarites.fr", "Contactez-nous", class: "btn btn-tertiary"
+              = link_to "Contactez-nous", contact_path(anchor: "tech-support"), class: "btn btn-tertiary"
             .col-md-3.p-2.px-3.p-md-0
               = link_to "Créez votre service", new_organisation_path, class: 'btn btn-tertiary'
             - unless demo?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
   resources :motif_libelles, only: :index
   get "health_checks/rdv_events_stats", to: "health_checks#rdv_events_stats"
   root "welcome#index"
+  resources :support_tickets, only: [:create]
 
   # temporary route after admin namespace introduction
   # rubocop:disable Style/StringLiterals, Style/FormatStringToken

--- a/spec/controllers/support_tickets_controller_spec.rb
+++ b/spec/controllers/support_tickets_controller_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe SupportTicketsController, type: :controller do
+  render_views
+
+  describe "POST #create" do
+    let(:support_ticket_form) { SupportTicketForm.new }
+
+    before do
+      expect(SupportTicketForm).to receive(:new)
+        .with(support_ticket_params)
+        .and_return(support_ticket_form)
+    end
+
+    subject { post(:create, params: { support_ticket: support_ticket_params }) }
+
+    context "broken params" do
+      let(:support_ticket_params) { { subject: "n'importe quoi" } }
+      before do
+        expect(support_ticket_form).to receive(:save).and_return(false)
+      end
+      it { should render_template("static_pages/contact") }
+    end
+
+    context "valid params" do
+      let(:support_ticket_params) do
+        {
+          subject: "Je suis usager et je n'arrive pas à accéder à mon compte",
+          first_name: "Jean",
+          last_name: "Jacques",
+          email: "jean@jacques.fr",
+          message: "Ca me gratte partout",
+          departement: "73"
+        }
+      end
+      before { expect(support_ticket_form).to receive(:save).and_return(true) }
+      it { should redirect_to(contact_path(anchor: "")) }
+    end
+  end
+end

--- a/spec/form_models/support_ticket_form_spec.rb
+++ b/spec/form_models/support_ticket_form_spec.rb
@@ -1,0 +1,48 @@
+describe SupportTicketForm do
+  describe "#save" do
+    subject { support_ticket_form.save }
+
+    context "valid attributes" do
+      let(:support_ticket_form) do
+        SupportTicketForm.new(
+          subject: "Je suis usager et je n'arrive pas à accéder à mon compte",
+          first_name: "Jean",
+          last_name: "Jacques",
+          email: "jean@jacques.fr",
+          message: "Ca me gratte partout",
+          departement: "73"
+        )
+      end
+
+      it "should call API" do
+        expect(ZammadApi).to receive(:create_ticket)
+          .with(
+            "jean@jacques.fr",
+            "Je suis usager et je n'arrive pas à accéder à mon compte - 73 - Jean Jacques",
+            "Prénom: Jean\nNom: Jacques\nDépartement: 73\n\nCa me gratte partout"
+          ).and_return([true, {}])
+        res = subject
+        expect(res).to eq true
+      end
+    end
+
+    context "invalid attributes" do
+      let(:support_ticket_form) do
+        SupportTicketForm.new(
+          subject: "Je suis usager et je n'arrive pas à accéder à mon compte",
+          first_name: "Jean",
+          last_name: "Jacques",
+          email: "jean@jacques.fr",
+          message: "Ca me gratte partout"
+          # missing dept
+        )
+      end
+
+      it "should not call API" do
+        expect(ZammadApi).not_to receive(:create_ticket)
+        res = subject
+        expect(res).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/L4cNwlGr/1187-mieux-qualifier-les-mails-depuis-la-page-contact

## Changements

<img width="1661" alt="stitched_2020_12_02-11_55_24" src="https://user-images.githubusercontent.com/883348/100863749-4ce85c80-3495-11eb-9e3f-e71a044e1283.png">

<img width="1552" alt="Screenshot_2020-12-02_at_11 58 46" src="https://user-images.githubusercontent.com/883348/100864054-bff1d300-3495-11eb-8e0b-691826ce30f2.png">


- La liste des sujets possible est : 

  "Je suis usager et je n'arrive pas à annuler mon RDV",
    "Je suis usager et je n'arrive pas à accéder à mon compte",
    "Je suis agent et je n'arrive pas à accéder à mon compte",
    "Je suis agent et j'ai une question ou je rencontre un problème",
    "Je suis agent ou décideur public et j'aimerais plus d'informations sur RDV-Solidarités",
    "Autre",

- J'ai hésité à utiliser le formulaire clé en mains fourni par Zammad mais il y a vraiment peu de config possible et ça rajoutait du JS pas beau. J'ai préferré faire cet effort d'intégrer l'API et avoir un formulaire qu'on gère nous même et qu'on pourra faire évoluer
- je ne remplis pas encore les bonnes infos aux bons endroits dans zammad, c'est un peu bourrin je mets tout dans le body. Il faudrait créer le customer en amont, et peut-être utiliser des tags dans les tickets ... je me dis qu'on améliorera si nécessaire.

La doc de l'API de zammad est ici : https://docs.zammad.org/en/latest/api/ticket.html#create

## Local

pour tester en local il faut ajouter cette var d'env: 

`ZAMMAD_API_TOKEN=xxxx`

pour recuperer un token d'accès à zammad ca se passe sur : https://rdv-solidarites.zammad.com/#profile/token_access , il faut selectionner les droits "agent.ticket et admin.ticket"

ou alors copier celui qui est sur la review app :  

`scalingo env -a demo-rdv-solidarites-pr984 --region osc-secnum-fr1 | grep ZAMMAD`