### PR TITLE
generize form confirm warnings and overlapping plage ouvertures display

### DIFF
--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -7,7 +7,6 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def show
     authorize(@plage_ouverture)
-    set_overlapping_details
   end
 
   def index
@@ -58,14 +57,12 @@ class Admin::PlageOuverturesController < AgentAuthController
       flash[:notice] = "Plage d'ouverture créée"
       redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
     else
-      set_overlapping_details
       render :new
     end
   end
 
   def update
     authorize(@plage_ouverture)
-    set_overlapping_details
     if @plage_ouverture.update(plage_ouverture_params)
       redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture), notice: "La plage d'ouverture a été modifiée."
     else
@@ -105,14 +102,5 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def filter_params
     params.permit(:start, :end, :organisation_id, :agent_id, :page, :current_tab)
-  end
-
-  def set_overlapping_details
-    @overlapping_plages_ouvertures = Agent::PlageOuverturePolicy::DepartementScope
-      .new(pundit_user, PlageOuverture)
-      .resolve
-      .merge(@plage_ouverture.overlapping_plages_ouvertures)
-    @overlapping_plages_ouvertures_out_of_scope_count = \
-      @plage_ouverture.overlapping_plages_ouvertures.count - @overlapping_plages_ouvertures.count
   end
 end

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -19,6 +19,7 @@ class AgentAuthController < ApplicationController
   def pundit_user
     AgentContext.new(current_agent, current_organisation)
   end
+  helper_method :pundit_user
 
   def authorize(record, *args)
     record.class.module_parent == Agent ? super(record, *args) : super([:agent, record], *args)

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -82,4 +82,11 @@ module PlageOuverturesHelper
   def po_exceptionnelle_tag(plage_ouverture)
     content_tag(:span, "Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
   end
+
+  def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)
+    Agent::PlageOuverturePolicy::DepartementScope
+      .new(pundit_user, PlageOuverture)
+      .resolve
+      .merge(plage_ouvertures)
+  end
 end

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -1,6 +1,12 @@
+- if plage_ouverture.warnings_need_confirmation? && plage_ouverture.overlapping_plages_ouvertures.any?
+  - content_for :warnings_description do
+    ul.pl-3
+      = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: plage_ouverture
+
 - if plage_ouverture.available_motifs.any?
   = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture] do |f|
     = render(partial: 'layouts/model_errors', locals: { model: plage_ouverture, f: f })
+
     .form-collapsable-fields-wrapper.collapse.js-collapse-warning-confirmation[
       class=(plage_ouverture.warnings_need_confirmation? ? "" : "show")
       aria-expanded=(plage_ouverture.warnings_need_confirmation? ? "false" : "true")

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -1,28 +1,6 @@
 - if plage_ouverture.available_motifs.any?
   = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture] do |f|
-
-    = render partial: 'layouts/model_errors', locals: { model: plage_ouverture }
-
-    - if plage_ouverture.warnings_need_confirmation?
-      ul.pl-3
-        = render "overlapping_plage_ouvertures", \
-          overlapping_plages_ouvertures: @overlapping_plages_ouvertures, \
-          overlapping_plages_ouvertures_out_of_scope_count: @overlapping_plages_ouvertures_out_of_scope_count
-
-      .collapse.show.js-collapse-warning-confirmation
-        .text-muted Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
-        = f.input :active_warnings_confirm_decision, as: :hidden, input_html: {class: "js-warning-confirm-input", value: "1" }
-        .d-flex.justify-content-between
-          div
-            a.btn.btn-outline-dark[
-              data-toggle="collapse"
-              data-target=".js-collapse-warning-confirmation"
-              href="#"
-              onclick="document.querySelector('.js-warning-confirm-input').setAttribute('disabled', 'disabled');"
-            ] Annuler et modifier
-          div= f.submit "Confirmer", class: "btn btn-warning"
-        hr
-
+    = render(partial: 'layouts/model_errors', locals: { model: plage_ouverture, f: f })
     .form-collapsable-fields-wrapper.collapse.js-collapse-warning-confirmation[
       class=(plage_ouverture.warnings_need_confirmation? ? "" : "show")
       aria-expanded=(plage_ouverture.warnings_need_confirmation? ? "false" : "true")

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,4 +1,6 @@
-- overlapping_plages_ouvertures.each do |overlapping_plage_ouverture|
+- in_scope = filter_plage_ouvertures_in_departement_scope(model.overlapping_plages_ouvertures)
+
+- in_scope.each do |overlapping_plage_ouverture|
   li.mb-1
     span>= link_to("Plage d'ouverture #{overlapping_plage_ouverture.id}", edit_admin_organisation_plage_ouverture_path(overlapping_plage_ouverture.organisation, overlapping_plage_ouverture))
     span> à #{overlapping_plage_ouverture.lieu.name}
@@ -10,6 +12,7 @@
     - if overlapping_plage_ouverture.organisation != current_organisation
       span>= "(Organisation #{overlapping_plage_ouverture.organisation.name})"
 
-- if overlapping_plages_ouvertures_out_of_scope_count == 1
+- out_of_scope_count = model.overlapping_plages_ouvertures.count - in_scope.count
+- if out_of_scope_count >= 1
   li.mb-1
-    = t("plage_ouvertures.overlapping_out_of_scope", count: overlapping_plages_ouvertures_out_of_scope_count)
+    = t("plage_ouvertures.overlapping_out_of_scope", count: out_of_scope_count)

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -51,9 +51,7 @@
               | Conflit de dates et d'horaires avec d'autres plages d'ouvertures
             .border-left.border-right.border-bottom.rounded.border-warning
               ul.pl-3.py-2.mb-0
-                = render "overlapping_plage_ouvertures", \
-                  overlapping_plages_ouvertures: @overlapping_plages_ouvertures, \
-                  overlapping_plages_ouvertures_out_of_scope_count: @overlapping_plages_ouvertures_out_of_scope_count
+                = render "overlapping_plage_ouvertures", model: @plage_ouverture
 
       .card-footer.d-flex.justify-content-between
         div

--- a/app/views/layouts/_model_errors.html.slim
+++ b/app/views/layouts/_model_errors.html.slim
@@ -6,9 +6,7 @@
       - model.warnings.each do |key, msg|
         li= msg
 
-  - if model.respond_to?(:overlapping_plages_ouvertures) && model.overlapping_plages_ouvertures.any?
-    ul.pl-3
-      = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: model
+  = content_for(:warnings_description)
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation

--- a/app/views/layouts/_model_errors.html.slim
+++ b/app/views/layouts/_model_errors.html.slim
@@ -6,6 +6,25 @@
       - model.warnings.each do |key, msg|
         li= msg
 
+  - if model.respond_to?(:overlapping_plages_ouvertures) && model.overlapping_plages_ouvertures.any?
+    ul.pl-3
+      = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: model
+
+  - if local_assigns[:f]
+    .collapse.show.js-collapse-warning-confirmation
+      .text-muted Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
+      = f.input :active_warnings_confirm_decision, as: :hidden, input_html: {class: "js-warning-confirm-input", value: "1" }
+      .d-flex.justify-content-between
+        div
+          a.btn.btn-outline-dark[
+            data-toggle="collapse"
+            data-target=".js-collapse-warning-confirmation"
+            href="#"
+            onclick="document.querySelector('.js-warning-confirm-input').setAttribute('disabled', 'disabled');"
+          ] Annuler et modifier
+        div= f.submit "Confirmer", class: "btn btn-warning"
+      hr
+
 - elsif model.errors.any?
   .alert.alert-danger.fade.show
     ul.m-0


### PR DESCRIPTION
preliminary to https://github.com/betagouv/rdv-solidarites.fr/pull/987

- extract logic to filter plage ouvertures on departement scope from the plage_ouvertures controller to a generic view helper
- generize `overlapping_plage_ouvertures` partial so it accepts a random `model` duck-typed to respond to a `overlapping_plage_ouvertures` method
- extract the display overlapping warnings + Confirm or change values view from the specific plage ouverture form to the generic `model_errors` partial