### PR TITLE
warn overlapping plage ouvertures conflicts on RDVs creation

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -81,7 +81,8 @@ class Admin::RdvsController < AgentAuthController
         notice: "Le rendez-vous a été créé."
       )
     else
-      @rdv_wizard = AgentRdvWizard::Step3.new(current_agent, current_organisation, @rdv.attributes)
+      @rdv_wizard = AgentRdvWizard::Step3.new(current_agent, current_organisation, users: @rdv.users, agent_ids: @rdv.agent_ids, **@rdv.attributes)
+      @rdv_wizard.valid? # trigger validation
       render "admin/rdv_wizard_steps/step3"
     end
   end
@@ -103,7 +104,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def rdv_params
-    params.require(:rdv).permit(:motif_id, :status, :lieu_id, :duration_in_min, :starts_at, :context, agent_ids: [], user_ids: [])
+    params.require(:rdv).permit(:motif_id, :status, :lieu_id, :duration_in_min, :starts_at, :context, :active_warnings_confirm_decision, agent_ids: [], user_ids: [])
   end
 
   def status_params

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -82,7 +82,7 @@ class Admin::RdvsController < AgentAuthController
       )
     else
       @rdv_wizard = AgentRdvWizard::Step3.new(current_agent, current_organisation, users: @rdv.users, agent_ids: @rdv.agent_ids, **@rdv.attributes)
-      @rdv_wizard.valid? # trigger validation
+      @rdv_wizard.valid? # necessary to explicitly trigger validations here so that errors and warnings appear in the view. the right fix would be to call rdv_wizard.save instead of rdv.save
       render "admin/rdv_wizard_steps/step3"
     end
   end

--- a/app/form_models/agent_rdv_wizard.rb
+++ b/app/form_models/agent_rdv_wizard.rb
@@ -46,5 +46,7 @@ module AgentRdvWizard
     validates :users, presence: true
   end
 
-  class Step3 < Step2; end
+  class Step3 < Step2
+    delegate :valid?, :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?, :warnings_need_confirmation?, :warnings, to: :rdv
+  end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,11 @@
+module AdminHelper
+  def collapsible_form_fields_for_warnings(model, &block)
+    content_tag(
+      :div,
+      class: ["form-collapsable-fields-wrapper", "collapse", "js-collapse-warning-confirmation"] +
+        (model.warnings_need_confirmation? ? [] : ["show"]),
+      "aria-expanded": model.warnings_need_confirmation? ? "false" : "true",
+      &block
+    )
+  end
+end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -72,6 +72,12 @@ module RecurrenceConcern
     recurrence&.to_hash&.[](:until)
   end
 
+  def recurrence_interval
+    return nil if recurrence.nil?
+
+    recurrence.to_hash[:interval] || 1 # when interval is nil, it means 1
+  end
+
   private
 
   def occurence_start_at_list_for(inclusive_date_range)

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -77,7 +77,31 @@ class PlageOuverture < ApplicationRecord
       .select { overlaps?(_1) }
   end
 
+  def self.overlapping_with_time_slot(time_slot)
+    regulieres.where("first_day <= ?", time_slot.to_date)
+      .or(exceptionnelles.where("first_day = ?", time_slot.to_date))
+      .to_a
+      .select { _1.overlaps_with_time_slot?(time_slot) }
+  end
+
+  def overlaps_with_time_slot?(time_slot)
+    covers_date?(time_slot.to_date) &&
+      time_slot_for_date(time_slot.to_date).intersects?(time_slot)
+  end
+
+  def covers_date?(date)
+    (
+      recurring? &&
+      recurrence_interval == 1 && # limited by https://github.com/rossta/montrose/pull/132
+      recurrence.include?(date.in_time_zone)
+    ) || (exceptionnelle? && first_day == date)
+  end
+
   private
+
+  def time_slot_for_date(date)
+    TimeSlot.new(start_time.on(date), end_time.on(date))
+  end
 
   def overlapping_plages_ouvertures_candidates
     return [] unless valid_date_and_times?

--- a/app/service_models/time_slot.rb
+++ b/app/service_models/time_slot.rb
@@ -1,0 +1,32 @@
+class TimeSlot
+  class DifferentDatesError < StandardError; end
+  class OutOfOrderTimesError < StandardError; end
+
+  attr_reader :starts_at, :ends_at
+
+  def initialize(starts_at, ends_at)
+    raise DifferentDatesError if starts_at.to_date != ends_at.to_date
+    raise OutOfOrderTimesError if starts_at >= ends_at
+
+    @starts_at = starts_at
+    @ends_at = ends_at
+  end
+
+  def intersects?(other_time_slot)
+    to_date == other_time_slot.to_date &&
+      start_time < other_time_slot.end_time &&
+      end_time > other_time_slot.start_time
+  end
+
+  def start_time
+    starts_at.to_time_of_day
+  end
+
+  def end_time
+    ends_at.to_time_of_day
+  end
+
+  def to_date
+    starts_at.to_date
+  end
+end

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -6,11 +6,7 @@
 - if plage_ouverture.available_motifs.any?
   = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture] do |f|
     = render(partial: 'layouts/model_errors', locals: { model: plage_ouverture, f: f })
-
-    .form-collapsable-fields-wrapper.collapse.js-collapse-warning-confirmation[
-      class=(plage_ouverture.warnings_need_confirmation? ? "" : "show")
-      aria-expanded=(plage_ouverture.warnings_need_confirmation? ? "false" : "true")
-    ]
+    = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
       = f.input :title, hint: 'Uniquement visible en interne', placeholder: 'Ex: Permanence PMI exceptionnelle'
       = f.association :lieu, collection: policy_scope(Lieu).ordered_by_name, label_method: :full_name, include_blank: false

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -3,6 +3,8 @@
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1
     span>= link_to("Plage d'ouverture #{overlapping_plage_ouverture.id}", edit_admin_organisation_plage_ouverture_path(overlapping_plage_ouverture.organisation, overlapping_plage_ouverture))
+    - if local_assigns[:display_agents]
+      span> de #{overlapping_plage_ouverture.agent.full_name}
     span> à #{overlapping_plage_ouverture.lieu.name}
     - if overlapping_plage_ouverture.recurring?
       span>= display_recurrence(overlapping_plage_ouverture).join(" ")

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -1,5 +1,10 @@
 - content_for(:menu_item) { 'menu-agendas' }
 
+- if @rdv_wizard.warnings_need_confirmation? && @rdv_wizard.overlapping_plages_ouvertures.any?
+  - content_for :warnings_description do
+    ul.pl-3
+      = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: @rdv_wizard, display_agents: true
+
 - content_for :title do
   | Choisir la durée et la date
 
@@ -17,31 +22,32 @@
           = users_inline_list_for_agents(@rdv.users)
 
       .card-body
-        = render partial: 'layouts/model_errors', locals: { model: @rdv_wizard }
         = simple_form_for(@rdv, url: admin_organisation_rdvs_path(current_organisation)) do |f|
-          = f.association :motif, as: :hidden,  wrapper_html: { class: 'm-0' }
-          = f.input :context, as: :hidden, wrapper_html: { class: 'm-0' }
-          .form-row
-            .col-md-6= datetime_input(f, :starts_at)
-            .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"
-            .col-md-12
-              - if @rdv.public_office?
-                = f.association :lieu, \
-                  collection: policy_scope(Lieu).ordered_by_name, \
-                  label_method: :full_name, \
-                  include_blank: true,
-                  required: true,
-                  input_html: { class: 'select2-input' }
-              - elsif @rdv.home?
-                = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}"
-            - @rdv.users.each do |user|
-              / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
-              = f.hidden_field "user_ids][", value: user.id
+          = render(partial: 'layouts/model_errors', locals: { model: @rdv_wizard, f: f })
+          = collapsible_form_fields_for_warnings(@rdv_wizard) do
+            = f.association :motif, as: :hidden,  wrapper_html: { class: 'm-0' }
+            = f.input :context, as: :hidden, wrapper_html: { class: 'm-0' }
+            .form-row
+              .col-md-6= datetime_input(f, :starts_at)
+              .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"
+              .col-md-12
+                - if @rdv.public_office?
+                  = f.association :lieu, \
+                    collection: policy_scope(Lieu).ordered_by_name, \
+                    label_method: :full_name, \
+                    include_blank: true,
+                    required: true,
+                    input_html: { class: 'select2-input' }
+                - elsif @rdv.home?
+                  = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}"
+              - @rdv.users.each do |user|
+                / https://stackoverflow.com/questions/2327621/creating-a-has-many-association-in-a-hidden-field
+                = f.hidden_field "user_ids][", value: user.id
 
-          = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
+            = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
 
-          .row
-            .col.text-left
-              = link_to 'Revenir en arrière', new_admin_organisation_rdv_wizard_step_path(@rdv_wizard.to_query.merge(step: 2)), class: 'btn btn-link'
-            .col.text-right
-              = f.button :submit, 'Créer RDV'
+            .row
+              .col.text-left
+                = link_to 'Revenir en arrière', new_admin_organisation_rdv_wizard_step_path(@rdv_wizard.to_query.merge(step: 2)), class: 'btn btn-link'
+              .col.text-right
+                = f.button :submit, 'Créer RDV'

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -3,14 +3,14 @@
     i.fa.fa-fw.fa-at>
     | RDV pris sur Internet
 
-.d-flex.card-text
+.d-flex.card-text.mb-2
   div.mr-1
     i.fa.fa-fw.fa-info-circle>
   div
     = rdv.motif.name
     div
       - if rdv.context.blank?
-        .text-muted  Pas de contexte renseigné
+        .text-muted Pas de contexte renseigné
       - else
         .text-muted Contexte :
         .border-left.pl-2= simple_format(rdv.context)
@@ -27,6 +27,7 @@
       = human_location(rdv)
     - elsif rdv.public_office?
       = human_location(rdv)
+
 p.card-text
   strong> Professionnel(s) :
   = agents_to_sentence(rdv.agents)
@@ -34,3 +35,11 @@ p.card-text
   p.card-text
     strong> Usager(s) :
     = users_inline_list_for_agents(rdv.users, display_links_to_users: local_assigns.fetch(:display_links_to_users, true))
+
+- if rdv.public_office? && rdv.overlapping_plages_ouvertures?
+  div.my-3
+    .alert.alert-warning.mt-1.mb-0
+      | Conflit de lieu avec des plages d'ouvertures
+    .border-left.border-right.border-bottom.rounded.border-warning
+      ul.pl-3.py-2.mb-0
+        = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: rdv, display_agents: true

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -1,5 +1,10 @@
 - content_for(:menu_item) { @agent ? 'menu-agendas' : 'menu-rdvs-list' }
 
+- if @rdv.warnings_need_confirmation? && @rdv.overlapping_plages_ouvertures.any?
+  - content_for :warnings_description do
+    ul.pl-3
+      = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: @rdv, display_agents: true
+
 - content_for :breadcrumb do
   ol.breadcrumb.m-0.p-0
     - if @agent
@@ -25,24 +30,25 @@
     .card
       .card-body
         = simple_form_for([:admin, @rdv.organisation, @rdv]) do |f|
-          = render partial: 'layouts/model_errors', locals: { model: @rdv }
-          = hidden_field_tag :agent_id, @agent&.id
-          = f.association :motif, disabled: true
-          = f.input :context, input_html: { rows: 3 }
-          .form-row
-            .col-md-6= datetime_input(f, :starts_at)
-            .col-md-6= f.input :duration_in_min
-          - if @rdv.motif.public_office?
-            = f.association :lieu, \
-              collection: policy_scope(Lieu), \
-              label_method: :full_name, \
-              include_blank: true, \
-              required: true,
-              input_html: { class: "select2-input" }
-          - elsif @rdv.motif.home?
-            = f.input :address, label: "Lieu (RDV à domicile)", disabled: true
-          = f.association :agents, collection: @rdv.organisation.agents.can_perform_motif(@rdv.motif), label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
-          = f.association :users, collection: policy_scope(User).order_by_last_name, label_method: lambda { |user| full_name_and_birthdate(user) }, input_html: { multiple: true, class: 'select2-input' }
-          .text-right
-            = link_to "Retour", admin_organisation_rdv_path(current_organisation, @rdv), class: "btn btn-link"
-            = f.button :submit, "Enregistrer"
+          = render partial: 'layouts/model_errors', locals: { model: @rdv, f: f }
+          = collapsible_form_fields_for_warnings(@rdv) do
+            = hidden_field_tag :agent_id, @agent&.id
+            = f.association :motif, disabled: true
+            = f.input :context, input_html: { rows: 3 }
+            .form-row
+              .col-md-6= datetime_input(f, :starts_at)
+              .col-md-6= f.input :duration_in_min
+            - if @rdv.motif.public_office?
+              = f.association :lieu, \
+                collection: policy_scope(Lieu), \
+                label_method: :full_name, \
+                include_blank: true, \
+                required: true,
+                input_html: { class: "select2-input" }
+            - elsif @rdv.motif.home?
+              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true
+            = f.association :agents, collection: @rdv.organisation.agents.can_perform_motif(@rdv.motif), label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
+            = f.association :users, collection: policy_scope(User).order_by_last_name, label_method: lambda { |user| full_name_and_birthdate(user) }, input_html: { multiple: true, class: 'select2-input' }
+            .text-right
+              = link_to "Retour", admin_organisation_rdv_path(current_organisation, @rdv), class: "btn btn-link"
+              = f.button :submit, "Enregistrer"

--- a/app/views/admin/rdvs/index.json.jbuilder
+++ b/app/views/admin/rdvs/index.json.jbuilder
@@ -1,12 +1,14 @@
 json.array! @rdvs do |rdv|
-  json.title rdv_title_for_agent(rdv)
+  json.title rdv_title_for_agent(rdv) + (rdv.overlapping_plages_ouvertures? ? " ⚠️" : "")
   json.id rdv.id
   json.extendedProps do
     json.status rdv.status
     json.readableStatus Rdv.human_enum_name(:status, rdv.status)
     json.motif rdv.motif.name
+    json.lieu rdv.public_office? && rdv.lieu&.name
     json.past rdv.past?
     json.duration rdv.duration_in_min
+    json.overlappingPlagesOuvertures rdv.overlapping_plages_ouvertures?
   end
   json.start rdv.starts_at
   json.end rdv.ends_at

--- a/app/views/layouts/_model_errors.html.slim
+++ b/app/views/layouts/_model_errors.html.slim
@@ -20,7 +20,7 @@
             href="#"
             onclick="document.querySelector('.js-warning-confirm-input').setAttribute('disabled', 'disabled');"
           ] Annuler et modifier
-        div= f.submit "Confirmer", class: "btn btn-warning"
+        div= f.submit "Confirmer en ignorant les avertissements", class: "btn btn-warning"
       hr
 
 - elsif model.errors.any?

--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -162,7 +162,7 @@ class CalendarRdvSolidarites {
     if (this.data.selectedEventId && info.event.id == this.data.selectedEventId)
       $el.addClass("selected");
     $el.addClass("fc-event-"+ info.event.extendedProps.status);
-    if (info.event.extendedProps.unclickable != true){
+    if (info.event.extendedProps.unclickable != true) {
       let title = `${moment(info.event.start).format('H:mm')} - ${moment(info.event.end).format('H:mm')}`;
       if (info.event.rendering == 'background') {
         $el.append("<div class=\"fc-title\" style=\"color: white; padding: 2px 4px; font-size: 12px; font-weight: bold;\">" + info.event.title + "</div>");
@@ -174,6 +174,12 @@ class CalendarRdvSolidarites {
           title += ` <br>${info.event.extendedProps.motif}`;
         }
         title += `<br><strong>${info.event.title}</strong>`;
+        if (info.event.extendedProps.lieu) {
+          title += `<br><strong>Lieu:</strong> ${info.event.extendedProps.lieu}`;
+          if (info.event.extendedProps.overlappingPlagesOuvertures) {
+            title += " ⚠️";
+          }
+        }
         title += `<br><strong>Statut:</strong> ${info.event.extendedProps.readableStatus}`;
       }
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -192,15 +192,15 @@ end
 
 # LIEUX
 
-lieu_org_paris_nord_sud = Lieu.create!(
-  name: "Maison Paris Sud",
+lieu_org_paris_nord_bolivar = Lieu.create!(
+  name: "MDS Bolivar",
   organisation: org_paris_nord,
-  address: "18 Rue des Terres au Curé, 75013 Paris",
-  latitude: 48.85295,
-  longitude: 2.34998
+  address: "126 Avenue Simon Bolivar, 75019, Paris",
+  latitude: 48.8809263,
+  longitude: 2.3739077
 )
-lieu_org_paris_nord_nord = Lieu.create!(
-  name: "Maison Paris Nord",
+lieu_org_paris_nord_bd_aubervilliers = Lieu.create!(
+  name: "MDS Bd Aubervilliers",
   organisation: org_paris_nord,
   address: "18 Boulevard d'Aubervilliers, 75019 Paris",
   latitude: 48.8882196,
@@ -396,7 +396,7 @@ _plage_ouverture_org_paris_nord_martine_classique = PlageOuverture.create!(
   title: "Permanence classique",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,
-  lieu_id: lieu_org_paris_nord_sud.id,
+  lieu_id: lieu_org_paris_nord_bolivar.id,
   motif_ids: [motif_org_paris_nord_pmi_rappel.id, motif_org_paris_nord_pmi_gyneco.id, motif_org_paris_nord_pmi_prenatale.id, motif_org_paris_nord_pmi_suivi.id, motif_org_paris_nord_pmi_securite.id],
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(8),
@@ -407,7 +407,7 @@ _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
   title: "Permanence enfant",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,
-  lieu_id: lieu_org_paris_nord_sud.id,
+  lieu_id: lieu_org_paris_nord_bolivar.id,
   motif_ids: [motif_org_paris_nord_pmi_rappel.id, motif_org_paris_nord_pmi_prenatale.id, motif_org_paris_nord_pmi_suivi.id, motif_org_paris_nord_pmi_securite.id],
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(8),
@@ -418,7 +418,7 @@ _plage_ouverture_org_paris_nord_martine_exceptionnelle = PlageOuverture.create!(
   title: "Aprem PMI exptn",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_martine.id,
-  lieu_id: lieu_org_paris_nord_sud.id,
+  lieu_id: lieu_org_paris_nord_bolivar.id,
   motif_ids: [motif_org_paris_nord_pmi_rappel.id, motif_org_paris_nord_pmi_prenatale.id, motif_org_paris_nord_pmi_suivi.id, motif_org_paris_nord_pmi_securite.id],
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(14),
@@ -428,7 +428,7 @@ _plage_ouverture_org_paris_nord_marco_perm = PlageOuverture.create!(
   title: "Perm.",
   organisation_id: org_paris_nord.id,
   agent_id: agent_org_paris_nord_pmi_marco.id,
-  lieu_id: lieu_org_paris_nord_nord.id,
+  lieu_id: lieu_org_paris_nord_bd_aubervilliers.id,
   motif_ids: [motif_org_paris_nord_pmi_rappel.id, motif_org_paris_nord_pmi_gyneco.id, motif_org_paris_nord_pmi_prenatale.id, motif_org_paris_nord_pmi_suivi.id, motif_org_paris_nord_pmi_securite.id, motif_org_paris_nord_pmi_prenatale_phone.id],
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(14),
@@ -476,7 +476,7 @@ rdv1 = Rdv.new(
   duration_in_min: 30,
   starts_at: Date.today + 3.days + 10.hours,
   motif_id: motif_org_paris_nord_pmi_rappel.id,
-  lieu: lieu_org_paris_nord_sud,
+  lieu: lieu_org_paris_nord_bolivar,
   organisation_id: org_paris_nord.id,
   agent_ids: [agent_org_paris_nord_pmi_martine.id],
   user_ids: [user_org_paris_nord_patricia.id],
@@ -488,7 +488,7 @@ rdv2 = Rdv.new(
   duration_in_min: 30,
   starts_at: Date.today + 4.days + 15.hours,
   motif_id: motif_org_paris_nord_pmi_suivi.id,
-  lieu: lieu_org_paris_nord_nord,
+  lieu: lieu_org_paris_nord_bd_aubervilliers,
   organisation_id: org_paris_nord.id,
   agent_ids: [agent_org_paris_nord_pmi_martine.id],
   user_ids: [user_org_paris_nord_josephine.id],

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Admin::RdvsController, type: :controller do
   end
 
   describe "GET index" do
-    let!(:rdv1) { create(:rdv, motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 08:00"), organisation: organisation) }
-    let!(:rdv2) { create(:rdv, motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 07:00"), organisation: organisation) }
+    let!(:lieu) { create(:lieu, organisation: organisation, name: "MDS Orgeval") }
+    let!(:rdv1) { create(:rdv, motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 08:00"), organisation: organisation, lieu: lieu) }
+    let!(:rdv2) { create(:rdv, motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 07:00"), organisation: organisation, lieu: lieu) }
 
     subject { get(:index, params: { organisation_id: organisation.id, agent_id: agent.id, start: start_time, end: end_time }, as: :json) }
 
@@ -39,7 +40,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
         expect(first["end"]).to eq(rdv1.ends_at.as_json)
         expect(first["backgroundColor"]).to eq(rdv1.motif.color)
         expect(first["url"]).to eq(admin_organisation_rdv_path(rdv1.organisation, rdv1, agent_id: agent.id))
-        expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv1.status), status: rdv1.status, motif: "Suivi", past: rdv1.past?, duration: rdv.duration_in_min }.as_json)
+        expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv1.status), status: rdv1.status, motif: "Suivi", past: rdv1.past?, duration: rdv.duration_in_min, lieu: "MDS Orgeval", overlappingPlagesOuvertures: false }.as_json)
 
         second = @parsed_response[1]
         expect(second.size).to eq(7)
@@ -48,7 +49,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
         expect(second["end"]).to eq(rdv2.ends_at.as_json)
         expect(second["backgroundColor"]).to eq(rdv2.motif.color)
         expect(second["url"]).to eq(admin_organisation_rdv_path(rdv2.organisation, rdv2, agent_id: agent.id))
-        expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv2.status), status: rdv2.status, motif: rdv2.motif.name, past: rdv2.past?, duration: rdv.duration_in_min }.as_json)
+        expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv2.status), status: rdv2.status, motif: rdv2.motif.name, past: rdv2.past?, duration: rdv.duration_in_min, lieu: "MDS Orgeval", overlappingPlagesOuvertures: false }.as_json)
       end
     end
 

--- a/spec/service_models/time_slot_spec.rb
+++ b/spec/service_models/time_slot_spec.rb
@@ -1,0 +1,75 @@
+describe TimeSlot, type: :service do
+  describe "initialize" do
+    it "should work with valid times" do
+      expect { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }.not_to raise_error
+    end
+
+    it "should raise with non consecutive times" do
+      expect { TimeSlot.new(Time.new(2020, 12, 2, 12, 30), Time.new(2020, 12, 2, 11, 30)) }.to raise_error(TimeSlot::OutOfOrderTimesError)
+    end
+
+    it "should raise with different dates" do
+      expect { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 3, 11, 30)) }.to raise_error(TimeSlot::DifferentDatesError)
+    end
+  end
+
+  describe "#intersects?" do
+    subject { slot1.intersects?(slot2) }
+
+    shared_examples "intersects" do
+      it { expect(slot1.intersects?(slot2)).to eq true }
+      it { expect(slot2.intersects?(slot1)).to eq true }
+    end
+
+    shared_examples "does not intersect" do
+      it { expect(slot1.intersects?(slot2)).to eq false }
+      it { expect(slot2.intersects?(slot1)).to eq false }
+    end
+
+    context "slot1 is before slot2" do
+      let(:slot1) { TimeSlot.new(Time.new(2020, 12, 2, 9), Time.new(2020, 12, 2, 10)) }
+      let(:slot2) { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }
+      # slot1    |-----|
+      # slot2              |-----|
+      it_behaves_like "does not intersect"
+    end
+
+    context "slot1 overlaps partially from beginning" do
+      # slot1    |-----|
+      # slot2        |-----|
+      let(:slot1) { TimeSlot.new(Time.new(2020, 12, 2, 9), Time.new(2020, 12, 2, 11)) }
+      let(:slot2) { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }
+      it_behaves_like "intersects"
+    end
+
+    context "slot1 is included in slot2" do
+      # slot1    |-----|
+      # slot2  |---------|
+      let(:slot1) { TimeSlot.new(Time.new(2020, 12, 2, 10, 45), Time.new(2020, 12, 2, 11)) }
+      let(:slot2) { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }
+      it_behaves_like "intersects"
+    end
+
+    context "slot1 overlaps partially from middle" do
+      # slot1        |-----|
+      # slot2    |-----|
+      let(:slot1) { TimeSlot.new(Time.new(2020, 12, 2, 11), Time.new(2020, 12, 2, 12)) }
+      let(:slot2) { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }
+      it_behaves_like "intersects"
+    end
+
+    context "slot1 is after slot2" do
+      # slot1               |-----|
+      # slot2    |-----|
+      let(:slot1) { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }
+      let(:slot2) { TimeSlot.new(Time.new(2020, 12, 2, 9), Time.new(2020, 12, 2, 10)) }
+      it_behaves_like "does not intersect"
+    end
+
+    context "dates mismatch" do
+      let(:slot1) { TimeSlot.new(Time.new(2020, 12, 2, 10, 30), Time.new(2020, 12, 2, 11, 30)) }
+      let(:slot2) { TimeSlot.new(Time.new(2020, 12, 3, 10, 30), Time.new(2020, 12, 3, 11, 30)) }
+      it_behaves_like "does not intersect"
+    end
+  end
+end

--- a/spec/services/creneaux_builder_service_spec.rb
+++ b/spec/services/creneaux_builder_service_spec.rb
@@ -113,7 +113,7 @@ describe CreneauxBuilderService, type: :service do
   end
 
   context "with a RDV" do
-    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], organisation: organisation) }
+    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], organisation: organisation, lieu: lieu) }
 
     it do
       expect(subject.size).to eq(3)
@@ -125,7 +125,7 @@ describe CreneauxBuilderService, type: :service do
   end
 
   context "with a RDV shorter than the motif" do
-    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 15, agents: [agent], organisation: organisation) }
+    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 15, agents: [agent], organisation: organisation, lieu: lieu) }
 
     it do
       expect(subject.size).to eq(4)
@@ -138,7 +138,7 @@ describe CreneauxBuilderService, type: :service do
   end
 
   context "with a RDV longer than the motif" do
-    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 45, agents: [agent], organisation: organisation) }
+    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 45, agents: [agent], organisation: organisation, lieu: lieu) }
 
     it do
       expect(subject.size).to eq(3)
@@ -150,7 +150,7 @@ describe CreneauxBuilderService, type: :service do
   end
 
   context "with a cancelled RDV" do
-    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], cancelled_at: Time.zone.local(2019, 9, 20, 9, 30), organisation: organisation) }
+    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], cancelled_at: Time.zone.local(2019, 9, 20, 9, 30), organisation: organisation, lieu: lieu) }
 
     it do
       expect(subject.size).to eq(4)
@@ -164,7 +164,7 @@ describe CreneauxBuilderService, type: :service do
 
   context "with a RDV on the last day of the range" do
     let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: Date.new(2019, 9, 25), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent, organisation: organisation) }
-    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 25, 10, 0), duration_in_min: 30, agents: [agent], organisation: organisation) }
+    let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 25, 10, 0), duration_in_min: 30, agents: [agent], organisation: organisation, lieu: lieu) }
 
     it do
       expect(subject.size).to eq(3)

--- a/spec/services/find_availability_service_spec.rb
+++ b/spec/services/find_availability_service_spec.rb
@@ -40,12 +40,12 @@ describe FindAvailabilityService, type: :service do
     end
 
     describe "with rdv" do
-      let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 0), duration_in_min: 120, agents: [agent], organisation: organisation) }
+      let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 0), duration_in_min: 120, agents: [agent], organisation: organisation, lieu: lieu) }
 
       it { should eq(nil) }
 
       context "which is cancelled" do
-        let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], cancelled_at: Time.zone.local(2019, 9, 20, 9, 30), organisation: organisation) }
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.local(2019, 9, 19, 9, 30), duration_in_min: 30, agents: [agent], cancelled_at: Time.zone.local(2019, 9, 20, 9, 30), organisation: organisation, lieu: lieu) }
 
         it { expect(subject.starts_at).to eq(Time.zone.local(2019, 9, 19, 9, 0)) }
       end


### PR DESCRIPTION
https://trello.com/c/6HOfDMIF/1170-alerter-lors-de-la-cr%C3%A9ation-de-rdvs-en-conflit-avec-des-plages-douvertures

# Screenshots

**agent rdv wizard tunnel step 3**

<img width="700" alt="Screenshot_2020-12-07_at_15 56 45" src="https://user-images.githubusercontent.com/883348/101366228-fd46ce00-38a4-11eb-8763-7f1a991e378b.png">

**rdvs show**

<img width="700" alt="Screenshot_2020-12-07_at_15 55 31" src="https://user-images.githubusercontent.com/883348/101366270-0cc61700-38a5-11eb-9aab-829e465e1c22.png">

(ca apparait de la meme maniere dans la liste des RDVs)

**calendar**

<img width="700" alt="Screenshot_2020-12-07_at_15 55 53" src="https://user-images.githubusercontent.com/883348/101366298-15b6e880-38a5-11eb-8712-1785569a1d06.png">

# Implementation

## `TimeSlot`

J'ai créé un petit modele hors AR qui represente un créneau temporel : `TimeSlot`. C'est un datetime de début + un datetime de fin. Il a deux comportements : 

- il valide que les datetimes appartiennent à la même journée et sont consécutifs
- on peut calculer si deux time slots se chevauchent ou non avec `#intersects?`

 Un `Creneau` peut etre vu comme un `TimeSlot` qualifié car il correspond a une plage d'ouverture + une duree de rdv etc

Dans les specs j'ai essayé de bien découper ce que je teste et de mocker le niveau en dessous a chaque fois pour limiter les responsabilités de chaque test. c'est a dire que d'un coté je teste que les dates se chevauchent, puis d'un autre que les horaires se chevauchent par ex.

## `plage_ouverture.covers_date?`

cette nouvelle methode est responsable de dire si une PO aura une occurence à une certaine date. Elle s'appuie sur la méthode `#include?` de Montrose, qui malheureusement n'a pas l'air de fonctionner pour des recurrences d'intervalles > 1 cf https://github.com/rossta/montrose/pull/132. 

Dans cette PR j'ai un peu contourné le pb en ignorant explicitement ces plages d'ouvertures. Je pense que c'est OK car en prod il y en a moins de 5% dans ce cas (mais non negligeable qd meme). On pourra corriger ce pb upstream dans montrose plus tard, je n'ai pas trouvé le fix hyper rapidement donc je préfère ne pas y passer trop de temps (cette PR a déjà pris pas mal de temps)

## bug lors creation rdv pour un autre agent

il y avait un bug lors d'une erreur de validation a la derniere etape du tunnel de prise de rdv agent. lorsqu'un agent créé un rdv pour un autre agent, on perdait le contexte de l'agent visé s'il y avait une erreur de validation. Le bug venait d'un manquement lors de l'instanciation de `AgentRdvWizard` dans la branche `else` du `rdv.save` dans le `rdvs#create`

```
irb(main):009:0> PlageOuverture.not_expired.where.not(recurrence: nil).to_a.select { (_1.recurrence.to_h[:interval] || 1) > 1 }.count
=> 104
irb(main):010:0> PlageOuverture.not_expired.count
=> 2862
```