### PR TITLE
migration + before_save hook to set recurrence.starts on absences and plage ouvertures

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -9,6 +9,7 @@ module RecurrenceConcern
     serialize :end_time, Tod::TimeOfDay
 
     before_save :clear_empty_recurrence
+    before_save :set_recurrence_starts_to_first_day, if: :recurring?
 
     validates :first_day, :start_time, :end_time, presence: true
 
@@ -91,5 +92,9 @@ module RecurrenceConcern
 
   def clear_empty_recurrence
     self.recurrence = nil if recurrence.present? && recurrence.to_hash == {}
+  end
+
+  def set_recurrence_starts_to_first_day
+    self.recurrence = recurrence.merge(starts: first_day.in_time_zone)
   end
 end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -9,9 +9,9 @@ module RecurrenceConcern
     serialize :end_time, Tod::TimeOfDay
 
     before_save :clear_empty_recurrence
-    before_save :set_recurrence_starts_to_first_day, if: :recurring?
 
     validates :first_day, :start_time, :end_time, presence: true
+    validate :recurrence_starts_matches_first_day, if: :recurring?
 
     scope :exceptionnelles, -> { where(recurrence: nil) }
     scope :regulieres, -> { where.not(recurrence: nil) }
@@ -94,7 +94,9 @@ module RecurrenceConcern
     self.recurrence = nil if recurrence.present? && recurrence.to_hash == {}
   end
 
-  def set_recurrence_starts_to_first_day
-    self.recurrence = recurrence.merge(starts: first_day.in_time_zone)
+  def recurrence_starts_matches_first_day
+    return true if recurrence.to_h[:starts]&.to_date == first_day
+
+    errors.add(:base, "Le début de la récurrence ne correspond pas au premier jour.")
   end
 end

--- a/app/webpacker/components/recurrence-form.js
+++ b/app/webpacker/components/recurrence-form.js
@@ -62,6 +62,7 @@ class RecurrenceForm {
     if (this.hasRecurrenceTarget.checked) {
       model.every = this.everyTarget.value;
       model.interval = Number(this.intervalTarget.value);
+      model.starts = this.firstDayTarget.value;
 
       if (model.every == "week") {
         let on = this.getOn();

--- a/app/webpacker/components/recurrence-form.js
+++ b/app/webpacker/components/recurrence-form.js
@@ -62,6 +62,7 @@ class RecurrenceForm {
     if (this.hasRecurrenceTarget.checked) {
       model.every = this.everyTarget.value;
       model.interval = Number(this.intervalTarget.value);
+      model.starts = this.firstDayTarget.value
 
       if (model.every == "week") {
         let on = this.getOn();

--- a/app/webpacker/components/recurrence-form.js
+++ b/app/webpacker/components/recurrence-form.js
@@ -62,7 +62,6 @@ class RecurrenceForm {
     if (this.hasRecurrenceTarget.checked) {
       model.every = this.everyTarget.value;
       model.interval = Number(this.intervalTarget.value);
-      model.starts = this.firstDayTarget.value;
 
       if (model.every == "week") {
         let on = this.getOn();

--- a/db/migrate/20201203112249_add_starts_to_recurrences.rb
+++ b/db/migrate/20201203112249_add_starts_to_recurrences.rb
@@ -4,6 +4,8 @@ class AddStartsToRecurrences < ActiveRecord::Migration[6.0]
     Absence.where.not(recurrence: nil).find_each { update_model(_1) }
   end
 
+  def down; end
+
   private
 
   def update_model(model)

--- a/db/migrate/20201203112249_add_starts_to_recurrences.rb
+++ b/db/migrate/20201203112249_add_starts_to_recurrences.rb
@@ -1,0 +1,14 @@
+class AddStartsToRecurrences < ActiveRecord::Migration[6.0]
+  def up
+    PlageOuverture.where.not(recurrence: nil).find_each { update_model(_1) }
+    Absence.where.not(recurrence: nil).find_each { update_model(_1) }
+  end
+
+  private
+
+  def update_model(model)
+    return if model.recurrence.to_h[:starts]&.present?
+
+    model.update_columns(recurrence: model.recurrence.merge(starts: model.first_day.in_time_zone))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_23_155850) do
+ActiveRecord::Schema.define(version: 2020_12_03_112249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -401,7 +401,7 @@ _plage_ouverture_org_paris_nord_martine_classique = PlageOuverture.create!(
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(8),
   end_time: Tod::TimeOfDay.new(12),
-  recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, on: [:monday, :tuesday, :thursday, :friday])
+  recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: [:monday, :tuesday, :thursday, :friday])
 )
 _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
   title: "Permanence enfant",
@@ -412,7 +412,7 @@ _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(8),
   end_time: Tod::TimeOfDay.new(12),
-  recurrence: Montrose.every(:week, on: [:wednesday], interval: 1)
+  recurrence: Montrose.every(:week, on: [:wednesday], interval: 1, starts: Date.tomorrow)
 )
 _plage_ouverture_org_paris_nord_martine_exceptionnelle = PlageOuverture.create!(
   title: "Aprem PMI exptn",
@@ -433,7 +433,7 @@ _plage_ouverture_org_paris_nord_marco_perm = PlageOuverture.create!(
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(14),
   end_time: Tod::TimeOfDay.new(16),
-  recurrence: Montrose.every(:week, on: [:tuesday], interval: 1)
+  recurrence: Montrose.every(:week, on: [:tuesday], interval: 1, starts: Date.tomorrow)
 )
 _plage_ouverture_org_arques_maya_tradi = PlageOuverture.create!(
   title: "Perm. tradi",
@@ -444,7 +444,7 @@ _plage_ouverture_org_arques_maya_tradi = PlageOuverture.create!(
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(9),
   end_time: Tod::TimeOfDay.new(15),
-  recurrence: Montrose.every(:week, interval: 1)
+  recurrence: Montrose.every(:week, interval: 1, starts: Date.tomorrow)
 )
 _plage_ouverture_org_bapaume_bruno_classique = PlageOuverture.create!(
   title: "Perm. classique",
@@ -455,7 +455,7 @@ _plage_ouverture_org_bapaume_bruno_classique = PlageOuverture.create!(
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(9),
   end_time: Tod::TimeOfDay.new(15),
-  recurrence: Montrose.every(:week, interval: 1)
+  recurrence: Montrose.every(:week, interval: 1, starts: Date.tomorrow)
 )
 _plage_ouverture_org_bapaume_gina_classique = PlageOuverture.create!(
   title: "Perm. prenatale",
@@ -466,7 +466,7 @@ _plage_ouverture_org_bapaume_gina_classique = PlageOuverture.create!(
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(11),
   end_time: Tod::TimeOfDay.new(18),
-  recurrence: Montrose.every(:week, interval: 1)
+  recurrence: Montrose.every(:week, interval: 1, starts: Date.tomorrow)
 )
 PlageOuverture.set_callback(:create, :after, :notify_agent_plage_ouverture_created)
 

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -16,19 +16,19 @@ FactoryBot.define do
     end
 
     trait :daily do
-      recurrence { Montrose.every(:day) }
+      recurrence { Montrose.every(:day, starts: first_day) }
     end
 
     trait :weekly do
-      recurrence { Montrose.weekly.to_json }
+      recurrence { Montrose.every(:week, starts: first_day) }
     end
 
     trait :monthly do
-      recurrence { Montrose.monthly.to_json }
+      recurrence { Montrose.every(:month, starts: first_day) }
     end
 
     trait :weekly_by_2 do
-      recurrence { Montrose.every(2.weeks).to_json }
+      recurrence { Montrose.every(:week, interval: 2, starts: first_day) }
     end
   end
 end

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -17,19 +17,19 @@ FactoryBot.define do
     end
 
     trait :daily do
-      recurrence { Montrose.every(:day) }
+      recurrence { Montrose.every(:day, starts: first_day) }
     end
 
     trait :weekly do
-      recurrence { Montrose.weekly.on([:monday]).to_json }
+      recurrence { Montrose.every(:week, on: [:monday], starts: first_day) }
     end
 
     trait :monthly do
-      recurrence { Montrose.monthly.to_json }
+      recurrence { Montrose.every(:month, starts: first_day) }
     end
 
     trait :weekly_by_2 do
-      recurrence { Montrose.every(2.weeks).to_json }
+      recurrence { Montrose.every(:week, interval: 2, starts: first_day) }
     end
 
     after(:build) do |plage_ouverture|

--- a/spec/jobs/update_plage_ouvertures_expirations_job_spec.rb
+++ b/spec/jobs/update_plage_ouvertures_expirations_job_spec.rb
@@ -1,5 +1,6 @@
 describe UpdatePlageOuverturesExpirationsJob, type: :job do
-  let!(:plage_ouverture_reguliere) { create(:plage_ouverture, recurrence: Montrose.every(:week, until: Time.now)) }
+  let(:first_day) { Date.today.next_week(:monday) }
+  let!(:plage_ouverture_reguliere) { create(:plage_ouverture, first_day: first_day, recurrence: Montrose.every(:week, until: Time.now, starts: first_day)) }
   let!(:plage_ouverture_exceptionnelle) { create(:plage_ouverture, :no_recurrence, first_day: Date.today) }
 
   subject do

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -21,12 +21,14 @@ shared_examples_for "recurrence" do
     end
 
     context "recurring without end date" do
-      let(:model_instance) { create(model_symbol, first_day: Date.new(2019, 7, 22), end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.weekly.on(:tuesday).to_json) }
+      let(:first_day) { Date.new(2019, 7, 22) }
+      let(:model_instance) { create(model_symbol, first_day: first_day, end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], starts: first_day)) }
       it { is_expected.to be_nil }
     end
 
     context "recurring with end date" do
-      let(:model_instance) { create(model_symbol, first_day: Date.new(2020, 11, 17), end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], until: Date.new(2020, 11, 25)).to_json) }
+      let(:first_day) { Date.new(2019, 11, 17) }
+      let(:model_instance) { create(model_symbol, first_day: first_day, end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], starts: first_day, until: Date.new(2020, 11, 25))) }
       it { is_expected.to eq(Time.zone.local(2020, 11, 25, 12)) }
     end
   end
@@ -108,7 +110,8 @@ shared_examples_for "recurrence" do
     end
 
     context "when there is a daily recurrence and until is set" do
-      let(:model_instance) { build(model_symbol, first_day: Date.new(2019, 7, 22), start_time: Tod::TimeOfDay.new(8), end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.daily.until(Date.new(2019, 8, 5)).to_json) }
+      let(:first_day) { Date.new(2019, 7, 22) }
+      let(:model_instance) { build(model_symbol, first_day: first_day, start_time: Tod::TimeOfDay.new(8), end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:day, starts: first_day, until: Date.new(2019, 8, 5)).to_json) }
       let(:date_range) { Date.new(2019, 8, 5)..Date.new(2019, 8, 11) }
 
       it do

--- a/spec/models/plage_ouverture/ics_spec.rb
+++ b/spec/models/plage_ouverture/ics_spec.rb
@@ -17,41 +17,42 @@ describe PlageOuverture::Ics, type: :model do
   end
 
   describe "#rrule" do
-    let(:plage_ouverture) { create(:plage_ouverture, recurrence: recurrence) }
+    let(:first_day) { Date.today.next_week(:monday) }
+    let(:plage_ouverture) { create(:plage_ouverture, first_day: first_day, recurrence: recurrence) }
 
     subject { ics.rrule }
 
     context "every week" do
-      let(:recurrence) { Montrose.every(:week, on: ["monday"]) }
+      let(:recurrence) { Montrose.every(:week, on: ["monday"], starts: first_day) }
 
       it { is_expected.to eq("FREQ=WEEKLY;BYDAY=MO;") }
 
       context "on monday and wednesday" do
-        let(:recurrence) { Montrose.every(:week, on: %w[monday tuesday wednesday thursday friday saturday]) }
+        let(:recurrence) { Montrose.every(:week, on: %w[monday tuesday wednesday thursday friday saturday], starts: first_day) }
 
         it { is_expected.to eq("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA;") }
       end
 
       context "until 22/10/2019" do
-        let(:recurrence) { Montrose.every(:week, until: Time.zone.local(2019, 10, 22)) }
+        let(:recurrence) { Montrose.every(:week, until: Time.zone.local(2019, 10, 22), starts: first_day) }
 
         it { is_expected.to eq("FREQ=WEEKLY;UNTIL=20191022T000000;") }
       end
     end
 
     context "every 2 weeks" do
-      let(:recurrence) { Montrose.every(:week, interval: 2) }
+      let(:recurrence) { Montrose.every(:week, interval: 2, starts: first_day) }
 
       it { is_expected.to eq("FREQ=WEEKLY;INTERVAL=2;") }
     end
 
     context "every month" do
-      let(:recurrence) { Montrose.every(:month) }
+      let(:recurrence) { Montrose.every(:month, starts: first_day) }
 
       it { is_expected.to eq("FREQ=MONTHLY;") }
 
       context "the 2nd wednesday of the month" do
-        let(:recurrence) { Montrose.every(:month, day: { 3 => [2] }) }
+        let(:recurrence) { Montrose.every(:month, day: { 3 => [2] }, starts: first_day) }
 
         it { is_expected.to eq("FREQ=MONTHLY;BYDAY=2WE;") }
       end

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -88,19 +88,22 @@ describe PlageOuverture, type: :model do
 
     context "with plages regulières" do
       describe "when until is in past" do
-        let(:plage_ouverture) { create(:plage_ouverture, recurrence: Montrose.every(:week, until: DateTime.parse("2020-07-30 10:30").in_time_zone).to_json, organisation: organisation) }
+        let(:first_day) { Date.today.next_week(:monday) }
+        let(:plage_ouverture) { create(:plage_ouverture, first_day: first_day, recurrence: Montrose.every(:week, until: DateTime.parse("2020-07-30 10:30").in_time_zone, starts: first_day), organisation: organisation) }
 
         it { should be true }
       end
 
       describe "when until is in future" do
-        let(:plage_ouverture) { create(:plage_ouverture, recurrence: Montrose.every(:week, until: 2.days.from_now).to_json, organisation: organisation) }
+        let(:first_day) { Date.today.next_week(:monday) }
+        let(:plage_ouverture) { create(:plage_ouverture, first_day: first_day, recurrence: Montrose.every(:week, until: 2.days.from_now, starts: first_day), organisation: organisation) }
 
         it { should be false }
       end
 
       describe "when until is today" do
-        let(:plage_ouverture) { create(:plage_ouverture, recurrence: Montrose.every(:week, until: Date.today).to_json, organisation: organisation) }
+        let(:first_day) { Date.today.next_week(:monday) }
+        let(:plage_ouverture) { create(:plage_ouverture, first_day: first_day, recurrence: Montrose.every(:week, until: Date.today, starts: first_day), organisation: organisation) }
 
         it { should be false }
       end

--- a/spec/service_models/plage_ouverture_overlap_spec.rb
+++ b/spec/service_models/plage_ouverture_overlap_spec.rb
@@ -105,37 +105,37 @@ describe PlageOuvertureOverlap do
   end
 
   context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 6 weeks after" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks).on([:monday, :tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, starts: monday).on([:monday, :tuesday])) }
     let(:po2) { build_po(monday + 6.weeks, 14, 18) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 4 weeks after" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks).on([:monday, :tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, on: [:monday, :tuesday], starts: monday)) }
     let(:po2) { build_po(monday + 4.weeks, 14, 18) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle before recurring" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
     let(:po2) { build_po(monday - 7.days, 14, 18) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle same weekday before po1 end date" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
     let(:po2) { build_po(monday + 7.days, 14, 18) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle other weekday before po1 end date" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
     let(:po2) { build_po(monday - 10.days, 14, 18) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle same weekday after po1 end date" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
     let(:po2) { build_po(monday + 4.weeks, 14, 18) }
     it_behaves_like "plage ouvertures do not overlap"
   end
@@ -143,80 +143,80 @@ describe PlageOuvertureOverlap do
   ## both recurring
 
   context "po1 and po2 recurring without end date, different weekdays" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday])) }
-    let(:po2) { build_po(monday, 14, 18, Montrose.every(:week, on: [:wednesday, :thursday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday)) }
+    let(:po2) { build_po(monday, 14, 18, Montrose.every(:week, on: [:wednesday, :thursday], starts: monday)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring without end date, overlapping weekdays" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday])) }
-    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], starts: monday + 7.days)) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 and po2 recurring without end date, overlapping weekdays but different times" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday])) }
-    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday)) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, on: [:tuesday, :wednesday], starts: monday)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring without end date, non-overlapping alternative weeks" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2)) }
-    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 2)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, starts: monday)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 2, starts: monday + 1.week)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring without end date, overlapping weeks" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2)) }
-    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 3)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, starts: monday)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 3, starts: monday + 1.week)) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring with end date, po2 recurring without end date, po2 starts before po1 ends, with weekdays overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], starts: monday + 7.days)) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring with end date, po2 recurring without end date, po2 starts before po1 ends, without weekdays overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:wednesday, :thursday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: [:wednesday, :thursday], starts: monday + 7.days)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 recurring without end date, po2 starts after po1 ends" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 4.weeks, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], starts: monday + 4.weeks)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring with end date, overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 1.weeks, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], until: monday + 5.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 1.weeks, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], starts: monday + 1.week, until: monday + 5.weeks)) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 and po2 recurring with end date, non-overlapping alternative weeks" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, until: monday + 10.weeks)) }
-    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 2, until: monday + 10.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, starts: monday, until: monday + 10.weeks)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 2, starts: monday + 1.week, until: monday + 10.weeks)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring with end date, overlapping weeks" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, until: monday + 10.weeks)) }
-    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 3, until: monday + 10.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], interval: 2, starts: monday, until: monday + 10.weeks)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: [:tuesday, :wednesday], interval: 3, starts: monday + 1.week, until: monday + 10.weeks)) }
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 and po2 recurring with end date, po2 starts after po1 ends" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: [:tuesday, :wednesday], until: monday + 6.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: [:tuesday, :wednesday], starts: monday + 4.weeks, until: monday + 6.weeks)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring with end date, overlap but weekdays mismatch" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: [:wednesday, :thursday], until: monday + 6.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: [:monday, :tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: [:wednesday, :thursday], starts: monday + 4.weeks, until: monday + 6.weeks)) }
     it_behaves_like "plage ouvertures do not overlap"
   end
 end

--- a/spec/services/creneaux_builder_service_spec.rb
+++ b/spec/services/creneaux_builder_service_spec.rb
@@ -64,7 +64,9 @@ describe CreneauxBuilderService, type: :service do
   end
 
   context "recurring plage ouverture" do
-    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes, recurrence: Montrose.every(:day), agent: agent, organisation: organisation) }
+    let!(:plage_ouverture) do
+      create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes, recurrence: Montrose.every(:day, starts: today), agent: agent, organisation: organisation)
+    end
 
     context "with absence spanning 2 days, ending before start of second day" do
       let!(:absence) { create(:absence, agent: agent, first_day: Date.new(2019, 9, 19), start_time: Tod::TimeOfDay.new(9, 45), end_day: Date.new(2019, 9, 20), end_time: Tod::TimeOfDay.new(6, 30), organisation: organisation) }
@@ -299,7 +301,9 @@ describe CreneauxBuilderService, type: :service do
   end
 
   context "recurring plage ouverture + absence ending late" do
-    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes, recurrence: Montrose.every(:day), agent: agent, organisation: organisation) }
+    let!(:plage_ouverture) do
+      create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes, recurrence: Montrose.every(:day, starts: today), agent: agent, organisation: organisation)
+    end
     let!(:absence) { create(:absence, :weekly, agent: agent, first_day: tomorrow, start_time: Tod::TimeOfDay.new(0, 0), end_day: tomorrow, end_time: absence_end_time, organisation: organisation) }
 
     context "absence end_time leaves enough time for a full creneau after" do

--- a/spec/services/find_availability_service_spec.rb
+++ b/spec/services/find_availability_service_spec.rb
@@ -33,7 +33,7 @@ describe FindAvailabilityService, type: :service do
       it { should eq(nil) }
 
       describe "when plage_ouverture is recurrence" do
-        before { plage_ouverture.update(recurrence: Montrose.monthly.to_json) }
+        before { plage_ouverture.update(recurrence: Montrose.every(:month, starts: plage_ouverture.first_day)) }
 
         it { expect(subject.starts_at).to eq(Time.zone.local(2019, 10, 19, 9, 0)) }
       end
@@ -51,7 +51,7 @@ describe FindAvailabilityService, type: :service do
       end
 
       describe "when plage_ouverture is recurrence" do
-        before { plage_ouverture.update(recurrence: Montrose.monthly.to_json) }
+        before { plage_ouverture.update(recurrence: Montrose.every(:month, starts: plage_ouverture.first_day)) }
 
         it { expect(subject.starts_at).to eq(Time.zone.local(2019, 10, 19, 9, 0)) }
       end


### PR DESCRIPTION
preliminary to #987 

Montrose accepte une option `starts` optionnelle pour définir le début d'une récurrence. Pour l'instant nous ne la définissons jamais. Or, nos plages d'ouvertures et absences ont **toujours** une date de début.

L'absence du `starts` dans les recurrences ne semblait pas gênante jusqu'ici mais elle le devient lorsqu'on veut utiliser la méthode `recurrence.include?` dans la PR #987 

dans cette PR :

- migration qui sette le `recurrence.starts` sur toutes les POs et absences ou il est manquant 
- before_save qui s'assure que `recurrence.starts = first_day` lorsque `recurrence` n'est pas nil

J'ai testé la migration sur la db de prod, ca passe bien