### PR TITLE
extract rdv#to_query to wizards objects

### DIFF
--- a/app/form_models/agent_rdv_wizard.rb
+++ b/app/form_models/agent_rdv_wizard.rb
@@ -25,7 +25,16 @@ module AgentRdvWizard
     end
 
     def to_query
-      @rdv.to_query.merge(service_id: service_id)
+      {
+        motif_id: rdv.motif&.id,
+        lieu_id: rdv.lieu_id,
+        duration_in_min: rdv.duration_in_min,
+        starts_at: rdv.starts_at&.to_s,
+        user_ids: rdv.users&.map(&:id),
+        agent_ids: rdv.agents&.map(&:id),
+        context: rdv.context,
+        service_id: service_id
+      }
     end
   end
 

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -39,7 +39,8 @@ module UserRdvWizard
     end
 
     def to_query
-      rdv.to_query.merge(@attributes.slice(:where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id))
+      { motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: rdv.users&.map(&:id) }
+        .merge(@attributes.slice(:where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id))
     end
 
     def to_search_query

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -87,18 +87,6 @@ class Rdv < ApplicationRecord
     !cancelled? && starts_at > 4.hours.from_now
   end
 
-  def to_query
-    {
-      motif_id: motif&.id,
-      lieu_id: lieu_id,
-      duration_in_min: duration_in_min,
-      starts_at: starts_at&.to_s,
-      user_ids: users&.map(&:id),
-      agent_ids: agents&.map(&:id),
-      context: context
-    }
-  end
-
   def available_to_file_attente?
     !cancelled? && starts_at > 7.days.from_now && !home?
   end


### PR DESCRIPTION
encore un mini refacto preliminaire pour https://github.com/betagouv/rdv-solidarites.fr/pull/987 !

Je m'apprete a rajouter des methodes dans le modèle RDV et ça fait dépasser la taille raisonnable acceptée par le linter. 
Plutôt que déplacer mes nouvelles méthodes dans un concern pour éviter ce problème, je propose de sortir une fonction qui je pense n'a pas sa place dans ce modèle : `to_query`. 

C'est une méthode utilisée pour générer des liens avec des query params correspondant à un RDV. C'est donc plus une méthode de présentation que de modèle. Elle est exclusivement appelée et surchargée depuis les form models user rdv wizard et agent rdv wizard. J'ai inliné et simplifié cette génération de query params, par ex côté user il n'y a pas besoin (et c'est un peu dangereux) de passer les paramètres `agent_ids` ou `context`.