### PR TITLE
do not show sectorisation_level in motifs#index when not reservable online

### DIFF
--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -8,7 +8,9 @@ tr
     = content_tag(:span, I18n.t("motifs.badges.reservable_online"), class: "badge badge-motif-reservable_online") if motif.reservable_online?
   - if @display_sectorisation_level
     td
-      - if motif.sectorisation_level_departement?
+      - if !motif.reservable_online?
+        | &nbsp;
+      - elsif motif.sectorisation_level_departement?
         | Tout le #{current_organisation.departement}
       - elsif motif.sectorisation_level_organisation?
         = t("motifs.index.sectorisation_level_organisation", count: @sectors_attributed_to_organisation_count)


### PR DESCRIPTION
https://trello.com/c/xxNscEiG/1188-masquer-le-niveau-de-sectorisation-dans-la-liste-pour-les-motifs-non-r%C3%A9servables-en-ligne

<img width="400" alt="Screenshot_2020-12-07_at_18 04 19" src="https://user-images.githubusercontent.com/883348/101381127-a9dd7b80-38b6-11eb-9bd9-49eaa154adb2.png">
