### PR TITLE
prevent agents from changing service

### DIFF
--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -17,6 +17,6 @@ class Admin::PermissionsController < AgentAuthController
   private
 
   def permission_params
-    params.require(:agent_permission).permit(:role, :service_id)
+    params.require(:agent_permission).permit(:role)
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -27,6 +27,7 @@ class Agent < ApplicationRecord
 
   validates :email, :role, presence: true
   validates :last_name, :first_name, presence: true, on: :update, if: :accepted_or_not_invited?
+  validate :service_cannot_be_changed
 
   scope :complete, -> { where.not(first_name: nil).where.not(last_name: nil) }
   scope :active, -> { where(deleted_at: nil) }
@@ -86,5 +87,11 @@ class Agent < ApplicationRecord
 
   def name_for_paper_trail
     "[Agent] #{full_name}"
+  end
+
+  def service_cannot_be_changed
+    return if new_record? || !service_id_changed?
+
+    errors.add(:service_id, "changement interdit")
   end
 end

--- a/app/views/admin/invitations/new.html.slim
+++ b/app/views/admin/invitations/new.html.slim
@@ -10,7 +10,7 @@
         = simple_form_for [:admin, resource], as: resource_name, url: admin_agent_organisation_invitation_path(current_organisation, resource), html: { method: :post } do |f|
           = devise_error_messages!
           = f.input :email, placeholder: 'jean.dupond@departement.fr', input_html: { autocomplete: 'off'}
-          = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, include_blank: false
+          = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
           - organisation_id = params[:agent] ? params.require(:agent).permit(:organisation_id)[:organisation_id] : params[:organisation_id]
           = f.input :organisation_id, as: :hidden, input_html: { value: organisation_id }
           = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons

--- a/app/views/admin/permissions/edit.html.slim
+++ b/app/views/admin/permissions/edit.html.slim
@@ -15,7 +15,8 @@
       .card-body
         = simple_form_for [:admin, @permission], url: admin_organisation_permission_path(current_organisation, @permission), remote: request.xhr?, html: { data: { rightbar: true } } do |f|
           = render partial: 'layouts/model_errors', locals: { model: @permission }
-          = f.input :service_id, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, as: :select, label: 'Service'
+          = f.input :service_id, collection: [@permission.agent.service], as: :select, label: 'Service', hint: "Vous ne pouvez pas changer un agent de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer et recréer l'agent", disabled: true
+
           = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons, label: "Rôle de #{@permission.agent.full_name}"
 
           .row

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -9,7 +9,7 @@
 
   = f.input :first_name, placeholder: 'Prénom'
   = f.input :last_name, placeholder: 'Nom'
-  = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve
+  = f.association :service, collection: [resource.service], hint: "Vous ne pouvez pas changer de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer votre compte et vous faire réinviter, ou bien vous créer un deuxième compte avec une autre adresse email.", disabled: true
 
   = f.input :password, placeholder: 'Votre mot de passe (au moins 6 caractères)'
   .form-text.text-muted.mb-2

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/lieux/index.html.slim",
-      "line": 18,
+      "line": 19,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => policy_scope(Lieu).includes(:organisation).ordered_by_name.page(params[:page]), {})",
       "render_path": [
@@ -32,33 +32,22 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "70b3c5f95e396f2dbf82d05bbcaa00342d6a11cbe91d45c6e82307dcc988662d",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/admin/departements/sectors/show.html.slim",
-      "line": 64,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Zone.human_enum_name(:level, (Unresolved Model).new.level).sub(\" \", \"&nbsp;\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Admin::Departements::SectorsController",
-          "method": "show",
-          "line": 32,
-          "file": "app/controllers/admin/departements/sectors_controller.rb",
-          "rendered": {
-            "name": "admin/departements/sectors/show",
-            "file": "app/views/admin/departements/sectors/show.html.slim"
-          }
-        }
-      ],
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "804a3970881d06ca61e93ad9f38f3fcc692fc49d8b2eb629cedeba2a0c78e0ca",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/admin/permissions_controller.rb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:agent_permission).permit(:role)",
+      "render_path": null,
       "location": {
-        "type": "template",
-        "template": "admin/departements/sectors/show"
+        "type": "method",
+        "class": "Admin::PermissionsController",
+        "method": "permission_params"
       },
-      "user_input": null,
+      "user_input": ":role",
       "confidence": "Medium",
       "note": ""
     },
@@ -94,33 +83,13 @@
       "note": ""
     },
     {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "cf1a40ea12517005d0224e24210107133e043f0fd5bf869bcbf290c7a15ead57",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/admin/permissions_controller.rb",
-      "line": 20,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:agent_permission).permit(:role, :service_id)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Admin::PermissionsController",
-        "method": "permission_params"
-      },
-      "user_input": ":role",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "d73171480d9871ed50cc113b6a9bfc457a0c694d2f085d7537447509b41509e0",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
-      "line": 23,
+      "line": 26,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page]), {})",
       "render_path": [
@@ -128,7 +97,7 @@
           "type": "controller",
           "class": "Admin::MotifsController",
           "method": "index",
-          "line": 9,
+          "line": 12,
           "file": "app/controllers/admin/motifs_controller.rb",
           "rendered": {
             "name": "admin/motifs/index",
@@ -145,6 +114,6 @@
       "note": ""
     }
   ],
-  "updated": "2020-10-08 16:13:25 +0200",
+  "updated": "2020-12-07 18:25:12 +0100",
   "brakeman_version": "4.7.2"
 }


### PR DESCRIPTION
https://trello.com/c/c3ycMAQT/1144-bug-changer-un-agent-de-service-rend-les-plages-douvertures-incoh%C3%A9rentes

J'ai rajouté des textes explicatifs : 

à l'invitation

<img width="1411" alt="Screenshot_2020-12-07_at_18 22 51" src="https://user-images.githubusercontent.com/883348/101383630-ab5c7300-38b9-11eb-8479-cc2e470beb62.png">

dans la page de modification du compte de l'agent courant

<img width="600" alt="Screenshot_2020-12-07_at_18 17 17" src="https://user-images.githubusercontent.com/883348/101382930-cd092a80-38b8-11eb-92f9-2ef0573a55e8.png">

sur le agent#edit (en fait permissions#edit, je sais pas trop pq)

<img width="600" alt="Screenshot_2020-12-07_at_18 08 40" src="https://user-images.githubusercontent.com/883348/101382955-d5f9fc00-38b8-11eb-9b13-5a256104deb0.png">
