### PR TITLE
restore displaying motif reservable online badge where appropriate

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -11,8 +11,8 @@ module MotifsHelper
     content_tag(:span, motif_name_with_location_type(motif)) + motif_badges(motif)
   end
 
-  def motif_badges(motif)
-    badges = [:secretariat, :follow_up]
+  def motif_badges(motif, only: nil)
+    badges = only || [:reservable_online, :secretariat, :follow_up]
     badges.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) }.join("").html_safe
   end
 

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -11,9 +11,8 @@ module MotifsHelper
     content_tag(:span, motif_name_with_location_type(motif)) + motif_badges(motif)
   end
 
-  def motif_badges(motif, only: nil)
-    badges = only || [:reservable_online, :secretariat, :follow_up]
-    badges.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) }.join("").html_safe
+  def motif_badges(motif, only: [:reservable_online, :secretariat, :follow_up])
+    only.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) }.join("").html_safe
   end
 
   def build_badge_tag_for(badge_name)

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -3,9 +3,9 @@ tr
     span.badge.badge-pill.ml-0.mr-2 style="background: #{motif.color};" &nbsp;
   td
     = link_to motif.name, edit_admin_organisation_motif_path(motif.organisation, motif)
-    = motif_badges(motif)
+    = motif_badges(motif, only: [:secretariat, :follow_up])
   td
-    = content_tag(:span, I18n.t("motifs.badges.reservable_online"), class: "badge badge-motif-reservable_online") if motif.reservable_online?
+    = motif_badges(motif, only: [:reservable_online])
   - if @display_sectorisation_level
     td
       - if motif.sectorisation_level_departement?


### PR DESCRIPTION
https://trello.com/c/U37LFm0b/1189-info-motif-en-ligne-ou-hors-ligne-au-moment-de-cr%C3%A9er-une-plage-douverture

J'avais effectivement cassé le comportement des badges il y a 2 semaines lorsque j'ai modifié `motifs#index`. J'y ai déplacé l'info "réservable en ligne" dans une colonne à part, il ne fallait donc plus afficher ce badge juste à côté du nom mais bien dans sa colonne propre. Je n'ai pas réalisé qu'en changeant ça dans le helper je cassais le comportement attendu sur la plage d'ouverture où ce badge doit bien s'afficher. Ce commit répare le comportement.

<img width="772" alt="Screenshot_2020-12-08_at_09 55 31" src="https://user-images.githubusercontent.com/883348/101462363-70e7ea00-393c-11eb-92c7-86464f400cee.png">
<img width="1153" alt="Screenshot_2020-12-08_at_09 55 37" src="https://user-images.githubusercontent.com/883348/101462381-73e2da80-393c-11eb-937b-635bc6793970.png">


