### PR TITLE
 in admin RDV forms, warn when agents have other RDVs ending shortly before

### DIFF
--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -10,10 +10,15 @@ module Admin::RdvFormConcern
 
     delegate(*::Rdv.attribute_names, to: :rdv)
     delegate :motif, :organisation, :agents, :users, to: :rdv
-    delegate :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?, to: :rdv
+    delegate(
+      :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?,
+      :rdvs_ending_shortly_before, :rdvs_ending_shortly_before?,
+      to: :rdv
+    )
 
     validate :validate_rdv
     caution :warn_overlapping_plage_ouverture
+    caution :warn_rdvs_ending_shortly_before
   end
 
   def save
@@ -34,5 +39,28 @@ module Admin::RdvFormConcern
     overlapping_plages_ouvertures
       .map { PlageOuverturePresenter.new(_1, agent_context) }
       .each { warnings.add(:base, _1.overlaps_rdv_error_message, active: true) }
+  end
+
+  def warn_rdvs_ending_shortly_before
+    return true unless rdvs_ending_shortly_before?
+
+    rdv_agent_pairs_ending_shortly_before_grouped_by_agent.values.map do
+      RdvEndingShortlyBeforePresenter
+        .new(
+          rdv: _1.rdv,
+          agent: _1.agent,
+          rdv_context: rdv,
+          agent_context: agent_context
+        )
+    end.each { warnings.add(:base, _1.warning_message, active: true) }
+  end
+
+  def rdv_agent_pairs_ending_shortly_before_grouped_by_agent
+    rdvs_ending_shortly_before
+      .flat_map do |rdv_before|
+        rdv_before.agents.select { rdv.agents.include?(_1) }.map { OpenStruct.new(agent: _1, rdv: rdv_before) }
+      end
+      .group_by { _1.agent }
+      .transform_values { _1.last } # we only want the last RDV for each agent
   end
 end

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -28,7 +28,7 @@ module Admin::RdvFormConcern
   private
 
   def validate_rdv
-    return unless rdv.valid?
+    return if rdv.valid?
 
     rdv.errors.each { errors.add(_1, _2) }
   end
@@ -45,13 +45,12 @@ module Admin::RdvFormConcern
     return true unless rdvs_ending_shortly_before?
 
     rdv_agent_pairs_ending_shortly_before_grouped_by_agent.values.map do
-      RdvEndingShortlyBeforePresenter
-        .new(
-          rdv: _1.rdv,
-          agent: _1.agent,
-          rdv_context: rdv,
-          agent_context: agent_context
-        )
+      RdvEndingShortlyBeforePresenter.new(
+        rdv: _1.rdv,
+        agent: _1.agent,
+        rdv_context: rdv,
+        agent_context: agent_context
+      )
     end.each { warnings.add(:base, _1.warning_message, active: true) }
   end
 
@@ -61,6 +60,6 @@ module Admin::RdvFormConcern
         rdv_before.agents.select { rdv.agents.include?(_1) }.map { OpenStruct.new(agent: _1, rdv: rdv_before) }
       end
       .group_by { _1.agent }
-      .transform_values { _1.last } # we only want the last RDV for each agent
+      .transform_values { _1.last }
   end
 end

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -10,11 +10,8 @@ module Admin::RdvFormConcern
 
     delegate(*::Rdv.attribute_names, to: :rdv)
     delegate :motif, :organisation, :agents, :users, to: :rdv
-    delegate(
-      :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?,
-      :rdvs_ending_shortly_before, :rdvs_ending_shortly_before?,
-      to: :rdv
-    )
+    delegate :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?, to: :rdv
+    delegate :rdvs_ending_shortly_before, :rdvs_ending_shortly_before?, to: :rdv_start_coherence
 
     validate :validate_rdv
     caution :warn_overlapping_plage_ouverture
@@ -61,5 +58,9 @@ module Admin::RdvFormConcern
       end
       .group_by { _1.agent }
       .transform_values { _1.last }
+  end
+
+  def rdv_start_coherence
+    @rdv_start_coherence ||= RdvStartCoherence.new(rdv)
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -3,7 +3,7 @@ class Rdv < ApplicationRecord
   include Rdv::NotifiableConcern
   include Rdv::AddressConcern
 
-  ENDS_AT_SQL = "(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)".freeze
+  ENDS_AT_SQL = Arel.sql("(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)")
 
   has_paper_trail(
     meta: { virtual_attributes: :virtual_attributes_for_paper_trail }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -125,19 +125,6 @@ class Rdv < ApplicationRecord
     TimeSlot.new(starts_at, ends_at)
   end
 
-  def rdvs_ending_shortly_before
-    return Rdv.none if starts_at.blank? || duration_in_min.blank? || agents.blank?
-
-    @rdvs_ending_shortly_before ||= Rdv
-      .with_agent_among(agents)
-      .ends_at_in_range((starts_at - 46.minutes)..(starts_at - 1.minute))
-      .ordered_by_ends_at
-  end
-
-  def rdvs_ending_shortly_before?
-    rdvs_ending_shortly_before.any?
-  end
-
   private
 
   def virtual_attributes_for_paper_trail

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -12,4 +12,16 @@ class Agent::RdvPolicy < DefaultAgentPolicy
       end
     end
   end
+
+  class DepartementScope < Scope
+    def resolve
+      if @context.agent.can_access_others_planning?
+        scope.where(organisation_id: @context.agent.organisations.pluck(:id))
+      else
+        scope.joins(:motif)
+          .where(organisation_id: @context.agent.organisations.pluck(:id))
+          .where(motifs: { service_id: @context.agent.service_id })
+      end
+    end
+  end
 end

--- a/app/policies/default_agent_policy.rb
+++ b/app/policies/default_agent_policy.rb
@@ -106,5 +106,11 @@ class DefaultAgentPolicy
     def resolve
       scope.where(agent_id: @context.agent.id, organisation_id: @context.organisation.id)
     end
+
+    def in_scope?(object)
+      return false unless object&.id.present?
+
+      resolve.where(id: object.id).any?
+    end
   end
 end

--- a/app/presenters/rdv_ending_shortly_before_presenter.rb
+++ b/app/presenters/rdv_ending_shortly_before_presenter.rb
@@ -1,0 +1,44 @@
+class RdvEndingShortlyBeforePresenter
+  include Rails.application.routes.url_helpers
+
+  attr_accessor :rdv, :agent, :agent_context, :rdv_context
+
+  def initialize(rdv:, agent:, rdv_context:, agent_context:)
+    @rdv = rdv
+    @agent = agent
+    @rdv_context = rdv_context
+    @agent_context = agent_context
+  end
+
+  def warning_message
+    i18n_suffix = \
+      if @agent == agent_context.agent
+        "current_agent"
+      elsif in_scope?
+        "in_scope"
+      else
+        "out_of_scope"
+      end
+    i18n_key = "rdv_ending_shortly_before.#{i18n_suffix}"
+    attrs = {
+      agent_names: agent.full_name,
+      ends_at_time: I18n.l(rdv.ends_at, format: :time_only),
+      gap_duration_in_min: ((rdv_context.starts_at - rdv.ends_at) / 1.minute).round
+    }
+    if in_scope?
+      attrs.merge!(
+        user_names: rdv.users.map(&:full_name).to_sentence,
+        path: admin_organisation_rdv_path(rdv.organisation, rdv)
+      )
+    end
+    I18n.t("activemodel.warnings.models.rdv.attributes.base.#{i18n_key}", **attrs)
+  end
+
+  def in_scope?
+    Agent::RdvPolicy::DepartementScope
+      .new(agent_context, Rdv)
+      .resolve
+      .where(id: rdv.id)
+      .any?
+  end
+end

--- a/app/presenters/rdv_ending_shortly_before_presenter.rb
+++ b/app/presenters/rdv_ending_shortly_before_presenter.rb
@@ -11,34 +11,43 @@ class RdvEndingShortlyBeforePresenter
   end
 
   def warning_message
-    i18n_suffix = \
-      if @agent == agent_context.agent
-        "current_agent"
-      elsif in_scope?
-        "in_scope"
-      else
-        "out_of_scope"
-      end
-    i18n_key = "rdv_ending_shortly_before.#{i18n_suffix}"
-    attrs = {
-      agent_names: agent.full_name,
+    I18n.t("activemodel.warnings.models.rdv.attributes.base.#{i18n_key}", **i18n_attrs_base, **i18n_attrs_in_scope)
+  end
+
+  private
+
+  def in_scope?
+    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).in_scope?(rdv)
+  end
+
+  def i18n_key
+    "rdv_ending_shortly_before.#{i18n_suffix}"
+  end
+
+  def i18n_suffix
+    if @agent == agent_context.agent
+      "current_agent"
+    elsif in_scope?
+      "in_scope"
+    else
+      "out_of_scope"
+    end
+  end
+
+  def i18n_attrs_base
+    {
+      agent_name: agent.full_name,
       ends_at_time: I18n.l(rdv.ends_at, format: :time_only),
       gap_duration_in_min: ((rdv_context.starts_at - rdv.ends_at) / 1.minute).round
     }
-    if in_scope?
-      attrs.merge!(
-        user_names: rdv.users.map(&:full_name).to_sentence,
-        path: admin_organisation_rdv_path(rdv.organisation, rdv)
-      )
-    end
-    I18n.t("activemodel.warnings.models.rdv.attributes.base.#{i18n_key}", **attrs)
   end
 
-  def in_scope?
-    Agent::RdvPolicy::DepartementScope
-      .new(agent_context, Rdv)
-      .resolve
-      .where(id: rdv.id)
-      .any?
+  def i18n_attrs_in_scope
+    return {} unless in_scope?
+
+    {
+      user_names: rdv.users.map(&:full_name).to_sentence,
+      path: admin_organisation_rdv_path(rdv.organisation, rdv)
+    }
   end
 end

--- a/app/service_models/rdv_start_coherence.rb
+++ b/app/service_models/rdv_start_coherence.rb
@@ -1,0 +1,42 @@
+class RdvStartCoherence
+  delegate :starts_at, :duration_in_min, :agents, to: :rdv
+  attr_reader :rdv
+
+  THRESHOLD = 1.minute
+
+  def initialize(rdv)
+    @rdv = rdv
+  end
+
+  def rdvs_ending_shortly_before
+    return [] if rdvs_ending_right_before?
+
+    @rdvs_ending_shortly_before ||= all_rdvs_ending_before
+      .select { _1.ends_at <= starts_at - THRESHOLD }
+  end
+
+  def rdvs_ending_shortly_before?
+    rdvs_ending_shortly_before.any?
+  end
+
+  private
+
+  def rdvs_ending_right_before
+    @rdvs_ending_right_before ||= all_rdvs_ending_before
+      .select { _1.ends_at > starts_at - THRESHOLD }
+  end
+
+  def rdvs_ending_right_before?
+    rdvs_ending_right_before.any?
+  end
+
+  def all_rdvs_ending_before
+    return Rdv.none if starts_at.blank? || duration_in_min.blank? || agents.blank?
+
+    @all_rdvs_ending_before ||= Rdv
+      .with_agent_among(agents)
+      .ends_at_in_range((starts_at - 46.minutes)..starts_at)
+      .ordered_by_ends_at
+      .to_a
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -32,6 +32,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "49daaf5634c3cea5615e4e839666cbf45c79615f13341971179463699b7521bc",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/rdv.rb",
+      "line": 55,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "where(\"#{Arel.sql(\"(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)\")} BETWEEN ? AND ?\", range.begin, range.end)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Rdv",
+        "method": "ends_at_in_range"
+      },
+      "user_input": "Arel.sql(\"(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)\")",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
       "fingerprint": "804a3970881d06ca61e93ad9f38f3fcc692fc49d8b2eb629cedeba2a0c78e0ca",
@@ -52,6 +72,26 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "b29b01ddc6769a460480ba9c5186a1a5bd6672337b58f498f623c022a31c2b19",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/rdv.rb",
+      "line": 63,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "where(\"starts_at <= ?\", (Time.zone.now + time_margin)).where(\"#{Arel.sql(\"(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)\")} >= ?\", (Time.zone.now - time_margin))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Rdv",
+        "method": "Rdv.ongoing"
+      },
+      "user_input": "Arel.sql(\"(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)\")",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "bdaeb989380e722b9a047a04d36090a280b52b0fbde8615842f34b6248b9dd9d",
@@ -66,7 +106,7 @@
           "type": "controller",
           "class": "Admin::UsersController",
           "method": "index",
-          "line": 23,
+          "line": 24,
           "file": "app/controllers/admin/users_controller.rb",
           "rendered": {
             "name": "admin/users/index",
@@ -114,6 +154,6 @@
       "note": ""
     }
   ],
-  "updated": "2020-12-07 18:25:12 +0100",
+  "updated": "2020-12-22 11:15:18 +0100",
   "brakeman_version": "4.7.2"
 }

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -35,6 +35,10 @@ fr:
                 out_of_scope:
                   in_current_organisation: "%{agent_name} a une plage d'ouverture dans un autre lieu au moment de ce RDV (vous n'avez pas les permissions nécessaires pour voir cette plage d'ouverture)"
                   in_other_organisation: "%{agent_name} a une plage d'ouverture dans une autre organisation au moment de ce RDV (vous n'avez pas les permissions nécessaires pour voir cette plage d'ouverture)"
+              rdv_ending_shortly_before:
+                current_agent: "Vous avez <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans votre agenda"
+                in_scope: "%{agent_names} a <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
+                out_of_scope: "%{agent_names} a un RDV finissant à %{ends_at_time}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
 
   agents:
     rdvs:

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -37,8 +37,8 @@ fr:
                   in_other_organisation: "%{agent_name} a une plage d'ouverture dans une autre organisation au moment de ce RDV (vous n'avez pas les permissions nécessaires pour voir cette plage d'ouverture)"
               rdv_ending_shortly_before:
                 current_agent: "Vous avez <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans votre agenda"
-                in_scope: "%{agent_names} a <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
-                out_of_scope: "%{agent_names} a un RDV finissant à %{ends_at_time}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
+                in_scope: "%{agent_name} a <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
+                out_of_scope: "%{agent_name} a un RDV finissant à %{ends_at_time}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
 
   agents:
     rdvs:

--- a/spec/form_models/admin/rdv_form_concern_spec.rb
+++ b/spec/form_models/admin/rdv_form_concern_spec.rb
@@ -1,0 +1,101 @@
+class DummyForm
+  include ActiveModel::Model
+  include Admin::RdvFormConcern
+
+  def initialize(rdv, agent)
+    @rdv = rdv
+    @agent = agent
+  end
+
+  def agent_context; end
+end
+
+describe Admin::RdvFormConcern, type: :form do
+  subject { DummyForm.new(rdv, agent_author) }
+  let!(:agent_author) { create(:agent, first_name: "Poney", last_name: "FOU") }
+  before { allow(subject).to receive(:agent_context).and_return(agent_context) }
+  let(:agent_context) { instance_double(AgentContext, agent: agent_author, organisation: build(:organisation)) }
+
+  describe "validations" do
+    context "rdv is not valid" do
+      let(:rdv) { build(:rdv) }
+      before do
+        expect(rdv).to receive(:valid?).and_return(false)
+        expect(rdv).to receive(:errors).and_return([[:base, "not cool"]])
+      end
+
+      it "should not be valid" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors[:base]).to include "not cool"
+      end
+    end
+
+    context "rdv is valid" do
+      let(:rdv) { build(:rdv) }
+      before { expect(rdv).to receive(:valid?).and_return(true) }
+
+      it "should be valid" do
+        expect(subject.valid?).to eq true
+      end
+    end
+
+    context "rdv is valid but there is another rdv ending shortly before" do
+      let!(:agent_new_rdv) { create(:agent) }
+      let(:rdv) { build(:rdv, agents: [agent_new_rdv]) }
+      let!(:rdv2) { create(:rdv, agents: [agent_new_rdv]) }
+      before do
+        allow(rdv).to receive(:valid?).and_return(true)
+        allow(rdv).to receive(:rdvs_ending_shortly_before?).and_return(true)
+        allow(rdv).to receive(:rdvs_ending_shortly_before).and_return([rdv2])
+        allow(RdvEndingShortlyBeforePresenter).to receive(:new)
+          .with(rdv: rdv2, agent: agent_new_rdv, rdv_context: rdv, agent_context: agent_context)
+          .and_return(instance_double(RdvEndingShortlyBeforePresenter, warning_message: "alerte RDV proche !"))
+      end
+
+      it "should not be valid" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors).not_to be_empty
+      end
+
+      it "should include warnings" do
+        subject.valid?
+        expect(subject.warnings_need_confirmation?).to eq true
+        expect(subject.warnings).not_to be_empty
+        expect(subject.warnings[:base]).to include("alerte RDV proche !")
+      end
+    end
+
+    context "rdv is valid but there are multiple other RDVs ending shortly before" do
+      let!(:agent_giono) { build(:agent, first_name: "Jean", last_name: "GIONO") }
+      let!(:agent_maceo) { build(:agent, first_name: "Maceo", last_name: "PARKER") }
+      let(:rdv) { build(:rdv, agents: [agent_giono, agent_maceo], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdvs_giono) { build_list(:rdv, 2, agents: [agent_giono]) }
+      let!(:rdvs_maceo) { build_list(:rdv, 2, agents: [agent_maceo]) }
+
+      before do
+        allow(rdv).to receive(:valid?).and_return(true)
+        allow(rdv).to receive(:rdvs_ending_shortly_before?).and_return(true)
+        allow(rdv).to receive(:rdvs_ending_shortly_before)
+          .and_return(rdvs_giono + rdvs_maceo) # this is considered sorted on ends_at ASC
+        allow(RdvEndingShortlyBeforePresenter).to receive(:new)
+          .with(rdv: rdvs_giono.last, agent: agent_giono, rdv_context: rdv, agent_context: agent_context)
+          .and_return(instance_double(RdvEndingShortlyBeforePresenter, warning_message: "alerte RDV Giono !"))
+        allow(RdvEndingShortlyBeforePresenter).to receive(:new)
+          .with(rdv: rdvs_maceo.last, agent: agent_maceo, rdv_context: rdv, agent_context: agent_context)
+          .and_return(instance_double(RdvEndingShortlyBeforePresenter, warning_message: "alerte RDV Maceo !"))
+      end
+
+      it "should not be valid" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors).not_to be_empty
+      end
+
+      it "should include warnings" do
+        subject.valid?
+        expect(subject.warnings_need_confirmation?).to eq true
+        expect(subject.warnings).not_to be_empty
+        expect(subject.warnings[:base]).to match_array(["alerte RDV Giono !", "alerte RDV Maceo !"])
+      end
+    end
+  end
+end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -337,4 +337,29 @@ describe Rdv, type: :model do
       end
     end
   end
+
+  describe "#rdvs_ending_shortly_before" do
+    subject { rdv.rdvs_ending_shortly_before }
+
+    context "ends shortly, agent in common" do
+      let!(:agent) { create(:agent) }
+      let!(:rdv) { create(:rdv, agents: [agent, build(:agent)], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, agents: [build(:agent), agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      it { should include(rdv2) }
+    end
+
+    context "ends shortly, no agent in common" do
+      let!(:agent) { create(:agent) }
+      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, agents: [build(:agent)], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      it { should_not include(rdv2) }
+    end
+
+    context "does not end shortly" do
+      let!(:agent) { create(:agent) }
+      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, agents: [agent], starts_at: rdv.starts_at - 2.hours, duration_in_min: 15) }
+      it { should_not include(rdv2) }
+    end
+  end
 end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -337,29 +337,4 @@ describe Rdv, type: :model do
       end
     end
   end
-
-  describe "#rdvs_ending_shortly_before" do
-    subject { rdv.rdvs_ending_shortly_before }
-
-    context "ends shortly, agent in common" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent, build(:agent)], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [build(:agent), agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
-      it { should include(rdv2) }
-    end
-
-    context "ends shortly, no agent in common" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [build(:agent)], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
-      it { should_not include(rdv2) }
-    end
-
-    context "does not end shortly" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [agent], starts_at: rdv.starts_at - 2.hours, duration_in_min: 15) }
-      it { should_not include(rdv2) }
-    end
-  end
 end

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -1,0 +1,45 @@
+describe RdvEndingShortlyBeforePresenter, type: :presenter do
+  let(:presenter) { RdvEndingShortlyBeforePresenter.new(rdv: rdv, agent: agent, rdv_context: rdv_context, agent_context: agent_context) }
+
+  describe "#warning_message" do
+    subject { presenter.warning_message }
+
+    before do
+      dbl = instance_double(Agent::RdvPolicy::DepartementScope, in_scope?: in_scope_mock_value)
+      allow(Agent::RdvPolicy::DepartementScope).to receive(:new).with(agent_context, Rdv).and_return(dbl)
+    end
+
+    context "same agent (=> in scope)" do
+      let(:in_scope_mock_value) { true }
+      let!(:organisation) { create(:organisation) }
+      let(:agent_context) { instance_double(AgentContext, agent: agent, organisation: organisation) }
+      let!(:agent) { create(:agent, organisations: [organisation]) }
+      let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
+      let!(:rdv_context) { create(:rdv, organisation: organisation, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 9.hours) }
+      let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
+      it { should match(%r{Vous avez <a .*>un RDV</a> finissant à 08h30 avec Milos FORMAN, vous allez laisser un trou de 30 minutes dans votre agenda}) }
+    end
+
+    context "rdv from other agent but still in scope" do
+      let(:in_scope_mock_value) { true }
+      let!(:organisation) { create(:organisation) }
+      let(:agent_context) { instance_double(AgentContext, agent: build(:agent), organisation: organisation) }
+      let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
+      let!(:rdv_context) { create(:rdv, organisation: organisation, starts_at: Date.today.next_week(:monday).in_time_zone + 9.hours) }
+      let!(:agent) { create(:agent, first_name: "Maya", last_name: "JOAO", organisations: [organisation]) }
+      let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
+      it { should match(%r{Maya JOAO a <a .*>un RDV</a> finissant à 08h30 avec Milos FORMAN, vous allez laisser un trou de 30 minutes dans son agenda}) }
+    end
+
+    context "rdv from other agent and not in scope" do
+      let(:in_scope_mock_value) { false }
+      let!(:organisation) { create(:organisation) }
+      let(:agent_context) { instance_double(AgentContext, agent: build(:agent), organisation: organisation) }
+      let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
+      let!(:rdv_context) { create(:rdv, organisation: organisation, starts_at: Date.today.next_week(:monday).in_time_zone + 9.hours) }
+      let!(:agent) { create(:agent, first_name: "Maya", last_name: "JOAO", organisations: [organisation]) }
+      let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
+      it { should eq "Maya JOAO a un RDV finissant à 08h30, vous allez laisser un trou de 30 minutes dans son agenda (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)" }
+    end
+  end
+end

--- a/spec/service_models/rdv_start_coherence_spec.rb
+++ b/spec/service_models/rdv_start_coherence_spec.rb
@@ -1,0 +1,26 @@
+describe RdvStartCoherence, type: :service do
+  describe "#rdvs_ending_shortly_before" do
+    subject { RdvStartCoherence.new(rdv).rdvs_ending_shortly_before }
+
+    context "ends shortly, agent in common" do
+      let!(:agent) { create(:agent) }
+      let!(:rdv) { create(:rdv, agents: [agent, build(:agent)], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, agents: [build(:agent), agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      it { should include(rdv2) }
+    end
+
+    context "ends shortly, no agent in common" do
+      let!(:agent) { create(:agent) }
+      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, agents: [build(:agent)], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      it { should_not include(rdv2) }
+    end
+
+    context "does not end shortly" do
+      let!(:agent) { create(:agent) }
+      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Date.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, agents: [agent], starts_at: rdv.starts_at - 2.hours, duration_in_min: 15) }
+      it { should_not include(rdv2) }
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/fbebJ0G5/1173-ajuster-lheure-de-d%C3%A9but-du-rdv-avec-la-fin-du-pr%C3%A9c%C3%A9dent

Cette PR est _relativement_ simple après le gros refacto des admin RDV forms.

# Screenshots

Pour l'agent courant

<img width="583" alt="Screenshot_2020-12-10_at_18 11 56" src="https://user-images.githubusercontent.com/883348/101806074-cfb38c00-3b13-11eb-8731-68dcefd0e9dc.png">

Pour un autre agent, dans le scope

<img width="600" alt="Screenshot_2020-12-10_at_18 12 48" src="https://user-images.githubusercontent.com/883348/101806109-db06b780-3b13-11eb-89d1-127373a63305.png">

Pour un autre agent, hors scope

<img width="637" alt="Screenshot_2020-12-22_at_14 03 10" src="https://user-images.githubusercontent.com/883348/102891428-76762180-445e-11eb-8346-750fdd2cbce8.png">


# Multi agent

Un point un peu tricky c'est le multi-agent. Il faut prendre en compte le fait que le RDV qu'on est en train de créer peut avoir plusieurs agents, et que le RDV qui est potentiellement en conflit a une autre liste d'agents et il faut faire l'intersection. 

Aussi, on ne veut pas afficher plusieurs warnings pour des RDVs d'un même agent comme : 

- Attention, Martine a un RDV finissant à 15h30
- Attention, Martine a un RDV finissant à 15h45
- Attention, Martine a un RDV finissant à 16h00 

etc, il faut bien prendre le dernier pour chaque agent. 

# RDVs s'enchainant

il faut aussi dans ce cas gerer le cas ou on aligne un RDV avec le dernier, mais ou les precedents pourraient etre considérés en conflit. 

- un RDV existe et finit a 14h15
- un autre RDV existe et finit a 14h30
- j'essaie de creer un autre RDV commencant a 14h30
- => il faut accepter sans warning, ne pas dire "attention il y en a un qui finit a 15".

## Implem

J'avais commencé par rajouter de la logique dans le modèle Rdv mais finalement je pense qu'il y en a assez pour l'extraire. J'ai fait un "service model" à part qui s'appelle `RdvStartCoherence` et qui a deux méthodes publiques : `rdvs_ending_shortly_before` et `rdvs_ending_shortly_before?` 

Pour les specs rajoutées dans cette PR j'essaie de limiter au max le fait de tester des dépendances sans le vouloir. C'est à dire que si je teste la classe A qui fait appel à la classe B, je mocke les appels et les valeurs renvoyées par B. Je mets des expect ou des allow selon qu'il y ait des effets de bords attendus ou non, cf https://medium.com/@christiancarey1/writing-specs-like-sandi-metz-9f2acf5026cb

ecrire les specs m'ont fait réaliser qu'il y avait un gros défaut d'implem dans le `rdvformconcern` : un unless au lieu d'un if 😨 . Je ne comprends pas trop comment ça pouvait marcher correctement, j'imagine que le comportement était bizarre mais que ça passait à peu près. On ne contournait pas non plus les validations mais elles devaient être exécutées au mauvais moment.