### PR TITLE
add users.notify_by_sms and email settings

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,6 +9,7 @@ class Admin::UsersController < AgentAuthController
     :first_name, :last_name, :birth_name, :email, :phone_number,
     :birth_date, :address, :caisse_affiliation, :affiliation_number,
     :family_situation, :number_of_children,
+    :notify_by_sms, :notify_by_email,
     :skip_duplicate_warnings
   ].freeze
 

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -65,6 +65,8 @@ class Users::RdvWizardStepsController < UserAuthController
                     :affiliation_number,
                     :family_situation,
                     :number_of_children,
+                    :notify_by_email,
+                    :notify_by_sms,
                     user_profiles_attributes: [:logement, :id, :organisation_id]
                   ])
   end

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -29,6 +29,8 @@ class Users::UsersController < UserAuthController
       :affiliation_number,
       :family_situation,
       :number_of_children,
+      :notify_by_email,
+      :notify_by_sms,
       user_profiles_attributes: [:logement, :id, :organisation_id]
     )
   end

--- a/app/helpers/displayable_user.rb
+++ b/app/helpers/displayable_user.rb
@@ -42,4 +42,16 @@ class DisplayableUser
 
     simple_format(@user_profile.notes)
   end
+
+  def notify_by_sms
+    return "pas de numéro de téléphone renseigné" if @user.responsible_phone_number.blank?
+
+    @user.responsible_notify_by_sms? ? "🟢 Activées" : "🔴 Désactivées"
+  end
+
+  def notify_by_email
+    return "pas d'email renseigné" if @user.responsible_email.blank?
+
+    @user.responsible_notify_by_email? ? "🟢 Activées" : "🔴 Désactivées"
+  end
 end

--- a/app/models/concerns/user/responsability_concern.rb
+++ b/app/models/concerns/user/responsability_concern.rb
@@ -9,6 +9,7 @@ module User::ResponsabilityConcern
 
   delegate(
     :phone_number, :email, :address,
+    :notify_by_email, :notify_by_email?, :notify_by_sms, :notify_by_sms?,
     to: :responsible_or_self,
     prefix: :responsible
   )

--- a/app/services/notifications/rdv/base_service_concern.rb
+++ b/app/services/notifications/rdv/base_service_concern.rb
@@ -9,11 +9,15 @@ module Notifications::Rdv::BaseServiceConcern
     return false if @rdv.starts_at < Time.zone.now || !@rdv.motif.visible_and_notified?
 
     if methods.include?(:notify_user_by_mail)
-      users_to_notify.select { _1.email.present? }.each { notify_user_by_mail(_1) }
+      users_to_notify
+        .select { _1.email.present? && _1.notify_by_email? }
+        .each { notify_user_by_mail(_1) }
     end
 
     if methods.include?(:notify_user_by_sms)
-      users_to_notify.select { _1.phone_number_formatted.present? }.each { notify_user_by_sms(_1) }
+      users_to_notify
+        .select { _1.phone_number_formatted.present? && _1.notify_by_sms? }
+        .each { notify_user_by_sms(_1) }
     end
 
     if methods.include?(:notify_agent)

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -61,10 +61,15 @@
             i.fa.fa-fw.fa-phone>
             - phone_number = DisplayableUser.new(user, current_organisation).phone_number
             = display_value_or_na_placeholder(phone_number)
+            - if phone_number.present?
+              span> - Notifications par SMS #{DisplayableUser.new(user, current_organisation).notify_by_sms}
           p.card-text
             i.fa.fa-fw.fa-envelope>
             - email = DisplayableUser.new(user, current_organisation).email
             = display_value_or_na_placeholder(phone_number)
+            - if email.present?
+              span> - Notifications par email #{DisplayableUser.new(user, current_organisation).notify_by_email}
+
           - if user.notes_for(current_organisation).present?
             .d-flex title="Remarques"
               div.mr-1

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -9,7 +9,6 @@
   .col-md-6= date_input(f, :birth_date, **input_opts)
 
 = f.input(:email, as: :email, **input_opts)
-
 - if user.new_record?
   label
     = check_box_tag :invite_on_create, \
@@ -19,6 +18,24 @@
     |&nbsp; Inviter l'utilisateur à se créer un compte sur RDV-solidarites.
 
 = f.input :phone_number, as: :tel, **input_opts
+
+label Préférences de notifications
+.d-flex.mb-2
+  div= f.input( \
+    :notify_by_email,  \
+    include_hidden: false, \
+    wrapper: false, \
+    **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
+  )
+  div.ml-3= f.input( \
+    :notify_by_sms,  \
+    include_hidden: false, \
+    wrapper: false, \
+    **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
+  )
+- if user.confirmed?
+  .mt-1.text-muted
+    | L'usager ayant validé son compte, vous ne pouvez plus modifier ses préférences
 
 = f.input :address, **(input_opts.deep_merge(input_html: { class: "places-js-container" }))
 

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -1,5 +1,5 @@
 ul.list-unstyled.mb-5
-  - [:first_name, :last_name, :birth_name, :birth_date, :phone_number, :address, :email].each do |attr_name|
+  - [:first_name, :last_name, :birth_name, :birth_date, :address, :email, :notify_by_email, :phone_number, :notify_by_sms].each do |attr_name|
     li.mb-2= render "common/user_attribute", user: user, attribute_name: attr_name
 
   - if user.pending_reconfirmation?

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -36,11 +36,14 @@ ul.list-group.list-group-flush
           | Informations de contact :&nbsp;
       .row
         .col.ml-3
-          | ✉️ Email :&nbsp;
-          = current_user.email
+          span> ✉️ Email :
+          b>= current_user.email
+          span>= "(notifications par email #{current_user.notify_by_email? ? "activées" : "désactivées"})"
       .row
         .col.ml-3
-          | 📞 Téléphone :&nbsp;
-          = current_user.phone_number || "Non renseigné"
+          span> 📞 Téléphone :
+          b>= current_user.phone_number || "Non renseigné"
+          - if current_user.phone_number.present?
+            span>= "(notifications par SMS #{current_user.notify_by_sms? ? "activées" : "désactivées"})"
         .col-auto
           = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -9,6 +9,10 @@
     .col-md-6= f.input :birth_name, placeholder: 'Nom de naissance'
     .col-md-6= date_input(f, :birth_date)
   = f.input :phone_number, as: :tel
+  label Préférences de notifications
+  .d-flex
+    div= f.input :notify_by_email
+    div.ml-3= f.input :notify_by_sms
   - address_value = local_assigns[:rdv_wizard].present? && user.address.nil? ? rdv_wizard[:where] : user.address
   = f.input :address, input_html: {value: address_value, class: "places-js-container" }
   .form-row

--- a/app/webpacker/components/agent-user-form.js
+++ b/app/webpacker/components/agent-user-form.js
@@ -34,9 +34,18 @@ class AgentUserForm {
     this.formElt.querySelectorAll("div[data-togglable]").forEach(d =>
       d.classList.toggle("d-none", !this.divShouldBeVisible(d))
     )
-    this.formElt.querySelectorAll("input[data-togglable], select[data-togglable], textarea[data-togglable]").forEach(i =>
-      i.disabled = !this.inputShouldBeEnabled(i)
-    )
+    this.formElt.querySelectorAll("input[data-togglable], select[data-togglable], textarea[data-togglable]").forEach(inputElt => {
+      const newDisabledValue = !this.inputShouldBeEnabled(inputElt)
+      inputElt.disabled = newDisabledValue
+      // bind disabled attribute of checkboxes' hidden field with 0 value
+      if (
+        inputElt.previousSibling &&
+        inputElt.previousSibling.type == "hidden" &&
+        inputElt.previousSibling.tagName == inputElt.tagName &&
+        inputElt.previousSibling.name == inputElt.name
+      )
+        inputElt.previousSibling.disabled = newDisabledValue
+    })
     new Select2Inputs()
   }
 
@@ -45,6 +54,8 @@ class AgentUserForm {
   }
 
   inputShouldBeEnabled = (inputElt) => {
+    if (inputElt.classList.contains("js-force-disabled"))
+      return false
     const { responsabilityType, relativeType } = inputElt.dataset
     return (
       responsabilityType == this.currentResponsabilityType &&

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -30,3 +30,5 @@ fr:
         responsability_types:
           responsible: "Responsable"
           relative: "Proche"
+        notify_by_sms: "Notifications par SMS"
+        notify_by_email: "Notifications par email"

--- a/db/migrate/20201208091156_add_notify_booleans_to_users.rb
+++ b/db/migrate/20201208091156_add_notify_booleans_to_users.rb
@@ -1,0 +1,6 @@
+class AddNotifyBooleansToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :notify_by_sms, :bool, default: true
+    add_column :users, :notify_by_email, :bool, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_03_112249) do
+ActiveRecord::Schema.define(version: 2020_12_08_091156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -358,6 +358,8 @@ ActiveRecord::Schema.define(version: 2020_12_03_112249) do
     t.string "birth_name"
     t.string "email_original"
     t.string "phone_number_formatted"
+    t.boolean "notify_by_sms", default: true
+    t.boolean "notify_by_email", default: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,13 +189,15 @@ describe User, type: :model do
         responsible_attributes: {
           first_name: "Jean",
           last_name: "durand",
-          email: "jean@durand.fr"
+          email: "jean@durand.fr",
+          notify_by_sms: false
         }
       )
       loulou.save!
       expect(User.count).to eq(2)
       expect(loulou.responsible).not_to be_nil
       expect(loulou.responsible.first_name).to eq("Jean")
+      expect(loulou.responsible.notify_by_sms).to eq(false)
     end
   end
 

--- a/spec/services/notifications/rdv/base_service_spec.rb
+++ b/spec/services/notifications/rdv/base_service_spec.rb
@@ -1,9 +1,14 @@
 class TestService < ::BaseService
   include Notifications::Rdv::BaseServiceConcern
+
+  def notify_user_by_mail(user); end
+
+  def notify_user_by_sms(user); end
 end
 
 describe Notifications::Rdv::BaseServiceConcern, type: :service do
-  subject { TestService.perform_with(rdv) }
+  let(:service) { TestService.new(rdv) }
+  subject { service.perform }
 
   context "rdv dans le futur" do
     let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day) }
@@ -24,5 +29,74 @@ describe Notifications::Rdv::BaseServiceConcern, type: :service do
     let(:motif) { build(:motif, :visible_and_not_notified) }
     let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, motif: motif) }
     it { should eq false }
+  end
+
+  context "rdv has two users, both with email notifications" do
+    let(:user1) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
+    let(:user2) { build(:user, email: "martine@lol.fr", notify_by_email: true) }
+    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    it "should call send emails to both" do
+      expect(service).to receive(:notify_user_by_mail).with(user1)
+      expect(service).to receive(:notify_user_by_mail).with(user2)
+      subject
+    end
+  end
+
+  context "rdv has two users, one without email notifications" do
+    let(:user1) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
+    let(:user2) { build(:user, email: "martine@lol.fr", notify_by_email: false) }
+    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    it "should call notify_user_by_email only for one user" do
+      expect(service).to receive(:notify_user_by_mail).with(user1)
+      expect(service).not_to receive(:notify_user_by_mail).with(user2)
+      subject
+    end
+  end
+
+  context "rdv has two users, one with missing email address" do
+    let(:user1) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
+    let(:user2) { build(:user, email: nil, notify_by_email: false) }
+    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    it "should call notify_user_by_email only for one user" do
+      expect(service).to receive(:notify_user_by_mail).with(user1)
+      expect(service).not_to receive(:notify_user_by_mail).with(user2)
+      subject
+    end
+  end
+
+  context "rdv has two users, both with sms notifications" do
+    # need to create for SMS because phone_number_formatted is computed in a before_save
+    let(:user1) { create(:user, phone_number: "0601020304", notify_by_sms: true) }
+    let(:user2) { create(:user, phone_number: "0601020305", notify_by_sms: true) }
+    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    it "should send SMS to both" do
+      expect(service).to receive(:notify_user_by_sms).with(user1)
+      expect(service).to receive(:notify_user_by_sms).with(user2)
+      subject
+    end
+  end
+
+  context "rdv has two users, one with SMS notifications disabled" do
+    # need to create for SMS because phone_number_formatted is computed in a before_save
+    let(:user1) { create(:user, phone_number: "0601020304", notify_by_sms: false) }
+    let(:user2) { create(:user, phone_number: "0601020305", notify_by_sms: true) }
+    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    it "should send SMS to only one" do
+      expect(service).not_to receive(:notify_user_by_sms).with(user1)
+      expect(service).to receive(:notify_user_by_sms).with(user2)
+      subject
+    end
+  end
+
+  context "rdv has two users, one with a mising phone_number" do
+    # need to create for SMS because phone_number_formatted is computed in a before_save
+    let(:user1) { create(:user, phone_number: "0601020304", notify_by_sms: true) }
+    let(:user2) { create(:user, phone_number: nil, notify_by_sms: true) }
+    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    it "should send SMS to only one" do
+      expect(service).to receive(:notify_user_by_sms).with(user1)
+      expect(service).not_to receive(:notify_user_by_sms).with(user2)
+      subject
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/onN13lua/1175-d%C3%A9sactiver-les-notifications-pour-un-usager

# Screenshots

### `users#edit`

<img width="1110" alt="user-edit" src="https://user-images.githubusercontent.com/883348/101511416-ed012280-397a-11eb-9bc2-eaac68d8664b.png">

### users rdv tunnel

<img width="1100" alt="users-rdv-tunnel" src="https://user-images.githubusercontent.com/883348/101511539-f4283080-397a-11eb-82f1-cbd1fcff41f3.png">

### `admin/users#show`

<img width="917" alt="admin-user-show" src="https://user-images.githubusercontent.com/883348/101511941-0ace8780-397b-11eb-8101-047350f5a66c.png">

### `admin/users#edit`

<img width="1427" alt="admin-user-edit-enabled" src="https://user-images.githubusercontent.com/883348/101603455-e23ca100-39ff-11eb-846c-766a888f0319.png">


L'admin ne peut pas modifier les prefs de notifs une fois le compte confirmé : 

<img width="1425" alt="admin-user-edit-disabled" src="https://user-images.githubusercontent.com/883348/101603464-e5379180-39ff-11eb-8bb4-971651aeb119.png">


### `admin/rdvs#show`

<img width="1552" alt="admin-rdv-show" src="https://user-images.githubusercontent.com/883348/101510946-d1961780-397a-11eb-8413-e5e0b2c54813.png">

# Implementation tweaks

J'ai du rajouter encore un peu de complexité dans le JS du formulaire des users dans l'admin. ce JS est responsable de basculer du mode "usager responsable" vers le mode "usager proche". Il gère la visibilité des bons champs selon le mod, et maintient à jour les attributs `disabled` sur les différents inputs pour s'assurer que le formulaire soumettra les bons champs.

L'utilisation de champs de types checkbox pour les nouvelles preferences de notifs fait que rails rajoute un hidden input avec la valeur 0 pour quand la checkbox n'est pas coché. Ce input n'a pas les memes classes et attributs que le principal, donc pas data-togglable et donc il n'était pas bien géré par le formulaire actuel.

Une alternative pour ne pas avoir à gérer ce JS supplémentaire c'est de ne pas utiliser des checkboxes mais par exemple des radio buttons OUI / NON pour les deux options. J'avais commencé par ça mais c'est vraiment pas terrible en UX je trouve.

# TODO

- [ ] test on review app

# Plus tard

Ca serait bien de rajouter du contenu sur `admin/rdv_wizard#step3` pour expliquer quelles notifs s'appretent a partir a la creation du RDV (aucune / sms / email / les deux). ce n'est pas mega evident ou faire apparaitre cette info donc je prefere le faire plus tard dans une PR a part.

<img width="958" alt="later" src="https://user-images.githubusercontent.com/883348/101604033-b0780a00-3a00-11eb-91dd-020a9e94f0b5.png">
