### PR TITLE
WIP optimize FindAvailabilityService by limiting creneaux computing to first ones

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -1,20 +1,6 @@
 class Admin::Creneaux::AgentSearchesController < AgentAuthController
   respond_to :html, :js
 
-  # def index
-  #   benchmark "benchmark around SearchCreneauxForAgentsService", silence: true do
-  #     SearchCreneauxForAgentsService.perform_with(
-  #       OpenStruct.new(
-  #         motif: Motif.find(800),
-  #         agent_ids: nil,
-  #         date_range: (Date.today..(Date.today + 6.days)),
-  #         organisation: Organisation.find(101),
-  #         lieu_ids: []
-  #       )
-  #     )
-  #   end
-  # end
-
   def index
     @form = build_agent_creneaux_search_form
     @search_results = SearchCreneauxForAgentsService.perform_with(@form) \

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -1,6 +1,20 @@
 class Admin::Creneaux::AgentSearchesController < AgentAuthController
   respond_to :html, :js
 
+  # def index
+  #   benchmark "benchmark around SearchCreneauxForAgentsService", silence: true do
+  #     SearchCreneauxForAgentsService.perform_with(
+  #       OpenStruct.new(
+  #         motif: Motif.find(800),
+  #         agent_ids: nil,
+  #         date_range: (Date.today..(Date.today + 6.days)),
+  #         organisation: Organisation.find(101),
+  #         lieu_ids: []
+  #       )
+  #     )
+  #   end
+  # end
+
   def index
     @form = build_agent_creneaux_search_form
     @search_results = SearchCreneauxForAgentsService.perform_with(@form) \

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -42,12 +42,11 @@ class PlageOuverture < ApplicationRecord
 
   def self.not_expired_for_motif_name_and_lieu(motif_name, lieu)
     PlageOuverture
-      .includes(:motifs_plageouvertures)
       .where(lieu: lieu)
       .not_expired
       .joins(:motifs)
       .where(motifs: { name: motif_name, organisation_id: lieu.organisation_id })
-      .includes(:motifs, agent: :absences)
+      .includes(:agent)
   end
 
   def expired?

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -1,4 +1,19 @@
 class BaseService
+  def self.count_time
+    @total_time ||= 0
+    res = nil
+    @total_time += Benchmark.measure { res = yield }.to_a.last
+    res
+  end
+
+  def self.total_time
+    @total_time
+  end
+
+  def self.reset_time
+    @total_time = 0
+  end
+
   def self.perform_with(*args, **kwargs)
     new(*args, **kwargs).perform
   end

--- a/app/services/creneaux_builder_for_date_service.rb
+++ b/app/services/creneaux_builder_for_date_service.rb
@@ -4,7 +4,6 @@ class CreneauxBuilderForDateService < BaseService
     @motif = motif
     @date = date
     @lieu = lieu
-    @inclusive_date_range = options[:inclusive_date_range]
     @for_agents = options.fetch(:for_agents, false)
     @agent_name = options.fetch(:agent_name, false)
     rewind
@@ -76,6 +75,6 @@ class CreneauxBuilderForDateService < BaseService
   end
 
   def inclusive_datetime_range
-    @inclusive_datetime_range ||= (@inclusive_date_range.begin.to_time)..(@inclusive_date_range.end.end_of_day)
+    @inclusive_datetime_range ||= (@date.beginning_of_day..@date.end_of_day)
   end
 end

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -1,4 +1,6 @@
 class CreneauxBuilderService < BaseService
+  include HasPlageOuverturesConcern
+
   def initialize(motif_name, lieu, inclusive_date_range, **options)
     @motif_name = motif_name
     @lieu = lieu
@@ -17,13 +19,6 @@ class CreneauxBuilderService < BaseService
     creneaux.uniq(&uniq_by).sort_by(&:starts_at)
   end
 
-  def plages_ouvertures
-    @plages_ouvertures ||= PlageOuverture
-      .not_expired_for_motif_name_and_lieu(@motif_name, @lieu)
-      .where(({ agent_id: @agent_ids } unless @agent_ids.nil?))
-      .where(({ motifs: { location_type: @motif_location_type } } if @motif_location_type.present?))
-  end
-
   private
 
   def motifs_for_plage_ouverture(plage_ouverture)
@@ -40,7 +35,7 @@ class CreneauxBuilderService < BaseService
   def creneaux_for_plage_ouverture_and_motif(plage_ouverture, motif)
     plage_ouverture.occurences_for(@inclusive_date_range).flat_map do |occurence|
       CreneauxBuilderForDateService
-        .perform_with(plage_ouverture, motif, occurence.starts_at.to_date, @lieu, inclusive_date_range: @inclusive_date_range, **@options)
+        .perform_with(plage_ouverture, motif, occurence.starts_at.to_date, @lieu, **@options)
     end
   end
 end

--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -8,8 +8,6 @@ class CreneauxBuilderService < BaseService
     @agent_ids = options.fetch(:agent_ids, nil)
     @agent_name = options.fetch(:agent_name, false)
     @motif_location_type = options.fetch(:motif_location_type, nil)
-    @plages_ouvertures = options[:plages_ouvertures]
-    @only_first = options[:only_first]
   end
 
   def perform
@@ -41,18 +39,8 @@ class CreneauxBuilderService < BaseService
 
   def creneaux_for_plage_ouverture_and_motif(plage_ouverture, motif)
     plage_ouverture.occurences_for(@inclusive_date_range).flat_map do |occurence|
-      creneaux_builder_for_date_service = CreneauxBuilderForDateService
-        .new(plage_ouverture, motif, occurence.starts_at.to_date, @lieu, inclusive_date_range: @inclusive_date_range, **@options)
-      if @only_first
-        enum = creneaux_builder_for_date_service.next_creneaux_enumerator
-        begin
-          [enum.next]
-        rescue StopIteration
-          []
-        end
-      else
-        creneaux_builder_for_date_service.perform
-      end
-    end.compact
+      CreneauxBuilderForDateService
+        .perform_with(plage_ouverture, motif, occurence.starts_at.to_date, @lieu, inclusive_date_range: @inclusive_date_range, **@options)
+    end
   end
 end

--- a/app/services/find_availability_service.rb
+++ b/app/services/find_availability_service.rb
@@ -9,15 +9,15 @@ class FindAvailabilityService < BaseService
   def perform
     available_creneau = nil
     @from.step(@from + 6.months, 7).find do |date|
-      creneaux = CreneauxBuilderService
+      available_creneau = CreneauxBuilderService
         .perform_with(
           @motif_name,
           @lieu,
           date..(date + 7.days),
           plages_ouvertures: plages_ouvertures_cached,
+          only_first: true,
           **@creneaux_builder_options
-        )
-      available_creneau = creneaux.first if creneaux.any?
+        )&.first
     end
     available_creneau
   end

--- a/app/services/find_availability_service.rb
+++ b/app/services/find_availability_service.rb
@@ -9,23 +9,45 @@ class FindAvailabilityService < BaseService
   def perform
     available_creneau = nil
     @from.step(@from + 6.months, 7).find do |date|
-      available_creneau = CreneauxBuilderService
-        .perform_with(
-          @motif_name,
-          @lieu,
-          date..(date + 7.days),
-          plages_ouvertures: plages_ouvertures_cached,
-          only_first: true,
-          **@creneaux_builder_options
-        )&.first
+      inclusive_date_range = date..(date + 7.days)
+      uniq_by = @for_agents ? ->(c) { [c.starts_at, c.agent_id] } : ->(c) { c.starts_at }
+      available_creneau = plages_ouverture_and_motif_pairs
+        .flat_map { |po, motif| creneaux_for_plage_ouverture_and_motif(po, motif, inclusive_date_range) }
+        .select { |c| c.starts_at >= Time.zone.now }
+        .uniq(&uniq_by)
+        .min_by(&:starts_at)
     end
     available_creneau
   end
 
   private
 
-  def plages_ouvertures_cached
-    @plages_ouvertures_cached ||= CreneauxBuilderService
+  def plages_ouverture_and_motif_pairs
+    @plages_ouverture_and_motif_pairs ||= plages_ouvertures
+      .flat_map { |po| motifs_for_plage_ouverture(po).map { [po, _1] } }
+  end
+
+  def motifs_for_plage_ouverture(plage_ouverture)
+    motifs = plage_ouverture.motifs.where(name: @motif_name).active
+    motifs = motifs.where(location_type: @motif_location_type) if @motif_location_type.present?
+    @for_agents ? motifs : motifs.reservable_online
+  end
+
+  def creneaux_for_plage_ouverture_and_motif(plage_ouverture, motif, inclusive_date_range)
+    plage_ouverture.occurences_for(inclusive_date_range).flat_map do |occurence|
+      [
+        CreneauxBuilderForDateService
+          .new(plage_ouverture, motif, occurence.starts_at.to_date, @lieu, inclusive_date_range: inclusive_date_range, **@creneaux_builder_options)
+          .next_creneaux_enumerator
+          .next
+      ]
+    rescue StopIteration
+      []
+    end.compact
+  end
+
+  def plages_ouvertures
+    @plages_ouvertures ||= CreneauxBuilderService
       .new(@motif_name, @lieu, @from..(@from + 7.days))
       .plages_ouvertures
   end

--- a/app/services/has_plage_ouvertures_concern.rb
+++ b/app/services/has_plage_ouvertures_concern.rb
@@ -1,0 +1,8 @@
+module HasPlageOuverturesConcern
+  def plages_ouvertures
+    @plages_ouvertures ||= PlageOuverture
+      .not_expired_for_motif_name_and_lieu(@motif_name, @lieu)
+      .where(({ agent_id: @agent_ids } unless @agent_ids.nil?))
+      .where(({ motifs: { location_type: @motif_location_type } } if @motif_location_type.present?))
+  end
+end

--- a/app/services/jours_feries_service.rb
+++ b/app/services/jours_feries_service.rb
@@ -37,4 +37,8 @@ class JoursFeriesService
       end
     end
   end
+
+  def self.includes?(date)
+    date.in?(JOURS_FERIES_2020 + JOURS_FERIES_2021)
+  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ default: &default
 
 development:
   <<: *default
-  database: lapin_development
+  database: rdv_solidarites_production_dump
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/scripts/anonymize_db.rb
+++ b/scripts/anonymize_db.rb
@@ -1,0 +1,9 @@
+User.all.each do |u|
+  u.update!(
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
+    phone_number: u.phone_number.present? ? Faker::Base.numerify("06 ## ## ## ##") : nil,
+    affiliation_number: u.affiliation_number.present? ? Faker::Base.numerify("############") : nil,
+    address: Faker::Address.street_address
+  )
+end

--- a/scripts/benchmark_pos.rb
+++ b/scripts/benchmark_pos.rb
@@ -1,10 +1,23 @@
 require "benchmark"
-ActiveRecord::Base.logger = nil
+# ActiveRecord::Base.logger = nil
 
 motif_name = "Je souhaite avoir un entretien avec mon référent"
 location_type = "public_office"
 date_range = (Date.today..(Date.today + 6.days))
-lieux = Organisation.find(101).lieux.for_motif(Motif.find(800))
+lieux = Organisation.find(101).lieux.for_motif(Motif.find(800)) # [153, 151, 344]
+
+# res = Benchmark.measure do
+#   SearchCreneauxForAgentsService.perform_with(
+#     OpenStruct.new(
+#       motif: Motif.find(800),
+#       agent_ids: nil,
+#       date_range: date_range,
+#       organisation: Organisation.find(101),
+#       lieu_ids: []
+#     )
+#   )
+# end
+# puts res
 
 res = Benchmark.measure do
   lieux.each do |lieu|

--- a/scripts/benchmark_pos.rb
+++ b/scripts/benchmark_pos.rb
@@ -1,8 +1,6 @@
 require "benchmark"
-# ActiveRecord::Base.logger = nil
+ActiveRecord::Base.logger = nil
 
-motif_name = "Je souhaite avoir un entretien avec mon référent"
-location_type = "public_office"
 date_range = (Date.today..(Date.today + 6.days))
 lieux = Organisation.find(101).lieux.for_motif(Motif.find(800)) # [153, 151, 344]
 
@@ -19,32 +17,100 @@ lieux = Organisation.find(101).lieux.for_motif(Motif.find(800)) # [153, 151, 344
 # end
 # puts res
 
-res = Benchmark.measure do
-  lieux.each do |lieu|
-    FindAvailabilityService.perform_with(
-      motif_name,
-      lieu,
-      date_range.begin,
-      motif_location_type: location_type
-    )
-  end
-end
-puts(res)
+# StackProf.run(mode: :cpu, out: 'tmp/stackprof-cpu-myapp.dump') do
+# res = Benchmark.measure do
+#   lieux.each do |lieu|
+#     FindAvailabilityService.perform_with(
+#       Motif.find(800).name,
+#       lieu,
+#       Date.today,
+#       for_agents: true,
+#       motif_location_type: Motif.find(800).location_type
+#     )
+#   end
+# end
+# puts(res)
+# puts "----"
+# puts(CreneauxBuilderForDateService.total_time)
+# puts(FindAvailabilityService.total_time)
+# puts(res.to_a.last)
+# end
 # 13s
 
 puts "-----------"
 puts "-----------"
 puts "-----------"
 
-res = Benchmark.measure do
-  lieux.each do |lieu|
-    CreneauxBuilderService.perform_with(
-      motif_name,
-      lieu,
-      date_range,
-      for_agents: true,
-      motif_location_type: location_type
-    )
+# res = Benchmark.measure do
+#   lieux.each do |lieu|
+#     CreneauxBuilderService.perform_with(
+#       motif_name,
+#       lieu,
+#       date_range,
+#       for_agents: true,
+#       motif_location_type: location_type
+#     )
+#   end
+# end
+# puts(res)
+
+puts(
+  Benchmark.measure do
+    PlageOuverture
+      .where(lieu: Lieu.find(151))
+      .not_expired
+      .joins(:motifs)
+      .where(motifs: { name: "Je souhaite avoir un entretien avec mon référent", organisation_id: 101 })
+      .includes(:motifs_plageouvertures, :motifs, agent: :absences)
+      .to_a
   end
-end
-puts(res)
+)
+
+
+  # def index
+  #   PlageOuverture
+  #     .where(lieu: Lieu.find(151))
+  #     .not_expired
+  #     .joins(:motifs)
+  #     .where(motifs: { name: "Je souhaite avoir un entretien avec mon référent", organisation_id: 101 })
+  #     .to_a
+  #     # .includes(:motifs_plageouvertures, :motifs, agent: :absences)
+  # end
+
+  def index
+    # StackProf.run(mode: :cpu, out: 'tmp/stackprof-cpu-myapp.dump') do
+    benchmark "benchmark around SearchCreneauxForAgentsService", silence: true do
+      # SearchCreneauxForAgentsService.perform_with(
+      #   OpenStruct.new(
+      #     motif: Motif.find(800),
+      #     agent_ids: nil,
+      #     date_range: (Date.today..(Date.today + 6.days)),
+      #     organisation: Organisation.find(101),
+      #     lieu_ids: []
+      #   )
+      # )
+      lieux = Organisation.find(101).lieux.for_motif(Motif.find(800)) # [153, 151, 344]
+      # FindAvailabilityService.reset_time
+      lieux.each do |lieu|
+        FindAvailabilityService.perform_with(
+          Motif.find(800).name,
+          lieu,
+          Date.today,
+          for_agents: true,
+          motif_location_type: Motif.find(800).location_type
+        )
+      end
+      # puts("FindAvailabilityService.total_time : #{FindAvailabilityService.total_time}")
+      # lieux.each do |lieu|
+      #   CreneauxBuilderService.perform_with(
+      #     Motif.find(800).name,
+      #     lieu,
+      #     (Date.today..(Date.today + 6.days)),
+      #     for_agents: true,
+      #     motif_location_type: Motif.find(800).location_type
+      #   )
+      # end
+    # end
+    # @search_results = []
+    end
+  end

--- a/scripts/benchmark_pos.rb
+++ b/scripts/benchmark_pos.rb
@@ -1,0 +1,37 @@
+require "benchmark"
+ActiveRecord::Base.logger = nil
+
+motif_name = "Je souhaite avoir un entretien avec mon référent"
+location_type = "public_office"
+date_range = (Date.today..(Date.today + 6.days))
+lieux = Organisation.find(101).lieux.for_motif(Motif.find(800))
+
+res = Benchmark.measure do
+  lieux.each do |lieu|
+    FindAvailabilityService.perform_with(
+      motif_name,
+      lieu,
+      date_range.begin,
+      motif_location_type: location_type
+    )
+  end
+end
+puts(res)
+# 13s
+
+puts "-----------"
+puts "-----------"
+puts "-----------"
+
+res = Benchmark.measure do
+  lieux.each do |lieu|
+    CreneauxBuilderService.perform_with(
+      motif_name,
+      lieu,
+      date_range,
+      for_agents: true,
+      motif_location_type: location_type
+    )
+  end
+end
+puts(res)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
   config.include Select2SpecHelper
   config.include RdvSpecHelper
   config.include ApiSpecHelper
+  config.include DatesSpecHelper
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Warden::Test::Helpers, type: :feature

--- a/spec/services/creneaux_builder_service_spec.rb
+++ b/spec/services/creneaux_builder_service_spec.rb
@@ -3,7 +3,7 @@ describe CreneauxBuilderService, type: :service do
   let!(:motif) { create(:motif, name: "Vaccination", default_duration_in_min: 30, reservable_online: reservable_online, organisation: organisation, location_type: :public_office) }
   let(:reservable_online) { true }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let(:today) { Date.new(2020, 12, 10) }
+  let(:today) { get_next_week_working_weekday(:thursday, consecutive_working_days: 8) }
   let(:tomorrow) { today + 1.day }
   let(:six_days_later) { today + 6.days }
   let!(:agent) { create(:agent, organisations: [organisation]) }

--- a/spec/support/dates_spec_helper.rb
+++ b/spec/support/dates_spec_helper.rb
@@ -1,0 +1,10 @@
+module DatesSpecHelper
+  def get_next_week_working_weekday(weekday_name, consecutive_working_days: 1)
+    d = Date.today.next_week(weekday_name)
+    loop do
+      return d if consecutive_working_days.times.none? { |offset| JoursFeriesService.includes?(d + offset.days) }
+
+      d += 7.days
+    end
+  end
+end

--- a/spec/support/dates_spec_helper_spec.rb
+++ b/spec/support/dates_spec_helper_spec.rb
@@ -1,0 +1,27 @@
+describe DatesSpecHelper, type: :helper do
+  describe "#get_next_week_working_weekday" do
+    context "next weekday is not a holiday" do
+      before { travel_to(Date.new(2020, 12, 15)) }
+      subject { get_next_week_working_weekday(:monday) }
+      it { should eq(Date.new(2020, 12, 21)) }
+    end
+
+    context "next weekday is a holiday" do
+      before { travel_to(Date.new(2020, 12, 19)) }
+      subject { get_next_week_working_weekday(:friday) } # next fridays are christmas then nye
+      it { should eq(Date.new(2021, 1, 8)) } # thus it skips 2 fridays
+    end
+
+    context "next weekday's day after is a holiday, with default 1 day inclusion" do
+      before { travel_to(Date.new(2020, 12, 19)) }
+      subject { get_next_week_working_weekday(:thursday) } # next friday is christmas
+      it { should eq(Date.new(2020, 12, 24)) }
+    end
+
+    context "next weekday's day after is a holiday, with 2 days inclusion" do
+      before { travel_to(Date.new(2020, 12, 19)) }
+      subject { get_next_week_working_weekday(:thursday, consecutive_working_days: 2) } # next fridays are christmas then nye
+      it { should eq(Date.new(2021, 1, 7)) } # thus it skips 2 thursdays
+    end
+  end
+end


### PR DESCRIPTION
```

# find orgas with lots of agents and plage ouvertures

Agent.joins(:plage_ouvertures).all.flat_map { |agent| agent.organisations.map { [_1.id, agent.id] } }.group_by(&:first).transform_values { _1.count }.map { [_1
, _2] }.sort_by(&:last)

# find motif with lots of plage ouvertures

PlageOuverture.where(organisation_id: 101).flat_map { |po| po.motifs.map { [_1.id, po.id] } }.group_by(&:first).transform_values(&:count).to_a.sort_by(&:last)
```

=> le motif "Je souhaite avoir un entretien avec mon référent", sur place dans MDS Noisiel est un bon exemple de lenteur.

http://localhost:5000/admin/organisations/101/agent_searches?service_id=&motif_id=800&from_date=24%2F12%2F2020&agent_ids[]=&lieu_ids[]=&commit=Afficher+les+cr%C3%A9neaux