### PR TITLE
affiche un bloc de rdvs courant

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
   end
 
   def next_rdvs(organisation)
-    rdvs_for_organisation(organisation).future
+    rdvs_for_organisation(organisation).where("starts_at > ?", Time.zone.now - 2.hours)
   end
 
   def rdvs_for_organisation(organisation)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,8 +124,8 @@ class User < ApplicationRecord
       .empty?
   end
 
-  def previous_rdvs(organisation)
-    rdvs_for_organisation(organisation).past.limit(5)
+  def previous_rdvs_ordered_and_truncated(organisation)
+    rdvs_for_organisation(organisation).past.order(starts_at: :desc).limit(5)
   end
 
   def next_rdvs(organisation)
@@ -137,7 +137,7 @@ class User < ApplicationRecord
   end
 
   def rdvs_for_organisation(organisation)
-    Rdv.where(organisation: organisation).with_user_in([self]).order("starts_at desc")
+    Rdv.where(organisation: organisation).with_user_in([self])
   end
 
   def email_tld

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,16 @@ class User < ApplicationRecord
   end
 
   def next_rdvs(organisation)
-    rdvs_for_organisation(organisation).where("starts_at > ?", Time.zone.now - 2.hours)
+    rdvs_for_organisation(organisation).future
+  end
+
+  def current_rdv(organisation)
+    rdvs = rdvs_for_organisation(organisation).for_today
+    rdvs.select do |rdv|
+      start_period = rdv.starts_at - 1.hour
+      end_period = rdv.starts_at + rdv.duration_in_min.minutes + 1.hour
+      start_period <= Time.zone.now && Time.zone.now <= end_period
+    end
   end
 
   def rdvs_for_organisation(organisation)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,13 +132,8 @@ class User < ApplicationRecord
     rdvs_for_organisation(organisation).future
   end
 
-  def current_rdv(organisation)
-    rdvs = rdvs_for_organisation(organisation).for_today
-    rdvs.select do |rdv|
-      start_period = rdv.starts_at - 1.hour
-      end_period = rdv.starts_at + rdv.duration_in_min.minutes + 1.hour
-      start_period <= Time.zone.now && Time.zone.now <= end_period
-    end
+  def ongoing_rdvs(organisation)
+    rdvs_for_organisation(organisation).ongoing(time_margin: 1.hour)
   end
 
   def rdvs_for_organisation(organisation)

--- a/app/views/admin/rdvs/_short_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_short_rdvs_list.html.slim
@@ -1,19 +1,19 @@
 .card
   .card-header= title
-  .card-body
-    - if rdvs.empty?
+  - if rdvs.empty?
+    .card-body
       .text-muted aucun #{title.downcase}
-    - rdvs.reverse.each do |rdv|
-      .mb-2
-        strong= link_to rdv_title(rdv), admin_organisation_rdv_path(current_organisation, rdv)
-        = rdv_status_tag(rdv)
-        div
-          = rdv.motif.name
+  - else
+    ul.list-unstyled.horizontal-border-between-items
+      - rdvs.each do |rdv|
+        li.card-body.py-2
+          strong= link_to rdv_title(rdv), admin_organisation_rdv_path(current_organisation, rdv)
+          = rdv_status_tag(rdv)
           div
-            - if rdv.context.blank?
-              .text-muted  Pas de contexte renseigné
-            - else
-              .text-muted Contexte :
-              .border-left.pl-2= simple_format(rdv.context)
-        - if rdvs.last != rdv
-          hr
+            = rdv.motif.name
+            div
+              - if rdv.context.blank?
+                .text-muted Pas de contexte renseigné
+              - else
+                .text-muted Contexte :
+                .border-left.pl-2= simple_format(rdv.context)

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -76,7 +76,7 @@
                 i.fa.fa-fw.fa-info-circle>
               div= simple_format(user.notes_for(current_organisation))
 
-      = render "admin/rdvs/short_rdvs_list", user: user, rdvs: user.previous_rdvs(current_organisation), title: "Rendez-vous précédents"
+      = render "admin/rdvs/short_rdvs_list", user: user, rdvs: user.previous_rdvs_ordered_and_truncated(current_organisation), title: "Rendez-vous précédents"
 
 .row
   .col-md-12

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -76,7 +76,7 @@
                 i.fa.fa-fw.fa-info-circle>
               div= simple_format(user.notes_for(current_organisation))
 
-      = render "admin/rdvs/short_rdvs_list", user: user, rdvs: user.previous_rdvs(current_organisation), title: "Rendez-vous précédent"
+      = render "admin/rdvs/short_rdvs_list", user: user, rdvs: user.previous_rdvs(current_organisation), title: "Rendez-vous précédents"
 
 .row
   .col-md-12

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -102,9 +102,9 @@
 
   .col-md-6
 
-    - if @user.current_rdv(current_organisation)
-      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.current_rdv(current_organisation), title: "Rendez-vous en cours (+/- 1 heure)"
-    = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.next_rdvs(current_organisation), title: "Prochain rendez-vous"
+    - if @user.ongoing_rdvs(current_organisation)
+      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.ongoing_rdvs(current_organisation), title: "Rendez-vous en cours (+/- 1 heure)"
+    = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.next_rdvs(current_organisation), title: "Prochains rendez-vous"
 
     .card
       .card-header
@@ -144,5 +144,3 @@
               p.h2= @rdvs.notexcused.count
               p.lead= t 'stats.rdv_counters.rdvs.notexcused', count: @rdvs.notexcused.count
               = link_to "Voir", admin_organisation_rdvs_path(current_organisation, user_id: @user.id, breadcrumb_page: "user", status: "notexcused"), class: "btn btn-outline-white"
-
-

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -102,6 +102,8 @@
 
   .col-md-6
 
+    - if @user.current_rdv(current_organisation)
+      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.current_rdv(current_organisation), title: "Rendez-vous en cours (+/- 1 heure)"
     = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.next_rdvs(current_organisation), title: "Prochain rendez-vous"
 
     .card

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -103,8 +103,8 @@
   .col-md-6
 
     - if @user.ongoing_rdvs(current_organisation)
-      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.ongoing_rdvs(current_organisation), title: "Rendez-vous en cours (+/- 1 heure)"
-    = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.next_rdvs(current_organisation), title: "Prochains rendez-vous"
+      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.ongoing_rdvs(current_organisation).order(starts_at: :asc), title: "Rendez-vous en cours (+/- 1 heure)"
+    = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: @user.next_rdvs(current_organisation).order(starts_at: :asc), title: "Prochains rendez-vous"
 
     .card
       .card-header

--- a/app/webpacker/stylesheets/components/_utilities.scss
+++ b/app/webpacker/stylesheets/components/_utilities.scss
@@ -35,3 +35,12 @@ a[disabled] {
 .flex-gap-1em {
   gap: 0 1em;
 }
+
+ul.horizontal-border-between-items {
+  li {
+    border-bottom: 1px solid #eee;
+  }
+  li:last-child {
+    border-bottom: none;
+  }
+}

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -14,7 +14,7 @@ describe "can see users' RDV" do
     before { click_link user.full_name }
     it do
       expect(page).to have_content("0\nÀ venir")
-      expect(page).to have_content("aucun prochain rendez-vous")
+      expect(page).to have_content("aucun prochains rendez-vous")
     end
   end
 

--- a/spec/lib/phonelib_spec.rb
+++ b/spec/lib/phonelib_spec.rb
@@ -1,0 +1,34 @@
+describe "Phonelib" do
+  describe "phone_number formatted normalization" do
+    context "on create" do
+      it "return nil with nil phone number" do
+        expect(create(:user, phone_number: nil).phone_number_formatted).to eq(nil)
+      end
+
+      it "return nil with a blank phone number" do
+        expect(create(:user, phone_number: "").phone_number_formatted).to eq(nil)
+      end
+
+      it "return valid +33 given phone number" do
+        expect(create(:user, phone_number: "01 30 30 40 40").phone_number_formatted).to eq("+33130304040")
+      end
+
+      it "not save with an invalid phone number" do
+        expect(build(:user, phone_number: "01 30 20").save).to be false
+      end
+    end
+
+    context "on update" do
+      context "previous phone number" do
+        it "should update it" do
+          user = create(:user, phone_number: "01 30 30 40 40")
+          expect(user.phone_number_formatted).to eq("+33130304040")
+          user.update!(phone_number: "04 300 32020")
+          expect(user.phone_number_formatted).to eq("+33430032020")
+          user.update!(phone_number: "")
+          expect(user.phone_number_formatted).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -287,4 +287,54 @@ describe Rdv, type: :model do
       expect(Rdv.for_today).to eq([rdv])
     end
   end
+
+  describe "Rdv.ongoing" do
+    context "without time_margin" do
+      subject { Rdv.ongoing }
+
+      context "rdv ongoing" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now - 30.minutes, duration_in_min: 45) }
+        it { should include(rdv) }
+      end
+
+      context "rdv finished shortly before" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now - 30.minutes, duration_in_min: 15) }
+        it { should_not include(rdv) }
+      end
+
+      context "rdv starting shortly after" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now + 30.minutes, duration_in_min: 15) }
+        it { should_not include(rdv) }
+      end
+    end
+
+    context "with 1 hour time_margin" do
+      subject { Rdv.ongoing(time_margin: 1.hour) }
+
+      context "rdv ongoing" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now - 30.minutes, duration_in_min: 45) }
+        it { should include(rdv) }
+      end
+
+      context "rdv finished shortly before" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now - 30.minutes, duration_in_min: 15) }
+        it { should include(rdv) }
+      end
+
+      context "rdv finished long before" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now - 2.hours, duration_in_min: 15) }
+        it { should_not include(rdv) }
+      end
+
+      context "rdv starting shortly after" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now + 30.minutes, duration_in_min: 15) }
+        it { should include(rdv) }
+      end
+
+      context "rdv starting long after" do
+        let!(:rdv) { create(:rdv, starts_at: Time.zone.now + 2.hours, duration_in_min: 15) }
+        it { should_not include(rdv) }
+      end
+    end
+  end
 end

--- a/spec/models/user_phone_spec.rb
+++ b/spec/models/user_phone_spec.rb
@@ -1,4 +1,4 @@
-describe "Phonelib" do
+describe "User#phone_number & User#phone_number_formatted" do
   describe "phone_number formatted normalization" do
     context "on create" do
       it "return nil with nil phone number" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -353,6 +353,19 @@ describe User, type: :model do
 
       expect(user.next_rdvs(organisation)).to eq([future_rdv])
     end
+
+    it "returns current rdv" do
+      now = Time.new(2020, 5, 23, 15, 56)
+      travel_to(now)
+
+      organisation = create(:organisation)
+      user = create(:user, organisations: [organisation])
+      create(:rdv, users: [user], starts_at: now - 1.day)
+      create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
+      current_rdv = create(:rdv, starts_at: now - 2.minutes, organisation: organisation, users: [user])
+
+      expect(user.next_rdvs(organisation)).to eq([current_rdv])
+    end
   end
 
   # cf https://github.com/heartcombo/devise/wiki/How-To:-Email-only-sign-up

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -341,7 +341,7 @@ describe User, type: :model do
       expect(user.next_rdvs(organisation)).to eq([next_rdv])
     end
 
-    it "returns only future rdv" do
+    it "returns only future rdv including current RDV (from 2 hours)" do
       today = Time.new(2020, 5, 23, 15, 56)
       travel_to(today)
 
@@ -350,21 +350,9 @@ describe User, type: :model do
       create(:rdv, users: [user], starts_at: today - 1.day)
       create(:rdv, starts_at: today - 4.days, organisation: organisation, users: [user])
       future_rdv = create(:rdv, starts_at: today + 4.days, organisation: organisation, users: [user])
-
-      expect(user.next_rdvs(organisation)).to eq([future_rdv])
-    end
-
-    it "returns current rdv" do
-      now = Time.new(2020, 5, 23, 15, 56)
-      travel_to(now)
-
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user], starts_at: now - 1.day)
-      create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
       current_rdv = create(:rdv, starts_at: now - 2.minutes, organisation: organisation, users: [user])
 
-      expect(user.next_rdvs(organisation)).to eq([current_rdv])
+      expect(user.next_rdvs(organisation).sort).to eq([current_rdv, future_rdv].sort)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -227,12 +227,12 @@ describe User, type: :model do
     end
   end
 
-  describe "#previous_rdvs" do
+  describe "#previous_rdvs_ordered_and_truncated" do
     it "return empty array without previous rdv" do
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
       create(:rdv, users: [user])
-      expect(user.previous_rdvs(organisation)).to eq([])
+      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([])
     end
 
     it "return rdv for same user and organisation" do
@@ -243,7 +243,7 @@ describe User, type: :model do
       create(:rdv, users: [user])
       previous_rdv = create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user])
 
-      expect(user.previous_rdvs(organisation)).to eq([previous_rdv])
+      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([previous_rdv])
     end
 
     it "return only 5 last previous rdv order by starts_at desc" do
@@ -258,7 +258,7 @@ describe User, type: :model do
       p2 = create(:rdv, starts_at: rdv.starts_at - 2.day, organisation: organisation, users: [user])
       p3 = create(:rdv, starts_at: rdv.starts_at - 4.day, organisation: organisation, users: [user])
 
-      expect(user.previous_rdvs(organisation)).to eq([p1, p2, p3, p4, p5])
+      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([p1, p2, p3, p4, p5])
     end
 
     it "returns only past rdv" do
@@ -269,7 +269,7 @@ describe User, type: :model do
       rdv = create(:rdv, users: [user], starts_at: today - 2.days)
       past_rdv = create(:rdv, starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user])
       create(:rdv, starts_at: rdv.starts_at + 4.days, organisation: organisation, users: [user])
-      expect(user.previous_rdvs(organisation)).to eq([past_rdv])
+      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([past_rdv])
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -273,28 +273,6 @@ describe User, type: :model do
     end
   end
 
-  describe "#current_rdv" do
-    it "return nil without current rdv" do
-      now = Time.new(2020, 5, 23, 15, 56)
-      travel_to(now)
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user], starts_at: now - 1.day, organisation: organisation)
-      expect(user.current_rdv(organisation)).to be_empty
-    end
-
-    it "return rdv that currently happen" do
-      now = Time.new(2020, 5, 23, 15, 56)
-      travel_to(now)
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user], starts_at: now - 2.hours, duration_in_min: 30, organisation: organisation)
-      rdv = create(:rdv, users: [user], starts_at: now - 20.minutes, duration_in_min: 30, organisation: organisation)
-      create(:rdv, users: [user], starts_at: now + 2.hours, duration_in_min: 30, organisation: organisation)
-      expect(user.current_rdv(organisation)).to eq([rdv])
-    end
-  end
-
   describe "#next_rdvs" do
     it "return empty array without next rdv" do
       organisation = create(:organisation)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -342,14 +342,14 @@ describe User, type: :model do
     end
 
     it "returns only future rdv including current RDV (from 2 hours)" do
-      today = Time.new(2020, 5, 23, 15, 56)
-      travel_to(today)
+      now = Time.new(2020, 5, 23, 15, 56)
+      travel_to(now)
 
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user], starts_at: today - 1.day)
-      create(:rdv, starts_at: today - 4.days, organisation: organisation, users: [user])
-      future_rdv = create(:rdv, starts_at: today + 4.days, organisation: organisation, users: [user])
+      create(:rdv, users: [user], starts_at: now - 1.day)
+      create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
+      future_rdv = create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])
       current_rdv = create(:rdv, starts_at: now - 2.minutes, organisation: organisation, users: [user])
 
       expect(user.next_rdvs(organisation).sort).to eq([current_rdv, future_rdv].sort)


### PR DESCRIPTION
https://trello.com/c/pYTq6GJX/1195-afficher-le-bloc-rdvs-precedents-sur-la-vue-usager


Après une discussion en visio avec Élodie du 62, nous avons conclu que le mieux serait d'avoir un encart sur le rendez-vous courant. Pour déterminer ce rendez-vous, 

![Capture d’écran de 2020-12-18 18-38-33](https://user-images.githubusercontent.com/42057/102644073-8345fd00-4160-11eb-9bc3-9c30aeaa3d8a.png)

Le bloc n'apparait pas quand il n'y a pas de rendez-vous courant

![Capture d’écran de 2020-12-18 18-39-14](https://user-images.githubusercontent.com/42057/102644068-8214d000-4160-11eb-98bf-5fe1bd101f99.png)

Je n'ai pas réussi à trouver une belle requête SQL qui fait sa en une fois... Du coup j'ai:
- récupéré l'ensemble des rdv du jour
- défini un début de période à une heure avant le rendez-vous
- défini une fin de période à une heure après la fin du rendez-vous
- selectionné les rdv dont maintenant tombe dans la période élargie.

J'ai re-utilisé la vue partielle de liste courte de rendez-vous car il peut y avoir plusieurs rdvs en court.