### PR TITLE
affiche les labels sur les champs d'inscription

### DIFF
--- a/app/views/devise/invitations/edit.html.slim
+++ b/app/views/devise/invitations/edit.html.slim
@@ -5,8 +5,8 @@
   = devise_error_messages!
   = f.hidden_field :invitation_token
   .form-row
-    .col-md-6= f.input :first_name, placeholder: 'Prénom', label: false
-    .col-md-6= f.input :last_name, placeholder: 'Nom', label: false
+    .col-md-6= f.input :first_name, placeholder: 'Dominique'
+    .col-md-6= f.input :last_name, placeholder: 'DUPONT'
   .form-group
     = f.label :password
     = f.password_field :password, required: true, class: 'form-control ', placeholder: 'Votre mot de passe', id: "password"


### PR DESCRIPTION
https://trello.com/c/58xrngIl/1194-label-explicite-pour-linscription-agent

![Capture d’écran de 2020-12-17 11-46-45](https://user-images.githubusercontent.com/42057/102478159-92905200-405d-11eb-8f4d-d135ccb54d05.png)
