### PR TITLE
updating RDV statuses should skip warnings

### DIFF
--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -17,7 +17,7 @@ ul.list-unstyled.topbar-right-menu.float-right.mb-0
             admin_organisation_rdv_path( \
               rdv.organisation, \
               rdv, \
-              rdv: { status: status[1] }, \
+              rdv: { status: status[1], active_warnings_confirm_decision: true }, \
               agent_id: local_assigns[:agent]&.id, \
               format: local_assigns[:remote] ? 'json' : 'html' \
             ), \

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -36,7 +36,7 @@
         .row
           .col
             - if !@rdv.past? && !@rdv.cancelled?
-              = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, rdv: {status: :excused}, agent_id: @agent&.id), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
+              = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, rdv: {status: :excused, active_warnings_confirm_decision: true}, agent_id: @agent&.id), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
               | ou
             = link_to "Supprimer ❌", admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
 


### PR DESCRIPTION
bug remonté par Elodie : 
- lorsqu'on essaie de modifier le statut d'un RDV, via le bouton annuler OU via le dropdown
- on peut se prendre un avertissement "ca va laisser un trou" et ca ramene au formulaire d'edition

quickfix: skipper les warnings depuis le bouton annuler et le dropdown d'update de statut