### PR TITLE
improve creneaux search perfs by removing extraneous includes

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -42,12 +42,11 @@ class PlageOuverture < ApplicationRecord
 
   def self.not_expired_for_motif_name_and_lieu(motif_name, lieu)
     PlageOuverture
-      .includes(:motifs_plageouvertures)
       .where(lieu: lieu)
       .not_expired
       .joins(:motifs)
       .where(motifs: { name: motif_name, organisation_id: lieu.organisation_id })
-      .includes(:motifs, agent: :absences)
+      .includes(:agent)
   end
 
   def expired?


### PR DESCRIPTION
cc #1027 

sur un dump de prod sur ce cas long : http://localhost:5000/admin/organisations/101/agent_searches?service_id=&motif_id=800&from_date=24%2F12%2F2020&agent_ids%5B%5D=&lieu_ids%5B%5D=&commit=Afficher+les+cr%C3%A9neaux

on passe de : 
- 22s a 5s 
- de 13M d'allocs à  3M 