### PR TITLE
ajoute mineur/majeur dans l'export stat orga

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -15,7 +15,7 @@ class Admin::RdvsController < AgentAuthController
       .order(starts_at: :desc)
     @breadcrumb_page = params[:breadcrumb_page]
     respond_to do |format|
-      format.xls { send_data(RdvExporterService.perform_with(@rdvs, StringIO.new), filename: "rdvs.xls", type: "application/xls") }
+      format.xls { send_data(RdvExporter.export(@rdvs, StringIO.new), filename: "rdvs.xls", type: "application/xls") }
       format.html { @rdvs = @rdvs.page(params[:page]) }
       format.json
     end

--- a/app/services/rdv_exporter_service.rb
+++ b/app/services/rdv_exporter_service.rb
@@ -8,6 +8,7 @@ class RdvExporterService < BaseService
     "heure prise rdv",
     "date rdv",
     "heure rdv",
+    "usager mineur/majeur",
     "motif",
     "pris par",
     "statut",
@@ -51,6 +52,7 @@ class RdvExporterService < BaseService
       rdv.created_at.to_time,
       rdv.starts_at.to_date,
       rdv.starts_at.to_time,
+      majeur_ou_mineur(rdv),
       rdv.motif.name,
       TYPE[rdv.created_by],
       ::Rdv.human_enum_name(:status, rdv.status),
@@ -58,5 +60,13 @@ class RdvExporterService < BaseService
       rdv.motif.service.name,
       rdv.agents.map(&:full_name).join(", ")
     ]
+  end
+
+  def majeur_ou_mineur(rdv)
+    rdv.users.select{ mineur?(_1.birth_date) }.any? ? "mineur" : "majeur"
+  end
+
+  def mineur?(birth_date)
+    ((Time.zone.now - birth_date.to_time) / 1.year.seconds).floor < 18
   end
 end

--- a/spec/service_functions/rdv_exporter_spec.rb
+++ b/spec/service_functions/rdv_exporter_spec.rb
@@ -1,23 +1,21 @@
-describe RdvExporterService, type: :service do
+describe RdvExporter, type: :service do
+  it "return a string" do
+    expect(RdvExporter.export([], StringIO.new)).to be_kind_of(String)
+  end
+
   it "build a workbook" do
-    rdv_stat_builder = RdvExporterService.new([], StringIO.new)
-    expect(rdv_stat_builder.workbook).to be_kind_of(Spreadsheet::Workbook)
+    expect(RdvExporter.build_workbook([])).to be_kind_of(Spreadsheet::Workbook)
   end
 
-  it "have a work sheet in workbook" do
-    rdv_stat_builder = RdvExporterService.new([], StringIO.new)
-    expect(rdv_stat_builder.workbook.worksheet(0)).to be_kind_of(Spreadsheet::Worksheet)
-  end
-
-  context "with a sheet inside" do
+  context "with a sheet inside," do
     it "have an header" do
-      sheet = RdvExporterService.new([], StringIO.new).workbook.worksheet(0)
+      sheet = RdvExporter.build_workbook([]).worksheet(0)
       expect(sheet.row(0)).to eq(["année", "date prise rdv", "heure prise rdv", "date rdv", "heure rdv", "usager mineur/majeur", "motif", "pris par", "statut", "lieu du rdv", "service", "agents"])
     end
 
     it "have a line for a RDV" do
       rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33))
-      sheet = RdvExporterService.new([rdv], StringIO.new).workbook.worksheet(0)
+      sheet = RdvExporter.build_workbook([rdv]).worksheet(0)
       expect(sheet.row(1)[0]).to eq(2020)
       expect(sheet.row(1)[1]).to eq(rdv.created_at.to_date)
       expect(sheet.row(1)[2].min).to eq(rdv.created_at.to_time.min)
@@ -36,7 +34,7 @@ describe RdvExporterService, type: :service do
   it "return empty lieu when it's phone rdv" do
     motif = build(:motif, :by_phone)
     rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33), motif: motif, lieu: nil)
-    sheet = RdvExporterService.new([rdv], StringIO.new).workbook.worksheet(0)
+    sheet = RdvExporter.build_workbook([rdv]).worksheet(0)
     expect(sheet.row(1)[9]).to eq("Par téléphone")
   end
 
@@ -46,8 +44,7 @@ describe RdvExporterService, type: :service do
       travel_to(now)
       user = build(:user, birth_date: Date.new(2016, 5, 30))
       rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33), users: [user])
-      exporter = RdvExporterService.new([rdv], StringIO.new)
-      expect(exporter.majeur_ou_mineur(rdv)).to eq("mineur")
+      expect(RdvExporter.majeur_ou_mineur(rdv)).to eq("mineur")
     end
 
     it "return mineur when only one of rdv's user is minor" do
@@ -56,8 +53,7 @@ describe RdvExporterService, type: :service do
       minor_user = build(:user, birth_date: Date.new(2000, 10, 4))
       major_user = build(:user, birth_date: Date.new(2016, 5, 30))
       rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33), users: [major_user, minor_user])
-      exporter = RdvExporterService.new([rdv], StringIO.new)
-      expect(exporter.majeur_ou_mineur(rdv)).to eq("mineur")
+      expect(RdvExporter.majeur_ou_mineur(rdv)).to eq("mineur")
     end
   end
 end

--- a/spec/services/rdv_exporter_service_spec.rb
+++ b/spec/services/rdv_exporter_service_spec.rb
@@ -12,7 +12,7 @@ describe RdvExporterService, type: :service do
   context "with a sheet inside" do
     it "have an header" do
       sheet = RdvExporterService.new([], StringIO.new).workbook.worksheet(0)
-      expect(sheet.row(0)).to eq(["année", "date prise rdv", "heure prise rdv", "date rdv", "heure rdv", "motif", "pris par", "statut", "lieu du rdv", "service", "agents"])
+      expect(sheet.row(0)).to eq(["année", "date prise rdv", "heure prise rdv", "date rdv", "heure rdv", "usager mineur/majeur", "motif", "pris par", "statut", "lieu du rdv", "service", "agents"])
     end
 
     it "have a line for a RDV" do
@@ -23,12 +23,13 @@ describe RdvExporterService, type: :service do
       expect(sheet.row(1)[2].min).to eq(rdv.created_at.to_time.min)
       expect(sheet.row(1)[3]).to eq(rdv.starts_at.to_date)
       expect(sheet.row(1)[4].min).to eq(rdv.starts_at.to_time.min)
-      expect(sheet.row(1)[5]).to eq(rdv.motif.name)
-      expect(sheet.row(1)[6]).to eq("Agent")
-      expect(sheet.row(1)[7]).to eq("Indéterminé")
-      expect(sheet.row(1)[8]).to eq(rdv.address_complete_without_personnal_details)
-      expect(sheet.row(1)[9]).to eq(rdv.motif.service.name)
-      expect(sheet.row(1)[10]).to eq(rdv.agents.map(&:full_name).join(", "))
+      expect(sheet.row(1)[5]).to eq("majeur")
+      expect(sheet.row(1)[6]).to eq(rdv.motif.name)
+      expect(sheet.row(1)[7]).to eq("Agent")
+      expect(sheet.row(1)[8]).to eq("Indéterminé")
+      expect(sheet.row(1)[9]).to eq(rdv.address_complete_without_personnal_details)
+      expect(sheet.row(1)[10]).to eq(rdv.motif.service.name)
+      expect(sheet.row(1)[11]).to eq(rdv.agents.map(&:full_name).join(", "))
     end
   end
 
@@ -36,6 +37,27 @@ describe RdvExporterService, type: :service do
     motif = build(:motif, :by_phone)
     rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33), motif: motif, lieu: nil)
     sheet = RdvExporterService.new([rdv], StringIO.new).workbook.worksheet(0)
-    expect(sheet.row(1)[8]).to eq("Par téléphone")
+    expect(sheet.row(1)[9]).to eq("Par téléphone")
+  end
+
+  describe "#mineur_ou_majeur" do
+    it "return mineur when rdv's user is minor" do
+      now = Time.zone.parse("2020-4-3 13:45")
+      travel_to(now)
+      user = build(:user, birth_date: Date.new(2016, 5, 30))
+      rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33), users: [user])
+      exporter = RdvExporterService.new([rdv], StringIO.new)
+      expect(exporter.majeur_ou_mineur(rdv)).to eq("mineur")
+    end
+
+    it "return mineur when only one of rdv's user is minor" do
+      now = Time.zone.parse("2020-4-3 13:45")
+      travel_to(now)
+      minor_user = build(:user, birth_date: Date.new(2000, 10, 4))
+      major_user = build(:user, birth_date: Date.new(2016, 5, 30))
+      rdv = build(:rdv, created_at: Time.new(2020, 3, 23, 9, 54, 33), users: [major_user, minor_user])
+      exporter = RdvExporterService.new([rdv], StringIO.new)
+      expect(exporter.majeur_ou_mineur(rdv)).to eq("mineur")
+    end
   end
 end


### PR DESCRIPTION
Ajouter la notion de Mineur ou Majeur pour chaque ligne de RDV dans l'export des statistiques par orgnisation.

Dans le cas d'un rendez-vous avec plusieurs usagers, je suis parti du principe que s'il y avait un mineur, il faut déclarer « mineur » dans l'export.

_Ça me fait me demander si le fait de pouvoir mettre plusieurs usager sur un rdv est utilisé et si oui, pourquoi, par qui ? J'ai l'impression que ça complexifie pas mal de règle metier pour un gain mineur_

#1009



