### PR TITLE
Calcul le contraste du texte dans l'agenda

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -1,5 +1,5 @@
 module MotifsHelper
-  DARK_LIGHT_FRONTIER = 128
+  YIQ_DARK_LIGHT_FRONTIER = 128
 
   def motif_name_with_location_type(motif)
     "#{motif.name} (#{Motif.human_enum_name(:location_type, motif.location_type)})"
@@ -35,7 +35,7 @@ module MotifsHelper
   end
 
   def dark_or_light?(color)
-    convert_hexa_color_to_yiq(color) >= DARK_LIGHT_FRONTIER
+    convert_hexa_color_to_yiq(color) >= YIQ_DARK_LIGHT_FRONTIER
   end
 
   def convert_hexa_color_to_yiq(color)

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -1,4 +1,6 @@
 module MotifsHelper
+  DARK_LIGHT_FRONTIER = 128
+
   def motif_name_with_location_type(motif)
     "#{motif.name} (#{Motif.human_enum_name(:location_type, motif.location_type)})"
   end
@@ -24,5 +26,24 @@ module MotifsHelper
      ["3 heures", 3.hours], ["6 heures", 6.hours], ["12 heures", 12.hours],
      ["1 jour", 1.day], ["2 jours", 2.days], ["3 jours", 3.days], ["1 semaine", 1.week], ["2 semaines", 2.weeks],
      ["1 mois", 1.month], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year]]
+  end
+
+  def text_color(color)
+    return "white" if color.blank?
+
+    dark_or_light?(color) ? "#000000" : "#FFFFFF"
+  end
+
+  def dark_or_light?(color)
+    convert_hexa_color_to_yiq(color) >= DARK_LIGHT_FRONTIER
+  end
+
+  def convert_hexa_color_to_yiq(color)
+    red, green, blue = *convert_hexa_color_to_rgb(color)
+    ((red * 299) + (green * 587) + (blue * 114)) / 1000
+  end
+
+  def convert_hexa_color_to_rgb(color)
+    [Integer("0x#{color[1..2]}"), Integer("0x#{color[3..4]}"), Integer("0x#{color[5..6]}")]
   end
 end

--- a/app/views/admin/rdvs/index.json.jbuilder
+++ b/app/views/admin/rdvs/index.json.jbuilder
@@ -13,5 +13,6 @@ json.array! @rdvs do |rdv|
   json.start rdv.starts_at
   json.end rdv.ends_at
   json.url admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: params[:agent_id])
+  json.textColor text_color(rdv.motif&.color)
   json.backgroundColor rdv.motif&.color
 end

--- a/app/webpacker/stylesheets/components/_calendar.scss
+++ b/app/webpacker/stylesheets/components/_calendar.scss
@@ -167,9 +167,6 @@
   .fc-time, .fc-title{
     text-align: left;
   }
-  .fc-content {
-    color: $white;
-  }
 }
 .fc-event-container {
   margin: 0 !important;

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
   let!(:service) { create(:service) }
   let(:agent) { create(:agent, organisations: [organisation], service: service) }
   let!(:user) { create(:user, first_name: "Marie", last_name: "Denis") }
-  let!(:motif) { create(:motif, name: "Suivi", organisation: organisation, service: service) }
+  let!(:motif) { create(:motif, name: "Suivi", organisation: organisation, service: service, color: "#1010FF") }
   let!(:rdv) { create(:rdv, motif: motif, agents: [agent], users: [user], organisation: organisation) }
 
   before do
@@ -34,19 +34,21 @@ RSpec.describe Admin::RdvsController, type: :controller do
         expect(@parsed_response.size).to eq(2)
 
         first = @parsed_response[0]
-        expect(first.size).to eq(7)
+        expect(first.size).to eq(8)
         expect(first["title"]).to eq("Marie DENIS")
         expect(first["start"]).to eq(rdv1.starts_at.as_json)
         expect(first["end"]).to eq(rdv1.ends_at.as_json)
+        expect(first["textColor"]).to eq("#FFFFFF")
         expect(first["backgroundColor"]).to eq(rdv1.motif.color)
         expect(first["url"]).to eq(admin_organisation_rdv_path(rdv1.organisation, rdv1, agent_id: agent.id))
         expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv1.status), status: rdv1.status, motif: "Suivi", past: rdv1.past?, duration: rdv.duration_in_min, lieu: "MDS Orgeval", overlappingPlagesOuvertures: false }.as_json)
 
         second = @parsed_response[1]
-        expect(second.size).to eq(7)
+        expect(second.size).to eq(8)
         expect(second["title"]).to eq("Marie DENIS")
         expect(second["start"]).to eq(rdv2.starts_at.as_json)
         expect(second["end"]).to eq(rdv2.ends_at.as_json)
+        expect(second["textColor"]).to eq("#FFFFFF")
         expect(second["backgroundColor"]).to eq(rdv2.motif.color)
         expect(second["url"]).to eq(admin_organisation_rdv_path(rdv2.organisation, rdv2, agent_id: agent.id))
         expect(first["extendedProps"]).to eq({ readableStatus: Rdv.human_enum_name(:status, rdv2.status), status: rdv2.status, motif: rdv2.motif.name, past: rdv2.past?, duration: rdv.duration_in_min, lieu: "MDS Orgeval", overlappingPlagesOuvertures: false }.as_json)

--- a/spec/helpers/motifs_helper_spec.rb
+++ b/spec/helpers/motifs_helper_spec.rb
@@ -23,4 +23,47 @@ describe MotifsHelper do
       expect(badges).to include("badge-motif-follow_up")
     end
   end
+
+  describe "#text_color" do
+    it "return white when blank given" do
+      expect(text_color(nil)).to eq("white")
+      expect(text_color("")).to eq("white")
+    end
+
+    it "return black when white given" do
+      expect(text_color("#FFFFFF")).to eq("#000000")
+    end
+
+    it "return white when a red given" do
+      expect(text_color("#F04049")).to eq("#FFFFFF")
+    end
+
+    it "return black when a orange given" do
+      expect(text_color("#FAA23F")).to eq("#000000")
+    end
+
+    it "return black when a yellow given" do
+      expect(text_color("#FDF04E")).to eq("#000000")
+    end
+
+    it "return black when a green given" do
+      expect(text_color("#80C357")).to eq("#000000")
+    end
+
+    it "return white when a other green given" do
+      expect(text_color("#17A079")).to eq("#FFFFFF")
+    end
+
+    it "return white when a other light blue given" do
+      expect(text_color("#88C8EA")).to eq("#000000")
+    end
+
+    it "return white when a other marine blue given" do
+      expect(text_color("#394C9A")).to eq("#FFFFFF")
+    end
+
+    it "return white when a other purple given" do
+      expect(text_color("#D64695")).to eq("#FFFFFF")
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/F0LCArHS/1116-probl%C3%A8me-de-contrastes-sur-lagenda-et-les-couleurs-de-motifs

Dans un premier temps, j'ai exploré la possibilité, comme évoqué dans le ticket, de proposer une palette de couleur prédéfini au moment de la configuration d'un motif.

Définition d'une palette à partir du [figma](https://www.figma.com/file/JhZCwwrmaw2NYrITCj8QAK/RDV-Solidarit%C3%A9?node-id=5%3A95), puis déclinaison pour trouver 22 couleurs de fond et de texte en accord avec le [référentiel d'accessibilité](https://www.numerique.gouv.fr/publications/rgaa-accessibilite/) en utilisant le site [a11yrocks/colorPalette](http://www.a11yrocks.com/colorPalette/)

Puis je me suis demandé s'il fallait proposer la palette à la façon de trello

![Capture d’écran de 2020-12-29 18-16-49](https://user-images.githubusercontent.com/42057/103301672-24a33d80-4a02-11eb-98db-bf753f9c8254.png)

Mais j'ai trouvé que ça faisait un composant très complexe pour un usage un peu limité.

J'ai donc exploré le fait de proposer une couleur par hasard, avec possibilité de relancer le choix, à la manière de github

![Capture d’écran de 2020-12-29 18-19-08](https://user-images.githubusercontent.com/42057/103301798-69c76f80-4a02-11eb-9027-ac355a0fd8a7.png)


Composant nécessitant du javascript. Problématique similaire au premier choix d'implémentation : composant complexe pour un intérêt limité.

En reprenant le problème à la base « le contraste dans l'agenda », je me suis demandé s'il n'y avait pas une autre approche : **calculer la couleur du texte assez contrasté à partir d'un couleur de fonds**.

Ça voudrait dire garder le color picker sur les motifs.
J'ai envie de me demander si c'est ok vis à vis d'un contexte d'éco-conception. Est-ce l'[input type color est compatible avec les vieilles versions de navigateur](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/color) ? **Je vais faire l'hypothèse que c'est ok pour le moment**

En cherchant un peu, je suis tombé sur l'article [Calculating Color Contrast](https://24ways.org/2010/calculating-color-contrast/). L'implémentation est plus simple. Cette PR implémente cette fonctionnalité dans un helper.