### PR TITLE
redirige vers la page d'inscription

### DIFF
--- a/app/lib/redirect_to_registration.rb
+++ b/app/lib/redirect_to_registration.rb
@@ -1,0 +1,5 @@
+class RedirectToRegistration < Devise::FailureApp
+  def route(_scope)
+    :new_user_registration_url
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -319,6 +319,9 @@ Devise.setup do |config|
   #   manager.intercept_401 = false
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
+  config.warden do |manager|
+    manager.failure_app = RedirectToRegistration
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -37,7 +37,7 @@ describe Users::RdvWizardStepsController, type: :controller do
     context "without logged user" do
       it "redirects to sign_in path" do
         get :new, params: { step: 2, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at }
-        expect(response).to redirect_to(new_user_session_path)
+        expect(response).to redirect_to(new_user_registration_path)
       end
     end
   end

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -48,7 +48,6 @@ describe "User can search for rdvs" do
 
       # Login page
       expect(page).to have_content("Se connecter")
-      click_link("Je m'inscris")
 
       # Sign up page
       expect(page).to have_content("Inscription")


### PR DESCRIPTION
https://trello.com/c/23F6PWYU/1129-afficher-le-formulaire-dinscription-usager-par-d%C3%A9faut-plutot-que-celui-de-connexion

Utilisation de la configuration suggéré dans l'article : https://trello.com/c/23F6PWYU/1129-afficher-le-formulaire-dinscription-usager-par-d%C3%A9faut-plutot-que-celui-de-connexion