### PR TITLE
valide la couleur du motif

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -28,6 +28,7 @@ class Motif < ApplicationRecord
   validates :max_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
   validate :booking_delay_validation
   validate :not_associated_with_secretariat
+  validates :color, css_hex_color: true
 
   scope :active, -> { where(deleted_at: nil) }
   scope :reservable_online, -> { where(reservable_online: true) }

--- a/config/initializers/css_hex_color_validator.rb
+++ b/config/initializers/css_hex_color_validator.rb
@@ -1,0 +1,5 @@
+class CssHexColorValidator < ActiveModel::EachValidator
+  def validate_each(object, attribute, value)
+    object.errors[attribute] << (options[:message] || "must be a valid CSS hex color code") unless value =~ /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/i
+  end
+end

--- a/config/initializers/css_hex_color_validator.rb
+++ b/config/initializers/css_hex_color_validator.rb
@@ -1,5 +1,5 @@
 class CssHexColorValidator < ActiveModel::EachValidator
   def validate_each(object, attribute, value)
-    object.errors[attribute] << (options[:message] || "must be a valid CSS hex color code") unless value =~ /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/i
+    object.errors[attribute] << (options[:message] || "doit être une couleur CSS valide (sous la forme #RRGGBB)") unless value =~ /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/i
   end
 end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -3,6 +3,12 @@ describe Motif, type: :model do
     expect(build(:motif)).to be_valid
   end
 
+  it "invalid without #RRGGBB format's color" do
+    expect(build(:motif, color: "vert")).to be_invalid
+    expect(build(:motif, color: "002233")).to be_invalid
+    expect(build(:motif, color: "#002233")).to be_valid
+  end
+
   let!(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, organisation: organisation) }
   let(:secretariat) { create(:service, :secretariat) }


### PR DESCRIPTION
Traitement du ticket #1082 

Valider le format en #RRGGBB de la couleur des motifs.

Je suis passé par un validateur externe (dans le `config/initialize/css_hex_color_validator.rb`) c'est peut-être _overkill_, mais ça me semble le plus élégant, sans avoir un coup extraordinaire
