### PR TITLE
narrow down select2 destroy selector to avoid JS errors

### DIFF
--- a/app/webpacker/components/select2-inputs.js
+++ b/app/webpacker/components/select2-inputs.js
@@ -23,7 +23,7 @@ class Select2Inputs {
   }
 
 
-  destroyInputs = () => $(this.selector).select2('destroy')
+  destroyInputs = () => $(`this.selector[data-select2-id]`).select2('destroy')
 }
 
 export { Select2Inputs };


### PR DESCRIPTION
trying to fix https://sentry.io/organizations/rdv-solidarites/issues/1910972605/?environment=production&project=1811205&query=is%3Aunresolved

le sélecteur que j'ajoute affine juste pour s'assurer de destroy des select ayant bien été initialisés