### PR TITLE
fix creating organisation not setting new agents' uid

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -16,6 +16,8 @@ class OrganisationsController < ApplicationController
       agent.skip_confirmation!
       agent.skip_invitation = true
       agent.define_singleton_method(:password_required?) { false }
+      agent.define_singleton_method(:postpone_email_change?) { false }
+      # forces devise_token_auth sync_uid to run
     end
     return render :new unless @organisation.save
 


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2037988059/?environment=production&project=1811205&query=is%3Aunresolved

Il me semble que la création d'organisations par des nouveaux agents est cassé, partiellement ou complètement. Le souci vient du fait que le before_save callback `sync_uid` de `devise_token_auth` (gem utilisée pour l'auth par token dans l'API) ne se déclenche pas bien dans le flow de création d'orga + agent. Ca fait que `uid = nil`, ca passe une fois mais la deuxième fois on prend une erreur due à la contrainte d'unicité sur `[uid, provider]`.

C'est ce court-circuit qui semble sauter à tort : https://github.com/lynndylanhurley/devise_token_auth/blob/master/app/models/devise_token_auth/concerns/user_omniauth_callbacks.rb#L26 . Ca s'appuie sur `postpone_email_change?` qui vient de `Devise::Confirmable` mais qui en plus est overriden dans cette gem (je ne vois pas vraiment la diff de l'override).

On n'est pas les seuls à avoir un souci avec ce court-circuit cf https://github.com/lynndylanhurley/devise_token_auth/pull/1407#issuecomment-704148697

Je n'ai pas tout à fait compris quelle est la vraie racine du problème mais ce contournement fonctionne et est assez contenu, à côté d'autres contournement déjà existants. J'ai pas mal creusé pour trouver d'autres moyens sans succès.

J'ai vérifié que le flow d'invitation continue de fonctionner, et que ça se passe bien aussi lorsqu'un agent change d'email (flow de confirmation préalable au changement effectif de mail - et d'uid)

Post release, il faudra corriger le compte agent avec un uid vide sur les differents environnements, probablement via une migration