### PR TITLE
soft handle absent search params in lieux controller

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -1,5 +1,6 @@
 class LieuxController < ApplicationController
   before_action \
+    :redirect_if_search_params_absent,
     :set_lieu_variables,
     :redirect_if_user_offline_and_motif_follow_up,
     :redirect_if_no_matching_motifs
@@ -41,6 +42,12 @@ class LieuxController < ApplicationController
   end
 
   private
+
+  def redirect_if_search_params_absent
+    return if params[:search].present?
+
+    redirect_to root_path, flash: { error: "Les paramètres de recherche n'ont pas été transmis correctement" }
+  end
 
   def redirect_if_user_offline_and_motif_follow_up
     return if !follow_up_motif? || current_user.present?


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2075664820/events/b44c5ad270ff4f83983c3f3582f81a9e/?environment=production&project=1811205

ce changement fait que les usagers qui arrivent sur les routes `/lieux` sans param `search` seront redirigés vers la home avec un message d'erreur plutôt que se prendre une 500. C'est peut etre un poil risqué car ca peut nous cacher des erreurs, mais pour l'instant ces erreurs "ne viennent pas de chez nous", c'est à dire que les gens arrivent avec des liens cassés de l'extérieur

On pourra éventuellement mettre des warning en place sans que ça fasse des 500 pour autant si jamais des usagers nous remontent qu'ils rencontrent ce message d'erreur