### PR TITLE
clear session return_to path when creneau is not available anymore

### DIFF
--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -15,5 +15,9 @@ module CanHaveRdvWizardContext
     return if [:motif_id, :starts_at, :lieu_id].any? { parsed_params[_1].blank? }
 
     @rdv_wizard = UserRdvWizard::Step1.new(nil, parsed_params)
+    return if @rdv_wizard.creneau.present?
+
+    @rdv_wizard = nil
+    session.delete(:user_return_to)
   end
 end


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2020843070/?environment=production&project=1811205&query=is%3Aunresolved

Pour reproduire : 
- créer une PO pour un certain motif
- dans un autre onglet faire une recherche usager pour ce motif et aller jusqu'à la page de sign up : les infos du RDV sont affichées (elles sont stockées dans un cookie dans un return_to)
- supprimer la PO ou la modifier
- rafraîchir la page de signup dans l'autre onglet : ça fait une 500 aujourd'hui

La source du problème est que le return_to path peut être valide syntatiquement mais ça ne signifie pas que le créneau est toujours disponible. On ne gère pas le cas où le créneau n'est pas dispo pour l'instant et ça explose.

Dans cette PR, je valide que le créneau associé au rdv wizard est tjs dispo. Si ce n'est pas le cas, je cleare le cookie.