### PR TITLE
soft delete agents when removed from last organisation

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -26,7 +26,7 @@ class Admin::AgentsController < AgentAuthController
       redirect_to edit_admin_organisation_permission_path(current_organisation, @agent)
     else
       removal_service.remove!
-      flash[:notice] = "L'agent a été retiré de l'organisation"
+      flash[:notice] = @agent.deleted_at? ? "Le compte agent a été supprimé" : "L'agent a été retiré de l'organisation"
       redirect_to admin_organisation_agents_path(current_organisation)
     end
   end

--- a/app/controllers/admin/permissions_controller.rb
+++ b/app/controllers/admin/permissions_controller.rb
@@ -1,11 +1,13 @@
 class Admin::PermissionsController < AgentAuthController
+  before_action :set_agent, :set_agent_removal_presenter
+
   def edit
-    @permission = Agent::Permission.new(agent: Agent.find(params[:id]))
+    @permission = Agent::Permission.new(agent: @agent)
     authorize(@permission)
   end
 
   def update
-    @permission = Agent::Permission.new(agent: Agent.find(params[:id]))
+    @permission = Agent::Permission.new(agent: @agent)
     authorize(@permission)
     if @permission.update(permission_params)
       redirect_to admin_organisation_agents_path(current_organisation), success: "Les permissions de l'agent ont été mises à jour"
@@ -18,5 +20,13 @@ class Admin::PermissionsController < AgentAuthController
 
   def permission_params
     params.require(:agent_permission).permit(:role)
+  end
+
+  def set_agent
+    @agent = Agent.find(params[:id])
+  end
+
+  def set_agent_removal_presenter
+    @agent_removal_presenter = AgentRemovalPresenter.new(@agent, current_organisation)
   end
 end

--- a/app/presenters/agent_removal_presenter.rb
+++ b/app/presenters/agent_removal_presenter.rb
@@ -1,0 +1,43 @@
+class AgentRemovalPresenter
+  delegate :will_soft_delete?, to: :agent_removal_service
+  attr_reader :agent, :organisation
+
+  def initialize(agent, organisation)
+    @agent = agent
+    @organisation = organisation
+  end
+
+  def button_value
+    if will_soft_delete?
+      "Supprimer le compte"
+    else
+      "Retirer de l'organisation"
+    end
+  end
+
+  def confirm_message
+    if will_soft_delete?
+      <<~STR
+        Cet agent appartient uniquement à l'organisation #{organisation.name}. Vous vous apprêtez à retirer cet agent de cette organisation et à supprimer son compte définitivement.
+
+        Toutes ses absences et ses plages d'ouvertures seront supprimées de manière irréversible.
+
+        Suite à cette suppression vous pourrez éventuellement créer un nouveau compte pour l'agent et l'affecter à un service différent
+      STR
+    else
+      <<~STR
+        Êtes-vous sûr de vouloir retirer cet agent de l'organisation #{organisation.name} ?
+
+        Toutes ses absences et ses plages d'ouvertures seront supprimées de manière irréversible.
+
+        Cet agent appartenant à d'autres organisations, son compte ne sera pas supprimé. L'agent pourra toujours se connecter aux autres organisations, et vous ne pourrez pas recréer son compte pour l'affecter à un service différent.
+      STR
+    end
+  end
+
+  private
+
+  def agent_removal_service
+    @agent_removal_service ||= AgentRemoval.new(agent, organisation)
+  end
+end

--- a/app/service_models/agent_removal.rb
+++ b/app/service_models/agent_removal.rb
@@ -11,6 +11,7 @@ class AgentRemoval
       @agent.organisations.delete(@organisation)
       @agent.absences.where(organisation: @organisation).each(&:destroy!)
       @agent.plage_ouvertures.where(organisation: @organisation).each(&:destroy!)
+      @agent.soft_delete if should_soft_delete?
       true
     end
   end
@@ -18,4 +19,9 @@ class AgentRemoval
   def upcoming_rdvs?
     @upcoming_rdvs ||= @agent.rdvs.where(organisation: @organisation).future.not_cancelled.any?
   end
+
+  def should_soft_delete?
+    (@agent.organisations - [@organisation]).empty?
+  end
+  alias will_soft_delete? should_soft_delete?
 end

--- a/app/views/admin/permissions/edit.html.slim
+++ b/app/views/admin/permissions/edit.html.slim
@@ -15,15 +15,15 @@
       .card-body
         = simple_form_for [:admin, @permission], url: admin_organisation_permission_path(current_organisation, @permission), remote: request.xhr?, html: { data: { rightbar: true } } do |f|
           = render partial: 'layouts/model_errors', locals: { model: @permission }
-          = f.input :service_id, collection: [@permission.agent.service], as: :select, label: 'Service', hint: "Vous ne pouvez pas changer un agent de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer et recréer l'agent", disabled: true
+          = f.input :service_id, collection: [@permission.agent.service], as: :select, label: 'Service', hint: "Vous ne pouvez pas changer un agent de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer et recréer le compte de l'agent", disabled: true
 
           = f.input :role, collection: Agent.human_enum_collection_html(:role), as: :radio_buttons, label: "Rôle de #{@permission.agent.full_name}"
 
           .row
             .col.text-left
-              = link_to "Retirer de l'organisation", \
+              = link_to @agent_removal_presenter.button_value, \
                 admin_organisation_agent_path(current_organisation, @permission.agent), \
-                data: { confirm: "Êtes-vous sûr de vouloir retirer cet agent de l'organisation #{current_organisation.name} ?\n\nToutes ses absences et ses plages d'ouvertures seront supprimées de manière irréversible." }, \
+                data: { confirm: @agent_removal_presenter.confirm_message }, \
                 method: :delete, \
                 class: 'btn btn-outline-danger'
             .col.text-right

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -62,7 +62,7 @@ describe "Admin can configure the organisation" do
     expect(page).to have_selector("span.badge.badge-danger", count: 2)
 
     click_link "Tony PATRICK"
-    click_link("Retirer de l'organisation")
+    click_link("Supprimer le compte")
 
     expect_page_title("Vos agents")
     expect(page).to have_no_content("Tony PATRICK")


### PR DESCRIPTION
issue #1088

j'en ai profité pour améliorer et contextualiser les textes de : 

- bouton de suppression / retrait de l'agent
- message d'avertissement avant retrait
- flash success après coup

<img width="1392" alt="Screenshot 2021-01-07 at 09 46 58" src="https://user-images.githubusercontent.com/883348/103871899-ef67b100-50cd-11eb-8ad3-17c9e94d054a.png">

<img width="1392" alt="Screenshot 2021-01-07 at 09 47 26" src="https://user-images.githubusercontent.com/883348/103871916-f4c4fb80-50cd-11eb-88d6-214533513c41.png">
