### PR TITLE
link to external page with street ban ids finder tool for sectorisation

### DIFF
--- a/app/views/admin/departements/zone_imports/new.html.slim
+++ b/app/views/admin/departements/zone_imports/new.html.slim
@@ -91,4 +91,10 @@
         span.text-monospace> sector_id
         span> contient des
         =link_to("identifiants de secteurs existants", admin_departement_sectors_path(current_departement))
-      li Les codes rue à utiliser sont ceux de la Base d'Adresses Nationale et sont obligatoires. Nous fournirons bientôt un outil externe pour vous aider à trouver ces codes.
+      li
+        span> Les codes rue à utiliser sont ceux de la
+        span>= link_to "Base Adresse Nationale", "https://adresse.data.gouv.fr/", target: "_blank"
+        span>et sont obligatoires. Pour trouver ces codes, vous pouvez utiliser
+        span>= link_to "https://codepen.io/adipasquale/full/GRjXvQK", target: "_blank" do
+          span> ce petit outil web
+          i.fa.fa-external-link-alt>


### PR DESCRIPTION
Pour la secto à la rue, on propose soit la sélection manuelle via un autocomplete BAN ce qui fonctionne bien, soit l'import d'un fichier pour les imports massifs. Dans ce dernier cas on demande une colonne `street_code` qui est un identifiant de rue dans le référentiel de la BAN, par ex `62080_0180`. C'est un identifiant quasi impossible à avoir pour l'instant, puisqu'aucun autre outil ne semble faire référence à ces codes, a contrario du city_code utilisé par la BAN qui est le code commune INSEE.

Cette PR rajoute un lien vers un mini-outil externe développé pour l'occasion qui permet d'entrer une liste de noms de rues et de récupérer les identifiants rue BAN correspondants. Le but est de permettre aux agents ou plutôt aux SI des départements d'agrémenter leurs fichiers d'imports. 

<img width="1270" alt="Screenshot 2021-01-11 at 11 19 54" src="https://user-images.githubusercontent.com/883348/104170389-56080a00-5401-11eb-9bc1-f3e0791c5d82.png">

Le processus envisagé est : 
- dans l'interface web : sélectionner une ville et coller le contenu de la colonne "nom de rue" du fichier excel / csv dans le textarea 
- récupérer la liste correspondante de `street_code` BAN sous format texte séparé par des \n
- coller cette liste dans une nouvelle colonne du Excel original, les tableurs reconnaissent généralement ce format texte et l'importent comme une colonne
- importer ce fichier Excel agrémenté de la nouvelle colonne street code dans RDV-Solidarités

C'est loin d'être parfait et ça ne sera peut-être utilisé que par nous équipe technique de RDV-Sol dans un premier temps, mais même pour ce cas d'usage ça vaut le coût. On doit déjà normalement importer un fichier de plusieurs centaines de rues pour Calais  et on aurait eu du mal à le faire sans cet outil. 

Petits détails techniques sur l'outil externe (code visible sur le codepen) : 

- j'ai préféré coder cet outil qui me semblait relativement indépendant hors de la codebase de RDV-Solidarités. J'ai espoir qu'on trouve une solution plus simple d'utilisation si on faisait quelque chose directement dans notre outil. C'est extrêmement discutable
- on ignore les résultats de l'API Adresse ayant un "score" inférieur à 0.5 ce qui est assez bas
- on ignore les résultats de l'API Adresse s'il y a plusieurs suggestions pour une rue et que la différence de score entre les deux premiers résultats est inférieure à 0.2
- J'affiche la liste des rues pas trouvées à part, pour permettre aux agents d'ensuite les traiter manuellement