### PR TITLE
improve organisation associations, remove zones, add plage_ouvertures

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,7 +7,7 @@ class Organisation < ApplicationRecord
   has_many :webhook_endpoints, dependent: :destroy
   has_many :sector_attributions, dependent: :destroy
   has_many :sectors, through: :sector_attributions
-  has_many :zones, through: :zones
+  has_many :plage_ouvertures, dependent: :destroy
   has_and_belongs_to_many :agents, -> { distinct }
 
   has_many :user_profiles


### PR DESCRIPTION
cf #1117 

- retire l'association `Organisation.zones` car il n'y a en fait pas de lien entre ces deux objets. Une orga est associée à un ou plusieurs Secteur, et un Secteur a une ou plusieurs zones, mais ça n'a pour autant pas de sens de dire qu'une orga a des zones. 
- ajoute l'organisation `Organisation.plage_ouvertures` utile pour la suppression en cascade.