### PR TITLE
destroy corrupt zones without sectors

### DIFF
--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,7 +1,7 @@
 class Sector < ApplicationRecord
   has_many :attributions, class_name: "SectorAttribution", dependent: :destroy
   has_many :organisations, through: :attributions
-  has_many :zones
+  has_many :zones, dependent: :destroy
 
   validates :departement, :name, :human_id, presence: true
   validates :human_id, uniqueness: { scope: :departement }

--- a/db/migrate/20210114143145_delete_corrupt_zones.rb
+++ b/db/migrate/20210114143145_delete_corrupt_zones.rb
@@ -1,0 +1,8 @@
+class DeleteCorruptZones < ActiveRecord::Migration[6.0]
+  def up
+    sector_ids = Sector.pluck(:id)
+    Zone.where.not(sector_id: sector_ids).each(&:destroy!)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_091426) do
+ActiveRecord::Schema.define(version: 2021_01_14_143145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2149603162/?environment=staging&project=1811205&query=is%3Aunresolved

le probleme était qu'on ne supprimait pas les zones lorsqu'on supprime un secteur (il manquait le dependent).

j'ai fait une migration pour corriger les problèmes existants.