### PR TITLE
prend en compte le cas sans date de naissance

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
   end
 
   def minor?
-    birth_date > 18.years.ago
+    birth_date.present? && birth_date > 18.years.ago
   end
 
   protected

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -338,5 +338,10 @@ describe User, type: :model do
       expect(user.minor?).to be false
       travel_back
     end
+
+    it "return false when no birthdate" do
+      user = build(:user, birth_date: nil)
+      expect(user.minor?).to be false
+    end
   end
 end


### PR DESCRIPTION
Pour résoudre ce problème https://sentry.io/organizations/rdv-solidarites/issues/2154627583/?project=1811205&query=is%3Aunresolved

Nous n'avions pas pris en compte le cas où l'usager n'a pas de date de naissance. Nous allons considéré qu'ille n'est pas mineur dans ce cas.