### PR TITLE
Alerte en cas de chevauchement avec un autre RDV dans le tunnel RDV agent

### DIFF
--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -12,10 +12,12 @@ module Admin::RdvFormConcern
     delegate :motif, :organisation, :agents, :users, to: :rdv
     delegate :overlapping_plages_ouvertures, :overlapping_plages_ouvertures?, to: :rdv
     delegate :rdvs_ending_shortly_before, :rdvs_ending_shortly_before?, to: :rdv_start_coherence
+    delegate :rdvs_overlapping_rdv, :rdvs_overlapping_rdv?, to: :rdvs_overlapping
 
     validate :validate_rdv
     caution :warn_overlapping_plage_ouverture
     caution :warn_rdvs_ending_shortly_before
+    caution :warn_rdvs_overlapping_rdv
   end
 
   def save
@@ -51,6 +53,19 @@ module Admin::RdvFormConcern
     end.each { warnings.add(:base, _1.warning_message, active: true) }
   end
 
+  def warn_rdvs_overlapping_rdv
+    return true unless rdvs_overlapping_rdv?
+
+    rdv_agent_pairs_rdvs_overlapping_grouped_by_agent.values.map do
+      RdvsOverlappingRdvPresenter.new(
+        rdv: _1.rdv,
+        agent: _1.agent,
+        rdv_context: rdv,
+        agent_context: agent_context
+      )
+    end.each { warnings.add(:base, _1.warning_message, active: true) }
+  end
+
   def rdv_agent_pairs_ending_shortly_before_grouped_by_agent
     rdvs_ending_shortly_before
       .flat_map do |rdv_before|
@@ -58,6 +73,19 @@ module Admin::RdvFormConcern
       end
       .group_by(&:agent)
       .transform_values(&:last)
+  end
+
+  def rdv_agent_pairs_rdvs_overlapping_grouped_by_agent
+    rdvs_overlapping_rdv
+      .flat_map do |rdv_overlapping|
+        rdv_overlapping.agents.select { rdv.agents.include?(_1) }.map { OpenStruct.new(agent: _1, rdv: rdv_overlapping) }
+      end
+      .group_by(&:agent)
+      .transform_values(&:last)
+  end
+
+  def rdvs_overlapping
+    @rdvs_overlapping ||= RdvsOverlapping.new(rdv)
   end
 
   def rdv_start_coherence

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -54,6 +54,7 @@ class Rdv < ApplicationRecord
   scope :with_lieu, ->(lieu) { joins(:lieu).where(lieux: { id: lieu.id }) }
   scope :visible, -> { joins(:motif).where(motifs: { visibility_type: [Motif::VISIBLE_AND_NOTIFIED, Motif::VISIBLE_AND_NOT_NOTIFIED] }) }
   scope :ends_at_in_range, ->(range) { where("#{ENDS_AT_SQL} BETWEEN ? AND ?", range.begin, range.end) }
+  scope :starts_at_in_range, ->(range) { where("starts_at BETWEEN ? AND ?", range.begin, range.end) }
   scope :ordered_by_ends_at, -> { order(ENDS_AT_SQL) }
 
   after_commit :reload_uuid, on: :create

--- a/app/presenters/rdvs_overlapping_rdv_presenter.rb
+++ b/app/presenters/rdvs_overlapping_rdv_presenter.rb
@@ -1,0 +1,53 @@
+class RdvsOverlappingRdvPresenter
+  include Rails.application.routes.url_helpers
+
+  attr_accessor :rdv, :agent, :agent_context, :rdv_context
+
+  def initialize(rdv:, agent:, rdv_context:, agent_context:)
+    @rdv = rdv
+    @agent = agent
+    @rdv_context = rdv_context
+    @agent_context = agent_context
+  end
+
+  def warning_message
+    I18n.t("activemodel.warnings.models.rdv.attributes.base.#{i18n_key}", **i18n_attrs_base, **i18n_attrs_in_scope)
+  end
+
+  private
+
+  def in_scope?
+    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).in_scope?(rdv)
+  end
+
+  def i18n_key
+    "rdvs_overlapping_rdv.#{i18n_suffix}"
+  end
+
+  def i18n_suffix
+    if @agent == agent_context.agent
+      "current_agent"
+    elsif in_scope?
+      "in_scope"
+    else
+      "out_of_scope"
+    end
+  end
+
+  def i18n_attrs_base
+    {
+      agent_name: agent.full_name,
+      ends_at_time: I18n.l(rdv.ends_at, format: :time_only),
+      gap_duration_in_min: ((rdv_context.starts_at - rdv.ends_at) / 1.minute).round
+    }
+  end
+
+  def i18n_attrs_in_scope
+    return {} unless in_scope?
+
+    {
+      user_names: rdv.users.map(&:full_name).to_sentence,
+      path: admin_organisation_rdv_path(rdv.organisation, rdv)
+    }
+  end
+end

--- a/app/presenters/rdvs_overlapping_rdv_presenter.rb
+++ b/app/presenters/rdvs_overlapping_rdv_presenter.rb
@@ -38,16 +38,12 @@ class RdvsOverlappingRdvPresenter
     {
       agent_name: agent.full_name,
       ends_at_time: I18n.l(rdv.ends_at, format: :time_only),
-      gap_duration_in_min: ((rdv_context.starts_at - rdv.ends_at) / 1.minute).round
     }
   end
 
   def i18n_attrs_in_scope
     return {} unless in_scope?
 
-    {
-      user_names: rdv.users.map(&:full_name).to_sentence,
-      path: admin_organisation_rdv_path(rdv.organisation, rdv)
-    }
+    { path: admin_organisation_rdv_path(rdv.organisation, rdv) }
   end
 end

--- a/app/service_models/rdvs_overlapping.rb
+++ b/app/service_models/rdvs_overlapping.rb
@@ -1,0 +1,22 @@
+class RdvsOverlapping
+  delegate :starts_at, :ends_at, :duration_in_min, :agents, to: :rdv
+  attr_reader :rdv
+
+  THRESHOLD = 1.minute
+
+  def initialize(rdv)
+    @rdv = rdv
+  end
+
+  def rdvs_overlapping_rdv
+    Rdv.where.not(id: @rdv.id)
+      .not_cancelled
+      .future
+      .with_agent_among(agents)
+      .where(id: (Rdv.select(:id).ends_at_in_range(starts_at..ends_at) +
+                  Rdv.select(:id).starts_at_in_range(starts_at..ends_at)))
+      .ordered_by_ends_at
+  end
+
+  def rdvs_overlapping_rdv?; end
+end

--- a/app/service_models/rdvs_overlapping.rb
+++ b/app/service_models/rdvs_overlapping.rb
@@ -14,7 +14,8 @@ class RdvsOverlapping
       .future
       .with_agent_among(agents)
       .where(id: (Rdv.select(:id).ends_at_in_range(starts_at..ends_at) +
-                  Rdv.select(:id).starts_at_in_range(starts_at..ends_at)))
+                  Rdv.select(:id).starts_at_in_range(starts_at..ends_at) +
+                  Rdv.select(:id).where("starts_at < ?", starts_at).where("#{Rdv::ENDS_AT_SQL} > ?", ends_at)))
       .ordered_by_ends_at
   end
 

--- a/app/service_models/rdvs_overlapping.rb
+++ b/app/service_models/rdvs_overlapping.rb
@@ -18,5 +18,7 @@ class RdvsOverlapping
       .ordered_by_ends_at
   end
 
-  def rdvs_overlapping_rdv?; end
+  def rdvs_overlapping_rdv?
+    rdvs_overlapping_rdv.any?
+  end
 end

--- a/app/service_models/rdvs_overlapping.rb
+++ b/app/service_models/rdvs_overlapping.rb
@@ -2,8 +2,6 @@ class RdvsOverlapping
   delegate :starts_at, :ends_at, :duration_in_min, :agents, to: :rdv
   attr_reader :rdv
 
-  THRESHOLD = 1.minute
-
   def initialize(rdv)
     @rdv = rdv
   end

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -39,6 +39,10 @@ fr:
                 current_agent: "Vous avez <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans votre agenda"
                 in_scope: "%{agent_name} a <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
                 out_of_scope: "%{agent_name} a un RDV finissant à %{ends_at_time}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
+              rdvs_overlapping_rdv:
+                current_agent: "Vous avez <a href='%{path}'>un RDV</a> qui cheuvauche un ou plusieurs autres [current agent]"
+                in_scope: "%{agent_name} a <a href='%{path}'>un RDV</a> qui cheuvauche un ou plusieurs autres [in scope]"
+                out_of_scope: "%{agent_name} a un RDV finissant à %{ends_at_time}, qui chevauche un ou plusieurs autres dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
 
   agents:
     rdvs:

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -40,9 +40,9 @@ fr:
                 in_scope: "%{agent_name} a <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
                 out_of_scope: "%{agent_name} a un RDV finissant à %{ends_at_time}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
               rdvs_overlapping_rdv:
-                current_agent: "Vous avez <a href='%{path}'>un RDV</a> qui cheuvauche un ou plusieurs autres [current agent]"
-                in_scope: "%{agent_name} a <a href='%{path}'>un RDV</a> qui cheuvauche un ou plusieurs autres [in scope]"
-                out_of_scope: "%{agent_name} a un RDV finissant à %{ends_at_time}, qui chevauche un ou plusieurs autres dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
+                current_agent: "Vous avez <a href='%{path}'>un autre RDV</a> qui cheuvauche celui-ci"
+                in_scope: "%{agent_name} a <a href='%{path}'>un autre RDV</a> qui cheuvauche celui-ci"
+                out_of_scope: "Ce rendez-vous en chevauche un autre. %{agent_name} a un RDV finissant à %{ends_at_time} dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
 
   agents:
     rdvs:

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -40,9 +40,9 @@ fr:
                 in_scope: "%{agent_name} a <a href='%{path}'>un RDV</a> finissant à %{ends_at_time} avec %{user_names}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda"
                 out_of_scope: "%{agent_name} a un RDV finissant à %{ends_at_time}, vous allez laisser un trou de %{gap_duration_in_min} minutes dans son agenda (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
               rdvs_overlapping_rdv:
-                current_agent: "Vous avez <a href='%{path}'>un autre RDV</a> qui cheuvauche celui-ci"
-                in_scope: "%{agent_name} a <a href='%{path}'>un autre RDV</a> qui cheuvauche celui-ci"
-                out_of_scope: "Ce rendez-vous en chevauche un autre. %{agent_name} a un RDV finissant à %{ends_at_time} dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
+                current_agent: "Vous avez <a href='%{path}'>un autre RDV</a> qui chevauche celui-ci"
+                in_scope: "%{agent_name} a <a href='%{path}'>un autre RDV</a> qui chevauche celui-ci"
+                out_of_scope: "Ce rendez-vous en chevauche un autre. %{agent_name} a un RDV dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
 
   agents:
     rdvs:

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -337,4 +337,16 @@ describe Rdv, type: :model do
       end
     end
   end
+
+  describe "#starts_at_in_range" do
+    it "return rdv that starts in range" do
+      now = Time.zone.parse("2020-10-14 11h30")
+      travel_to(now)
+      rdv = create(:rdv, starts_at: now + 1.day + 3.hours)
+      create(:rdv, starts_at: now + 2.day + 3.hours)
+      create(:rdv, starts_at: now - 1.day)
+      expect(Rdv.starts_at_in_range((now + 1.day)..(now + 2.day))).to eq([rdv])
+      travel_back
+    end
+  end
 end

--- a/spec/service_models/rdvs_overlapping_spec.rb
+++ b/spec/service_models/rdvs_overlapping_spec.rb
@@ -1,0 +1,23 @@
+describe RdvsOverlapping, type: :service do
+  describe "#rdvs_overlapping_rdv" do
+    it "return rdvs that end during rdv" do
+      now = Time.zone.parse("2020-12-23 12h40")
+      travel_to(now)
+      agent = create(:agent)
+      overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day + 15.minutes)
+      expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
+      travel_back
+    end
+
+    it "return rdvs that starts during rdv" do
+      now = Time.zone.parse("2020-12-23 12h40")
+      travel_to(now)
+      agent = create(:agent)
+      overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
+      expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
+      travel_back
+    end
+  end
+end

--- a/spec/service_models/rdvs_overlapping_spec.rb
+++ b/spec/service_models/rdvs_overlapping_spec.rb
@@ -19,5 +19,15 @@ describe RdvsOverlapping, type: :service do
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
       travel_back
     end
+
+    it "return rdvs that starts before and end after rdv" do
+      now = Time.zone.parse("2020-12-23 12h40")
+      travel_to(now)
+      agent = create(:agent)
+      overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 30.minutes, duration_in_min: 60)
+      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
+      expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
+      travel_back
+    end
   end
 end


### PR DESCRIPTION
#1120 

Ajoute la possibilité de retrouver les rendez-vous commençant sur une période donnée.

Je ne suis pas super satisfait d'avoir « dupliqué » l'existant pour faire cette feature, mais je ne me vois pas prendre du temps pour proposer un refactoring pour le moment.
