### PR TITLE
fix js bug when using rdv status dropdown on non authorized RDV

### DIFF
--- a/app/webpacker/components/rdv-status-dropdowns.js
+++ b/app/webpacker/components/rdv-status-dropdowns.js
@@ -15,6 +15,9 @@ class RdvStatusDropdown {
 
   statusChanged = event => {
     const rdv = event.detail[0].rdv
+    if (!rdv) return
+    // happens when authorize fails, UJS + Turbolinks auto-reloads, but doesn't
+    // detach callbacks
     this.currentStatusElt.innerHTML = rdv.temporal_status_human
     this.currentStatusElt.removeAttribute("disabled")
     this.changeRdvStatusClass(rdv.status)


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2052301596/?environment=production&project=1811205&query=is%3Aunresolved

Ce bug se produit quand le retour de l'update du statut d'un RDV ne renvoie pas de RDV. Ça peut se produire dans le cas où un agent essaie d'updater un RDV sur lequel il n'a pas les permissions adéquates. UJS + Turbolinks déclenche alors un refresh auto de la page avec un flash "non autorisé", mais il ne détache pas les callbacks attachés à ajax:success, ce qui est surprenant.

J'ai essayé sans succès de comprendre la source du problème : pourquoi est-ce qu'on propose d'updater les status de RDV pour lesquels l'agent courant n'a pas les permissions mais je n'ai pas trouvé. Les scopes m'ont l'air cohérents et bien appliqués. 

On manque un peu d'infos pour reproduire : dans ces erreurs sentry du JS on n'a ni le current_agent ni l'ID du RDV .. il faudrait améliorer ça pour aller plus loin.