### PR TITLE
Netsize Support + SMS service refactos

### DIFF
--- a/app/jobs/send_transactional_sms_job.rb
+++ b/app/jobs/send_transactional_sms_job.rb
@@ -1,7 +1,5 @@
 class SendTransactionalSmsJob < ApplicationJob
-  def perform(status, rdv_id, user_id, options = {})
-    rdv = Rdv.find(rdv_id)
-    user = User.find(user_id)
-    SendTransactionalSmsService.perform_with(status, rdv, user, **options)
+  def perform(status, rdv_id, user_id)
+    TransactionalSms::Builder.with(Rdv.find(rdv_id), User.find(user_id), status).send!
   end
 end

--- a/app/service_models/transactional_sms/base_concern.rb
+++ b/app/service_models/transactional_sms/base_concern.rb
@@ -23,7 +23,12 @@ module TransactionalSms::BaseConcern
   end
 
   def tags
-    [ENV["APP"], rdv.organisation.id, self.class.name.demodulize.underscore]
+    [
+      ENV["APP"],
+      "dpt-#{rdv.organisation.departement}",
+      "org-#{rdv.organisation.id}",
+      self.class.name.demodulize.underscore
+    ]
   end
 
   def rdv_footer

--- a/app/service_models/transactional_sms/base_concern.rb
+++ b/app/service_models/transactional_sms/base_concern.rb
@@ -1,0 +1,45 @@
+module TransactionalSms::BaseConcern
+  extend ActiveSupport::Concern
+
+  included do
+    include Rails.application.routes.url_helpers
+
+    attr_reader :user, :rdv
+
+    delegate :phone_number_formatted, to: :user
+  end
+
+  def initialize(rdv, user)
+    @user = user
+    @rdv = rdv
+  end
+
+  def content
+    raw_content.tr("áâãëẽêíïîĩóôõúûũçÀÁÂÃÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ", "aaaeeeiiiiooouuucAAAAEEEEIIIIIOOOOUUUU")
+  end
+
+  def send!
+    SendTransactionalSmsService.perform_with(self)
+  end
+
+  def tags
+    [ENV["APP"], rdv.organisation.id, self.class.name.demodulize.underscore]
+  end
+
+  def rdv_footer
+    message = if rdv.phone?
+                "RDV Téléphonique\n"
+              elsif rdv.home?
+                "RDV à domicile\n#{rdv.address}\n"
+              else
+                "#{rdv.address_complete}\n"
+              end
+    message += "Infos et annulation: #{rdvs_shorten_url(host: ENV['HOST'])}"
+    message += " / #{rdv.organisation.phone_number}" if rdv.organisation.phone_number
+    message
+  end
+
+  def to_s
+    "content: #{content} | recipient: #{phone_number_formatted} | tags: #{tags.join(',')}"
+  end
+end

--- a/app/service_models/transactional_sms/builder.rb
+++ b/app/service_models/transactional_sms/builder.rb
@@ -1,0 +1,5 @@
+class TransactionalSms::Builder
+  def self.with(rdv, user, event_type)
+    "TransactionalSms::#{event_type.to_s.camelize}".constantize.new(rdv, user)
+  end
+end

--- a/app/service_models/transactional_sms/file_attente.rb
+++ b/app/service_models/transactional_sms/file_attente.rb
@@ -1,0 +1,13 @@
+class TransactionalSms::FileAttente
+  include TransactionalSms::BaseConcern
+
+  def raw_content
+    "Des créneaux se sont libérés plus tôt.\nCliquez pour voir les disponibilités : #{url}"
+  end
+
+  private
+
+  def url
+    users_creneaux_index_url(rdv_id: rdv.id, host: ENV["HOST"])
+  end
+end

--- a/app/service_models/transactional_sms/rdv_cancelled.rb
+++ b/app/service_models/transactional_sms/rdv_cancelled.rb
@@ -1,0 +1,25 @@
+class TransactionalSms::RdvCancelled
+  include TransactionalSms::BaseConcern
+
+  def raw_content
+    if @rdv.organisation.phone_number
+      base_message + call_or_visit_message
+    else
+      base_message + visit_message
+    end
+  end
+
+  private
+
+  def base_message
+    "RDV #{@rdv.motif.service.short_name} #{I18n.l(@rdv.starts_at, format: :short)} a été annulé\n"
+  end
+
+  def call_or_visit_message
+    "Appelez le #{@rdv.organisation.phone_number} ou allez sur https://rdv-solidarites.fr pour reprendre RDV."
+  end
+
+  def visit_message
+    "Allez sur https://rdv-solidarites.fr pour reprendre RDV."
+  end
+end

--- a/app/service_models/transactional_sms/rdv_created.rb
+++ b/app/service_models/transactional_sms/rdv_created.rb
@@ -1,0 +1,17 @@
+class TransactionalSms::RdvCreated
+  include TransactionalSms::BaseConcern
+
+  def raw_content
+    body + rdv_footer
+  end
+
+  private
+
+  def body
+    if rdv.home?
+      "RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short_approx)}\n"
+    else
+      "RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short)}\n"
+    end
+  end
+end

--- a/app/service_models/transactional_sms/reminder.rb
+++ b/app/service_models/transactional_sms/reminder.rb
@@ -1,0 +1,17 @@
+class TransactionalSms::Reminder
+  include TransactionalSms::BaseConcern
+
+  def raw_content
+    body + rdv_footer
+  end
+
+  private
+
+  def body
+    "Rappel RDV #{@rdv.motif.service.short_name} le #{I18n.l(@rdv.starts_at, format: time_format)}\n"
+  end
+
+  def time_format
+    @rdv.home? ? :short_approx : :short
+  end
+end

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -1,83 +1,42 @@
 class SendTransactionalSmsService < BaseService
-  include Rails.application.routes.url_helpers
+  attr_reader :transactional_sms
 
-  attr_reader :user, :rdv, :from, :type
+  SENDER_NAME = "RdvSoli".freeze
 
-  def initialize(type, rdv, user, options = {})
-    @type = type
-    @user = user
-    @rdv = rdv
-    @options = options
-    @from = "RdvSoli"
+  def initialize(transactional_sms)
+    @transactional_sms = transactional_sms
   end
 
   def perform
-    sms_params = {
-      sender: @from,
-      recipient: @user.phone_number_formatted,
-      content: replace_special_chars(send(@type)),
-      tag: [ENV["APP"], @rdv.organisation.id, @type].join(" ")
-    }
-    if Rails.env.production?
-      sib_transac_sms = SibApiV3Sdk::SendTransacSms.new(sms_params)
-      SibApiV3Sdk::TransactionalSMSApi.new.send_transac_sms(sib_transac_sms)
-    else
-      Rails.logger.debug("following SMS would have been sent in production environment: #{sms_params}")
-    end
+    send("send_with_#{sms_provider}")
   end
 
   private
 
-  def replace_special_chars(body)
-    body.tr("áâãëẽêíïîĩóôõúûũçÀÁÂÃÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ", "aaaeeeiiiiooouuucAAAAEEEEIIIIIOOOOUUUU")
+  def sms_provider
+    if ENV["FORCE_SMS_PROVIDER"]
+      ENV["FORCE_SMS_PROVIDER"].to_sym
+    elsif Rails.env.production?
+      :netsize
+    else
+      :debug_logger
+    end
   end
 
-  def sms_footer
-    message = if @rdv.phone?
-                "RDV Téléphonique\n"
-              elsif @rdv.home?
-                "RDV à domicile\n#{@rdv.address}\n"
-              else
-                "#{@rdv.address_complete}\n"
-              end
-    message += "Infos et annulation: #{rdvs_shorten_url(host: ENV['HOST'])}"
-    message += " / #{@rdv.organisation.phone_number}" if @rdv.organisation.phone_number
-    message
+  def send_with_send_in_blue
+    SibApiV3Sdk::TransactionalSMSApi.new.send_transac_sms(
+      SibApiV3Sdk::SendTransacSms.new(
+        sender: SENDER_NAME,
+        recipient: transactional_sms.phone_number_formatted,
+        content: transactional_sms.content,
+        tag: transactional_sms.tags.join(" ")
+      )
+    )
   end
 
-  def rdv_created
-    message = if @rdv.home?
-                "RDV #{@rdv.motif.service.short_name} #{I18n.l(@rdv.starts_at, format: :short_approx)}\n"
-              else
-                "RDV #{@rdv.motif.service.short_name} #{I18n.l(@rdv.starts_at, format: :short)}\n"
-              end
-    message += sms_footer
-    message
-  end
+  def send_with_netsize; end
 
-  def rdv_cancelled
-    message = "RDV #{@rdv.motif.service.short_name} #{I18n.l(@rdv.starts_at, format: :short)} a été annulé\n"
-    message += if @rdv.organisation.phone_number
-                 "Appelez le #{@rdv.organisation.phone_number} ou allez sur https://rdv-solidarites.fr pour reprendre RDV."
-               else
-                 "Allez sur https://rdv-solidarites.fr pour reprendre RDV."
-               end
-    message
-  end
-
-  def reminder
-    message = if @rdv.home?
-                "Rappel RDV #{@rdv.motif.service.short_name} le #{I18n.l(@rdv.starts_at, format: :short_approx)}\n"
-              else
-                "Rappel RDV #{@rdv.motif.service.short_name} le #{I18n.l(@rdv.starts_at, format: :short)}\n"
-              end
-    message += sms_footer
-    message
-  end
-
-  def file_attente
-    message = "Des créneaux se sont libérés plus tôt.\n"
-    message += "Cliquez pour voir les disponibilités : #{users_creneaux_index_url(rdv_id: @rdv.id, host: ENV['HOST'])}"
-    message
+  def send_with_debug_logger
+    Rails.logger.debug("following SMS would have been sent in production environment: #{transactional_sms}")
   end
 end

--- a/spec/service_models/transactional_sms/base_concern_spec.rb
+++ b/spec/service_models/transactional_sms/base_concern_spec.rb
@@ -1,0 +1,58 @@
+module SomeModule
+  class TestSms
+    include TransactionalSms::BaseConcern
+
+    def raw_content
+      "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ"
+    end
+  end
+end
+
+describe TransactionalSms::BaseConcern, type: :service do
+  let(:user) { build(:user, phone_number: "+33640404040", address: "10 rue de Toulon, Lille") }
+
+  describe "#rdv_footer" do
+    let(:rdv) { build(:rdv, motif: motif, users: [user], starts_at: 5.days.from_now) }
+    subject { SomeModule::TestSms.new(rdv, user).rdv_footer }
+
+    context "when regular Rdv" do
+      let(:motif) { build(:motif, :at_public_office) }
+      it { should include(rdv.address) }
+    end
+
+    context "when Rdv is at home" do
+      let(:motif) { build(:motif, :at_home) }
+      it { should include("RDV à domicile") }
+      it { should include(rdv.address) }
+    end
+
+    context "when Rdv is by phone" do
+      let(:motif) { build(:motif, :by_phone) }
+      it { should include("RDV Téléphonique") }
+      it { should include(rdv.address) }
+    end
+  end
+
+  describe "#tags" do
+    let(:organisation) { create(:organisation) }
+    let(:rdv) { build(:rdv, organisation: organisation) }
+    subject { SomeModule::TestSms.new(rdv, build(:user)).tags }
+    it { should include(organisation.id) }
+    it { should include("test_sms") }
+  end
+
+  describe "#content" do
+    subject { SomeModule::TestSms.new(build(:rdv), build(:user)).content }
+    it { should eq("àaäaaèéeeeìiiiiòoöooùuüuuñcAAÄAAEÉEEEIIIIIOOÖOOUUÜUUÑÇ") }
+  end
+
+  describe "#send!" do
+    let(:sms) { SomeModule::TestSms.new(build(:rdv), build(:user)) }
+    before do
+      expect(SendTransactionalSmsService).to receive(:perform_with).with(sms)
+    end
+    it "should call send service" do
+      sms.send!
+    end
+  end
+end

--- a/spec/service_models/transactional_sms/base_concern_spec.rb
+++ b/spec/service_models/transactional_sms/base_concern_spec.rb
@@ -34,10 +34,11 @@ describe TransactionalSms::BaseConcern, type: :service do
   end
 
   describe "#tags" do
-    let(:organisation) { create(:organisation) }
+    let(:organisation) { create(:organisation, departement: "77") }
     let(:rdv) { build(:rdv, organisation: organisation) }
     subject { SomeModule::TestSms.new(rdv, build(:user)).tags }
-    it { should include(organisation.id) }
+    it { should include("org-#{organisation.id}") }
+    it { should include("dpt-77") }
     it { should include("test_sms") }
   end
 

--- a/spec/service_models/transactional_sms/builder_spec.rb
+++ b/spec/service_models/transactional_sms/builder_spec.rb
@@ -1,0 +1,27 @@
+describe TransactionalSms::Builder, type: :service do
+  describe "#with" do
+    let(:rdv) { build(:rdv) }
+    let(:user) { build(:user) }
+    subject { TransactionalSms::Builder.with(rdv, user, event_type) }
+
+    context "rdv_created" do
+      let(:event_type) { :rdv_created }
+      it { should be_an_instance_of(TransactionalSms::RdvCreated) }
+    end
+
+    context "file_attente" do
+      let(:event_type) { :file_attente }
+      it { should be_an_instance_of(TransactionalSms::FileAttente) }
+    end
+
+    context "rdv_cancelled" do
+      let(:event_type) { :rdv_cancelled }
+      it { should be_an_instance_of(TransactionalSms::RdvCancelled) }
+    end
+
+    context "reminder" do
+      let(:event_type) { :reminder }
+      it { should be_an_instance_of(TransactionalSms::Reminder) }
+    end
+  end
+end

--- a/spec/service_models/transactional_sms/file_attente_spec.rb
+++ b/spec/service_models/transactional_sms/file_attente_spec.rb
@@ -1,0 +1,10 @@
+describe TransactionalSms::FileAttente, type: :service do
+  let(:rdv) { build(:rdv) }
+  let(:user) { build(:user) }
+
+  describe "#content" do
+    subject { TransactionalSms::FileAttente.new(rdv, user).content }
+    it { should include("Des créneaux se sont libérés plus tot") } # oh la belle faute
+    it { should include("Cliquez pour voir les disponibilités") }
+  end
+end

--- a/spec/service_models/transactional_sms/rdv_cancelled_spec.rb
+++ b/spec/service_models/transactional_sms/rdv_cancelled_spec.rb
@@ -1,0 +1,12 @@
+describe TransactionalSms::RdvCancelled, type: :service do
+  let(:pmi) { build(:service, short_name: "PMI") }
+  let(:motif) { build(:motif, service: pmi) }
+  let(:rdv) { build(:rdv, motif: motif, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+  let(:user) { build(:user) }
+
+  describe "#content" do
+    subject { TransactionalSms::RdvCancelled.new(rdv, user).content }
+    it { should include("RDV PMI 10 déc. à 13h10 a été annulé") }
+    it { should include("Allez sur https://rdv-solidarites.fr pour reprendre RDV") }
+  end
+end

--- a/spec/service_models/transactional_sms/rdv_created_spec.rb
+++ b/spec/service_models/transactional_sms/rdv_created_spec.rb
@@ -1,0 +1,14 @@
+describe TransactionalSms::RdvCreated, type: :service do
+  let(:pmi) { build(:service, short_name: "PMI") }
+  let(:motif) { build(:motif, service: pmi) }
+  let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+  let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+  let(:user) { build(:user) }
+
+  describe "#content" do
+    subject { TransactionalSms::RdvCreated.new(rdv, user).content }
+    it { should include("RDV PMI 10 déc. à 13h10") }
+    it { should include("MDS Centre (10 rue d'ici)") }
+    it { should include("Infos et annulation") }
+  end
+end

--- a/spec/service_models/transactional_sms/reminder_spec.rb
+++ b/spec/service_models/transactional_sms/reminder_spec.rb
@@ -1,0 +1,14 @@
+describe TransactionalSms::Reminder, type: :service do
+  let(:pmi) { build(:service, short_name: "PMI") }
+  let(:motif) { build(:motif, service: pmi) }
+  let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+  let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+  let(:user) { build(:user) }
+
+  describe "#content" do
+    subject { TransactionalSms::Reminder.new(rdv, user).content }
+    it { should include("Rappel RDV PMI le 10 déc. à 13h10") }
+    it { should include("MDS Centre (10 rue d'ici)") }
+    it { should include("Infos et annulation") }
+  end
+end


### PR DESCRIPTION
# 1er commit  : refacto des services SMS

Le but initial était d'isoler plus clairement la partie envoi de SMS, qui va varier selon le provider, de la partie génération du SMS.
Dans la foulée, je suis allé trop loin, mais je n'ai pas pu m'empêcher de refacto la partie génération du SMS qui ne me plaisait vraiment pas avec un `send(@type)` assez bizarre. J'ai séparé chaque événement dans une classe à part comme `TransactionalSms::RdvCancelled` , et elles partagent du comportement via un concern `TransactionalSms::BaseConcern` qui contient par exemple le footer commun, ou la fonction pour éviter les caractères spéciaux.

# 2e commit : support de netsize

J'ai laissé le support de SendInBlue pour l'instant, car on va vouloir consommer le crédit restant. J'ai mis le switch sur une variable d'env.

rien de spécial pour le support Netsize; je me suis appuyé sur le script préliminaire de Thomas dans l'issue, merci ! J'ai juste du rajouter le charset utf-8 sinon l'encodage était cassé, ce n'était pas documenté. Les tests ont bien fonctionné, rien à signaler

# 3e commit: amélioration des tags

Les tags des sms permettront de faire des stats. J'ai rajouté un préfixe devant l'id de l'organisation : `883 -> org-883`, et rajouté un tag département : `dpt-77`. 

# Tests sur la review app 

Il faut toggler `FORCE_SMS_PROVIDER=send_in_blue` sur la review app pour passer de SIB a netsize
