### PR TITLE
invitations mail reply_to inviter agent with CustomDeviseMailer

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,0 +1,13 @@
+class CustomDeviseMailer < Devise::Mailer
+  include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
+
+  helper :application
+  default template_path: "devise/mailer"
+  layout "mailer"
+
+  def invitation_instructions(record, token, opts = {})
+    @token = token
+    opts[:reply_to] = record.invited_by.email if record.is_a? Agent
+    devise_mail(record, :invitation_instructions, opts)
+  end
+end

--- a/app/models/super_admin.rb
+++ b/app/models/super_admin.rb
@@ -1,6 +1,10 @@
 class SuperAdmin < ApplicationRecord
   include DeviseInvitable::Inviter
 
+  def full_name
+    "Équipe technique de RDV-Solidarités"
+  end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :omniauthable, omniauth_providers: [:github]

--- a/app/views/agents/mailer/invitation_instructions.html.erb
+++ b/app/views/agents/mailer/invitation_instructions.html.erb
@@ -1,0 +1,18 @@
+<p><%= t("devise.mailer.invitation_instructions_for_agents.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions_for_agents.body", inviter: @resource.invited_by.full_name, organisation: @resource.organisations.last.name, service: @resource.service.name) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions_for_agents.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p>
+    <%= t( \
+      "devise.mailer.invitation_instructions_for_agents.accept_until", \
+      due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format'), \
+      inviter: @resource.invited_by.full_name, \
+      inviter_email: @resource.invited_by.email \
+    ).html_safe %>
+  </p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions_for_agents.ignore") %></p>

--- a/app/views/agents/mailer/invitation_instructions.text.erb
+++ b/app/views/agents/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,6 @@ module Lapin
       [Devise::RegistrationsController, Devise::SessionsController, Devise::ConfirmationsController, Devise::PasswordsController, Devise::InvitationsController].each do |controller|
         controller.layout "registration"
       end
-      Devise::Mailer.layout "mailer"
     end
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
   config.mailer_sender = "contact@rdv-solidarites.fr"
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = "CustomDeviseMailer"
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -32,10 +32,17 @@ fr:
         header: "Choisir son mot de passe"
         submit_button: "Enregistrer"
     mailer:
-      invitation_instructions:
-        subject: "Vous avez été invité sur RDV Solidarités."
+      invitation_instructions_for_agents:
+        subject: "Vous avez été invité sur RDV-Solidarités."
         hello: "Bonjour %{email}"
-        someone_invited_you: "Vous avez été invité sur RDV Solidarités. Vous pouvez accepter cette invitation grâce au lien ci-dessous."
+        body: "Vous avez été invité par %{inviter} à rejoindre l'organisation %{organisation} en tant qu'agent du service %{service} dans l'outil RDV-Solidarités."
+        accept: "Accepter l'invitation"
+        accept_until: "Cette invitation est valable jusqu'au %{due_date}. Si vous ratez cette date mais souhaitez accepter, veuillez demander à <a href='mailto:%{inviter_email}'>%{inviter} (%{inviter_email})</a> de vous renvoyer l'invitation"
+        ignore: "Si vous n'acceptez pas cette invitation, ignorez cet email. Aucun compte ne sera créé sans votre autorisation."
+      invitation_instructions:
+        subject: "Vous avez été invité sur RDV-Solidarités."
+        hello: "Bonjour %{email}"
+        someone_invited_you: "Vous avez été invité sur RDV-Solidarités. Vous pouvez accepter cette invitation grâce au lien ci-dessous."
         accept: "Accepter l'invitation"
         accept_until: "Cette invitation est valable jusqu'au %{due_date}."
         ignore: "Si vous n'acceptez pas cette invitation, ignorez cet email. Aucun compte ne sera créé sans votre autorisation."

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Admin::InvitationsController, type: :controller do
   end
 
   describe "POST #reinvite" do
-    let(:agent_invitee) { create(:agent, confirmed_at: nil, first_name: nil, last_name: nil, organisations: [organisation]) }
+    let(:agent_invitee) { create(:agent, invited_by: agent, confirmed_at: nil, first_name: nil, last_name: nil, organisations: [organisation]) }
 
     it "returns a success response" do
       post :reinvite, params: { organisation_id: organisation.id, id: agent_invitee.to_param }

--- a/spec/mailers/previews/custom_devise_mailer_preview.rb
+++ b/spec/mailers/previews/custom_devise_mailer_preview.rb
@@ -1,0 +1,17 @@
+class CustomDeviseMailerPreview < ActionMailer::Preview
+  def confirmation_instructions
+    CustomDeviseMailer.confirmation_instructions(Agent.first, {})
+  end
+
+  def reset_password_instructions
+    CustomDeviseMailer.reset_password_instructions(Agent.first, "faketoken")
+  end
+
+  def invitation_instructions_for_agents
+    CustomDeviseMailer.invitation_instructions(Agent.last, "faketoken")
+  end
+
+  def invitation_instructions
+    CustomDeviseMailer.invitation_instructions(User.last, "faketoken")
+  end
+end

--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -1,9 +1,0 @@
-class DeviseMailerPreview < ActionMailer::Preview
-  def confirmation_instructions
-    Devise::Mailer.confirmation_instructions(Agent.first, {})
-  end
-
-  def reset_password_instructions
-    Devise::Mailer.reset_password_instructions(Agent.first, "faketoken")
-  end
-end


### PR DESCRIPTION
# Changement du reply_to

J'ai du introduire un DeviseCustomMailer qui hérite de `Devise::Mailer` pour pouvoir modifier le reply_to à la volée. cf https://github.com/heartcombo/devise/wiki/How-To:-Use-custom-mailer

# Autres améliorations

Jusqu'ici on utilisait exactement le meme template de mail pour les invitations usagers et les invitations agents.

J'ai changé ça pour donner plus de détails dans les invitations agents : 

avant :

<img width="784" alt="Screenshot 2021-01-19 at 15 51 58" src="https://user-images.githubusercontent.com/883348/105058022-17fc8d00-5a76-11eb-809a-26fb1ac14cf7.png">

apres : 

<img width="775" alt="Screenshot 2021-01-19 at 16 39 45" src="https://user-images.githubusercontent.com/883348/105058040-1b901400-5a76-11eb-9b4a-a4e1c659b219.png">

