### PR TITLE
introduce read-only list of motifs for non-admin agents

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -2,7 +2,7 @@ class Admin::MotifsController < AgentAuthController
   respond_to :html, :json
 
   before_action :set_organisation, only: [:new, :create]
-  before_action :set_motif, only: [:edit, :update, :destroy]
+  before_action :set_motif, only: [:show, :edit, :update, :destroy]
 
   def index
     @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page])
@@ -17,6 +17,10 @@ class Admin::MotifsController < AgentAuthController
   end
 
   def edit
+    authorize(@motif)
+  end
+
+  def show
     authorize(@motif)
   end
 
@@ -36,7 +40,7 @@ class Admin::MotifsController < AgentAuthController
     authorize(@motif)
     if @motif.update(motif_params)
       flash[:notice] = "Le motif a été modifié."
-      redirect_to admin_organisation_motifs_path(@motif.organisation)
+      redirect_to admin_organisation_motif_path(@motif.organisation, @motif)
     else
       render :edit
     end

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -28,6 +28,10 @@ module MotifsHelper
      ["1 mois", 1.month], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year]]
   end
 
+  def min_max_delay_int_to_human(int_value)
+    min_max_delay_options.map { |arr| [arr[0], arr[1].to_i] }.to_h.invert[int_value]
+  end
+
   def text_color(color)
     return "white" if color.blank?
 
@@ -45,5 +49,24 @@ module MotifsHelper
 
   def convert_hexa_color_to_rgb(color)
     [Integer("0x#{color[1..2]}"), Integer("0x#{color[3..4]}"), Integer("0x#{color[5..6]}")]
+  end
+
+  def motif_option_value(motif, option_name)
+    if motif.send("#{option_name}?")
+      content_tag(:span, "☑️ ") + content_tag(:span, t("activerecord.attributes.motif.#{option_name}_hint"))
+    else
+      content_tag(:span, "╳ désactivée", class: "text-muted")
+    end
+  end
+
+  def motif_attribute_row(legend, arg_value = nil, hint: nil, &block)
+    value = block.present? ? capture(&block) : display_value_or_na_placeholder(arg_value)
+    value += content_tag(:div, hint, class: "text-muted") if arg_value.present? && hint.present?
+    content_tag(
+      :div,
+      content_tag(:div, legend, class: "col-md-4 text-bold text-right") +
+        content_tag(:div, value, class: "col-md-8"),
+      class: "row"
+    )
   end
 end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -1,4 +1,8 @@
 class Agent::MotifPolicy < Agent::AdminPolicy
+  def show?
+    admin_and_same_org? || same_agent_or_has_access?
+  end
+
   class Scope < Scope
     def resolve
       if @context.agent.can_access_others_planning?

--- a/app/policies/default_agent_policy.rb
+++ b/app/policies/default_agent_policy.rb
@@ -56,7 +56,7 @@ class DefaultAgentPolicy
   end
 
   def same_service?
-    if @record.is_a? Agent
+    if @record.is_a?(Agent) || @record.is_a?(Motif)
       @record.service_id == @context.agent.service_id
     elsif @record.respond_to?(:agent_id)
       @record.agent.service_id == @context.agent.service_id

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -16,36 +16,28 @@
 
   .card
     .card-body
-      h5.card-title Type de RDV
-      = label_tag do
-        = f.radio_button(:location_type, :public_office)
-        span.ml-1= t("activerecord.attributes.motif.location_types.public_office")
-        p.text-muted.font-14 Le RDV aura lieu au lieu sélectionné (MDS...)
-      = label_tag do
-        = f.radio_button(:location_type, :phone)
-        span.ml-1= t("activerecord.attributes.motif.location_types.phone")
-        p.text-muted.font-14 L'usager sera notifié que le RDV se passera par téléphone, au numéro indiqué dans son profil.
-      = label_tag do
-        = f.radio_button(:location_type, :home)
-        span.ml-1= t("activerecord.attributes.motif.location_types.home")
-        p.text-muted.font-14 L'usager sera notifié que le RDV aura lieu à l'adresse remplie dans son profil.
+      h5.card-title= t("activerecord.attributes.motif.location_type")
+      - [:public_office, :phone, :home].each do |value|
+        = label_tag do
+          = f.radio_button(:location_type, value)
+          span.ml-1= Motif.human_enum_name(:location_type, value)
+          p.text-muted.font-14= Motif.human_enum_name(:location_type_hint, value)
 
   .card
     .card-body
-      h5.card-title RDV de suivi
-      = f.input :follow_up, label: "Ce motif est réservé aux usagers bénéficiant d'un accompagnement"
+      h5.card-title= t("activerecord.attributes.motif.follow_up_short")
+      = f.input :follow_up
 
   .card
     .card-body
-      h5.card-title RDV secrétariat
-      p.text-muted.font-14 Les membres du service Secrétariat pourront poser des RDV dans leur agenda et configurer les plages d'ouverture avec ce motif.
-      = f.input :for_secretariat, label: 'Le RDV pourra être effectué par le service secrétariat'
+      h5.card-title= t("activerecord.attributes.motif.for_secretariat_short")
+      p.text-muted.font-14= t("activerecord.attributes.motif.for_secretariat_hint")
+      = f.input :for_secretariat, label: t("activerecord.attributes.motif.for_secretariat_label")
 
   .card
     .card-body
-      h5.card-title Prise de RDV en ligne par les usagers
-      p.text-muted.font-14 Ce motif sera disponible à la réservation en ligne par les usagers.
-
+      h5.card-title= t("activerecord.attributes.motif.reservable_online_title")
+      p.text-muted.font-14= t("activerecord.attributes.motif.reservable_online_hint")
       = f.input :reservable_online
       .form-row
         .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
@@ -53,24 +45,24 @@
 
   .card.js-sectorisation-card
     .card-body
-      h5.mb-2 Sectorisation géographique
+      h5.mb-2= t("activerecord.attributes.motif.sectorisation_level_title")
       .text-muted.mb-3
-        span> Seules les recherches des usagers sont concernées par ces règles de sectorisation. Elles n'ont donc pas d'effet si le motif n'est pas réservable en ligne.
+        span>= t("activerecord.attributes.motif.sectorisation_level_hint")
         = link_to "https://doc.rdv-solidarites.fr/sectorisation-geographique" do
           span> Documentation sur la sectorisation
           i.fa.fa-external-link-alt>
       .mb-2= label_tag do
         = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
-        span.ml-1= "Réservable par les usagers dans l'ensemble du #{current_organisation.departement}"
+        span.ml-1= Motif.human_enum_name(:sectorisation_level_hint, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
       = label_tag do
         = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION)
-        span.ml-1= "Réservable par les usagers uniquement dans les secteurs attribués à l'organisation #{current_organisation.name}"
+        span.ml-1= Motif.human_enum_name(:sectorisation_level_hint, Motif::SECTORISATION_LEVEL_ORGANISATION)
         .text-muted.font-14.my-1.ml-3
           - sectors_attributed_to_orga = Sector.attributed_to_organisation(current_organisation)
           = t("motifs.form.sectorisation_level.sectors_attributed_to_orga", count: sectors_attributed_to_orga.count, sectors: sectors_attributed_to_orga.map(&:name).to_sentence.truncate(100), organisation: current_organisation.name)
       = label_tag do
         = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT)
-        span.ml-1 Réservable par les usagers uniquement dans les secteurs attribués à des agents spécifiques
+        span.ml-1= Motif.human_enum_name(:sectorisation_level_hint, Motif::SECTORISATION_LEVEL_AGENT)
         - if motif.service.present?
           - attributions_group = SectorAttribution.level_agent_grouped_by_service(current_organisation).fetch(motif.service_id, {agents_count: 0, attributions: []})
           .text-muted.font-14.my-1.ml-3
@@ -84,19 +76,12 @@
 
   .card
     .card-body
-      h5 Visibilité usager
-      = label_tag do
-        = f.radio_button(:visibility_type, :visible_and_notified)
-        span.ml-1= t("activerecord.attributes.motif.visibility_types.visible_and_notified")
-        p.text-muted.font-14 Le RDV sera visible dans la liste des RDVs côté usager, l'usager sera notifié par SMS et/ou email
-      = label_tag do
-        = f.radio_button(:visibility_type, :visible_and_not_notified)
-        span.ml-1= t("activerecord.attributes.motif.visibility_types.visible_and_not_notified")
-        p.text-muted.font-14 Le RDV sera visible dans la liste des RDVs côté usager, l'usager ne recevra aucune notification (ni SMS ni email)
-      = label_tag do
-        = f.radio_button(:visibility_type, :invisible)
-        span.ml-1= t("activerecord.attributes.motif.visibility_types.invisible")
-        p.text-muted.font-14 Le RDV sera invisible dans la liste des RDVs côté usager, l'usager ne recevra aucune notification (ni SMS ni email)
+      h5.card-title= t("activerecord.attributes.motif.visibility_type")
+      - [:visible_and_notified, :visible_and_not_notified, :invisible].each do |value|
+        = label_tag do
+          = f.radio_button(:visibility_type, value)
+          span.ml-1= Motif.human_enum_name(:visibility_type, value)
+          p.text-muted.font-14= Motif.human_enum_name(:visibility_type_hint, value)
 
   .card
     .card-body

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -2,7 +2,7 @@ tr
   td.pr-0.text-right
     span.badge.badge-pill.ml-0.mr-2 style="background: #{motif.color};" &nbsp;
   td
-    = link_to motif.name, edit_admin_organisation_motif_path(motif.organisation, motif)
+    = link_to motif.name, admin_organisation_motif_path(motif.organisation, motif)
     = motif_badges(motif, only: [:secretariat, :follow_up])
   td
     = motif_badges(motif, only: [:reservable_online])
@@ -21,4 +21,12 @@ tr
   td= motif.service.short_name
   td= Motif.human_enum_name(:location_type, motif.location_type)
   td= "#{motif.default_duration_in_min} min."
-  td= link_to "Éditer", edit_admin_organisation_motif_path(motif.organisation, motif)
+  - if policy([:agent, motif]).edit? || policy([:agent, motif]).destroy?
+    td
+      .d-flex
+        - if policy([:agent, motif]).edit?
+          div.mr-3= link_to edit_admin_organisation_motif_path(current_organisation, motif), title: "Modifier" do
+            i.fa.fa-edit
+        - if policy([:agent, motif]).destroy?
+          div= link_to admin_organisation_motif_path(current_organisation, motif), method: :delete, title: "Supprimer", data: { confirm: "Confirmez-vous la suppression de ce motif ?"} do
+            i.fa.fa-trash-alt

--- a/app/views/admin/motifs/_motif_attributes.html.slim
+++ b/app/views/admin/motifs/_motif_attributes.html.slim
@@ -1,0 +1,60 @@
+- with_options scope: 'activerecord.attributes.motif' do |i18n|
+  = motif_attribute_row(i18n.t(:name), motif.name)
+  = motif_attribute_row(i18n.t(:service), motif.service.name)
+  = motif_attribute_row \
+    i18n.t(:default_duration_in_min_short),  \
+    "#{motif.default_duration_in_min} minutes"
+  = motif_attribute_row(i18n.t(:color)) do
+    span.motif-color-badge>[style="background-color: #{motif.color};"]
+    span.text-muted= motif.color
+  hr
+
+  = motif_attribute_row("Type de RDV") do
+    div= Motif.human_enum_name(:location_type, motif.location_type)
+    div.text-muted
+      = Motif.human_enum_name(:location_type_hint, motif.location_type)
+  hr
+
+  = motif_attribute_row \
+    i18n.t(:follow_up_short), \
+    motif_option_value(motif, :follow_up)
+  = motif_attribute_row \
+    i18n.t(:for_secretariat_short), \
+    motif_option_value(motif, :for_secretariat)
+  hr
+
+  = motif_attribute_row \
+    i18n.t(:reservable_online), \
+    motif_option_value(motif, :reservable_online)
+  = motif_attribute_row \
+    i18n.t(:min_booking_delay_short), \
+    motif.reservable_online? && \
+      min_max_delay_int_to_human(motif.min_booking_delay), \
+    hint: i18n.t(:min_booking_delay_hint)
+  = motif_attribute_row \
+    i18n.t(:max_booking_delay_short), \
+    motif.reservable_online? && \
+      min_max_delay_int_to_human(motif.max_booking_delay), \
+    hint: i18n.t(:max_booking_delay_hint)
+  = motif_attribute_row("Sectorisation") do
+    - if motif.reservable_online?
+      div= Motif.human_enum_name(:sectorisation_level, motif.sectorisation_level)
+      div.text-muted= Motif.human_enum_name(:sectorisation_level_hint, motif.sectorisation_level)
+    - else
+      span.text-muted N/A
+  hr
+
+  = motif_attribute_row(i18n.t(:visibility_type)) do
+    div= Motif.human_enum_name(:visibility_type, motif.visibility_type)
+    div.text-muted
+      = Motif.human_enum_name(:visibility_type_hint, motif.visibility_type)
+  hr
+
+  = motif_attribute_row \
+    i18n.t(:restriction_for_rdv_short), \
+    motif.restriction_for_rdv, \
+    hint: i18n.t(:restriction_for_rdv_hint)
+  = motif_attribute_row \
+    i18n.t(:instruction_for_rdv_short), \
+    motif.instruction_for_rdv, \
+    hint: i18n.t(:instruction_for_rdv_hint)

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -3,8 +3,10 @@
 - content_for :title do
   | Vos motifs
 
-- content_for :breadcrumb do
-  = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-white"
+- mock_motif = Motif.new(organisation: current_organisation)
+- if policy([:agent, mock_motif]).create?
+  - content_for :breadcrumb do
+    = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-white"
 
 .row
   .col-md-12
@@ -21,7 +23,8 @@
               th= t("activerecord.attributes.motif.service")
               th= t("activerecord.attributes.motif.location_type")
               th= t("activerecord.attributes.motif.default_duration")
-              th
+              - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
+                th Actions
           tbody
             = render @motifs
         .d-flex.justify-content-center id="users-pagination"
@@ -34,5 +37,6 @@
             span.fa-stack.fa-4x
               i.fa.fa-circle.fa-stack-2x.text-primary
               i.far.fa-calendar.fa-stack-1x.text-white
-      .text-center.mb-3
-        = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+      - if policy([:agent, Motif.new(organisation: current_organisation)]).create?
+        .text-center.mb-3
+          = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -1,0 +1,24 @@
+- motif_policy = policy([:agent, @motif])
+- content_for(:menu_item) { 'menu-motifs' }
+
+- content_for :title do
+  | Motif #{@motif.name} (#{@motif.service.short_name})
+
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to 'Vos motifs', admin_organisation_motifs_path(current_organisation)
+    li.breadcrumb-item.active #{@motif.name}
+
+.row.justify-content-center
+  .col-md-8
+    .card
+      .card-body
+        = render "motif_attributes", motif: @motif
+      - if motif_policy.edit? || motif_policy.destroy?
+        .card-footer
+          .d-flex.justify-content-end
+            - if motif_policy.destroy?
+              div.mr-2= link_to "Supprimer", admin_organisation_motif_path(current_organisation, @motif), method: :delete, data: { confirm: "Confirmez-vous la suppression de ce motif ?"}, class: "btn btn-danger w-100"
+            - if motif_policy.edit?
+              div= link_to "Éditer", edit_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -114,6 +114,13 @@
           do
             i.fa.fa-building>
             span.ml-1 Lieux
+        li.side-nav-item.mb-4.pl-3.pr-2
+          = link_to \
+            admin_organisation_motifs_path(current_organisation), \
+            class: ("active" if content_for(:menu_item) == 'menu-motifs') \
+          do
+            i.fa.fa-paste>
+            span.ml-1 Motifs
 
       - if current_agent.admin?
         li.side-nav-item.mb-4.pl-3.pr-2

--- a/app/webpacker/stylesheets/components/_motifs.scss
+++ b/app/webpacker/stylesheets/components/_motifs.scss
@@ -28,3 +28,10 @@
 .badge-motif-sectorisation_level_departement {
   border: 1px solid $gray-900;
 }
+
+.motif-color-badge {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+}

--- a/app/webpacker/stylesheets/components/_utilities.scss
+++ b/app/webpacker/stylesheets/components/_utilities.scss
@@ -52,3 +52,7 @@ ul.horizontal-border-between-items {
     border-bottom: none;
   }
 }
+
+.text-bold {
+  font-weight: bold;
+}

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -8,26 +8,57 @@ fr:
         service: Service
         name: Nom
         color: Couleur
-        reservable_online: Réservable
+        reservable_online_title: Prise de RDV en ligne par les usagers
+        reservable_online: Réservable en ligne
+        reservable_online_hint: Ce motif sera disponible à la réservation en ligne par les usagers
         visibility_type: Visibilité usager
         visibility_types:
           visible_and_notified: Visible et notifié
           visible_and_not_notified: Visible et non notifié
           invisible: Invisible
+        visibility_type_hints:
+          visible_and_notified: Le RDV sera visible dans la liste des RDVs côté usager, l'usager sera notifié par SMS et/ou email
+          visible_and_not_notified: Le RDV sera visible dans la liste des RDVs côté usager, l'usager ne recevra aucune notification (ni SMS ni email)
+          invisible: Le RDV sera invisible dans la liste des RDVs côté usager, l'usager ne recevra aucune notification (ni SMS ni email)
         sectorisation_level: Sectorisation
+        sectorisation_level_title: Sectorisation géographique
+        sectorisation_level_hint: Seules les recherches des usagers sont concernées par ces règles de sectorisation. Elles n'ont donc pas d'effet si le motif n'est pas réservable en ligne.
         sectorisation_levels:
           agent: Sectorisation à l'agent
           organisation: Sectorisation à l'organisation
           departement: Sectorisation au département
+        sectorisation_level_hints:
+          agent: Réservable par les usagers uniquement dans les secteurs attribués à des agents spécifiques
+          organisation: Réservable par les usagers uniquement dans les secteurs attribués à l'organisation
+          departement: Réservable par les usagers dans l'ensemble du département
         location_type: Type de RDV
         location_types:
           home: À domicile
           phone: Par téléphone
           public_office: Sur place
+        location_type_hints:
+          home: Le RDV aura lieu au lieu sélectionné (MDS...)
+          phone: L'usager sera notifié que le RDV se passera par téléphone, au numéro indiqué dans son profil
+          public_office: L'usager sera notifié que le RDV aura lieu à l'adresse remplie dans son profil
         for_secretariat: Motif accessible au secrétariat
+        for_secretariat_label: Le RDV pourra être effectué par le service secrétariat
+        for_secretariat_short: RDV Secrétariat
+        for_secretariat_hint: Les membres du service Secrétariat pourront poser des RDV dans leur agenda et configurer les plages d'ouverture avec ce motif
+        follow_up: Ce motif est réservé aux usagers bénéficiant d'un accompagnement
+        follow_up_short: RDV de suivi
+        follow_up_hint: Ce motif est réservé aux usagers bénéficiant d'un accompagnement
         default_duration_in_min: Durée par défaut en minutes
+        default_duration_in_min_short: Durée par défaut
         default_duration: Durée par défaut
         min_booking_delay: Délai minimum de réservation
+        min_booking_delay_short: Délai minimum
+        min_booking_delay_hint: Les premiers créneaux proposés aux usagers ne commenceront pas avant ce délai minimum
         max_booking_delay: Délai maximum de réservation
+        max_booking_delay_short: Délai maximum
+        max_booking_delay_hint: Les derniers créneaux proposés aux usagers n'iront pas au delà de ce délai maximum
         restriction_for_rdv: Instructions à accepter avant la prise du rendez-vous
+        restriction_for_rdv_hint: Instructions à accepter avant la prise du rendez-vous
+        restriction_for_rdv_short: Instructions avant
         instruction_for_rdv: Indications affichées après la confirmation du rendez-vous
+        instruction_for_rdv_hint: Indications affichées après la confirmation du rendez-vous
+        instruction_for_rdv_short: Indications après

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,7 @@ Rails.application.routes.draw do
         resources :plage_ouvertures, except: [:index, :new]
         resources :agent_searches, only: :index, module: "creneaux"
         resources :lieux, except: :show
-        resources :motifs, except: :show
+        resources :motifs
         resources :rdvs, except: [:new] do
           resources :versions, only: [:index]
         end

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe Admin::MotifsController, type: :controller do
     end
   end
 
+  describe "GET #show" do
+    it "returns a success response" do
+      get :show, params: { organisation_id: organisation_id, id: motif.to_param }
+      expect(response).to be_successful
+    end
+  end
+
   describe "GET #new" do
     it "returns a success response" do
       get :new, params: { organisation_id: organisation_id }
@@ -101,7 +108,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
       end
 
       it "redirects to the motif" do
-        expect(response).to redirect_to(admin_organisation_motifs_path(organisation_id))
+        expect(response).to redirect_to(admin_organisation_motif_path(organisation_id, motif))
       end
     end
 

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -95,13 +95,16 @@ describe "Admin can configure the organisation" do
     expect_page_title("Vos motifs")
 
     click_link motif.name
-    expect(page).to have_content("Modifier le motif")
+    expect(page).to have_content("Motif 1")
+    click_link "Éditer"
     expect(page.find_by_id("motif_name")).to have_content(motif.name)
     select(motif_libelle2.name, from: :motif_name)
     click_button("Modifier")
     expect(page).to have_content(motif_libelle2.name)
-    expect_page_title("Vos motifs")
+    expect_page_title("Motif Motif 2 (PMI)")
 
+    click_link "Paramètres"
+    click_link "Vos motifs"
     click_link le_nouveau_motif.name
     expect(page).to have_content(le_nouveau_motif.name)
     click_link("Supprimer")


### PR DESCRIPTION
# Overview

Ajoute une vue `motifs#show`, et rend la vue `motifs#index` accessible aux non-admins

# Screenshots

Vues agent non admin:

<img width="1392" alt="Screenshot 2021-01-20 at 11 25 54" src="https://user-images.githubusercontent.com/883348/105162881-788dd780-5b13-11eb-94a1-94d99eade953.png">

<img width="1392" alt="Screenshot 2021-01-20 at 11 26 02" src="https://user-images.githubusercontent.com/883348/105162891-7af03180-5b13-11eb-83ee-f436bb6abe99.png">

Vues agent admin: 

<img width="1392" alt="Screenshot 2021-01-20 at 13 01 08" src="https://user-images.githubusercontent.com/883348/105172274-a8db7300-5b1f-11eb-83dd-ef6552e10f04.png">

<img width="1392" alt="Screenshot 2021-01-20 at 13 01 16" src="https://user-images.githubusercontent.com/883348/105172280-ab3dcd00-5b1f-11eb-89d0-b91c64c26c64.png">


# Détails d'implém

Pour le lien dans le menu de gauche, j'ai fait comme pour la liste des lieux : le lien apparaît au top level pour les agents non admin , et dans paramètres pour les agents admin. A mon avis on pourrait harmoniser en mettant ces deux items top level même pour les admins.

J'ai essayé de génériser au maximum les wordings dans I18n pour éviter que notre vocabulaire ne diverge entre les différentes vues index, show, edit.
J'en ai profité pour génériser un tout petit peu le code du formulaire sur certaines options à valeurs multiples où ça se justifiait bien.

J'ai peut-être un poil trop fait de helpers pour être plus DRY, c'est un peu moins évident à lire que si tout était inlined mais ça commençait à faire de gros paquets.