### PR TITLE
fix netsize : error handling + break from proc + campaign names

### DIFF
--- a/app/service_models/transactional_sms/base_concern.rb
+++ b/app/service_models/transactional_sms/base_concern.rb
@@ -24,11 +24,11 @@ module TransactionalSms::BaseConcern
 
   def tags
     [
-      ENV["APP"],
+      ENV["APP"]&.gsub("-rdv-solidarites", ""), # shorter names
       "dpt-#{rdv.organisation.departement}",
       "org-#{rdv.organisation.id}",
       self.class.name.demodulize.underscore
-    ]
+    ].compact
   end
 
   def rdv_footer

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -2,6 +2,8 @@ class NetsizeTimeout < StandardError; end
 
 class NetsizeHttpError < StandardError; end
 
+class NetsizeApiError < StandardError; end
+
 class SendTransactionalSmsService < BaseService
   attr_reader :transactional_sms
 
@@ -50,17 +52,25 @@ class SendTransactionalSmsService < BaseService
         messageText: transactional_sms.content,
         originatingAddress: SENDER_NAME,
         originatorTON: 1,
-        campaignName: transactional_sms.tags.join(" "),
+        campaignName: transactional_sms.tags.join(" ").truncate(49),
       }
     )
-    request.on_complete do |response|
-      next if response.success?
-
-      raise NetsizeTimeout if response.timed_out?
-
-      raise NetsizeHttpError, "code: #{response.code}, message: #{response.return_message}"
-    end
+    request.on_complete { netsize_on_complete(_1) }
     request.run
+  end
+
+  def netsize_on_complete(response)
+    if response.success?
+      parsed_res = JSON.parse(response.body)
+      return if parsed_res["responseCode"].zero?
+
+      ::Sentry.set_extras(parsed_res)
+      raise NetsizeApiError, "HTTP 200, responseCode: #{parsed_res['responseCode']}, #{parsed_res['responseMessage']}"
+    end
+
+    raise NetsizeTimeout if response.timed_out?
+
+    raise NetsizeHttpError, "code: #{response.code}, message: #{response.return_message}"
   end
 
   def send_with_debug_logger

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -54,7 +54,7 @@ class SendTransactionalSmsService < BaseService
       }
     )
     request.on_complete do |response|
-      break if response.success?
+      next if response.success?
 
       raise NetsizeTimeout if response.timed_out?
 


### PR DESCRIPTION
don't know how I missed this

il y avait en fait plusieurs problèmes : 
- utilisation de next au lieu de break (mtn return car extrait dans une fonction)
- l'API Netsize renvoie 200 même quand ça marche pas 😬  il faut vérifier le responseCode contenu dans la réponse JSON
- on envoyait des noms de campagne trop longs sur les environnements de demo/prod, la limite est à 50 caractères