### PR TITLE
redirect agents to sign in rather than user sign up

### DIFF
--- a/app/lib/redirect_to_registration.rb
+++ b/app/lib/redirect_to_registration.rb
@@ -1,5 +1,5 @@
 class RedirectToRegistration < Devise::FailureApp
-  def route(_scope)
-    :new_user_registration_url
+  def route(scope)
+    scope == :user ? :new_user_registration_url : super
   end
 end


### PR DESCRIPTION
fix #1135

cf https://github.com/heartcombo/devise/wiki/Redirect-to-new-registration-(sign-up)-path-if-unauthenticated#working-with-multiple-devise-resources