### PR TITLE
Filtre et recherche dans la page des motifs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## Run the tests and rubocop
-	bundle exec rubocop -a && bundle exec brakeman --no-pager && bundle exec rspec --profile 3
+	bundle exec rubocop -a && bundle exec rspec --profile 3 && bundle exec brakeman
 
 install: ## Install or update dependencies
 	bundle install && yarn install && bundle exec rails db:migrate

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: ## Run the tests and rubocop
-	bundle exec rubocop -a && bundle exec rspec --profile 3 && bundle exec brakeman
+	bundle exec rubocop -a && bundle exec brakeman --no-pager && bundle exec rspec --profile 3
 
 install: ## Install or update dependencies
 	bundle install && yarn install && bundle exec rails db:migrate

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -5,7 +5,10 @@ class Admin::MotifsController < AgentAuthController
   before_action :set_motif, only: [:show, :edit, :update, :destroy]
 
   def index
-    @motifs = policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page])
+    @motifs = policy_scope(Motif).active
+    @motifs = params[:search].present? ? @motifs.search_by_text(params[:search]) : @motifs
+    @motifs = @motifs.includes(:organisation).includes(:service).ordered_by_name.page(params[:page])
+
     @sectors_attributed_to_organisation_count = Sector.attributed_to_organisation(current_organisation).count
     @sectorisation_level_agent_counts_by_service = SectorAttribution.level_agent_grouped_by_service(current_organisation)
     @display_sectorisation_level = current_organisation.motifs.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -7,6 +7,15 @@ class Admin::MotifsController < AgentAuthController
   def index
     @motifs = policy_scope(Motif).active
     @motifs = params[:search].present? ? @motifs.search_by_text(params[:search]) : @motifs
+    if params[:online_filter].present?
+      if params[:online_filter] == "En ligne"
+        @motifs = @motifs.reservable_online
+      else
+        @motifs = @motifs.not_reservable_online
+      end
+    end
+    @motifs = params[:service_filter].present? ? @motifs.where(service_id: params[:service_filter]) : @motifs
+    @motifs = params[:location_type_filter].present? ? @motifs.where(location_type: params[:location_type_filter]) : @motifs
     @motifs = @motifs.includes(:organisation).includes(:service).ordered_by_name.page(params[:page])
 
     @sectors_attributed_to_organisation_count = Sector.attributed_to_organisation(current_organisation).count

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -63,9 +63,9 @@ class Admin::MotifsController < AgentAuthController
   private
 
   def filtered(motifs, params)
-    motifs = online_filtered(@motifs, params[:online_filter]) if params[:online_filter].present?
-    motifs = service_filtered(@motifs, params[:service_filter]) if params[:service_filter].present?
-    motifs = location_type_filtered(@motifs, params[:location_type_filter]) if params[:location_type_filter].present?
+    motifs = online_filtered(motifs, params[:online_filter]) if params[:online_filter].present?
+    motifs = motifs.where(service_id: params[:service_filter]) if params[:service_filter].present?
+    motifs = motifs.where(location_type: params[:location_type_filter]) if params[:location_type_filter].present?
     motifs
   end
 
@@ -75,14 +75,6 @@ class Admin::MotifsController < AgentAuthController
     else
       motifs.not_reservable_online
     end
-  end
-
-  def service_filtered(motifs, service_filter)
-    motifs.where(service_id: service_filter)
-  end
-
-  def location_type_filtered(motifs, location_type_filter)
-    motifs.where(location_type: location_type_filter)
   end
 
   def set_motif

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -56,6 +56,14 @@ class Motif < ApplicationRecord
   scope :sectorisation_level_organisation, -> { where(sectorisation_level: SECTORISATION_LEVEL_ORGANISATION) }
   scope :sectorisation_level_agent, -> { where(sectorisation_level: SECTORISATION_LEVEL_AGENT) }
 
+  include PgSearch::Model
+  pg_search_scope(
+    :search_by_text,
+    ignoring: :accents,
+    using: { tsearch: { prefix: true } },
+    against: [:name]
+  )
+
   def soft_delete
     rdvs.any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
   end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -32,6 +32,7 @@ class Motif < ApplicationRecord
 
   scope :active, -> { where(deleted_at: nil) }
   scope :reservable_online, -> { where(reservable_online: true) }
+  scope :not_reservable_online, -> { where(reservable_online: false) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
   scope :for_secretariat, -> { where(for_secretariat: true) }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(motifs.name))")) }

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -13,35 +13,53 @@
     .card
       .m-3.d-flex.justify-content-end
         div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
-        div= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline' }, wrapper: :inline_form do |f|
+        div= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline search-and-filter-form' }, wrapper: :inline_form do |f|
           = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
+          = f.input :service_filter, as: :hidden, value: params[:service_filter]
+          = f.input :online_filter, as: :hidden, value: params[:online_filter]
+          = f.input :location_type_filter, as: :hidden, value: params[:location_type_filter]
           = f.button :submit, 'Rechercher'
-      - if @motifs.any?
-        table.table
-          thead
-            tr
-              th
-              th= t("activerecord.attributes.motif.name")
-              th= t("activerecord.attributes.motif.reservable_online")
-              - if @display_sectorisation_level
-                th= t("activerecord.attributes.motif.sectorisation_level")
-              th= t("activerecord.attributes.motif.service")
-              th= t("activerecord.attributes.motif.location_type")
-              th= t("activerecord.attributes.motif.default_duration")
-              - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
-                th Actions
-          tbody
+      table.table
+        thead
+          tr
+            th
+            th= t("activerecord.attributes.motif.name")
+            th
+              div
+                = t("activerecord.attributes.motif.reservable_online")
+              div
+                = select_tag("online_filter_select", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "motif-filters")
+            - if @display_sectorisation_level
+              th= t("activerecord.attributes.motif.sectorisation_level")
+            th
+              div
+                = t("activerecord.attributes.motif.service")
+              div
+                = select_tag("service_filter_select", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "motif-filters")
+            th
+              div
+                = t("activerecord.attributes.motif.location_type")
+              div
+                = select_tag("location_type_filter_select", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "motif-filters")
+            th= t("activerecord.attributes.motif.default_duration")
+            - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
+              th Actions
+        tbody
+          - if @motifs.any?
             = render @motifs
-        .d-flex.justify-content-center id="users-pagination"
-          = paginate @motifs, theme: 'twitter-bootstrap-4'
-      - else
-        .row.justify-content-md-center
-          .col-md-6.text-center.my-5
-            p.mb-2.lead Vous n'avez pas encore créé de motif.
-            p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
-            span.fa-stack.fa-4x
-              i.fa.fa-circle.fa-stack-2x.text-primary
-              i.far.fa-calendar.fa-stack-1x.text-white
+            .d-flex.justify-content-center id="users-pagination"
+              = paginate @motifs, theme: 'twitter-bootstrap-4'
+          - else
+            tr
+              td(colspan=6)
+                .row.justify-content-md-center
+                  .col-md-6.text-center.my-5
+                    p.mb-2.lead Vous n'avez pas encore créé de motif.
+                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
+                    span.fa-stack.fa-4x
+                      i.fa.fa-circle.fa-stack-2x.text-primary
+                      i.far.fa-calendar.fa-stack-1x.text-white
       - if policy([:agent, Motif.new(organisation: current_organisation)]).create?
         .text-center.mb-3
           = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -28,19 +28,19 @@
               div
                 = t("activerecord.attributes.motif.reservable_online")
               div
-                = select_tag("online_filter_select", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "motif-filters")
+                = select_tag("online_filter_select", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "motif-filters select2-input")
             - if @display_sectorisation_level
               th= t("activerecord.attributes.motif.sectorisation_level")
             th
               div
                 = t("activerecord.attributes.motif.service")
               div
-                = select_tag("service_filter_select", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "motif-filters")
+                = select_tag("service_filter_select", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "motif-filters select2-input")
             th
               div
                 = t("activerecord.attributes.motif.location_type")
               div
-                = select_tag("location_type_filter_select", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "motif-filters")
+                = select_tag("location_type_filter_select", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "motif-filters select2-input")
             th= t("activerecord.attributes.motif.default_duration")
             - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
               th Actions

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -11,6 +11,11 @@
 .row
   .col-md-12
     .card
+      .m-3.d-flex.justify-content-end
+        div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
+        div= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline' }, wrapper: :inline_form do |f|
+          = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
+          = f.button :submit, 'Rechercher'
       - if @motifs.any?
         table.table
           thead

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -8,58 +8,56 @@
   - content_for :breadcrumb do
     = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-white"
 
-.row
-  .col-md-12
-    .card
-      .m-3.d-flex.justify-content-end
-        div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
-        div= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline search-and-filter-form' }, wrapper: :inline_form do |f|
+= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline search-and-filter-form' }, wrapper: :inline_form do |f|
+
+  .row
+    .col-md-12
+      .card
+        .m-3.d-flex.justify-content-end
+          div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
           = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
-          = f.input :service_filter, as: :hidden, value: params[:service_filter]
-          = f.input :online_filter, as: :hidden, value: params[:online_filter]
-          = f.input :location_type_filter, as: :hidden, value: params[:location_type_filter]
           = f.button :submit, 'Rechercher'
-      table.table
-        thead
-          tr
-            th
-            th= t("activerecord.attributes.motif.name")
-            th
-              div
-                = t("activerecord.attributes.motif.reservable_online")
-              div
-                = select_tag("online_filter_select", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "motif-filters select2-input")
-            - if @display_sectorisation_level
-              th= t("activerecord.attributes.motif.sectorisation_level")
-            th
-              div
-                = t("activerecord.attributes.motif.service")
-              div
-                = select_tag("service_filter_select", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "motif-filters select2-input")
-            th
-              div
-                = t("activerecord.attributes.motif.location_type")
-              div
-                = select_tag("location_type_filter_select", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "motif-filters select2-input")
-            th= t("activerecord.attributes.motif.default_duration")
-            - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
-              th Actions
-        tbody
-          - if @motifs.any?
-            = render @motifs
-            .d-flex.justify-content-center id="users-pagination"
-              = paginate @motifs, theme: 'twitter-bootstrap-4'
-          - else
+        table.table
+          thead
             tr
-              td(colspan=6)
-                .row.justify-content-md-center
-                  .col-md-6.text-center.my-5
-                    p.mb-2.lead Vous n'avez pas encore créé de motif.
-                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
-                    span.fa-stack.fa-4x
-                      i.fa.fa-circle.fa-stack-2x.text-primary
-                      i.far.fa-calendar.fa-stack-1x.text-white
-      - if policy([:agent, Motif.new(organisation: current_organisation)]).create?
-        .text-center.mb-3
-          = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+              th
+              th= t("activerecord.attributes.motif.name")
+              th
+                div
+                  = t("activerecord.attributes.motif.reservable_online")
+                div
+                  = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "motif-filters select2-input")
+              - if @display_sectorisation_level
+                th= t("activerecord.attributes.motif.sectorisation_level")
+              th
+                div
+                  = t("activerecord.attributes.motif.service")
+                div
+                  = select_tag("service_filter", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "motif-filters select2-input")
+              th
+                div
+                  = t("activerecord.attributes.motif.location_type")
+                div
+                  = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "motif-filters select2-input")
+              th= t("activerecord.attributes.motif.default_duration")
+              - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
+                th Actions
+          tbody
+            - if @motifs.any?
+              = render @motifs
+              .d-flex.justify-content-center id="users-pagination"
+                = paginate @motifs, theme: 'twitter-bootstrap-4'
+            - else
+              tr
+                td(colspan=6)
+                  .row.justify-content-md-center
+                    .col-md-6.text-center.my-5
+                      p.mb-2.lead Vous n'avez pas encore créé de motif.
+                      p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
+                      span.fa-stack.fa-4x
+                        i.fa.fa-circle.fa-stack-2x.text-primary
+                        i.far.fa-calendar.fa-stack-1x.text-white
+        - if policy([:agent, Motif.new(organisation: current_organisation)]).create?
+          .text-center.mb-3
+            = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
 

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -8,7 +8,7 @@
   - content_for :breadcrumb do
     = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-white"
 
-= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline search-and-filter-form' }, wrapper: :inline_form do |f|
+= simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline js-search-and-filter-form' }, wrapper: :inline_form do |f|
 
   .row
     .col-md-12
@@ -26,19 +26,19 @@
                 div
                   = t("activerecord.attributes.motif.reservable_online")
                 div
-                  = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "motif-filters select2-input")
+                  = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
               - if @display_sectorisation_level
                 th= t("activerecord.attributes.motif.sectorisation_level")
               th
                 div
                   = t("activerecord.attributes.motif.service")
                 div
-                  = select_tag("service_filter", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "motif-filters select2-input")
+                  = select_tag("service_filter", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
               th
                 div
                   = t("activerecord.attributes.motif.location_type")
                 div
-                  = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "motif-filters select2-input")
+                  = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
               th= t("activerecord.attributes.motif.default_duration")
               - if policy([:agent, mock_motif]).edit? || policy([:agent, mock_motif]).destroy?
                 th Actions

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -33,7 +33,7 @@
                 div
                   = t("activerecord.attributes.motif.service")
                 div
-                  = select_tag("service_filter", options_from_collection_for_select(Service.all, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+                  = select_tag("service_filter", options_from_collection_for_select(@motifs.map(&:service).uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
               th
                 div
                   = t("activerecord.attributes.motif.location_type")

--- a/app/webpacker/components/motif-filters.js
+++ b/app/webpacker/components/motif-filters.js
@@ -1,0 +1,17 @@
+class MotifFilters {
+  constructor() {
+    document.querySelectorAll('.motif-filters').forEach(formElt =>
+      formElt.addEventListener('change', this.changeFilters)
+    )
+  }
+
+  changeFilters = () => {
+    document.querySelector("#service_filter").value = document.querySelector("#service_filter_select").value
+    document.querySelector("#online_filter").value = document.querySelector("#online_filter_select").value
+    document.querySelector("#location_type_filter").value = document.querySelector("#location_type_filter_select").value
+    document.querySelector(".search-and-filter-form").submit()
+  }
+}
+
+export { MotifFilters };
+

--- a/app/webpacker/components/motif-filters.js
+++ b/app/webpacker/components/motif-filters.js
@@ -1,14 +1,13 @@
 class MotifFilters {
   constructor() {
-    console.log("dans le motif filters constructor")
-    document.querySelectorAll('.motif-filters').forEach(formElt => {
+    document.querySelectorAll('.js-motif-filters').forEach(formElt => {
       $(formElt).on('change', this.changeFilters)
     }
     )
   }
 
   changeFilters = () => {
-    document.querySelector(".search-and-filter-form").submit()
+    document.querySelector(".js-search-and-filter-form").submit()
   }
 }
 

--- a/app/webpacker/components/motif-filters.js
+++ b/app/webpacker/components/motif-filters.js
@@ -6,9 +6,9 @@ class MotifFilters {
   }
 
   changeFilters = () => {
-    document.querySelector("#service_filter").value = document.querySelector("#service_filter_select").value
-    document.querySelector("#online_filter").value = document.querySelector("#online_filter_select").value
-    document.querySelector("#location_type_filter").value = document.querySelector("#location_type_filter_select").value
+    ["service", "online", "location_type"].forEach(function (field) {
+      document.querySelector(`#${field}_filter`).value = document.querySelector(`#${field}_filter_select`).value
+    })
     document.querySelector(".search-and-filter-form").submit()
   }
 }

--- a/app/webpacker/components/motif-filters.js
+++ b/app/webpacker/components/motif-filters.js
@@ -1,14 +1,13 @@
 class MotifFilters {
   constructor() {
-    document.querySelectorAll('.motif-filters').forEach(formElt =>
-      formElt.addEventListener('change', this.changeFilters)
+    console.log("dans le motif filters constructor")
+    document.querySelectorAll('.motif-filters').forEach(formElt => {
+      $(formElt).on('change', this.changeFilters)
+    }
     )
   }
 
   changeFilters = () => {
-    ["service", "online", "location_type"].forEach(function (field) {
-      document.querySelector(`#${field}_filter`).value = document.querySelector(`#${field}_filter_select`).value
-    })
     document.querySelector(".search-and-filter-form").submit()
   }
 }

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -107,7 +107,6 @@ $(document).on('turbolinks:load', function() {
 
   new AgentsCreneaux();
 
-
   new AgentUserForm();
 
   new RecordVersions();

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -18,6 +18,7 @@ import { Modal } from 'components/modal';
 import { Rightbar } from 'components/rightbar';
 import { PopulateLibelle } from 'components/populate-libelle';
 import { ServiceFilterForMotifsSelects } from 'components/service-filter-for-motifs-selects';
+import { MotifFilters } from 'components/motif-filters';
 import 'components/analytic.js';
 import { PlacesInputs } from 'components/places-inputs.js';
 import { RdvWizardStep2 } from 'components/rdv_wizard_step2.js';
@@ -98,11 +99,14 @@ $(document).on('turbolinks:load', function() {
 
   new MotifForm();
 
+  new MotifFilters();
+
   new RdvWizardStep2();
 
   new ZonesMap();
 
   new AgentsCreneaux();
+
 
   new AgentUserForm();
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -38,7 +38,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/rdv.rb",
-      "line": 55,
+      "line": 56,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"#{Arel.sql(\"(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)\")} BETWEEN ? AND ?\", range.begin, range.end)",
       "render_path": null,
@@ -58,7 +58,7 @@
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/admin/permissions_controller.rb",
-      "line": 20,
+      "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:agent_permission).permit(:role)",
       "render_path": null,
@@ -78,7 +78,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/rdv.rb",
-      "line": 63,
+      "line": 65,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "where(\"starts_at <= ?\", (Time.zone.now + time_margin)).where(\"#{Arel.sql(\"(starts_at + (duration_in_min::text|| 'minute')::INTERVAL)\")} >= ?\", (Time.zone.now - time_margin))",
       "render_path": null,
@@ -125,19 +125,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "d73171480d9871ed50cc113b6a9bfc457a0c694d2f085d7537447509b41509e0",
+      "fingerprint": "d47b97da06b485e3b3e6da6d8056f1fb1f0beb9a247bc81f90ae0947d5f4d584",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
-      "line": 26,
+      "line": 49,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => policy_scope(Motif).includes(:organisation).active.includes(:service).ordered_by_name.page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active), params).includes(:organisation).includes(:service).ordered_by_name.page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
           "class": "Admin::MotifsController",
           "method": "index",
-          "line": 12,
+          "line": 16,
           "file": "app/controllers/admin/motifs_controller.rb",
           "rendered": {
             "name": "admin/motifs/index",
@@ -154,6 +154,6 @@
       "note": ""
     }
   ],
-  "updated": "2020-12-22 11:15:18 +0100",
-  "brakeman_version": "4.7.2"
+  "updated": "2021-01-28 15:14:14 +0100",
+  "brakeman_version": "4.10.1"
 }

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Admin::MotifsController, type: :controller do
   render_views
 
-  let(:agent) { create(:agent, :admin) }
-  let(:organisation_id) { agent.organisation_ids.first }
-  let!(:motif) { create(:motif, organisation_id: organisation_id) }
+  let(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, :admin, organisations: [organisation]) }
+  let!(:motif) { create(:motif, organisation_id: organisation.id) }
 
   before do
     sign_in agent
@@ -11,28 +11,37 @@ RSpec.describe Admin::MotifsController, type: :controller do
 
   describe "GET #index" do
     it "returns a success response" do
-      get :index, params: { organisation_id: organisation_id }
+      get :index, params: { organisation_id: organisation.id }
       expect(response).to be_successful
+    end
+
+    context "with a filter query parameter" do
+      it "returns motif list where name match" do
+        create(:motif, organisation: organisation)
+        bla_motif = create(:motif, name: "bla", organisation: organisation)
+        get :index, params: { organisation_id: organisation.id , search: "bla"}
+        expect(assigns(:motifs)).to eq([bla_motif])
+      end
     end
   end
 
   describe "GET #show" do
     it "returns a success response" do
-      get :show, params: { organisation_id: organisation_id, id: motif.to_param }
+      get :show, params: { organisation_id: organisation.id, id: motif.to_param }
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: { organisation_id: organisation_id }
+      get :new, params: { organisation_id: organisation.id }
       expect(response).to be_successful
     end
   end
 
   describe "GET #edit" do
     it "returns a success response" do
-      get :edit, params: { organisation_id: organisation_id, id: motif.to_param }
+      get :edit, params: { organisation_id: organisation.id, id: motif.to_param }
       expect(response).to be_successful
     end
   end
@@ -45,13 +54,13 @@ RSpec.describe Admin::MotifsController, type: :controller do
 
       it "creates a new Motif" do
         expect do
-          post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
+          post :create, params: { organisation_id: organisation.id, motif: valid_attributes }
         end.to change(Motif, :count).by(1)
       end
 
       it "redirects to the created motif" do
-        post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
-        expect(response).to redirect_to(admin_organisation_motifs_path(organisation_id))
+        post :create, params: { organisation_id: organisation.id, motif: valid_attributes }
+        expect(response).to redirect_to(admin_organisation_motifs_path(organisation.id))
       end
     end
 
@@ -64,12 +73,12 @@ RSpec.describe Admin::MotifsController, type: :controller do
 
       it "does not create a new Motif" do
         expect do
-          post :create, params: { organisation_id: organisation_id, motif: invalid_attributes }
+          post :create, params: { organisation_id: organisation.id, motif: invalid_attributes }
         end.not_to change(Motif, :count)
       end
 
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: { organisation_id: organisation_id, motif: invalid_attributes }
+        post :create, params: { organisation_id: organisation.id, motif: invalid_attributes }
         expect(response).to be_successful
       end
     end
@@ -81,7 +90,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
       end
 
       subject do
-        post :create, params: { organisation_id: organisation_id, motif: valid_attributes }
+        post :create, params: { organisation_id: organisation.id, motif: valid_attributes }
       end
 
       it "creates a new Motif" do
@@ -91,7 +100,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
   end
 
   describe "PUT #update" do
-    subject { put :update, params: { organisation_id: organisation_id, id: motif.to_param, motif: new_attributes } }
+    subject { put :update, params: { organisation_id: organisation.id, id: motif.to_param, motif: new_attributes } }
 
     before { subject }
 
@@ -108,7 +117,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
       end
 
       it "redirects to the motif" do
-        expect(response).to redirect_to(admin_organisation_motif_path(organisation_id, motif))
+        expect(response).to redirect_to(admin_organisation_motif_path(organisation.id, motif))
       end
     end
 
@@ -133,13 +142,13 @@ RSpec.describe Admin::MotifsController, type: :controller do
   describe "DELETE #destroy" do
     it "destroys the requested motif" do
       expect do
-        delete :destroy, params: { organisation_id: organisation_id, id: motif.to_param }
+        delete :destroy, params: { organisation_id: organisation.id, id: motif.to_param }
       end.to change(Motif, :count).by(-1)
     end
 
     it "redirects to the motifs list" do
-      delete :destroy, params: { organisation_id: organisation_id, id: motif.to_param }
-      expect(response).to redirect_to(admin_organisation_motifs_path(organisation_id))
+      delete :destroy, params: { organisation_id: organisation.id, id: motif.to_param }
+      expect(response).to redirect_to(admin_organisation_motifs_path(organisation.id))
     end
   end
 end

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
       it "returns motif list where name match" do
         create(:motif, organisation: organisation)
         bla_motif = create(:motif, name: "bla", organisation: organisation)
-        get :index, params: { organisation_id: organisation.id , search: "bla"}
+        get :index, params: { organisation_id: organisation.id, search: "bla" }
         expect(assigns(:motifs)).to eq([bla_motif])
       end
     end


### PR DESCRIPTION
fix #1054

Pour faciliter la consultation des motifs (liste longue parfois), ajout
- d'un champ de recherche (basé sur le nom pour le moment)
- de filtres sur les colonnes « Réservable en ligne », « Service » et « Type de rendez-vous »



