### PR TITLE
Supprime la tache CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - *yarn_install
       - run:
           name: Run linters
-          command: bundle exec rake ci
+          command: bundle exec brakeman --no-page && bundle exec rubocop
       - slack/status:
           fail_only: true
           only_for_branches: master

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,4 +1,0 @@
-task :ci do
-  sh "bundle exec brakeman --no-pager"
-  sh "bundle exec rubocop"
-end


### PR DESCRIPTION
Je viens de découvrir qu'il y a une tache pour exécuter 2 commandes. Je les déplace dans le fichier CI et supprime la tache.

Ça n'a rien à voir avec le souci de Brakeman que j'avais, mais je trouve ça plus clair ainsi.