### PR TITLE
 rajouter liens mailto sur les emails d'usagers

### DIFF
--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -1,6 +1,7 @@
-class DisplayableUser
+class DisplayableUserPresenter
   include UsersHelper
   include ActionView::Helpers::TextHelper
+  include Rails.application.routes.url_helpers
 
   delegate :first_name, :last_name, :birth_name, :address, :affiliation_number, :number_of_children, to: :user
 

--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -55,4 +55,16 @@ class DisplayableUserPresenter
 
     @user.responsible_notify_by_email? ? "🟢 Activées" : "🔴 Désactivées"
   end
+
+  def email_and_notification
+    return "n/a" unless @user.email
+
+    "#{email} - Notifications par email #{notify_by_email}"
+  end
+
+  def phone_number_and_notification
+    return "n/a" unless @user.phone_number
+
+    "#{phone_number} - Notifications par SMS #{notify_by_sms}"
+  end
 end

--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -61,15 +61,27 @@ class DisplayableUserPresenter
     @user.responsible_notify_by_email? ? "🟢 Activées" : "🔴 Désactivées"
   end
 
+  def clickable_email
+    return "N/A" unless email
+
+    mail_to(email)
+  end
+
+  def clickable_phone_number
+    return "N/A" unless phone_number
+
+    link_to(phone_number, "tel:#{phone_number_formatted}")
+  end
+
   def email_and_notification
     return "N/A" unless email
 
-    "#{mail_to(email)} - Notifications par email #{notify_by_email}".html_safe
+    "#{clickable_email} - Notifications par email #{notify_by_email}".html_safe
   end
 
   def phone_number_and_notification
     return "N/A" unless phone_number
 
-    "#{link_to(phone_number, "tel:#{phone_number_formatted}")} - Notifications par SMS #{notify_by_sms}".html_safe
+    "#{clickable_phone_number} - Notifications par SMS #{notify_by_sms}".html_safe
   end
 end

--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -62,25 +62,25 @@ class DisplayableUserPresenter
   end
 
   def clickable_email
-    return "N/A" unless email
+    return "N/A" unless email.present?
 
     mail_to(email)
   end
 
   def clickable_phone_number
-    return "N/A" unless phone_number
+    return "N/A" unless phone_number.present?
 
     link_to(phone_number, "tel:#{phone_number_formatted}")
   end
 
   def email_and_notification
-    return "N/A" unless email
+    return "N/A" unless email.present?
 
     "#{clickable_email} - Notifications par email #{notify_by_email}".html_safe
   end
 
   def phone_number_and_notification
-    return "N/A" unless phone_number
+    return "N/A" unless phone_number.present?
 
     "#{clickable_phone_number} - Notifications par SMS #{notify_by_sms}".html_safe
   end

--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -29,6 +29,10 @@ class DisplayableUserPresenter
     @user.responsible_phone_number
   end
 
+  def phone_number_formatted
+    @user.responsible_or_self.phone_number_formatted
+  end
+
   def email
     @user.responsible_email
   end
@@ -58,21 +62,14 @@ class DisplayableUserPresenter
   end
 
   def email_and_notification
-    return "n/a" unless @user.email
+    return "N/A" unless email
 
     "#{mail_to(email)} - Notifications par email #{notify_by_email}".html_safe
   end
 
   def phone_number_and_notification
-    return "n/a" unless @user.phone_number
+    return "N/A" unless phone_number
 
-    "#{link_to_phone} - Notifications par SMS #{notify_by_sms}".html_safe
-  end
-
-  private
-
-  def link_to_phone
-    user = @user.responsible_or_self
-    link_to(user.phone_number, "tel:#{user.phone_number_formatted}")
+    "#{link_to(phone_number, "tel:#{phone_number_formatted}")} - Notifications par SMS #{notify_by_sms}".html_safe
   end
 end

--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -1,6 +1,7 @@
 class DisplayableUserPresenter
   include UsersHelper
   include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::UrlHelper
   include Rails.application.routes.url_helpers
 
   delegate :first_name, :last_name, :birth_name, :address, :affiliation_number, :number_of_children, to: :user
@@ -59,12 +60,19 @@ class DisplayableUserPresenter
   def email_and_notification
     return "n/a" unless @user.email
 
-    "#{email} - Notifications par email #{notify_by_email}"
+    "#{mail_to(email)} - Notifications par email #{notify_by_email}".html_safe
   end
 
   def phone_number_and_notification
     return "n/a" unless @user.phone_number
 
-    "#{phone_number} - Notifications par SMS #{notify_by_sms}"
+    "#{link_to_phone} - Notifications par SMS #{notify_by_sms}".html_safe
+  end
+
+  private
+
+  def link_to_phone
+    user = @user.responsible_or_self
+    link_to(user.phone_number, "tel:#{user.phone_number_formatted}")
   end
 end

--- a/app/views/admin/merge_users/new.html.slim
+++ b/app/views/admin/merge_users/new.html.slim
@@ -36,7 +36,7 @@
             - if @merge_users_form.user1
               div.pr-2
                 label.d-flex.justify-content-end for="merge_users_form_#{attribute}_1"
-                  - value = DisplayableUser.new(@merge_users_form.user1, current_organisation).send(attribute)
+                  - value = DisplayableUserPresenter.new(@merge_users_form.user1, current_organisation).send(attribute)
                   - if value&.present?
                     div= value
                   - else
@@ -48,7 +48,7 @@
               label for="merge_users_form_#{attribute}_2"
                 - if @merge_users_form.attribute_comparison(attribute) == :different
                   span.mr-2= f.radio_button attribute, "2", required: true
-                - value = DisplayableUser.new(@merge_users_form.user2, current_organisation).send(attribute)
+                - value = DisplayableUserPresenter.new(@merge_users_form.user2, current_organisation).send(attribute)
                 - if value&.present?
                   = value
                 - else

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -57,18 +57,19 @@
               = link_to "Voir la fiche usager", admin_organisation_user_path(current_organisation, user), class: "btn btn-outline-primary small"
 
         .card-body
+          - displayable_user = DisplayableUser.new(user, current_organisation)
           p.card-text
             i.fa.fa-fw.fa-phone>
-            - phone_number = DisplayableUser.new(user, current_organisation).phone_number
+            - phone_number = displayable_user.phone_number
             = display_value_or_na_placeholder(phone_number)
             - if phone_number.present?
-              span> - Notifications par SMS #{DisplayableUser.new(user, current_organisation).notify_by_sms}
+              span> - Notifications par SMS #{displayable_user.notify_by_sms}
           p.card-text
             i.fa.fa-fw.fa-envelope>
-            - email = DisplayableUser.new(user, current_organisation).email
+            - email = displayable_user.email
             = display_value_or_na_placeholder(email)
             - if email.present?
-              span> - Notifications par email #{DisplayableUser.new(user, current_organisation).notify_by_email}
+              span> - Notifications par email #{displayable_user.notify_by_email}
 
           - if user.notes_for(current_organisation).present?
             .d-flex title="Remarques"

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -60,22 +60,16 @@
           - displayable_user = DisplayableUserPresenter.new(user, current_organisation)
           p.card-text
             i.fa.fa-fw.fa-phone>
-            - phone_number = displayable_user.phone_number
-            = display_value_or_na_placeholder(phone_number)
-            - if phone_number.present?
-              span> - Notifications par SMS #{displayable_user.notify_by_sms}
+            = displayable_user.phone_number_and_notification
           p.card-text
             i.fa.fa-fw.fa-envelope>
-            - email = displayable_user.email
-            = display_value_or_na_placeholder(email)
-            - if email.present?
-              span> - Notifications par email #{displayable_user.notify_by_email}
+            = displayable_user.email_and_notification
 
-          - if user.notes_for(current_organisation).present?
+          - if displayable_user.notes.present?
             .d-flex title="Remarques"
               div.mr-1
                 i.fa.fa-fw.fa-info-circle>
-              div= simple_format(user.notes_for(current_organisation))
+              div= displayable_user.notes
 
       = render "admin/rdvs/short_rdvs_list", user: user, rdvs: user.previous_rdvs_ordered_and_truncated(current_organisation), title: "Rendez-vous précédents"
 

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -57,7 +57,7 @@
               = link_to "Voir la fiche usager", admin_organisation_user_path(current_organisation, user), class: "btn btn-outline-primary small"
 
         .card-body
-          - displayable_user = DisplayableUser.new(user, current_organisation)
+          - displayable_user = DisplayableUserPresenter.new(user, current_organisation)
           p.card-text
             i.fa.fa-fw.fa-phone>
             - phone_number = displayable_user.phone_number

--- a/app/views/common/_user_attribute.html.slim
+++ b/app/views/common/_user_attribute.html.slim
@@ -1,3 +1,4 @@
+- displayable_user = DisplayableUserPresenter.new(user, current_organisation)
 - value = DisplayableUserPresenter.new(user, current_organisation).send(attribute_name)
 - if value.present? || !local_assigns[:skip_empty]
   - if attribute_name == :logement
@@ -13,6 +14,16 @@
           span<>= ":"
       div
         = display_value_or_na_placeholder(value)
+  - elsif attribute_name == :email
+    strong
+      = I18n.t("activerecord.attributes.user.email")
+      span<>= ":"
+    = displayable_user.clickable_email
+  - elsif attribute_name == :phone_number
+    strong
+      = I18n.t("activerecord.attributes.user.phone_number")
+      span<>= ":"
+    = displayable_user.clickable_phone_number
   - else
     strong
       = I18n.t("activerecord.attributes.user.#{attribute_name}")

--- a/app/views/common/_user_attribute.html.slim
+++ b/app/views/common/_user_attribute.html.slim
@@ -1,4 +1,4 @@
-- value = DisplayableUser.new(user, current_organisation).send(attribute_name)
+- value = DisplayableUserPresenter.new(user, current_organisation).send(attribute_name)
 - if value.present? || !local_assigns[:skip_empty]
   - if attribute_name == :logement
     strong

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -1,0 +1,148 @@
+describe DisplayableUserPresenter, type: :presenter do
+  describe "#birth_date" do
+    it "return something" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], birth_date: Date.new(1976, 10, 23))
+      displayable_user = DisplayableUserPresenter.new(user, organisation)
+      expect(displayable_user.birth_date).to eq("23/10/1976 - 44 ans")
+    end
+  end
+
+  describe "#user" do
+    it "return given user" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation])
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.user).to eq(user)
+    end
+  end
+
+  describe "delegation user's attributes" do
+    [:first_name, :last_name, :birth_name, :address, :affiliation_number, :number_of_children].each do |attribute|
+      it "delegate #{attribute} to user" do
+        organisation = build(:organisation)
+        user = build(:user, organisations: [organisation])
+        displayable_user = described_class.new(user, organisation)
+        expect(displayable_user.send(attribute)).to eq(user.send(attribute))
+      end
+    end
+  end
+
+  describe "#caisse_affiliation" do
+    it "return user enum value for caisse d'affiliation" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], caisse_affiliation: 1)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.caisse_affiliation).to eq("CAF")
+    end
+  end
+
+  describe "#family_situation" do
+    it "return user's family_situation" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], family_situation: 1)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.family_situation).to eq("En couple")
+    end
+  end
+
+  describe "#phone_number" do
+    it "return user's phone_number" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: "01 23 45 67 89")
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.phone_number).to eq("01 23 45 67 89")
+    end
+
+    it "return user's responsible phone_number" do
+      organisation = build(:organisation)
+      responsible = build(:user, organisations: [organisation], phone_number: "98 78 45 56 32")
+      user = build(:user, organisations: [organisation], phone_number: nil, responsible: responsible)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.phone_number).to eq("98 78 45 56 32")
+    end
+  end
+
+  describe "#email" do
+    it "return user's email" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: "truc@bla.com")
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.email).to eq("truc@bla.com")
+    end
+
+    it "return user's responsible email" do
+      organisation = build(:organisation)
+      responsible = build(:user, organisations: [organisation], email: "bla@truc.net")
+      user = build(:user, organisations: [organisation], email: nil, responsible: responsible)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.email).to eq("bla@truc.net")
+    end
+  end
+
+  describe "#logement" do
+    it "return user's logement from profile" do
+      organisation = create(:organisation)
+      user_profile = create(:user_profile, organisation: organisation, logement: 1)
+      user = create(:user, organisations: [organisation], user_profiles: [user_profile])
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.logement).to eq("Hébergé")
+    end
+  end
+
+  describe "#notes" do
+    it "return user's profile notes" do
+      organisation = create(:organisation)
+      user_profile = create(:user_profile, organisation: organisation, notes: "Quelques notes")
+      user = create(:user, organisations: [organisation], user_profiles: [user_profile])
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notes).to eq("<p>Quelques notes</p>")
+    end
+  end
+
+  describe "#notify_by_sms" do
+    it "returns no phone number when user dont have phone number" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: nil)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_sms).to eq("pas de numéro de téléphone renseigné")
+    end
+
+    it "return activated when user allow sms notifications" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_sms).to eq("🟢 Activées")
+    end
+
+    it "return desactivated when user disallow sms notifications" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: false)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_sms).to eq("🔴 Désactivées")
+    end
+  end
+
+  describe "#notify_by_email" do
+    it "return no email when user responsible don't have email" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: nil)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_email).to eq("pas d'email renseigné")
+    end
+
+    it "return activées when user allow notification_by_email" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: "truc@bla.net", notify_by_email: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_email).to eq("🟢 Activées")
+    end
+
+    it "return desactivées when user disallow notification by email" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: "truc@bla.net", notify_by_email: false)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_email).to eq("🔴 Désactivées")
+    end
+  end
+end

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -158,14 +158,14 @@ describe DisplayableUserPresenter, type: :presenter do
       organisation = build(:organisation)
       user = build(:user, organisations: [organisation], email: "bob@eponge.net", notify_by_email: true)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.email_and_notification).to eq("bob@eponge.net - Notifications par email 🟢 Activées")
+      expect(displayable_user.email_and_notification).to eq("<a href=\"mailto:bob@eponge.net\">bob@eponge.net</a> - Notifications par email 🟢 Activées")
     end
 
     it "returns email and activate notification with a user's email and notification desactivated" do
       organisation = build(:organisation)
       user = build(:user, organisations: [organisation], email: "bob@eponge.net", notify_by_email: false)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.email_and_notification).to eq("bob@eponge.net - Notifications par email 🔴 Désactivées")
+      expect(displayable_user.email_and_notification).to eq("<a href=\"mailto:bob@eponge.net\">bob@eponge.net</a> - Notifications par email 🔴 Désactivées")
     end
   end
 
@@ -179,16 +179,16 @@ describe DisplayableUserPresenter, type: :presenter do
 
     it "returns phone_number and activate notification with a user's email and notification activated" do
       organisation = build(:organisation)
-      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
+      user = create(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.phone_number_and_notification).to eq("01 02 03 04 05 - Notifications par SMS 🟢 Activées")
+      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a> - Notifications par SMS 🟢 Activées")
     end
 
     it "returns phone_number and activate notification with a user's email and notification desactivated" do
       organisation = build(:organisation)
-      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: false)
+      user = create(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: false)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.phone_number_and_notification).to eq("01 02 03 04 05 - Notifications par SMS 🔴 Désactivées")
+      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a> - Notifications par SMS 🔴 Désactivées")
     end
   end
 end

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -147,11 +147,11 @@ describe DisplayableUserPresenter, type: :presenter do
   end
 
   describe "#email_and_notification" do
-    it "returns n/a when no email in user" do
+    it "returns N/A when no email in user" do
       organisation = build(:organisation)
       user = build(:user, organisations: [organisation], email: nil)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.email_and_notification).to eq("n/a")
+      expect(displayable_user.email_and_notification).to eq("N/A")
     end
 
     it "returns email and activate notification with a user's email and notification activated" do
@@ -170,11 +170,11 @@ describe DisplayableUserPresenter, type: :presenter do
   end
 
   describe "#phone_number_and_notification" do
-    it "returns n/a when no phone in user" do
+    it "returns N/A when no phone in user" do
       organisation = build(:organisation)
       user = build(:user, organisations: [organisation], phone_number: nil)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.phone_number_and_notification).to eq("n/a")
+      expect(displayable_user.phone_number_and_notification).to eq("N/A")
     end
 
     it "returns phone_number and activate notification with a user's email and notification activated" do

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -145,4 +145,50 @@ describe DisplayableUserPresenter, type: :presenter do
       expect(displayable_user.notify_by_email).to eq("🔴 Désactivées")
     end
   end
+
+  describe "#email_and_notification" do
+    it "returns n/a when no email in user" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: nil)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.email_and_notification).to eq("n/a")
+    end
+
+    it "returns email and activate notification with a user's email and notification activated" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: "bob@eponge.net", notify_by_email: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.email_and_notification).to eq("bob@eponge.net - Notifications par email 🟢 Activées")
+    end
+
+    it "returns email and activate notification with a user's email and notification desactivated" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: "bob@eponge.net", notify_by_email: false)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.email_and_notification).to eq("bob@eponge.net - Notifications par email 🔴 Désactivées")
+    end
+  end
+
+  describe "#phone_number_and_notification" do
+    it "returns n/a when no phone in user" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: nil)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.phone_number_and_notification).to eq("n/a")
+    end
+
+    it "returns phone_number and activate notification with a user's email and notification activated" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.phone_number_and_notification).to eq("01 02 03 04 05 - Notifications par SMS 🟢 Activées")
+    end
+
+    it "returns phone_number and activate notification with a user's email and notification desactivated" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: false)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.phone_number_and_notification).to eq("01 02 03 04 05 - Notifications par SMS 🔴 Désactivées")
+    end
+  end
 end

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -191,4 +191,36 @@ describe DisplayableUserPresenter, type: :presenter do
       expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a> - Notifications par SMS 🔴 Désactivées")
     end
   end
+
+  describe "#clickable_email" do
+    it "returns N/A when no email in user" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: nil)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.clickable_email).to eq("N/A")
+    end
+
+    it "returns clickable email with a user's email" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], email: "bob@eponge.net", notify_by_email: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.clickable_email).to eq("<a href=\"mailto:bob@eponge.net\">bob@eponge.net</a>")
+    end
+  end
+
+  describe "#clickable_phone_number" do
+    it "returns N/A when no phone in user" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: nil)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.clickable_phone_number).to eq("N/A")
+    end
+
+    it "returns clickable phone_number with a user's phone_number" do
+      organisation = build(:organisation)
+      user = create(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.clickable_phone_number).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a>")
+    end
+  end
 end


### PR DESCRIPTION
#1159

J'en profite pour faire un peu de nettoyage.

- utilisation d'une seul instance de `DisplayableUser` dans le show d'un RDV
- Déplacement du `DisplayableUser` depuis les helpers pour en faire un `DisplayableUserHelper`
- Mise en place de lien `mail_to` et `tel` pour le mail et le téléphone de l'usage sur la fiche RDV
