### PR TITLE
active le module Trackable de devise

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,10 +5,13 @@ class User < ApplicationRecord
   include AccountNormalizerConcern
   include User::SearchableConcern
 
-  attr_accessor :skip_duplicate_warnings
+  # HACK : add *_sign_in_ip to accessor to bypass recording IPs from Trackable Devise's module
+  # HACK : add sign_in_count and current_sign_in_at to accessor to bypass recording IPs from Trackable Devise's module
+  attr_accessor :skip_duplicate_warnings, :current_sign_in_ip, :last_sign_in_ip, :sign_in_count, :current_sign_in_at
 
   devise :invitable, :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable, :async
+         :recoverable, :rememberable, :validatable, :confirmable, :async,
+         :trackable
 
   has_many :user_profiles
   has_many :organisations, through: :user_profiles

--- a/db/migrate/20210205140023_add_trackable_fields_to_user.rb
+++ b/db/migrate/20210205140023_add_trackable_fields_to_user.rb
@@ -1,0 +1,5 @@
+class AddTrackableFieldsToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :last_sign_in_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_141233) do
+ActiveRecord::Schema.define(version: 2021_02_05_140023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -361,6 +361,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_141233) do
     t.string "phone_number_formatted"
     t.boolean "notify_by_sms", default: true
     t.boolean "notify_by_email", default: true
+    t.datetime "last_sign_in_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true


### PR DESCRIPTION
Le modulde [Trackable](https://www.rubydoc.info/github/heartcombo/devise/master/Devise/Models/Trackable) de devis propose d'enregistrer la date et l'heure de la dernière connexion. 

Le hic, c'est que ça enregistre aussi les adresses IP. Est-ce un problème pour nous ? C'est un peu dommage de récolter une information qui ne nous sert à rien.

fix #1156
