### PR TITLE
fix agent policy for sector attribution agents form

### DIFF
--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -25,7 +25,7 @@ class Agent::AgentPolicy < Agent::AdminPolicy
 
   class Scope < Scope
     def resolve
-      if @context.organisation.nil? && @context.can_access_others_planning?
+      if @context.organisation.nil?
         scope.joins(:organisations).where(organisations: { id: @context.agent.organisation_ids })
       elsif @context.can_access_others_planning?
         scope.joins(:organisations).where(organisations: { id: @context.organisation.id })


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2206711239/?environment=production&project=1811205&query=is%3Aunresolved

C'est un peu limite comme solution en terme de rigueur des policies, je relache la contrainte, mais je ne comprends pas à quoi elle servait. Je ne suis pas tout à fait sûr de ce que j'ai cassé dans la PR des rôles indépendants par orga, j'ai peut-être rajouté cette contrainte par erreur. Je n'ai pas envie d'y passer trop de temps car on va probablement attaquer l'introduction du niveau département bientôt et que ça va cleaner tout ça. 
