### PR TITLE
better support floats in XLS zones import + migration to fix corrupt values

### DIFF
--- a/app/lib/csv_or_xls_reader.rb
+++ b/app/lib/csv_or_xls_reader.rb
@@ -28,7 +28,17 @@ module CsvOrXlsReader
       book = Spreadsheet.open(@form_file.tempfile)
       worksheet = book.worksheets.first
       header_row = worksheet.row(0)
-      worksheet.each(1).map { header_row.zip(_1.map(&:to_s)).to_h }
+      worksheet.each(1).map do |row|
+        header_row.zip(row.map { cast_value(_1) }).to_h
+      end
+    end
+
+    def cast_value(cell_value)
+      # workaround https://github.com/zdavatz/spreadsheet/issues/41
+      # XLS does not store Floats properly
+      return cell_value.to_i.to_s if cell_value.is_a?(Float) && cell_value.to_s.ends_with?(".0")
+
+      cell_value.to_s
     end
   end
 end

--- a/db/migrate/20210210114138_fix_traling_zeros_in_city_code_in_zones.rb
+++ b/db/migrate/20210210114138_fix_traling_zeros_in_city_code_in_zones.rb
@@ -1,0 +1,7 @@
+class FixTralingZerosInCityCodeInZones < ActiveRecord::Migration[6.0]
+  def up
+    Zone.where("city_code LIKE '%\.0%'").each do |zone|
+      zone.update!(city_code: zone.city_code.gsub(/\.0$/, ""))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_140023) do
+ActiveRecord::Schema.define(version: 2021_02_10_114138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
XLS est un format un peu naze, et apparement supporte mal la distinction entre texte et floats. Quand une colonne ne semble contenir que des données numériques, la gem qu'on utilise considère par défaut que ce sont des floats. Quand on les affiche en strings, ça nous affiche donc un trailing `.0`. Par exemple un code commune INSEE 62002 devient 62002.0. 

Cela casse les imports XLS de zones, cf le pb de christelle cufay.

Il y a une partie des données en prod corrompues, environ 10 zones. 

Cette PR fait un fix de workaround pour gérer ce cas dans le lecteur XLS, et une migration pour corriger les entrées corrompues. 

Il faudrait peut-être rajouter des validations sur le format autorisé des champs city_code et city_ban_id, plus tard.