### PR TITLE
prevent trying to send SMS to landlines

### DIFF
--- a/app/helpers/user_notifications_helper.rb
+++ b/app/helpers/user_notifications_helper.rb
@@ -1,0 +1,15 @@
+module UserNotificationsHelper
+  def user_notifiable_by_sms_text(user)
+    notif_details = \
+      if user.phone_number.blank?
+        nil
+      elsif !user.phone_number_mobile?
+        "impossibles car le numéro n'est pas mobile"
+      else
+        user.notify_by_sms? ? "activées" : "désactivées"
+      end
+    number_tag = content_tag(:b, user.phone_number.presence || "Non renseigné")
+    details_tag = notif_details ? content_tag(:span, "(notifications par SMS #{notif_details})") : ""
+    "#{number_tag} #{details_tag}".html_safe
+  end
+end

--- a/app/models/concerns/user/notificable_concern.rb
+++ b/app/models/concerns/user/notificable_concern.rb
@@ -1,0 +1,11 @@
+module User::NotificableConcern
+  extend ActiveSupport::Concern
+
+  def notifiable_by_email?
+    email.present? && notify_by_email?
+  end
+
+  def notifiable_by_sms?
+    phone_number_formatted.present? && notify_by_sms?
+  end
+end

--- a/app/models/concerns/user/notificable_concern.rb
+++ b/app/models/concerns/user/notificable_concern.rb
@@ -6,6 +6,12 @@ module User::NotificableConcern
   end
 
   def notifiable_by_sms?
-    phone_number_formatted.present? && notify_by_sms?
+    phone_number_formatted.present? && phone_number_mobile? && notify_by_sms?
+  end
+
+  def phone_number_mobile?
+    return false unless phone_number_formatted.present?
+
+    Phonelib.parse(phone_number_formatted).types.include?(:mobile)
   end
 end

--- a/app/models/concerns/user/responsability_concern.rb
+++ b/app/models/concerns/user/responsability_concern.rb
@@ -10,6 +10,7 @@ module User::ResponsabilityConcern
   delegate(
     :phone_number, :email, :address,
     :notify_by_email, :notify_by_email?, :notify_by_sms, :notify_by_sms?,
+    :phone_number_mobile?,
     to: :responsible_or_self,
     prefix: :responsible
   )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   include FullNameConcern
   include AccountNormalizerConcern
   include User::SearchableConcern
+  include User::NotificableConcern
 
   ONGOING_MARGIN = 1.hour.freeze
 

--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -52,6 +52,8 @@ class DisplayableUserPresenter
   def notify_by_sms
     return "pas de numéro de téléphone renseigné" if @user.responsible_phone_number.blank?
 
+    return "🔴 le numéro de téléphone renseigné n'est pas un mobile" unless @user.responsible_phone_number_mobile?
+
     @user.responsible_notify_by_sms? ? "🟢 Activées" : "🔴 Désactivées"
   end
 

--- a/app/service_models/transactional_sms/base_concern.rb
+++ b/app/service_models/transactional_sms/base_concern.rb
@@ -1,3 +1,5 @@
+class InvalidMobilePhoneNumberError < StandardError; end
+
 module TransactionalSms::BaseConcern
   extend ActiveSupport::Concern
 
@@ -10,6 +12,9 @@ module TransactionalSms::BaseConcern
   end
 
   def initialize(rdv, user)
+    raise InvalidMobilePhoneNumberError, "#{user.phone_number_formatted} is not a valid mobile phone number" \
+      unless user.phone_number_mobile?
+
     @user = user
     @rdv = rdv
   end

--- a/app/services/notifications/rdv/base_service_concern.rb
+++ b/app/services/notifications/rdv/base_service_concern.rb
@@ -10,13 +10,13 @@ module Notifications::Rdv::BaseServiceConcern
 
     if methods.include?(:notify_user_by_mail)
       users_to_notify
-        .select { _1.email.present? && _1.notify_by_email? }
+        .select(&:notifiable_by_email?)
         .each { notify_user_by_mail(_1) }
     end
 
     if methods.include?(:notify_user_by_sms)
       users_to_notify
-        .select { _1.phone_number_formatted.present? && _1.notify_by_sms? }
+        .select(&:notifiable_by_sms?)
         .each { notify_user_by_sms(_1) }
     end
 

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -44,6 +44,13 @@ ul.list-group.list-group-flush
           span> 📞 Téléphone :
           b>= current_user.phone_number || "Non renseigné"
           - if current_user.phone_number.present?
-            span>= "(notifications par SMS #{current_user.notify_by_sms? ? "activées" : "désactivées"})"
+            span>= "(notifications par SMS"
+            - if !current_user.phone_number_mobile?
+              | impossibles car le numéro n'est pas mobile
+            - elsif current_user.notify_by_sms?
+              | activées
+            - else
+              | désactivées
+            = ")"
         .col-auto
           = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -42,15 +42,6 @@ ul.list-group.list-group-flush
       .row
         .col.ml-3
           span> 📞 Téléphone :
-          b>= current_user.phone_number || "Non renseigné"
-          - if current_user.phone_number.present?
-            span>= "(notifications par SMS"
-            - if !current_user.phone_number_mobile?
-              | impossibles car le numéro n'est pas mobile
-            - elsif current_user.notify_by_sms?
-              | activées
-            - else
-              | désactivées
-            = ")"
+          = user_notifiable_by_sms_text(current_user)
         .col-auto
           = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -9,6 +9,8 @@
     .col-md-6= f.input :birth_name, placeholder: 'Nom de naissance'
     .col-md-6= date_input(f, :birth_date)
   = f.input :phone_number, as: :tel
+  - if user.phone_number.present? && !user.phone_number_mobile?
+    .alert.alert-warning Vous ne recevrez pas de SMS avec ce numéro non-mobile
   label Préférences de notifications
   .d-flex
     div= f.input :notify_by_email

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
       num = Faker::Base.numerify("06 ## ## ## ##") until Phonelib.valid?(num)
       num
     end
+    phone_number_formatted { Phonelib.parse(phone_number).e164 }
     birth_date { Date.parse("1985-07-20") }
     address { "20 avenue de Ségur, Paris" }
     password { "12345678" }

--- a/spec/models/concerns/user/notificable_concern_spec.rb
+++ b/spec/models/concerns/user/notificable_concern_spec.rb
@@ -1,0 +1,49 @@
+describe User::NotificableConcern do
+  describe "#notifiable_by_email?" do
+    subject { user.notifiable_by_email? }
+
+    context "user has email and email notifications enabled" do
+      let(:user) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
+      it { should be_truthy }
+    end
+
+    context "user has email but email notifications disabled" do
+      let(:user) { build(:user, email: "jean@lol.fr", notify_by_email: false) }
+      it { should be_falsy }
+    end
+
+    context "user has no email but email notifications enabled" do
+      let(:user) { build(:user, email: nil, notify_by_email: true) }
+      it { should be_falsy }
+    end
+
+    context "user has blank email but email notifications enabled" do
+      let(:user) { build(:user, email: "", notify_by_email: true) }
+      it { should be_falsy }
+    end
+  end
+
+  describe "#notifiable_by_sms?" do
+    subject { user.notifiable_by_sms? }
+
+    context "user has phone number and SMS notifications enabled" do
+      let(:user) { build(:user, phone_number_formatted: "+33634343434", notify_by_sms: true) }
+      it { should be_truthy }
+    end
+
+    context "user has phone number but SMS notifications disabled" do
+      let(:user) { build(:user, phone_number_formatted: "+33634343434", notify_by_sms: false) }
+      it { should be_falsy }
+    end
+
+    context "user has SMS notifications enabled but no phone number" do
+      let(:user) { build(:user, phone_number_formatted: nil, notify_by_sms: true) }
+      it { should be_falsy }
+    end
+
+    context "user has SMS notifications enabled but blank phone number" do
+      let(:user) { build(:user, phone_number_formatted: "", notify_by_sms: true) }
+      it { should be_falsy }
+    end
+  end
+end

--- a/spec/models/concerns/user/notificable_concern_spec.rb
+++ b/spec/models/concerns/user/notificable_concern_spec.rb
@@ -45,5 +45,10 @@ describe User::NotificableConcern do
       let(:user) { build(:user, phone_number_formatted: "", notify_by_sms: true) }
       it { should be_falsy }
     end
+
+    context "user has SMS notifications enabled but landline phone number" do
+      let(:user) { build(:user, phone_number_formatted: "+33129292929", notify_by_sms: true) }
+      it { should be_falsy }
+    end
   end
 end

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -110,14 +110,21 @@ describe DisplayableUserPresenter, type: :presenter do
 
     it "return activated when user allow sms notifications" do
       organisation = build(:organisation)
-      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
+      user = build(:user, organisations: [organisation], phone_number: "06 30 30 30 30", notify_by_sms: true)
       displayable_user = described_class.new(user, organisation)
       expect(displayable_user.notify_by_sms).to eq("🟢 Activées")
     end
 
+    it "returns disabled when user allow sms notifications but landline number" do
+      organisation = build(:organisation)
+      user = build(:user, organisations: [organisation], phone_number: "01 30 30 30 30", notify_by_sms: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.notify_by_sms).to eq("🔴 le numéro de téléphone renseigné n'est pas un mobile")
+    end
+
     it "return desactivated when user disallow sms notifications" do
       organisation = build(:organisation)
-      user = build(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: false)
+      user = build(:user, organisations: [organisation], phone_number: "06 30 30 30 30", notify_by_sms: false)
       displayable_user = described_class.new(user, organisation)
       expect(displayable_user.notify_by_sms).to eq("🔴 Désactivées")
     end
@@ -177,18 +184,25 @@ describe DisplayableUserPresenter, type: :presenter do
       expect(displayable_user.phone_number_and_notification).to eq("N/A")
     end
 
-    it "returns phone_number and activate notification with a user's email and notification activated" do
+    it "returns phone_number and enabled notification with a user's sms setting enabled" do
+      organisation = build(:organisation)
+      user = create(:user, organisations: [organisation], phone_number: "06 30 30 30 30", notify_by_sms: true)
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33630303030\">06 30 30 30 30</a> - Notifications par SMS 🟢 Activées")
+    end
+
+    it "returns phone_number and disabled notification with a user's sms setting enabled but a landline" do
       organisation = build(:organisation)
       user = create(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: true)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a> - Notifications par SMS 🟢 Activées")
+      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a> - Notifications par SMS 🔴 le numéro de téléphone renseigné n'est pas un mobile")
     end
 
-    it "returns phone_number and activate notification with a user's email and notification desactivated" do
+    it "returns phone_number and disabled notification with a user's sms setting disabled" do
       organisation = build(:organisation)
-      user = create(:user, organisations: [organisation], phone_number: "01 02 03 04 05", notify_by_sms: false)
+      user = create(:user, organisations: [organisation], phone_number: "06 30 30 30 30", notify_by_sms: false)
       displayable_user = described_class.new(user, organisation)
-      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33102030405\">01 02 03 04 05</a> - Notifications par SMS 🔴 Désactivées")
+      expect(displayable_user.phone_number_and_notification).to eq("<a href=\"tel:+33630303030\">06 30 30 30 30</a> - Notifications par SMS 🔴 Désactivées")
     end
   end
 

--- a/spec/service_models/transactional_sms/base_concern_spec.rb
+++ b/spec/service_models/transactional_sms/base_concern_spec.rb
@@ -9,8 +9,23 @@ module SomeModule
 end
 
 describe TransactionalSms::BaseConcern, type: :service do
-  let(:user) { build(:user, phone_number: "+33640404040", address: "10 rue de Toulon, Lille") }
+  describe "#initialize" do
+    context "user has valid mobile phone number" do
+      it "should raise" do
+        expect { SomeModule::TestSms.new(build(:rdv), build(:user)) }.not_to raise_error
+      end
+    end
 
+    context "user has landline phone number" do
+      let(:user) { build(:user, phone_number_formatted: "+33130303030") }
+      it "should raise" do
+        expect { SomeModule::TestSms.new(build(:rdv), user) }.to \
+          raise_error(InvalidMobilePhoneNumberError)
+      end
+    end
+  end
+
+  let(:user) { build(:user, address: "10 rue de Toulon, Lille") }
   describe "#rdv_footer" do
     let(:rdv) { build(:rdv, motif: motif, users: [user], starts_at: 5.days.from_now) }
     subject { SomeModule::TestSms.new(rdv, user).rdv_footer }

--- a/spec/services/notifications/rdv/base_service_spec.rb
+++ b/spec/services/notifications/rdv/base_service_spec.rb
@@ -32,9 +32,13 @@ describe Notifications::Rdv::BaseServiceConcern, type: :service do
   end
 
   context "rdv has two users, both with email notifications" do
-    let(:user1) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
-    let(:user2) { build(:user, email: "martine@lol.fr", notify_by_email: true) }
+    let(:user1) { build(:user) }
+    let(:user2) { build(:user) }
     let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    before do
+      allow(user1).to receive(:notifiable_by_email?).and_return(true)
+      allow(user2).to receive(:notifiable_by_email?).and_return(true)
+    end
     it "should call send emails to both" do
       expect(service).to receive(:notify_user_by_mail).with(user1)
       expect(service).to receive(:notify_user_by_mail).with(user2)
@@ -43,20 +47,13 @@ describe Notifications::Rdv::BaseServiceConcern, type: :service do
   end
 
   context "rdv has two users, one without email notifications" do
-    let(:user1) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
-    let(:user2) { build(:user, email: "martine@lol.fr", notify_by_email: false) }
+    let(:user1) { build(:user) }
+    let(:user2) { build(:user) }
     let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
-    it "should call notify_user_by_email only for one user" do
-      expect(service).to receive(:notify_user_by_mail).with(user1)
-      expect(service).not_to receive(:notify_user_by_mail).with(user2)
-      subject
+    before do
+      allow(user1).to receive(:notifiable_by_email?).and_return(true)
+      allow(user2).to receive(:notifiable_by_email?).and_return(false)
     end
-  end
-
-  context "rdv has two users, one with missing email address" do
-    let(:user1) { build(:user, email: "jean@lol.fr", notify_by_email: true) }
-    let(:user2) { build(:user, email: nil, notify_by_email: false) }
-    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
     it "should call notify_user_by_email only for one user" do
       expect(service).to receive(:notify_user_by_mail).with(user1)
       expect(service).not_to receive(:notify_user_by_mail).with(user2)
@@ -65,10 +62,13 @@ describe Notifications::Rdv::BaseServiceConcern, type: :service do
   end
 
   context "rdv has two users, both with sms notifications" do
-    # need to create for SMS because phone_number_formatted is computed in a before_save
-    let(:user1) { create(:user, phone_number: "0601020304", notify_by_sms: true) }
-    let(:user2) { create(:user, phone_number: "0601020305", notify_by_sms: true) }
+    let(:user1) { build(:user) }
+    let(:user2) { build(:user) }
     let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    before do
+      allow(user1).to receive(:notifiable_by_sms?).and_return(true)
+      allow(user2).to receive(:notifiable_by_sms?).and_return(true)
+    end
     it "should send SMS to both" do
       expect(service).to receive(:notify_user_by_sms).with(user1)
       expect(service).to receive(:notify_user_by_sms).with(user2)
@@ -77,25 +77,16 @@ describe Notifications::Rdv::BaseServiceConcern, type: :service do
   end
 
   context "rdv has two users, one with SMS notifications disabled" do
-    # need to create for SMS because phone_number_formatted is computed in a before_save
-    let(:user1) { create(:user, phone_number: "0601020304", notify_by_sms: false) }
-    let(:user2) { create(:user, phone_number: "0601020305", notify_by_sms: true) }
+    let(:user1) { build(:user) }
+    let(:user2) { build(:user) }
     let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
+    before do
+      allow(user1).to receive(:notifiable_by_sms?).and_return(false)
+      allow(user2).to receive(:notifiable_by_sms?).and_return(true)
+    end
     it "should send SMS to only one" do
       expect(service).not_to receive(:notify_user_by_sms).with(user1)
       expect(service).to receive(:notify_user_by_sms).with(user2)
-      subject
-    end
-  end
-
-  context "rdv has two users, one with a mising phone_number" do
-    # need to create for SMS because phone_number_formatted is computed in a before_save
-    let(:user1) { create(:user, phone_number: "0601020304", notify_by_sms: true) }
-    let(:user2) { create(:user, phone_number: nil, notify_by_sms: true) }
-    let(:rdv) { build(:rdv, starts_at: DateTime.now + 1.day, users: [user1, user2]) }
-    it "should send SMS to only one" do
-      expect(service).to receive(:notify_user_by_sms).with(user1)
-      expect(service).not_to receive(:notify_user_by_sms).with(user2)
       subject
     end
   end


### PR DESCRIPTION
#1176 

# Refacto pour extraire User::NotificableConcern

Avant de complexifier légèrement la règle pour décider de l'envoi d'un SMS je l'ai extraite dans un concern rattaché au User. J'ai déplacé les tests afférents.

# Prevent sending SMS to landlines

j'essaie d'empêcher l'envoi à deux niveaux : 

- en haut dans l'enqueuing des jobs en filtrant sur les users avec des numéros de mobiles - via la complexification de la méthode `notifiable_by_sms?`
- au plus bas en raisant quand on essaie de construire un TransactionalSMS pour un user n'ayant pas un numero de mobile

# Display info in user & admin dashboards

<img width="568" alt="Screenshot 2021-02-11 at 09 28 32" src="https://user-images.githubusercontent.com/883348/107615217-0dd04780-6c4c-11eb-9e08-42b51fa7fbd0.png">
<img width="699" alt="Screenshot 2021-02-11 at 09 26 23" src="https://user-images.githubusercontent.com/883348/107615226-1163ce80-6c4c-11eb-9f0a-e0ec325f11eb.png">


<img width="627" alt="Screenshot 2021-02-11 at 09 32 59" src="https://user-images.githubusercontent.com/883348/107615269-22acdb00-6c4c-11eb-9ee8-5353bea5a675.png">