### PR TITLE
Revoie la suppression d'organisation et d'agent depuis l'interface super admin

### DIFF
--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -1,6 +1,3 @@
-- content_for(:title) do
-  | Modifier mes informations
-
 .row.justify-content-md-center.pt-3
   .col-md-6
     .card

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,6 +1,3 @@
-- content_for(:title) do
-  | Accueil
-
 - content_for :header
   section#hero.hero.hero-home.py-3.py-lg-5
     .container


### PR DESCRIPTION
Avec l'introduction des rôles agents, nous n'avons pas fait attention que la suppression des organisations depuis l'interface super admin ne fonctionne plus (la suppression des agents aussi ?).

fix #1189

Un des soucis, c'est l'utilisation d'un callback pour veiller à ce qu'une organisation ait toujours un agent lié. Depuis l'interface de super admin, ce callback est bloquant. L'idée est donc de le déplacer ailleurs, dans le service `AgentRemoval`

J'en profite pour déplacer un peu de code autour du service `AgentRemoval` en espérant que ça le rende plus lisible.

- déplacement d'une méthode `will_soft_delete?` inliné dans le service, et copié dans le présenter.
- 