### PR TITLE
Remaniement de code autour de la suppression et modification d'agent

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -108,4 +108,8 @@ class Agent < ApplicationRecord
   def admin_in_organisation?(organisation)
     role_in_organisation(organisation).admin?
   end
+
+  def only_in_this_organisation?(organisation)
+    (organisations - [organisation]).empty?
+  end
 end

--- a/app/presenters/agent_removal_presenter.rb
+++ b/app/presenters/agent_removal_presenter.rb
@@ -1,5 +1,4 @@
 class AgentRemovalPresenter
-  delegate :will_soft_delete?, to: :agent_removal_service
   attr_reader :agent, :organisation
 
   def initialize(agent, organisation)
@@ -8,7 +7,7 @@ class AgentRemovalPresenter
   end
 
   def button_value
-    if will_soft_delete?
+    if @agent.only_in_this_organisation?(@organisation)
       "Supprimer le compte"
     else
       "Retirer de l'organisation"
@@ -16,7 +15,7 @@ class AgentRemovalPresenter
   end
 
   def confirm_message
-    if will_soft_delete?
+    if @agent.only_in_this_organisation?(@organisation)
       <<~STR
         Cet agent appartient uniquement à l'organisation #{organisation.name}. Vous vous apprêtez à retirer cet agent de cette organisation et à supprimer son compte définitivement.
 

--- a/app/service_functions/agent_remover.rb
+++ b/app/service_functions/agent_remover.rb
@@ -1,0 +1,18 @@
+module AgentRemover
+
+  def self.remove!(agent, organisation)
+    return false if upcoming_rdvs?
+
+    Agent.transaction do
+      agent.organisations.delete(organisation)
+      agent.absences.where(organisation: organisation).each(&:destroy!)
+      agent.plage_ouvertures.where(organisation: organisation).each(&:destroy!)
+      agent.soft_delete if agent.only_in_this_organisation?(organisation)
+      true
+    end
+  end
+
+  def self.upcoming_rdvs?(agent, organisation)
+    agent.rdvs.where(organisation: organisation).future.not_cancelled.any?
+  end
+end

--- a/app/service_functions/agent_remover.rb
+++ b/app/service_functions/agent_remover.rb
@@ -1,7 +1,7 @@
 module AgentRemover
 
-  def self.remove!(agent, organisation)
-    return false if upcoming_rdvs?
+  def self.remove(agent, organisation)
+    return false if upcoming_rdvs?(agent, organisation)
 
     Agent.transaction do
       agent.organisations.delete(organisation)

--- a/app/service_models/agent_removal.rb
+++ b/app/service_models/agent_removal.rb
@@ -11,7 +11,7 @@ class AgentRemoval
       @agent.organisations.delete(@organisation)
       @agent.absences.where(organisation: @organisation).each(&:destroy!)
       @agent.plage_ouvertures.where(organisation: @organisation).each(&:destroy!)
-      @agent.soft_delete if should_soft_delete?
+      @agent.soft_delete if @agent.only_in_this_organisation?(@organisation)
       true
     end
   end
@@ -19,9 +19,4 @@ class AgentRemoval
   def upcoming_rdvs?
     @upcoming_rdvs ||= @agent.rdvs.where(organisation: @organisation).future.not_cancelled.any?
   end
-
-  def should_soft_delete?
-    (@agent.organisations - [@organisation]).empty?
-  end
-  alias will_soft_delete? should_soft_delete?
 end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -39,4 +39,25 @@ describe Agent, type: :model do
       expect(agent.uid).to eq("agent_#{agent.id}@deleted.rdv-solidarites.fr")
     end
   end
+
+  describe "#only_in_this_organisation?" do
+    it "return true when single orga left" do
+      organisation = build(:organisation)
+      agent = build(:agent, organisations: [organisation])
+      expect(agent.only_in_this_organisation?(organisation)).to be true
+    end
+
+    it "return true when no orga left" do
+      organisation = build(:organisation)
+      agent = build(:agent, organisations: [])
+      expect(agent.only_in_this_organisation?(organisation)).to be true
+    end
+
+    it "return false when orgas left" do
+      organisation = build(:organisation)
+      other_organisation = build(:organisation)
+      agent = build(:agent, organisations: [organisation, other_organisation])
+      expect(agent.only_in_this_organisation?(organisation)).to be false
+    end
+  end
 end

--- a/spec/service_functions/agent_remover_spec.rb
+++ b/spec/service_functions/agent_remover_spec.rb
@@ -1,0 +1,96 @@
+describe AgentRemover, type: :service do
+
+  context "agent belongs to single organisation, with a few absences and plages ouvertures" do
+    it "should succeed" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      expect(AgentRemover.remove!(agent, organisation)).to eq true
+    end
+
+    it "should destroy absences" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      absences = create_list(:absence, 2, agent: agent, organisation: organisation)
+      AgentRemover.remove!(agent, organisation)
+      expect(agent.absences).to be_empty
+    end
+
+    it "should destroy plages ouvertures" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      plage_ouvertures = create_list(:plage_ouverture, 2, agent: agent, organisation: organisation)
+      AgentRemover.remove!(agent, organisation)
+      expect(agent.plage_ouvertures).to be_empty
+    end
+
+    it "soft_delete" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      expect(agent).to receive(:soft_delete)
+      AgentRemover.remove!(agent, organisation)
+    end
+
+    it "should remove organisation's agent link" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      result = AgentRemover.remove!(agent, organisation)
+      expect(agent.reload.organisations).to be_empty
+    end
+  end
+
+  context "agent belongs to multiple organisations" do
+    it "should succeed and destroy absences and plages ouvertures and not soft delete" do
+      organisation1 = create(:organisation)
+      organisation2 = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation1, organisation2])
+      plage_ouvertures1 = create_list(:plage_ouverture, 2, agent: agent, organisation: organisation1)
+      absences1 = create_list(:absence, 2, agent: agent, organisation: organisation1)
+      plage_ouvertures2 = create_list(:plage_ouverture, 2, agent: agent, organisation: organisation2)
+      absences2 = create_list(:absence, 2, agent: agent, organisation: organisation2)
+
+
+      expect(agent).not_to receive(:soft_delete)
+      result = AgentRemoval.remove!(agent, organisation1)
+      expect(result).to eq true
+      expect(agent.organisations).to contain_exactly(organisation2)
+      expect(agent.plage_ouvertures).to contain_exactly(*plage_ouvertures2)
+      expect(agent.absences).to contain_exactly(*absences2)
+    end
+  end
+
+  context "agent has upcoming RDVs" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let!(:rdv) do
+      rdv = build(:rdv, agents: [agent], organisation: organisation, starts_at: Date.today.next_week(:monday) + 10.hours)
+      rdv.define_singleton_method(:notify_rdv_created) {}
+      rdv.save!
+      rdv
+    end
+
+    it "should not succeed" do
+      expect(agent).not_to receive(:soft_delete)
+      result = AgentRemoval.remove!(agent, organisation)
+      expect(result).to eq false
+      expect(agent.organisations).to include(organisation)
+    end
+  end
+
+  context "agent has old RDVs" do
+    let!(:organisation) { create(:organisation) }
+    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let!(:rdv) do
+      rdv = build(:rdv, agents: [agent], organisation: organisation, starts_at: Date.today.prev_week(:monday) + 10.hours)
+      rdv.define_singleton_method(:notify_rdv_created) {}
+      rdv.save!
+      rdv
+    end
+
+    it "should succeed" do
+      expect(agent).to receive(:soft_delete)
+      result = AgentRemoval.remove!(agent, organisation)
+      expect(result).to eq true
+      expect(agent.organisations).to be_empty
+    end
+  end
+end

--- a/spec/service_functions/agent_remover_spec.rb
+++ b/spec/service_functions/agent_remover_spec.rb
@@ -1,17 +1,16 @@
 describe AgentRemover, type: :service do
-
   context "agent belongs to single organisation, with a few absences and plages ouvertures" do
     it "should succeed" do
       organisation = create(:organisation)
       agent = create(:agent, basic_role_in_organisations: [organisation])
-      expect(AgentRemover.remove!(agent, organisation)).to eq true
+      expect(described_class.remove(agent, organisation)).to eq true
     end
 
     it "should destroy absences" do
       organisation = create(:organisation)
       agent = create(:agent, basic_role_in_organisations: [organisation])
       absences = create_list(:absence, 2, agent: agent, organisation: organisation)
-      AgentRemover.remove!(agent, organisation)
+      described_class.remove(agent, organisation)
       expect(agent.absences).to be_empty
     end
 
@@ -19,7 +18,7 @@ describe AgentRemover, type: :service do
       organisation = create(:organisation)
       agent = create(:agent, basic_role_in_organisations: [organisation])
       plage_ouvertures = create_list(:plage_ouverture, 2, agent: agent, organisation: organisation)
-      AgentRemover.remove!(agent, organisation)
+      described_class.remove(agent, organisation)
       expect(agent.plage_ouvertures).to be_empty
     end
 
@@ -27,13 +26,13 @@ describe AgentRemover, type: :service do
       organisation = create(:organisation)
       agent = create(:agent, basic_role_in_organisations: [organisation])
       expect(agent).to receive(:soft_delete)
-      AgentRemover.remove!(agent, organisation)
+      described_class.remove(agent, organisation)
     end
 
     it "should remove organisation's agent link" do
       organisation = create(:organisation)
       agent = create(:agent, basic_role_in_organisations: [organisation])
-      result = AgentRemover.remove!(agent, organisation)
+      result = described_class.remove(agent, organisation)
       expect(agent.reload.organisations).to be_empty
     end
   end
@@ -48,9 +47,8 @@ describe AgentRemover, type: :service do
       plage_ouvertures2 = create_list(:plage_ouverture, 2, agent: agent, organisation: organisation2)
       absences2 = create_list(:absence, 2, agent: agent, organisation: organisation2)
 
-
       expect(agent).not_to receive(:soft_delete)
-      result = AgentRemoval.remove!(agent, organisation1)
+      result = described_class.remove(agent, organisation1)
       expect(result).to eq true
       expect(agent.organisations).to contain_exactly(organisation2)
       expect(agent.plage_ouvertures).to contain_exactly(*plage_ouvertures2)
@@ -70,7 +68,7 @@ describe AgentRemover, type: :service do
 
     it "should not succeed" do
       expect(agent).not_to receive(:soft_delete)
-      result = AgentRemoval.remove!(agent, organisation)
+      result = described_class.remove(agent, organisation)
       expect(result).to eq false
       expect(agent.organisations).to include(organisation)
     end
@@ -88,7 +86,7 @@ describe AgentRemover, type: :service do
 
     it "should succeed" do
       expect(agent).to receive(:soft_delete)
-      result = AgentRemoval.remove!(agent, organisation)
+      result = described_class.remove(agent, organisation)
       expect(result).to eq true
       expect(agent.organisations).to be_empty
     end


### PR DESCRIPTION
Avec l'introduction des rôles agents, nous n'avons pas fait attention que la suppression des organisations depuis l'interface super admin ne fonctionne plus (la suppression des agents aussi ?).

fix #1189

Un des soucis, c'est l'utilisation d'un callback pour veiller à ce qu'une organisation ait toujours un agent lié. Depuis l'interface de super admin, ce callback est bloquant. L'idée est donc de le déplacer ailleurs, dans le service `AgentRemoval`

J'en profite pour déplacer un peu de code autour du service `AgentRemoval` en espérant que ça le rende plus lisible.

- déplacement d'une méthode `will_soft_delete?` inliné dans le service, et copié dans le présenter.
- 