### PR TITLE
Améliorations du bloc de RDVs précédents sur la vue RDV admin

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,10 +135,6 @@ class User < ApplicationRecord
       .empty?
   end
 
-  def previous_rdvs_ordered_and_truncated(organisation)
-    rdvs_for_organisation(organisation).past.order(starts_at: :desc).limit(5)
-  end
-
   def rdvs_future_without_ongoing(organisation)
     rdvs_for_organisation(organisation).start_after(Time.zone.now + ONGOING_MARGIN)
   end

--- a/app/presenters/admin/rdv_user_presenter.rb
+++ b/app/presenters/admin/rdv_user_presenter.rb
@@ -1,0 +1,28 @@
+class Admin::RdvUserPresenter
+  attr_reader :rdv, :user
+
+  delegate :starts_at, :organisation, to: :rdv
+
+  def initialize(rdv, user)
+    @rdv = rdv
+    @user = user
+  end
+
+  def previous_rdvs_truncated
+    previous_rdvs.limit(5)
+  end
+
+  def previous_rdvs_count
+    previous_rdvs.count
+  end
+
+  private
+
+  def previous_rdvs
+    Rdv
+      .with_user(user)
+      .where(organisation: organisation)
+      .where("starts_at < ?", starts_at)
+      .order(starts_at: :desc)
+  end
+end

--- a/app/presenters/admin/rdv_user_presenter.rb
+++ b/app/presenters/admin/rdv_user_presenter.rb
@@ -1,4 +1,6 @@
 class Admin::RdvUserPresenter
+  PREVIOUS_RDVS_LIMIT = 5
+
   attr_reader :rdv, :user
 
   delegate :starts_at, :organisation, to: :rdv
@@ -9,11 +11,15 @@ class Admin::RdvUserPresenter
   end
 
   def previous_rdvs_truncated
-    previous_rdvs.limit(5)
+    previous_rdvs.limit(PREVIOUS_RDVS_LIMIT)
   end
 
   def previous_rdvs_count
     previous_rdvs.count
+  end
+
+  def previous_rdvs_more?
+    previous_rdvs_count > PREVIOUS_RDVS_LIMIT
   end
 
   private

--- a/app/views/admin/rdvs/_short_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_short_rdvs_list.html.slim
@@ -1,19 +1,17 @@
-.card
-  .card-header= title
-  - if rdvs.empty?
-    .card-body
-      .text-muted aucun #{title.downcase}
-  - else
-    ul.list-unstyled.horizontal-border-between-items
-      - rdvs.each do |rdv|
-        li.card-body.py-2
-          strong= link_to rdv_title(rdv), admin_organisation_rdv_path(current_organisation, rdv)
-          = rdv_status_tag(rdv)
+- if rdvs.empty?
+  .card-body
+    .text-muted aucun RDV
+- else
+  ul.list-unstyled.horizontal-border-between-items
+    - rdvs.each do |rdv|
+      li.card-body.py-2
+        strong= link_to rdv_title(rdv), admin_organisation_rdv_path(current_organisation, rdv)
+        = rdv_status_tag(rdv)
+        div
+          = rdv.motif.name
           div
-            = rdv.motif.name
-            div
-              - if rdv.context.blank?
-                .text-muted Pas de contexte renseigné
-              - else
-                .text-muted Contexte :
-                .border-left.pl-2= simple_format(rdv.context)
+            - if rdv.context.blank?
+              .text-muted Pas de contexte renseigné
+            - else
+              .text-muted Contexte :
+              .border-left.pl-2= simple_format(rdv.context)

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -71,7 +71,8 @@
                 i.fa.fa-fw.fa-info-circle>
               div= displayable_user.notes
 
-      = render "admin/rdvs/short_rdvs_list", user: user, rdvs: user.previous_rdvs_ordered_and_truncated(current_organisation), title: "Rendez-vous précédents"
+        .card-header.card-footer= "Rendez-vous précédents"
+        = render "admin/rdvs/short_rdvs_list", user: user, rdvs: Admin::RdvUserPresenter.new(@rdv, user).previous_rdvs_truncated
 
 .row
   .col-md-12

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -71,8 +71,14 @@
                 i.fa.fa-fw.fa-info-circle>
               div= displayable_user.notes
 
+        - rdv_user_presenter = Admin::RdvUserPresenter.new(@rdv, user)
         .card-header.card-footer= "Rendez-vous précédents"
-        = render "admin/rdvs/short_rdvs_list", user: user, rdvs: Admin::RdvUserPresenter.new(@rdv, user).previous_rdvs_truncated
+        = render "admin/rdvs/short_rdvs_list", user: user, rdvs: rdv_user_presenter.previous_rdvs_truncated
+        - if rdv_user_presenter.previous_rdvs_more?
+          .card-footer
+            = link_to \
+              "Voir les #{rdv_user_presenter.previous_rdvs_count} RDVs précédents…", \
+              admin_organisation_rdvs_path(current_organisation, user_id: user.id, end: @rdv.starts_at)
 
 .row
   .col-md-12

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -106,8 +106,13 @@
   .col-md-6
 
     - if policy_scope(Rdv).merge(@user.ongoing_rdvs(current_organisation)).any?
-      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: policy_scope(Rdv).merge(@user.ongoing_rdvs(current_organisation)).order(starts_at: :asc), title: "Rendez-vous en cours (+/- 1 heure)"
-    = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: policy_scope(Rdv).merge(@user.rdvs_future_without_ongoing(current_organisation)).order(starts_at: :asc), title: "Prochains rendez-vous"
+      .card
+        .card-header Rendez-vous en cours (+/- 1 heure)
+        = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: policy_scope(Rdv).merge(@user.ongoing_rdvs(current_organisation)).order(starts_at: :asc)
+
+    .card
+      .card-header Prochains rendez-vous
+      = render "admin/rdvs/short_rdvs_list", user: @user, rdvs: policy_scope(Rdv).merge(@user.rdvs_future_without_ongoing(current_organisation)).order(starts_at: :asc)
 
     .card
       .card-header

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -14,7 +14,7 @@ describe "can see users' RDV" do
     before { click_link user.full_name }
     it do
       expect(page).to have_content("À venir\n0 RDV")
-      expect(page).to have_content("aucun prochains rendez-vous")
+      expect(page).to have_content("aucun RDV")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -227,53 +227,6 @@ describe User, type: :model do
     end
   end
 
-  describe "#previous_rdvs_ordered_and_truncated" do
-    it "return empty array without previous rdv" do
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user])
-      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([])
-    end
-
-    it "return rdv for same user and organisation" do
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      rdv = create(:rdv, users: [user])
-      create(:rdv)
-      create(:rdv, users: [user])
-      previous_rdv = create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user])
-
-      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([previous_rdv])
-    end
-
-    it "return only 5 last previous rdv order by starts_at desc" do
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      rdv = create(:rdv, users: [user])
-
-      p4 = create(:rdv, starts_at: rdv.starts_at - 7.day, organisation: organisation, users: [user])
-      p5 = create(:rdv, starts_at: rdv.starts_at - 13.day, organisation: organisation, users: [user])
-      p1 = create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user])
-      create(:rdv, starts_at: rdv.starts_at - 16.day, organisation: organisation, users: [user])
-      p2 = create(:rdv, starts_at: rdv.starts_at - 2.day, organisation: organisation, users: [user])
-      p3 = create(:rdv, starts_at: rdv.starts_at - 4.day, organisation: organisation, users: [user])
-
-      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([p1, p2, p3, p4, p5])
-    end
-
-    it "returns only past rdv" do
-      today = Time.new(2020, 5, 23, 15, 56)
-      travel_to(today)
-      organisation = create(:organisation)
-      user = create(:user, organisations: [organisation])
-      rdv = create(:rdv, users: [user], starts_at: today - 2.days)
-      past_rdv = create(:rdv, starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user])
-      create(:rdv, starts_at: rdv.starts_at + 4.days, organisation: organisation, users: [user])
-      expect(user.previous_rdvs_ordered_and_truncated(organisation)).to eq([past_rdv])
-      travel_back
-    end
-  end
-
   describe "#rdvs_future_without_ongoing" do
     it "return empty array without next rdv" do
       organisation = create(:organisation)

--- a/spec/presenters/admin/rdv_user_presenter_spec.rb
+++ b/spec/presenters/admin/rdv_user_presenter_spec.rb
@@ -1,0 +1,43 @@
+describe Admin::RdvUserPresenter do
+  describe "#previous_rdvs_truncated" do
+    subject { Admin::RdvUserPresenter.new(rdv, user).previous_rdvs_truncated }
+
+    context "no previous RDVs" do
+      let!(:organisation) { create(:organisation) }
+      let!(:user) { create(:user, organisations: [organisation]) }
+      let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
+      it { should be_empty }
+    end
+
+    context "single previous RDV" do
+      let!(:organisation) { create(:organisation) }
+      let!(:user) { create(:user, organisations: [organisation]) }
+      let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
+      let!(:previous_rdv) { create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user]) }
+      it { should eq([previous_rdv]) }
+    end
+
+    context "6 previous RDVs" do
+      let!(:organisation) { create(:organisation) }
+      let!(:user) { create(:user, organisations: [organisation]) }
+      let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
+      let!(:p4) { create(:rdv, starts_at: rdv.starts_at - 7.day, organisation: organisation, users: [user]) }
+      let!(:p5) { create(:rdv, starts_at: rdv.starts_at - 13.day, organisation: organisation, users: [user]) }
+      let!(:p1) { create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user]) }
+      let!(:p6) { create(:rdv, starts_at: rdv.starts_at - 16.day, organisation: organisation, users: [user]) }
+      let!(:p2) { create(:rdv, starts_at: rdv.starts_at - 2.day, organisation: organisation, users: [user]) }
+      let!(:p3) { create(:rdv, starts_at: rdv.starts_at - 4.day, organisation: organisation, users: [user]) }
+      it { should eq([p1, p2, p3, p4, p5]) }
+    end
+
+    context "with next RDVs" do
+      let(:some_date) { Time.new(2020, 5, 23, 15, 56) }
+      let!(:organisation) { create(:organisation) }
+      let!(:user) { create(:user, organisations: [organisation]) }
+      let!(:rdv) { create(:rdv, organisation: organisation, users: [user], starts_at: some_date - 2.days) }
+      let!(:previous_rdv) { create(:rdv, starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
+      let!(:next_rdv) { create(:rdv, starts_at: rdv.starts_at + 4.days, organisation: organisation, users: [user]) }
+      it { should eq([previous_rdv]) }
+    end
+  end
+end


### PR DESCRIPTION
closes #1031

# Changement visuel

Le bloc intitulé "rendez-vous précédents" apparaît maintenant dans la carte de l'usager plutôt que dans une carte indépendante, pour exprimer le fait que ce sont les RDVs de cet usager dont on parle (utile si plusieurs usagers).

<img width="500" alt="stitched_2021_03_01-10_19_38" src="https://user-images.githubusercontent.com/883348/109476958-c33a3200-7a77-11eb-8c16-7ac692c6662a.png">


# Changement de scope temporel

Jusqu'ici le filtre "rdvs précédents" se faisait sur base de l'heure actuelle, on parlait des RDVs dans le passé de l'usager. Or, si je suis par exemple en train de regarder la page d'un RDV qui a eu lieu il y a un mois, et que je vois un rdv qui a eu lieu il y a 1j dans un bloc "rdvs précédents" ça n'a pas trop de sens à mon avis. J'ai changé ce filtre temporel, pour qu'on n'affiche ici que les RDVs précédents par rapport au RDV regardé. 

Les "RDVs précédents" au sens ceux dans le passé sont toujours visible sur les fiches usagers, mais plus sur les pages RDVs. 

# Déplacement du code

J'ai déplacé la méthode `User#previous_rdvs_ordered_and_truncated` dans un nouveau presenter `Admin::RdvUserPresenter#previous_rdvs_truncated` (au sens un RDV dans le contexte d'un user de ce RDV). 

La méthode de User était utilisée uniquement une fois, pour ce cas d'usage. Elle me paraît très spécifique et concerne en fait plutôt des RDVs qu'un user. Je pense aussi que tout ce qu'on peut sortir du modèle User mérite de l'être car ce modèle est déjà trop long selon le linter.

# Ajout d'un lien s'il y a plus de 5 RDVs précédents

<img width="600" alt="Screenshot 2021-03-01 at 10 43 44" src="https://user-images.githubusercontent.com/883348/109479853-211c4900-7a7b-11eb-96d4-77bf75dd568a.png">
