### PR TITLE
quickfix to ignore duplicate user warnings on FC upsert

### DIFF
--- a/app/services/upsert_user_for_franceconnect_service.rb
+++ b/app/services/upsert_user_for_franceconnect_service.rb
@@ -31,6 +31,7 @@ class UpsertUserForFranceconnectService < BaseService
         created_through: "franceconnect_sign_up"
       )
     )
+    @user.skip_duplicate_warnings = true
     @user.skip_confirmation!
     @user.save!
     @user


### PR DESCRIPTION
should fix https://sentry.io/organizations/rdv-solidarites/issues/2244974663/?environment=production&project=1811205&referrer=alert_email

fix rapide sans specs car : 
- je crois qu'il ne faudrait pas tester au niveau du service d'upsert de FC mais plutot au niveau du model User, ce qui est deja fait il me semble
- je crois qu'en fait ce warning de duplicate user ne devrait pas etre dans le modele mais dans un form model specifique a l'admin
- je crois aussi qu'il faudrait refacto ce systeme de warning maison par la gem qu'on utilise maintenant pour les warnings du tunnel RDV admin pour harmoniser