### PR TITLE
 Changer le défaut du formulaire de création d'usager (responsable -> proche) dans le tunnel de RDV agent pour le service PMI

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,6 +30,7 @@ class Admin::UsersController < AgentAuthController
   end
 
   def new
+    @motif = Motif.find(params[:motif_id]) if params[:motif_id]
     @user = User.new
     @user.user_profiles.build(organisation: current_organisation)
     @user.responsible = policy_scope(User).find(params[:responsible_id]) if params[:responsible_id].present?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,7 +30,7 @@ class Admin::UsersController < AgentAuthController
   end
 
   def new
-    @motif = Motif.find(params[:motif_id]) if params[:motif_id]
+    @role = params[:role] if params[:role]
     @user = User.new
     @user.user_profiles.build(organisation: current_organisation)
     @user.responsible = policy_scope(User).find(params[:responsible_id]) if params[:responsible_id].present?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -107,8 +107,9 @@ module UsersHelper
     }[email_tld]
   end
 
-  def default_service_selection(user, motif = nil)
-    return :relative if motif&.service&.pmi? || user.relative?
+  def default_service_selection_from(source)
+    return :relative if source.respond_to?(:pmi?) && source.pmi?
+    return :relative if source.respond_to?(:relative?) && source.relative?
 
     :responsible
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -106,4 +106,11 @@ module UsersHelper
       "free.fr" => { url: "https://webmail.free.fr/", name: "Free Webmail" }
     }[email_tld]
   end
+
+  def default_service_selection(user, motif = nil)
+    return :relative if motif&.service&.pmi?
+    return :relative if user.relative?
+
+    :responsible
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -108,8 +108,7 @@ module UsersHelper
   end
 
   def default_service_selection(user, motif = nil)
-    return :relative if motif&.service&.pmi?
-    return :relative if user.relative?
+    return :relative if motif&.service&.pmi? || user.relative?
 
     :responsible
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,6 +5,7 @@ class Service < ApplicationRecord
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
   SECRETARIAT = "Secrétariat".freeze
   SERVICE_SOCIAL = "Service social".freeze
+  PMI = "PMI (Protection Maternelle Infantile)".freeze
 
   scope :with_motifs, -> { where.not(name: SECRETARIAT) }
   scope :secretariat, -> { where(name: SECRETARIAT).first }
@@ -16,6 +17,10 @@ class Service < ApplicationRecord
 
   def service_social?
     name == SERVICE_SOCIAL
+  end
+
+  def pmi?
+    name == PMI
   end
 
   def user_field_groups

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -31,7 +31,7 @@ do
             = link_to \
               "✎ Modifier usager", \
               edit_admin_organisation_user_path( \
-                current_organisation, user, modal: true, return_location: modals_return_location \
+                current_organisation, user, modal: true, return_location: modals_return_location, role: default_service_selection_from(user) \
               ), \
               data: { modal: "true" }
 
@@ -50,7 +50,7 @@ do
         = link_to \
           'Créer un usager', \
           new_admin_organisation_user_path( \
-            current_organisation, modal: true, return_location: modals_return_location, motif_id: @rdv.motif.id \
+            current_organisation, modal: true, return_location: modals_return_location, role: default_service_selection_from(@rdv.motif.service) \
           ), \
           data: { modal: true }
 

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -50,7 +50,7 @@ do
         = link_to \
           'Créer un usager', \
           new_admin_organisation_user_path( \
-            current_organisation, modal: true, return_location: modals_return_location \
+            current_organisation, modal: true, return_location: modals_return_location, motif_id: @rdv.motif.id \
           ), \
           data: { modal: true }
 

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -24,6 +24,7 @@
       :responsability_type, \
       as: :radio_buttons, \
       collection: [:responsible, :relative], \
+      checked: default_service_selection(user, @motif), \
       label_method: -> { I18n.t("activerecord.attributes.user.responsability_types.#{_1}") }, \
       disabled: user.persisted?, \
       wrapper: :vertical_collection_inline, \

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -24,7 +24,7 @@
       :responsability_type, \
       as: :radio_buttons, \
       collection: [:responsible, :relative], \
-      checked: default_service_selection(user, @motif), \
+      checked: @role, \
       label_method: -> { I18n.t("activerecord.attributes.user.responsability_types.#{_1}") }, \
       disabled: user.persisted?, \
       wrapper: :vertical_collection_inline, \

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -3,17 +3,23 @@ FactoryBot.define do
 
   factory :service do
     name { generate(:service_name) }
-    trait :secretariat do
-      name { "Secrétariat" }
-    end
-    trait :pmi do
-      name { "PMI" }
-    end
 
     after(:build) do |service|
       unless service.short_name.present?
         service.short_name = service.name
       end
+    end
+
+    trait :social do
+      name { Service::SERVICE_SOCIAL }
+    end
+
+    trait :secretariat do
+      name { Service::SECRETARIAT }
+    end
+
+    trait :pmi do
+      name { Service::PMI }
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
       password_confirmation { nil }
     end
     trait :relative do
+      responsible { create(:user) }
       phone_number { nil }
       address { nil }
       password { nil }

--- a/spec/helpers/users_spec.rb
+++ b/spec/helpers/users_spec.rb
@@ -25,4 +25,32 @@ describe UsersHelper, type: :helper do
       expect(age(user)).to eq("20 jours")
     end
   end
+
+  describe "#default_service_selection" do
+    context "when edit" do
+      it "returns relative when" do
+        user = create(:user, :relative)
+        expect(default_service_selection(user)).to eq(:relative)
+      end
+
+      it "returns responsible when" do
+        user = create(:user)
+        expect(default_service_selection(user)).to eq(:responsible)
+      end
+    end
+
+    context "when from rdv_wizard" do
+      it "returns relative if pmi service" do
+        user = build(:user)
+        motif = build(:motif, service: build(:service, :pmi))
+        expect(default_service_selection(user, motif)).to eq(:relative)
+      end
+
+      it "returns responsible if other service" do
+        user = build(:user)
+        motif = build(:motif, service: build(:service, :social))
+        expect(default_service_selection(user, motif)).to eq(:responsible)
+      end
+    end
+  end
 end

--- a/spec/helpers/users_spec.rb
+++ b/spec/helpers/users_spec.rb
@@ -26,30 +26,28 @@ describe UsersHelper, type: :helper do
     end
   end
 
-  describe "#default_service_selection" do
-    context "when edit" do
+  describe "#default_service_selection_from" do
+    context "user" do
       it "returns relative when" do
         user = create(:user, :relative)
-        expect(default_service_selection(user)).to eq(:relative)
+        expect(default_service_selection_from(user)).to eq(:relative)
       end
 
       it "returns responsible when" do
         user = create(:user)
-        expect(default_service_selection(user)).to eq(:responsible)
+        expect(default_service_selection_from(user)).to eq(:responsible)
       end
     end
 
-    context "when from rdv_wizard" do
+    context "service" do
       it "returns relative if pmi service" do
-        user = build(:user)
-        motif = build(:motif, service: build(:service, :pmi))
-        expect(default_service_selection(user, motif)).to eq(:relative)
+        service = build(:service, :pmi)
+        expect(default_service_selection_from(service)).to eq(:relative)
       end
 
       it "returns responsible if other service" do
-        user = build(:user)
-        motif = build(:motif, service: build(:service, :social))
-        expect(default_service_selection(user, motif)).to eq(:responsible)
+        service = build(:service, :social)
+        expect(default_service_selection_from(service)).to eq(:responsible)
       end
     end
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,0 +1,11 @@
+describe Service, type: :model do
+  describe "#pmi?" do
+    it "returns false when social service" do
+      expect(build(:service, :social).pmi?).to be false
+    end
+
+    it "returns true when pmi service" do
+      expect(build(:service, :pmi).pmi?).to be true
+    end
+  end
+end


### PR DESCRIPTION
fix #1184

Pour « orienter » la création d'un usager dans le tunnel de conversion, j'ai ajouté le motif dans l'appel du formulaire usager. L'idée est de pouvoir retrouver le service au moment d'une création. Si nous sommes en PMI, on affiche le proche par défaut. En général, en PMI, c'est l'enfant qui a rendez-vous.


