### PR TITLE
refactor users and ApplicationPolicy

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,49 +1,23 @@
 class ApplicationPolicy
-  attr_reader :user, :record
+  attr_reader :pundit_user, :record
 
-  def initialize(user, record)
-    @user = user
+  def initialize(pundit_user, record)
+    @pundit_user = pundit_user
     @record = record
   end
 
-  def index?
-    false
-  end
-
-  def show?
-    false
-  end
-
-  def create?
-    false
-  end
-
-  def new?
-    create?
-  end
-
-  def update?
-    false
-  end
-
-  def edit?
-    update?
-  end
-
-  def destroy?
-    false
-  end
-
   class Scope
-    attr_reader :user, :scope
+    attr_reader :pundit_user, :scope
 
-    def initialize(user, scope)
-      @user = user
+    def initialize(pundit_user, scope)
+      @pundit_user = pundit_user
       @scope = scope
     end
 
-    def resolve
-      scope.all
+    def in_scope?(object)
+      return false unless object&.id.present?
+
+      resolve.where(id: object.id).any?
     end
   end
 end

--- a/app/policies/user/user_policy.rb
+++ b/app/policies/user/user_policy.rb
@@ -1,25 +1,28 @@
 class User::UserPolicy < ApplicationPolicy
-  class Scope < Scope
-    def resolve
-      scope.where(id: @user.id).or(User.where(responsible_id: @user.id))
-    end
-  end
-
-  def create?
-    user_is_responsible?
-  end
-
-  def update?
-    @record.id == @user.id || user_is_responsible?
-  end
-
-  def destroy?
-    @record.id == @user.id || user_is_responsible?
-  end
-
-  private
+  alias current_user pundit_user
 
   def user_is_responsible?
-    @record.responsible_id == @user.id
+    record.responsible_id == current_user.id
+  end
+
+  alias new? user_is_responsible?
+  alias create? user_is_responsible?
+
+  def current_user_or_responsible?
+    record.id == current_user.id || user_is_responsible?
+  end
+
+  alias edit? current_user_or_responsible?
+  alias update? current_user_or_responsible?
+  alias destroy? current_user_or_responsible?
+
+  class Scope < Scope
+    alias current_user pundit_user
+
+    def resolve
+      scope
+        .where(id: current_user.id)
+        .or(User.where(responsible_id: current_user.id))
+    end
   end
 end


### PR DESCRIPTION
preliminary to #1215 

# Direction

La direction que j'envisage pour les policies est de **limiter le contexte à l'agent ou l'usager connecté**. Le contexte désigne ici le `pundit_user`utilisé comme premier argument d'instanciation des policies.

Aujourd'hui côté agent on utilise comme `pundit_user` un `AgentContext` qui contient l'agent connecté + l'organisation courante si l'agent parcoure des routes scopées à l'organisation. Pour les routes scopées au département entier, pour l'instant on hacke complètement. 

Une direction alternative pourrait être de rajouter dans le contexte le Territoire pour supprimer le hack et faire quelque chose de propre. 

A mon avis, il vaut mieux simplifier au maximum le contexte et donc les policies. La policy devrait être uniquement en charge de dire si, dans l'absolu, un agent a le droit de faire telle action sur telle ressource, indépendamment du contexte. 

Ça devient la responsabilité des controlleurs de scoper sur l'orga courante ou le département courant.

# Changement sur les users

Cette premiere PR ne fait pas ce refacto côté agent, mais elle simplifie d'abord les policies côté User. 

- Simplification et générisation de l'`ApplicationPolicy`. Le but est de pouvoir l'utiliser ensuite comme classe de base pour toutes les policies, dont celles Agent. 
- j'ai tenté de transformer cet héritage en composition via concerns mais ce n'est pas très pratique à cause des classes scopées `Scope` qui doivent aussi hériter d'un peu de comportement. C'est aussi la manière de faire recommandée par Pundit et ça suit les conventions Rails d'hériter d'un ApplicationController::Base etc. 
- utilisation d'un alias `current_user` pour designer le `pundit_user` dans les policies user. L'idée sera d'aliaser symmétriquement le pundit_user en `current_agent` côté policies Agents. J'utilise la même convention que devise pour désigner l'agent connecté même si ce n'est pas nécessaire je pense que ça peut aider la lisibilité.

Il faudrait ensuite refacto les policies Agent pour supprimer la notion de current_organisation dans le AgentContext et simplifier toutes les policies.