### PR TITLE
introduce AgentAgendas and refactor AgentPolicy

### DIFF
--- a/app/controllers/admin/agent_agendas_controller.rb
+++ b/app/controllers/admin/agent_agendas_controller.rb
@@ -1,0 +1,10 @@
+class Admin::AgentAgendasController < AgentAuthController
+  def show
+    @agent = policy_scope(Agent).find(params[:id])
+    authorize(AgentAgenda.new(agent: @agent, organisation: current_organisation))
+    @status = params[:status]
+    @organisation = current_organisation
+    @selected_event_id = params[:selected_event_id]
+    @date = params[:date].present? ? Date.parse(params[:date]) : nil
+  end
+end

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -2,7 +2,9 @@ class Admin::AgentsController < AgentAuthController
   respond_to :html, :json
 
   def index
-    agents = policy_scope(Agent).active.order_by_last_name
+    agents = policy_scope(Agent)
+      .joins(:organisations).where(organisations: { id: current_organisation.id })
+      .active.order_by_last_name
     @invited_agents = agents.invitation_not_accepted.created_by_invite
     @complete_agents = params[:search].present? ? agents.search_by_text(params[:search]) : agents
     @complete_agents = @complete_agents.complete.includes(:service).page(params[:page])

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -12,7 +12,9 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
           .where(id: @motifs.pluck(:service_id).uniq)
           .ordered_by_name
         @form.service_id = @services.first.id if @services.count == 1
-        @agents = policy_scope(Agent).complete.active.order_by_last_name
+        @agents = policy_scope(Agent)
+          .joins(:organisations).where(organisations: { id: current_organisation.id })
+          .complete.active.order_by_last_name
         @lieux = policy_scope(Lieu).ordered_by_name
       end
       format.js do

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -1,6 +1,10 @@
 class Admin::InvitationsController < AgentAuthController
   def index
-    @invited_agents = policy_scope(Agent).invitation_not_accepted.created_by_invite.order(invitation_sent_at: :desc)
+    @invited_agents = policy_scope(Agent)
+      .joins(:organisations).where(organisations: { id: current_organisation.id })
+      .invitation_not_accepted
+      .created_by_invite
+      .order(invitation_sent_at: :desc)
   end
 
   def reinvite

--- a/app/controllers/admin/organisations/setup_checklists_controller.rb
+++ b/app/controllers/admin/organisations/setup_checklists_controller.rb
@@ -4,7 +4,10 @@ class Admin::Organisations::SetupChecklistsController < AgentAuthController
   def show
     authorize(@organisation)
     @lieux = policy_scope(Lieu)
-    @other_agents = policy_scope(Agent).order_by_last_name.filter { |a| a.id != current_agent.id }
+    @other_agents = policy_scope(Agent)
+      .joins(:organisations).where(organisations: { id: current_organisation.id })
+      .order_by_last_name
+      .filter { |a| a.id != current_agent.id }
 
     @motifs = policy_scope(Motif)
   end

--- a/app/controllers/admin/organisations/stats_controller.rb
+++ b/app/controllers/admin/organisations/stats_controller.rb
@@ -2,7 +2,12 @@ class Admin::Organisations::StatsController < AgentAuthController
   before_action :set_organisation
 
   def index
-    @stats = Stat.new(rdvs: policy_scope(Rdv), agents: policy_scope(Agent), users: policy_scope(User))
+    @stats = Stat.new(
+      rdvs: policy_scope(Rdv),
+      agents: policy_scope(Agent)
+        .joins(:organisations).where(organisations: { id: current_organisation.id }),
+      users: policy_scope(User)
+    )
   end
 
   def rdvs

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -64,7 +64,7 @@ class Admin::RdvsController < AgentAuthController
       Sentry.capture_exception(Exception.new("Deletion failed for rdv : #{@rdv.id}"))
     end
     # TODO : redirection makes no sense when coming from a users#show
-    redirect_to admin_organisation_agent_path(current_organisation, @agent || current_agent)
+    redirect_to admin_organisation_agent_agenda_path(current_organisation, @agent || current_agent)
   end
 
   private

--- a/app/form_models/admin/rdv_wizard_form/step4.rb
+++ b/app/form_models/admin/rdv_wizard_form/step4.rb
@@ -7,7 +7,7 @@ class Admin::RdvWizardForm::Step4
   end
 
   def success_path
-    admin_organisation_agent_path(
+    admin_organisation_agent_agenda_path(
       rdv.organisation,
       agents.include?(@agent_author) ? @agent_author : agents.first,
       selected_event_id: rdv.id,

--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -59,7 +59,7 @@ module Admin::RdvWizardFormConcern
 
   def previous_step_path
     if step_number <= 1
-      admin_organisation_agent_path(organisation, agent_author)
+      admin_organisation_agent_agenda_path(organisation, agent_author)
     else
       path_for_step(step_number - 1)
     end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -59,9 +59,12 @@ module AgentsHelper
   end
 
   def selectable_planning_agents_options
-    path_helper_name = content_for(:menu_agent_select_path_helper_name) || :admin_organisation_agent_path
+    path_helper_name = content_for(:menu_agent_select_path_helper_name) || :admin_organisation_agent_agenda_path
     options_for_select(
-      policy_scope(Agent).complete.active.order_by_last_name.map do |agent|
+      policy_scope(Agent)
+        .joins(:organisations).where(organisations: { id: current_organisation.id })
+        .complete.active.order_by_last_name
+        .map do |agent|
         [
           agent.full_name,
           agent.id,

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -3,7 +3,7 @@ module OrganisationsHelper
     if organisation.recent?
       admin_organisation_setup_checklist_path(organisation)
     else
-      admin_organisation_agent_path(organisation, current_agent)
+      admin_organisation_agent_agenda_path(organisation, current_agent)
     end
   end
 

--- a/app/models/agent_agenda.rb
+++ b/app/models/agent_agenda.rb
@@ -1,0 +1,16 @@
+class AgentAgenda
+  attr_reader :organisation, :agent
+
+  def initialize(organisation: nil, agent: nil)
+    @organisation = organisation
+    @agent = agent
+  end
+
+  def organisation_id
+    organisation.id
+  end
+
+  def agent_id
+    agent.id
+  end
+end

--- a/app/policies/agent/absence_policy.rb
+++ b/app/policies/agent/absence_policy.rb
@@ -1,10 +1,10 @@
 class Agent::AbsencePolicy < DefaultAgentPolicy
   class Scope < Scope
     def resolve
-      if @context.organisation.present?
-        scope_down_absences(scope, @context.organisation.id, @context.agent_role)
+      if current_organisation.present?
+        scope_down_absences(scope, current_organisation.id, current_agent_role)
       else
-        @context.agent.roles.map do |agent_role|
+        current_agent.roles.map do |agent_role|
           scope_down_absences(scope, agent_role.organisation_id, agent_role)
         end.reduce(:or)
       end
@@ -12,7 +12,7 @@ class Agent::AbsencePolicy < DefaultAgentPolicy
 
     def scope_down_absences(scope, organisation_id, agent_role)
       new_scope = scope.where(organisation_id: organisation_id)
-      new_scope = new_scope.joins(:agent).where(agents: { service: @context.agent.service }) \
+      new_scope = new_scope.joins(:agent).where(agents: { service: current_agent.service }) \
         unless agent_role.can_access_others_planning?
       new_scope
     end

--- a/app/policies/agent/admin_policy.rb
+++ b/app/policies/agent/admin_policy.rb
@@ -17,7 +17,7 @@ class Agent::AdminPolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(organisation_id: @context.organisation.id)
+      scope.where(organisation_id: current_organisation.id)
     end
   end
 end

--- a/app/policies/agent/agent_agenda_policy.rb
+++ b/app/policies/agent/agent_agenda_policy.rb
@@ -1,0 +1,18 @@
+class Agent::AgentAgendaPolicy < ApplicationPolicy
+  include CurrentAgentInPolicyConcern
+
+  def show?
+    agent_role_in_record_organisation.present? && (
+      record.agent_id == current_agent.id ||
+      record.agent.service_id == current_agent.service_id ||
+      agent_role_in_record_organisation.can_access_others_planning?
+    )
+  end
+
+  private
+
+  def agent_role_in_record_organisation
+    @agent_role_in_record_organisation ||= \
+      current_agent.roles.find_by(organisation_id: record.organisation_id)
+  end
+end

--- a/app/policies/agent/agent_role_policy.rb
+++ b/app/policies/agent/agent_role_policy.rb
@@ -5,7 +5,7 @@ class Agent::AgentRolePolicy < Agent::AdminPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(agent_id: @context.agent.id)
+      scope.where(agent_id: current_agent.id)
     end
   end
 end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -5,10 +5,10 @@ class Agent::MotifPolicy < Agent::AdminPolicy
 
   class Scope < Scope
     def resolve
-      if @context.can_access_others_planning?
-        scope.where(organisation: @context.organisation)
+      if context.can_access_others_planning?
+        scope.where(organisation: current_organisation)
       else
-        scope.where(organisation: @context.organisation, service: @context.agent.service)
+        scope.where(organisation: current_organisation, service: current_agent.service)
       end
     end
   end

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -1,6 +1,6 @@
 class Agent::OrganisationPolicy < DefaultAgentPolicy
   def link_to_organisation?
-    @context.agent.organisation_ids.include?(@record.id)
+    current_agent.organisation_ids.include?(@record.id)
   end
 
   def new?
@@ -25,7 +25,7 @@ class Agent::OrganisationPolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(id: @context.agent.organisation_ids)
+      scope.where(id: current_agent.organisation_ids)
     end
   end
 end

--- a/app/policies/agent/plage_ouverture_policy.rb
+++ b/app/policies/agent/plage_ouverture_policy.rb
@@ -1,22 +1,22 @@
 class Agent::PlageOuverturePolicy < DefaultAgentPolicy
   class Scope < Scope
     def resolve
-      if @context.can_access_others_planning?
-        scope.where(organisation_id: @context.organisation.id)
+      if context.can_access_others_planning?
+        scope.where(organisation_id: current_organisation.id)
       else
-        scope.joins(:agent).where(organisation_id: @context.organisation.id, agents: { service_id: @context.agent.service_id })
+        scope.joins(:agent).where(organisation_id: current_organisation.id, agents: { service_id: current_agent.service_id })
       end
     end
   end
 
   class DepartementScope < Scope
     def resolve
-      if @context.can_access_others_planning?
-        scope.where(organisation_id: @context.agent.organisations.pluck(:id))
+      if context.can_access_others_planning?
+        scope.where(organisation_id: current_agent.organisations.pluck(:id))
       else
         scope.joins(:agent)
-          .where(organisation_id: @context.agent.organisations.pluck(:id))
-          .where(agents: { service_id: @context.agent.service_id })
+          .where(organisation_id: current_agent.organisations.pluck(:id))
+          .where(agents: { service_id: current_agent.service_id })
       end
     end
   end

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -5,22 +5,22 @@ class Agent::RdvPolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      if @context.can_access_others_planning?
-        scope.where(organisation_id: @context.organisation.id)
+      if context.can_access_others_planning?
+        scope.where(organisation_id: current_organisation.id)
       else
-        scope.joins(:motif).where(organisation_id: @context.organisation.id, motifs: { service_id: @context.agent.service_id })
+        scope.joins(:motif).where(organisation_id: current_organisation.id, motifs: { service_id: current_agent.service_id })
       end
     end
   end
 
   class DepartementScope < Scope
     def resolve
-      if @context.can_access_others_planning?
-        scope.where(organisation_id: @context.agent.organisations.pluck(:id))
+      if context.can_access_others_planning?
+        scope.where(organisation_id: current_agent.organisations.pluck(:id))
       else
         scope.joins(:motif)
-          .where(organisation_id: @context.agent.organisations.pluck(:id))
-          .where(motifs: { service_id: @context.agent.service_id })
+          .where(organisation_id: current_agent.organisations.pluck(:id))
+          .where(motifs: { service_id: current_agent.service_id })
       end
     end
   end

--- a/app/policies/agent/sector_attribution_policy.rb
+++ b/app/policies/agent/sector_attribution_policy.rb
@@ -9,7 +9,7 @@ class Agent::SectorAttributionPolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      departements = @context.agent.organisations.pluck(:departement).uniq
+      departements = current_agent.organisations.pluck(:departement).uniq
       scope.joins(:sectors).where(sectors: { departement: departements })
     end
   end

--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -1,17 +1,17 @@
 class Agent::ServicePolicy < Agent::AdminPolicy
   class Scope < Scope
     def resolve
-      return scope.all if @context.agent_role.admin? || @context.agent.service.secretariat?
+      return scope.all if current_agent_role.admin? || current_agent.service.secretariat?
 
-      scope.where(id: @context.agent.service_id)
+      scope.where(id: current_agent.service_id)
     end
   end
 
   class AdminScope < Scope
     def resolve
-      return scope.all if @context.agent_role.admin?
+      return scope.all if current_agent_role.admin?
 
-      scope.where(id: @context.agent.service_id)
+      scope.where(id: current_agent.service_id)
     end
   end
 end

--- a/app/policies/agent/support_ticket_policy.rb
+++ b/app/policies/agent/support_ticket_policy.rb
@@ -1,5 +1,5 @@
 class Agent::SupportTicketPolicy < DefaultAgentPolicy
   def create?
-    @record.email == @context.agent.email
+    @record.email == current_agent.email
   end
 end

--- a/app/policies/agent/user_note_policy.rb
+++ b/app/policies/agent/user_note_policy.rb
@@ -13,13 +13,13 @@ class Agent::UserNotePolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      scope.where(organisation: @context.organisation)
+      scope.where(organisation: current_organisation)
     end
   end
 
   protected
 
   def same_org?
-    @record.organisation == @context.organisation
+    @record.organisation == current_organisation
   end
 end

--- a/app/policies/agent/user_policy.rb
+++ b/app/policies/agent/user_policy.rb
@@ -10,7 +10,7 @@ class Agent::UserPolicy < DefaultAgentPolicy
 
     (
       @record.user_profiles.map(&:organisation_id) -
-      (@context.organisation.present? ? [@context.organisation.id] : @context.agent.organisation_ids)
+      (current_organisation.present? ? [current_organisation.id] : current_agent.organisation_ids)
     ).empty?
   end
 
@@ -32,7 +32,7 @@ class Agent::UserPolicy < DefaultAgentPolicy
         .joins(:organisations)
         .where(
           organisations: {
-            id: @context.organisation&.id || @context.agent.organisation_ids
+            id: current_organisation&.id || current_agent.organisation_ids
           }
         )
     end
@@ -47,10 +47,10 @@ class Agent::UserPolicy < DefaultAgentPolicy
     # nor updates. we cannot either use pluck for the same reason
 
     authorized_organisation_ids = \
-      if @context.organisation
-        [@context.organisation.id]
+      if current_organisation
+        [current_organisation.id]
       else
-        @context.agent.organisation_ids
+        current_agent.organisation_ids
       end
     (@record.user_profiles.map(&:organisation_id) & authorized_organisation_ids).present?
 

--- a/app/policies/agent/user_profile_policy.rb
+++ b/app/policies/agent/user_profile_policy.rb
@@ -6,16 +6,16 @@ class Agent::UserProfilePolicy < DefaultAgentPolicy
   protected
 
   def same_org?
-    if @context.organisation.present?
-      @record.organisation_id == @context.organisation.id
+    if current_organisation.present?
+      @record.organisation_id == current_organisation.id
     else
-      @context.agent.organisation_ids.include?(@record.organisation_id)
+      current_agent.organisation_ids.include?(@record.organisation_id)
     end
   end
 
   class Scope < Scope
     def resolve
-      scope.where(organisation_id: @context.organisation&.id || @context.agent.organisation_ids)
+      scope.where(organisation_id: current_organisation&.id || current_agent.organisation_ids)
     end
   end
 end

--- a/app/policies/agent/zone_policy.rb
+++ b/app/policies/agent/zone_policy.rb
@@ -9,7 +9,7 @@ class Agent::ZonePolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      departements = @context.agent.organisations.pluck(:departement).uniq
+      departements = current_agent.organisations.pluck(:departement).uniq
       scope.joins(:sectors).where(sectors: { departement: departements })
     end
   end

--- a/app/policies/concerns/current_agent_in_policy_concern.rb
+++ b/app/policies/concerns/current_agent_in_policy_concern.rb
@@ -1,0 +1,8 @@
+module CurrentAgentInPolicyConcern
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method :context, :pundit_user
+    delegate :agent, to: :context, prefix: :current # defines current_agent
+  end
+end

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -1,5 +1,5 @@
 - content_for(:menu_item) { 'menu-agendas' }
-- content_for(:menu_agent_select_path_helper_name) { "admin_organisation_agent_path" }
+- content_for(:menu_agent_select_path_helper_name) { "admin_organisation_agent_agenda_path" }
 
 - content_for :title do
   - if current_agent == @agent
@@ -8,7 +8,7 @@
     | Agenda de #{@agent.full_name_and_service}
 
 - content_for :breadcrumb do
-  = form_tag(admin_organisation_agent_path(current_organisation, @agent), method: "get", class: "d-inline-flex mr-2") do
+  = form_tag(admin_organisation_agent_agenda_path(current_organisation, @agent), method: "get", class: "d-inline-flex mr-2") do
     = select_tag :status, options_for_select(Rdv.human_enum_collection(:statuses).unshift(["Tous les rdvs", ""]), rdv_status_value(@status)), class:"select2-input", onchange: 'this.form.submit()'
   = link_to "Trouver un créneau", admin_organisation_agent_searches_path(@organisation), class: "btn btn-outline-white align-bottom"
 

--- a/app/views/admin/organisations/setup_checklists/show.slim
+++ b/app/views/admin/organisations/setup_checklists/show.slim
@@ -43,11 +43,11 @@
             span>= link_to "Créer une fiche usager", new_admin_organisation_user_path(@organisation)
           li.mb-2
             span>= setup_checklist_item(current_agent.rdvs.length > 0)
-            span>= link_to "Ajouter un RDV dans votre agenda", admin_organisation_agent_path(@organisation, current_agent.id)
+            span>= link_to "Ajouter un RDV dans votre agenda", admin_organisation_agent_agenda_path(@organisation, current_agent.id)
           - @other_agents.each do |agent|
             li.mb-2
               span>= setup_checklist_item(agent.rdvs.length > 0)
-              span>= link_to "Ajouter un RDV dans l'agenda de #{agent.full_name}#{agent.complete? ? '' : ' (en attente de validation)'}", admin_organisation_agent_path(@organisation, agent.id)
+              span>= link_to "Ajouter un RDV dans l'agenda de #{agent.full_name}#{agent.complete? ? '' : ' (en attente de validation)'}", admin_organisation_agent_agenda_path(@organisation, agent.id)
 
         h5 Créneaux d'absences
         .mb-2

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -5,9 +5,9 @@
     - if @agent
       li.breadcrumb-item.p-0
         - if @agent != current_agent
-          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_path(current_organisation, @agent)
+          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_agenda_path(current_organisation, @agent)
         - else
-          = link_to "Votre agenda", admin_organisation_agent_path(current_organisation, current_agent)
+          = link_to "Votre agenda", admin_organisation_agent_agenda_path(current_organisation, current_agent)
     li.breadcrumb-item.p-0.ml-2
       | RDV
       |&nbsp;

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -7,7 +7,7 @@
   - if @breadcrumb_page == "agenda" && @form.agent.present?
     ol.breadcrumb.m-0
       li.breadcrumb-item
-        = link_to "Agenda de #{@form.agent.full_name}", admin_organisation_agent_path(current_organisation, @form.agent, date: @form.start)
+        = link_to "Agenda de #{@form.agent.full_name}", admin_organisation_agent_agenda_path(current_organisation, @form.agent, date: @form.start)
       li.breadcrumb-item.active Liste des RDV
 
   - if @breadcrumb_page == "agent_stats" && @form.agent == current_agent
@@ -37,7 +37,12 @@
     = simple_form_for(@form, method: "GET", url: url_for({}), as: "") do |f|
       .row
         .col-md-6
-          = f.input :agent_id, collection: policy_scope(Agent), label: "Agent", label_method: :full_name, input_html: { class: 'select2-input' }, wrapper: "horizontal_form"
+          = f.input :agent_id, \
+            collection: policy_scope(Agent).joins(:organisations).where(organisations: { id: current_organisation.id }), \
+            label: "Agent", \
+            label_method: :full_name, \
+            input_html: { class: 'select2-input' }, \
+            wrapper: "horizontal_form"
           = f.input :user_id, collection: policy_scope(User), label: "Usager", label_method: :full_name, input_html: { class: 'select2-input' }, wrapper: "horizontal_form"
           = f.input :lieu_id, collection: policy_scope(Lieu), label: "Lieu", label_method: :name, input_html: { class: 'select2-input' }, wrapper: "horizontal_form"
           = f.input :show_user_details, as: :boolean, wrapper: "horizontal_form", label: "Détails usagers"

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -5,9 +5,9 @@
     - if @agent
       li.breadcrumb-item.p-0
         - if @agent != current_agent
-          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_path(current_organisation, @agent)
+          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_agenda_path(current_organisation, @agent)
         - else
-          = link_to "Votre agenda", admin_organisation_agent_path(current_organisation, current_agent)
+          = link_to "Votre agenda", admin_organisation_agent_agenda_path(current_organisation, current_agent)
     li.breadcrumb-item.p-0.ml-2
       div
         span> RDV
@@ -31,7 +31,7 @@
           i.fa.fa-fw.fa-calendar>
           = rdv_time_and_duration(@rdv)
           |&nbsp;
-          = link_to "voir dans l'agenda", admin_organisation_agent_path(current_organisation, @rdv.agents.first, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date)
+          = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, @rdv.agents.first, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date)
         = render 'rdv_details', rdv: @rdv, display_links_to_users: false
         .row
           .col

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -59,7 +59,13 @@
         .card-body
           .collapse.collapse-referent-form
             = simple_form_for(@user, url: admin_organisation_user_referents_path(current_organisation, @user), method: :put) do |f|
-              = f.association(:agents, collection: policy_scope(Agent).order_by_last_name, label_method: :full_name_and_service, label: false, multiple: true, input_html: {class: 'select2-input'})
+              = f.association \
+                :agents, \
+                collection: policy_scope(Agent).joins(:organisations).where(organisations: { id: current_organisation.id }).order_by_last_name, \
+                label_method: :full_name_and_service, \
+                label: false, \
+                multiple: true, \
+                input_html: {class: 'select2-input'}
               = f.button :submit, "Enregistrer"
           .show.collapse-referent-form
             ul.list-unstyled.mb-2

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -79,7 +79,7 @@
               )
           li.my-2
             = link_to 'Agenda', \
-              admin_organisation_agent_path(current_organisation, agent_for_left_menu), \
+              admin_organisation_agent_agenda_path(current_organisation, agent_for_left_menu), \
               class: ("active" if content_for(:menu_item) == "menu-agendas")
           li.my-2
             = link_to "Plages d'ouverture", \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,8 @@ Rails.application.routes.draw do
         end
         resources :absences, except: [:index, :show, :new]
         resources :agent_roles, only: [:edit, :update]
-        resources :agents, only: [:index, :show, :destroy] do
+        resources :agent_agendas, only: [:show]
+        resources :agents, only: [:index, :destroy] do
           resources :absences, only: [:index, :new]
           resources :plage_ouvertures, only: [:index, :new]
           resources :stats, only: :index do

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -17,7 +17,7 @@ describe "Agent can create a Rdv with creneau search" do
   before do
     travel_to(Time.zone.local(2019, 7, 22))
     login_as(agent, scope: :agent)
-    visit admin_organisation_agent_path(organisation, agent)
+    visit admin_organisation_agent_agenda_path(organisation, agent)
 
     expect(user.rdvs.count).to eq(0)
     click_link("Trouver un créneau")
@@ -92,7 +92,7 @@ describe "Agent can create a Rdv with creneau search" do
     expect(rdv.duration_in_min).to eq(motif.default_duration_in_min)
     expect(rdv.created_by_agent?).to be(true)
 
-    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
+    expect(page).to have_current_path(admin_organisation_agent_agenda_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
     expect(page).to have_content("Le rendez-vous a été créé.")
     expect(page).to have_content("Votre agenda")
   end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -85,7 +85,7 @@ describe "Agent can create a Rdv with wizard" do
     expect(rdv.created_by_agent?).to be(true)
     expect(rdv.context).to eq("RDV très spécial")
 
-    expect(page).to have_current_path(admin_organisation_agent_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
+    expect(page).to have_current_path(admin_organisation_agent_agenda_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
     expect(page).to have_content("Le rendez-vous a été créé.")
     sleep(0.5) # wait for ajax request
   end

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -1,0 +1,78 @@
+describe Agent::AgentPolicy, type: :policy do
+  subject { described_class }
+
+  let(:pundit_context) { AgentContext.new(agent) }
+  let!(:organisation) { create(:organisation) }
+
+  describe "#show?" do
+    context "regular agent, self" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      permissions(:show?) { it { should permit(pundit_context, agent) } }
+    end
+
+    context "regular agent, other agent same orga" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      permissions(:show?) { it { should_not permit(pundit_context, other_agent) } }
+    end
+
+    context "admin agent, other agent same orga" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      permissions(:show?) { it { should permit(pundit_context, other_agent) } }
+    end
+
+    context "admin agent, other agent different orga" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
+      permissions(:show?) { it { should_not permit(pundit_context, other_agent) } }
+    end
+
+    context "regular agent, other agent is admin in same orga" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, admin_role_in_organisations: [create(:organisation)]) }
+      permissions(:show?) { it { should_not permit(pundit_context, other_agent) } }
+    end
+  end
+end
+
+describe Agent::AgentPolicy::Scope, type: :policy do
+  describe "#resolve?" do
+    subject { Agent::AgentPolicy::Scope.new(AgentContext.new(agent), Agent).resolve }
+
+    context "regular agent" do
+      let!(:services) { create_list(:service, 2) }
+      let!(:organisations) { create_list(:organisation, 2) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisations[0]], service: services[0]) }
+      let!(:other_agent_same_service) { create(:agent, basic_role_in_organisations: [organisations[0]], service: services[0]) }
+      let!(:other_agent_different_orga) { create(:agent, basic_role_in_organisations: [organisations[1]], service: services[0]) }
+      let!(:other_agent_different_service) { create(:agent, basic_role_in_organisations: [organisations[0]], service: services[1]) }
+      it { should include(agent) }
+      it { should include(other_agent_same_service) }
+      it { should_not include(other_agent_different_orga) }
+      it { should_not include(other_agent_different_service) }
+    end
+
+    context "admin agent, misc state" do
+      let!(:organisations) { create_list(:organisation, 4) }
+      let!(:agent) do
+        create(
+          :agent,
+          basic_role_in_organisations: [organisations[0]],
+          admin_role_in_organisations: [organisations[1], organisations[2]]
+        )
+      end
+      let!(:other_agent1) { create(:agent, basic_role_in_organisations: [organisations[0]]) }
+      let!(:other_agent2) { create(:agent, basic_role_in_organisations: [organisations[1]]) }
+      let!(:other_agent3) { create(:agent, basic_role_in_organisations: [organisations[2]]) }
+      let!(:other_agent4) { create(:agent, basic_role_in_organisations: [organisations[3]]) }
+      let!(:other_agent5) { create(:agent, admin_role_in_organisations: [organisations[2]]) }
+
+      it { should_not include(other_agent1) }
+      it { should include(other_agent2) }
+      it { should include(other_agent3) }
+      it { should_not include(other_agent4) }
+      it { should include(other_agent5) }
+    end
+  end
+end

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -1,5 +1,3 @@
-require "pundit/rspec"
-
 describe Agent::RdvPolicy, type: :policy do
   subject { described_class }
 

--- a/spec/policies/agent/user_policy_spec.rb
+++ b/spec/policies/agent/user_policy_spec.rb
@@ -1,5 +1,3 @@
-require "pundit/rspec"
-
 describe Agent::UserPolicy, type: :policy do
   subject { described_class }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require "capybara/rspec"
 require "capybara/email/rspec"
 require "webdrivers"
 require "capybara-screenshot/rspec"
+require "pundit/rspec"
 
 Capybara.register_driver :selenium do |app|
   # these args seem to reduce test flakyness


### PR DESCRIPTION
refacto preliminaire a #1215 

# Nouvelle ressource AgentAgenda

Aujourd'hui les agendas agents apparaissent sur la route `organisations/:orga_id/agents/:agent_id` , et sont donc traités par `AgentsController#show`. Ca n'est pas très juste sémantiquement à mon avis : l'agent n'est pas vraiment défini par son agenda au sein d'une orga, mais plutôt par son rôle, son nom et prénom, son service etc. C'est d'ailleurs ce que permettent d'éditer les autres actions de ce controlleur, pas l'agenda. 

Ca pose aussi un souci avec les policies : le `policy_scope(Agent)` n'est pas tout à fait le même. Pour l'instant, les agents non-admin ne peuvent pas voir la liste des autres agents et les éditer; supprimer etc, MAIS les agents non-admin peuvent voir et éditer les agendas d'autres agents de leur services. Ca fait que la policy Agent remplit un double rôle aujourd'hui et est donc un peu trop souple je pense.

J'introduis un modele non persisté AgentAgenda qui est juste une paire Agent - Orga, une policy attachée, et une route et un controlleur pour déplacer vers `AgentAgendasController#show`. 

# Refactos préliminaires communs de toutes les policies

- nouvel héritage de DefaultAgentPolicy depuis `ApplicationPolicy`

Le but est de peu à peu supprimer les méthodes de `DefaultAgentPolicy` pour completement supprimer cette classe une fois toutes les policies refactored

- `@context.agent` est aliasé `current_agent` 
- `@context.organisation` est aliasé `current_organisation`
- `@context.agent_role` est aliasé `current_agent_role` 

Ces changements permettront j'espère de plus facilement les remplacer et les supprimer au fur et à mesure - le but étant de ne garder que `current_agent` comme contexte

déplacement du require pundit/spec_helper vers un require commun

# Refacto de AgentPolicy

- introduction de specs
- nouvel héritage depuis `ApplicationPolicy` 
- ignore l'organisation du contexte `pundit_user`, pour devenir absolue
- déplacement du scoping des Agents à l'orga courante dans les controlleurs et vues