### PR TITLE
refactor AbsencePolicy to inherit from ApplicationPolicy

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -6,7 +6,9 @@ class Admin::AbsencesController < AgentAuthController
   before_action :set_agent
 
   def index
-    absences = policy_scope(Absence).where(agent_id: filter_params[:agent_id])
+    absences = policy_scope(Absence)
+      .where(organisation: current_organisation)
+      .where(agent_id: filter_params[:agent_id])
     respond_to do |f|
       f.json { @absence_occurrences = absences.flat_map { |ab| ab.occurences_for(date_range_params).map { |occurence| [ab, occurence] } }.sort_by(&:second) }
       f.html { @absences = absences.includes(:organisation).page(filter_params[:page]) }
@@ -56,7 +58,9 @@ class Admin::AbsencesController < AgentAuthController
   private
 
   def set_absence
-    @absence = policy_scope(Absence).find(params[:id])
+    @absence = policy_scope(Absence)
+      .where(organisation: current_organisation)
+      .find(params[:id])
   end
 
   def build_absence

--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::AbsencesController < Api::V1::BaseController
   def index
-    render json: AbsenceBlueprint.render(policy_scope(Absence).limit(100).all, root: :absences)
+    absences = policy_scope(Absence)
+    absences = absences.where(organisation: Organisation.find(params[:organisation_id])) \
+      if params[:organisation_id].present?
+    render json: AbsenceBlueprint.render(absences.limit(100).all, root: :absences)
   end
 
   def create

--- a/spec/policies/agent/absence_policy_spec.rb
+++ b/spec/policies/agent/absence_policy_spec.rb
@@ -1,0 +1,70 @@
+describe Agent::AbsencePolicy, type: :policy do
+  subject { described_class }
+
+  let(:pundit_context) { AgentContext.new(agent) }
+  let!(:organisation) { create(:organisation) }
+
+  describe "#show?" do
+    context "regular agent, own absence" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:absence) { create(:absence, agent: agent, organisation: organisation) }
+      permissions(:show?) { it { should permit(pundit_context, absence) } }
+    end
+
+    context "regular agent, other agent's absence BUT same service" do
+      let!(:service) { create(:service) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+      let!(:absence) { create(:absence, agent: other_agent, organisation: organisation) }
+      permissions(:show?) { it { should permit(pundit_context, absence) } }
+    end
+
+    context "regular agent, other agent's absence, different service" do
+      let!(:service) { create(:service) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], service: create(:service)) }
+      let!(:absence) { create(:absence, agent: other_agent, organisation: organisation) }
+      permissions(:show?) { it { should_not permit(pundit_context, absence) } }
+    end
+
+    context "admin agent, other agent's absence, different service" do
+      let!(:service) { create(:service) }
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation], service: create(:service)) }
+      let!(:absence) { create(:absence, agent: other_agent, organisation: organisation) }
+      permissions(:show?) { it { should permit(pundit_context, absence) } }
+    end
+  end
+end
+
+describe Agent::AbsencePolicy::Scope, type: :policy do
+  describe "#resolve?" do
+    subject { Agent::AbsencePolicy::Scope.new(AgentContext.new(agent), Absence).resolve }
+
+    context "misc state" do
+      let!(:organisations) { create_list(:organisation, 4) }
+      let!(:services) { create_list(:service, 2) }
+      let!(:agent) do
+        create(
+          :agent,
+          basic_role_in_organisations: [organisations[0], organisations[1]],
+          admin_role_in_organisations: [organisations[2]],
+          service: services[0]
+        )
+      end
+      let!(:absence1) { create(:absence, agent: agent, organisation: organisations[0]) }
+      let!(:absence2) { create(:absence, agent: agent, organisation: organisations[1]) }
+      let!(:absence_same_service) { create(:absence, agent: create(:agent, service: services[0]), organisation: organisations[1]) }
+      let!(:absence_other_service) { create(:absence, agent: create(:agent, service: services[1]), organisation: organisations[1]) }
+      let!(:absence_other_service_but_admin) { create(:absence, agent: create(:agent, service: services[1]), organisation: organisations[2]) }
+      let!(:absence_other_orga) { create(:absence, agent: create(:agent, service: services[0]), organisation: organisations[3]) }
+
+      it { should include(absence1) }
+      it { should include(absence2) }
+      it { should include(absence_same_service) }
+      it { should_not include(absence_other_service) }
+      it { should include(absence_other_service_but_admin) }
+      it { should_not include(absence_other_orga) }
+    end
+  end
+end


### PR DESCRIPTION
suite a #1224 : refacto des policies admin 

- heritage direct de `ApplicationPolicy`
- définition explicite des actions utilisées uniquement
- ajout de specs