### PR TITLE
fix error in agent_roles_controller_spec that causes flaky specs

### DIFF
--- a/spec/controllers/admin/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/agent_roles_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::AgentRolesController, type: :controller do
 
   describe "GET #edit" do
     it "returns a success response" do
-      get :edit, params: { organisation_id: organisation.id, id: agent_user.id }
+      get :edit, params: { organisation_id: organisation.id, id: agent_role.id }
       expect(response).to be_successful
     end
   end


### PR DESCRIPTION
on utilisait le mauvais id pour generer la route, ca passait la plupart du temps par chance 😅 