### PR TITLE
simplifie le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # rdv-solidarites.fr
 
+[![View performance data on Skylight](https://badges.skylight.io/status/RgR7i58P67xN.svg)](https://oss.skylight.io/app/applications/RgR7i58P67xN)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+
 Réduire le nombre de rendez-vous annulés dans les maisons départementales de solidarité.
 
-## Des milliers de lapins dans les Maisons départementales de solidarité !
+Ce service public est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 
-Chaque année, des dizaines de milliers de rendez-vous pris dans les maisons départementales de solidarité (MDS). Selon nos estimations réalisées dans plusieurs départements, près de 20 % en moyenne ne sont ni honorés, ni excusés : ce sont des lapins. A ces lapins s’ajoutent des rendez-vous annulés et non remplacés, portant la moyenne des rendez-vous vacants à près de 25%.
+- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/)
+- En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/)
 
-Le projet est né dans le Pas-de-Calais, sur proposition de deux travailleuses médico-sociales devenues intrapreneuses du projet. Pendant un an, l’équipe a cherché à caractériser le problème et ses causes et à expérimenter des solutions. Elle a trouvé les moyens de réduire le taux de lapins à un niveau inférieur à 5% sur les zones pilotes.
+## Documentation
 
-Les conditions de la prise de rendez-vous sont déterminantes. Aujourd’hui, les rendez-vous sont pris par téléphone ou physiquement et les annulations faites par téléphone. Les créneaux sont souvent imposés aux usagers. Les délais d’attente peuvent être importants, ce qui favorise l’oubli. Il y a rarement de confirmation avant la date de rendez-vous et pas de conséquences pour l’usager qui pose un lapin.
+- Documentation par l'équipe sur [doc.rdv-solidarites.fr](https://doc.rdv-solidarites.fr/)
+- La fiche du service sur [beta.gouv.fr](https://beta.gouv.fr/startups/lapins.html).
 
-Les activités de la Protection Maternelle et Infantile (PMI) et d’accueil social sont particulièrement concernées. Ces lapins ont un coût financier substantiel et un coût social, avec l’allongement de délais de prise de rendez-vous, des conséquences sur les situations individuelles de personnes fragiles et des impacts négatifs sur les agents.
+## Communauté
 
-Les solutions trouvées pour le Pas-de-Calais ont vocation à être étendues, enrichies et partagées avec d’autres départements. Une rapide étude a confirmé l’existence de cette situation dans un nombre considérable de départements.
+Le forum [forum.rdv-solidarites.fr](https://forum.rdv-solidarites.fr/) accueille toutes les personnes utilisant RDV-Solidarités.
 
-_Voir toute la documentation sur [doc.rdv-solidarites.fr](https://doc.rdv-solidarites.fr/)_
+## Statistiques
 
-[Statistique de RDV](https://www.rdv-solidarites.fr/stats)
+- [Statistique de RDV](https://www.rdv-solidarites.fr/stats)
+- [stastistiques d'accès](https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=123&period=range&date=previous30&updated=1#?idSite=123&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1)
 
-[stastistiques d'accès](https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=123&period=range&date=previous30&updated=1#?idSite=123&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1)
-
-[![View performance data on Skylight](https://badges.skylight.io/status/RgR7i58P67xN.svg)](https://oss.skylight.io/app/applications/RgR7i58P67xN)
-
-## Licence 
-
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+## Licence
 
 Ce logiciel et son code source sont distribués sous [licence AGPL](https://www.gnu.org/licenses/why-affero-gpl.fr.html).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# rdv-solidarites.fr
+# RDV Solidarités
 
 [![View performance data on Skylight](https://badges.skylight.io/status/RgR7i58P67xN.svg)](https://oss.skylight.io/app/applications/RgR7i58P67xN)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-Réduire le nombre de rendez-vous annulés dans les maisons départementales de solidarité.
+L'objectif de ce service publique est de réduire le nombre de lapins (rendez-vous non annulés et non honorés) dans les maisons des solidarités.
 
-Ce service public est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
+Ce service est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 
 - En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/)
 - En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/)
@@ -21,8 +21,8 @@ Le forum [forum.rdv-solidarites.fr](https://forum.rdv-solidarites.fr/) accueille
 
 ## Statistiques
 
-- [Statistique de RDV](https://www.rdv-solidarites.fr/stats)
-- [stastistiques d'accès](https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=123&period=range&date=previous30&updated=1#?idSite=123&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1)
+- [Statistiques de RDV](https://www.rdv-solidarites.fr/stats)
+- [statistiques de traffic](https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=123&period=range&date=previous30&updated=1#?idSite=123&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1)
 
 ## Licence
 


### PR DESCRIPTION
J'ai supprimé le grand texte. Je crois que ce n'est pas vraiment la peine d'écrire tout cette historique dans le README.

Un axe plutôt « index » de documentation me semble plus intéressant. J'ai donc ajouté quelques liens. Il en manque peut-être.