### PR TITLE
Redirige les URL pointant précédemment vers les agendas

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -10,13 +10,6 @@ class Admin::AgentsController < AgentAuthController
     @complete_agents = @complete_agents.complete.includes(:service).page(params[:page])
   end
 
-  def show
-    @agent = policy_scope(Agent).find(params[:id])
-    authorize(@agent)
-    flash[:notice] = "Les pages d'agendas ont changées de lieux. Il faut mettre à jour vos favoris et raccourcis."
-    redirect_to admin_organisation_agent_agenda_path(current_organisation, @agent || current_agent)
-  end
-
   def destroy
     @agent = policy_scope(Agent).find(params[:id])
     authorize(@agent)

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -13,6 +13,7 @@ class Admin::AgentsController < AgentAuthController
   def show
     @agent = policy_scope(Agent).find(params[:id])
     authorize(@agent)
+    flash[:notice] = "Les pages d'agendas ont changées de lieux. Il faut mettre à jour vos favoris et raccourcis."
     redirect_to admin_organisation_agent_agenda_path(current_organisation, @agent || current_agent)
   end
 

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -13,10 +13,7 @@ class Admin::AgentsController < AgentAuthController
   def show
     @agent = policy_scope(Agent).find(params[:id])
     authorize(@agent)
-    @status = params[:status]
-    @organisation = current_organisation
-    @selected_event_id = params[:selected_event_id]
-    @date = params[:date].present? ? Date.parse(params[:date]) : nil
+    redirect_to admin_organisation_agent_agenda_path(current_organisation, @agent || current_agent)
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
         resources :absences, except: [:index, :show, :new]
         resources :agent_roles, only: [:edit, :update]
         resources :agent_agendas, only: [:show]
-        resources :agents, only: [:index, :show, :destroy] do
+        resources :agents, only: [:index, :destroy] do
           resources :absences, only: [:index, :new]
           resources :plage_ouvertures, only: [:index, :new]
           resources :stats, only: :index do
@@ -189,8 +189,10 @@ Rails.application.routes.draw do
   root "welcome#index"
   resources :support_tickets, only: [:create]
 
-  # temporary route after admin namespace introduction
   # rubocop:disable Style/StringLiterals, Style/FormatStringToken
+  # temporary route after admin namespace introduction
   get "/organisations/*rest", to: redirect('admin/organisations/%{rest}')
+  # old agenda rule was bookmarked by some agents
+  get "admin/organisations/:organisation_id/agents/:agent_id", to: redirect("/admin/organisations/%{organisation_id}/agent_agendas/%{agent_id}")
   # rubocop:enable Style/StringLiterals, Style/FormatStringToken
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
         resources :absences, except: [:index, :show, :new]
         resources :agent_roles, only: [:edit, :update]
         resources :agent_agendas, only: [:show]
-        resources :agents, only: [:index, :destroy] do
+        resources :agents, only: [:index, :show, :destroy] do
           resources :absences, only: [:index, :new]
           resources :plage_ouvertures, only: [:index, :new]
           resources :stats, only: :index do


### PR DESCRIPTION
Avec #1224, `admin/organisations/XXX/agents/YYY` est devenu `admin/organisations/XXX/agent_agendas/YYY`

On a cassé l'API public de RDV-Solidarités :sweat_smile: 
Des agents ont mis en favori le lien vers leur agenda et ces liens sont désormais dysfonctionnels.

Cette PR est une ébauche (peut-être pas fonctionnelle) mais donne une proposition de solution.
En plus de cela, il serait bien d'ajouter un message pour prévenir que les liens ont changés et demander à la création de nouveaux favoris / liens / raccourcis.
