### PR TITLE
Allonge la durée avant fermeture

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,4 @@ jobs:
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        days-before-close: 42


### PR DESCRIPTION
Je trouve que c'est un peu court pour réagir. Je modifie le temps avant fermeture de 7 à 42 jours.

Je pense que c'est aussi en gardant ce type d'issue que certaines personnes peuvent venir participer plus facilement.
