### PR TITLE
arrête de vérifier l'autorisation d'un responsable

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -134,7 +134,8 @@ class Admin::UsersController < AgentAuthController
 
   def prepare_create
     @user = User.new(user_params)
-    authorize(@user.responsible) if @user.responsible&.persisted?
+    # TODO: est-ce necessaire de verifier l'autorisation du responsable ?
+    # authorize(@user.responsible) if @user.responsible&.persisted?
     @user.created_through = "agent_creation"
     @user.invited_by = current_agent
     @user.responsible.created_through = "agent_creation" if @user.responsible&.new_record?


### PR DESCRIPTION
Fix #1247

Lors de la création d'un usager « proche », nous vérifions l'autorisation du responsable s'il est déjà enregistré.
Cette vérification s'assure que toutes les organisations sont autorisé dans le contexte :

```ruby
    # for the creation we want to make sure that all organisation IDs are                                                                             
    # authorized for the current context (orga or agent)
    return false if @record.user_profiles.empty?

    (   
      @record.user_profiles.map(&:organisation_id) -
      (current_organisation.present? ? [current_organisation.id] : current_agent.organisation_ids)
    ).empty?
```

Je ne suis pas très sûr de pourquoi nous vérifions l'autorisation du responsable. 
Je ne suis pas très sûr de pourquoi nous vérifions toutes les organisations.

J'ai l'impression que les deux éléments pourrait être revu. Pour débloquer la situation rapidement, je supprime la vérification d'autorisation sur l'usager responsable.

