### PR TITLE
utilise le nouveau auth_agent pour l'agenda

### DIFF
--- a/app/controllers/admin/agent_agendas_controller.rb
+++ b/app/controllers/admin/agent_agendas_controller.rb
@@ -1,10 +1,17 @@
-class Admin::AgentAgendasController < AgentAuthController
+class Admin::AgentAgendasController < ApplicationController
+  include Admin::AuthenticatedControllerConcern
+
   def show
-    @agent = policy_scope(Agent).find(params[:id])
-    authorize(AgentAgenda.new(agent: @agent, organisation: current_organisation))
+    current_organisation = Organisation.find(params[:organisation_id])
+    @agent = policy_scope_admin(Agent).find(params[:id])
+    authorize_admin(AgentAgenda.new(agent: @agent, organisation: current_organisation))
     @status = params[:status]
     @organisation = current_organisation
     @selected_event_id = params[:selected_event_id]
     @date = params[:date].present? ? Date.parse(params[:date]) : nil
+  end
+
+  def pundit_user
+    AgentContext.new(current_agent)
   end
 end

--- a/app/controllers/admin/agent_agendas_controller.rb
+++ b/app/controllers/admin/agent_agendas_controller.rb
@@ -2,11 +2,10 @@ class Admin::AgentAgendasController < ApplicationController
   include Admin::AuthenticatedControllerConcern
 
   def show
-    current_organisation = Organisation.find(params[:organisation_id])
+    @organisation = Organisation.find(params[:organisation_id])
     @agent = policy_scope_admin(Agent).find(params[:id])
-    authorize_admin(AgentAgenda.new(agent: @agent, organisation: current_organisation))
+    authorize_admin(AgentAgenda.new(agent: @agent, organisation: @organisation))
     @status = params[:status]
-    @organisation = current_organisation
     @selected_event_id = params[:selected_event_id]
     @date = params[:date].present? ? Date.parse(params[:date]) : nil
   end

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -8,7 +8,7 @@
     | Agenda de #{@agent.full_name_and_service}
 
 - content_for :breadcrumb do
-  = form_tag(admin_organisation_agent_agenda_path(current_organisation, @agent), method: "get", class: "d-inline-flex mr-2") do
+  = form_tag(admin_organisation_agent_agenda_path(@organisation, @agent), method: "get", class: "d-inline-flex mr-2") do
     = select_tag :status, options_for_select(Rdv.human_enum_collection(:statuses).unshift(["Tous les rdvs", ""]), rdv_status_value(@status)), class:"select2-input", onchange: 'this.form.submit()'
   = link_to "Trouver un créneau", admin_organisation_agent_searches_path(@organisation), class: "btn btn-outline-white align-bottom"
 
@@ -22,7 +22,7 @@
       data-event-sources-json="#{[admin_organisation_rdvs_path(@organisation, agent_id: @agent.id, status: @status, format: :json), admin_organisation_agent_absences_path(@organisation, @agent), admin_organisation_agent_plage_ouvertures_path(@organisation, @agent), admin_jours_feries_path].to_json}"
     ]
     .mt-3
-      = link_to admin_organisation_rdvs_path(current_organisation, agent_id: @agent.id, start: @date, end: @date, show_user_details: true, breadcrumb_page: "agenda"), class: "js-link-print-rdvs" do
+      = link_to admin_organisation_rdvs_path(@organisation, agent_id: @agent.id, start: @date, end: @date, show_user_details: true, breadcrumb_page: "agenda"), class: "js-link-print-rdvs" do
         - if current_agent == @agent
           ' 🖨 Liste détaillée des RDVs du
           span.js-date

--- a/spec/controllers/admin/agent_agendas_controller_spec.rb
+++ b/spec/controllers/admin/agent_agendas_controller_spec.rb
@@ -1,0 +1,18 @@
+describe Admin::AgentAgendasController, type: :controller do
+  let(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, organisations: [organisation]) }
+
+  before { sign_in agent }
+
+  describe "#show" do
+    before do
+      get :show, params: { id: agent.id, organisation_id: organisation.id }
+    end
+    it { expect(response).to be_successful }
+    it { expect(assigns(:organisation)).to eq(organisation) }
+    it { expect(assigns(:agent)).to eq(agent) }
+    it { expect(assigns(:status)).to be_nil }
+    it { expect(assigns(:selected_event_id)).to be_nil }
+    it { expect(assigns(:date)).to be_nil }
+  end
+end


### PR DESCRIPTION
En prévision de la PR #1241 je refactor le controller d'agenda agent pour utiliser la nouvelle orientation d'authentification. Celle qui extrait l'organisation des policies.
