### PR TITLE
Améliorations d'interface de la liste de motifs pour les admins

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -5,8 +5,8 @@ class Admin::MotifsController < AgentAuthController
   before_action :set_motif, only: [:show, :edit, :update, :destroy]
 
   def index
-    @motifs = policy_scope(Motif).active
-    @motifs = params[:search].present? ? @motifs.search_by_text(params[:search]) : @motifs
+    @unfiltered_motifs = policy_scope(Motif).active
+    @motifs = params[:search].present? ? @unfiltered_motifs.search_by_text(params[:search]) : @unfiltered_motifs
     @motifs = filtered(@motifs, params)
     @motifs = @motifs.includes(:organisation).includes(:service).ordered_by_name.page(params[:page])
 

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -51,8 +51,11 @@
               td(colspan=6)
                 .row.justify-content-md-center
                   .col-md-6.text-center.my-5
-                    p.mb-2.lead Vous n'avez pas encore créé de motif.
-                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
+                    - if params[:search].present? || params[:online_filter].present? || params[:service_filter].present? || params[:location_type_filter].present?
+                      p.mb-2.lead Aucun motif ne correspond à votre filtre
+                    - else
+                      p.mb-2.lead Vous n'avez pas encore créé de motif.
+                      p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
                     span.fa-stack.fa-4x
                       i.fa.fa-circle.fa-stack-2x.text-primary
                       i.far.fa-calendar.fa-stack-1x.text-white

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -32,7 +32,7 @@
               div
                 = t("activerecord.attributes.motif.service")
               div
-                = select_tag("service_filter", options_from_collection_for_select(@motifs.map(&:service).uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+                = select_tag("service_filter", options_from_collection_for_select(Service.all.uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
             th
               div
                 = t("activerecord.attributes.motif.location_type")

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -9,53 +9,57 @@
 
 = simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline js-search-and-filter-form' }, wrapper: :inline_form do |f|
 
-  .row
-    .col-md-12
-      .card
-        .m-3.d-flex.justify-content-end
-          div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
-          = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
-          = f.button :submit, 'Rechercher'
-        table.table
-          thead
+  .card style="width:100%"
+    .card-body
+
+      .m-3.d-flex.justify-content-end
+        div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
+        = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
+        = f.button :submit, 'Rechercher'
+      table.table
+        thead
+          tr
+            th
+            th= t("activerecord.attributes.motif.name")
+            th
+              div
+                = t("activerecord.attributes.motif.reservable_online")
+              div
+                = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+            - if @display_sectorisation_level
+              th= t("activerecord.attributes.motif.sectorisation_level")
+            th
+              div
+                = t("activerecord.attributes.motif.service")
+              div
+                = select_tag("service_filter", options_from_collection_for_select(@motifs.map(&:service).uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+            th
+              div
+                = t("activerecord.attributes.motif.location_type")
+              div
+                = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+            th= t("activerecord.attributes.motif.default_duration")
+            - if current_agent_can?(:edit, Motif) || current_agent_can?(:destroy, Motif)
+              th Actions
+        tbody
+          - if @motifs.any?
+            = render @motifs
+            .d-flex.justify-content-center id="users-pagination"
+              = paginate @motifs, theme: 'twitter-bootstrap-4'
+          - else
             tr
-              th
-              th= t("activerecord.attributes.motif.name")
-              th
-                div
-                  = t("activerecord.attributes.motif.reservable_online")
-                div
-                  = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
-              - if @display_sectorisation_level
-                th= t("activerecord.attributes.motif.sectorisation_level")
-              th
-                div
-                  = t("activerecord.attributes.motif.service")
-                div
-                  = select_tag("service_filter", options_from_collection_for_select(@motifs.map(&:service).uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
-              th
-                div
-                  = t("activerecord.attributes.motif.location_type")
-                div
-                  = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
-              th= t("activerecord.attributes.motif.default_duration")
-              - if current_agent_can?(:edit, Motif) || current_agent_can?(:destroy, Motif)
-                th Actions
-          tbody
-            - if @motifs.any?
-              = render @motifs
-              .d-flex.justify-content-center id="users-pagination"
-                = paginate @motifs, theme: 'twitter-bootstrap-4'
-            - else
-              tr
-                td(colspan=6)
-                  .row.justify-content-md-center
-                    .col-md-6.text-center.my-5
-                      p.mb-2.lead Vous n'avez pas encore créé de motif.
-                      p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
-                      span.fa-stack.fa-4x
-                        i.fa.fa-circle.fa-stack-2x.text-primary
-                        i.far.fa-calendar.fa-stack-1x.text-white
-        - if current_agent_can?(:create, Motif)
-          .text-center.mb-3
-            = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+              td(colspan=6)
+                .row.justify-content-md-center
+                  .col-md-6.text-center.my-5
+                    p.mb-2.lead Vous n'avez pas encore créé de motif.
+                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
+                    span.fa-stack.fa-4x
+                      i.fa.fa-circle.fa-stack-2x.text-primary
+                      i.far.fa-calendar.fa-stack-1x.text-white
+                    - if current_agent_can?(:create, Motif)
+                      .text-center.m-3
+                        = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+
+      - if @motifs.any? && current_agent_can?(:create, Motif)
+        .text-center.m-3
+          = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -9,60 +9,59 @@
 
 = simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline js-search-and-filter-form' }, wrapper: :inline_form do |f|
 
-  .card style="width:100%"
-    .card-body
+  .container-fluid.bg-white.m-2.rounded
 
-      .m-3.d-flex.justify-content-end
-        div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
-        = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
-        = f.button :submit, 'Rechercher'
-      table.table
-        thead
+    .m-3.d-flex.justify-content-end
+      div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
+      = f.input :search, placeholder: 'ex. Être appelé par la MDS', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
+      = f.button :submit, 'Rechercher'
+    table.table
+      thead
+        tr
+          th
+          th= t("activerecord.attributes.motif.name")
+          th
+            div
+              = t("activerecord.attributes.motif.reservable_online")
+            div
+              = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+          - if @display_sectorisation_level
+            th= t("activerecord.attributes.motif.sectorisation_level")
+          th
+            div
+              = t("activerecord.attributes.motif.service")
+            div
+              = select_tag("service_filter", options_from_collection_for_select(Service.all.uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+          th
+            div
+              = t("activerecord.attributes.motif.location_type")
+            div
+              = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
+          th= t("activerecord.attributes.motif.default_duration")
+          - if current_agent_can?(:edit, Motif) || current_agent_can?(:destroy, Motif)
+            th Actions
+      tbody
+        - if @motifs.any?
+          = render @motifs
+          .d-flex.justify-content-center id="users-pagination"
+            = paginate @motifs, theme: 'twitter-bootstrap-4'
+        - else
           tr
-            th
-            th= t("activerecord.attributes.motif.name")
-            th
-              div
-                = t("activerecord.attributes.motif.reservable_online")
-              div
-                = select_tag("online_filter", options_for_select(["En ligne", "Hors ligne"], params[:online_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
-            - if @display_sectorisation_level
-              th= t("activerecord.attributes.motif.sectorisation_level")
-            th
-              div
-                = t("activerecord.attributes.motif.service")
-              div
-                = select_tag("service_filter", options_from_collection_for_select(Service.all.uniq.sort, "id", "short_name", params[:service_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
-            th
-              div
-                = t("activerecord.attributes.motif.location_type")
-              div
-                = select_tag("location_type_filter", options_for_select(Motif.location_types.map{|l| [Motif.human_enum_name(:location_type, l[0]), l[1]] }, params[:location_type_filter]), include_blank: "Tous", class: "js-motif-filters select2-input")
-            th= t("activerecord.attributes.motif.default_duration")
-            - if current_agent_can?(:edit, Motif) || current_agent_can?(:destroy, Motif)
-              th Actions
-        tbody
-          - if @motifs.any?
-            = render @motifs
-            .d-flex.justify-content-center id="users-pagination"
-              = paginate @motifs, theme: 'twitter-bootstrap-4'
-          - else
-            tr
-              td(colspan=6)
-                .row.justify-content-md-center
-                  .col-md-6.text-center.my-5
-                    - if @unfiltered_motifs.any?
-                      p.mb-2.lead Aucun motif ne correspond à votre filtre
-                    - else
-                      p.mb-2.lead Vous n'avez pas encore créé de motif.
-                      p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
-                    span.fa-stack.fa-4x
-                      i.fa.fa-circle.fa-stack-2x.text-primary
-                      i.far.fa-calendar.fa-stack-1x.text-white
-                    - if current_agent_can?(:create, Motif)
-                      .text-center.m-3
-                        = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+            td(colspan=6)
+              .row.justify-content-md-center
+                .col-md-6.text-center.my-5
+                  - if @unfiltered_motifs.any?
+                    p.mb-2.lead Aucun motif ne correspond à votre filtre
+                  - else
+                    p.mb-2.lead Vous n'avez pas encore créé de motif.
+                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
+                  span.fa-stack.fa-4x
+                    i.fa.fa-circle.fa-stack-2x.text-primary
+                    i.far.fa-calendar.fa-stack-1x.text-white
+                  - if current_agent_can?(:create, Motif)
+                    .text-center.m-3
+                      = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
 
-      - if @motifs.any? && current_agent_can?(:create, Motif)
-        .text-center.m-3
-          = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'
+    - if @motifs.any? && current_agent_can?(:create, Motif)
+      .text-center.m-3
+        = link_to 'Créer un motif', new_admin_organisation_motif_path(current_organisation), class: 'btn btn-primary'

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -51,7 +51,7 @@
               td(colspan=6)
                 .row.justify-content-md-center
                   .col-md-6.text-center.my-5
-                    - if params[:search].present? || params[:online_filter].present? || params[:service_filter].present? || params[:location_type_filter].present?
+                    - if @unfiltered_motifs.any?
                       p.mb-2.lead Aucun motif ne correspond à votre filtre
                     - else
                       p.mb-2.lead Vous n'avez pas encore créé de motif.

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Admin::MotifsController, type: :controller do
 
     context "with a filter query parameter" do
       it "returns motif list where name match" do
-        create(:motif, organisation: organisation)
-        bla_motif = create(:motif, name: "bla", organisation: organisation)
+        bla_motif = create(:motif, name: "Bla", organisation: organisation)
         get :index, params: { organisation_id: organisation.id, search: "bla" }
         expect(assigns(:motifs)).to eq([bla_motif])
+        expect(assigns(:unfiltered_motifs).sort).to eq([bla_motif, motif].sort)
       end
     end
   end


### PR DESCRIPTION
link #1174 

- Gardé l'entête du tableau, pour plus de cohérence avec la liste des agents.
- Alignement du bouton (je n'ai pas trouvé de meilleur moyen qu'en le dupliquant dans le code)
- Spécifie pourquoi il n'y a pas de motifs affiché


