### PR TITLE
fix holiday edge case in find availability service specs

### DIFF
--- a/spec/services/find_availability_service_spec.rb
+++ b/spec/services/find_availability_service_spec.rb
@@ -3,10 +3,14 @@ describe FindAvailabilityService, type: :service do
   let!(:motif) { create(:motif, name: "Vaccination", default_duration_in_min: 30, reservable_online: reservable_online, organisation: organisation) }
   let(:reservable_online) { true }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let(:today) { Date.today.next_week(:thursday) }
-  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent, organisation: organisation) }
+  let(:today) { Date.new(2021, 3, 18) }
   let(:now) { today.to_time }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let!(:plage_ouverture) do
+    travel_to(now) do # important so that expired_cached is set correctly
+      create(:plage_ouverture, motifs: [motif], lieu: lieu, first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent, organisation: organisation)
+    end
+  end
 
   before { travel_to(now) }
   after { travel_back }


### PR DESCRIPTION
should fix https://github.com/betagouv/rdv-solidarites.fr/runs/2165957522?check_suite_focus=true

Le test echoue aujourd'hui specifiquement : 

- https://github.com/betagouv/rdv-solidarites.fr/blob/master/app/services/jours_feries_service.rb/#L20
le 1er mai est férié
- le test verifie que quand il y a une plage d’ouverture avec une recurrence mensuelle mais la premiere occurence couverte par une absence, ca renvoie bien le mois d’apres mais la ca saute un mois
- c’est probablement parce que la premiere occurence est le 1er avril -> bien couverte et deuxieme occurence 1er mai => couverte par le jour férié mais ce n’est pas prevu

le fix consiste a :
- hardcoder une date dans le passé plutot qu'une date future indeterminée (jeudi prochain)
- je dois wrapper la creation de la PlageOuverture dans `travel_to(now)` pour que le champ `plage_ouvertures.expired_cached` soit bien mis a false par le before_create hook