### PR TITLE
Nettoyage des variables d’environnement dans .env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,13 +1,45 @@
+# Rails configuration
 HOST=http://localhost:5000
+CSP_REPORT_URI=change_me
+
+# Feature flags and App configuration
+DEGRADED_SERVICE_MESSAGE_USERS=
+# RDV_SOLIDARITES_VERSION is set automatically in bin/start_web_server
+SIGN_IN_AS_ALLOWED=true
+FRANCECONNECT_DISABLED=true
+SAFE_DOMAIN_LIST=
+FORCE_SMS_PROVIDER=
+
+# Scalingo configuration
+MAINTENANCE_PAGE_URL=
+SCALINGO_STOPPED_PAGE_URL=
+SCALINGO_NO_FRONT_ERROR_URL=
+
+# Third-party tools
+## Monitoring
+SENTRY_DSN_RAILS=change_me
+SENTRY_ENVIRONMENT=change_me
+## Performance
+SKYLIGHT_AUTHENTICATION=change_me
+SKYLIGHT_DISABLE_DEV_WARNING=true
+## Analytics
+MATOMO_APP_ID=change_me
+
+# Third-party authentication services
+## Github (SuperAdmins)
 GITHUB_APP_ID=change_me
 GITHUB_APP_SECRET=change_me
-PLACES_APP_ID=change_me
-PLACES_API_KEY=change_me
-TWILIO_ACCOUNT_SID=change_me
-TWILIO_AUTH_TOKEN=change_me
-TWILIO_PHONE_NUMBER=change_me
-SIGN_IN_AS_ALLOWED=true
-APPSIGNAL_PUSH_API_KEY=change_me
-CSP_REPORT_URI=change_me
-SKYLIGHT_DISABLE_DEV_WARNING=true
-SECTORISATION_ENABLED_DEPARTMENT_LIST="62 64"
+## France Connect (Users)
+FRANCECONNECT_APP_ID=change_me
+FRANCECONNECT_APP_SECRET=change_me
+FRANCECONNECT_HOST=change_me
+
+# Third-party services
+## SMS
+NETSIZE_API_USERPWD=change_me
+## Emails
+SENDINBLUE_PASSWORD=change_me
+SENDINBLUE_SMS_API_KEY=change_me
+SENDINBLUE_USERNAME=change_me
+## Helpdesk
+ZAMMAD_API_TOKEN=change_me

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -20,7 +20,7 @@ class SendTransactionalSmsService < BaseService
   private
 
   def sms_provider
-    if ENV["FORCE_SMS_PROVIDER"]
+    if ENV["FORCE_SMS_PROVIDER"].present?
       ENV["FORCE_SMS_PROVIDER"].to_sym
     elsif Rails.env.production?
       :netsize

--- a/app/views/common/_env.html.slim
+++ b/app/views/common/_env.html.slim
@@ -1,8 +1,6 @@
 javascript:
   var ENV = {
     MATOMO_APP_ID: "#{ ENV['MATOMO_APP_ID'] }",
-    PLACES_APP_ID: "#{ ENV['PLACES_APP_ID'] }",
-    PLACES_API_KEY: "#{ ENV['PLACES_API_KEY'] }",
     SENTRY_DSN_RAILS: "#{ ENV['SENTRY_DSN_RAILS'] }",
     ENV: "#{ Rails.env }"
   };


### PR DESCRIPTION
J’ai repris les variables déclarées sur scalingo, et fait un peu de tri, mais ça amène plus de questions 😅 

Si je comprends bien, celles-ci sont dépréciées :
- `SECTORISATION_ENABLED_DEPARTMENT_LIST` était utile pour une migration passée
- `MAINTENANCE_PAGE_URL` n’est pas utilisé par scalingo, c’est `SCALINGO_*_PAGE_URL`. 
- `LAPIN_DATABASE_PASSWORD` idem, je présume que l’ancienne configuration de prod?

Par contre, je n’ai pas compris à quoi servaient ces deux variables:
- `MATOMO_AUTH_TOKEN` est utilisé par `matomo.rake` un script qui… anonymise les données sur matomo?
- `APP` est utilisé dans `TransactionalSms::BaseConcern#tags`, mais n’est pas valué en prod. Je présume qu’on peut supprimer le code?

