### PR TITLE
fix plage ouverture ICS rrule

### DIFF
--- a/app/service_functions/admin/ics/plage_ouverture.rb
+++ b/app/service_functions/admin/ics/plage_ouverture.rb
@@ -45,6 +45,7 @@ class Admin::Ics::PlageOuverture
     event.summary = "#{BRAND} #{payload[:title]}"
     event.location = payload[:address]
     event.ip_class = "PUBLIC"
+    event.rrule = payload[:recurrence]
     event.status = Admin::Ics.status_from_action(payload[:action])
     event.attendee = "mailto:#{payload[:agent_email]}"
     event.organizer = "mailto:secretariat-auto@rdv-solidarites.fr"

--- a/spec/service_functions/admin/ics/plage_ouverture_spec.rb
+++ b/spec/service_functions/admin/ics/plage_ouverture_spec.rb
@@ -112,9 +112,9 @@ describe Admin::Ics::PlageOuverture, type: :service do
     end
 
     context "with recurrence" do
-      let(:recurrence_payload) { payload.merge(recurrence: "FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10") }
-      subject { described_class.to_ical(payload) }
-      it { is_expected.to include("RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10") }
+      let(:recurrence_payload) { payload.merge(recurrence: "FREQ=WEEKLY;") }
+      subject { described_class.to_ical(recurrence_payload) }
+      it { is_expected.to include("FREQ=WEEKLY") }
     end
   end
 


### PR DESCRIPTION
fixes #1273 

corrige probleme introduit dans le commit https://github.com/betagouv/rdv-solidarites.fr/commit/3f8b9dd6ef93af3cd28368609fbdf9e9e68813bf

ce commit avait retiré la ligne `event.rrule = payload[:recurrence]`

dans cette PR je fixe le test associé qui ne testait en fait pas la bonne chose

- tous les fichiers ICS qu'on genere, meme non recurrents, contiennent tous deux lignes RRULE qui ressemblent a celle-ci RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
- cette ligne est en fait utilisee pour definir la timezone ou qqch, en tout cas ca ne decrit pas l'evenement
- le payload.merge(recurrence: "FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10") de ce test n'a en fait aucune importance : on peut l'enlever et le test passe. c'est parce que tous les ICS contiennent cette ligne
- par contre si on met quoi que ce soit d'autre, par ex : FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA; ca echoue.

de plus, le test utilisait le mauvais `payload` au lieu de `recurrence_payload` 

# pour tester sur la review app

j'ai changé le mail de martine@demo.rdv-solidarites.fr vers le mien pour recevoir l'ICS
vous pouvez utiliser le compte de bruno par exemple