### PR TITLE
remet à zéro les séquences à la fin de chaque test

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+    FactoryBot.rewind_sequences
+  end
 end


### PR DESCRIPTION
J'ai encore eu le souci de la taille d'un numéro de département qui explose.

Plutôt que de remettre le modulo sur la séquence du numéro de département, je propose de mettre en place la commande `rewind_sequence` disponible sur factory_bot.