### PR TITLE
supprimes les dépendances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,17 @@ jobs:
           POSTGRES_DB: lapin_test
           NUMBER_OF_NODES: 5
           CI_NODE_INDEX: ${{ matrix.index }}
+  check_if_deploy:
+    runs-on: ubuntu-latest
+    needs: [tests, brakeman, test_seeds, rubocop]
+
+    steps:
+      - name: Branche master ?
+        if:  github.ref == 'refs/heads/master'
+        run: exit 1
+
   deploy:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: check_if_deploy
     name: deploie en production et demo
     runs-on: ubuntu-latest
     environment: lapin-beta-gouv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
     name: deploie en production et demo
     runs-on: ubuntu-latest
     environment: lapin-beta-gouv
-    needs: [tests, brakeman, test_seeds, rubocop]
     steps:
       - uses: actions/checkout@v2
       - name: Configure SSH


### PR DESCRIPTION
Je me demande si la duplication d'exécution, et le fait que la deuxième exécution reste en pending n'est pas lié au fait que j'avais mis un attribut `needs` sur le déploiement...

![Capture d’écran de 2021-03-29 09-55-53](https://user-images.githubusercontent.com/42057/112806117-bb6dad80-9076-11eb-89d8-a27dd8e4021c.png)

J'essaie sans.