### PR TITLE
corrige les couleurs de badges de la vue usager

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -15,7 +15,7 @@ module RdvsHelper
   end
 
   def rdv_status_tag(rdv)
-    content_tag(:span, Rdv.human_enum_name(:status, rdv.status), class: "badge badge-info rdv-status-#{rdv.status}")
+    content_tag(:span, Rdv.human_enum_name(:status, rdv.status), class: "badge badge-info rdv-status rdv-status-#{rdv.status}")
   end
 
   def no_rdv_for_users


### PR DESCRIPTION
J'ai découvert que le badge n'affichais pas la bonne couleur dans la fiche usager et fiche rdv coté admin.

Avant correction :
![Capture d’écran de 2021-03-29 13-05-13](https://user-images.githubusercontent.com/42057/112828009-6f7b3280-908f-11eb-81cf-9da6c5f69a1f.png)

Après correction : 
![Capture d’écran de 2021-03-29 13-05-19](https://user-images.githubusercontent.com/42057/112828064-7f931200-908f-11eb-9411-f026827c0da6.png)
