### PR TITLE
Corrige un crash à l’annulation d’une nouvelle plage d’ouverture

### DIFF
--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -19,7 +19,7 @@
       .row
         .col.text-left
           = link_to "Annuler", \
-            plage_ouverture.persisted? ? admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture) : admin_organisation_plage_ouvertures_path(current_organisation), \
+            plage_ouverture.persisted? ? admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture) : admin_organisation_agent_plage_ouvertures_path(current_organisation, current_agent), \
             class: "btn btn-link"
         .col.text-right
           = f.button :submit

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -31,9 +31,14 @@ describe "Agent can CRUD plage d'ouverture" do
       expect_page_title("Vos plages d'ouverture")
       expect(page).to have_content("Vous n'avez pas encore créé de plage d'ouverture")
 
+      # Navigate back and forth between the list and the detail
       click_link "Créer une plage d'ouverture", match: :first
-
       expect_page_title("Nouvelle plage d'ouverture")
+      click_link("Annuler")
+      expect_page_title("Vos plages d'ouverture")
+      click_link "Créer une plage d'ouverture", match: :first
+      expect_page_title("Nouvelle plage d'ouverture")
+
       fill_in "Description", with: "Accueil"
       check "Suivi bonjour"
       click_button "Créer"


### PR DESCRIPTION
fixes #1295: une erreur 404 au retour du formulaire de création d’une nouvelle plage d’ouverture. Je présume que c’est liée au chantier sur les contextes agents/organisation.