### PR TITLE
remove extraneous save override in Admin::RdvWizardForm::Step3

### DIFF
--- a/app/form_models/admin/rdv_wizard_form/step3.rb
+++ b/app/form_models/admin/rdv_wizard_form/step3.rb
@@ -6,10 +6,6 @@ class Admin::RdvWizardForm::Step3
     new_admin_organisation_rdv_wizard_step_path(@organisation, step: 4, **to_query)
   end
 
-  def save
-    valid?
-  end
-
   protected
 
   def agent_context


### PR DESCRIPTION
cette redefinition du `save` date probablement de l'introduction du `Admin::RdvFormConcern` qui a du redefinir ce save a a un moment et l'override redevenait necessaire.

Ce n'est plus le cas