### PR TITLE
Use default settings in sentry to ignore 4xx errors

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,11 +1,9 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN_RAILS"]
 
-  config.excluded_exceptions = [
-    "ActionController::InvalidAuthenticityToken",
-    "ActiveRecord::RecordNotFound",
-    "CGI::Session::CookieStore::TamperedWithCookie",
-    "Sinatra::NotFound",
-    "ActiveJob::DeserializationError",
-  ]
+  # Most 4xx errors are excluded by default.
+  # See Sentry::Configuration::IGNORE_DEFAULT
+  # and Sentry::Rails::IGNORE_DEFAULT
+  # Cf https://docs.sentry.io/platforms/ruby/configuration/options/#optional-settings
+  # config.excluded_exceptions += []
 end


### PR DESCRIPTION
See this issue: https://sentry.io/organizations/rdv-solidarites/issues/2292048716/events/18b550feebca4468b30f70c011e7d59f/?project=1811205

I think setting `excluded_exceptions` is unneeded with the new sentry ruby gems.

- checklist avant review: 
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [ ] Attendre que les tests soient verts sur la CI
- [ ] Tester la fonctionnalité (si pertinent) sur la review app
