### PR TITLE
Change le label des boutons

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -153,9 +153,9 @@ fr:
     select:
       prompt: Veuillez sélectionner
     submit:
-      create: Créer
+      create: Enregistrer
       submit: Enregistrer
-      update: Modifier
+      update: Enregistrer
   number:
     currency:
       format:

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -30,7 +30,7 @@ describe "Admin can configure the organisation" do
     expect_page_title("Modifier le lieu")
     fill_in "Nom", with: "Le nouveau lieu"
     fill_in "Téléphone", with: "01 02 03 04 05"
-    click_button("Modifier")
+    click_button("Enregistrer")
 
     expect_page_title("Vos lieux de consultation")
 
@@ -51,19 +51,13 @@ describe "Admin can configure the organisation" do
     fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est"
     first("input#lieu_latitude", visible: false).set(48.583844)
     first("input#lieu_longitude", visible: false).set(7.735253)
-<<<<<<< HEAD
-    click_button "Créer"
+    click_button "Enregistrer"
     expect_page_title("Vos lieux de consultation")
 
     le_nouveau_lieu = Lieu.find_by(name: "Un autre nouveau lieu")
     within("#lieu_#{le_nouveau_lieu.id}") do
       click_link "Modifier"
     end
-=======
-    click_button "Enregistrer"
-    expect_page_title("Vos lieux de consultation")
-    click_link "Un autre nouveau lieu"
->>>>>>> enregistre des modifications
   end
 
   scenario "CRUD on agents" do

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -51,6 +51,7 @@ describe "Admin can configure the organisation" do
     fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est"
     first("input#lieu_latitude", visible: false).set(48.583844)
     first("input#lieu_longitude", visible: false).set(7.735253)
+<<<<<<< HEAD
     click_button "Créer"
     expect_page_title("Vos lieux de consultation")
 
@@ -58,6 +59,11 @@ describe "Admin can configure the organisation" do
     within("#lieu_#{le_nouveau_lieu.id}") do
       click_link "Modifier"
     end
+=======
+    click_button "Enregistrer"
+    expect_page_title("Vos lieux de consultation")
+    click_link "Un autre nouveau lieu"
+>>>>>>> enregistre des modifications
   end
 
   scenario "CRUD on agents" do
@@ -67,7 +73,7 @@ describe "Admin can configure the organisation" do
     click_link "Tony PATRICK"
     expect_page_title("Modifier le rôle de l'agent Tony PATRICK")
     choose :agent_role_level_admin
-    click_button("Modifier")
+    click_button("Enregistrer")
 
     expect_page_title("Vos agents")
     expect(page).to have_content("Admin", count: 2)
@@ -95,7 +101,7 @@ describe "Admin can configure the organisation" do
     fill_in "Nom", with: la_nouvelle_org.name
     fill_in "Téléphone", with: la_nouvelle_org.phone_number
     fill_in "Horaires", with: la_nouvelle_org.horaires
-    click_button "Modifier"
+    click_button "Enregistrer"
 
     expect(page).to have_content("L'organisation a été modifiée.")
   end
@@ -110,7 +116,7 @@ describe "Admin can configure the organisation" do
     click_link "Éditer"
     expect(page.find_by_id("motif_name")).to have_content(motif.name)
     select(motif_libelle2.name, from: :motif_name)
-    click_button("Modifier")
+    click_button("Enregistrer")
     expect(page).to have_content(motif_libelle2.name)
     expect_page_title("Motif Motif 2 (PMI)")
 
@@ -137,7 +143,7 @@ describe "Admin can configure the organisation" do
     expect(page).to have_select("motif[name]", with_options: ["", motif_libelle3.name], wait: 10)
     select(motif_libelle3.name, from: :motif_name)
     fill_in "Couleur", with: le_nouveau_motif.color
-    click_button "Créer"
+    click_button "Enregistrer"
     expect(page).to have_link(motif_libelle3.name)
   end
 end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -17,7 +17,7 @@ describe "Agent can CRUD absences" do
 
       expect_page_title("Modifier votre absence")
       fill_in "Description", with: "La belle absence"
-      click_button("Modifier")
+      click_button("Enregistrer")
 
       expect_page_title("Vos absences")
       click_link "La belle absence"
@@ -32,7 +32,7 @@ describe "Agent can CRUD absences" do
       fill_in "Description", with: new_absence.title
       fill_in "absence[first_day]", with: new_absence.first_day
       fill_in "absence[end_day]", with: new_absence.first_day + 1.day
-      click_button "Créer"
+      click_button "Enregistrer"
 
       expect_page_title("Vos absences")
       click_link new_absence.title
@@ -51,7 +51,7 @@ describe "Agent can CRUD absences" do
 
       expect_page_title("Modifier l'absence de Jane FAROU")
       fill_in "Description", with: "La belle absence"
-      click_button("Modifier")
+      click_button("Enregistrer")
 
       expect_page_title("Absences de Jane FAROU (PMI)")
       click_link "La belle absence"
@@ -66,7 +66,7 @@ describe "Agent can CRUD absences" do
       fill_in "Description", with: new_absence.title
       fill_in "absence[first_day]", with: new_absence.first_day
       fill_in "absence[end_day]", with: new_absence.first_day + 1.day
-      click_button "Créer"
+      click_button "Enregistrer"
 
       expect_page_title("Absences de Jane FAROU (PMI)")
       click_link new_absence.title

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -23,7 +23,7 @@ describe "Agent can CRUD plage d'ouverture" do
 
       expect_page_title("Modifier votre plage d'ouverture")
       fill_in "Description", with: "La belle plage"
-      click_button("Modifier")
+      click_button("Enregistrer")
 
       expect_page_title("La belle plage")
       click_link("Supprimer")
@@ -41,7 +41,7 @@ describe "Agent can CRUD plage d'ouverture" do
 
       fill_in "Description", with: "Accueil"
       check "Suivi bonjour"
-      click_button "Créer"
+      click_button "Enregistrer"
 
       expect_page_title("Accueil")
       click_link "Modifier"
@@ -83,7 +83,7 @@ describe "Agent can CRUD plage d'ouverture" do
 
       expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
       fill_in "Description", with: "La belle plage"
-      click_button("Modifier")
+      click_button("Enregistrer")
 
       expect_page_title("La belle plage")
       click_link("Supprimer")
@@ -96,7 +96,7 @@ describe "Agent can CRUD plage d'ouverture" do
       expect_page_title("Nouvelle plage d'ouverture")
       fill_in "Description", with: "Accueil"
       check "Suivi bonjour"
-      click_button "Créer"
+      click_button "Enregistrer"
 
       expect_page_title("Accueil")
       click_link "Modifier"

--- a/spec/features/agents/relatives/agent_can_update_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_update_relative_spec.rb
@@ -21,7 +21,7 @@ describe "Agent can update a relative" do
     fill_in :user_first_name, with: "Michelle"
     fill_in :user_last_name, with: "Mythe"
     fill_in :user_birth_date, with: "07/11/2001"
-    click_button "Modifier"
+    click_button "Enregistrer"
     expect_page_title "Michelle MYTHE"
     expect(page).to have_content("L'usager a été modifié")
     expect(find("#spec-primary-user-card")).to have_content("Informations de votre proche")

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -21,7 +21,7 @@ describe "Agent can create user" do
     expect(page).to have_no_content("Inviter")
     click_link "Modifier"
     fill_in "Email", with: "marco@lebreton.bzh"
-    click_button "Modifier"
+    click_button "Enregistrer"
     click_link "Inviter"
     open_email("marco@lebreton.bzh")
     expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -19,7 +19,7 @@ describe "Agent can update user" do
     fill_in :user_first_name, with: "jeanne"
     fill_in :user_last_name, with: "reynolds"
     fill_in "Email", with: "jeanne@reynolds.com"
-    click_button "Modifier"
+    click_button "Enregistrer"
     # When the user has already a pwd, changing email send a confirmation email
     open_email("jeanne@reynolds.com")
     expect(current_email.subject).to eq I18n.t("devise.mailer.confirmation_instructions.subject")
@@ -29,7 +29,7 @@ describe "Agent can update user" do
 
   scenario "update user notes" do
     fill_in "Remarques", with: "Pas très sympa"
-    click_button "Modifier"
+    click_button "Enregistrer"
     expect(page).to have_content("Pas très sympa")
   end
 
@@ -40,7 +40,7 @@ describe "Agent can update user" do
 
     scenario "add email to existing user", js: true do
       fill_in "Email", with: "jean@legende.com"
-      click_button "Modifier"
+      click_button "Enregistrer"
       click_link "Inviter"
       open_email("jean@legende.com")
       expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -88,7 +88,7 @@ describe "User can search for rdvs" do
       fill_in("Prénom", with: "Mathieu")
       fill_in("Nom", with: "Lapin")
       fill_in("Date de naissance", with: Date.yesterday)
-      click_button("Créer")
+      click_button("Enregistrer")
       expect(page).to have_content("Mathieu LAPIN")
 
       click_button("Continuer")


### PR DESCRIPTION
Nous avons eu plusieurs retours sur l'aspect perturbant d'appuyer sur un bouton modifier pour enregistrer des informations. Dans le flux, on se retrouve à appuyer sur un bouton modifier pour accéder a un formulaire puis, à appuyer à nouveau sur modifier pour l'enregistrer.

Cette PR propose donc d'utiliser le mot Enregistrer à la place de modifier et créer pour les boutons de submit des formulaires.