### PR TITLE
supprime les références au bureau ouvert

### DIFF
--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -39,24 +39,6 @@
     .card
       .card-header
         h5.card-title
-          span> Bureau Ouvert
-          i.fa.fa-comments
-      .card-body
-        p
-          span> L'équipe technique de RDV-Solidarités tient un Bureau Ouvert
-          b tous les jeudis de 14h30 à 15h30
-          span . Nous sommes à votre disposition pour répondre à vos questions et vous dépanner en cas de problème.
-        p
-          span> Ouvert aux agents et aux usagers
-        p
-          span> Ça se passe
-          span>= link_to "https://visio.incubateur.net/b/adr-gcy-x7h", target: "_blank" do
-            span> en visio ici !
-            i.fa.fa-external-link-alt>
-
-    .card
-      .card-header
-        h5.card-title
           span> Communauté d'agents
           i.fa.fa-users
       .card-body

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -41,16 +41,6 @@
           = f.input :message, label: "Message", as: :text, hint: "Merci de ne pas inclure d'informations confidentielles vous concernant", input_html: { rows: 5 }
           = f.button :submit, value: "Envoyer la demande à l'équipe technique", data: { disable_with: "Envoi en cours…" }
 
-      h3.mt-4 Bureau Ouvert
-      p L'équipe technique de RDV-Solidarités tient un Bureau Ouvert tous les jeudis de 14h30 à 15h30. Nous sommes à votre disposition pour répondre à vos questions et vous dépanner en cas de problème.
-      p
-        span> Ouvert aux agents et aux usagers
-        b> pour des sujets techniques uniquement
-      p
-        span> Ça se passe
-        span>= link_to "https://visio.incubateur.net/b/adr-gcy-x7h", target: "_blank" do
-          span> en visio ici !
-          i.fa.fa-external-link-alt>
       .alert.alert-warning.my-4.d-flex.align-items-center
         i.fa.fa-exclamation-triangle>
         .ml-2


### PR DESCRIPTION
Le bureau ouvert n'était que peut fréquenter. Plusieurs raisons à cela :
- les agents remonte leurs soucis, questions et demande aux personnes référentes de leur territoire, pas besoin d'un bureau ouvert avec nous, mais plutôt avec leur référente... Et encore.
- nous voyons les personnes référentes toutes les deux semaines pour l'instant. Nous aimerions passer à toutes les semaines. Le rythme semble suffisant pour ne pas avoir en plus un bureau ouvert à tenir.
