### PR TITLE
Empêche d'inviter des agents à des organisations non-autorisées

### DIFF
--- a/app/controllers/admin/invitations_devise_controller.rb
+++ b/app/controllers/admin/invitations_devise_controller.rb
@@ -29,12 +29,6 @@ class Admin::InvitationsDeviseController < Devise::InvitationsController
 
   protected
 
-  def invite_resource
-    super do |agent|
-      agent.uid = agent.email
-    end
-  end
-
   def pundit_user
     AgentContext.new(current_agent, current_organisation)
   end
@@ -62,6 +56,9 @@ class Admin::InvitationsDeviseController < Devise::InvitationsController
 
     # Only ever invite to the current organisation
     params[:roles_attributes]["0"][:organisation] = current_organisation
+
+    # The omniauth uid _is_ the email, always. Note: this may be better suited in a hook in Agent.rb
+    params[:uid] = params[:email]
 
     params
   end

--- a/app/controllers/admin/invitations_devise_controller.rb
+++ b/app/controllers/admin/invitations_devise_controller.rb
@@ -8,12 +8,15 @@ class Admin::InvitationsDeviseController < Devise::InvitationsController
   def create
     agent = Agent.find_by(email: invite_params[:email].downcase)
     if agent.nil?
-      self.resource = invite_resource
+      # Authorize against a dummy Agent
+      authorize(Agent.new(invite_params))
+      self.resource = invite_resource # invite_resource creates the new Agent in DB and sends the invitation.
     else
+      # Authorize against a dummy AgentRole
+      authorize(AgentRole.new(agent: agent, organisation: current_organisation))
       self.resource = agent
       agent.add_organisation(current_organisation)
     end
-    authorize(resource)
     if resource.errors.empty?
       flash[:notice] = \
         if resource.invitation_accepted_at.present?

--- a/app/policies/agent/agent_role_policy.rb
+++ b/app/policies/agent/agent_role_policy.rb
@@ -5,6 +5,7 @@ class Agent::AgentRolePolicy < ApplicationPolicy
     agent_role_in_record_organisation&.admin?
   end
 
+  alias create? current_agent_admin_in_record_organisation?
   alias edit? current_agent_admin_in_record_organisation?
   alias update? current_agent_admin_in_record_organisation?
 

--- a/app/views/admin/invitations_devise/new.html.slim
+++ b/app/views/admin/invitations_devise/new.html.slim
@@ -21,6 +21,5 @@
               collection: AgentRole::LEVELS, \
               label_method: -> { I18n.t("activerecord.attributes.agent_role.levels.#{_1}_html").html_safe }, \
               as: :radio_buttons
-            = ff.input :organisation_id, as: :hidden
           .text-right
             = f.button :submit, t("devise.invitations.new.submit_button")

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
-                organisation_id: organisation.id
+                level: "basic"
               }
             }
           }
@@ -68,8 +67,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
-                organisation_id: organisation.id
+                level: "basic"
               }
             }
           }
@@ -99,9 +97,8 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
         }
       end
 
-      it "should reject the change" do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
-        expect(Agent.last.email).not_to eq "hacker@renard.com"
+      it "should ignore the organisation param" do
+        expect(Agent.last.organisations).to eq [organisation]
       end
     end
 
@@ -114,8 +111,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
-                organisation_id: organisation.id
+                level: "basic"
               }
             }
           }
@@ -146,8 +142,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
-                organisation_id: organisation.id
+                level: "basic"
               }
             }
           }
@@ -178,8 +173,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
-                organisation_id: organisation.id
+                level: "basic"
               }
             }
           }
@@ -223,8 +217,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
-                organisation_id: organisation.id
+                level: "basic"
               }
             }
           }

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -34,6 +34,77 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
       end
     end
 
+    context "when trying to invite while not being an admin" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "hacker@renard.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+                organisation_id: organisation.id
+              }
+            }
+          }
+        }
+      end
+
+      it "should reject the change" do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(Agent.last.email).not_to eq "hacker@renard.com"
+      end
+    end
+
+    context "when trying to invite to another organisation" do
+      let(:params) do
+        {
+          organisation_id: organisation2.id,
+          agent: {
+            email: "hacker@renard.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+                organisation_id: organisation.id
+              }
+            }
+          }
+        }
+      end
+
+      it "should reject the change" do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(Agent.last.email).not_to eq "hacker@renard.com"
+      end
+    end
+
+    context "when trying to set the role to another organisation" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "hacker@renard.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+                organisation_id: organisation2.id
+              }
+            }
+          }
+        }
+      end
+
+      it "should reject the change" do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(Agent.last.email).not_to eq "hacker@renard.com"
+      end
+    end
+
     context "when email is correct and no invitation has been sent" do
       let(:params) do
         {


### PR DESCRIPTION
-> issue #1308 
Ça se relit assez bien commit par commit. J’ai fait les deux solutions qu’on a évoquées: 
- on ne prend plus en compte l’organisation passée en paramètre du rôle
- on `authorize` avant d’inviter.

Au passage, j’ai un tout petit peu simplifié InvitationsController, mais c’est toujours un sac de noeuds dans ma tête entre Devise et Pundit 😬.