### PR TITLE
Valide l’existence de roles pour un agent

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -32,6 +32,7 @@ class Agent < ApplicationRecord
   validates :email, presence: true
   validates :last_name, :first_name, presence: true, on: :update
   validate :service_cannot_be_changed
+  validates :roles, presence: true
 
   scope :complete, -> { where.not(first_name: nil).where.not(last_name: nil) }
   scope :active, -> { where(deleted_at: nil) }

--- a/app/policies/agent/agent_role_policy.rb
+++ b/app/policies/agent/agent_role_policy.rb
@@ -20,6 +20,10 @@ class Agent::AgentRolePolicy < ApplicationPolicy
     include CurrentAgentInPolicyConcern
 
     def resolve
+      # Make sure to return an empty scope rather than nil if there are no roles.
+      # (This should not happen with valid data.)
+      return scope.none if current_agent.roles.empty?
+
       current_agent.roles.map do |agent_role|
         if agent_role.admin?
           scope.where(organisation_id: agent_role.organisation_id)

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -22,15 +22,19 @@ FactoryBot.define do
       role_in_territories { [] }
     end
 
-    after(:create) do |agent, evaluator|
+    before(:create) do |agent, evaluator|
+      # Give this agent a role
       evaluator.basic_role_in_organisations.each do |organisation|
-        create :agent_role, agent: agent, organisation: organisation
+        agent.roles << build(:agent_role, agent: nil, organisation: organisation)
       end
       evaluator.admin_role_in_organisations.each do |organisation|
-        create :agent_role, :admin, agent: agent, organisation: organisation
+        agent.roles << build(:agent_role, :admin, agent: nil, organisation: organisation)
       end
+      agent.roles << build(:agent_role, agent: nil) if agent.roles.empty?
+
+      # And a territory role
       evaluator.role_in_territories.each do |territory|
-        create :agent_territorial_role, agent: agent, territory: territory
+        agent.territorial_roles << build(:agent_territorial_role, agent: nil, territory: territory)
       end
     end
 


### PR DESCRIPTION
Fait en passant pour #1309 (en fait, c’est même le point de départ de l’investigation de #1308).

On ne peut pas, en principe, créer un agent sans rôle. Je l’avais fait en local via `super_admin`: dans ce cas, on arrive sur un crash à l’accueil (parce que la policy retourne un nil pour le scope des organisations accessible, au lieu de retourner none).

Idéalement, on validerait la présence de `Agent#has_many :roles`. Par contre, ça casse largement les tests, parce que les factories ne sont pas pensées comme ça, et que “créer un Agent valide”, c’est quelque chose qu’on fait beaucoup dans les tests.