### PR TITLE
remove dead code in plage_ouvertures form partial

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -118,5 +118,7 @@ class PlageOuverture < ApplicationRecord
     return if overlapping_plages_ouvertures.empty?
 
     warnings.add(:base, "Conflit de dates et d'horaires avec d'autres plages d'ouvertures", active: true)
+    # TODO: display richer warning messages by rendering the partial
+    # overlapping_plage_ouvertures (implies passing view locals which may be tricky)
   end
 end

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -1,8 +1,3 @@
-- if plage_ouverture.warnings_need_confirmation? && plage_ouverture.overlapping_plages_ouvertures.any?
-  - content_for :warnings_description do
-    ul.pl-3
-      = render "admin/plage_ouvertures/overlapping_plage_ouvertures", model: plage_ouverture
-
 - if plage_ouverture.available_motifs.any?
   = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture] do |f|
     = render(partial: 'layouts/model_errors', locals: { model: plage_ouverture, f: f })


### PR DESCRIPTION
Ce code n'est en fait pas utilisé pour afficher le warning actuellement existant: 

<img width="536" alt="Screenshot 2021-04-07 at 12 29 03" src="https://user-images.githubusercontent.com/883348/113852513-ec4b9200-979c-11eb-8f25-387e86de3071.png">

Si on souhaitait afficher un message plus riche comme ceux affichés sur le show, le bon fix serait de modifier `PlageOuverture#warn_overlapping_plage_ouvertures` pour faire un `render partial : admin/plage_ouvertures/overlapping_plage_ouvertures`

<img width="527" alt="Screenshot 2021-04-07 at 12 30 59" src="https://user-images.githubusercontent.com/883348/113852689-1d2bc700-979d-11eb-98a7-e1eadcfbc5a0.png">
