### PR TITLE
Valide (réellement) la présence de Agent#first_name et last_name

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -26,8 +26,11 @@ class Agent < ApplicationRecord
   has_many :territories, through: :territorial_roles
   has_and_belongs_to_many :users
 
+  # Note about validation and Devise:
+  # * Invitable#invite! creates the Agent without validation, but validates manually in advance (because we set validate_on_invite to true)
+  # * it validates :email (the invite_key) specifically with Devise.email_regexp.
   validates :email, presence: true
-  validates :last_name, :first_name, presence: true, on: :update, if: :accepted_or_not_invited?
+  validates :last_name, :first_name, presence: true, on: :update
   validate :service_cannot_be_changed
 
   scope :complete, -> { where.not(first_name: nil).where.not(last_name: nil) }


### PR DESCRIPTION
En fait, c’était déjà en place, mais le fonctionnement de Devise#Invitable et des validations est un peu subtil. Devise peut créer l’Agent et envoyer l‘invitation sans valider du tout, sauf si on validate_on_invite. C’est ce qu’on fait, et jusqu’ici c’est bien. Par contre, `accepted_or_not_invited` est contre intuitif, et en fait il vaut `false` pendant l’acceptation de l’invitation, ce qui fait que le first_name et last_name peuvent être laissés vide en base.

* On a un peu de baddata (15 agents) en prod avec first_name ou last_name vide, mais on peut les corriger à la main.
* Ça n’aiderait à rien de spécifier que les colonnes doivent être nonnull en base: ça n’empêcherait pas des chaines vides, et de toute façon, on veut que le first_name et last_name soient vide quand l’agent est invité et créé, pour que l’admin n’ait qu’à saisir un email.

fixes #1268

