### PR TITLE
Ajout d’une colonne “Actions” à admin/organisations/:id/agents

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -23,9 +23,18 @@ module AdminHelper
     @current_agent_role ||= current_agent.roles.find_by(organisation: current_organisation)
   end
 
+  # Build a dummy model linked the current_organisation to fetch its policy.
+  # eg. current_agent_can?(:create, Lieu)
   def current_agent_can?(action, klass)
-    # eg. current_agent_can?(:create, Lieu)
-    mock = klass.new(organisation: current_organisation)
+    if klass.reflections.include?("organisations")
+      # klass has_many :organisations
+      mock = klass.new(organisations: [current_organisation])
+    elsif klass.reflections.include?("organisation")
+      # klass has_one or belongs_to :organisation
+      mock = klass.new(organisation: current_organisation)
+    else
+      raise "Invalid klass for current_agent_can?: #{klass}  has no organisation association."
+    end
     policy([:agent, mock]).send("#{action}?")
   end
 end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -2,7 +2,11 @@ class Agent::AgentPolicy < ApplicationPolicy
   include CurrentAgentInPolicyConcern
 
   def current_agent_or_admin_in_record_organisation?
-    record == current_agent || (
+    record == current_agent || admin_in_record_organisation?
+  end
+
+  def admin_in_record_organisation?
+    (
       record.roles.map(&:organisation_id) &
       current_agent.roles.level_admin.pluck(:organisation_id)
     ).any?
@@ -15,7 +19,11 @@ class Agent::AgentPolicy < ApplicationPolicy
   alias invite? current_agent_or_admin_in_record_organisation?
   alias rdvs? current_agent_or_admin_in_record_organisation?
   alias reinvite? current_agent_or_admin_in_record_organisation?
-  alias destroy? current_agent_or_admin_in_record_organisation?
+
+  def destroy?
+    # Even admins cannot destroy themselves
+    admin_in_record_organisation? && record != current_agent
+  end
 
   class Scope < Scope
     include CurrentAgentInPolicyConcern

--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -31,11 +31,12 @@
             as: :radio_buttons
 
           .row
-            .col.text-left
-              = link_to @agent_removal_presenter.button_value, \
-                admin_organisation_agent_path(current_organisation, @agent_role.agent), \
-                data: { confirm: @agent_removal_presenter.confirm_message }, \
-                method: :delete, \
-                class: 'btn btn-outline-danger'
+            - if policy([:agent, @agent_role.agent]).destroy?
+              .col.text-left
+                = link_to @agent_removal_presenter.button_value, \
+                  admin_organisation_agent_path(current_organisation, @agent_role.agent), \
+                  data: { confirm: @agent_removal_presenter.confirm_message }, \
+                  method: :delete, \
+                  class: 'btn btn-outline-danger'
             .col.text-right
               = f.button :submit

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -3,7 +3,10 @@
 tr id="agent_#{agent.id}"
   td
     - if agent.complete?
-      = link_to agent.full_name, edit_admin_organisation_agent_role_path(current_organisation, agent.role_in_organisation(current_organisation)), class: "mr-2"
+      - if policy([:agent, agent_role]).edit?
+        = link_to agent.full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
+      - else
+        span.mr-2= agent.full_name
       = me_tag(agent)
   td.word-break-all
     = agent.email
@@ -13,3 +16,13 @@ tr id="agent_#{agent.id}"
     span>= AgentRole.human_enum_name(:level, agent_role.level)
     - if agent_role.admin?
       i.fa.fa-user-cog
+  td
+    .d-flex
+      - if policy([:agent, agent_role]).edit?
+        div.mr-3= link_to edit_admin_organisation_agent_role_path(current_organisation, agent_role), title: "Modifier" do
+          i.fa.fa-edit
+      - if policy([:agent, agent]).destroy?
+        - agent_removal_presenter = AgentRemovalPresenter.new(agent, current_organisation)
+        - path = admin_organisation_agent_path(current_organisation, agent_role.agent)
+        = link_to path, title: agent_removal_presenter.button_value, data: { confirm: agent_removal_presenter.confirm_message }, method: :delete do
+          i.fa.fa-trash-alt

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -1,48 +1,39 @@
 - content_for(:menu_item) { 'menu-agents' }
-- content_for(:title, "Vos agents")
 
-.row
-  div class=(current_agent_role.admin? ? "col-md-8" : "col-md-12")
-    .card
-      .m-3.d-flex.justify-content-end
-        div= link_to 'Réinitialiser', admin_organisation_agents_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
-        div= simple_form_for '', url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: 'form-inline' }, wrapper: :inline_form do |f|
-          = f.input :search, placeholder: 'Prénom, Nom, Email', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
-          = f.button :submit, 'Rechercher'
-      .table-responsive
-        table.table
-          thead
-            tr
-              th Nom
-              th Email
-              th Service
-              th= t("activerecord.attributes.agent_role.level")
-          tbody
-            = render partial: 'agent', collection: @complete_agents
+- content_for(:title, "Agents de #{current_organisation.name}")
 
-      - if @complete_agents.empty?
-        .mb-4.p.text-center Aucun agent trouvé
-      - elsif @complete_agents.total_pages > 1
-        .m-3
-          .d-flex.justify-content-center
-            = paginate @complete_agents, theme: 'twitter-bootstrap-4'
-          .text-center= page_entries_info @complete_agents
+- if current_agent_can?(:create, Agent)
+  - content_for :breadcrumb do
+    = link_to 'Inviter un agent', new_admin_agent_organisation_invitation_path(current_organisation), class:"btn btn-outline-white"
 
-  - if current_agent_role.admin?
-    .col-md-4
-      .card
-        .card-header
-          h5 Vos invitations
-          .card-body
-            - if @invited_agents.any?
-              = link_to "Voir les #{@invited_agents.count} invitations en attente", admin_organisation_invitations_path(current_organisation)
-            - else
-              .row.justify-content-md-center
-                .text-center.mb-3
-                  p.mb-2.lead Vous n'avez pas d'invitation en cours.
-                  span.fa-stack.fa-4x
-                    i.fa.fa-circle.fa-stack-2x.text-primary
-                    i.far.fa-envelope.fa-stack-1x.text-white
-        .card-footer
-          .mb-3.ml-2.mr-2.text-center
-            = link_to 'Inviter un professionnel', new_admin_agent_organisation_invitation_path(current_organisation), class: "btn btn-primary"
+= simple_form_for '', url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: 'form-inline' }, wrapper: :inline_form do |f|
+  .container-fluid.bg-white.rounded
+    .m-3.d-flex.justify-content-end
+      div= link_to 'Réinitialiser', admin_organisation_agents_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"
+      = f.input :search, placeholder: 'Prénom, Nom, Email', label: false, input_html: { autocomplete: 'off', class: 'search-form-control', value: params[:search] }, required: false
+      = f.button :submit, 'Rechercher'
+    table.table
+      thead
+        tr
+          th Nom
+          th Email
+          th Service
+          th= t("activerecord.attributes.agent_role.level")
+          th Actions
+      tbody
+        = render partial: 'agent', collection: @complete_agents
+    - if @complete_agents.empty?
+      .mb-4.p.text-center Aucun agent trouvé
+    - elsif @complete_agents.total_pages > 1
+      .m-3
+        .d-flex.justify-content-center
+          = paginate @complete_agents, theme: 'twitter-bootstrap-4'
+        .text-center= page_entries_info @complete_agents
+
+    - if current_agent_can?(:create, Agent)
+      .m-3.d-flex.justify-content-center
+        = link_to 'Inviter un agent', new_admin_agent_organisation_invitation_path(current_organisation), class: 'btn btn-primary'
+        - if @invited_agents.any?
+          = link_to "Voir les #{@invited_agents.count} invitations en attente", admin_organisation_invitations_path(current_organisation), class: "btn btn-link"
+        - else
+          .m-2 Aucune invitation en attente

--- a/app/views/admin/lieux/index.html.slim
+++ b/app/views/admin/lieux/index.html.slim
@@ -17,7 +17,7 @@
             th Adresse
             th Téléphone
             th RDV aujourd'hui
-            th action
+            th Actions
         tbody
           = render @lieux
       .d-flex.justify-content-center= paginate @lieux, theme: 'twitter-bootstrap-4'

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -9,7 +9,7 @@
 
 = simple_form_for '', url: admin_organisation_motifs_path(current_organisation), html: { method: :get, class: 'form-inline js-search-and-filter-form' }, wrapper: :inline_form do |f|
 
-  .container-fluid.bg-white.m-2.rounded
+  .container-fluid.bg-white.rounded
 
     .m-3.d-flex.justify-content-end
       div= link_to 'Réinitialiser', admin_organisation_motifs_path(current_organisation), class: "btn btn-link #{params[:search].blank? && 'd-none'}"

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -62,14 +62,14 @@ describe "Admin can configure the organisation" do
 
   scenario "CRUD on agents" do
     click_link "Vos agents"
-    expect_page_title("Vos agents")
+    expect_page_title("Agents de Organisation n°1")
 
     click_link "Tony PATRICK"
     expect_page_title("Modifier le rôle de l'agent Tony PATRICK")
     choose :agent_role_level_admin
     click_button("Enregistrer")
 
-    expect_page_title("Vos agents")
+    expect_page_title("Agents de Organisation n°1")
     expect(page).to have_content("Admin", count: 2)
 
     click_link "Tony PATRICK"

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -34,6 +34,25 @@ describe Agent::AgentPolicy, type: :policy do
       permissions(:show?) { it { should_not permit(pundit_context, other_agent) } }
     end
   end
+
+  describe "#destroy?" do
+    context "regular agent, other agent same org" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      permissions(:destroy?) { it { should_not permit(pundit_context, other_agent) } }
+    end
+
+    context "admin agent, other agent same org" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      permissions(:destroy?) { it { should permit(pundit_context, other_agent) } }
+    end
+
+    context "admin agent, self" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      permissions(:destroy?) { it { should_not permit(pundit_context, agent) } }
+    end
+  end
 end
 
 describe Agent::AgentPolicy::Scope, type: :policy do


### PR DESCRIPTION
fixes #1267

Avec un design plus ou moins inspiré de Lieux#index.
* Ajout d’une colonne Actions, avec les boutons edit et delete
* Redesign pour déplacer les invitations en dessous, plutôt qu’à droite.
* Je n’ai pas réussi à utiliser les policies dans les vues, je me suis résolu à utiliser `current_agent_role.admin?`. C’est probablement faisable, mais je veux bien en parler, j’ai l’impression que c’est lié à des travaux en cours.

Ça permet aussi de répondre à  https://rdv-solidarites.zammad.com/#ticket/zoom/61, puisqu’on peut modifier les agents sans nom (voir aussi #1313)