### PR TITLE
refactor DuplicateUserFinderService to return multiple matches

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,7 +42,7 @@ class Admin::UsersController < AgentAuthController
   def create
     prepare_create
     authorize(@user)
-    @duplicate_user_result = DuplicateUserFinderService.perform_with(@user)
+    @duplicate_user_result = DuplicateUsersFinderService.perform_with(@user).first
     @user.skip_confirmation_notification!
     user_persisted = @user.save
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,7 +178,7 @@ class User < ApplicationRecord
   end
 
   def user_is_not_duplicate
-    DuplicateUsersFinderService.new(self).perform
+    DuplicateUsersFinderService.perform_with(self)
       .select { _1.severity == :error || !skip_duplicate_warnings? }
       .each do |duplicate_result|
       duplicate_result.attributes.each { |k| errors.add(k, "déjà utilisé") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,10 +178,11 @@ class User < ApplicationRecord
   end
 
   def user_is_not_duplicate
-    duplicate_result = DuplicateUserFinderService.new(self).perform
-    return if duplicate_result.nil? || (duplicate_result.severity == :warning && skip_duplicate_warnings?)
-
-    duplicate_result.attributes.each { |k| errors.add(k, "déjà utilisé") }
+    DuplicateUsersFinderService.new(self).perform
+      .select { _1.severity == :error || !skip_duplicate_warnings? }
+      .each do |duplicate_result|
+      duplicate_result.attributes.each { |k| errors.add(k, "déjà utilisé") }
+    end
   end
 
   def do_soft_delete(organisation)

--- a/app/services/duplicate_users_finder_service.rb
+++ b/app/services/duplicate_users_finder_service.rb
@@ -1,14 +1,15 @@
-class DuplicateUserFinderService < BaseService
-  def initialize(user, organisation = nil, only: nil)
+class DuplicateUsersFinderService < BaseService
+  def initialize(user, organisation = nil)
     @user = user
     @organisation = organisation
-    @only = only || [:email, :identity, :phone_number]
   end
 
   def perform
-    (@only.include?(:email) && check_email) ||
-      (@only.include?(:identity) && check_identity) ||
-      (@only.include?(:phone_number) && check_phone_number)
+    @duplicates = []
+    check_email
+    check_identity
+    check_phone_number
+    @duplicates
   end
 
   private
@@ -21,7 +22,7 @@ class DuplicateUserFinderService < BaseService
     similar_user = users_in_scope.where(email: user.email).first
     return nil unless similar_user.present?
 
-    OpenStruct.new(severity: :error, attributes: [:email], user: similar_user)
+    @duplicates << OpenStruct.new(severity: :error, attributes: [:email], user: similar_user)
   end
 
   def check_identity
@@ -34,7 +35,7 @@ class DuplicateUserFinderService < BaseService
     ).first
     return nil unless similar_user.present?
 
-    OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: similar_user)
+    @duplicates << OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: similar_user)
   end
 
   def check_phone_number
@@ -45,7 +46,7 @@ class DuplicateUserFinderService < BaseService
       .first
     return if similar_user.nil?
 
-    OpenStruct.new(severity: :warning, attributes: [:phone_number], user: similar_user)
+    @duplicates << OpenStruct.new(severity: :warning, attributes: [:phone_number], user: similar_user)
   end
 
   def users_in_scope

--- a/app/views/common/_user_attribute.html.slim
+++ b/app/views/common/_user_attribute.html.slim
@@ -32,7 +32,7 @@
 
   - if ( \
     attribute_name == :phone_number && \
-    DuplicateUserFinderService.perform_with(user, current_organisation, only: [:phone_number]).present? \
+    DuplicateUsersFinderService.perform_with(user, current_organisation).any? { _1.attributes == [:phone_number] } \
   )
     .alert.alert-warning.mt-1
       span> ⚠️ D'autres usagers utilisent ce numéro de téléphone.

--- a/spec/services/duplicate_users_finder_service_spec.rb
+++ b/spec/services/duplicate_users_finder_service_spec.rb
@@ -1,63 +1,63 @@
-describe DuplicateUserFinderService, type: :service do
+describe DuplicateUsersFinderService, type: :service do
   let(:user) { build(:user, first_name: "Mathieu", last_name: "Lapin", email: "lapin@beta.fr", birth_date: "21/10/2000", phone_number: "0658032518") }
 
   describe ".perform" do
-    subject { DuplicateUserFinderService.new(user).perform }
+    subject { DuplicateUsersFinderService.new(user).perform }
 
     context "there is no other user" do
-      it { should be_nil }
+      it { should be_empty }
     end
 
     context "email is nil" do
       let(:user) { build(:user, first_name: "Mathieu", last_name: "Lapin", email: nil) }
       let!(:user_without_email) { create(:user, :with_no_email) }
-      it { should be_nil }
+      it { should be_empty }
     end
 
     context "phone_number is nil" do
       let(:user) { build(:user, first_name: "Mathieu", last_name: "Lapin", phone_number: nil) }
       let!(:user_without_phone_number) { create(:user, phone_number: nil) }
-      it { should be_nil }
+      it { should be_empty }
     end
 
     context "there is an homonym" do
       let!(:homonym_user) { create(:user, first_name: "Mathieu", last_name: "Lapin") }
-      it { should be_nil }
+      it { should be_empty }
     end
 
     context "persisted user" do
       before { user.save! }
-      it { should be_nil } # to make sure we're not returning self as a duplicate
+      it { should be_empty } # to make sure we're not returning self as a duplicate
     end
 
     context "there is a duplicate" do
       context "same email" do
         let!(:duplicated_user) { create(:user, email: "lapin@beta.fr") }
-        it { should eq(OpenStruct.new(severity: :error, attributes: [:email], user: duplicated_user)) }
+        it { should include(OpenStruct.new(severity: :error, attributes: [:email], user: duplicated_user)) }
 
         context "but soft deleted" do
           before { duplicated_user.soft_delete }
-          it { should be_nil }
+          it { should be_empty }
         end
       end
 
       context "same main first_name, last_name, birth_date" do
         let!(:duplicated_user) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: "21/10/2000") }
-        it { should eq(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user)) }
+        it { should include(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user)) }
 
         context "but soft deleted" do
           before { duplicated_user.soft_delete }
-          it { should be_nil }
+          it { should be_empty }
         end
       end
 
       context "same phone_number" do
         let!(:duplicated_user) { create(:user, phone_number: "0658032518") }
-        it { should eq(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user)) }
+        it { should include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user)) }
 
         context "but soft deleted" do
           before { duplicated_user.soft_delete }
-          it { should be_nil }
+          it { should be_empty }
         end
       end
 
@@ -65,11 +65,13 @@ describe DuplicateUserFinderService, type: :service do
         let!(:duplicated_user1) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: "21/10/2000") }
         let!(:duplicated_user2) { create(:user, phone_number: "0658032518") }
         let!(:rdv) { create(:rdv, users: [duplicated_user1]) }
-        it { should eq(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user1)) }
+        it { should include(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user1)) }
+        it { should include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user2)) }
 
         context "but first soft deleted" do
           before { duplicated_user1.soft_delete }
-          it { should eq(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user2)) }
+          it { should_not include(OpenStruct.new(severity: :error, attributes: [:first_name, :last_name, :birth_date], user: duplicated_user1)) }
+          it { should include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user2)) }
         end
 
         context "but both soft deleted" do
@@ -77,7 +79,7 @@ describe DuplicateUserFinderService, type: :service do
             duplicated_user1.soft_delete
             duplicated_user2.soft_delete
           end
-          it { should be_nil }
+          it { should be_empty }
         end
       end
     end
@@ -85,53 +87,21 @@ describe DuplicateUserFinderService, type: :service do
 
   describe "#perform with orga context" do
     let(:organisation) { create(:organisation) }
-    subject { DuplicateUserFinderService.new(user, organisation).perform }
+    subject { DuplicateUsersFinderService.new(user, organisation).perform }
 
     context "same phone_number duplicate in same orga" do
       let!(:duplicated_user) { create(:user, phone_number: "0658032518", organisations: [organisation]) }
-      it { should eq(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user)) }
+      it { should include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user)) }
     end
 
     context "same phone_number duplicate in different orga" do
       let!(:duplicated_user) { create(:user, phone_number: "0658032518", organisations: [create(:organisation)]) }
-      it { should be_nil }
+      it { should be_empty }
     end
 
     context "same phone_number duplicate in no orgas" do
       let!(:duplicated_user) { create(:user, phone_number: "0658032518", organisations: []) }
-      it { should be_nil }
-    end
-  end
-
-  describe "#perform with only arg" do
-    let!(:duplicated_email) { create(:user, email: "lapin@beta.fr") }
-    let!(:duplicated_phone_number) { create(:user, phone_number: "0658032518") }
-
-    context "no only passed" do
-      it "should return the email duplicate" do
-        result = DuplicateUserFinderService.new(user).perform
-        expect(result).not_to be_nil
-        expect(result.attributes).to eq([:email])
-        expect(result.user).to eq(duplicated_email)
-      end
-    end
-
-    context "only email passed" do
-      it "should return the email duplicate" do
-        result = DuplicateUserFinderService.new(user, only: [:email]).perform
-        expect(result).not_to be_nil
-        expect(result.attributes).to eq([:email])
-        expect(result.user).to eq(duplicated_email)
-      end
-    end
-
-    context "only phone_number passed" do
-      it "should return the phone_number duplicate" do
-        result = DuplicateUserFinderService.new(user, only: [:phone_number]).perform
-        expect(result).not_to be_nil
-        expect(result.attributes).to eq([:phone_number])
-        expect(result.user).to eq(duplicated_phone_number)
-      end
+      it { should be_empty }
     end
   end
 end


### PR DESCRIPTION
encore une PR préliminaire à #1284 

Refacto pur, pas de changement de comportement

désolé @n-b je change un peu de direction par rapport à hier : 

- J'avais introduit un param `only` mais en fait ça ne m'arrange pas par rapport à ce que je veux faire dans la PR successive
- C'est en fait plus pratique que le service renvoie tous les doublons et qu'on les filtre a posteriori si besoin
- C'est un peu moins optimisé pour l'instant puisqu'on utilise le service puis on filtre les résultats pour n'afficher que les doublons sur base du numéro de téléphone dans le users/show. Il n'y a en fait probablement pas de raison de faire ça, on devrait par cohérence afficher tous types de doublons qui se produisent je pense (par ex ceux sur base de l'identité). Je n'ai pas changé ça dans la PR mais on pourra le faire plus tard.