### PR TITLE
fix rdv upcoming reminder mail rendering

### DIFF
--- a/app/views/mailers/users/rdv_mailer/rdv_upcoming_reminder.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_upcoming_reminder.html.slim
@@ -7,4 +7,4 @@ div
       | Nous vous rappellons que vous avez un RDV prévu le #{l(@rdv.starts_at, format: :human)}.
 
   = render "mailers/common/rdv_overview", rdv: @rdv
-  = render "mailers/common/rdv_cancellable"
+  = render "mailers/common/rdv_cancellable", rdv: @rdv

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -111,4 +111,12 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       expect(mail.body).to match(rdv.motif.service_name)
     end
   end
+
+  it "send mail to user" do
+    rdv = create(:rdv)
+    user = rdv.users.first
+    mail = Users::RdvMailer.rdv_upcoming_reminder(rdv, user)
+    expect(mail.to).to eq([user.email])
+    expect(mail.body).to include("Nous vous rappellons que vous avez un RDV prévu")
+  end
 end


### PR DESCRIPTION
#1318 

pas de chance c'était le seul mail pas testé 🤷 

visible sur la demo app via https://demo-rdv-solidarites-pr1319.osc-secnum-fr1.scalingo.io/super_admins/mailer_previews/users%2Frdv_mailer%2Frdv_upcoming_reminder

<img width="1392" alt="Screenshot 2021-04-08 at 15 36 53" src="https://user-images.githubusercontent.com/883348/114036491-686ad600-9880-11eb-91f7-e405e1d24b2e.png">


@n-b sur les review apps l'auth a la super admin se fait via basic auth, le login c'est `rdv-solidarites` et le mot de passe est une var d'env, `scalingo env -a demo-rdv-solidarites-pr1319 --region osc-secnum-fr1 | grep BASIC | sed 's/.*=//' | pbcopy`