### PR TITLE
Endpoint permettant d'assigner un agent référent à un usager 

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -40,9 +40,22 @@ class Api::V1::UsersController < Api::V1::BaseController
     render json: { invitation_url: accept_user_invitation_url(invitation_token: user.raw_invitation_token) }
   end
 
+  def update
+    user = User.find(params[:user_id])
+    authorize(user)
+    agents = Agent.where(id: user_params[:agent_ids])
+    if user.update(agents: agents)
+      render json: { success: true }
+    elsif user_params[:agent_ids].blank?
+      render json: { success: false, errors: ["agents_ids doit être rempli"] }
+    else
+      render json: { success: false }
+    end
+  end
+
   private
 
   def user_params
-    params.permit(*PERMITTED_PARAMS, organisation_ids: [])
+    params.permit(*PERMITTED_PARAMS, organisation_ids: [], agent_ids: [])
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::UsersController < Api::V1::BaseController
     user = User.find(params[:user_id])
     authorize(user)
     user.invite! { |u| u.skip_invitation = true }
-    render json: {invitation_url: accept_user_invitation_url(invitation_token: user.raw_invitation_token)}
+    render json: { invitation_url: accept_user_invitation_url(invitation_token: user.raw_invitation_token) }
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::UsersController < Api::V1::BaseController
   PERMITTED_PARAMS = [
     :first_name, :birth_name, :last_name, :email, :address, :phone_number,
     :birth_date, :responsible_id, :caisse_affiliation, :affiliation_number,
-    :family_situation, :number_of_children, :notify_by_sms, :notify_by_email
+    :family_situation, :number_of_children, :notify_by_sms, :notify_by_email, organisation_ids: []
   ].freeze
 
   def show
@@ -33,9 +33,16 @@ class Api::V1::UsersController < Api::V1::BaseController
     end
   end
 
+  def invite
+    user = User.find(params[:user_id])
+    authorize(user)
+    user.invite! { |u| u.skip_invitation = true }
+    render json: {invitation_url: accept_user_invitation_url(invitation_token: user.raw_invitation_token)}
+  end
+
   private
 
   def user_params
-    params.permit(*PERMITTED_PARAMS, organisation_ids: [])
+    params.permit(*PERMITTED_PARAMS)
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::UsersController < Api::V1::BaseController
   PERMITTED_PARAMS = [
     :first_name, :birth_name, :last_name, :email, :address, :phone_number,
     :birth_date, :responsible_id, :caisse_affiliation, :affiliation_number,
-    :family_situation, :number_of_children, :notify_by_sms, :notify_by_email, organisation_ids: []
+    :family_situation, :number_of_children, :notify_by_sms, :notify_by_email
   ].freeze
 
   def show
@@ -43,6 +43,6 @@ class Api::V1::UsersController < Api::V1::BaseController
   private
 
   def user_params
-    params.permit(*PERMITTED_PARAMS)
+    params.permit(*PERMITTED_PARAMS, organisation_ids: [])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
       resources :absences, only: [:index, :create]
-      resources :users, only: [:create, :show]
+      resources :users, only: [:create, :show] do
+        get "invite" => "users#invite", as: "invite_user"
+      end
       resources :user_profiles, only: [:create]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
       resources :absences, only: [:index, :create]
-      resources :users, only: [:create, :show] do
+      resources :users, only: [:create, :show, :update] do
         get "invite" => "users#invite", as: "invite_user"
       end
       resources :user_profiles, only: [:create]


### PR DESCRIPTION
- Issue #1322 
- Fonctionnalité nécessaire dans le cadre de notre expérimentation avec les Ardennes.
-  put /users/id/update avec un array d'id d'agents dans la requête pour assigner des agents à un usager
