### PR TITLE
Ajout d'un endpoint pour ajouter des agents référents aux usagers

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -33,9 +33,22 @@ class Api::V1::UsersController < Api::V1::BaseController
     end
   end
 
+  def update
+    user = User.find(params[:user_id])
+    authorize(user)
+    agents = Agent.where(id: user_params[:agent_ids])
+    if user.update(agents: agents)
+      render json: { success: true }
+    elsif user_params[:agent_ids].blank?
+      render json: { success: false, errors: ["agents_ids doit être rempli"] }
+    else
+      render json: { success: false }
+    end
+  end
+
   private
 
   def user_params
-    params.permit(*PERMITTED_PARAMS, organisation_ids: [])
+    params.permit(*PERMITTED_PARAMS, organisation_ids: [], agent_ids: [])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
       resources :absences, only: [:index, :create]
-      resources :users, only: [:create, :show]
+      resources :users, only: [:create, :show, :update]
       resources :user_profiles, only: [:create]
     end
   end


### PR DESCRIPTION
- Issue #1322 
- Fonctionnalité nécessaire dans le cadre de notre expérimentation avec les Ardennes.
- put /users/id/update avec un array d'id d'agents dans la requête pour assigner des agents à un usager