### PR TITLE
Meilleur affichage des messages de connexion à l’usager

### DIFF
--- a/app/views/layouts/user_registration.html.slim
+++ b/app/views/layouts/user_registration.html.slim
@@ -10,11 +10,10 @@ html lang="fr"
         = yield :header
     .container
       .row
-        .col-md-12
-          = render 'layouts/flash'
-        .col-md-6.m-auto.pt-3
+        .col-md-8.m-auto.pt-3
           - if content_for :title
             h1.mb-3= yield :title
+          = render 'layouts/flash'
           = yield
 
     #modal-holder


### PR DESCRIPTION
Fixes #1305, j’ai juste décalé le flash dans le container, et un peu élargi celui-ci.

Avant:
<img width="1583" alt="avant" src="https://user-images.githubusercontent.com/139391/114415098-aaad5380-9baf-11eb-97dc-00b3cfae2bc6.png">

Après:
<img width="1583" alt="après" src="https://user-images.githubusercontent.com/139391/114415083-a84af980-9baf-11eb-9459-36b270601fa5.png">

De fait, ça modifie aussi le message pour l’inscription pour un motif non “suivi” :
<img width="1583" alt="aussi" src="https://user-images.githubusercontent.com/139391/114415106-abde8080-9baf-11eb-8d0d-2673bb2e9ea5.png">



- checklist avant review: 
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [x] Attendre que les tests soient verts sur la CI
- [x] ~~Tester la fonctionnalité (si pertinent) sur la review app~~
