### PR TITLE
Retrait (en mieux) de la bordure en haut des tables

### DIFF
--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -22,8 +22,8 @@
     table.table
       thead
         tr
-          th.border-top-0 Description
-          th.border-top-0 Dates
+          th Description
+          th Dates
       tbody
         = render @absences
     .d-flex.justify-content-center

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -22,11 +22,11 @@
     table.table
       thead
         tr
-          th.border-top-0 Description
-          th.border-top-0 Motifs
-          th.border-top-0 Lieu
-          th.border-top-0 Dates
-          th.border-top-0
+          th Description
+          th Motifs
+          th Lieu
+          th Dates
+          th
       tbody
         = render @plage_ouvertures
     .d-flex.justify-content-center

--- a/app/webpacker/stylesheets/components/_tables.scss
+++ b/app/webpacker/stylesheets/components/_tables.scss
@@ -6,6 +6,9 @@
 
 // Custom table components (Custom)
 .table {
+  thead th {
+    border-top: 0;
+  }
   .table-user {
     img {
       height: 30px;


### PR DESCRIPTION
Suite à #1333: retire la border en haut des table.table, et les usages de `border-top-0`.

J’ai fait un tour rapide: ça fait plus clair sur certains écrans, en fait j’aime autant comme ça :)

- checklist avant review: 
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [x] Attendre que les tests soient verts sur la CI
- [x] Tester la fonctionnalité (si pertinent) sur la review app
