### PR TITLE
bloque la suppression de lieu avec au moins un RDV

### DIFF
--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -3,7 +3,7 @@ class Lieu < ApplicationRecord
 
   belongs_to :organisation
   has_many :plage_ouvertures, dependent: :restrict_with_error
-  has_many :rdvs
+  has_many :rdvs, dependent: :restrict_with_error
   validates :name, :address, :latitude, :longitude, presence: true
 
   scope :for_motif, lambda { |motif|

--- a/spec/controllers/admin/lieux_controller_spec.rb
+++ b/spec/controllers/admin/lieux_controller_spec.rb
@@ -119,5 +119,31 @@ RSpec.describe Admin::LieuxController, type: :controller do
       delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
       expect(response).to redirect_to(admin_organisation_lieux_path(organisation.id))
     end
+
+    it "render EDIT when lieu have rdvs" do
+      lieu = create(:lieu, organisation: organisation, rdvs: [create(:rdv)])
+      delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
+      expect(response).to render_template(:edit)
+    end
+
+    it "dont destroy lieu when it have rdvs" do
+      lieu = create(:lieu, organisation: organisation, rdvs: [create(:rdv)])
+      expect do
+        delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
+      end.not_to change(Lieu, :count)
+    end
+
+    it "render EDIT when lieu have plage ouvertures" do
+      lieu = create(:lieu, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)])
+      delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
+      expect(response).to render_template(:edit)
+    end
+
+    it "dont destroy lieu when it have plage_ouvertures" do
+      lieu = create(:lieu, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)])
+      expect do
+        delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
+      end.not_to change(PlageOuverture, :count)
+    end
   end
 end

--- a/spec/controllers/admin/lieux_controller_spec.rb
+++ b/spec/controllers/admin/lieux_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Admin::LieuxController, type: :controller do
+describe Admin::LieuxController, type: :controller do
   render_views
 
   let!(:organisation) { create(:organisation) }
@@ -109,12 +109,6 @@ RSpec.describe Admin::LieuxController, type: :controller do
   end
 
   describe "DELETE #destroy" do
-    it "destroys the requested lieu" do
-      expect do
-        delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
-      end.to change(Lieu, :count).by(-1)
-    end
-
     it "redirects to the lieux list" do
       delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
       expect(response).to redirect_to(admin_organisation_lieux_path(organisation.id))
@@ -126,24 +120,10 @@ RSpec.describe Admin::LieuxController, type: :controller do
       expect(response).to render_template(:edit)
     end
 
-    it "dont destroy lieu when it have rdvs" do
-      lieu = create(:lieu, organisation: organisation, rdvs: [create(:rdv)])
-      expect do
-        delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
-      end.not_to change(Lieu, :count)
-    end
-
     it "render EDIT when lieu have plage ouvertures" do
       lieu = create(:lieu, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)])
       delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
       expect(response).to render_template(:edit)
-    end
-
-    it "dont destroy lieu when it have plage_ouvertures" do
-      lieu = create(:lieu, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)])
-      expect do
-        delete :destroy, params: { organisation_id: organisation.id, id: lieu.to_param }
-      end.not_to change(PlageOuverture, :count)
     end
   end
 end

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -1,127 +1,147 @@
 describe Lieu, type: :model do
   let!(:territory) { create(:territory, departement_number: "62") }
   let!(:organisation) { create(:organisation, territory: territory) }
-  let!(:motif) { create(:motif, name: "Vaccination", reservable_online: reservable_online, organisation: organisation) }
   let!(:lieu) { create(:lieu) }
-  let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, organisation: organisation) }
   let!(:user) { create(:user) }
 
-  describe ".for_motif_and_departement" do
-    subject { described_class.for_motif_and_departement("Vaccination", "62") }
+  context "with motif" do
+    let!(:motif) { create(:motif, name: "Vaccination", reservable_online: reservable_online, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, organisation: organisation) }
 
-    let(:service_id) { Service.first.id }
-    let(:reservable_online) { true }
+    describe ".for_motif_and_departement" do
+      subject { described_class.for_motif_and_departement("Vaccination", "62") }
 
-    before { freeze_time }
+      let(:service_id) { Service.first.id }
+      let(:reservable_online) { true }
 
-    after { travel_back }
+      before { freeze_time }
 
-    it { expect(subject).to contain_exactly(lieu) }
+      after { travel_back }
 
-    context "with an other plage_ouverture" do
-      let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2) }
+      it { expect(subject).to contain_exactly(lieu) }
 
-      it { expect(subject).to contain_exactly(lieu, lieu2) }
+      context "with an other plage_ouverture" do
+        let!(:lieu2) { create(:lieu) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2) }
+
+        it { expect(subject).to contain_exactly(lieu, lieu2) }
+      end
+
+      context "with a plage_ouverture not yet started" do
+        let!(:lieu2) { create(:lieu) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2, first_day: 8.days.from_now) }
+
+        it { expect(subject).to contain_exactly(lieu, lieu2) }
+      end
+
+      context "with a motif not reservable_online" do
+        let(:reservable_online) { false }
+
+        it { expect(subject).to eq([]) }
+      end
+
+      context "with a plage_ouverture with no recurrence and closed" do
+        let!(:lieu2) { create(:lieu) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: Date.parse("2020-07-30")) }
+
+        it { expect(subject).to contain_exactly(lieu) }
+      end
+
+      context "with a motif not active" do
+        before { motif.update(deleted_at: Time.zone.now) }
+
+        it { expect(subject).to eq([]) }
+      end
     end
 
-    context "with a plage_ouverture not yet started" do
-      let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2, first_day: 8.days.from_now) }
+    describe ".for_motif" do
+      subject { described_class.for_motif(motif) }
 
-      it { expect(subject).to contain_exactly(lieu, lieu2) }
-    end
-
-    context "with a motif not reservable_online" do
       let(:reservable_online) { false }
 
-      it { expect(subject).to eq([]) }
-    end
+      before { freeze_time }
 
-    context "with a plage_ouverture with no recurrence and closed" do
-      let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: Date.parse("2020-07-30")) }
+      after { travel_back }
 
       it { expect(subject).to contain_exactly(lieu) }
+
+      context "with an other plage_ouverture" do
+        let!(:lieu2) { create(:lieu) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2) }
+
+        it { expect(subject).to contain_exactly(lieu, lieu2) }
+      end
+
+      context "with a plage_ouverture not yet started" do
+        let!(:lieu2) { create(:lieu) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2, first_day: 8.days.from_now) }
+
+        it { expect(subject).to contain_exactly(lieu, lieu2) }
+      end
+
+      context "with a plage_ouverture with no recurrence and closed" do
+        let!(:lieu2) { create(:lieu) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: Date.parse("2020-07-30")) }
+
+        it { expect(subject).to contain_exactly(lieu) }
+      end
+
+      context "with a motif not active" do
+        before { motif.update(deleted_at: Time.zone.now) }
+
+        it { expect(subject).to eq([]) }
+      end
     end
 
-    context "with a motif not active" do
-      before { motif.update(deleted_at: Time.zone.now) }
+    describe ".distance" do
+      let!(:lieu_lille) { create(:lieu, latitude: 50.63, longitude: 3.053) }
+      let(:paris_loc) { { latitude: 48.83, longitude: 2.37 } }
+      let(:reservable_online) { true }
 
-      it { expect(subject).to eq([]) }
+      it { expect(lieu_lille.distance(paris_loc[:latitude], paris_loc[:longitude])).to be_a_kind_of(Float) }
+      it { expect(lieu_lille.distance(paris_loc[:latitude], paris_loc[:longitude])).to be_within(10_000).of(204_000) }
+    end
+
+    describe "#with_open_slots_for_motifs" do
+      subject { described_class.with_open_slots_for_motifs([motif]) }
+
+      context "motif has current plage ouvertures" do
+        let!(:motif) { create(:motif, name: "Vaccination") }
+        let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu) }
+
+        it { is_expected.to include(lieu) }
+      end
+
+      context "motif has finished plage ouverture" do
+        let!(:motif) { create(:motif, name: "Vaccination") }
+        let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, first_day: 2.days.ago, recurrence: nil) }
+
+        it { is_expected.not_to include(lieu) }
+      end
+
+      context "motif has no plage ouvertures" do
+        let!(:motif) { create(:motif, name: "Vaccination") }
+        let(:plage_ouverture) { nil }
+
+        it { is_expected.not_to include(lieu) }
+      end
     end
   end
 
-  describe ".for_motif" do
-    subject { described_class.for_motif(motif) }
-
-    let(:reservable_online) { false }
-
-    before { freeze_time }
-
-    after { travel_back }
-
-    it { expect(subject).to contain_exactly(lieu) }
-
-    context "with an other plage_ouverture" do
-      let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2) }
-
-      it { expect(subject).to contain_exactly(lieu, lieu2) }
+  describe "#destroy" do
+    it "dont destroy lieu when it have rdvs" do
+      lieu = create(:lieu, organisation: organisation, rdvs: [create(:rdv)])
+      expect(lieu.destroy).to be(false)
     end
 
-    context "with a plage_ouverture not yet started" do
-      let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2, first_day: 8.days.from_now) }
-
-      it { expect(subject).to contain_exactly(lieu, lieu2) }
+    it "dont destroy lieu when it have plage_ouvertures" do
+      lieu = create(:lieu, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)])
+      expect(lieu.destroy).to be(false)
     end
 
-    context "with a plage_ouverture with no recurrence and closed" do
-      let!(:lieu2) { create(:lieu) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif], lieu: lieu2, first_day: Date.parse("2020-07-30")) }
-
-      it { expect(subject).to contain_exactly(lieu) }
-    end
-
-    context "with a motif not active" do
-      before { motif.update(deleted_at: Time.zone.now) }
-
-      it { expect(subject).to eq([]) }
-    end
-  end
-
-  describe ".distance" do
-    let!(:lieu_lille) { create(:lieu, latitude: 50.63, longitude: 3.053) }
-    let(:paris_loc) { { latitude: 48.83, longitude: 2.37 } }
-    let(:reservable_online) { true }
-
-    it { expect(lieu_lille.distance(paris_loc[:latitude], paris_loc[:longitude])).to be_a_kind_of(Float) }
-    it { expect(lieu_lille.distance(paris_loc[:latitude], paris_loc[:longitude])).to be_within(10_000).of(204_000) }
-  end
-
-  describe "#with_open_slots_for_motifs" do
-    subject { described_class.with_open_slots_for_motifs([motif]) }
-
-    context "motif has current plage ouvertures" do
-      let!(:motif) { create(:motif, name: "Vaccination") }
-      let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu) }
-
-      it { is_expected.to include(lieu) }
-    end
-
-    context "motif has finished plage ouverture" do
-      let!(:motif) { create(:motif, name: "Vaccination") }
-      let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, first_day: 2.days.ago, recurrence: nil) }
-
-      it { is_expected.not_to include(lieu) }
-    end
-
-    context "motif has no plage ouvertures" do
-      let!(:motif) { create(:motif, name: "Vaccination") }
-      let(:plage_ouverture) { nil }
-
-      it { is_expected.not_to include(lieu) }
+    it "destroy lieu without rdvs or plage d'ouverture" do
+      lieu = create(:lieu, organisation: organisation, rdvs: [], plage_ouvertures: [])
+      expect(lieu.destroy).to eq(lieu)
     end
   end
 end


### PR DESCRIPTION
Corrige le souci remonté par Élise (en tout cas une partie).

C'est aussi la correction pour cette entrée Sentry https://sentry.io/organizations/rdv-solidarites/issues/2333945966/?project=1811205&query=is%3Aunresolved

Dans un email du 13 avril 2021, Élise nous signale une erreur 500 au moment de la suppression d'un lieu. Le souci, c'est que le lieu à encore des rendez-vous, nous ne pouvons pas le supprimer.

Cette correction affichera correctement la raison de l'échec de la suppression.

La demande de pouvoir supprimer des lieux inutilisés est déjà posé sur le forum https://forum.rdv-solidarites.fr/t/gestion-des-lieux-inutilises/28

Ça pose la question des rendez-vous passés, des plages d'ouvertures passées, des absences passées.

Mais c'est un autre sujet. Je vais le relancer sur le forum.

