### PR TITLE
Ajouter une colonnes actions (et bouton dupliquer) à Absences#index

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -25,6 +25,19 @@ class Admin::AbsencesController < AgentAuthController
 
   def new
     @absence = Absence.new(organisation: current_organisation, agent: @agent)
+    if params[:duplicate_absence_id].present?
+      original_abs = Absence.find(params[:duplicate_absence_id])
+      defaults = original_abs.slice(:title, :first_day, :start_time, :end_day, :end_time, :recurrence)
+    else
+      defaults = {
+        first_day: Time.zone.tomorrow,
+        start_time: Tod::TimeOfDay.new(9),
+        end_time: Tod::TimeOfDay.new(18)
+      }
+    end
+
+    @absence = Absence.new(organisation: current_organisation, agent: @agent, **defaults)
+
     authorize(@absence)
   end
 

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -1,6 +1,7 @@
 tr
+  - organisation = absence.organisation
   td
-    = link_to absence.title_or_default, edit_admin_organisation_absence_path(absence.organisation, absence)
+    = link_to absence.title_or_default, edit_admin_organisation_absence_path(organisation, absence)
     = absence_tag(absence)
   td
     | Du #{l(absence.starts_at, format: :human)} au #{l(absence.first_occurrence_ends_at, format: :human)}
@@ -10,3 +11,16 @@ tr
       | Se répète :
       br
       = sanitize(display_recurrence(absence).join("<br/>"))
+  td
+    .d-flex
+      div.mr-3= link_to edit_admin_organisation_absence_path(organisation, absence),
+                title: t("helpers.edit") do
+        i.fa.fa-edit
+      div.mr-3= link_to new_admin_organisation_agent_absence_path(organisation, absence.agent, duplicate_absence_id: absence),
+              title: t("helpers.clone") do
+        i.fa.fa-clone
+      div.mr-3= link_to( admin_organisation_absence_path(organisation, absence),
+              method: :delete,
+              title: t("helpers.delete"),
+              data: { confirm: "Confirmez-vous la suppression de cette absence ?"} ) do
+        i.fa.fa-trash-alt

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -24,6 +24,7 @@
         tr
           th Description
           th Dates
+          th Actions
       tbody
         = render @absences
     .d-flex.justify-content-center

--- a/app/views/admin/lieux/_lieu.html.slim
+++ b/app/views/admin/lieux/_lieu.html.slim
@@ -8,8 +8,12 @@ tr id="lieu_#{lieu.id}"
     - if policy([:agent, lieu]).edit? || policy([:agent, lieu]).destroy?
       .d-flex
         - if policy([:agent, lieu]).edit?
-          div.mr-3= link_to edit_admin_organisation_lieu_path(current_organisation, lieu), title: "Modifier" do
+          div.mr-3= link_to edit_admin_organisation_lieu_path(current_organisation, lieu),
+                  title: t("helpers.edit") do
             i.fa.fa-edit
         - if policy([:agent, lieu]).destroy?
-          div= link_to admin_organisation_lieu_path(current_organisation, lieu), method: :delete, title: "Supprimer", data: { confirm: "Confirmez-vous la suppression de ce lieu ?"} do
+          div= link_to admin_organisation_lieu_path(current_organisation, lieu),
+                  title: t("helpers.delete"),
+                  method: :delete,
+                  data: { confirm: "Confirmez-vous la suppression de ce lieu ?"} do
             i.fa.fa-trash-alt

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -1,6 +1,7 @@
 tr
+  - organisation = plage_ouverture.organisation
   td
-    = link_to plage_ouverture.title, admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
+    = link_to plage_ouverture.title, admin_organisation_plage_ouverture_path(organisation, plage_ouverture)
     = po_exceptionnelle_tag(plage_ouverture)
     br
     small
@@ -21,16 +22,15 @@ tr
     - if plage_ouverture.overlapping_plages_ouvertures?
       .alert.alert-warning.py-1.px-2.mt-1 ⚠️ Conflit de dates
   td
-    div
-      = link_to admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture) do
-        i.fa.fa-eye
-    div
-      = link_to edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture) do
-        i.fa.fa-pencil-alt
-    div
-      = link_to( \
-        admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture), \
-        method: :delete, \
-        data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"} \
-      ) do
-        i.fa.fa-trash
+    .d-flex
+      div.mr-3= link_to edit_admin_organisation_plage_ouverture_path(organisation, plage_ouverture),
+              title: t("helpers.edit") do
+        i.fa.fa-edit
+      div.mr-3= link_to new_admin_organisation_agent_plage_ouverture_path(organisation, plage_ouverture.agent, duplicate_plage_ouverture_id: plage_ouverture),
+                title: t("helpers.clone") do
+        i.fa.fa-clone
+      div.mr-3= link_to( admin_organisation_plage_ouverture_path(organisation, plage_ouverture),
+              method: :delete,
+              title: t("helpers.delete"),
+              data: { confirm: "Confirmez-vous la suppression de cette plage d'ouverture ?"} ) do
+        i.fa.fa-trash-alt

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -26,7 +26,7 @@
           th Motifs
           th Lieu
           th Dates
-          th
+          th Actions
       tbody
         = render @plage_ouvertures
     .d-flex.justify-content-center

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -150,6 +150,10 @@ fr:
         one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
         other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
+    clone: Dupliquer
+    delete: Supprimer
+    edit: Modifier
+    show: Afficher
     select:
       prompt: Veuillez sélectionner
     submit:


### PR DESCRIPTION
fixes #1331

Au passage, quelques petits ajustements sur les lieux et les plages d’ouvertures; je vais peut-être essayer d’utiliser les policies pour afficher les actions de façon conditionnelle, mais ça avait l’air un peu touchy à première vue. 

- checklist avant review: 
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [x] Attendre que les tests soient verts sur la CI
- [x] Tester la fonctionnalité (si pertinent) sur la review app
