### PR TITLE
Met à jour les paramètres de l’usager à sa véritable inscription

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,6 +64,8 @@ class ApplicationController < ActionController::Base
     elsif resource_class == User
       devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name email phone_number password])
       devise_parameter_sanitizer.permit(:invite, keys: %i[email first_name last_name address phone_number birth_date])
+      # params for accept_invitation may be passed from the signup to the invitation via the invitation_instructions email.
+      devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name email phone_number password])
     end
   end
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -3,11 +3,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def edit
     # Reuse prefilled params from the invitation email
-    resource.assign_attributes(prefilled_params)
+    resource.assign_attributes(update_resource_params)
     super
-  end
-
-  def prefilled_params
-    params.permit(:first_name, :last_name, :phone_number)
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,3 +1,13 @@
 class Users::InvitationsController < Devise::InvitationsController
   layout "user_registration"
+
+  def edit
+    # Reuse prefilled params from the invitation email
+    resource.assign_attributes(prefilled_params)
+    super
+  end
+
+  def prefilled_params
+    params.permit(:first_name, :last_name, :phone_number)
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def invite_and_redirect
     user = User.find_by(email: sign_up_params[:email], confirmed_at: nil)
-    user.invite!
+    user.invite!(nil, prefill_params: sign_up_params)
     set_flash_message! :notice, :signed_up_but_unconfirmed
     respond_with user, location: after_inactive_sign_up_path_for(user)
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def invite_and_redirect
     user = User.find_by(email: sign_up_params[:email], confirmed_at: nil)
-    user.invite!(nil, prefill_params: sign_up_params)
+    user.invite!(nil, user_params: sign_up_params)
     set_flash_message! :notice, :signed_up_but_unconfirmed
     respond_with user, location: after_inactive_sign_up_path_for(user)
   end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -7,6 +7,7 @@ class CustomDeviseMailer < Devise::Mailer
 
   def invitation_instructions(record, token, opts = {})
     @token = token
+    @prefill_params = opts[:prefill_params] || {}
     opts[:reply_to] = record.invited_by.email if record.is_a? Agent
     devise_mail(record, :invitation_instructions, opts)
   end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -7,7 +7,7 @@ class CustomDeviseMailer < Devise::Mailer
 
   def invitation_instructions(record, token, opts = {})
     @token = token
-    @prefill_params = opts[:prefill_params] || {}
+    @user_params = opts[:user_params] || {}
     opts[:reply_to] = record.invited_by.email if record.is_a? Agent
     devise_mail(record, :invitation_instructions, opts)
   end

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,7 +2,8 @@
 
 <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
 
-<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %></p>
+<!-- Prefill params from the sign_up form to the invitation accept form -->
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token, **@prefill_params) %></p>
 
 <% if @resource.invitation_due_at %>
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -3,7 +3,7 @@
 <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
 
 <!-- Prefill params from the sign_up form to the invitation accept form -->
-<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token, **@prefill_params) %></p>
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token, user: @user_params) %></p>
 
 <% if @resource.invitation_due_at %>
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -11,6 +11,8 @@
         .form-row
           .col-md-6= f.input :first_name, placeholder: 'Prénom', label: false
           .col-md-6= f.input :last_name, placeholder: 'Nom', label: false
+        .form-row
+          .col-md-12= f.input :phone_number, as: :tel # may be prefilled
         .form-group
           = f.label :password
           = f.password_field :password, required: true, class: 'form-control ', placeholder: 'Votre mot de passe', id: "password"

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -1,20 +1,20 @@
-- content_for :title
-  h1 Inscription
+- content_for :title, "Inscription"
 
-.container.mt-3
-  .card
-    .card-body
-      = simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f|
-        .text-center.w-75.m-auto
-        = devise_error_messages!
-        = f.hidden_field :invitation_token
-        .form-row
-          .col-md-6= f.input :first_name, placeholder: 'Prénom', label: false
-          .col-md-6= f.input :last_name, placeholder: 'Nom', label: false
-        .form-row
-          .col-md-12= f.input :phone_number, as: :tel # may be prefilled
-        .form-group
-          = f.label :password
-          = f.password_field :password, required: true, class: 'form-control ', placeholder: 'Votre mot de passe', id: "password"
-          span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
-        .text-center= f.button :submit, t("devise.invitations.edit.submit_button")
+.card
+  .card-body
+    = simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f|
+      .text-center.w-75.m-auto
+      = devise_error_messages!
+      = f.hidden_field :invitation_token
+      .form-row
+        .col-md-6= f.input :first_name, placeholder: 'Prénom'
+        .col-md-6= f.input :last_name, placeholder: 'Nom'
+      .form-row
+        .col-md-12= f.input :email, value: resource.email, disabled: true
+      .form-row
+        .col-md-12= f.input :phone_number, as: :tel
+      .form-group
+        = f.label :password
+        = f.password_field :password, required: true, class: 'form-control ', placeholder: 'Votre mot de passe', id: "password"
+        span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
+      .text-center= f.button :submit, t("devise.invitations.edit.submit_button")


### PR DESCRIPTION
- fixes #1328 

Quand un usage se crée un “nouveau” compte alors qu’il avait déjà un compte non-activé créé par un agent, on fait en fait une invitation au compte existante au lieu de créer un nouveau compte. Cette PR permet de passer les paramètres :first_name, :last_name, et :phone_number jusqu’au formulaire de validation de l’invitation, en passant par le lien dans le mail d’invitation.

Je sais pas exactement comment écrire des tests pour ça, je vais voir si j’arrive à un truc pertinent.

- checklist avant review: 
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [x] Attendre que les tests soient verts sur la CI
- [x] Tester la fonctionnalité (si pertinent) sur la review app
