### PR TITLE
Corrige une 404 à l’affichage de l’historique d’un Rdv si un ancien Lieu a été supprimé

### DIFF
--- a/app/helpers/paper_trail_helper.rb
+++ b/app/helpers/paper_trail_helper.rb
@@ -43,7 +43,7 @@ module PaperTrailHelper
 
       class LieuId < Base
         def to_s
-          Lieu.find(@value).full_name
+          ::Lieu.find_by(id: @value)&.full_name || super
         end
       end
     end


### PR DESCRIPTION
Relevé par Élodie, pas d’Issue associée. Ce n’est pas une iframe, mais ça y ressemble un peu: VersionsController#index retourne du html, qui est inclus en ajax dans le layout de Admin::RdvsController#show.
Je n’ai pas rajouté de test, parce que ça demanderait un peu plus de travail : VersionsController n’est actuellement pas testé, et Admin::RdvsController en controller, alors que j’aurais besoin de Capybara. 

Après ce commit, le changement dans l’historique affiche l’id de l’objet supprimé, au lieu de planter en essayant de récupérer les détails:

<img width="1330" alt="image" src="https://user-images.githubusercontent.com/139391/115237355-c28b5700-a11c-11eb-9bca-0ed16272ae77.png">


- checklist avant review: 
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touched inutilement, debug logs qui trainent...).
- [ ] Attendre que les tests soient verts sur la CI
- [ ] Tester la fonctionnalité (si pertinent) sur la review app
