### PR TITLE
revise les liens vers les informations légales

### DIFF
--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -32,14 +32,11 @@ footer.main-footer
             span> Code Source sur GitHub
             i.fa.fa-external-link-alt
       .col-6.col-md
-        h5 Information légales
+        h5 Informations légales
         ul.list-unstyled.text-small
-          li.mb-1 = link_to "https://doc.rdv-solidarites.fr/mentions-legales" do
+          li.mb-1 = link_to "https://doc.rdv-solidarites.fr/informations-legales/mentions-legales" do
             span> Mentions Légales
-            i.fa.fa-external-link-alt
-          li.mb-1 = link_to "https://doc.rdv-solidarites.fr/conditions-dutilisation-de-la-plateforme-rdv-solidarites" do
+          li.mb-1 = link_to "https://doc.rdv-solidarites.fr/informations-legales/conditions-dutilisation-de-la-plateforme-rdv-solidarites" do
             span> C.G.U.
-            i.fa.fa-external-link-alt
-          li.mb-1 = link_to "https://doc.rdv-solidarites.fr/politique-de-confidentialite" do
+          li.mb-1 = link_to "https://doc.rdv-solidarites.fr/informations-legales/politique-de-confidentialite" do
             span> Politique de confidentialité
-            i.fa.fa-external-link-alt


### PR DESCRIPTION
Pas d'issue liée.

- Resynchronisé la doc avec le repo github (c'était fait avec le compte d'Adrien, c'était à refaire) ;
- ranger un peu quelques éléments de la doc, dont les informations légales, dans une sous rubrique ;
- modifié les liens ici pour pointer vers les nouveaux (il y a redirection en attendant) ;
- supprimer les icônes de lien externe.
- 
