### PR TITLE
Affiche le service a nouveau

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -37,12 +37,12 @@ module AgentsHelper
 
   def display_meta_note(note)
     meta = tag.span("le #{l(note.created_at.to_date)}", title: l(note.created_at))
-    meta += " par #{note.agent.full_name}"
+    meta += " par #{note.agent.full_name_and_service}"
     tag.span(meta, class: "font-italic")
   end
 
   def agents_to_sentence(agents)
-    agents.map(&:full_name).sort.to_sentence
+    agents.map(&:full_name_and_service).sort.to_sentence
   end
 
   def menu_top_level_item

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -51,6 +51,10 @@ class Agent < ApplicationRecord
 
   accepts_nested_attributes_for :roles
 
+  def full_name_and_service
+    service.present? ? "#{full_name} (#{service.short_name})" : full_name
+  end
+
   def complete?
     first_name.present? && last_name.present?
   end

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -5,7 +5,7 @@
   - if current_agent == @agent
     | Vos absences
   - else
-    | Absences de #{@agent.full_name}
+    | Absences de #{@agent.full_name_and_service}
 
 - content_for :breadcrumb do
   = link_to 'Créer une absence', new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-outline-white align-bottom"

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -5,7 +5,7 @@
   - if current_agent == @agent
     | Votre agenda
   - else
-    | Agenda de #{@agent.full_name}
+    | Agenda de #{@agent.full_name_and_service}
 
 - content_for :breadcrumb do
   = form_tag(admin_organisation_agent_agenda_path(current_organisation, @agent), method: "get", class: "d-inline-flex mr-2") do

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -5,7 +5,7 @@
   - if current_agent == @agent
     | Vos plages d'ouverture
   - else
-    | Plages d'ouverture de #{@agent.full_name}
+    | Plages d'ouverture de #{@agent.full_name_and_service}
 
 - content_for :breadcrumb do
   = link_to 'Créer une plage d\'ouverture', new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-outline-white align-bottom"

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -25,5 +25,5 @@ do
           input_html: { class: 'select2-input' }
       - elsif @rdv.home?
         = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}"
-      = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :full_name, input_html: { multiple: true, class: 'select2-input' }
+      = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
       = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -42,7 +42,7 @@
                 input_html: { class: "select2-input" }
             - elsif @rdv_form.motif.home?
               = f.input :address, label: "Lieu (RDV à domicile)", disabled: true
-            = f.association :agents, collection: @rdv_form.organisation.agents.can_perform_motif(@rdv_form.motif), label_method: :full_name, input_html: { multiple: true, class: 'select2-input' }
+            = f.association :agents, collection: @rdv_form.organisation.agents.can_perform_motif(@rdv_form.motif), label_method: :full_name_and_service, input_html: { multiple: true, class: 'select2-input' }
             = f.association :users, collection: policy_scope(User).order_by_last_name, label_method: lambda { |user| full_name_and_birthdate(user) }, input_html: { multiple: true, class: 'select2-input' }
             .text-right
               = link_to "Retour", admin_organisation_rdv_path(current_organisation, @rdv), class: "btn btn-link"

--- a/app/views/admin/territories/agent_territorial_roles/index.html.slim
+++ b/app/views/admin/territories/agent_territorial_roles/index.html.slim
@@ -16,7 +16,7 @@
             tr
               td
                 div
-                  = role.agent.full_name
+                  = role.agent.full_name_and_service
                   - if role.agent == current_agent
                     .badge.badge-primary Vous
                 .text-muted= role.agent.email

--- a/app/views/admin/territories/agent_territorial_roles/new.html.slim
+++ b/app/views/admin/territories/agent_territorial_roles/new.html.slim
@@ -17,5 +17,5 @@
           = f.input :territory_id, as: :hidden
           = f.association :agent, \
             collection: @possible_agents,
-            label_method: -> { _1.full_name }
+            label_method: -> { _1.full_name_and_service }
           = f.submit class: "btn btn-primary", value: "Donner le rôle d'administrateur du #{current_territory}"

--- a/app/views/admin/territories/sector_attributions/_form.html.slim
+++ b/app/views/admin/territories/sector_attributions/_form.html.slim
@@ -37,7 +37,7 @@ do |f|
       include_blank: true, \
       required: true, \
       disabled: available_agents.blank?, \
-      label_method: :full_name,
+      label_method: :full_name_and_service,
       input_html: { class: "select2-input" }
 
   = f.submit \

--- a/app/views/admin/territories/sectorisation_tests/_attribution.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/_attribution.html.slim
@@ -1,7 +1,7 @@
 - if attribution.level_agent?
   div
     span> L'agent
-    b>= attribution.agent.full_name
+    b>= attribution.agent.full_name_and_service
     span> dans l'organisation
     b>= attribution.organisation.name
   - if sectorisation_test_form.available_motifs_from_attributed_agent(attribution.agent, attribution.organisation).empty?

--- a/app/views/admin/territories/sectors/index.html.slim
+++ b/app/views/admin/territories/sectors/index.html.slim
@@ -48,7 +48,7 @@
                           = "Agents de l'organisation #{organisation.name}:"
                           ul.pl-2
                             - attributions.each do |attribution|
-                              li= attribution.agent.full_name
+                              li= attribution.agent.full_name_and_service
                 - else
                   .text-muted Aucune attribution
               td

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -62,7 +62,7 @@
               = f.association \
                 :agents, \
                 collection: policy_scope(Agent).joins(:organisations).where(organisations: { id: current_organisation.id }).order_by_last_name, \
-                label_method: :full_name, \
+                label_method: :full_name_and_service, \
                 label: false, \
                 multiple: true, \
                 input_html: {class: 'select2-input'}

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -71,7 +71,7 @@
             ul.list-unstyled.mb-2
               - @user.agents.includes([:service]).each do |agent|
                 li.mb-2
-                | #{agent.full_name}
+                | #{agent.full_name_and_service}
               - if @user.agents.empty?
                 .font-italic aucun référent
 
@@ -88,7 +88,7 @@
           ul.list-unstyled.mb-2
             - @user.responsible.agents.includes([:service]).each do |agent|
               li.mb-2
-              | #{agent.full_name}
+              | #{agent.full_name_and_service}
             - if @user.responsible.agents.empty?
               .font-italic aucun référent
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -23,6 +23,7 @@
                 i.far.fa-id-card
               div.d-flex.flex-column
                 span.h5.mb-1= current_agent.first_name&.capitalize
+                span= current_agent.service&.short_name
                 span= current_organisation.name
             div.d-flex.align-items-center
               i.fa.fa-angle-right.menu-arrow.mt-1

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -22,7 +22,7 @@ html lang="fr"
             - elsif agent_path? && current_agent.present?
               h4
                 i.far.fa-id-card>
-                = current_agent.full_name
+                = current_agent.full_name_and_service
               .d-flex.flex-row.justify-content-center
                 ul.list-unstyled.text-left
                   li

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -91,6 +91,6 @@ describe "Agent can create a Rdv with wizard" do
   end
 
   def select_agent(agent)
-    select(agent.full_name, from: "rdv_agent_ids")
+    select(agent.full_name_and_service, from: "rdv_agent_ids")
   end
 end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -47,18 +47,18 @@ describe "Agent can CRUD absences" do
 
     it "can crud a absence" do
       visit admin_organisation_agent_absences_path(organisation, other_agent.id)
-      expect_page_title("Absences de Jane FAROU")
+      expect_page_title("Absences de Jane FAROU (PMI)")
       click_link absence.title
 
       expect_page_title("Modifier l'absence de Jane FAROU")
       fill_in "Description", with: "La belle absence"
       click_button("Enregistrer")
 
-      expect_page_title("Absences de Jane FAROU")
+      expect_page_title("Absences de Jane FAROU (PMI)")
       click_link "La belle absence"
 
       click_link("Supprimer")
-      expect_page_title("Absences de Jane FAROU")
+      expect_page_title("Absences de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n'a pas encore créé d'absence")
 
       click_link "Créer une absence", match: :first
@@ -69,7 +69,7 @@ describe "Agent can CRUD absences" do
       fill_in "absence[end_day]", with: Time.zone.today + 2
       click_button "Enregistrer"
 
-      expect_page_title("Absences de Jane FAROU")
+      expect_page_title("Absences de Jane FAROU (PMI)")
       click_link "Nouvelle Absence"
     end
   end

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -76,7 +76,7 @@ describe "Agent can CRUD plage d'ouverture" do
     it "can crud a plage_ouverture" do
       visit admin_organisation_agent_plage_ouvertures_path(organisation, other_agent.id)
 
-      expect_page_title("Plages d'ouverture de Jane FAROU")
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
       click_link "Permanence"
 
       expect_page_title("Permanence")
@@ -89,7 +89,7 @@ describe "Agent can CRUD plage d'ouverture" do
       expect_page_title("La belle plage")
       click_link("Supprimer")
 
-      expect_page_title("Plages d'ouverture de Jane FAROU")
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
 
       click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first


### PR DESCRIPTION
Nous avions fait une PR (en fait avec un patch en plus) pour masquer le nom du service auquel un agent appartient. Je crois que c'est mieux de le remettre (en attendant que nous changions les mécanismes autour des services).

Cette PR est un (en fait deux) revert des commits en questions.
