### PR TITLE
corrige la duplication de rendez-vous

### DIFF
--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -16,7 +16,7 @@
           span.badge.badge-danger
 
 - content_for :breadcrumb do
-  = link_to "Dupliquer…", admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context), class: "btn btn-outline-white"
+  = link_to "Dupliquer…", admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, motif_id: @rdv.motif_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context, commit: "commit"), class: "btn btn-outline-white"
 
 .row
   .col-md-6.mb-3


### PR DESCRIPTION
Pas de ticket sur ce point, mais une correction de la duplication d'un rdv.

Suite au message d'agent expliquant que la duplication ne fonctionne plus (depuis Zammad)
