### PR TITLE
Améliorations sur le mail quotidien de stats de mails et SMS

### DIFF
--- a/app/mailers/admins/system_mailer.rb
+++ b/app/mailers/admins/system_mailer.rb
@@ -1,7 +1,8 @@
 class Admins::SystemMailer < ApplicationMailer
   def rdv_events_stats
-    @today_stats = RdvEvent.date_stats(Date.today)
-    @yesterday_stats = RdvEvent.date_stats(Date.yesterday)
-    mail(to: "contact@rdv-solidarites.fr", subject: "[monitoring] Notifications Stats")
+    @today_stats = RdvEvent.date_stats(Time.zone.today)
+    @yesterday_stats = RdvEvent.date_stats(Time.zone.today - 1.day)
+    title = I18n.t("admins.system_mailer.rdv_events_stats.title", date: I18n.l(Time.zone.today))
+    mail(to: "contact@rdv-solidarites.fr", subject: "[monitoring] #{title}")
   end
 end

--- a/app/views/mailers/admins/system_mailer/rdv_events_stats.html.slim
+++ b/app/views/mailers/admins/system_mailer/rdv_events_stats.html.slim
@@ -1,19 +1,22 @@
-h1 Notification Stats
+h1= t('.title', date: l(Time.zone.today))
 
+h4= link_to t(".view_on_server"), health_checks_rdv_events_stats_url
+
+h3= t('.today')
 - @today_stats.each do |event_type, stats|
-  h3= "Today #{event_type}"
+  h4= RdvEvent.human_enum_name(:event_type, event_type)
   table
     - stats.each do |event_name, count|
       tr
-        td[style='text-align: right;']= event_name
+        td[style='text-align: right;']= RdvEvent.human_enum_name(:event_name, event_name)
         td[style='padding-left: 10px;']= count
 
-hr
-
-- @today_stats.each do |event_type, stats|
-  h3= "Yesterday #{event_type}"
+h3= t('.yesterday')
+- @yesterday_stats.each do |event_type, stats|
+  h4= RdvEvent.human_enum_name(:event_type, event_type)
   table
     - stats.each do |event_name, count|
       tr
-        td[style='text-align: right;']= event_name
+        td[style='text-align: right;']= RdvEvent.human_enum_name(:event_name, event_name)
         td[style='padding-left: 10px;']= count
+

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  admins:
+    system_mailer:
+      rdv_events_stats:
+        title: Notifications de RDV - %{date}
+        today: Aujourd’hui
+        yesterday: Hier
+        view_on_server: Page de monitoring

--- a/config/locales/models/rdv_event.fr.yml
+++ b/config/locales/models/rdv_event.fr.yml
@@ -1,0 +1,16 @@
+fr:
+  activerecord:
+    models:
+      rdv_event: Notification
+    attributes:
+      rdv_event:
+        event_types:
+          notification_sms: Par SMS
+          notification_mail: Par email
+        event_names:
+          cancelled_by_user: Annulation (par l’usager)
+          cancelled_by_agent: Annulation (par l’agent)
+          created: Création
+          updated: Mise à jour
+          upcoming_reminder: Rappel
+          total: Total


### PR DESCRIPTION
refs #1026

Je n’ai pas fait grand chose de plus que traduire, mais c’est plus clair pour moi comme ça. Il y avait aussi un bug: on affichait les `today_stats` pour hier comme pour aujourd’hui.

Avant:
<img width="774" alt="Capture d’écran 2021-04-26 à 16 19 04" src="https://user-images.githubusercontent.com/139391/116098492-6b046280-a6ab-11eb-992d-9b7d3b264116.png">
Après:
<img width="774" alt="Capture d’écran 2021-04-26 à 16 18 56" src="https://user-images.githubusercontent.com/139391/116098501-6d66bc80-a6ab-11eb-8c10-bbc50c4e79ad.png">

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
