### PR TITLE
Corrige la recherche d‘adresse avec un numéro de rue

### DIFF
--- a/app/webpacker/components/places-inputs.js
+++ b/app/webpacker/components/places-inputs.js
@@ -54,12 +54,15 @@ class PlacesInput {
   })
 
   remapBanStreetFeature = feature => {
-    if (feature.properties.type !== "street") return {}
-
-    return {
-      street_ban_id: feature.properties.id,
-      street_name: feature.properties.name
+    if (feature.properties.type === "street") {
+      return { street_ban_id: feature.properties.id }
     }
+    if (feature.properties.type === "housenumber") {
+      // 5 chars for city insee code, 1 for _, 4 for street fantoir
+      return { street_ban_id: feature.properties.id.substring(0,10) }
+    }
+
+    return {}
   }
 
   getFeatureValueText = ({ properties }) => {


### PR DESCRIPTION
fixes #1363, refs #1285

Pour #1285, je pense qu’on devrait passer l’identifiant BAN complet et l’interpréter _au mieux_ côté serveur.

WIP: 
* [x] ~~ça corrige le bug (enfin je crois :D) mais je vais tâcher d’écrire un test pour ça.~~ edit: places-input.js n’est pas facilement testable en l’état, et on aura l’occasion de réécrire des choses pour #1285, donc bon. Je propose de passer à autre chose. 😕 (note, l’implémentation actuelle est #935)

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app
