### PR TITLE
Envoie un ics pour le CUD des absences

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -49,6 +49,7 @@ class Admin::AbsencesController < AgentAuthController
     @absence.organisation = current_organisation
     authorize(@absence)
     if @absence.save
+      Agents::AbsenceMailer.absence_created(Admin::Ics::Absence.create_payload(@absence)).deliver_later
       flash[:notice] = "L'absence a été créée."
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
@@ -59,6 +60,7 @@ class Admin::AbsencesController < AgentAuthController
   def update
     authorize(@absence)
     if @absence.update(absence_params)
+      Agents::AbsenceMailer.absence_updated(Admin::Ics::Absence.update_payload(@absence)).deliver_later
       flash[:notice] = "L'absence a été modifiée."
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
@@ -69,6 +71,7 @@ class Admin::AbsencesController < AgentAuthController
   def destroy
     authorize(@absence)
     if @absence.destroy
+      Agents::AbsenceMailer.absence_destroyed(Admin::Ics::Absence.destroy_payload(@absence)).deliver_later
       flash[:notice] = "L'absence a été supprimée."
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else

--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -1,0 +1,38 @@
+class Agents::AbsenceMailer < ApplicationMailer
+  def absence_created(absence_payload)
+    send_mail(absence_payload)
+  end
+
+  def absence_updated(absence_payload)
+    send_mail(absence_payload)
+  end
+
+  def absence_destroyed(absence_payload)
+    send_mail(absence_payload)
+  end
+
+  private
+
+  def send_mail(absence_payload)
+    attachments[absence_payload[:name]] = {
+      mime_type: "text/calendar",
+      content: Admin::Ics::Absence.to_ical(absence_payload),
+      encoding: "8bit" # fixes encoding issues in ICS
+    }
+
+    m = mail(
+      from: "secretariat-auto@rdv-solidarites.fr",
+      to: absence_payload[:agent_email],
+      subject: "#{BRAND} - #{absence_payload[:title]}"
+    )
+    m.add_part(
+      Mail::Part.new do
+        content_type "text/calendar; method=REQUEST; charset=utf-8"
+        body Base64.encode64(Admin::Ics::Absence.to_ical(absence_payload))
+        content_transfer_encoding "base64"
+        # quoted-printable would be more adapted but there seems to be an encoding problem with extra =0D
+      end
+    )
+    m
+  end
+end

--- a/app/service_functions/admin/ics/absence.rb
+++ b/app/service_functions/admin/ics/absence.rb
@@ -1,0 +1,93 @@
+class Admin::Ics::Absence
+  include Admin::Ics
+
+  def self.create_payload(absence)
+    payload(absence).merge(action: :create)
+  end
+
+  def self.update_payload(absence)
+    payload(absence).merge(action: :update)
+  end
+
+  def self.destroy_payload(absence)
+    payload(absence).merge(action: :destroy)
+  end
+
+  def self.payload(absence)
+    {
+      name: "plage-ouverture-#{absence.title.parameterize}-#{absence.starts_at.to_s.parameterize}.ics",
+      agent_email: absence.agent.email,
+      starts_at: absence.starts_at,
+      recurrence: rrule(absence),
+      ical_uid: absence.ical_uid,
+      title: absence.title,
+      first_occurrence_ends_at: absence.first_occurrence_ends_at,
+    }
+  end
+
+  def self.to_ical(payload)
+    cal = Icalendar::Calendar.new
+
+    tz = TZInfo::Timezone.get Admin::Ics::TZID
+    timezone = tz.ical_timezone payload[:starts_at]
+    cal.add_timezone timezone
+    cal.prodid = BRAND
+    cal.event { populate_event(_1, payload) }
+    cal.ip_method = "REQUEST"
+    cal.to_ical
+  end
+
+  def self.populate_event(event, payload)
+    event.uid = payload[:ical_uid]
+    event.dtstart = Icalendar::Values::DateTime.new(payload[:starts_at], "tzid" => TZID)
+    event.dtend = Icalendar::Values::DateTime.new(payload[:first_occurrence_ends_at], "tzid" => TZID)
+    event.summary = "#{BRAND} #{payload[:title]}"
+    event.location = payload[:address]
+    event.ip_class = "PUBLIC"
+    event.rrule = payload[:recurrence]
+    event.status = Admin::Ics.status_from_action(payload[:action])
+    event.attendee = "mailto:#{payload[:agent_email]}"
+    event.organizer = "mailto:secretariat-auto@rdv-solidarites.fr"
+  end
+
+  def self.rrule(absence)
+    return if absence.recurrence.blank?
+
+    recurrence_hash = absence.recurrence.to_hash
+
+    case recurrence_hash[:every]
+    when :week
+      freq = "FREQ=WEEKLY;"
+      by_day = "BYDAY=#{by_week_day(recurrence_hash[:on])};" if recurrence_hash[:on]
+    when :month
+      freq = "FREQ=MONTHLY;"
+      by_day = "BYDAY=#{by_month_day(recurrence_hash[:day])};" if recurrence_hash[:day]
+    end
+
+    interval = interval_from_hash(recurrence_hash)
+
+    until_date = until_from_hash(recurrence_hash)
+
+    "#{freq}#{interval}#{by_day}#{until_date}"
+  end
+
+  def self.by_month_day(day)
+    "#{day.values.first.first}#{Date::DAYNAMES[day.keys.first][0, 2].upcase}"
+  end
+
+  def self.interval_from_hash(recurrence_hash)
+    "INTERVAL=#{recurrence_hash[:interval]};" if recurrence_hash[:interval]
+  end
+
+  def self.until_from_hash(recurrence_hash)
+    "UNTIL=#{Icalendar::Values::DateTime.new(recurrence_hash[:until], 'tzid' => TZID).value_ical};" if recurrence_hash[:until]
+  end
+
+  def self.by_week_day(on)
+    if on.is_a?(String)
+      on[0, 2].upcase
+    else
+      on.map { |d| d[0, 2].upcase }.join(",")
+    end
+  end
+end

--- a/app/service_functions/admin/ics/absence.rb
+++ b/app/service_functions/admin/ics/absence.rb
@@ -15,7 +15,7 @@ class Admin::Ics::Absence
 
   def self.payload(absence)
     {
-      name: "plage-ouverture-#{absence.title.parameterize}-#{absence.starts_at.to_s.parameterize}.ics",
+      name: "absence-#{absence.title.parameterize}-#{absence.starts_at.to_s.parameterize}.ics",
       agent_email: absence.agent.email,
       starts_at: absence.starts_at,
       recurrence: rrule(absence),

--- a/app/service_functions/admin/ics/absence.rb
+++ b/app/service_functions/admin/ics/absence.rb
@@ -21,7 +21,7 @@ class Admin::Ics::Absence
       recurrence: rrule(absence),
       ical_uid: absence.ical_uid,
       title: absence.title,
-      first_occurrence_ends_at: absence.first_occurrence_ends_at,
+      first_occurrence_ends_at: absence.first_occurrence_ends_at
     }
   end
 

--- a/app/views/mailers/agents/absence_mailer/absence_created.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_created.html.slim
@@ -1,0 +1,4 @@
+p Bonjour,
+
+p Vous venez de créer une absence sur votre planning de RDV Solidarités.
+p Vous pouvez synchroniser cette absence sur votre calendrier en ouvrant la pièce-jointe de cet email.

--- a/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
@@ -1,0 +1,4 @@
+p Bonjour,
+
+p Une de vos absences a été supprimée.
+p Vous pouvez supprimer l'événement correspondant de votre logiciel de calendrier externe (Outlook, Zimbra, Thunderbird etc) en ouvrant la pièce jointe

--- a/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
@@ -1,0 +1,4 @@
+p Bonjour,
+
+p Une de vos absences a été modifiée.
+p Vous pouvez synchroniser cette plage sur votre calendrier en ouvrant la pièce-jointe de cet email.

--- a/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
@@ -1,4 +1,4 @@
 p Bonjour,
 
 p Une de vos absences a été modifiée.
-p Vous pouvez synchroniser cette plage sur votre calendrier en ouvrant la pièce-jointe de cet email.
+p Vous pouvez synchroniser cette absence sur votre calendrier en ouvrant la pièce-jointe de cet email.

--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Admin::AbsencesController, type: :controller do
         end
 
         it "send notification after create" do
-          expect(Agents::AbsenceMailer).to receive(:absence_created).and_return(double(deliver_later: nil))
+          expect(Agents::AbsenceMailer).to receive(:absence_created).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
           post :create, params: { organisation_id: organisation.id, absence: valid_attributes }
         end
       end
@@ -174,7 +174,6 @@ RSpec.describe Admin::AbsencesController, type: :controller do
     end
 
     describe "PUT #update" do
-
       context "with valid params" do
         let(:new_attributes) do
           {
@@ -194,7 +193,7 @@ RSpec.describe Admin::AbsencesController, type: :controller do
         end
 
         it "send notification after update" do
-          expect(Agents::AbsenceMailer).to receive(:absence_updated).and_return(double(deliver_later: nil))
+          expect(Agents::AbsenceMailer).to receive(:absence_updated).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
           put :update, params: { organisation_id: organisation.id, id: absence.to_param, absence: new_attributes }
         end
       end
@@ -234,11 +233,10 @@ RSpec.describe Admin::AbsencesController, type: :controller do
       end
 
       it "send notification after delete" do
-        expect(Agents::AbsenceMailer).to receive(:absence_destroyed).and_return(double(deliver_later: nil))
+        expect(Agents::AbsenceMailer).to receive(:absence_destroyed).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
         delete :destroy, params: { organisation_id: organisation.id, id: absence.to_param }
       end
     end
-
   end
 
   context "agent can CRUD on his absences" do

--- a/spec/mailers/previews/agents/absence_mailer_preview.rb
+++ b/spec/mailers/previews/agents/absence_mailer_preview.rb
@@ -1,0 +1,16 @@
+class Agents::AbsenceMailerPreview < ActionMailer::Preview
+  def absence_created
+    absence = Absence.last
+    Agents::AbsenceMailer.absence_created(Admin::Ics::Absence.create_payload(absence))
+  end
+
+  def absence_updated
+    absence = Absence.last
+    Agents::AbsenceMailer.absence_updated(Admin::Ics::Absence.create_payload(absence))
+  end
+
+  def absence_destroyed
+    absence = Absence.last
+    Agents::AbsenceMailer.absence_destroyed(Admin::Ics::Absence.create_payload(absence))
+  end
+end

--- a/spec/mailers/previews/agents/plage_ouverture_mailer_preview.rb
+++ b/spec/mailers/previews/agents/plage_ouverture_mailer_preview.rb
@@ -1,11 +1,16 @@
 class Agents::PlageOuvertureMailerPreview < ActionMailer::Preview
   def plage_ouverture_created
     plage_ouverture = PlageOuverture.last
-    Agents::PlageOuvertureMailer.plage_ouverture_created(plage_ouverture)
+    Agents::PlageOuvertureMailer.plage_ouverture_created(Admin::Ics::PlageOuverture.create_payload(plage_ouverture))
   end
 
   def plage_ouverture_updated
     plage_ouverture = PlageOuverture.last
-    Agents::PlageOuvertureMailer.plage_ouverture_updated(plage_ouverture)
+    Agents::PlageOuvertureMailer.plage_ouverture_updated(Admin::Ics::PlageOuverture.create_payload(plage_ouverture))
+  end
+
+  def plage_ouverture_destroyed
+    plage_ouverture = PlageOuverture.last
+    Agents::PlageOuvertureMailer.plage_ouverture_destroyed(Admin::Ics::PlageOuverture.create_payload(plage_ouverture))
   end
 end

--- a/spec/service_functions/admin/ics/absence_spec.rb
+++ b/spec/service_functions/admin/ics/absence_spec.rb
@@ -10,7 +10,7 @@ describe Admin::Ics::Absence, type: :service do
     describe ":name" do
       let(:absence) { build(:absence, title: "something", start_time: Time.zone.parse("12h30"), first_day: Date.new(2020, 11, 13)) }
 
-      it { expect(described_class.payload(absence)[:name]).to eq("plage-ouverture-something-2020-11-13-12-30-00-0100.ics") }
+      it { expect(described_class.payload(absence)[:name]).to eq("absence-something-2020-11-13-12-30-00-0100.ics") }
     end
 
     describe ":agent_email" do
@@ -66,7 +66,7 @@ describe Admin::Ics::Absence, type: :service do
     let(:now) { Time.zone.parse("20190628 17h43") }
     let(:payload) do
       {
-        name: "plage-ouverture--.ics",
+        name: "absence--.ics",
         agent_email: "bob@demo.rdv-solidarites.fr",
         starts_at: Time.zone.parse("20190704 15h00"),
         recurrence: "",

--- a/spec/service_functions/admin/ics/absence_spec.rb
+++ b/spec/service_functions/admin/ics/absence_spec.rb
@@ -50,7 +50,6 @@ describe Admin::Ics::Absence, type: :service do
 
       it { expect(described_class.payload(absence)[:first_occurrence_ends_at]).to eq(starts_at + 5.hours) }
     end
-
   end
 
   %i[create update destroy].each do |action|

--- a/spec/service_functions/admin/ics/absence_spec.rb
+++ b/spec/service_functions/admin/ics/absence_spec.rb
@@ -1,0 +1,179 @@
+describe Admin::Ics::Absence, type: :service do
+  describe "#payload" do
+    %i[name agent_email starts_at recurrence ical_uid title first_occurrence_ends_at].each do |key|
+      it "return an hash with key #{key}" do
+        absence = build(:absence)
+        expect(described_class.payload(absence)).to have_key(key)
+      end
+    end
+
+    describe ":name" do
+      let(:absence) { build(:absence, title: "something", start_time: Time.zone.parse("12h30"), first_day: Date.new(2020, 11, 13)) }
+
+      it { expect(described_class.payload(absence)[:name]).to eq("plage-ouverture-something-2020-11-13-12-30-00-0100.ics") }
+    end
+
+    describe ":agent_email" do
+      let(:absence) { build(:absence, agent: build(:agent, email: "polo@demo.rdv-solidarites.fr")) }
+
+      it { expect(described_class.payload(absence)[:agent_email]).to eq("polo@demo.rdv-solidarites.fr") }
+    end
+
+    describe ":starts_at" do
+      let(:starts_at) { Time.zone.parse("20201009 11h45") }
+      let(:absence) { build(:absence, start_time: starts_at, first_day: starts_at.to_date) }
+
+      it { expect(described_class.payload(absence)[:starts_at]).to eq(starts_at) }
+    end
+
+    describe ":recurrence" do
+      let(:absence) { build(:absence, recurrence: Montrose.every(:week, starts: Date.new(2020, 11, 18), on: [:wednesday]).to_json) }
+
+      it { expect(described_class.payload(absence)[:recurrence]).to eq("FREQ=WEEKLY;BYDAY=WE;") }
+    end
+
+    describe ":ical_uid" do
+      let(:absence) { create(:absence) }
+
+      it { expect(described_class.payload(absence)[:ical_uid]).to eq("absence_#{absence.id}@#{BRAND}") }
+    end
+
+    describe ":title" do
+      let(:absence) { build(:absence, title: "Permanence") }
+
+      it { expect(described_class.payload(absence)[:title]).to eq("Permanence") }
+    end
+
+    describe ":first_occurrence_ends_at" do
+      let(:starts_at) { Time.zone.parse("20201009 11h45") }
+      let(:absence) { build(:absence, end_time: starts_at + 5.hours, first_day: starts_at.to_date) }
+
+      it { expect(described_class.payload(absence)[:first_occurrence_ends_at]).to eq(starts_at + 5.hours) }
+    end
+
+  end
+
+  %i[create update destroy].each do |action|
+    describe "##{action}_payload_for" do
+      it "return an hash with key action key and value #{action}" do
+        expect(described_class.send("#{action}_payload", build(:absence))[:action]).to eq(action)
+      end
+    end
+  end
+
+  describe "#to_ical" do
+    subject { described_class.to_ical(payload) }
+
+    let(:now) { Time.zone.parse("20190628 17h43") }
+    let(:payload) do
+      {
+        name: "plage-ouverture--.ics",
+        agent_email: "bob@demo.rdv-solidarites.fr",
+        starts_at: Time.zone.parse("20190704 15h00"),
+        recurrence: "",
+        ical_uid: "absence_15@RDV Solidarités",
+        title: "Elisa SIMON <> Consultation initiale",
+        first_occurrence_ends_at: Time.zone.parse("20190704 15h45"),
+        address: "10 rue de la Ferronerie 44100 Nantes"
+      }
+    end
+    let(:first_day) { Date.new(2019, 7, 22) }
+
+    before { travel_to(now) }
+
+    after { travel_back }
+
+    it do
+      expect(subject).to include("METHOD:REQUEST")
+      expect(subject).to include("BEGIN:VEVENT")
+      expect(subject).to include("DTSTAMP:20190628T154300Z")
+      expect(subject).to include("DTSTART;TZID=Europe/Paris:20190704T150000")
+      expect(subject).to include("DTEND;TZID=Europe/Paris:20190704T154500")
+      expect(subject).to include("CLASS:PUBLIC")
+      expect(subject).to include("UID:absence_15@RDV Solidarités")
+      expect(subject).to include("SUMMARY:RDV Solidarités Elisa SIMON <> Consultation initiale")
+      expect(subject).to include("LOCATION:10 rue de la Ferronerie 44100 Nantes")
+      expect(subject).to include("END:VEVENT")
+    end
+
+    context "with a create action" do
+      subject { described_class.to_ical(create_payload) }
+
+      let(:create_payload) { payload.merge(action: :create) }
+
+      it { is_expected.to include("STATUS:CONFIRMED") }
+    end
+
+    context "with an update action" do
+      subject { described_class.to_ical(update_payload) }
+
+      let(:update_payload) { payload.merge(action: :update) }
+
+      it { is_expected.to include("STATUS:CONFIRMED") }
+    end
+
+    context "with a destroy action" do
+      subject { described_class.to_ical(destroy_payload) }
+
+      let(:destroy_payload) { payload.merge(action: :destroy) }
+
+      it { is_expected.to include("STATUS:CANCELLED") }
+    end
+
+    context "with recurrence" do
+      subject { described_class.to_ical(recurrence_payload) }
+
+      let(:recurrence_payload) { payload.merge(recurrence: "FREQ=WEEKLY;") }
+
+      it { is_expected.to include("FREQ=WEEKLY") }
+    end
+  end
+
+  describe "#rrule" do
+    subject { described_class.rrule(absence) }
+
+    let(:now) { Time.zone.parse("20190628 17h43") }
+    let(:absence) { build(:absence, recurrence: recurrence) }
+    let(:first_day) { Date.new(2019, 7, 22) }
+
+    before { travel_to(now) }
+
+    after { travel_back }
+
+    context "every week" do
+      let(:recurrence) { Montrose.every(:week, on: ["monday"], starts: first_day) }
+
+      it { is_expected.to eq("FREQ=WEEKLY;BYDAY=MO;") }
+
+      context "on monday and wednesday" do
+        let(:recurrence) { Montrose.every(:week, on: %w[monday tuesday wednesday thursday friday saturday], starts: first_day) }
+
+        it { is_expected.to eq("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA;") }
+      end
+
+      context "until 22/10/2019" do
+        let(:recurrence) { Montrose.every(:week, until: Time.zone.local(2019, 10, 22), starts: first_day) }
+
+        it { is_expected.to eq("FREQ=WEEKLY;UNTIL=20191022T000000;") }
+      end
+    end
+
+    context "every 2 weeks" do
+      let(:recurrence) { Montrose.every(:week, interval: 2, starts: first_day) }
+
+      it { is_expected.to eq("FREQ=WEEKLY;INTERVAL=2;") }
+    end
+
+    context "every month" do
+      let(:recurrence) { Montrose.every(:month, starts: first_day) }
+
+      it { is_expected.to eq("FREQ=MONTHLY;") }
+
+      context "the 2nd wednesday of the month" do
+        let(:recurrence) { Montrose.every(:month, day: { 3 => [2] }, starts: first_day) }
+
+        it { is_expected.to eq("FREQ=MONTHLY;BYDAY=2WE;") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #1051 

Envoie des fichiers ICS pour les créations, suppression et mise à jour d'absence. À la manière des plages d'ouverture.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
