### PR TITLE
fige le temps utilisé dans les tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,30 +94,3 @@ jobs:
           POSTGRES_DB: lapin_test
           NUMBER_OF_NODES: 5
           CI_NODE_INDEX: ${{ matrix.index }}
-  deploy:
-    if: ${{ github.ref == 'refs/heads/master' }}
-    name: Deploy
-    runs-on: ubuntu-latest
-    environment: lapin-beta-gouv
-    needs: [tests, brakeman, test_seeds, rubocop]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure SSH
-        run: |
-          echo "Creating TAR archive..."
-          tar --transform='s,^,master/,' -czf /tmp/archive.tar.gz .
-          echo "Downloading scaliogo CLI"
-          version=$(curl -s https://cli-dl.scalingo.com/version | tr -d ' \t\n')
-          curl -L https://github.com/Scalingo/cli/releases/download/${version}/scalingo_${version}_linux_amd64.tar.gz -o /tmp/scalingo_cli.tar.gz
-          mkdir /tmp/scalingo_cli
-          tar -C /tmp/scalingo_cli -xf /tmp/scalingo_cli.tar.gz
-          export PATH=$PATH:/tmp/scalingo_cli/scalingo_${version}_linux_amd64
-          echo "Authenticating..."
-          scalingo login --api-token $API_TOKEN
-          echo "Starting deployment"
-          scalingo --region $REGION --app demo-rdv-solidarites deploy /tmp/archive.tar.gz
-          scalingo --region $REGION --app production-rdv-solidarites deploy /tmp/archive.tar.gz
-        env:
-          REGION: osc-secnum-fr1
-          API_TOKEN: ${{secrets.SCALINGO_API_TOKEN}}
-

--- a/spec/services/notifications/rdv/rdv_cancelled_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_service_spec.rb
@@ -1,34 +1,41 @@
 describe Notifications::Rdv::RdvCancelledService, type: :service do
-  subject { described_class.perform_with(rdv) }
-
-  let(:user1) { build(:user) }
-  let(:agent1) { build(:agent, first_name: "Sean", last_name: "PAUL") }
-  let(:agent2) { build(:agent) }
-  let(:starts_at_initial) { 2.hours.from_now }
-  let!(:rdv) { create_rdv_skip_notify(starts_at: starts_at_initial, users: [user1], agents: [agent1, agent2]) }
-
-  before do
-    PaperTrail.request.whodunnit = "[Agent] Sean PAUL"
-    update_rdv_skip_notify!(rdv, status: :excused)
-  end
 
   context "starts in more than 2 days" do
-    let(:starts_at_initial) { 3.days.from_now }
-
     it "does not triggers sending mail to agents" do
+      starts_at_initial = Time.zone.parse("2021-04-26 8h15")
+      travel_to(starts_at_initial)
+
+      agent1 = build(:agent, first_name: "Sean", last_name: "PAUL")
+      agent2 = build(:agent)
+      rdv =  create_rdv_skip_notify(starts_at: starts_at_initial + 3.days, agents: [agent1, agent2])
+
+      PaperTrail.request.whodunnit = "[Agent] Sean PAUL"
+      update_rdv_skip_notify!(rdv, status: :excused)
+
       expect(Agents::RdvMailer).not_to receive(:rdv_starting_soon_cancelled)
-      subject
+      described_class.perform_with(rdv)
     end
   end
 
   context "starts today or tomorrow" do
     it "triggers sending mails to the agents (except the one who initiated the change)" do
+      starts_at_initial = Time.zone.parse("2021-04-29 8h15")
+      travel_to(starts_at_initial)
+
+      agent1 = build(:agent, first_name: "Sean", last_name: "PAUL")
+      agent2 = build(:agent)
+      rdv =  create_rdv_skip_notify(starts_at: starts_at_initial + 1.day, agents: [agent1, agent2])
+
+      PaperTrail.request.whodunnit = "[Agent] Sean PAUL"
+      update_rdv_skip_notify!(rdv, status: :excused)
+
+
       expect(Agents::RdvMailer).not_to receive(:rdv_starting_soon_cancelled)
         .with(rdv, agent1, "[Agent] Sean PAUL", starts_at_initial)
       expect(Agents::RdvMailer).to receive(:rdv_starting_soon_cancelled)
         .with(rdv, agent2, "[Agent] Sean PAUL")
         .and_return(double(deliver_later: nil))
-      subject
+      described_class.perform_with(rdv)
     end
   end
 end

--- a/spec/services/notifications/rdv/rdv_cancelled_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_service_spec.rb
@@ -1,5 +1,4 @@
 describe Notifications::Rdv::RdvCancelledService, type: :service do
-
   context "starts in more than 2 days" do
     it "does not triggers sending mail to agents" do
       starts_at_initial = Time.zone.parse("2021-04-26 8h15")
@@ -28,7 +27,6 @@ describe Notifications::Rdv::RdvCancelledService, type: :service do
 
       PaperTrail.request.whodunnit = "[Agent] Sean PAUL"
       update_rdv_skip_notify!(rdv, status: :excused)
-
 
       expect(Agents::RdvMailer).not_to receive(:rdv_starting_soon_cancelled)
         .with(rdv, agent1, "[Agent] Sean PAUL", starts_at_initial)


### PR DESCRIPTION
Pour faire en sorte que le test soit plus lisible et fonction à chaque heure de le journée
