### PR TITLE
Fix superadmin after upgrade to rails 6.0.3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "pg", ">= 0.18", "< 2.0"
 gem "pg_search", "~> 2.3"
 gem "kaminari", "~> 1.2"
 gem "bootstrap4-kaminari-views", "~> 1.0"
-gem "administrate"
+gem "administrate", git: "https://github.com/thoughtbot/administrate.git", ref: "refs/pull/1972/head" # Provides an administration UI (pull request #1972 has fixes for Rails 6.1.3.2)
 gem "administrate-field-belongs_to_search"
 gem "paper_trail"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,22 @@ GIT
       activesupport (~> 6.0.3.5)
       railties (~> 6.0.3.5)
 
+GIT
+  remote: https://github.com/thoughtbot/administrate.git
+  revision: 0e4c1865df14bbfcbee0b16979910c4f5b49ba2f
+  ref: refs/pull/1972/head
+  specs:
+    administrate (0.15.0)
+      actionpack (>= 5.0)
+      actionview (>= 5.0)
+      activerecord (>= 5.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,16 +94,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    administrate (0.15.0)
-      actionpack (>= 5.0)
-      actionview (>= 5.0)
-      activerecord (>= 5.0)
-      datetime_picker_rails (~> 0.0.7)
-      jquery-rails (>= 4.0)
-      kaminari (>= 1.0)
-      momentjs-rails (~> 2.8)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
     administrate-field-belongs_to_search (0.7.0)
       administrate (>= 0.3, < 1.0)
       jbuilder (~> 2)
@@ -569,7 +575,7 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel-caution!
-  administrate
+  administrate!
   administrate-field-belongs_to_search
   better_errors
   binding_of_caller


### PR DESCRIPTION
administrate currently crashes in rails 6.0.3.7 and 6.1.3.2 with the error “Please use symbols for polymorphic route arguments.”. A fix is coming in https://github.com/thoughtbot/administrate/pull/1972, but we can’t really wait, and we can’t rollback rails either.

👋 Coucou la team DS https://github.com/betagouv/demarches-simplifiees.fr/pull/6178

close #issue_number

// Description de la fonctionnalité ou du bug

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app
