### PR TITLE
autorise les iframe

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,4 +83,8 @@ class ApplicationController < ActionController::Base
     parsed_uri.to_s
   end
   helper_method :add_query_string_params_to_url
+
+  def allow_iframe
+    response.headers.except! "X-Frame-Options"
+  end
 end

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -4,6 +4,7 @@ class LieuxController < ApplicationController
     :set_lieu_variables,
     :redirect_if_user_offline_and_motif_follow_up,
     :redirect_if_no_matching_motifs
+  after_action :allow_iframe
 
   def index
     @lieux = Lieu

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -1,6 +1,7 @@
 class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = %i[lieu_id departement where created_user_id latitude longitude city_code street_ban_id].freeze
+  after_action :allow_iframe
 
   def new
     @rdv_wizard = rdv_wizard_for(current_user, query_params)

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -1,6 +1,7 @@
 class Users::RdvsController < UserAuthController
   before_action :set_rdv, only: [:cancel]
   before_action :set_geo_search, only: [:create]
+  after_action :allow_iframe
 
   def index
     @rdvs = policy_scope(Rdv).includes(:motif, :rdvs_users, :users)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,6 +2,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   layout :user_devise_layout
 
   include CanHaveRdvWizardContext
+  after_action :allow_iframe
 
   def create
     return invite_and_redirect if User.find_by(email: sign_up_params[:email], confirmed_at: nil)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,7 @@ class Users::SessionsController < Devise::SessionsController
   include CanHaveRdvWizardContext
 
   before_action :exclude_signed_in_agents, only: [:new]
+  after_action :allow_iframe
 
   def create
     if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -4,6 +4,7 @@ class WelcomeController < ApplicationController
   ].freeze
 
   before_action :set_lieu_variables, only: %i[welcome_departement welcome_service]
+  after_action :allow_iframe
 
   def index; end
 


### PR DESCRIPTION
Pour permettre au 62 d'utiliser RDV-Solidarités dans une iframe.

Il y aurait peut-être quelque chose à creuser autour de composant qui s'intègre dans une application existante (pour l'interface usager)