### PR TITLE
Filtre les RDV par date dans le json pour l’agenda

### DIFF
--- a/app/controllers/admin/agents/rdvs_controller.rb
+++ b/app/controllers/admin/agents/rdvs_controller.rb
@@ -6,6 +6,7 @@ class Admin::Agents::RdvsController < ApplicationController
     agent = Agent.find(params[:agent_id])
     @organisation = Organisation.find(params[:organisation_id])
     @rdvs = custom_policy.with_agent(agent).includes(%i[organisation lieu motif users])
+    @rdvs = @rdvs.where(starts_at: date_range_params) if date_range_params.present?
   end
 
   private
@@ -19,5 +20,13 @@ class Admin::Agents::RdvsController < ApplicationController
 
   def pundit_user
     AgentContext.new(current_agent)
+  end
+
+  def date_range_params
+    return unless params[:start].present? && params[:end].present?
+
+    start_param = Time.zone.parse(params[:start])
+    end_param = Time.zone.parse(params[:end])
+    start_param..end_param
   end
 end

--- a/spec/controllers/admin/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/agents/rdvs_controller_spec.rb
@@ -28,9 +28,9 @@ describe Admin::Agents::RdvsController, type: :controller do
         now = Time.zone.parse("2021-01-23 10h00")
         travel_to(now)
 
-        create(:rdv, starts_at: now - 1.day)
+        create(:rdv, agents: [agent], organisation: organisation, starts_at: now - 1.day)
         rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 2.days)
-        create(:rdv, starts_at: now + 8.days)
+        create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 8.days)
 
         get :index, params: { agent_id: agent.id, organisation_id: organisation.id, start: now, end: now + 7.days, format: :json }
         expect(assigns(:rdvs)).to eq([rdv])


### PR DESCRIPTION
followup #1396

A priori, seul `admin/agents/:id/rdvs` est concerné, et pas `plage_ouvertures` ni `absences`.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
