### PR TITLE
SMS-Configuration #2 Utilise la configuration sms en db link to 1408

### DIFF
--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -29,7 +29,7 @@ class SendTransactionalSmsService < BaseService
 
   def send_with_send_in_blue
     config = SibApiV3Sdk::Configuration.new
-    config.api_key = @configuration["send_in_blue"]["api_key"]
+    config.api_key = @configuration["api_key"]
     api_client = SibApiV3Sdk::ApiClient.new(config)
     SibApiV3Sdk::TransactionalSMSApi.new(api_client).send_transac_sms(
       SibApiV3Sdk::SendTransacSms.new(
@@ -43,9 +43,9 @@ class SendTransactionalSmsService < BaseService
 
   def send_with_netsize
     request = Typhoeus::Request.new(
-      @configuration["netsize"]["api_url"],
+      @configuration["api_url"],
       method: :post,
-      userpwd: @configuration["netsize"]["user_pwd"],
+      userpwd: @configuration["user_pwd"],
       headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
       timeout: 5,
       body: {

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -35,11 +35,10 @@ class SendTransactionalSmsService < BaseService
   end
 
   def send_with_send_in_blue
-    SibApiV3Sdk.configure do |config|
-      config.api_key["api-key"] = @configuration["send_in_blue"]["api_key"]
-    end
-
-    SibApiV3Sdk::TransactionalSMSApi.new.send_transac_sms(
+    config = SibApiV3Sdk::Configuration.new
+    config.api_key = @configuration["send_in_blue"]["api_key"]
+    api_client = SibApiV3Sdk::ApiClient.new(config)
+    SibApiV3Sdk::TransactionalSMSApi.new(api_client).send_transac_sms(
       SibApiV3Sdk::SendTransacSms.new(
         sender: SENDER_NAME,
         recipient: transactional_sms.phone_number_formatted,

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -49,7 +49,6 @@ class SendTransactionalSmsService < BaseService
   end
 
   def send_with_netsize
-    # "https://europe.ipx.com/restapi/v1/sms/send"
     request = Typhoeus::Request.new(
       @configuration["netsize"]["api_url"],
       method: :post,

--- a/config/initializers/sendinblue.rb
+++ b/config/initializers/sendinblue.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-SibApiV3Sdk.configure do |config|
-  config.api_key["api-key"] = ENV["SENDINBLUE_SMS_API_KEY"]
-end

--- a/spec/services/send_transactional_sms_service_spec.rb
+++ b/spec/services/send_transactional_sms_service_spec.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
 describe SendTransactionalSmsService, type: :service do
-  subject { described_class.new(transactional_sms) }
+  let(:sms_configuration) do
+    {
+      send_in_blue: {
+        api_key: ""
+      },
+      netsize: {
+        api_url: "https://europe.ipx.com/restapi/v1/sms/send",
+        user_pwd: "Ubb3rP4ss0wrD"
+      }
+    }
+  end
 
   let(:transactional_sms) do
     instance_double(
       TransactionalSms::RdvCreated,
       phone_number_formatted: "+33606060606",
       content: "Bonjour c'est rdv-sol",
-      tags: ["RDV-Sol test", 10, "rdv_created"]
+      tags: ["RDV-Sol test", 10, "rdv_created"],
+      rdv: build(:rdv, \
+                 organisation: build(:organisation, \
+                                     territory: build(:territory, \
+                                                      sms_configuration: sms_configuration)))
     )
   end
 
@@ -16,6 +30,7 @@ describe SendTransactionalSmsService, type: :service do
     context "production with SIB forced" do
       before do
         allow(Rails.env).to receive(:production?).and_return(true)
+        allow(ENV).to receive(:[]).with("SENDINBLUE_SMS_API_KEY").and_return("send_in_blue")
         allow(ENV).to receive(:[]).with("FORCE_SMS_PROVIDER").and_return("send_in_blue")
       end
 
@@ -23,7 +38,7 @@ describe SendTransactionalSmsService, type: :service do
         sib_api_mock = instance_double(SibApiV3Sdk::TransactionalSMSApi)
         allow(SibApiV3Sdk::TransactionalSMSApi).to receive(:new).and_return(sib_api_mock)
         expect(sib_api_mock).to receive(:send_transac_sms)
-        subject.perform
+        described_class.new(transactional_sms).perform
       end
     end
 
@@ -31,10 +46,8 @@ describe SendTransactionalSmsService, type: :service do
       before { allow(Rails.env).to receive(:production?).and_return(false) }
 
       it "does not call netsize nor SIB" do
-        # allow(Rails.logger).to receive(:debug).and_call_original # so that other calls to debug work
-        # expect(Rails.logger).to receive(:debug).with(/following SMS would have been sent/)
         expect(SibApiV3Sdk::TransactionalSMSApi).not_to receive(:new)
-        subject.perform
+        described_class.new(transactional_sms).perform
       end
     end
   end


### PR DESCRIPTION
Deuxième étape, lié au #1408 

Maintenant que la base contient la configuration SMS, nous allons l'utilisé pour l'envoie des notifications.

**PR Clef dans la migration, les notifications doivent continuer à être envoyées après sa livraison :)**

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
