### PR TITLE
répare les dashboards restants du superadmin

### DIFF
--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -13,10 +13,7 @@ class AgentDashboard < Administrate::BaseDashboard
     first_name: Field::String,
     last_name: Field::String,
     organisations: Field::HasMany,
-    plage_ouvertures: Field::HasMany,
-    absences: Field::HasMany,
     service: Field::BelongsTo,
-    rdvs: Field::HasMany,
     invitation_sent_at: Field::DateTime,
     deleted_at: Field::DateTime,
     created_at: Field::DateTime,
@@ -44,9 +41,6 @@ class AgentDashboard < Administrate::BaseDashboard
     last_name
     organisations
     service
-    plage_ouvertures
-    absences
-    rdvs
     invitation_sent_at
     created_at
     deleted_at

--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -11,7 +11,6 @@ class OrganisationDashboard < Administrate::BaseDashboard
     id: Field::Number,
     name: Field::String,
     agents: Field::HasMany,
-    lieux: Field::HasMany,
     motifs: Field::HasMany,
     horaires: Field::String,
     phone_number: Field::String,
@@ -38,7 +37,6 @@ class OrganisationDashboard < Administrate::BaseDashboard
     horaires
     phone_number
     agents
-    lieux
     motifs
     human_id
     created_at
@@ -53,7 +51,6 @@ class OrganisationDashboard < Administrate::BaseDashboard
     horaires
     phone_number
     agents
-    lieux
     human_id
   ].freeze
 

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -22,7 +22,6 @@ class UserDashboard < Administrate::BaseDashboard
     family_situation: EnumField,
     affiliation_number: Field::String,
     number_of_children: Field::Number,
-    rdvs: Field::HasMany,
     birth_date: Field::DateTime,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -58,7 +57,6 @@ class UserDashboard < Administrate::BaseDashboard
     affiliation_number
     family_situation
     number_of_children
-    rdvs
     created_at
     updated_at
     deleted_at


### PR DESCRIPTION
Pour réparer https://sentry.io/organizations/rdv-solidarites/issues/2393361557/?project=1811205&query=is%3Aunresolved

En supprimant des dashboards, j'ai créé des erreurs dans la vue de certains éléments restants. Cette PR les nettoies.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
