### PR TITLE
Remove Spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,12 +119,7 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem "web-console", ">= 3.3.0"
   gem "listen", ">= 3.0.5", "< 3.2"
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem "spring"
-  gem "spring-commands-rspec"
   gem "guard-rspec", require: false
-  gem "guard-spring"
-  gem "spring-watcher-listen", "~> 2.0.0"
   gem "letter_opener", "~> 1.7"
   gem "fuubar"
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,10 +217,6 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    guard-spring (1.1.1)
-      guard (~> 2.0)
-      guard-compat (~> 1.1)
-      spring
     hashie (4.1.0)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -510,12 +506,6 @@ GEM
       tilt (>= 2.0.6, < 2.1)
     spreadsheet (1.2.6)
       ruby-ole (>= 1.0)
-    spring (2.1.1)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -608,7 +598,6 @@ DEPENDENCIES
   fuubar
   groupdate (~> 4.2)
   guard-rspec
-  guard-spring
   icalendar (~> 2.5)
   image_processing (~> 1.8)
   jbuilder (~> 2.5)
@@ -644,9 +633,6 @@ DEPENDENCIES
   skylight
   slim (~> 4.0)
   spreadsheet
-  spring
-  spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
   sprockets-rails
   tod (~> 2.2)
   turbolinks (~> 5)


### PR DESCRIPTION
Avec bootsnap, la différence de performance est négligeable, et pour une raison que j’ignore et que je ne veux pas investiguer, ça fait tourner deux cores à 100%. Adrien me disait qu’il avait le même problème. @yaf tu en penses quoi?

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
