### PR TITLE
Refactor pour les notifications des agents 

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -11,4 +11,11 @@ module DateHelper
       l(date, format: fallback_format)
     end
   end
+
+  # true if the passed date (or time) is today or tomorrow
+  def soon_date?(date)
+    return false unless date.respond_to?(:to_date)
+
+    [Date.current, Date.current + 1].include?(date.to_date)
+  end
 end

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DateHelper
+  def relative_date(date, fallback_format = :short)
+    date = date.to_date
+    if date == Date.current
+      t "date.helpers.today"
+    elsif date == Date.current + 1
+      t "date.helpers.tomorrow"
+    else
+      l(date, format: fallback_format)
+    end
+  end
+end

--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 class Agents::RdvMailer < ApplicationMailer
+  include DateHelper
+  add_template_helper DateHelper
+
   def rdv_starting_soon_created(rdv, agent)
     @rdv = rdv
     @agent = agent
-    @date_str = date_to_string(@rdv.starts_at.to_date)
+
     mail(
       to: agent.email,
-      subject: "Nouveau RDV ajouté sur votre agenda rdv-solidarités pour #{@date_str}"
+      subject: "Nouveau RDV ajouté sur votre agenda rdv-solidarités pour #{relative_date @rdv.starts_at}"
     )
   end
 
@@ -15,23 +18,17 @@ class Agents::RdvMailer < ApplicationMailer
     @rdv = rdv
     @agent = agent
     @cancelled_by_str = cancelled_by_str
-    @date_str = date_to_string(@rdv.starts_at.to_date)
-    mail(to: agent.email, subject: "RDV annulé #{@date_str}")
+
+    mail(to: agent.email, subject: "RDV annulé #{relative_date @rdv.starts_at}")
   end
 
-  def rdv_starting_soon_date_updated(rdv, agent, rdv_updated_by_str, rdv_starts_at_before_update)
+  def rdv_starting_soon_date_updated(rdv, agent, rdv_updated_by_str)
+    old_starts_at = rdv.attribute_before_last_save(:starts_at)
     @rdv = rdv
     @agent = agent
     @rdv_updated_by_str = rdv_updated_by_str
-    @rdv_starts_at_before_update_date_str = date_to_string(rdv_starts_at_before_update.to_date)
-    @rdv_starts_at_before_update = rdv_starts_at_before_update
-    mail(to: agent.email, subject: "RDV #{@rdv_starts_at_before_update_date_str} reporté à plus tard")
-  end
+    @old_starts_at = old_starts_at
 
-  private
-
-  def date_to_string(date)
-    # TODO: should be a helper
-    { Date.today => "aujourd'hui", Date.tomorrow => "demain" }[date]
+    mail(to: agent.email, subject: "RDV #{relative_date old_starts_at} reporté à plus tard")
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -88,7 +88,7 @@ class Rdv < ApplicationRecord
   end
 
   def today?
-    starts_at.to_date.today?
+    Time.zone.today == starts_at.to_date
   end
 
   def temporal_status

--- a/app/services/notifications/rdv/base_service_concern.rb
+++ b/app/services/notifications/rdv/base_service_concern.rb
@@ -2,6 +2,7 @@
 
 module Notifications::Rdv::BaseServiceConcern
   extend ActiveSupport::Concern
+  include DateHelper
 
   def initialize(rdv)
     @rdv = rdv
@@ -10,25 +11,48 @@ module Notifications::Rdv::BaseServiceConcern
   def perform
     return false if @rdv.starts_at < Time.zone.now || !@rdv.motif.visible_and_notified?
 
-    if methods.include?(:notify_user_by_mail)
-      users_to_notify
-        .select(&:notifiable_by_email?)
-        .each { notify_user_by_mail(_1) }
-    end
-
-    if methods.include?(:notify_user_by_sms)
-      users_to_notify
-        .select(&:notifiable_by_sms?)
-        .each { notify_user_by_sms(_1) }
-    end
-
-    @rdv.agents.each { notify_agent(_1) } if methods.include?(:notify_agent)
+    notify_users_by_mail
+    notify_users_by_sms
+    notify_agents
 
     true
   end
 
+  private
+
+  def notify_users_by_mail
+    return unless methods.include?(:notify_user_by_mail)
+
+    users_to_notify
+      .select(&:notifiable_by_email?)
+      .each { notify_user_by_mail(_1) }
+  end
+
+  def notify_users_by_sms
+    return unless methods.include?(:notify_user_by_sms)
+
+    users_to_notify
+      .select(&:notifiable_by_sms?)
+      .each { notify_user_by_sms(_1) }
+  end
+
+  def notify_agents
+    return unless methods.include?(:notify_agent)
+
+    @rdv.agents
+      .select { should_notify_agent(_1) }
+      .each { notify_agent(_1) }
+  end
+
   def users_to_notify
     @rdv.users.map(&:user_to_notify).uniq
+  end
+
+  def should_notify_agent(agent)
+    return false if change_triggered_by?(agent)
+    return false if !soon_date?(@rdv.starts_at) && !soon_date?(@rdv.attribute_before_last_save(:starts_at))
+
+    true
   end
 
   protected

--- a/app/services/notifications/rdv/rdv_cancelled_service.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_service.rb
@@ -6,9 +6,6 @@ class Notifications::Rdv::RdvCancelledService < ::BaseService
   protected
 
   def notify_agent(agent)
-    return if change_triggered_by?(agent)
-    return unless soon_date?(@rdv.starts_at)
-
     Agents::RdvMailer
       .rdv_starting_soon_cancelled(@rdv, agent, change_triggered_by_str)
       .deliver_later

--- a/app/services/notifications/rdv/rdv_cancelled_service.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_service.rb
@@ -6,9 +6,8 @@ class Notifications::Rdv::RdvCancelledService < ::BaseService
   protected
 
   def notify_agent(agent)
-    return false if \
-      change_triggered_by?(agent) ||
-      [Date.today, Date.tomorrow].exclude?(@rdv.starts_at.to_date)
+    return if change_triggered_by?(agent)
+    return unless soon_date?(@rdv.starts_at)
 
     Agents::RdvMailer
       .rdv_starting_soon_cancelled(@rdv, agent, change_triggered_by_str)

--- a/app/services/notifications/rdv/rdv_created_service.rb
+++ b/app/services/notifications/rdv/rdv_created_service.rb
@@ -16,7 +16,7 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
   end
 
   def notify_agent(agent)
-    return false unless [Date.today, Date.tomorrow].include?(@rdv.starts_at.to_date)
+    return unless soon_date?(@rdv.starts_at)
 
     Agents::RdvMailer.rdv_starting_soon_created(@rdv, agent).deliver_later
   end

--- a/app/services/notifications/rdv/rdv_created_service.rb
+++ b/app/services/notifications/rdv/rdv_created_service.rb
@@ -16,8 +16,6 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
   end
 
   def notify_agent(agent)
-    return unless soon_date?(@rdv.starts_at)
-
     Agents::RdvMailer.rdv_starting_soon_created(@rdv, agent).deliver_later
   end
 end

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -18,12 +18,10 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
   end
 
   def notify_agent(agent)
-    return if change_triggered_by?(agent)
-    return unless soon_date?(@rdv.starts_at) || soon_date?(@rdv.starts_at_before_last_save)
-
     Agents::RdvMailer.rdv_starting_soon_date_updated(
       @rdv,
       agent,
-      change_triggered_by_str).deliver_later
+      change_triggered_by_str
+    ).deliver_later
   end
 end

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -18,9 +18,8 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
   end
 
   def notify_agent(agent)
-    return false if \
-      change_triggered_by?(agent) ||
-      [Date.today, Date.tomorrow].exclude?(@rdv.starts_at_before_last_save.to_date)
+    return if change_triggered_by?(agent)
+    return unless soon_date?(@rdv.starts_at) || soon_date?(@rdv.starts_at_before_last_save)
 
     Agents::RdvMailer.rdv_starting_soon_date_updated(
       @rdv,

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -25,8 +25,6 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
     Agents::RdvMailer.rdv_starting_soon_date_updated(
       @rdv,
       agent,
-      change_triggered_by_str,
-      @rdv.starts_at_before_last_save
-    ).deliver_later
+      change_triggered_by_str).deliver_later
   end
 end

--- a/app/views/mailers/admins/system_mailer/rdv_events_stats.html.slim
+++ b/app/views/mailers/admins/system_mailer/rdv_events_stats.html.slim
@@ -2,7 +2,7 @@ h1= t('.title', date: l(Time.zone.today))
 
 h4= link_to t(".view_on_server"), health_checks_rdv_events_stats_url
 
-h3= t('.today')
+h3= t('date.helpers.today').capitalize
 - @today_stats.each do |event_type, stats|
   h4= RdvEvent.human_enum_name(:event_type, event_type)
   table
@@ -11,7 +11,7 @@ h3= t('.today')
         td[style='text-align: right;']= RdvEvent.human_enum_name(:event_name, event_name)
         td[style='padding-left: 10px;']= count
 
-h3= t('.yesterday')
+h3= t('date.helpers.yesterday').capitalize
 - @yesterday_stats.each do |event_type, stats|
   h4= RdvEvent.human_enum_name(:event_type, event_type)
   table

--- a/app/views/mailers/agents/rdv_mailer/rdv_starting_soon_cancelled.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_starting_soon_cancelled.html.slim
@@ -1,7 +1,7 @@
 div
   p Bonjour,
   p
-    | Un RDV qui devait avoir lieu #{@date_str} vient d'être annulé par #{@cancelled_by_str}
+    | Un RDV qui devait avoir lieu #{relative_date @rdv.starts_at} vient d’être annulé par #{@cancelled_by_str}.
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter

--- a/app/views/mailers/agents/rdv_mailer/rdv_starting_soon_created.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_starting_soon_created.html.slim
@@ -1,7 +1,7 @@
 div
   p Bonjour,
   p
-    | Un nouveau RDV qui aura lieu #{@date_str} vient d'être ajouté à votre agenda
+    | Un nouveau RDV qui aura lieu #{relative_date @rdv.starts_at} vient d’être ajouté à votre agenda.
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter

--- a/app/views/mailers/agents/rdv_mailer/rdv_starting_soon_date_updated.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_starting_soon_date_updated.html.slim
@@ -1,7 +1,7 @@
 div
   p Bonjour,
   p
-    | Un RDV qui devait avoir lieu #{@rdv_starts_at_before_update_date_str} à #{l(@rdv_starts_at_before_update, format: "%H:%M")} vient d'être modifié par #{@rdv_updated_by_str}. La date de ce RDV a changé, voir ci-dessous:
+    | Un RDV qui devait avoir lieu #{relative_date @old_starts_at} à #{l(@old_starts_at, format: "%H:%M")} vient d'être modifié par #{@rdv_updated_by_str}. La date de ce RDV a changé, voir ci-dessous:
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -1,43 +1,39 @@
 - for_role = local_assigns.fetch(:for_role, :user)
 .overview
-  h3.aligncenter Recapitulatif
+  h3.aligncenter Récapitulatif
   div.row-result
-    span.title Date :
-    - if rdv.home?
-      span.float-right= l(rdv.starts_at, format: :human_approx)
-    - else
-      span.float-right= l(rdv.starts_at, format: :human)
+    span.title Date :
+    span.float-right= l(rdv.starts_at, format: (rdv.home? ? :human_approx : :human))
     .clear
   - if for_role == :agent
     div.row-result
-      span.title Usager(s):
+      span.title Usager(s) :
       span.float-right= rdv.users.map(&:full_name).sort.to_sentence
       .clear
     div.row-result
-      span.title Motif:
+      span.title Motif :
       span.float-right= rdv.motif.name
       .clear
   div.row-result
-    span.title Service :
+    span.title Service :
     span.float-right= rdv.motif.service.name
     .clear
   div.row-result
-    span.title Durée :
-    span.float-right
-      = "#{rdv.duration_in_min} minutes"
+    span.title Durée :
+    span.float-right= "#{rdv.duration_in_min} minutes"
     .clear
   - if rdv.phone?
     div.row-result
       span.title Ceci est un rendez-vous téléphonique
   - elsif rdv.home?
     div.row-result
-      span.title Ceci est un rendez-vous à domicile à l'adresse&nbsp;:
+      span.title Ceci est un rendez-vous à domicile à l'adresse :
       div.alignright
         a href="https://maps.google.com?q=#{rdv.address.split(/,?\s/).join('+')}" target="_blank"
           = rdv.address_complete
   - else
     div.row-result
-      span.title Adresse&nbsp;:
+      span.title Adresse :
       span.float-right
         a href="https://maps.google.com?q=#{rdv.address.split(/,?\s/).join('+')}" target="_blank"
           = rdv.address_complete

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,6 +10,10 @@ fr:
           has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
             dépendants existent
   date:
+    helpers:
+      tomorrow: demain
+      today: aujourd’hui
+      yesterday: hier
     abbr_day_names:
     - dim
     - lun

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -3,6 +3,4 @@ fr:
     system_mailer:
       rdv_events_stats:
         title: Notifications de RDV - %{date}
-        today: Aujourd’hui
-        yesterday: Hier
         view_on_server: Page de monitoring

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
       let(:rdv) { create(:rdv, starts_at: t + 10.minutes, agents: [agent]) }
 
       it "has a correct subject" do
-        expect(mail.subject).to eq("Nouveau RDV ajouté sur votre agenda rdv-solidarités pour aujourd'hui")
+        expect(mail.subject).to eq("Nouveau RDV ajouté sur votre agenda rdv-solidarités pour aujourd’hui")
       end
     end
 

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -18,12 +18,11 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_starting_soon_date_updated
     rdv = Rdv.not_cancelled.last
     rdv.starts_at = Date.today + 10.days + 10.hours
-    rdv.define_singleton_method(:starts_at_before_last_save) { 2.hours.from_now }
+    rdv.define_singleton_method(:attribute_before_last_save) { |_| 2.hours.from_now } # fake the result of the helper
     Agents::RdvMailer.rdv_starting_soon_date_updated(
       rdv,
       rdv.agents.first,
-      "[Agent] Jean MICHEL",
-      2.hours.from_now
+      "[Agent] Jean MICHEL"
     )
   end
 end

--- a/spec/services/notifications/rdv/rdv_date_updated_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_date_updated_service_spec.rb
@@ -32,9 +32,9 @@ describe Notifications::Rdv::RdvDateUpdatedService, type: :service do
       allow(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1).and_return(double(deliver_later: nil))
       allow(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2).and_return(double(deliver_later: nil))
       expect(Agents::RdvMailer).not_to receive(:rdv_starting_soon_date_updated)
-        .with(rdv, agent1, "[Agent] Sean PAUL", starts_at_initial)
+        .with(rdv, agent1, "[Agent] Sean PAUL")
       allow(Agents::RdvMailer).to receive(:rdv_starting_soon_date_updated)
-        .with(rdv, agent2, "[Agent] Sean PAUL", starts_at_initial)
+        .with(rdv, agent2, "[Agent] Sean PAUL")
         .and_return(double(deliver_later: nil))
       subject
     end


### PR DESCRIPTION
Préliminaire à  #1059, normalement aucun changement fonctionnel

* Ajustements de code style sur le partial rdv overview utilisé dans les mails
* Ajouts de helpers de date `soon?(date)` et `relative_date(date)`
* Déplacé les conditions d’envoi des emails aux agents dans le “base concern”, dans une méthode `should_notify_agent`. C’est là qu’on va prendre en compte les préférences.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
