### PR TITLE
Prevent DelayedJob from reloading the app every second in development

### DIFF
--- a/config/initializers/delayed_worker_class_reloading_patch.rb
+++ b/config/initializers/delayed_worker_class_reloading_patch.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This prevents high cpu usage by delayed_job in development, caused by constant reloading of the app.
+# See https://github.com/collectiveidea/delayed_job/issues/821#issuecomment-259435251
+
+module Delayed::WorkerClassReloadingPatch
+  # Override Delayed::Worker#reserve_job to optionally reload classes before running a job
+  def reserve_job(*)
+    job = super
+
+    if job && self.class.reload_app?
+      if defined?(ActiveSupport::Reloader)
+        Rails.application.reloader.reload!
+      else
+        ActionDispatch::Reloader.cleanup!
+        ActionDispatch::Reloader.prepare!
+      end
+    end
+
+    job
+  end
+
+  # Override Delayed::Worker#reload! which is called from the job polling loop to not reload classes
+  def reload!
+    # no-op
+  end
+end
+
+Delayed::Worker.prepend Delayed::WorkerClassReloadingPatch if Rails.env.development?


### PR DESCRIPTION
Suite de #1447: en fait les soucis de performances sont dûs à delayed_job qui fait du polling sur la base (ce qui est [un peu scandaleux](https://github.com/collectiveidea/delayed_job/issues/584), mais bon) et qui [reload l’app](https://github.com/collectiveidea/delayed_job/issues/821) chaque seconde. Spring n’améliore pas le problème, mais n’était pas la cause principale. Au bout d’un moment, forcément, ça leake un peu.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
