### PR TITLE
Correction de la redirection après création/modification d’un secteur

### DIFF
--- a/app/controllers/admin/territories/sectors_controller.rb
+++ b/app/controllers/admin/territories/sectors_controller.rb
@@ -19,8 +19,11 @@ class Admin::Territories::SectorsController < Admin::Territories::BaseController
     @sector = Sector.new(**sector_params, territory: current_territory)
     authorize_admin(@sector)
     if @sector.save
-      redirect_path = params[:commit] == "Créer" ? admin_territory_sector_path(current_territory, @sector) : new_admin_territory_sector_path(current_territory)
-      redirect_to redirect_path, flash: { success: "Secteur #{@sector.name} créé" }
+      if params[:commit] == I18n.t("helpers.submit.create")
+        redirect_to admin_territory_sector_path(current_territory, @sector)
+      else
+        redirect_to new_admin_territory_sector_path(current_territory), flash: { success: t(".created", sector: @sector.name) }
+      end
     else
       render :new
     end
@@ -42,7 +45,7 @@ class Admin::Territories::SectorsController < Admin::Territories::BaseController
     @sector.assign_attributes(**sector_params)
     authorize_admin(@sector)
     if @sector.save
-      redirect_to admin_territory_sectors_path(current_territory), flash: { success: "Commune mise à jour" }
+      redirect_to admin_territory_sector_path(current_territory, @sector), flash: { success: t(".updated") }
     else
       render :edit
     end
@@ -52,9 +55,9 @@ class Admin::Territories::SectorsController < Admin::Territories::BaseController
     sector = Sector.find(params[:id])
     authorize_admin(sector)
     if sector.destroy
-      redirect_to admin_territory_sectors_path(current_territory), flash: { success: "Secteur supprimé" }
+      redirect_to admin_territory_sectors_path(current_territory), flash: { success: t(".deleted") }
     else
-      redirect_to admin_territory_sectors_path(current_territory), flash: { error: "Erreur lors de la suppression" }
+      redirect_to admin_territory_sectors_path(current_territory), flash: { error: t(".delete_error") }
     end
   end
 

--- a/config/locales/views/admin_territories_sectors.fr.yml
+++ b/config/locales/views/admin_territories_sectors.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  admin:
+    territories:
+      sectors:
+        created: Secteur %{sector} créé
+        updated: Secteur mis à jour
+        deleted: Secteur supprimé
+        delete_error: Erreur lors de la suppression


### PR DESCRIPTION
close #1346

* redirige vers admin_territory_sector_path au lieu de admin_territory_sectors_path après un update
* corrige la redirection après création (qui se base sur le nom du bouton. Ce n’est pas idéal…)
* utilise i18n pour les messages

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
