### PR TITLE
Fix a crash in Agents::RdvMailer#rdv_starting_soon_date_updated 

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -2,6 +2,8 @@
 
 module DateHelper
   def relative_date(date, fallback_format = :short)
+    return if date.nil?
+
     date = date.to_date
     if date == Date.current
       t "date.helpers.today"

--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -22,8 +22,7 @@ class Agents::RdvMailer < ApplicationMailer
     mail(to: agent.email, subject: "RDV annulé #{relative_date @rdv.starts_at}")
   end
 
-  def rdv_starting_soon_date_updated(rdv, agent, rdv_updated_by_str)
-    old_starts_at = rdv.attribute_before_last_save(:starts_at)
+  def rdv_starting_soon_date_updated(rdv, agent, rdv_updated_by_str, old_starts_at)
     @rdv = rdv
     @agent = agent
     @rdv_updated_by_str = rdv_updated_by_str

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -21,7 +21,8 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
     Agents::RdvMailer.rdv_starting_soon_date_updated(
       @rdv,
       agent,
-      change_triggered_by_str
+      change_triggered_by_str,
+      @rdv.attribute_before_last_save(:starts_at)
     ).deliver_later
   end
 end

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -18,11 +18,11 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_starting_soon_date_updated
     rdv = Rdv.not_cancelled.last
     rdv.starts_at = Date.today + 10.days + 10.hours
-    rdv.define_singleton_method(:attribute_before_last_save) { |_| 2.hours.from_now } # fake the result of the helper
     Agents::RdvMailer.rdv_starting_soon_date_updated(
       rdv,
       rdv.agents.first,
-      "[Agent] Jean MICHEL"
+      "[Agent] Jean MICHEL",
+      2.hours.from_now
     )
   end
 end

--- a/spec/services/notifications/rdv/rdv_date_updated_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_date_updated_service_spec.rb
@@ -32,9 +32,9 @@ describe Notifications::Rdv::RdvDateUpdatedService, type: :service do
       allow(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1).and_return(double(deliver_later: nil))
       allow(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2).and_return(double(deliver_later: nil))
       expect(Agents::RdvMailer).not_to receive(:rdv_starting_soon_date_updated)
-        .with(rdv, agent1, "[Agent] Sean PAUL")
+        .with(rdv, agent1, "[Agent] Sean PAUL", starts_at_initial)
       allow(Agents::RdvMailer).to receive(:rdv_starting_soon_date_updated)
-        .with(rdv, agent2, "[Agent] Sean PAUL")
+        .with(rdv, agent2, "[Agent] Sean PAUL", starts_at_initial)
         .and_return(double(deliver_later: nil))
       subject
     end


### PR DESCRIPTION
Introduced in #1449

Of course, we can’t use rdv.attribute_before_last_save in the job. Huh.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
