### PR TITLE
Fix street-level sector zone creation

### DIFF
--- a/app/webpacker/components/places-inputs.js
+++ b/app/webpacker/components/places-inputs.js
@@ -55,7 +55,7 @@ class PlacesInput {
 
   remapBanStreetFeature = feature => {
     if (feature.properties.type === "street") {
-      return { street_ban_id: feature.properties.id }
+      return { street_ban_id: feature.properties.id, street_name: feature.properties.name }
     }
     if (feature.properties.type === "housenumber") {
       // 5 chars for city insee code, 1 for _, 4 for street fantoir


### PR DESCRIPTION
`street_name` is a required param, but it’s not something that exists in the api according to https://geo.api.gouv.fr/adresse

Broken in #1384 🤷 

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
