### PR TITLE
empêche de poser des rendez-vous dans le passé

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -34,7 +34,7 @@ class Rdv < ApplicationRecord
   def starts_at_in_the_future
     return if starts_at >= Time.zone.now
 
-    errors.add(:start_at, "doit être dans le futur")
+    errors.add(:start_at, :must_be_future)
   end
 
   scope :not_cancelled, -> { where(cancelled_at: nil) }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -34,7 +34,7 @@ class Rdv < ApplicationRecord
   def starts_at_in_the_future
     return if starts_at >= Time.zone.now
 
-    errors.add(:start_at, :must_be_future)
+    errors.add(:starts_at, :must_be_future)
   end
 
   scope :not_cancelled, -> { where(cancelled_at: nil) }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -29,6 +29,13 @@ class Rdv < ApplicationRecord
 
   validates :users, :organisation, :motif, :starts_at, :duration_in_min, :agents, presence: true
   validates :lieu, presence: true, if: :public_office?
+  validate :starts_at_in_the_future, on: :create
+
+  def starts_at_in_the_future
+    return if starts_at >= Time.zone.now
+
+    errors.add(:start_at, "doit être dans le futur")
+  end
 
   scope :not_cancelled, -> { where(cancelled_at: nil) }
   scope :cancelled, -> { where.not(cancelled_at: nil) }

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -1,5 +1,12 @@
 fr:
   activerecord:
+
+    errors:
+      models:
+        rdv:
+          attributes:
+            starts_at:
+              must_be_future: "doit être dans le futur"
     models:
       rdv: Rendez-vous
     attributes:
@@ -44,3 +51,4 @@ fr:
                 current_agent: "Vous avez <a href='%{path}'>un autre RDV</a> qui chevauche celui-ci"
                 in_scope: "%{agent_name} a <a href='%{path}'>un autre RDV</a> qui chevauche celui-ci"
                 out_of_scope: "Ce rendez-vous en chevauche un autre. %{agent_name} a un RDV dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
+

--- a/spec/controllers/admin/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/agents/rdvs_controller_spec.rb
@@ -30,7 +30,7 @@ describe Admin::Agents::RdvsController, type: :controller do
         now = Time.zone.parse("2021-01-23 10h00")
         travel_to(now)
 
-        create(:rdv, agents: [agent], organisation: organisation, starts_at: now - 1.day)
+        build(:rdv, agents: [agent], organisation: organisation, starts_at: now - 1.day).save
         rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 2.days)
         create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 8.days)
 

--- a/spec/controllers/admin/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/agents/rdvs_controller_spec.rb
@@ -28,11 +28,12 @@ describe Admin::Agents::RdvsController, type: :controller do
 
       it "assigns rdvs of given agent from start to end" do
         now = Time.zone.parse("2021-01-23 10h00")
-        travel_to(now)
 
-        build(:rdv, agents: [agent], organisation: organisation, starts_at: now - 1.day).save
+        travel_to(now - 2.days)
+        create(:rdv, agents: [agent], organisation: organisation, starts_at: now - 1.day)
         rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 2.days)
         create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 8.days)
+        travel_to(now)
 
         get :index, params: { agent_id: agent.id, organisation_id: organisation.id, start: now, end: now + 7.days, format: :json }
         expect(assigns(:rdvs)).to eq([rdv])

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -15,16 +15,15 @@ describe Admin::RdvsController, type: :controller do
   end
 
   describe "GET index" do
-
     let(:lieu) { create(:lieu, organisation: organisation, name: "MDS Orgeval") }
 
     it "respond success and assign RDVS" do
       get(:index, params: {
-        organisation_id: organisation.id,
-        agent_id: agent.id,
-        start: Time.zone.parse("20/07/2019 08:00"),
-        end: Time.zone.parse("27/07/2019 09:00")
-      })
+            organisation_id: organisation.id,
+            agent_id: agent.id,
+            start: Time.zone.parse("20/07/2019 08:00"),
+            end: Time.zone.parse("27/07/2019 09:00")
+          })
 
       expect(response).to be_successful
       expect(assigns(:rdvs)).to eq([])

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -20,8 +20,8 @@ describe Admin::RdvsController, type: :controller do
     before { subject }
 
     let!(:lieu) { create(:lieu, organisation: organisation, name: "MDS Orgeval") }
-    let!(:rdv1) { create(:rdv, motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 08:00"), organisation: organisation, lieu: lieu) }
-    let!(:rdv2) { create(:rdv, motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 07:00"), organisation: organisation, lieu: lieu) }
+    let!(:rdv1) { create_rdv_without_validation(motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 08:00"), organisation: organisation, lieu: lieu) }
+    let!(:rdv2) { create_rdv_without_validation(motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 07:00"), organisation: organisation, lieu: lieu) }
 
     context "when rdvs starts_at is in window" do
       let(:start_time) { Time.zone.parse("20/07/2019 08:00") }
@@ -49,51 +49,10 @@ describe Admin::RdvsController, type: :controller do
 
   describe "PUT #update" do
     context "with valid params" do
-      it "updates the requested rdv" do
-        lieu = create(:lieu, organisation: organisation)
-        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { lieu_id: lieu.id } }
-        expect(rdv.reload.lieu).to eq(lieu)
-      end
-
-      it "updates the requested rdv status" do
-        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "waiting" } }
-        expect(rdv.reload.status).to eq("waiting")
-      end
-
-      it "set cancelled_at to nil when change status from cancel to other" do
-        rdv = create(:rdv, :excused, motif: motif, agents: [agent], users: [user], organisation: organisation)
-        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "waiting" } }
-        expect(rdv.reload.cancelled_at).to eq(nil)
-        expect(rdv.reload.status).to eq("waiting")
-      end
-
       it "redirects to the rdv" do
         lieu = create(:lieu, organisation: organisation)
         put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { lieu_id: lieu.id } }
         expect(response).to redirect_to(admin_organisation_rdv_path(organisation, rdv))
-      end
-
-      it "where status is excused, cancelled_at should not be nil" do
-        today = rdv.starts_at - 3.days
-        travel_to(today)
-        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "excused" } }
-        expect(rdv.reload.cancelled_at).to eq(today)
-        expect(rdv.reload.status).to eq("excused")
-      end
-
-      it "where status is excused, changing other fields should not reset cancelled_at" do
-        today = rdv.starts_at - 3.days
-        rdv.update(cancelled_at: today, status: "excused")
-        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { context: "change the context" } }
-        expect(rdv.reload.cancelled_at).to eq(today)
-        expect(rdv.reload.status).to eq("excused")
-      end
-
-      it "where status is excused, changing status should reset cancelled_at" do
-        rdv.update(cancelled_at: 2.days.ago, status: "excused")
-        put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: { status: "unknown" } }
-        expect(rdv.reload.cancelled_at).to eq(nil)
-        expect(rdv.reload.status).to eq("unknown")
       end
     end
 

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -15,28 +15,19 @@ describe Admin::RdvsController, type: :controller do
   end
 
   describe "GET index" do
-    subject { get(:index, params: { organisation_id: organisation.id, agent_id: agent.id, start: start_time, end: end_time }) }
 
-    before { subject }
+    let(:lieu) { create(:lieu, organisation: organisation, name: "MDS Orgeval") }
 
-    let!(:lieu) { create(:lieu, organisation: organisation, name: "MDS Orgeval") }
-    let!(:rdv1) { create_rdv_without_validation(motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 08:00"), organisation: organisation, lieu: lieu) }
-    let!(:rdv2) { create_rdv_without_validation(motif: motif, agents: [agent], users: [user], starts_at: Time.zone.parse("21/07/2019 07:00"), organisation: organisation, lieu: lieu) }
+    it "respond success and assign RDVS" do
+      get(:index, params: {
+        organisation_id: organisation.id,
+        agent_id: agent.id,
+        start: Time.zone.parse("20/07/2019 08:00"),
+        end: Time.zone.parse("27/07/2019 09:00")
+      })
 
-    context "when rdvs starts_at is in window" do
-      let(:start_time) { Time.zone.parse("20/07/2019 08:00") }
-      let(:end_time) { Time.zone.parse("27/07/2019 09:00") }
-
-      it { expect(response).to be_successful }
-      it { expect(assigns(:rdvs).to_a).to eq([rdv1, rdv2]) }
-    end
-
-    context "when rdvs starts_at is outside of window" do
-      let(:start_time) { Time.zone.parse("10/07/2019 00:00") }
-      let(:end_time) { Time.zone.parse("17/07/2019 00:00") }
-
-      it { expect(response).to be_successful }
-      it { expect(assigns(:rdvs).to_a).to eq([]) }
+      expect(response).to be_successful
+      expect(assigns(:rdvs)).to eq([])
     end
   end
 

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -19,23 +19,6 @@ FactoryBot.define do
       motif { build(:motif, :by_phone, organisation: organisation) }
       lieu { nil }
     end
-    trait :random_start do
-      sequence :starts_at do |n|
-        d = [
-          "2020-03-01 10:30",
-          "2019-02-10 15:05",
-          "2020-06-17 10:00",
-          "2020-12-01 07:30",
-          "2021-10-01 11:30",
-          "2020-07-10 12:45",
-          "2020-01-13 09:10",
-          "2020-08-03 17:30",
-          "2020-11-20 16:05",
-          "2020-04-01 15:35"
-        ][n % 10]
-        DateTime.parse(d).in_time_zone
-      end
-    end
     trait :future do
       starts_at { 2.days.from_now.at_noon }
     end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     agents { [build(:agent, organisations: [organisation])] }
 
     duration_in_min { 45 }
-    starts_at { DateTime.parse("2020-06-15 10:30").in_time_zone }
+    starts_at { Time.zone.now + 3.days }
 
     status { "unknown" }
 
@@ -38,9 +38,6 @@ FactoryBot.define do
     end
     trait :future do
       starts_at { 2.days.from_now.at_noon }
-    end
-    trait :past do
-      starts_at { DateTime.parse("2020-01-15 10:30").in_time_zone }
     end
     trait :at_home do
       motif { build(:motif, :at_home, organisation: organisation) }

--- a/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
+++ b/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
@@ -6,7 +6,7 @@ describe "Admin can configure the organisation" do
     agent_admin = create(:agent, admin_role_in_organisations: [organisation])
     login_as(agent_admin, scope: :agent)
     visit authenticated_agent_root_path
-    click_link "Statistiques de l'organisation"
+    click_link "Statistiques"
     expect(page).to have_content("Statistiques")
     expect(page).to have_content("RDV créés")
     expect(page).to have_content("Usagers créés")

--- a/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
+++ b/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
@@ -1,30 +1,14 @@
 # frozen_string_literal: true
 
 describe "Admin can configure the organisation" do
-  let!(:organisation) { create(:organisation) }
-  let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation]) }
-
-  before do
+  it "displays all the stats" do
+    organisation = create(:organisation)
+    agent_admin = create(:agent, admin_role_in_organisations: [organisation])
     login_as(agent_admin, scope: :agent)
     visit authenticated_agent_root_path
-  end
-
-  shared_examples "a stats page" do
-    it "displays all the stats" do
-      click_link "Statistiques"
-      expect(page).to have_content("Statistiques")
-      expect(page).to have_content("RDV créés")
-      expect(page).to have_content("Usagers créés")
-    end
-  end
-
-  context "with no RDV" do
-    it_behaves_like "a stats page"
-  end
-
-  context "with RDVs" do
-    before { create_list :rdv, 10, :random_start }
-
-    it_behaves_like "a stats page"
+    click_link "Statistiques de l'organisation"
+    expect(page).to have_content("Statistiques")
+    expect(page).to have_content("RDV créés")
+    expect(page).to have_content("Usagers créés")
   end
 end

--- a/spec/features/agents/agent_can_see_his_stats_spec.rb
+++ b/spec/features/agents/agent_can_see_his_stats_spec.rb
@@ -1,28 +1,12 @@
 # frozen_string_literal: true
 
 describe "Agent can see his stats" do
-  let!(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
-
-  before do
+  it "displays all the stats" do
+    agent = create(:agent, basic_role_in_organisations: [create(:organisation)])
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path
-  end
-
-  shared_examples "a stats page" do
-    it "displays all the stats" do
-      click_link "Mes statistiques"
-      expect(page).to have_content("Statistiques")
-      expect(page).to have_content("RDV créés")
-    end
-  end
-
-  context "with no RDV" do
-    it_behaves_like "a stats page"
-  end
-
-  context "with RDVs" do
-    before { create_list :rdv, 10, :random_start }
-
-    it_behaves_like "a stats page"
+    click_link "Mes statistiques"
+    expect(page).to have_content("Statistiques")
+    expect(page).to have_content("RDV créés")
   end
 end

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -1,26 +1,11 @@
 # frozen_string_literal: true
 
 describe "Anybody can see stats" do
-  before do
+  it "displays all the stats" do
     visit root_path
-  end
-
-  shared_examples "a stats page" do
-    it "displays all the stats" do
-      click_link "Statistiques"
-      expect(page).to have_content("Statistiques")
-      expect(page).to have_content("RDV créés")
-      expect(page).to have_content("Usagers créés")
-    end
-  end
-
-  context "with no RDV" do
-    it_behaves_like "a stats page"
-  end
-
-  context "with RDVs" do
-    before { create_list :rdv, 10, :random_start }
-
-    it_behaves_like "a stats page"
+    click_link "Statistiques"
+    expect(page).to have_content("Statistiques")
+    expect(page).to have_content("RDV créés")
+    expect(page).to have_content("Usagers créés")
   end
 end

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -26,15 +26,12 @@ describe "User views his rdv" do
     end
   end
 
-  context "with past rdv" do
-    let!(:rdv) { create(:rdv, :past, users: [user], organisation: organisation) }
-
-    before { click_link "Vos rendez-vous" }
-
-    it do
-      expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
-      click_link "Voir vos RDV passés"
-      expect(page).to have_content("le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
-    end
+  it "even past rdvs" do
+    rdv = build(:rdv, starts_at: DateTime.parse("2020-01-15 10:30").in_time_zone, users: [user], organisation: organisation)
+    rdv.save(validate: false)
+    click_link "Vos rendez-vous"
+    expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
+    click_link "Voir vos RDV passés"
+    expect(page).to have_content("le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
   end
 end

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -27,8 +27,11 @@ describe "User views his rdv" do
   end
 
   it "even past rdvs" do
-    rdv = build(:rdv, starts_at: DateTime.parse("2020-01-15 10:30").in_time_zone, users: [user], organisation: organisation)
-    rdv.save(validate: false)
+    now = Time.zone.parse("2021-04-25 18:00")
+    travel_to(now - 1.week)
+    rdv = create(:rdv, starts_at: now - 3.days, users: [user], organisation: organisation)
+
+    travel_to(now)
     click_link "Vos rendez-vous"
     expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
     click_link "Voir vos RDV passés"

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -27,8 +27,11 @@ describe Admin::EditRdvForm, type: :form do
 
     it "set cancelled_at to nil when change status from cancel to other" do
       now = Time.zone.parse("2020-08-03 9h00")
+
+      travel_to(now - 2.day)
+      rdv = create(:rdv, cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
+
       travel_to(now)
-      rdv = create_rdv_without_validation(cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
 
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "waiting")
@@ -39,8 +42,9 @@ describe Admin::EditRdvForm, type: :form do
 
     it "when status is excused, cancelled_at should not be nil" do
       now = Time.zone.parse("2020-08-03 9h00")
+      travel_to(now - 3.days)
+      rdv = create(:rdv, starts_at: now - 2.days, agents: [agent], organisation: organisation)
       travel_to(now)
-      rdv = create_rdv_without_validation(starts_at: now - 2.days, agents: [agent], organisation: organisation)
 
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "excused")
@@ -51,8 +55,9 @@ describe Admin::EditRdvForm, type: :form do
 
     it "when status is excused, changing status should reset cancelled_at" do
       now = Time.zone.parse("2020-08-03 9h00")
+      travel_to(now - 4.days)
+      rdv = create(:rdv, cancelled_at: 2.days.ago, starts_at: now - 2.days, agents: [agent], organisation: organisation, status: "excused")
       travel_to(now)
-      rdv = create_rdv_without_validation(cancelled_at: 2.days.ago, starts_at: now - 2.days, agents: [agent], organisation: organisation, status: "excused")
 
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "unknown")

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe Admin::EditRdvForm, type: :form do
+  let(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent) }
+  let(:agent_context) { instance_double(AgentContext, agent: agent, organisation: organisation) }
+
+  describe "#update" do
+    it "updates rdv's lieu" do
+      rdv = create(:rdv, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
+      new_lieu = create(:lieu, organisation: organisation)
+
+      edit_rdv_form = described_class.new(rdv, agent_context)
+      edit_rdv_form.update(lieu: new_lieu)
+
+      expect(rdv.reload.lieu).to eq(new_lieu)
+    end
+
+    it "updates the requested rdv status" do
+      rdv = create(:rdv, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
+
+      edit_rdv_form = described_class.new(rdv, agent_context)
+      edit_rdv_form.update(status: "waiting")
+
+      expect(rdv.reload.status).to eq("waiting")
+    end
+
+    it "set cancelled_at to nil when change status from cancel to other" do
+      now = Time.zone.parse("2020-08-03 9h00")
+      travel_to(now)
+      rdv = create_rdv_without_validation(cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
+
+      edit_rdv_form = described_class.new(rdv, agent_context)
+      edit_rdv_form.update(status: "waiting")
+
+      expect(rdv.reload.cancelled_at).to eq(nil)
+      expect(rdv.reload.status).to eq("waiting")
+    end
+
+    it "when status is excused, cancelled_at should not be nil" do
+      now = Time.zone.parse("2020-08-03 9h00")
+      travel_to(now)
+      rdv = create_rdv_without_validation(starts_at: now - 2.days, agents: [agent], organisation: organisation)
+
+      edit_rdv_form = described_class.new(rdv, agent_context)
+      edit_rdv_form.update(status: "excused")
+
+      expect(rdv.reload.cancelled_at).to eq(now)
+      expect(rdv.reload.status).to eq("excused")
+    end
+
+    it "when status is excused, changing status should reset cancelled_at" do
+      now = Time.zone.parse("2020-08-03 9h00")
+      travel_to(now)
+      rdv = create_rdv_without_validation(cancelled_at: 2.days.ago, starts_at: now - 2.days, agents: [agent], organisation: organisation, status: "excused")
+
+      edit_rdv_form = described_class.new(rdv, agent_context)
+      edit_rdv_form.update(status: "unknown")
+
+      expect(rdv.reload.cancelled_at).to eq(nil)
+      expect(rdv.reload.status).to eq("unknown")
+    end
+  end
+end

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -36,8 +36,9 @@ describe Admin::EditRdvForm, type: :form do
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "waiting")
 
-      expect(rdv.reload.cancelled_at).to eq(nil)
-      expect(rdv.reload.status).to eq("waiting")
+      rdv.reload
+      expect(rdv.cancelled_at).to eq(nil)
+      expect(rdv.status).to eq("waiting")
     end
 
     it "when status is excused, cancelled_at should not be nil" do
@@ -49,8 +50,9 @@ describe Admin::EditRdvForm, type: :form do
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "excused")
 
-      expect(rdv.reload.cancelled_at).to eq(now)
-      expect(rdv.reload.status).to eq("excused")
+      rdv.reload
+      expect(rdv.cancelled_at).to eq(now)
+      expect(rdv.status).to eq("excused")
     end
 
     it "when status is excused, changing status should reset cancelled_at" do
@@ -62,8 +64,9 @@ describe Admin::EditRdvForm, type: :form do
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "unknown")
 
-      expect(rdv.reload.cancelled_at).to eq(nil)
-      expect(rdv.reload.status).to eq("unknown")
+      rdv.reload
+      expect(rdv.cancelled_at).to eq(nil)
+      expect(rdv.status).to eq("unknown")
     end
   end
 end

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -28,7 +28,7 @@ describe Admin::EditRdvForm, type: :form do
     it "set cancelled_at to nil when change status from cancel to other" do
       now = Time.zone.parse("2020-08-03 9h00")
 
-      travel_to(now - 2.day)
+      travel_to(now - 2.days)
       rdv = create(:rdv, cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
 
       travel_to(now)

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -71,8 +71,8 @@ describe Admin::RdvSearchForm do
       now = Time.zone.parse("20/07/2019 15:00")
       travel_to(now)
 
-      rdv1 = create(:rdv, starts_at: Time.zone.parse("21/07/2019 08:00"))
-      rdv2 = create(:rdv, starts_at: Time.zone.parse("21/07/2019 07:00"))
+      create(:rdv, starts_at: Time.zone.parse("21/07/2019 08:00"))
+      create(:rdv, starts_at: Time.zone.parse("21/07/2019 07:00"))
 
       agent_rdv_search_form = described_class.new(
         organisation_id: organisation.id,
@@ -82,7 +82,5 @@ describe Admin::RdvSearchForm do
 
       expect(agent_rdv_search_form.rdvs).to eq([])
     end
-
-
   end
 end

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe Admin::RdvSearchForm do
+  let(:organisation) { create(:organisation) }
+
   describe "#lieu" do
     it "have a lieu when given" do
       lieu = create(:lieu)
@@ -11,7 +13,6 @@ describe Admin::RdvSearchForm do
 
   describe "#to_query" do
     it "return query with lieu" do
-      organisation = create(:organisation)
       lieu = create(:lieu, organisation: organisation)
 
       agent_rdv_search_form = described_class.new(organisation_id: organisation.id, lieu_id: lieu.id)
@@ -50,5 +51,38 @@ describe Admin::RdvSearchForm do
       expect(Rdv).to receive(:with_user).with(user)
       agent_rdv_search_form.rdvs
     end
+
+    it "return rdvs that starts_at is in window" do
+      now = Time.zone.parse("20/07/2019 15:00")
+      travel_to(now)
+      rdv1 = create(:rdv, starts_at: Time.zone.parse("21/07/2019 08:00"), organisation: organisation)
+      rdv2 = create(:rdv, starts_at: Time.zone.parse("21/07/2019 07:00"), organisation: organisation)
+
+      agent_rdv_search_form = described_class.new(
+        organisation_id: organisation.id,
+        start: Time.zone.parse("20/07/2019 08:00"),
+        end: Time.zone.parse("27/07/2019 09:00")
+      )
+
+      expect(agent_rdv_search_form.rdvs).to eq([rdv1, rdv2])
+    end
+
+    it "return empty when starts_at is outside of window" do
+      now = Time.zone.parse("20/07/2019 15:00")
+      travel_to(now)
+
+      rdv1 = create(:rdv, starts_at: Time.zone.parse("21/07/2019 08:00"))
+      rdv2 = create(:rdv, starts_at: Time.zone.parse("21/07/2019 07:00"))
+
+      agent_rdv_search_form = described_class.new(
+        organisation_id: organisation.id,
+        start: Time.zone.parse("10/07/2019 00:00"),
+        end: Time.zone.parse("17/07/2019 00:00")
+      )
+
+      expect(agent_rdv_search_form.rdvs).to eq([])
+    end
+
+
   end
 end

--- a/spec/models/concerns/has_phone_number_concern_spec.rb
+++ b/spec/models/concerns/has_phone_number_concern_spec.rb
@@ -1,36 +1,40 @@
 # frozen_string_literal: true
 
 describe HasPhoneNumberConcern do
-  describe "phone_number formatted normalization" do
-    context "on create" do
-      it "return nil with nil phone number" do
-        expect(create(:user, phone_number: nil).phone_number_formatted).to eq(nil)
+  shared_examples "has phone number concern" do |element|
+    describe "phone_number formatted normalization" do
+      context "on create" do
+        it "return nil with nil phone number" do
+          expect(create(element, phone_number: nil).phone_number_formatted).to eq(nil)
+        end
+
+        it "return nil with a blank phone number" do
+          expect(create(element, phone_number: "").phone_number_formatted).to eq(nil)
+        end
+
+        it "return valid +33 given phone number" do
+          expect(create(element, phone_number: "01 30 30 40 40").phone_number_formatted).to eq("+33130304040")
+        end
+
+        it "not save with an invalid phone number" do
+          expect(build(element, phone_number: "01 30 20").save).to be false
+        end
       end
 
-      it "return nil with a blank phone number" do
-        expect(create(:user, phone_number: "").phone_number_formatted).to eq(nil)
-      end
-
-      it "return valid +33 given phone number" do
-        expect(create(:user, phone_number: "01 30 30 40 40").phone_number_formatted).to eq("+33130304040")
-      end
-
-      it "not save with an invalid phone number" do
-        expect(build(:user, phone_number: "01 30 20").save).to be false
-      end
-    end
-
-    context "on update" do
-      context "previous phone number" do
-        it "updates it" do
-          user = create(:user, phone_number: "01 30 30 40 40")
-          expect(user.phone_number_formatted).to eq("+33130304040")
-          user.update!(phone_number: "04 300 32020")
-          expect(user.phone_number_formatted).to eq("+33430032020")
-          user.update!(phone_number: "")
-          expect(user.phone_number_formatted).to eq(nil)
+      context "on update" do
+        context "previous phone number" do
+          it "updates it" do
+            created_element = create(element, phone_number: "01 30 30 40 40")
+            expect(created_element.phone_number_formatted).to eq("+33130304040")
+            created_element.update!(phone_number: "04 300 32020")
+            expect(created_element.phone_number_formatted).to eq("+33430032020")
+            created_element.update!(phone_number: "")
+            expect(created_element.phone_number_formatted).to eq(nil)
+          end
         end
       end
     end
   end
+
+  it_behaves_like "has phone number concern", :user, :rdv
 end

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -13,7 +13,7 @@ describe FileAttente, type: :model do
     let!(:lieu) { create(:lieu, organisation: organisation) }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:plage_ouverture) { create(:plage_ouverture, first_day: now + 2.weeks, start_time: Tod::TimeOfDay.new(10), agent: agent, lieu: lieu, motifs: [motif], organisation: organisation) }
-    let!(:rdv) { create(:rdv, starts_at: now + 2.weeks, lieu: lieu, motif: motif, agents: [agent], organisation: organisation) }
+    let!(:rdv) { create_rdv_without_validation(starts_at: now + 2.weeks, lieu: lieu, motif: motif, agents: [agent], organisation: organisation) }
     let!(:file_attente) { create(:file_attente, rdv: rdv) }
 
     before do

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
 describe FileAttente, type: :model do
+  let(:now) { DateTime.parse("01-01-2019 09:00 +0100") }
+
+  before do
+    travel_to(now)
+  end
+
   describe "#send_notifications" do
     subject do
       described_class.send_notifications
       file_attente.reload
     end
 
-    let(:now) { DateTime.parse("01-01-2019 09:00 +0100") }
     let!(:organisation) { create(:organisation) }
     let(:motif) { create(:motif, organisation: organisation) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:plage_ouverture) { create(:plage_ouverture, first_day: now + 2.weeks, start_time: Tod::TimeOfDay.new(10), agent: agent, lieu: lieu, motifs: [motif], organisation: organisation) }
-    let!(:rdv) { create_rdv_without_validation(starts_at: now + 2.weeks, lieu: lieu, motif: motif, agents: [agent], organisation: organisation) }
+    let!(:rdv) { create(:rdv, starts_at: now + 2.weeks, lieu: lieu, motif: motif, agents: [agent], organisation: organisation) }
     let!(:file_attente) { create(:file_attente, rdv: rdv) }
-
-    before do
-      travel_to(now)
-      freeze_time
-    end
 
     context "with availabilities before rdv" do
       let!(:plage_ouverture2) { create(:plage_ouverture, first_day: 1.day.from_now, start_time: Tod::TimeOfDay.new(9), lieu: lieu, agent: agent, motifs: [motif], organisation: organisation) }

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -268,10 +268,11 @@ describe Rdv, type: :model do
 
     it "return ONLY the daily rdv" do
       now = Time.zone.parse("2020/12/23 12:30")
-      travel_to(now)
-      build(:rdv, starts_at: now - 2.days).save(validate: false)
+      travel_to(now - 3.days)
+      create(:rdv, starts_at: now - 2.days)
       rdv = create(:rdv, starts_at: now)
       create(:rdv, starts_at: now + 1.day)
+      travel_to(now)
 
       expect(described_class.for_today).to eq([rdv])
     end
@@ -280,19 +281,25 @@ describe Rdv, type: :model do
   describe "Rdv.ongoing" do
     context "without time_margin" do
       it "returns RDV that ongoing" do
-        rdv_that_ongoing = create_rdv_without_validation(starts_at: Time.zone.now - 30.minutes, duration_in_min: 45)
-        create_rdv_without_validation(starts_at: Time.zone.now + 30.minutes, duration_in_min: 15) # rdv_starting_shortly_after
+        now = Time.zone.parse("2020-01-13 16:45")
+        travel_to(now - 3.days)
+        rdv_that_ongoing = create(:rdv, starts_at: now - 30.minutes, duration_in_min: 45)
+        create(:rdv, starts_at: now + 30.minutes, duration_in_min: 15) # rdv_starting_shortly_after
+        travel_to(now)
         expect(described_class.ongoing).to eq([rdv_that_ongoing])
       end
     end
 
     context "with 1 hour time_margin" do
       it "returns RDV that ongoing" do
-        rdv_that_ongoing = create_rdv_without_validation(starts_at: Time.zone.now - 30.minutes, duration_in_min: 45)
-        rdv_finished_shortly_before = create_rdv_without_validation(starts_at: Time.zone.now - 30.minutes, duration_in_min: 15)
-        create_rdv_without_validation(starts_at: Time.zone.now - 2.hours, duration_in_min: 15) # rdv finished long before
-        rdv_starting_shortly_after = create_rdv_without_validation(starts_at: Time.zone.now + 30.minutes, duration_in_min: 15)
-        create_rdv_without_validation(starts_at: Time.zone.now + 2.hours, duration_in_min: 15) # rdv_starting_long_after
+        now = Time.zone.parse("2020-01-13 16:45")
+        travel_to(now - 3.days)
+        rdv_that_ongoing = create(:rdv, starts_at: now - 30.minutes, duration_in_min: 45)
+        rdv_finished_shortly_before = create(:rdv, starts_at: now - 30.minutes, duration_in_min: 15)
+        create(:rdv, starts_at: now - 2.hours, duration_in_min: 15) # rdv finished long before
+        rdv_starting_shortly_after = create(:rdv, starts_at: now + 30.minutes, duration_in_min: 15)
+        create(:rdv, starts_at: now + 2.hours, duration_in_min: 15) # rdv_starting_long_after
+        travel_to(now)
 
         expected_rdvs = [
           rdv_finished_shortly_before,
@@ -308,10 +315,11 @@ describe Rdv, type: :model do
   describe "#starts_at_in_range" do
     it "return rdv that starts in range" do
       now = Time.zone.parse("2020-10-14 11h30")
-      travel_to(now)
+      travel_to(now - 2.days)
       rdv = create(:rdv, starts_at: now + 1.day + 3.hours)
       create(:rdv, starts_at: now + 2.days + 3.hours)
-      build(:rdv, starts_at: now - 1.day).save(validate: false)
+      create(:rdv, starts_at: now - 1.day)
+      travel_to(now)
       expect(described_class.starts_at_in_range((now + 1.day)..(now + 2.days))).to eq([rdv])
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -267,7 +267,7 @@ describe User, type: :model do
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
 
-      travel_to(now - 5.day)
+      travel_to(now - 5.days)
       create(:rdv, users: [user], starts_at: now - 1.day)
       create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
       future_rdv = create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -246,28 +246,32 @@ describe User, type: :model do
 
     it "return rdv for same user and organisation" do
       today = Time.zone.local(2020, 5, 23, 15, 56)
-      travel_to(today)
 
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
-      build(:rdv, users: [user], starts_at: today - 1.day).save(validate: false)
-      build(:rdv, starts_at: today - 1.day).save(validate: false)
-      build(:rdv, users: [user], starts_at: today - 2.days).save(validate: false)
+
+      travel_to(today - 4.days)
+      create(:rdv, users: [user], starts_at: today - 1.day)
+      create(:rdv, starts_at: today - 1.day)
+      create(:rdv, users: [user], starts_at: today - 2.days)
       next_rdv = create(:rdv, starts_at: today + 1.day, organisation: organisation, users: [user])
 
+      travel_to(today)
       expect(user.rdvs_future_without_ongoing(organisation)).to eq([next_rdv])
       travel_back
     end
 
     it "returns only future rdv" do
       now = Time.zone.local(2020, 5, 23, 15, 56)
-      travel_to(now)
 
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
-      build(:rdv, users: [user], starts_at: now - 1.day).save(validate: false)
-      build(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user]).save(validate: false)
+
+      travel_to(now - 5.day)
+      create(:rdv, users: [user], starts_at: now - 1.day)
+      create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
       future_rdv = create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])
+      travel_to(now)
 
       expect(user.rdvs_future_without_ongoing(organisation)).to eq([future_rdv])
       travel_back

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -250,9 +250,9 @@ describe User, type: :model do
 
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user], starts_at: today - 1.day)
-      create(:rdv, starts_at: today - 1.day)
-      create(:rdv, users: [user], starts_at: today - 2.days)
+      build(:rdv, users: [user], starts_at: today - 1.day).save(validate: false)
+      build(:rdv, starts_at: today - 1.day).save(validate: false)
+      build(:rdv, users: [user], starts_at: today - 2.days).save(validate: false)
       next_rdv = create(:rdv, starts_at: today + 1.day, organisation: organisation, users: [user])
 
       expect(user.rdvs_future_without_ongoing(organisation)).to eq([next_rdv])
@@ -265,8 +265,8 @@ describe User, type: :model do
 
       organisation = create(:organisation)
       user = create(:user, organisations: [organisation])
-      create(:rdv, users: [user], starts_at: now - 1.day)
-      create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
+      build(:rdv, users: [user], starts_at: now - 1.day).save(validate: false)
+      build(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user]).save(validate: false)
       future_rdv = create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])
 
       expect(user.rdvs_future_without_ongoing(organisation)).to eq([future_rdv])

--- a/spec/presenters/admin/rdv_user_presenter_spec.rb
+++ b/spec/presenters/admin/rdv_user_presenter_spec.rb
@@ -1,49 +1,48 @@
 # frozen_string_literal: true
 
 describe Admin::RdvUserPresenter do
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:user, organisations: [organisation]) }
+
   describe "#previous_rdvs_truncated" do
-    subject { described_class.new(rdv, user).previous_rdvs_truncated }
 
-    context "no previous RDVs" do
-      let!(:organisation) { create(:organisation) }
-      let!(:user) { create(:user, organisations: [organisation]) }
-      let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
+    it "returns no previous RDVs" do
+      rdv = create(:rdv, users: [user], organisation: organisation)
 
-      it { is_expected.to be_empty }
+      expect(described_class.new(rdv, user).previous_rdvs_truncated).to be_empty
     end
 
-    context "single previous RDV" do
-      let!(:organisation) { create(:organisation) }
-      let!(:user) { create(:user, organisations: [organisation]) }
-      let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
-      let!(:previous_rdv) { create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user]) }
+    it "returns single previous RDV" do
+      rdv = create(:rdv, users: [user], organisation: organisation)
+      previous_rdv = create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user])
 
-      it { is_expected.to eq([previous_rdv]) }
+      expect(described_class.new(rdv, user).previous_rdvs_truncated).to eq([previous_rdv])
     end
 
-    context "6 previous RDVs" do
-      let!(:organisation) { create(:organisation) }
-      let!(:user) { create(:user, organisations: [organisation]) }
-      let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
-      let!(:p4) { create_rdv_without_validation(starts_at: rdv.starts_at - 7.days, organisation: organisation, users: [user]) }
-      let!(:p5) { create_rdv_without_validation(starts_at: rdv.starts_at - 13.days, organisation: organisation, users: [user]) }
-      let!(:p1) { create_rdv_without_validation(starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user]) }
-      let!(:p6) { create_rdv_without_validation(starts_at: rdv.starts_at - 16.days, organisation: organisation, users: [user]) }
-      let!(:p2) { create_rdv_without_validation(starts_at: rdv.starts_at - 2.days, organisation: organisation, users: [user]) }
-      let!(:p3) { create_rdv_without_validation(starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
+    it "returns 6 previous RDVs" do
+      now = Time.zone.parse("2020-02-12 12:00")
+      travel_to(now - 1.month)
+      rdv = create(:rdv, starts_at: now - 1.hour, users: [user], organisation: organisation)
+      p4 = create(:rdv, starts_at: now - 7.days, organisation: organisation, users: [user])
+      p5 = create(:rdv, starts_at: now - 13.days, organisation: organisation, users: [user])
+      p1 = create(:rdv, starts_at: now - 1.day, organisation: organisation, users: [user])
+      p6 = create(:rdv, starts_at: now - 16.days, organisation: organisation, users: [user])
+      p2 = create(:rdv, starts_at: now - 2.days, organisation: organisation, users: [user])
+      p3 = create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
+      travel_to(now)
 
-      it { is_expected.to eq([p1, p2, p3, p4, p5]) }
+      expect(described_class.new(rdv, user).previous_rdvs_truncated).to eq([p1, p2, p3, p4, p5])
     end
 
-    context "with next RDVs" do
-      let(:some_date) { Time.zone.local(2020, 5, 23, 15, 56) }
-      let!(:organisation) { create(:organisation) }
-      let!(:user) { create(:user, organisations: [organisation]) }
-      let!(:rdv) { create_rdv_without_validation(organisation: organisation, users: [user], starts_at: some_date - 2.days) }
-      let!(:previous_rdv) { create_rdv_without_validation(starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
-      let!(:next_rdv) { create_rdv_without_validation(starts_at: rdv.starts_at + 4.days, organisation: organisation, users: [user]) }
+    it "returns with next RDVs" do
+      now = Time.zone.local(2020, 5, 23, 15, 56)
+      travel_to(now - 6.days)
+      rdv = create(:rdv, organisation: organisation, users: [user], starts_at: now - 2.days)
+      previous_rdv = create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
+      next_rdv = create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])
+      travel_to(now)
 
-      it { is_expected.to eq([previous_rdv]) }
+      expect(described_class.new(rdv, user).previous_rdvs_truncated).to eq([previous_rdv])
     end
   end
 end

--- a/spec/presenters/admin/rdv_user_presenter_spec.rb
+++ b/spec/presenters/admin/rdv_user_presenter_spec.rb
@@ -5,7 +5,6 @@ describe Admin::RdvUserPresenter do
   let(:user) { create(:user, organisations: [organisation]) }
 
   describe "#previous_rdvs_truncated" do
-
     it "returns no previous RDVs" do
       rdv = create(:rdv, users: [user], organisation: organisation)
 
@@ -26,7 +25,7 @@ describe Admin::RdvUserPresenter do
       p4 = create(:rdv, starts_at: now - 7.days, organisation: organisation, users: [user])
       p5 = create(:rdv, starts_at: now - 13.days, organisation: organisation, users: [user])
       p1 = create(:rdv, starts_at: now - 1.day, organisation: organisation, users: [user])
-      p6 = create(:rdv, starts_at: now - 16.days, organisation: organisation, users: [user])
+      create(:rdv, starts_at: now - 16.days, organisation: organisation, users: [user])
       p2 = create(:rdv, starts_at: now - 2.days, organisation: organisation, users: [user])
       p3 = create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
       travel_to(now)
@@ -39,7 +38,7 @@ describe Admin::RdvUserPresenter do
       travel_to(now - 6.days)
       rdv = create(:rdv, organisation: organisation, users: [user], starts_at: now - 2.days)
       previous_rdv = create(:rdv, starts_at: now - 4.days, organisation: organisation, users: [user])
-      next_rdv = create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])
+      create(:rdv, starts_at: now + 4.days, organisation: organisation, users: [user])
       travel_to(now)
 
       expect(described_class.new(rdv, user).previous_rdvs_truncated).to eq([previous_rdv])

--- a/spec/presenters/admin/rdv_user_presenter_spec.rb
+++ b/spec/presenters/admin/rdv_user_presenter_spec.rb
@@ -25,12 +25,12 @@ describe Admin::RdvUserPresenter do
       let!(:organisation) { create(:organisation) }
       let!(:user) { create(:user, organisations: [organisation]) }
       let(:rdv) { create(:rdv, users: [user], organisation: organisation) }
-      let!(:p4) { create(:rdv, starts_at: rdv.starts_at - 7.days, organisation: organisation, users: [user]) }
-      let!(:p5) { create(:rdv, starts_at: rdv.starts_at - 13.days, organisation: organisation, users: [user]) }
-      let!(:p1) { create(:rdv, starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user]) }
-      let!(:p6) { create(:rdv, starts_at: rdv.starts_at - 16.days, organisation: organisation, users: [user]) }
-      let!(:p2) { create(:rdv, starts_at: rdv.starts_at - 2.days, organisation: organisation, users: [user]) }
-      let!(:p3) { create(:rdv, starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
+      let!(:p4) { create_rdv_without_validation(starts_at: rdv.starts_at - 7.days, organisation: organisation, users: [user]) }
+      let!(:p5) { create_rdv_without_validation(starts_at: rdv.starts_at - 13.days, organisation: organisation, users: [user]) }
+      let!(:p1) { create_rdv_without_validation(starts_at: rdv.starts_at - 1.day, organisation: organisation, users: [user]) }
+      let!(:p6) { create_rdv_without_validation(starts_at: rdv.starts_at - 16.days, organisation: organisation, users: [user]) }
+      let!(:p2) { create_rdv_without_validation(starts_at: rdv.starts_at - 2.days, organisation: organisation, users: [user]) }
+      let!(:p3) { create_rdv_without_validation(starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
 
       it { is_expected.to eq([p1, p2, p3, p4, p5]) }
     end
@@ -39,9 +39,9 @@ describe Admin::RdvUserPresenter do
       let(:some_date) { Time.zone.local(2020, 5, 23, 15, 56) }
       let!(:organisation) { create(:organisation) }
       let!(:user) { create(:user, organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, organisation: organisation, users: [user], starts_at: some_date - 2.days) }
-      let!(:previous_rdv) { create(:rdv, starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
-      let!(:next_rdv) { create(:rdv, starts_at: rdv.starts_at + 4.days, organisation: organisation, users: [user]) }
+      let!(:rdv) { create_rdv_without_validation(organisation: organisation, users: [user], starts_at: some_date - 2.days) }
+      let!(:previous_rdv) { create_rdv_without_validation(starts_at: rdv.starts_at - 4.days, organisation: organisation, users: [user]) }
+      let!(:next_rdv) { create_rdv_without_validation(starts_at: rdv.starts_at + 4.days, organisation: organisation, users: [user]) }
 
       it { is_expected.to eq([previous_rdv]) }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,8 +76,3 @@ RSpec.configure do |config|
   end
 end
 
-def create_rdv_without_validation(**options)
-  rdv = build(:rdv, options)
-  rdv.save(validate: false)
-  rdv
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,3 +75,9 @@ RSpec.configure do |config|
     FactoryBot.rewind_sequences
   end
 end
+
+def create_rdv_without_validation(**options)
+  rdv = build(:rdv, options)
+  rdv.save(validate: false)
+  rdv
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,4 +75,3 @@ RSpec.configure do |config|
     FactoryBot.rewind_sequences
   end
 end
-

--- a/spec/service_functions/rdv_exporter_spec.rb
+++ b/spec/service_functions/rdv_exporter_spec.rb
@@ -102,7 +102,7 @@ describe RdvExporter, type: :service do
 
     describe "statut" do
       it "return rdv statut" do
-        rdv = build(:rdv, :past, status: "unknown")
+        rdv = build(:rdv, starts_at: Time.zone.now - 1.day, status: "unknown")
         expect(described_class.row_array_from(rdv)[9]).to eq("À renseigner")
       end
     end

--- a/spec/service_models/agent_removal_spec.rb
+++ b/spec/service_models/agent_removal_spec.rb
@@ -42,7 +42,7 @@ describe AgentRemoval, type: :service do
     let!(:rdv) do
       rdv = build(:rdv, agents: [agent], organisation: organisation, starts_at: Date.today.next_week(:monday) + 10.hours)
       rdv.define_singleton_method(:notify_rdv_created, -> {})
-      rdv.save!
+      rdv.save(validate: false)
       rdv
     end
 
@@ -60,7 +60,7 @@ describe AgentRemoval, type: :service do
     let!(:rdv) do
       rdv = build(:rdv, agents: [agent], organisation: organisation, starts_at: Date.today.prev_week(:monday) + 10.hours)
       rdv.define_singleton_method(:notify_rdv_created, -> {})
-      rdv.save!
+      rdv.save(validate: false)
       rdv
     end
 


### PR DESCRIPTION
close #1427 

Le problème a été résolu en corrigeant les dates de rendez-vous posé dans le passé (sans doute par erreur de saisie).

Pour limiter (empêcher ?) la reproduction de ce problème, nous ajoutons une limitation sur la création de rendez-vous dans le passé.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
