### PR TITLE
déplace les statistiques de l'organisation

### DIFF
--- a/app/controllers/admin/organisations/stats_controller.rb
+++ b/app/controllers/admin/organisations/stats_controller.rb
@@ -13,7 +13,7 @@ class Admin::Organisations::StatsController < AgentAuthController
   end
 
   def rdvs
-    authorize(@organisation)
+    skip_authorization
     stats = Stat.new(rdvs: policy_scope(Rdv))
     stats = if params[:by_service].present?
               stats.rdvs_group_by_service
@@ -26,7 +26,7 @@ class Admin::Organisations::StatsController < AgentAuthController
   end
 
   def users
-    authorize(@organisation)
+    skip_authorization
     render json: Stat.new(users: policy_scope(User)).users_group_by_week
   end
 end

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -10,25 +10,27 @@
 
 .card.mb-5
   .card-body
+    = link_to "stats", add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), departement: @departement)
     h4.card-title.mb-3 RDV créés (#{@stats.rdvs.count})
-    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation), departement: @departement), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), departement: @departement), stacked: true
+
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés par service (#{@stats.rdvs.count})
-    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation), by_service: true, departement: @departement), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), by_service: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV par type (#{@stats.rdvs.count})
-    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation), by_location_type: true, departement: @departement), stacked: true
+    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), by_location_type: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 Usagers créés (#{@stats.users_active.count})
-    = column_chart add_query_string_params_to_url(users_admin_organisation_stats_path(@organisation), departement: @departement)
+    = column_chart add_query_string_params_to_url(users_admin_organisation_stats_path(@organisation, format: :json), departement: @departement)
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 Agents créés (#{@stats.agents_for_default_range.count})
-    = column_chart add_query_string_params_to_url(agents_stats_path, departement: @departement)
+    = column_chart add_query_string_params_to_url(agents_stats_path(format: :json), departement: @departement)

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -106,6 +106,15 @@
           i.fa.fa-list>
           span.ml-1 Liste des RDV
 
+      li.side-nav-item.mb-4.pl-3.pr-2
+        = link_to( \
+          admin_organisation_stats_path(current_organisation), \
+          class: ("active" if content_for(:menu_item) == 'menu-organisation-stats') \
+        ) do
+          i.fa.fa-chart-bar>
+          span.ml-1 Statistiques
+          = unknown_past_rdvs_danger_bage
+
       - unless current_agent_role.admin?
         li.side-nav-item.mb-4.pl-3.pr-2
           = link_to \
@@ -162,14 +171,6 @@
               li.my-2
                 = link_to "Sectorisation #{current_organisation.territory}", \
                   admin_territory_setup_checklist_path(current_organisation.territory)
-            li.my-2
-              = link_to( \
-                admin_organisation_stats_path(current_organisation), \
-                class: ("active" if content_for(:menu_item) == 'menu-organisation-stats') \
-              ) do
-                | Statistiques de l'organisation
-                = unknown_past_rdvs_danger_bage
-
       li.side-nav-item.pl-3.pr-2
         = link_to \
           admin_organisation_support_path(current_organisation), \

--- a/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
+++ b/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
@@ -11,7 +11,7 @@ describe "Admin can configure the organisation" do
 
   shared_examples "a stats page" do
     it "displays all the stats" do
-      click_link "Statistiques de l'organisation"
+      click_link "Statistiques"
       expect(page).to have_content("Statistiques")
       expect(page).to have_content("RDV créés")
       expect(page).to have_content("Usagers créés")


### PR DESCRIPTION
close #1404 

Rend visible les statistiques de l'organisation à tous les agents de l'organisation

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
