### PR TITLE
Fix Rdv versions history display

### DIFF
--- a/app/helpers/paper_trail_helper.rb
+++ b/app/helpers/paper_trail_helper.rb
@@ -5,7 +5,11 @@ module PaperTrailHelper
     return "N/A" if value.nil?
     return I18n.l(value, format: :dense) if value.is_a? Time
 
-    send(property_name, value) || value.to_s
+    if respond_to?(property_name)
+      send(property_name, value)
+    else
+      value.to_s
+    end
   end
 
   def user_ids(value)

--- a/spec/helpers/paper_trail_helper_spec.rb
+++ b/spec/helpers/paper_trail_helper_spec.rb
@@ -26,5 +26,9 @@ describe PaperTrailHelper do
 
       expect(helper.paper_trail_change_value("agent_ids", [agent1.id, agent2.id])).to eq("Patricia ALLO, Marco LABAT")
     end
+
+    it "returns stringified value when passed an unknown property of arbitrary type" do
+      expect(helper.paper_trail_change_value("some_value", :some_symbol)).to eq("some_symbol")
+    end
   end
 end


### PR DESCRIPTION
fixes #1474
followup #1470

L’erreur 500 est visible à l’affichage des versions d’un Rdv, dans `admin/organisations/:organisation_id/rdvs/:id`.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
