### PR TITLE
Autorise les numéros de téléphone ultramarins

### DIFF
--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -4,16 +4,36 @@ module HasPhoneNumberConcern
   extend ActiveSupport::Concern
 
   included do
-    validates :phone_number, phone: { allow_blank: true }
+    validate :validate_phone_number
     before_save :format_phone_number
   end
 
+  def validate_phone_number
+    errors.add(:phone_number, :invalid) if phone_number.present? && !phone_number_is_valid?
+  end
+
   def format_phone_number
-    self.phone_number_formatted = (
-      phone_number.present? &&
-      Phonelib.valid?(phone_number) &&
-      Phonelib.parse(phone_number).e164
-    ) || nil
+    self.phone_number_formatted = phone_number_is_valid? ? Phonelib.parse(phone_number).e164 : nil
+  end
+
+  def phone_number_is_valid?
+    return false if phone_number.blank?
+
+    parsed_number = Phonelib.parse(phone_number)
+    country_codes = %i[FR GP GF MQ RE YT]
+    # See issue #1471. We want to allow:
+    # * international (e164) phone numbers
+    # * “french format” (ten digits with a leading 0)
+    # However, we need to special-case some ten-digit numbers,
+    # because the ARCEP assigns some blocks of "O6 XX XX XX XX" numbers to DROM operators.
+    # Guadeloupe | GP | +590 | 0690XXXXXX, 0691XXXXXX
+    # Guyane     | GF | +594 | 0694XXXXXX
+    # Martinique | MQ | +596 | 0696XXXXXX, 0697XXXXXX
+    # Réunion    | RE | +262 | 0692XXXXXX, 0693XXXXXX
+    # Mayotte    | YT | +262 | 0692XXXXXX, 0693XXXXXX
+    # Cf: Plan national de numérotation téléphonique,
+    # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
+    parsed_number.valid? || country_codes.any?{ parsed_number.valid_for_country? _1 }
   end
 
   def phone_number_formatted

--- a/app/models/concerns/user/improved_unicity_error_concern.rb
+++ b/app/models/concerns/user/improved_unicity_error_concern.rb
@@ -5,7 +5,9 @@ module User::ImprovedUnicityErrorConcern
 
   included do
     after_validation do
-      email_taken_error = errors.details[:email]&.select { _1[:error] == :taken }&.first
+      next unless errors.details.include?(:email) # The details Hash implicitely creates values when accessed, let’s avoid that.
+
+      email_taken_error = errors.details[:email].select { _1[:error] == :taken }&.first
       next if email_taken_error.blank?
 
       email_taken_error["id"] = User.where.not(id: id).find_by(email: email).id

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -44,3 +44,7 @@ fr:
               franceconnect_frozen_field_cannot_change: Le nom de naissance ne peut-être changé car il a été certifié par FranceConnect
             birth_date:
               franceconnect_frozen_field_cannot_change: La date de naissance ne peut-être changée car elle a été certifiée par FranceConnect
+  simple_form:
+    hints:
+      user:
+        phone_number: Saisissez un numéro français ou outre-mer à 10 chiffres, ou bien un numéro international avec le préfixe du pays.

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name.upcase }
     phone_number do
       num = ""
-      num = Faker::Base.numerify("06 ## ## ## ##") until Phonelib.valid?(num)
+      num = Faker::PhoneNumber.cell_phone until Phonelib.valid?(num)
       num
     end
     birth_date { Date.parse("1985-07-20") }

--- a/spec/models/concerns/has_phone_number_concern_spec.rb
+++ b/spec/models/concerns/has_phone_number_concern_spec.rb
@@ -2,6 +2,42 @@
 
 describe HasPhoneNumberConcern do
   shared_examples "has phone number concern" do |element|
+    describe "phone number validation" do
+      def errors_with_phone(phone_number)
+        user = build(:user, phone_number: phone_number)
+        user.validate
+        user.errors.details[:phone_number]
+      end
+
+      it "prevents malformed numbers" do
+        expect(errors_with_phone("wrong value")).not_to be_empty
+        expect(errors_with_phone("06 12 34 56 7")).not_to be_empty
+        expect(errors_with_phone(" +33 6 10 00 00 00 1")).not_to be_empty
+      end
+
+      it "allows ten-digit DROM numbers" do
+        expect(errors_with_phone("    06 10 00 00 00")).to be_empty
+        expect(errors_with_phone(" +33 6 10 00 00 00")).to be_empty
+        expect(errors_with_phone("    06 90 00 00 00")).to be_empty
+        expect(errors_with_phone("+590 6 90 00 00 00")).to be_empty
+        expect(errors_with_phone(" +33 6 90 00 00 00")).not_to be_empty
+        expect(errors_with_phone("    06 93 00 00 00")).to be_empty
+        expect(errors_with_phone("+262 6 93 00 00 00")).to be_empty
+        expect(errors_with_phone(" +33 6 93 00 00 00")).not_to be_empty
+        expect(errors_with_phone("    06 94 00 00 00")).to be_empty
+        expect(errors_with_phone("+594 6 94 00 00 00")).to be_empty
+        expect(errors_with_phone(" +33 6 94 00 00 00")).not_to be_empty
+        expect(errors_with_phone("    06 96 00 00 00")).to be_empty
+        expect(errors_with_phone("+596 6 96 00 00 00")).to be_empty
+        expect(errors_with_phone(" +33 6 96 00 00 00")).not_to be_empty
+      end
+
+      it "allows international numbers" do
+        expect(errors_with_phone("+1 2014000000")).to be_empty   # USA
+        expect(errors_with_phone("+212 5222-54321")).to be_empty # Maroc
+      end
+    end
+
     describe "phone_number formatted normalization" do
       context "on create" do
         it "return nil with nil phone number" do


### PR DESCRIPTION
close #1471

* Validation spéciale pour les numéros de téléphone, avec les DROM concernés. La référence est ce document https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf sur le site de l’ARCEP. (Il y a plusieurs section, le Plan de Numérotation commence après 16 pages).
* Affichage d’un indice sur les numéros acceptés: <img width="668" alt="Capture d’écran 2021-05-31 à 17 02 11" src="https://user-images.githubusercontent.com/139391/120212593-77dc1f00-c232-11eb-8e34-e44d426b2afa.png">
* Petites corrections au passage sur les erreurs et les numéros de téléphone dans les tests.


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
