### PR TITLE
Bloque l'enregistrement de rdv dans le passé

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -28,9 +28,10 @@ class Rdv < ApplicationRecord
 
   validates :users, :organisation, :motif, :starts_at, :duration_in_min, :agents, presence: true
   validates :lieu, presence: true, if: :public_office?
-  validate :starts_at_in_the_future, on: :create
+  validate :starts_at_in_the_future
 
   def starts_at_in_the_future
+    return unless will_save_change_to_attribute?("starts_at")
     return if starts_at >= Time.zone.now
 
     errors.add(:starts_at, :must_be_future)

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -32,7 +32,7 @@ class Rdv < ApplicationRecord
 
   def starts_at_in_the_future
     return unless will_save_change_to_attribute?("starts_at")
-    return if starts_at >= Time.zone.now
+    return if starts_at >= Time.zone.now - 2.days
 
     errors.add(:starts_at, :must_be_future)
   end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 describe Rdv, type: :model do
-  it "a une fabrique valide" do
-    expect(build(:rdv)).to be_valid
-  end
-
   describe "#cancellable?" do
     let(:now) { Time.zone.parse("2021-05-03 14h00") }
 
@@ -299,8 +295,18 @@ describe Rdv, type: :model do
 
     before { travel_to(now) }
 
+    it "a une fabrique valide" do
+      expect(build(:rdv)).to be_valid
+    end
+
     it "returns invalid with past starts_at" do
       expect(build(:rdv, starts_at: now - 1.hour)).to be_invalid
+    end
+
+    it "returns invalid when updated to a past starts_at" do
+      rdv = create(:rdv, starts_at: now + 1.hour)
+      rdv.starts_at = now - 1.hour
+      expect(rdv).to be_invalid
     end
 
     it "returns valid with future starts_at" do

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -300,13 +300,17 @@ describe Rdv, type: :model do
     end
 
     it "returns invalid with past starts_at" do
-      expect(build(:rdv, starts_at: now - 1.hour)).to be_invalid
+      expect(build(:rdv, starts_at: now - 2.days - 1.hour)).to be_invalid
     end
 
-    it "returns invalid when updated to a past starts_at" do
+    it "returns invalid when postpone by more than two days" do
       rdv = create(:rdv, starts_at: now + 1.hour)
-      rdv.starts_at = now - 1.hour
+      rdv.starts_at = now - 2.days - 1.hour
       expect(rdv).to be_invalid
+    end
+
+    it "returns valid with starts_at is less than two days in past" do
+      expect(build(:rdv, starts_at: now - 2.days + 1.hour)).to be_valid
     end
 
     it "returns valid with future starts_at" do


### PR DESCRIPTION
Nous bloquons la création de rendez-vous dans le passé. Mais nous pouvons déplacer un rendez-vous dans le passé.
Cette PR permet ajoute le blocage en case de mise à jour également.

Nous considérons qu'il est possible de créer ou modifier un rendez-vous 2 jours dans le passé, pas plus loin.

TODO : traiter le message d'erreur vraiment pas beau « Starts at doit être dans le futur » :confused: 

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
