### PR TITLE
[RDVJobs 3/N] Passe un payload au job d’envoi de mail plutôt qu’un record

### DIFF
--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -4,17 +4,17 @@ class Agents::RdvMailer < ApplicationMailer
   include DateHelper
   add_template_helper DateHelper
 
-  def rdv_created(rdv, agent)
-    @rdv = rdv
+  def rdv_created(rdv_payload, agent)
+    @rdv = OpenStruct.new(rdv_payload)
     @agent = agent
 
-    with_ics_for(@rdv) do
+    with_ics_for(rdv_payload) do
       mail(to: agent.email, subject: "Nouveau RDV ajouté sur votre agenda rdv-solidarités pour #{relative_date @rdv.starts_at}")
     end
   end
 
-  def rdv_cancelled(rdv, agent, author)
-    @rdv = rdv
+  def rdv_cancelled(rdv_payload, agent, author)
+    @rdv = OpenStruct.new(rdv_payload)
     @agent = agent
     @author = author
 
@@ -23,8 +23,8 @@ class Agents::RdvMailer < ApplicationMailer
     end
   end
 
-  def rdv_date_updated(rdv, agent, author, old_starts_at)
-    @rdv = rdv
+  def rdv_date_updated(rdv_payload, agent, author, old_starts_at)
+    @rdv = OpenStruct.new(rdv_payload)
     @agent = agent
     @author = author
     @old_starts_at = old_starts_at
@@ -34,8 +34,7 @@ class Agents::RdvMailer < ApplicationMailer
     end
   end
 
-  def with_ics_for(rdv, &block)
-    ics_payload = rdv.payload(nil, rdv.users.first)
+  def with_ics_for(ics_payload, &block)
     ics = IcalHelpers::Ics.from_payload(ics_payload)
     message.attachments[ics_payload[:name]] = { # as an attachment
       mime_type: "text/calendar",

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 class Users::RdvMailer < ApplicationMailer
+  include DateHelper
   add_template_helper UsersHelper
   add_template_helper RdvsHelper
   add_template_helper DateHelper
 
-  def rdv_created(rdv, user)
-    @rdv = rdv
+  def rdv_created(rdv_payload, user)
+    @rdv = OpenStruct.new(rdv_payload)
     @user = user
-
-    rdv_payload = @rdv.payload(nil, @user)
 
     attachments[rdv_payload[:name]] = {
       mime_type: "text/calendar",
@@ -18,17 +17,15 @@ class Users::RdvMailer < ApplicationMailer
     }
     mail(
       to: user.email,
-      subject: "RDV confirmé le #{l(rdv.starts_at, format: :human)}"
+      subject: "RDV confirmé le #{l(@rdv.starts_at, format: :human)}"
     )
   end
 
-  def rdv_date_updated(rdv, user, old_starts_at)
-    @rdv = rdv
+  def rdv_date_updated(rdv_payload, user, old_starts_at)
+    @rdv = OpenStruct.new(rdv_payload)
     @user = user
     @old_starts_at = old_starts_at
 
-    rdv_payload = @rdv.payload(nil, @user)
-
     attachments[rdv_payload[:name]] = {
       mime_type: "text/calendar",
       content: IcalHelpers::Ics.from_payload(rdv_payload),
@@ -36,26 +33,26 @@ class Users::RdvMailer < ApplicationMailer
     }
     mail(
       to: user.email,
-      subject: "RDV confirmé le #{l(rdv.starts_at, format: :human)}"
+      subject: "RDV #{relative_date old_starts_at} reporté à plus tard"
     )
   end
 
-  def rdv_upcoming_reminder(rdv, user)
-    @rdv = rdv
+  def rdv_upcoming_reminder(rdv_payload, user)
+    @rdv = OpenStruct.new(rdv_payload)
     @user = user
     mail(
       to: user.email,
-      subject: "[Rappel] RDV le #{l(rdv.starts_at, format: :human)}"
+      subject: "[Rappel] RDV le #{l(@rdv.starts_at, format: :human)}"
     )
   end
 
-  def rdv_cancelled(rdv, user, author)
-    @rdv = rdv
+  def rdv_cancelled(rdv_payload, user, author)
+    @rdv = OpenStruct.new(rdv_payload)
     @user = user
     @author = author
     mail(
       to: user.email,
-      subject: "RDV annulé le #{l(rdv.starts_at, format: :human)} avec #{rdv.organisation.name}"
+      subject: "RDV annulé le #{l(@rdv.starts_at, format: :human)} avec #{@rdv.organisation_name}"
     )
   end
 end

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -19,6 +19,27 @@ module Payloads
       description += "Infos et annulation: #{Rails.application.routes.url_helpers.rdvs_shorten_url(host: ENV['HOST'])}"
       payload[:description] = description
 
+      payload.merge!(
+        {
+          home?: home?,
+          phone?: phone?,
+          reservable_online?: reservable_online?,
+          users_full_names: users.map(&:full_name).sort.to_sentence,
+          motif_name: motif.name,
+          motif_instruction: motif.instruction_for_rdv,
+          service_name: motif.service.name,
+          duration_in_min: duration_in_min,
+          address_complete: address_complete,
+          phone_number: phone_number,
+          phone_number_formatter: phone_number_formatted,
+          organisation_id: organisation.id,
+          service_id: motif.service.id,
+          organisation_name: organisation.name,
+          organisation_departement_number: organisation.departement_number,
+          motif_name_with_location_type: motif.name_with_location_type
+        }
+      )
+
       payload[:action] = action if action.present?
 
       payload

--- a/app/services/notifications/rdv/rdv_cancelled_service.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_service.rb
@@ -6,14 +6,14 @@ class Notifications::Rdv::RdvCancelledService < ::BaseService
   protected
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_cancelled(@rdv, agent, @author).deliver_later
+    Agents::RdvMailer.rdv_cancelled(@rdv.payload(:destroy), agent, @author).deliver_later
   end
 
   def notify_user_by_mail(user)
     # Only send sms for excused cancellations (not for no-show)
     return unless @rdv.status == "excused"
 
-    Users::RdvMailer.rdv_cancelled(@rdv, user, @author).deliver_later
+    Users::RdvMailer.rdv_cancelled(@rdv.payload(:destroy, user), user, @author).deliver_later
 
     event_name = @author.is_a?(Agent) ? :cancelled_by_agent : :cancelled_by_user
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: event_name)

--- a/app/services/notifications/rdv/rdv_created_service.rb
+++ b/app/services/notifications/rdv/rdv_created_service.rb
@@ -6,7 +6,7 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
   protected
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_created(@rdv, user).deliver_later
+    Users::RdvMailer.rdv_created(@rdv.payload(:create, user), user).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :created)
   end
 
@@ -16,6 +16,6 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
   end
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_created(@rdv, agent).deliver_later
+    Agents::RdvMailer.rdv_created(@rdv.payload(:create), agent).deliver_later
   end
 end

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -6,7 +6,7 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
   protected
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_date_updated(@rdv, user, @rdv.attribute_before_last_save(:starts_at)).deliver_later
+    Users::RdvMailer.rdv_date_updated(@rdv.payload(:update, user), user, @rdv.attribute_before_last_save(:starts_at)).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :updated)
   end
 
@@ -17,7 +17,7 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
 
   def notify_agent(agent)
     Agents::RdvMailer.rdv_date_updated(
-      @rdv,
+      @rdv.payload(:update),
       agent,
       @author,
       @rdv.attribute_before_last_save(:starts_at)

--- a/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
+++ b/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
@@ -6,7 +6,7 @@ class Notifications::Rdv::RdvUpcomingReminderService < ::BaseService
   protected
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_upcoming_reminder(@rdv, user).deliver_later
+    Users::RdvMailer.rdv_upcoming_reminder(@rdv.payload(nil, user), user).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :upcoming_reminder)
   end
 

--- a/app/views/mailers/agents/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_cancelled.html.slim
@@ -5,4 +5,4 @@ div
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter
-    = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation, @agent),  class: 'btn btn-primary'
+    = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation_id, @agent),  class: 'btn btn-primary'

--- a/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
@@ -5,4 +5,4 @@ div
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter
-    = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation, @agent),  class: 'btn btn-primary'
+    = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation_id, @agent),  class: 'btn btn-primary'

--- a/app/views/mailers/agents/rdv_mailer/rdv_date_updated.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_date_updated.html.slim
@@ -5,4 +5,4 @@ div
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter
-    = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation, @agent),  class: 'btn btn-primary'
+    = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation_id , @agent),  class: 'btn btn-primary'

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -8,15 +8,15 @@
   - if for_role == :agent
     div.row-result
       span.title Usager(s) :
-      span.float-right= rdv.users.map(&:full_name).sort.to_sentence
+      span.float-right= rdv.users_full_names
       .clear
     div.row-result
       span.title Motif :
-      span.float-right= rdv.motif.name
+      span.float-right= rdv.motif_name
       .clear
   div.row-result
     span.title Service :
-    span.float-right= rdv.motif.service.name
+    span.float-right= rdv.service_name
     .clear
   div.row-result
     span.title Durée :
@@ -38,7 +38,7 @@
         a href="https://maps.google.com?q=#{rdv.address.split(/,?\s/).join('+')}" target="_blank"
           = rdv.address_complete
       .clear
-  - if rdv.motif.instruction_for_rdv.present? && for_role == :user
+  - if rdv.motif_instruction.present? && for_role == :user
     .div.row-result.no-border
       span.title Informations supplémentaires :
-      = simple_format(rdv.motif.instruction_for_rdv)
+      = simple_format(rdv.motif_instruction)

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -1,9 +1,9 @@
 div
   p Bonjour,
   - if @author.is_a? Agent
-    p Votre RDV #{@rdv.motif.service.name} du #{l(@rdv.starts_at, format: :human)} a été annulé.
+    p Votre RDV #{@rdv.service_name} du #{l(@rdv.starts_at, format: :human)} a été annulé.
   - else
-    p Votre RDV #{@rdv.motif.service.name} du #{l(@rdv.starts_at, format: :human)} a bien été annulé.
+    p Votre RDV #{@rdv.service_name} du #{l(@rdv.starts_at, format: :human)} a bien été annulé.
 
   - if @rdv.phone_number.present?
     p Vous pouvez reprendre un rendez-vous en appelant au #{link_to @rdv.phone_number, "tel:#{@rdv.phone_number_formatted}"}
@@ -13,9 +13,9 @@ div
 
     .btn-wrapper
       = link_to 'Reprendre RDV', lieux_url(search: { \
-        departement: @rdv.organisation.departement_number, \
-        motif_name_with_location_type: @rdv.motif.name_with_location_type, \
-        service: @rdv.motif.service.id, \
+        departement: @rdv.organisation_departement_number, \
+        motif_name_with_location_type: @rdv.motif_name_with_location_type, \
+        service: @rdv.service_id, \
         where: @rdv.address \
       }), class:'btn btn-primary'
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -514,6 +514,16 @@ Rdv.create(
   user_ids: [user_org_paris_nord_josephine.id],
   context: "Suivi vaccins"
 )
+Rdv.create(
+  duration_in_min: 30,
+  starts_at: Time.zone.today + 5.days + 11.hours,
+  motif_id: motif_org_paris_nord_pmi_securite.id,
+  lieu: lieu_org_paris_nord_bd_aubervilliers,
+  organisation_id: org_paris_nord.id,
+  agent_ids: [agent_org_paris_nord_pmi_martine.id],
+  user_ids: [user_org_paris_nord_josephine.id],
+  context: "Visite à domicile"
+)
 
 # User Notes
 

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_created" do
     let(:agent) { build(:agent) }
     let(:t) { DateTime.parse("2020-03-01 10:20") }
-    let(:mail) { described_class.rdv_created(rdv, agent) }
+    let(:mail) { described_class.rdv_created(rdv.payload(:create), agent) }
     let(:rdv) { create(:rdv, starts_at: t + 2.hours, agents: [agent]) }
 
     before { travel_to(t) }

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -4,7 +4,7 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_created
     rdv = Rdv.not_cancelled.last
     rdv.starts_at = 2.hours.from_now
-    Agents::RdvMailer.rdv_created(rdv, rdv.agents.first)
+    Agents::RdvMailer.rdv_created(rdv.payload(:create), rdv.agents.first)
   end
 
   def rdv_cancelled
@@ -12,16 +12,16 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
     rdv.starts_at = 2.hours.from_now
     rdv.status = :excused
     Agents::RdvMailer
-      .rdv_cancelled(rdv, rdv.agents.first, "[Agent] Jean MICHEL")
+      .rdv_cancelled(rdv.payload(:destroy), rdv.agents.first, rdv.agents.first)
   end
 
   def rdv_date_updated
     rdv = Rdv.not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
     Agents::RdvMailer.rdv_date_updated(
-      rdv,
+      rdv.payload(:update),
       rdv.agents.first,
-      "[Agent] Jean MICHEL",
+      rdv.agents.first,
       2.hours.from_now
     )
   end

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -7,40 +7,57 @@ class Users::RdvMailerPreview < ActionMailer::Preview
 
   def rdv_created
     rdv = Rdv.not_cancelled.last
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
   end
 
   def rdv_created_CONTEXT_visite_a_domicile
     rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
   end
 
   def rdv_created_CONTEXT_phone
     rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
   end
 
   def rdv_created_CONTEXT_public_office
     rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
+  end
+
+  def rdv_date_updated
+    rdv = Rdv.not_cancelled.last
+    rdv.starts_at = Time.zone.today + 10.days + 10.hours
+    Users::RdvMailer.rdv_date_updated(
+      rdv.payload(:update),
+      rdv.agents.first,
+      2.hours.from_now
+    )
+  end
+
+  def rdv_cancelled_by_user
+    rdv = Rdv.not_cancelled.last
+    raise ActiveRecord::RecordNotFound unless rdv
+
+    Users::RdvMailer.rdv_cancelled(rdv.payload(:destroy), rdv.users.first, rdv.users.first)
   end
 
   def rdv_cancelled_by_agent
     rdv = Rdv.not_cancelled.last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_cancelled_by_agent(rdv, rdv.users.first)
+    Users::RdvMailer.rdv_cancelled(rdv.payload(:destroy), rdv.users.first, rdv.agents.first)
   end
 
   def rdv_upcoming_reminder
     rdv = Rdv.not_cancelled.last
-    Users::RdvMailer.rdv_upcoming_reminder(rdv, rdv.users.first)
+    Users::RdvMailer.rdv_upcoming_reminder(rdv.payload, rdv.users.first)
   end
 
   # rubocop:enable Naming/MethodName

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
   describe "#rdv_created" do
     let(:rdv) { create(:rdv) }
     let(:user) { rdv.users.first }
-    let(:mail) { described_class.rdv_created(rdv, user) }
+    let(:mail) { described_class.rdv_created(rdv.payload(:create), user) }
 
     it "renders the headers" do
       expect(mail.to).to eq([user.email])
@@ -25,10 +25,12 @@ RSpec.describe Users::RdvMailer, type: :mailer do
   end
 
   describe "#rdv_cancelled" do
+    before { travel_to Time.zone.parse("2020-06-10 12:30") }
+
     it "send mail to user" do
       rdv = create(:rdv)
       user = rdv.users.first
-      mail = described_class.rdv_cancelled(rdv, user, user)
+      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, user)
 
       expect(mail.to).to eq([user.email])
     end
@@ -36,8 +38,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "subject contains date of cancelled rdv" do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
-      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, user)
+      rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, user)
 
       expect(mail.subject).to eq("RDV annulé le lundi 15 juin 2020 à 12h30 avec Orga du coin")
     end
@@ -45,8 +47,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "body contains cancelled confirmation with dateTime" do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
-      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, user)
+      rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, user)
 
       expect(mail.body).to match("lundi 15 juin 2020 à 12h30")
     end
@@ -54,8 +56,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "body contains cancelled confirmation with motif's service name" do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
-      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, user)
+      rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, user)
 
       expect(mail.body).to match(rdv.motif.service_name)
     end
@@ -63,8 +65,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "body contains link to book a new RDV" do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
-      rdv = build(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, user)
+      rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
+      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, rdv.agents.first)
 
       expected_url = lieux_url(search: { \
                                  departement: rdv.organisation.departement_number, \
@@ -81,7 +83,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "send mail to user" do
       rdv = create(:rdv)
       user = rdv.users.first
-      mail = described_class.rdv_upcoming_reminder(rdv, user)
+      mail = described_class.rdv_upcoming_reminder(rdv.payload, user)
       expect(mail.to).to eq([user.email])
       expect(mail.body).to include("Nous vous rappellons que vous avez un RDV prévu")
     end

--- a/spec/services/notifications/rdv/rdv_cancelled_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_cancelled_service_spec.rb
@@ -6,7 +6,8 @@ describe Notifications::Rdv::RdvCancelledService, type: :service do
   let(:agent1) { build(:agent) }
   let(:agent2) { build(:agent) }
   let(:user) { build(:user) }
-  let!(:rdv) { build(:rdv, starts_at: starts_at, users: [user], agents: [agent1, agent2]) }
+  let(:rdv) { build(:rdv, starts_at: starts_at, users: [user], agents: [agent1, agent2]) }
+  let(:rdv_payload) { rdv.payload(:destroy) }
 
   before do
     rdv.update!(status: :excused)
@@ -22,9 +23,9 @@ describe Notifications::Rdv::RdvCancelledService, type: :service do
       let(:starts_at) { 3.days.from_now }
 
       it "only notifies the user" do
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent1, agent1)
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent2, agent1)
-        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, agent1)
+        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv_payload, agent1, agent1)
+        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv_payload, agent2, agent1)
+        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload, user, agent1)
 
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
@@ -36,9 +37,9 @@ describe Notifications::Rdv::RdvCancelledService, type: :service do
       let(:starts_at) { 1.day.from_now }
 
       it "notifies the users and the other agents (not the author)" do
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent1, agent1)
-        expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent2, agent1)
-        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, agent1)
+        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv_payload, agent1, agent1)
+        expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload, agent2, agent1)
+        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload, user, agent1)
 
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
@@ -52,9 +53,9 @@ describe Notifications::Rdv::RdvCancelledService, type: :service do
     let(:starts_at) { 1.day.from_now }
 
     it "notifies the user and the agents" do
-      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent1, user)
-      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent2, user)
-      expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, user)
+      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload, agent1, user)
+      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload, agent2, user)
+      expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload, user, user)
 
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_user").count).to eq 1

--- a/spec/services/notifications/rdv/rdv_created_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_created_service_spec.rb
@@ -8,6 +8,8 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
   let(:agent1) { build(:agent) }
   let(:agent2) { build(:agent) }
   let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, users: [user1, user2], agents: [agent1, agent2]) }
+  let(:rdv_payload1) { rdv.payload(:create, user1) }
+  let(:rdv_payload2) { rdv.payload(:create, user2) }
 
   before do
     allow(Users::RdvMailer).to receive(:rdv_created).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
@@ -19,8 +21,8 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
     let(:motif) { build(:motif) }
 
     it "triggers sending mail to users but not to agents" do
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1)
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload1, user1)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload2, user2)
       expect(Agents::RdvMailer).not_to receive(:rdv_created)
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "created").count).to eq 2
@@ -32,10 +34,10 @@ describe Notifications::Rdv::RdvCreatedService, type: :service do
     let(:motif) { build(:motif) }
 
     it "triggers sending mails to both user and agents" do
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1)
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2)
-      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv, agent1)
-      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv, agent2)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload1, user1)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload2, user2)
+      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv_payload1, agent1)
+      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv_payload1, agent2)
       subject
     end
   end

--- a/spec/services/notifications/rdv/rdv_date_updated_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_date_updated_service_spec.rb
@@ -7,7 +7,9 @@ describe Notifications::Rdv::RdvDateUpdatedService, type: :service do
   let(:user2) { build(:user) }
   let(:agent1) { build(:agent, first_name: "Sean", last_name: "PAUL") }
   let(:agent2) { build(:agent) }
-  let!(:rdv) { create(:rdv, starts_at: starts_at_initial, users: [user1, user2], agents: [agent1, agent2]) }
+  let(:rdv) { create(:rdv, starts_at: starts_at_initial, users: [user1, user2], agents: [agent1, agent2]) }
+  let(:rdv_payload1) { rdv.payload(:update, user1) }
+  let(:rdv_payload2) { rdv.payload(:update, user2) }
 
   before do
     rdv.update!(starts_at: 4.days.from_now)
@@ -20,8 +22,8 @@ describe Notifications::Rdv::RdvDateUpdatedService, type: :service do
     let(:starts_at_initial) { 3.days.from_now }
 
     it "triggers sending mail to users but not to agents" do
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user1, starts_at_initial)
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user2, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload1, user1, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload2, user2, starts_at_initial)
       expect(Agents::RdvMailer).not_to receive(:rdv_date_updated)
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "updated").count).to eq 2
@@ -32,10 +34,10 @@ describe Notifications::Rdv::RdvDateUpdatedService, type: :service do
     let(:starts_at_initial) { 2.hours.from_now }
 
     it "triggers sending mails to both user and agents (except the one who initiated the change)" do
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user1, starts_at_initial)
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user2, starts_at_initial)
-      expect(Agents::RdvMailer).not_to receive(:rdv_date_updated).with(rdv, agent1, agent1, starts_at_initial)
-      expect(Agents::RdvMailer).to receive(:rdv_date_updated).with(rdv, agent2, agent1, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload1, user1, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload2, user2, starts_at_initial)
+      expect(Agents::RdvMailer).not_to receive(:rdv_date_updated).with(rdv_payload1, agent1, agent1, starts_at_initial)
+      expect(Agents::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload1, agent2, agent1, starts_at_initial)
       subject
     end
   end

--- a/spec/services/notifications/rdv/rdv_upcoming_reminder_service_spec.rb
+++ b/spec/services/notifications/rdv/rdv_upcoming_reminder_service_spec.rb
@@ -5,14 +5,15 @@ describe Notifications::Rdv::RdvUpcomingReminderService, type: :service do
 
   let(:user1) { build(:user) }
   let(:rdv) { create(:rdv, starts_at: 2.days.from_now, users: [user1]) }
+  let(:rdv_payload) { rdv.payload }
+
+  before do
+    allow(Users::RdvMailer).to receive(:rdv_upcoming_reminder).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
+    allow(SendTransactionalSmsJob).to receive(:perform_later)
+  end
 
   it "sends an sms and an email" do
-    allow(Users::RdvMailer).to receive(:rdv_upcoming_reminder)
-      .with(rdv, user1)
-      .and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
-    allow(SendTransactionalSmsJob).to receive(:perform_later)
-      .with(:reminder, rdv.id, user1.id)
-    # .and_call_original
+    expect(Users::RdvMailer).to receive(:rdv_upcoming_reminder).with(rdv_payload, user1)
     subject
     expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "upcoming_reminder").count).to eq 1
     expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: "upcoming_reminder").count).to eq 1


### PR DESCRIPTION
refs #1361

- passe un payload (un hash) des attributs du Rdv au lieu de passer le Rdv en lui-même. Ainsi, le job peut être exécuté même si le Rdv est supprimé entretemps.

Checklist avant review:
* [x] #1485 et #1486 d’abord
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
