### PR TITLE
[RDVJobs 4/N] Passe un payload au job d’envoi de sms plutôt qu’un record

### DIFF
--- a/app/jobs/send_transactional_sms_job.rb
+++ b/app/jobs/send_transactional_sms_job.rb
@@ -3,7 +3,7 @@
 class SendTransactionalSmsJob < ApplicationJob
   queue_as :sms
 
-  def perform(status, rdv_id, user_id)
-    TransactionalSms::Builder.with(Rdv.find(rdv_id), User.find(user_id), status).send!
+  def perform(status, rdv_payload, user_id)
+    TransactionalSms::Builder.with(OpenStruct.new(rdv_payload), User.find(user_id), status).send!
   end
 end

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -21,21 +21,25 @@ module Payloads
 
       payload.merge!(
         {
+          id: id,
           home?: home?,
           phone?: phone?,
           reservable_online?: reservable_online?,
           users_full_names: users.map(&:full_name).sort.to_sentence,
           motif_name: motif.name,
           motif_instruction: motif.instruction_for_rdv,
-          service_name: motif.service.name,
+          motif_service_name: motif.service.name,
+          motif_service_short_name: motif.service.short_name,
           duration_in_min: duration_in_min,
           address_complete: address_complete,
           phone_number: phone_number,
           phone_number_formatter: phone_number_formatted,
           organisation_id: organisation.id,
-          service_id: motif.service.id,
+          motif_service_id: motif.service.id,
           organisation_name: organisation.name,
           organisation_departement_number: organisation.departement_number,
+          organisation_phone_number: organisation.phone_number,
+          organisation_territory_id: organisation.territory.id,
           motif_name_with_location_type: motif.name_with_location_type
         }
       )

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -33,7 +33,7 @@ class FileAttente < ApplicationRecord
   def send_notification
     rdv.users.map(&:user_to_notify).uniq.each do |user|
       if user.notifiable_by_sms?
-        SendTransactionalSmsJob.perform_later(:file_attente, rdv.id, user.id)
+        SendTransactionalSmsJob.perform_later(:file_attente, rdv.payload, user.id)
         rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :file_attente_creneaux_available)
       end
 

--- a/app/service_models/transactional_sms/base_concern.rb
+++ b/app/service_models/transactional_sms/base_concern.rb
@@ -34,8 +34,8 @@ module TransactionalSms::BaseConcern
   def tags
     [
       ENV["APP"]&.gsub("-rdv-solidarites", ""), # shorter names
-      "dpt-#{rdv.organisation.departement_number}",
-      "org-#{rdv.organisation.id}",
+      "dpt-#{rdv.organisation_departement_number}",
+      "org-#{rdv.organisation_id}",
       self.class.name.demodulize.underscore
     ].compact
   end
@@ -49,7 +49,7 @@ module TransactionalSms::BaseConcern
                 "#{rdv.address_complete}\n"
               end
     message += "Infos et annulation: #{rdvs_shorten_url(host: ENV['HOST'])}"
-    message += " / #{rdv.organisation.phone_number}" if rdv.organisation.phone_number
+    message += " / #{rdv.organisation_phone_number}" if rdv.organisation_phone_number
     message
   end
 

--- a/app/service_models/transactional_sms/rdv_cancelled.rb
+++ b/app/service_models/transactional_sms/rdv_cancelled.rb
@@ -14,7 +14,7 @@ class TransactionalSms::RdvCancelled
   private
 
   def base_message
-    "RDV #{@rdv.motif.service.short_name} #{I18n.l(@rdv.starts_at, format: :short)} a été annulé\n"
+    "RDV #{@rdv.motif_service_short_name} #{I18n.l(@rdv.starts_at, format: :short)} a été annulé\n"
   end
 
   def call_or_visit_message

--- a/app/service_models/transactional_sms/rdv_created.rb
+++ b/app/service_models/transactional_sms/rdv_created.rb
@@ -11,9 +11,9 @@ class TransactionalSms::RdvCreated
 
   def body
     if rdv.home?
-      "RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short_approx)}\n"
+      "RDV #{rdv.motif_service_short_name} #{I18n.l(rdv.starts_at, format: :short_approx)}\n"
     else
-      "RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short)}\n"
+      "RDV #{rdv.motif_service_short_name} #{I18n.l(rdv.starts_at, format: :short)}\n"
     end
   end
 end

--- a/app/service_models/transactional_sms/rdv_updated.rb
+++ b/app/service_models/transactional_sms/rdv_updated.rb
@@ -10,6 +10,6 @@ class TransactionalSms::RdvUpdated
   private
 
   def body
-    "RDV modifié: #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: (rdv.home? ? :short_approx : :short))}\n"
+    "RDV modifié: #{rdv.motif_service_short_name} #{I18n.l(rdv.starts_at, format: (rdv.home? ? :short_approx : :short))}\n"
   end
 end

--- a/app/service_models/transactional_sms/reminder.rb
+++ b/app/service_models/transactional_sms/reminder.rb
@@ -10,7 +10,7 @@ class TransactionalSms::Reminder
   private
 
   def body
-    "Rappel RDV #{@rdv.motif.service.short_name} le #{I18n.l(@rdv.starts_at, format: time_format)}\n"
+    "Rappel RDV #{@rdv.motif_service_short_name} le #{I18n.l(@rdv.starts_at, format: time_format)}\n"
   end
 
   def time_format

--- a/app/services/notifications/rdv/rdv_cancelled_service.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_service.rb
@@ -24,7 +24,7 @@ class Notifications::Rdv::RdvCancelledService < ::BaseService
     return unless @author.is_a? Agent
     return unless @rdv.status == "excused"
 
-    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.id, user.id)
+    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.payload(:destroy), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :cancelled_by_agent)
   end
 end

--- a/app/services/notifications/rdv/rdv_created_service.rb
+++ b/app/services/notifications/rdv/rdv_created_service.rb
@@ -11,7 +11,7 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
   end
 
   def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.id, user.id)
+    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.payload(:create), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :created)
   end
 

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -11,7 +11,7 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
   end
 
   def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:rdv_updated, @rdv.id, user.id)
+    SendTransactionalSmsJob.perform_later(:rdv_updated, @rdv.payload(:update), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :updated)
   end
 

--- a/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
+++ b/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
@@ -11,7 +11,7 @@ class Notifications::Rdv::RdvUpcomingReminderService < ::BaseService
   end
 
   def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:reminder, @rdv.id, user.id)
+    SendTransactionalSmsJob.perform_later(:reminder, @rdv.payload, user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :upcoming_reminder)
   end
 end

--- a/app/services/send_transactional_sms_service.rb
+++ b/app/services/send_transactional_sms_service.rb
@@ -19,7 +19,7 @@ class SendTransactionalSmsService < BaseService
 
   def initialize(transactional_sms)
     @transactional_sms = transactional_sms
-    territory = @transactional_sms.rdv.organisation.territory
+    territory = Territory.find(@transactional_sms.rdv.organisation_territory_id)
     @configuration = territory.sms_configuration || DEFAULT_SMS_CONFIGURATION
 
     @provider = :debug_logger

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -16,7 +16,7 @@
       .clear
   div.row-result
     span.title Service :
-    span.float-right= rdv.service_name
+    span.float-right= rdv.motif_service_name
     .clear
   div.row-result
     span.title Durée :

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -1,9 +1,9 @@
 div
   p Bonjour,
   - if @author.is_a? Agent
-    p Votre RDV #{@rdv.service_name} du #{l(@rdv.starts_at, format: :human)} a été annulé.
+    p Votre RDV #{@rdv.motif_service_name} du #{l(@rdv.starts_at, format: :human)} a été annulé.
   - else
-    p Votre RDV #{@rdv.service_name} du #{l(@rdv.starts_at, format: :human)} a bien été annulé.
+    p Votre RDV #{@rdv.motif_service_name} du #{l(@rdv.starts_at, format: :human)} a bien été annulé.
 
   - if @rdv.phone_number.present?
     p Vous pouvez reprendre un rendez-vous en appelant au #{link_to @rdv.phone_number, "tel:#{@rdv.phone_number_formatted}"}
@@ -15,7 +15,7 @@ div
       = link_to 'Reprendre RDV', lieux_url(search: { \
         departement: @rdv.organisation_departement_number, \
         motif_name_with_location_type: @rdv.motif_name_with_location_type, \
-        service: @rdv.service_id, \
+        service: @rdv.motif_service_id, \
         where: @rdv.address \
       }), class:'btn btn-primary'
 

--- a/spec/service_models/transactional_sms/base_concern_spec.rb
+++ b/spec/service_models/transactional_sms/base_concern_spec.rb
@@ -29,7 +29,7 @@ describe TransactionalSms::BaseConcern, type: :service do
   end
 
   describe "#rdv_footer" do
-    subject { SomeModule::TestSms.new(rdv, user).rdv_footer }
+    subject { SomeModule::TestSms.new(OpenStruct.new(rdv.payload), user).rdv_footer }
 
     let(:rdv) { build(:rdv, motif: motif, users: [user], starts_at: 5.days.from_now) }
 
@@ -42,28 +42,34 @@ describe TransactionalSms::BaseConcern, type: :service do
     context "when Rdv is at home" do
       let(:motif) { build(:motif, :at_home) }
 
-      it { is_expected.to include("RDV à domicile") }
-      it { is_expected.to include(rdv.address) }
+      it do
+        expect(subject).to include("RDV à domicile")
+        expect(subject).to include(rdv.address)
+      end
     end
 
     context "when Rdv is by phone" do
       let(:motif) { build(:motif, :by_phone) }
 
-      it { is_expected.to include("RDV Téléphonique") }
-      it { is_expected.to include(rdv.address) }
+      it do
+        expect(subject).to include("RDV Téléphonique")
+        expect(subject).to include(rdv.address)
+      end
     end
   end
 
   describe "#tags" do
-    subject { SomeModule::TestSms.new(rdv, build(:user)).tags }
+    subject { SomeModule::TestSms.new(OpenStruct.new(rdv.payload), build(:user)).tags }
 
     let!(:territory77) { create(:territory, departement_number: "77") }
     let(:organisation) { create(:organisation, territory: territory77) }
     let(:rdv) { build(:rdv, organisation: organisation) }
 
-    it { is_expected.to include("org-#{organisation.id}") }
-    it { is_expected.to include("dpt-77") }
-    it { is_expected.to include("test_sms") }
+    it do
+      expect(subject).to include("org-#{organisation.id}")
+      expect(subject).to include("dpt-77")
+      expect(subject).to include("test_sms")
+    end
   end
 
   describe "#content" do

--- a/spec/service_models/transactional_sms/file_attente_spec.rb
+++ b/spec/service_models/transactional_sms/file_attente_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 describe TransactionalSms::FileAttente, type: :service do
-  let(:rdv) { build(:rdv) }
-  let(:user) { build(:user) }
-
   describe "#content" do
-    subject { described_class.new(rdv, user).content }
+    subject { described_class.new(OpenStruct.new(rdv.payload(:update)), user).content }
 
-    it { is_expected.to include("Des créneaux se sont libérés plus tot") } # oh la belle faute
-    it { is_expected.to include("Cliquez pour voir les disponibilités") }
+    let(:rdv) { build(:rdv) }
+    let(:user) { build(:user) }
+
+    it do
+      expect(subject).to include("Des créneaux se sont libérés plus tot")
+      expect(subject).to include("Cliquez pour voir les disponibilités")
+    end
   end
 end

--- a/spec/service_models/transactional_sms/rdv_cancelled_spec.rb
+++ b/spec/service_models/transactional_sms/rdv_cancelled_spec.rb
@@ -1,53 +1,57 @@
 # frozen_string_literal: true
 
 describe TransactionalSms::RdvCancelled, type: :service do
-  let(:user) { build(:user) }
-  let(:pmi) { build(:service, short_name: "PMI") }
-  let(:motif) { build(:motif, service: pmi) }
-
   describe "#content" do
+    subject { described_class.new(OpenStruct.new(rdv.payload(:update)), user).content }
+
+    let(:pmi) { build(:service, short_name: "PMI") }
+    let(:motif) { build(:motif, service: pmi) }
+    let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+    let(:user) { build(:user) }
+
     context "with lieu phone number" do
+      let(:lieu) { build(:lieu, phone_number: "0123456789") }
+      let(:organisation) { build(:organisation, phone_number: "9876543210") }
+
       it "contains cancelled RDV's infos and lieu's phone number" do
-        lieu = build(:lieu, phone_number: "0123456789")
-        organisation = build(:organisation, phone_number: "9876543210")
-        rdv = build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10))
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
         expected_content += "Appelez le 0123456789 "
         expected_content += "ou allez sur https://rdv-solidarites.fr pour reprendre RDV."
-        expect(described_class.new(rdv, user).content).to eq(expected_content)
+        expect(subject).to eq(expected_content)
       end
     end
 
     context "with only organisation number" do
+      let(:lieu) { build(:lieu, phone_number: nil) }
+      let(:organisation) { build(:organisation, phone_number: "9876543210") }
+
       it "contains cancelled RDV's infos" do
-        lieu = build(:lieu, phone_number: nil)
-        organisation = build(:organisation, phone_number: "9876543210")
-        rdv = build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10))
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
         expected_content += "Appelez le 9876543210 "
         expected_content += "ou allez sur https://rdv-solidarites.fr pour reprendre RDV."
-        expect(described_class.new(rdv, user).content).to eq(expected_content)
+        expect(subject).to eq(expected_content)
       end
     end
 
     context "with no phone number" do
+      let(:lieu) { build(:lieu, phone_number: nil) }
+      let(:organisation) { build(:organisation, phone_number: nil) }
+
       it "contains cancelled RDV's infos" do
-        lieu = build(:lieu, phone_number: nil)
-        organisation = build(:organisation, phone_number: nil)
-        rdv = build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10))
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
         expected_content += "Allez sur https://rdv-solidarites.fr pour reprendre RDV."
-        expect(described_class.new(rdv, user).content).to eq(expected_content)
+        expect(subject).to eq(expected_content)
       end
     end
 
     context "without lieu and no organisation number" do
+      let(:lieu) { nil }
+      let(:organisation) { build(:organisation, phone_number: nil) }
+
       it "contains cancelled RDV's infos" do
-        organisation = build(:organisation, phone_number: nil)
-        rdv = build(:rdv, motif: motif, organisation: organisation, lieu: nil, starts_at: Time.zone.local(2021, 12, 10, 13, 10))
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
         expected_content += "Allez sur https://rdv-solidarites.fr pour reprendre RDV."
-        expect(described_class.new(rdv, user).content).to eq(expected_content)
+        expect(subject).to eq(expected_content)
       end
     end
   end

--- a/spec/service_models/transactional_sms/rdv_created_spec.rb
+++ b/spec/service_models/transactional_sms/rdv_created_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 describe TransactionalSms::RdvCreated, type: :service do
-  let(:pmi) { build(:service, short_name: "PMI") }
-  let(:motif) { build(:motif, service: pmi) }
-  let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
-  let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
-  let(:user) { build(:user) }
-
   describe "#content" do
-    subject { described_class.new(rdv, user).content }
+    subject { described_class.new(OpenStruct.new(rdv.payload(:update)), user).content }
 
-    it { is_expected.to include("RDV PMI vendredi 10/12 à 13h10") }
-    it { is_expected.to include("MDS Centre (10 rue d'ici)") }
-    it { is_expected.to include("Infos et annulation") }
+    let(:pmi) { build(:service, short_name: "PMI") }
+    let(:motif) { build(:motif, service: pmi) }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+    let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+    let(:user) { build(:user) }
+
+    it do
+      expect(subject).to include("RDV PMI vendredi 10/12 à 13h10")
+      expect(subject).to include("MDS Centre (10 rue d'ici)")
+      expect(subject).to include("Infos et annulation")
+    end
   end
 end

--- a/spec/service_models/transactional_sms/rdv_updated_spec.rb
+++ b/spec/service_models/transactional_sms/rdv_updated_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 describe TransactionalSms::RdvUpdated, type: :service do
-  let(:pmi) { build(:service, short_name: "PMI") }
-  let(:motif) { build(:motif, service: pmi) }
-  let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
-  let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
-  let(:user) { build(:user) }
-
   describe "#content" do
-    subject { described_class.new(rdv, user).content }
+    subject { described_class.new(OpenStruct.new(rdv.payload(:update)), user).content }
 
-    it { is_expected.to include("RDV modifié: PMI vendredi 10/12 à 13h10") }
-    it { is_expected.to include("MDS Centre (10 rue d'ici)") }
-    it { is_expected.to include("Infos et annulation") }
+    let(:pmi) { build(:service, short_name: "PMI") }
+    let(:motif) { build(:motif, service: pmi) }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+    let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+    let(:user) { build(:user) }
+
+    it do
+      expect(subject).to include("RDV modifié: PMI vendredi 10/12 à 13h10")
+      expect(subject).to include("MDS Centre (10 rue d'ici)")
+      expect(subject).to include("Infos et annulation")
+    end
   end
 end

--- a/spec/service_models/transactional_sms/reminder_spec.rb
+++ b/spec/service_models/transactional_sms/reminder_spec.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 describe TransactionalSms::Reminder, type: :service do
-  let(:pmi) { build(:service, short_name: "PMI") }
-  let(:motif) { build(:motif, service: pmi) }
-  let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
-  let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
-  let(:user) { build(:user) }
-
   describe "#content" do
-    subject { described_class.new(rdv, user).content }
+    subject { described_class.new(OpenStruct.new(rdv.payload(:update)), user).content }
 
-    it { is_expected.to include("Rappel RDV PMI le vendredi 10/12 à 13h10") }
-    it { is_expected.to include("MDS Centre (10 rue d'ici)") }
-    it { is_expected.to include("Infos et annulation") }
+    let(:pmi) { build(:service, short_name: "PMI") }
+    let(:motif) { build(:motif, service: pmi) }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+    let(:rdv) { build(:rdv, motif: motif, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10)) }
+    let(:user) { build(:user) }
+
+    it do
+      expect(subject).to include("Rappel RDV PMI le vendredi 10/12 à 13h10")
+      expect(subject).to include("MDS Centre (10 rue d'ici)")
+      expect(subject).to include("Infos et annulation")
+    end
   end
 end

--- a/spec/services/send_transactional_sms_service_spec.rb
+++ b/spec/services/send_transactional_sms_service_spec.rb
@@ -1,34 +1,22 @@
 # frozen_string_literal: true
 
 describe SendTransactionalSmsService, type: :service do
-  let(:sms_configuration) do
-    {
-      send_in_blue: {
-        api_key: ""
-      },
-      netsize: {
-        api_url: "https://europe.ipx.com/restapi/v1/sms/send",
-        user_pwd: "Ubb3rP4ss0wrD"
-      }
-    }
-  end
-
+  let(:sms_configuration) { { api_key: "mykey" } }
+  let(:rdv) { create(:rdv, organisation: create(:organisation, territory: create(:territory, sms_configuration: sms_configuration))) }
   let(:transactional_sms) do
     instance_double(
       TransactionalSms::RdvCreated,
       phone_number_formatted: "+33606060606",
       content: "Bonjour c'est rdv-sol",
       tags: ["RDV-Sol test", 10, "rdv_created"],
-      rdv: build(:rdv, \
-                 organisation: build(:organisation, \
-                                     territory: build(:territory, \
-                                                      sms_configuration: sms_configuration)))
+      rdv: OpenStruct.new(rdv.payload)
     )
   end
 
   describe "#perform" do
     context "production with SIB forced" do
       before do
+        allow(ENV).to receive(:[]).with("HOST").and_return("example.com")
         allow(Rails.env).to receive(:production?).and_return(true)
         allow(ENV).to receive(:[]).with("SENDINBLUE_SMS_API_KEY").and_return("send_in_blue")
         allow(ENV).to receive(:[]).with("FORCE_SMS_PROVIDER").and_return("send_in_blue")


### PR DESCRIPTION
refs #1361

- idem à #1487, mais pour les SMS cette fois-ci: passe un payload (un hash) des attributs du Rdv au lieu de passer le Rdv en lui-même. Ainsi, le job peut être exécuté même si le Rdv est supprimé entretemps.

Checklist avant review:
* [x] #1485 #1486, #1487 d’abord
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
