### PR TITLE
prend en compte l'agent du nouveau créneau

### DIFF
--- a/app/controllers/users/creneaux_controller.rb
+++ b/app/controllers/users/creneaux_controller.rb
@@ -21,7 +21,7 @@ class Users::CreneauxController < UserAuthController
   end
 
   def update
-    @rdv.update(starts_at: @creneau.starts_at, created_by: :file_attente)
+    @rdv.update(starts_at: @creneau.starts_at, agent_ids: [@creneau.agent_id], created_by: :file_attente)
     Notifications::Rdv::RdvDateUpdatedService.perform_with(@rdv, current_user)
   end
 

--- a/app/views/users/creneaux/_creneaux.html.slim
+++ b/app/views/users/creneaux/_creneaux.html.slim
@@ -21,7 +21,7 @@ div id="creneaux-lieu"
             - if creneaux_for_date.any?
               - creneaux_for_date.each do |date, creneaux|
                 - creneaux.sort_by(&:starts_at).each do |creneau|
-                  = link_to l(creneau.starts_at, format: "%H:%M"), edit_users_creneaux_path(@rdv.id, starts_at: creneau.starts_at), class: "btn btn-light mr-1 mb-1 w-100"
+                  = link_to l(creneau.starts_at, format: "%H:%M"), edit_users_creneaux_path(@rdv.id, starts_at: creneau.starts_at, agent_id: creneau.agent.id), class: "btn btn-light mr-1 mb-1 w-100"
     - if date_range.end < @all_creneaux.last.starts_at.to_date
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
         = link_to users_creneaux_index_path(rdv_id: rdv.id, date: date_range.end + 1.day), remote: true, class: 'btn btn-primary', data: { disable_with: "..." } do

--- a/spec/controllers/users/creneaux_controller_spec.rb
+++ b/spec/controllers/users/creneaux_controller_spec.rb
@@ -5,17 +5,17 @@ describe Users::CreneauxController, type: :controller do
   let(:organisation) { create(:organisation) }
 
   describe "GET #index" do
+    subject do
+      get :index, params: { rdv_id: rdv.id }
+      rdv.reload
+    end
+
     let(:now) { "01/01/2019 10:00".to_datetime }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation) }
-
-    subject do
-      get :index, params: { rdv_id: rdv.id }
-      rdv.reload
-    end
 
     before do
       travel_to(now)
@@ -42,20 +42,19 @@ describe Users::CreneauxController, type: :controller do
   end
 
   describe "GET #edit" do
+    subject do
+      get :edit, params: { rdv_id: rdv.id, starts_at: starts_at }
+      rdv.reload
+    end
+
     let(:organisation) { create(:organisation) }
+    let(:starts_at) { 3.days.from_now }
     let(:now) { "01/01/2019 10:00".to_datetime }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation) }
-
-    subject do
-      get :edit, params: { rdv_id: rdv.id, starts_at: starts_at }
-      rdv.reload
-    end
-
-    let(:starts_at) { 3.days.from_now }
 
     before do
       travel_to(now)
@@ -105,36 +104,34 @@ describe Users::CreneauxController, type: :controller do
       let(:returned_creneau) { Creneau.new(starts_at: starts_at, agent_id: agent.id) }
 
       it "respond success" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id}
+        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(response).to be_successful
       end
 
       it "update RDV starts_at" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id}
+        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(rdv.reload.starts_at).to eq(starts_at)
       end
 
-      it "update RDV starts_at" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id}
+      it "update RDV agent ids with only one agent" do
+        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(rdv.reload.agent_ids).to eq([agent.id])
       end
 
-      it "update RDV starts_at" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id}
+      it "update RDV created_by with file_attente" do
+        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(rdv.reload.created_by).to eq("file_attente")
       end
-
     end
 
     context "without an available creneau" do
-      let(:returned_creneau) {nil}
+      let(:returned_creneau) { nil }
 
       it "redirect to index when not available" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id}
+        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
 
         expect(subject).to redirect_to(users_creneaux_index_path(rdv_id: rdv.id))
       end
-
     end
   end
 end

--- a/spec/controllers/users/creneaux_controller_spec.rb
+++ b/spec/controllers/users/creneaux_controller_spec.rb
@@ -103,23 +103,11 @@ describe Users::CreneauxController, type: :controller do
     context "with an available creneau" do
       let(:returned_creneau) { Creneau.new(starts_at: starts_at, agent_id: agent.id) }
 
-      it "respond success" do
+      it "respond success and update RDV" do
         put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(response).to be_successful
-      end
-
-      it "update RDV starts_at" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(rdv.reload.starts_at).to eq(starts_at)
-      end
-
-      it "update RDV agent ids with only one agent" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(rdv.reload.agent_ids).to eq([agent.id])
-      end
-
-      it "update RDV created_by with file_attente" do
-        put :update, params: { rdv_id: rdv.id, starts_at: starts_at, agent_id: agent.id }
         expect(rdv.reload.created_by).to eq("file_attente")
       end
     end


### PR DESCRIPTION
close #1479 

Dans un rendez-vous mis en file d'attente ;
Si un créneau se libère, il est proposé à l'usager ;
Il peut le choisir pour avancer son rendez-vous.

Le hic, c'est que nous ne changions que la date et l'heure. Or les nouveaux créneaux proposés sont calculé à partir du motif du rendez-vous, sur tous les agents qui le proposent donc.

Cette PR prend en compte la mise à jour de l'agent chargé du rendez-vous dans le cas d'une modification de rendez-vous via file d'attente.

L'analyse de ce problème m'a permis de faire une doc sur la file d'attente. C'est peut-être une bonne idée d'y jeter un coup d'œil pour vérifier que c'est clair  https://doc.rdv-solidarites.fr/tutoriels/file-dattente

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
