### PR TITLE
ajoute autolink pour avoir des liens clickable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,8 @@ gem "spreadsheet"
 
 gem "omniauth-rails_csrf_protection", "~> 0.1"
 
+gem "rails_autolink"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,8 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_autolink (1.1.6)
+      rails (> 3.1)
     railties (6.0.3.7)
       actionpack (= 6.0.3.7)
       activesupport (= 6.0.3.7)
@@ -626,6 +628,7 @@ DEPENDENCIES
   rails (~> 6.0)
   rails-controller-testing
   rails-erd
+  rails_autolink
   rspec-rails (>= 4.0.0.beta)
   rspec_junit_formatter
   rubocop (~> 1)

--- a/app/views/common/_creneaux.html.slim
+++ b/app/views/common/_creneaux.html.slim
@@ -35,7 +35,7 @@ div id="creneaux-lieu-#{lieu.id}"
                         small= creneau.agent_name
 
                     =  render "/common/modal", id: "js-rdv-restriction-motif#{creneau.starts_at.to_i}" , title: "À lire avant de prendre un rendez-vous", confirm_path: new_users_rdv_wizard_step_path(@query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)) do
-                      = simple_format(creneau.motif.restriction_for_rdv)
+                      = ActionController::Base.helpers.auto_link(simple_format(creneau.motif.restriction_for_rdv), html: { target: '_blank'})
             - elsif date >= (Time.now + max_booking_delay.seconds).to_date
               p.text-center.text-muted
                 | Date fermée à la reservation

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -41,4 +41,4 @@
   - if rdv.motif_instruction.present? && for_role == :user
     .div.row-result.no-border
       span.title Informations supplémentaires :
-      = simple_format(rdv.motif_instruction)
+      = auto_link(simple_format(rdv.motif_instruction), html: { target: "_blank" })

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -33,7 +33,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       i.fa.fa-exclamation-triangle>
       strong Informations supplémentaires :
-      = simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1")
+      = auto_link(simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1"), html: { target: "_blank" })
   - unless defined?(hide_file_attente_infos) && hide_file_attente_infos
     = render "/users/rdvs/file_attente", rdv: rdv
 - unless defined?(hide_cancellation_infos) && hide_cancellation_infos


### PR DESCRIPTION
Close #1483 

Ajout de [autolink](https://github.com/tenderlove/rails_autolink), et mise en place aux endroits où l'on affiche les consignes.

_Merci @n-b pour la suggestion_

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
