### PR TITLE
Corrige l’affichage du titre du Rdv

### DIFF
--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -9,11 +9,10 @@
         - else
           = link_to "Votre agenda", admin_organisation_agent_agenda_path(current_organisation, current_agent)
     li.breadcrumb-item.p-0.ml-2
-      div
-        span> RDV
-        span>= rdv_title_for_agent(@rdv)
-        - if @rdv.cancelled?
-          span.badge.badge-danger
+      span> RDV
+      span>= rdv_title_for_agent(@rdv)
+      - if @rdv.cancelled?
+        span.badge.badge-danger
 
 - content_for :breadcrumb do
   = link_to "Dupliquer…", admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, motif_id: @rdv.motif_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context, commit: "commit"), class: "btn btn-outline-white"


### PR DESCRIPTION
fixes #1439

Je ne sais pas exactement quel était le problème: en gros, j’ai l’impression que mettre un `div` dans un `li` dans le `.breadcrumb` dans `.page-title` ça pose problème. À vue de nez, breadcrumb utilise une flexbox, et ça fait des choses bizarre.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
