### PR TITLE
Unify and cleanup icalendar email attachment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash', 'heredoc']
-  Max: 15
+  Max: 20
   Exclude:
     - 'db/migrate/20210301135256_create_territories.rb'
 

--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -16,25 +16,12 @@ class Agents::AbsenceMailer < ApplicationMailer
   private
 
   def send_mail(absence_payload)
-    attachments[absence_payload[:name]] = {
-      mime_type: "text/calendar",
-      content: IcalHelpers::Ics.from_payload(absence_payload),
-      encoding: "8bit" # fixes encoding issues in ICS
-    }
+    self.ics_payload = absence_payload
 
-    m = mail(
+    mail(
       from: "secretariat-auto@rdv-solidarites.fr",
       to: absence_payload[:agent_email],
       subject: "#{BRAND} - #{absence_payload[:title]}"
     )
-    m.add_part(
-      Mail::Part.new do
-        content_type "text/calendar; method=REQUEST; charset=utf-8"
-        body Base64.encode64(IcalHelpers::Ics.from_payload(absence_payload))
-        content_transfer_encoding "base64"
-        # quoted-printable would be more adapted but there seems to be an encoding problem with extra =0D
-      end
-    )
-    m
   end
 end

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -16,25 +16,12 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
   private
 
   def send_mail(plage_ouverture_payload)
-    attachments[plage_ouverture_payload[:name]] = {
-      mime_type: "text/calendar",
-      content: IcalHelpers::Ics.from_payload(plage_ouverture_payload),
-      encoding: "8bit" # fixes encoding issues in ICS
-    }
+    self.ics_payload = plage_ouverture_payload
 
-    m = mail(
+    mail(
       from: "secretariat-auto@rdv-solidarites.fr",
       to: plage_ouverture_payload[:agent_email],
       subject: "#{BRAND} - #{plage_ouverture_payload[:title]}"
     )
-    m.add_part(
-      Mail::Part.new do
-        content_type "text/calendar; method=REQUEST; charset=utf-8"
-        body Base64.encode64(IcalHelpers::Ics.from_payload(plage_ouverture_payload))
-        content_transfer_encoding "base64"
-        # quoted-printable would be more adapted but there seems to be an encoding problem with extra =0D
-      end
-    )
-    m
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
+  prepend IcsMultipartAttached
+
   default from: "contact@rdv-solidarites.fr"
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"

--- a/app/mailers/concerns/ics_multipart_attached.rb
+++ b/app/mailers/concerns/ics_multipart_attached.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module IcsMultipartAttached
+  # Sending icalendar events by email is complicated, buggy and unreliable.
+  # This module is added to ApplicationMailer and used in all emails that include an icalendar
+  # to make sure we use the same hacks everywhere.
+
+  attr_accessor :ics_payload
+
+  def mail(*args)
+    cal = ics_payload.present? ? IcalHelpers::Ics.from_payload(ics_payload) : nil
+
+    # Specs
+    # iCalendar: https://datatracker.ietf.org/doc/html/rfc2445
+    #   * See section 4.6.1 for VEVENT
+    # iTIP: https://datatracker.ietf.org/doc/html/rfc2446
+    #   * See section 3.2 for the semantics of the METHOD
+
+    # Previous icalendar-related pull requests in RDV-solidarités
+    # https://github.com/betagouv/rdv-solidarites.fr/pull/933
+    # https://github.com/betagouv/rdv-solidarites.fr/pull/729
+
+    # Related StackOverflow discussions
+    # https://stackoverflow.com/questions/24259827/why-are-my-icalendar-invitations-not-processed-by-the-outlook-sniffer
+    # https://stackoverflow.com/questions/19523861/multipart-email-with-text-and-calendar-outlook-doesnt-recognize-ics
+
+    # We try to mimic the behaviour of google calendar emails:
+    #
+    # 1. We add the icalendar twice to the email:
+    #    * once as a `text/calendar` part (with a `method=` in the content type),
+    #    * once as an `application/ics` attached .ics file.
+    #
+    # 2. The method is PUBLISH or CANCEL, not REQUEST: we don’t want replies.
+    #
+    # 3. the `application/ics` attachment is base64-encoded
+    #
+    # 4. the `text/calendar` part is in raw text (`quoted-printable`).
+
+    # The final email parts look like this:
+    # - multipart/mixed
+    #   - multipart/alternative
+    #     - text/plain
+    #     - text/html
+    #   - text/calendar
+    #   - application/ics
+    # Google calendar puts the text/calendar inside the multipart/alternative part.
+    # We might want to try that too.
+
+    if cal.present?
+      message.attachments[ics_payload[:name]] = {
+        mime_type: "application/ics",
+        content: Base64.encode64(cal.to_ical),
+        encoding: "base64"
+      }
+    end
+
+    message = super
+
+    if cal.present?
+      message.add_part(
+        Mail::Part.new do
+          content_type "text/calendar; method=#{cal.ip_method}; charset=utf-8"
+          body cal.to_ical
+        end
+      )
+    end
+
+    message
+  end
+end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -10,11 +10,7 @@ class Users::RdvMailer < ApplicationMailer
     @rdv = OpenStruct.new(rdv_payload)
     @user = user
 
-    attachments[rdv_payload[:name]] = {
-      mime_type: "text/calendar",
-      content: IcalHelpers::Ics.from_payload(rdv_payload),
-      encoding: "8bit" # fixes encoding issues in ICS
-    }
+    self.ics_payload = rdv_payload
     mail(
       to: user.email,
       subject: "RDV confirmé le #{l(@rdv.starts_at, format: :human)}"
@@ -26,11 +22,7 @@ class Users::RdvMailer < ApplicationMailer
     @user = user
     @old_starts_at = old_starts_at
 
-    attachments[rdv_payload[:name]] = {
-      mime_type: "text/calendar",
-      content: IcalHelpers::Ics.from_payload(rdv_payload),
-      encoding: "8bit" # fixes encoding issues in ICS
-    }
+    self.ics_payload = rdv_payload
     mail(
       to: user.email,
       subject: "RDV #{relative_date old_starts_at} reporté à plus tard"
@@ -40,6 +32,8 @@ class Users::RdvMailer < ApplicationMailer
   def rdv_upcoming_reminder(rdv_payload, user)
     @rdv = OpenStruct.new(rdv_payload)
     @user = user
+
+    self.ics_payload = rdv_payload
     mail(
       to: user.email,
       subject: "[Rappel] RDV le #{l(@rdv.starts_at, format: :human)}"
@@ -50,6 +44,8 @@ class Users::RdvMailer < ApplicationMailer
     @rdv = OpenStruct.new(rdv_payload)
     @user = user
     @author = author
+
+    self.ics_payload = rdv_payload
     mail(
       to: user.email,
       subject: "RDV annulé le #{l(@rdv.starts_at, format: :human)} avec #{@rdv.organisation_name}"

--- a/app/models/concerns/ical_helpers/ics.rb
+++ b/app/models/concerns/ical_helpers/ics.rb
@@ -5,7 +5,7 @@ require "icalendar/tzinfo"
 module IcalHelpers
   module Ics
     def to_ical(*args)
-      IcalHelpers::Ics.from_payload(payload(*args))
+      IcalHelpers::Ics.from_payload(payload(*args)).to_ical
     end
 
     def self.from_payload(payload)
@@ -14,8 +14,9 @@ module IcalHelpers
       cal.add_timezone Time.zone_default.tzinfo.ical_timezone payload[:starts_at]
       cal.prodid = BRAND
       cal.event { |event| populate_event(event, payload) }
+      cal.ip_method = (payload[:action] == :destroy ? "CANCEL" : "PUBLISH")
 
-      cal.to_ical
+      cal
     end
 
     def self.populate_event(event, payload)
@@ -38,6 +39,7 @@ module IcalHelpers
       event.rrule = payload[:recurrence]
       event.sequence = payload[:sequence]
       event.description = payload[:description]
+      event.organizer = "mailto:secretariat-auto@rdv-solidarites.fr"
     end
   end
 end

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -29,7 +29,8 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
 
       it "has a ICS file join with UID" do
         mail = described_class.send("plage_ouverture_#{action}", ics_payload)
-        expect(mail.attachments[0].to_s).to match("UID:plage_ouverture_@RDV Solidarit=C3=A9s")
+        cal = mail.find_first_mime_type("text/calendar")
+        expect(cal.body.raw_source).to match("UID:plage_ouverture_@RDV Solidarités")
       end
     end
   end
@@ -48,7 +49,8 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
         address: "une adresse"
       }
       mail = described_class.send("plage_ouverture_destroyed", ics_payload)
-      expect(mail.attachments[0].to_s).to match("STATUS:CANCELLED")
+      cal = mail.find_first_mime_type("text/calendar")
+      expect(cal.body.raw_source).to match("STATUS:CANCELLED")
     end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
       mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, user)
 
-      expect(mail.body).to match("lundi 15 juin 2020 à 12h30")
+      expect(mail.html_part.body).to match("lundi 15 juin 2020 à 12h30")
     end
 
     it "body contains cancelled confirmation with motif's service name" do
@@ -59,7 +59,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
       mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, user)
 
-      expect(mail.body).to match(rdv.motif.service_name)
+      expect(mail.html_part.body).to match(rdv.motif.service_name)
     end
 
     it "body contains link to book a new RDV" do
@@ -75,7 +75,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
                                  where: rdv.address \
                                })
 
-      expect(mail.body).to have_link("Reprendre RDV", href: expected_url)
+      expect(mail.html_part.body).to have_link("Reprendre RDV", href: expected_url)
     end
   end
 
@@ -85,7 +85,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       user = rdv.users.first
       mail = described_class.rdv_upcoming_reminder(rdv.payload, user)
       expect(mail.to).to eq([user.email])
-      expect(mail.body).to include("Nous vous rappellons que vous avez un RDV prévu")
+      expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
     end
   end
 end

--- a/spec/models/concerns/ical_helpers/ics_spec.rb
+++ b/spec/models/concerns/ical_helpers/ics_spec.rb
@@ -4,7 +4,7 @@ require "rspec"
 
 describe IcalHelpers::Ics do
   describe "from_payload" do
-    subject { described_class.from_payload(payload) }
+    subject { described_class.from_payload(payload).to_ical }
 
     let(:payload) do
       {


### PR DESCRIPTION
* use a single helper for all emails
* base64-encode the attached ics file
* properly use PUBLISH/CANCEL methods

refs #1354

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
