### PR TITLE
Corrige l’envoi de trop de notifications pour les changements de Rdv

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,6 +140,9 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/app/service_functions/rdv_updater.rb
+++ b/app/service_functions/rdv_updater.rb
@@ -22,7 +22,9 @@ module RdvUpdater
           Notifications::Rdv::RdvCancelledService.perform_with(rdv, author)
         end
 
-        Notifications::Rdv::RdvDateUpdatedService.perform_with(rdv, author) if rdv.previous_changes["starts_at"].present?
+        if rdv.previous_changes["starts_at"].present?
+          Notifications::Rdv::RdvDateUpdatedService.perform_with(rdv, author)
+        end
       end
       result
     end

--- a/app/service_functions/rdv_updater.rb
+++ b/app/service_functions/rdv_updater.rb
@@ -3,32 +3,28 @@
 module RdvUpdater
   class << self
     def update(author, rdv, rdv_params)
+      # Explicitly touch the Rdv to make sure a new Version is saved on paper_trail
+      # This may be needed when changing associations, when adding/removing an agent or a user.
       rdv.updated_at = Time.zone.now
-      # TODO: replace this manual touch. It forces creating a version when an
-      # agent or a user is removed from the RDV. the touch: true option on the
-      # association does not do it for some reason I could not figure out
 
+      # Set/reset cancelled_at when the status changes
       if rdv_params[:status].present?
         rdv_params[:cancelled_at] = rdv_params[:status].in?(%w[excused notexcused]) ? Time.zone.now : nil
       end
 
       result = rdv.update(rdv_params)
-      send_relevant_notifications(author, rdv, rdv_params) if result
+
+      # Send relevant notifications (cancellation and date update)
+      if result
+        if rdv.previous_changes["status"]&.last.in? %w[excused notexcused]
+          # Also destroy the file_attentes
+          rdv.file_attentes.destroy_all
+          Notifications::Rdv::RdvCancelledService.perform_with(rdv, author)
+        end
+
+        Notifications::Rdv::RdvDateUpdatedService.perform_with(rdv, author) if rdv.previous_changes["starts_at"].present?
+      end
       result
-    end
-
-    def send_relevant_notifications(author, rdv, rdv_params)
-      notify_cancellation(author, rdv) if rdv_params[:status].in? %w[excused notexcused]
-      notify_starts_at_change(author, rdv) if rdv_params[:starts_at].present?
-    end
-
-    def notify_cancellation(author, rdv)
-      rdv.file_attentes.destroy_all
-      Notifications::Rdv::RdvCancelledService.perform_with(rdv, author)
-    end
-
-    def notify_starts_at_change(author, rdv)
-      Notifications::Rdv::RdvDateUpdatedService.perform_with(rdv, author)
     end
   end
 end

--- a/spec/service_functions/rdv_updater_spec.rb
+++ b/spec/service_functions/rdv_updater_spec.rb
@@ -2,91 +2,118 @@
 
 describe RdvUpdater, type: :service do
   describe "#update" do
-    it "true when everything is ok" do
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent])
-      rdv_params = {}
-      expect(described_class.update(agent, rdv, rdv_params)).to eq(true)
+    describe "return value" do
+      it "true when everything is ok" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent])
+        rdv_params = {}
+        expect(described_class.update(agent, rdv, rdv_params)).to eq(true)
+      end
+
+      it "return false when update fail" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent])
+        rdv_params = { agents: [] }
+        expect(described_class.update(agent, rdv, rdv_params)).to eq(false)
+      end
     end
 
-    it "call rdv.update with params" do
-      agent = build :agent
-      rdv = create(:rdv, context: "un contexte", agents: [agent])
-      rdv_params = { context: "un autre context" }
-      expect(rdv).to receive(:update).with(rdv_params)
-      described_class.update(agent, rdv, rdv_params)
+    describe "clear the file_attentes" do
+      it "destroy all file_attentes" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent])
+        create(:file_attente, rdv: rdv)
+        rdv_params = { status: "excused" }
+        described_class.update(agent, rdv, rdv_params)
+        expect(rdv.reload.file_attentes).to be_empty
+      end
     end
 
-    it "destroy all file_attentes" do
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent])
-      create(:file_attente, rdv: rdv)
-      rdv_params = { status: "excused" }
-      described_class.update(agent, rdv, rdv_params)
-      expect(rdv.reload.file_attentes).to be_empty
+    describe "sends relevant notifications" do
+      it "notifies when rdv cancelled" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "waiting")
+        rdv_params = { status: "excused" }
+        expect(Notifications::Rdv::RdvCancelledService).to receive(:perform_with).with(rdv, agent)
+        described_class.update(agent, rdv, rdv_params)
+      end
+
+      it "does not notify when status does not change" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "waiting")
+        rdv_params = { status: "waiting" }
+        expect(Notifications::Rdv::RdvCancelledService).not_to receive(:perform_with)
+        described_class.update(agent, rdv, rdv_params)
+      end
+
+      it "notifies when date changes" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "waiting")
+        rdv_params = { starts_at: Time.zone.now + 1.day }
+        expect(Notifications::Rdv::RdvDateUpdatedService).to receive(:perform_with).with(rdv, agent)
+        described_class.update(agent, rdv, rdv_params)
+      end
+
+      it "does not notify when date does not change" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "waiting")
+        rdv_params = { starts_at: rdv.starts_at }
+        expect(Notifications::Rdv::RdvDateUpdatedService).not_to receive(:perform_with)
+        described_class.update(agent, rdv, rdv_params)
+      end
+
+      it "does not notify when other attributes change" do
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "waiting")
+        rdv_params = { context: "some context" }
+        expect(Notifications::Rdv::RdvCancelledService).not_to receive(:perform_with)
+        expect(Notifications::Rdv::RdvDateUpdatedService).not_to receive(:perform_with)
+        described_class.update(agent, rdv, rdv_params)
+      end
     end
 
-    it "return false when update fail" do
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent])
-      rdv_params = { agents: [] }
-      expect(described_class.update(agent, rdv, rdv_params)).to eq(false)
+    describe "manually touches the rdv" do
+      it "force updated_at to ensure new version will be recorded" do
+        now = Time.zone.local(2020, 4, 23, 12, 56)
+        travel_to(now)
+        previous_date = now - 3.days
+
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], updated_at: previous_date, context: "")
+        rdv_params = { context: "un nouveau context" }
+        described_class.update(agent, rdv, rdv_params)
+        expect(rdv.reload.updated_at).to be_within(3.seconds).of now
+        travel_back
+      end
     end
 
-    it "notify user when rdv cancelled by agent" do
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent], status: "waiting")
-      rdv_params = { status: "excused" }
-      expect(Notifications::Rdv::RdvCancelledService).to receive(:perform_with).with(rdv, agent)
-      described_class.update(agent, rdv, rdv_params)
-    end
+    describe "sets and resets cancelled_at" do
+      it "reset cancelled_at when status change" do
+        cancelled_at = Time.zone.local(2020, 1, 12, 12, 56)
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "notexcused", cancelled_at: cancelled_at)
+        rdv_params = { status: "waiting" }
+        described_class.update(agent, rdv, rdv_params)
+        expect(rdv.reload.cancelled_at).to eq(nil)
+      end
 
-    it "notify user and agent when rdv cancelled by user" do
-      user = build(:user)
-      rdv = create(:rdv, status: "waiting", users: [user])
-      rdv_params = { status: "excused" }
-      expect(Notifications::Rdv::RdvCancelledService).to receive(:perform_with).with(rdv, user)
-      described_class.update(user, rdv, rdv_params)
-    end
+      it "dont reset cancelled_at when no status change" do
+        cancelled_at = Time.zone.local(2020, 1, 12, 12, 56)
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: cancelled_at, context: "")
+        rdv_params = { context: "something new" }
+        described_class.update(agent, rdv, rdv_params)
+        expect(rdv.reload.cancelled_at).to be_within(3.seconds).of cancelled_at
+      end
 
-    it "force updated_at to ensure new version will be recorded" do
-      now = Time.zone.local(2020, 4, 23, 12, 56)
-      travel_to(now)
-      previous_date = now - 3.days
-
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent], updated_at: previous_date, context: "")
-      rdv_params = { context: "un nouveau context" }
-      described_class.update(agent, rdv, rdv_params)
-      expect(rdv.reload.updated_at).to be_within(3.seconds).of now
-      travel_back
-    end
-
-    it "reset cancelled_at when status change" do
-      cancelled_at = Time.zone.local(2020, 1, 12, 12, 56)
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent], status: "notexcused", cancelled_at: cancelled_at)
-      rdv_params = { status: "waiting" }
-      described_class.update(agent, rdv, rdv_params)
-      expect(rdv.reload.cancelled_at).to eq(nil)
-    end
-
-    it "dont reset cancelled_at when no status change" do
-      cancelled_at = Time.zone.local(2020, 1, 12, 12, 56)
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: cancelled_at, context: "")
-      rdv_params = { context: "something new" }
-      described_class.update(agent, rdv, rdv_params)
-      expect(rdv.reload.cancelled_at).to be_within(3.seconds).of cancelled_at
-    end
-
-    it "where status change from excused to notexcused, cancelled_at should be refresh" do
-      now = Time.zone.local(2020, 4, 23, 12, 56)
-      travel_to(now)
-      agent = build :agent
-      rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
-      described_class.update(agent, rdv, { status: "notexcused" })
-      expect(rdv.reload.cancelled_at).to be_within(3.seconds).of now
+      it "where status change from excused to notexcused, cancelled_at should be refresh" do
+        now = Time.zone.local(2020, 4, 23, 12, 56)
+        travel_to(now)
+        agent = build :agent
+        rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
+        described_class.update(agent, rdv, { status: "notexcused" })
+        expect(rdv.reload.cancelled_at).to be_within(3.seconds).of now
+      end
     end
   end
 end


### PR DESCRIPTION
close #1537

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
