### PR TITLE
affiche uniquement les lieux ouverts

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -17,7 +17,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
         @agents = policy_scope(Agent)
           .joins(:organisations).where(organisations: { id: current_organisation.id })
           .complete.active.order_by_last_name
-        @lieux = policy_scope(Lieu).ordered_by_name
+        @lieux = policy_scope(Lieu).enabled.ordered_by_name
       end
       format.js do
         skip_policy_scope # TODO: improve pundit checks for creneaux

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -9,7 +9,7 @@ class Lieu < ApplicationRecord
   validates :name, :address, :latitude, :longitude, presence: true
 
   scope :enabled, -> { where(enabled: true) }
-  scope :disabled, -> { where.not(enabled: false) }
+  scope :disabled, -> { where.not(enabled: true) }
 
   scope :for_motif, lambda { |motif|
     lieux_ids = PlageOuverture

--- a/spec/controllers/admin/creneaux/agent_searches_controller_spec.rb
+++ b/spec/controllers/admin/creneaux/agent_searches_controller_spec.rb
@@ -25,6 +25,13 @@ describe Admin::Creneaux::AgentSearchesController, type: :controller do
         get :index, params: { organisation_id: organisation_id, user_ids: [user.id] }
         expect(assigns(:form).user_ids).to eq([user.id.to_s])
       end
+
+      it "assigns enabled lieux" do
+        enabled_lieu = create(:lieu, enabled: true, organisation: organisation)
+        create(:lieu, enabled: false, organisation: organisation)
+        get :index, params: { organisation_id: organisation_id }
+        expect(assigns(:lieux)).to eq([enabled_lieu])
+      end
     end
   end
 end

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -113,7 +113,7 @@ describe Lieu, type: :model do
     end
   end
 
-  describe "disaabled" do
+  describe "disabled" do
     it "returns only disabled lieu" do
       create(:lieu, enabled: true)
       disabled_lieu = create(:lieu, enabled: false)

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -3,12 +3,12 @@
 describe Lieu, type: :model do
   let!(:territory) { create(:territory, departement_number: "62") }
   let!(:organisation) { create(:organisation, territory: territory) }
-  let!(:lieu) { create(:lieu) }
   let!(:user) { create(:user) }
 
   context "with motif" do
     let!(:motif) { create(:motif, name: "Vaccination", reservable_online: reservable_online, organisation: organisation) }
     let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:lieu) { create(:lieu) }
 
     describe ".for_motif" do
       subject { described_class.for_motif(motif) }
@@ -50,6 +50,7 @@ describe Lieu, type: :model do
     end
 
     describe ".distance" do
+      let!(:lieu) { create(:lieu) }
       let!(:lieu_lille) { create(:lieu, latitude: 50.63, longitude: 3.053) }
       let(:paris_loc) { { latitude: 48.83, longitude: 2.37 } }
       let(:reservable_online) { true }
@@ -60,6 +61,8 @@ describe Lieu, type: :model do
 
     describe "#with_open_slots_for_motifs" do
       subject { described_class.with_open_slots_for_motifs([motif]) }
+
+      let!(:lieu) { create(:lieu) }
 
       context "motif has current plage ouvertures" do
         let!(:motif) { create(:motif, name: "Vaccination") }
@@ -98,6 +101,23 @@ describe Lieu, type: :model do
     it "destroy lieu without rdvs or plage d'ouverture" do
       lieu = create(:lieu, organisation: organisation, rdvs: [], plage_ouvertures: [])
       expect(lieu.destroy).to eq(lieu)
+    end
+  end
+
+  describe "enabled" do
+    it "returns only enabled lieu" do
+      enabled_lieu = create(:lieu, enabled: true)
+      create(:lieu, enabled: false)
+      expect(described_class.count).to eq(2)
+      expect(described_class.enabled).to eq([enabled_lieu])
+    end
+  end
+
+  describe "disaabled" do
+    it "returns only disabled lieu" do
+      create(:lieu, enabled: true)
+      disabled_lieu = create(:lieu, enabled: false)
+      expect(described_class.disabled).to eq([disabled_lieu])
     end
   end
 end


### PR DESCRIPTION
close #1530 

Nous avions oublié de filtrer les lieux dans le formulaire de recherche de créneaux coté agent. Cette PR corrige cette oublie.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
