### PR TITLE
Encode the text/calendar part of emails as base64 too

### DIFF
--- a/app/mailers/concerns/ics_multipart_attached.rb
+++ b/app/mailers/concerns/ics_multipart_attached.rb
@@ -34,7 +34,9 @@ module IcsMultipartAttached
     #
     # 3. the `application/ics` attachment is base64-encoded
     #
-    # 4. the `text/calendar` part is in raw text (`quoted-printable`).
+    # 4. the `text/calendar` part is base64-encoded, too.
+    # This is different from Google: quoted-printable, in ActiveMailer, encodes line breaks as =0D\n,
+    # and this seems to break the Outlook automatic integration. #1354
 
     # The final email parts look like this:
     # - multipart/mixed
@@ -60,7 +62,8 @@ module IcsMultipartAttached
       message.add_part(
         Mail::Part.new do
           content_type "text/calendar; method=#{cal.ip_method}; charset=utf-8"
-          body cal.to_ical
+          body Base64.encode64(cal.to_ical)
+          content_transfer_encoding "base64"
         end
       )
     end

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -30,7 +30,7 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
       it "has a ICS file join with UID" do
         mail = described_class.send("plage_ouverture_#{action}", ics_payload)
         cal = mail.find_first_mime_type("text/calendar")
-        expect(cal.body.raw_source).to match("UID:plage_ouverture_@RDV Solidarités")
+        expect(cal.decoded).to match("UID:plage_ouverture_@RDV Solidarités")
       end
     end
   end
@@ -50,7 +50,7 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
       }
       mail = described_class.send("plage_ouverture_destroyed", ics_payload)
       cal = mail.find_first_mime_type("text/calendar")
-      expect(cal.body.raw_source).to match("STATUS:CANCELLED")
+      expect(cal.decoded).to match("STATUS:CANCELLED")
     end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     end
 
     it "contains the ics" do
-      expect(mail.body.encoded).to match("UID:#{rdv.uuid}")
-      expect(mail.body.encoded).to match("STATUS:CANCELLED") if rdv.cancelled?
+      cal = mail.find_first_mime_type("text/calendar")
+      expect(cal.decoded).to match("UID:#{rdv.uuid}")
+      expect(cal.decoded).to match("STATUS:CANCELLED") if rdv.cancelled?
     end
   end
 


### PR DESCRIPTION
This is a return to what we used to do before #1531. Fixes #1354

Quoted-printable would make sense, and this is what Google Calendar uses.
However, with quoted-printable, Rails (in quoted-printable.rb) uses “pack("M")” which gives `=OD\n`.
I’m not 100% sure if this is fine by the specs.(See RFC2045) But:
* We know that Zimbra doesn’t like it very much: when the application/ics attachment is encoded as such, zimbra decodes it as CRCRLF and its icalendar parsing library crashes.
* Outlook apparently does not automatically interpret the text/calendar part anymore, since #1531

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
  - [ ] E Vaneecke 
  - [ ] C Cufay
  - [ ] A Perriot