### PR TITLE
Send matomo hits even when navigating with turbolinks

### DIFF
--- a/app/webpacker/components/analytic.js
+++ b/app/webpacker/components/analytic.js
@@ -1,5 +1,3 @@
-let previousPageUrl = null;
-
 if (ENV.ENV == "production") {
   window._paq = window._paq || [];
 
@@ -9,7 +7,6 @@ if (ENV.ENV == "production") {
 
   // Configure Matomo analytics
   window._paq.push(['setDoNotTrack', true]);
-  window._paq.push(['trackPageView']);
   window._paq.push(['enableLinkTracking']);
 
   // Load script from Matomo
@@ -25,16 +22,21 @@ if (ENV.ENV == "production") {
   firstScript.parentNode.insertBefore(script, firstScript);
 
   $(document).on('shown.bs.modal', '.modal', sendDataToMatomo);
+  $(document).on('turbolinks:load', sendDataToMatomo);
 }
 
 // see https://developer.matomo.org/guides/spa-tracking
 function sendDataToMatomo (event) {
-  window._paq.push(['setDocumentTitle', document.title]);
   if (event.data && event.data.timing) {
-    window._paq.push([
-      'setGenerationTimeMs',
-      event.data.timing.visitEnd - event.data.timing.visitStart
-    ]);
+    let loadTimeMs = event.data.timing.visitEnd - event.data.timing.visitStart;
+    window._paq.push(['setGenerationTimeMs', loadTimeMs]);
   }
+  if (window.gMatomoPreviousPageUrl !== undefined) {
+    window._paq.push(['setReferrerUrl', window.gMatomoPreviousPageUrl]);
+  }
+  window._paq.push(['setCustomUrl', window.location.href]);
+  window._paq.push(['setDocumentTitle', document.title]);
   window._paq.push(['trackPageView']);
+
+  window.gMatomoPreviousPageUrl = window.location.href;
 }


### PR DESCRIPTION
Je crois qu’on envoie pas d’évènement à matomo quand on navigue “via turbolinks”, c’est à dire 99% du temps en usage normal. Si je lis bien le code, on n’envoie de hit que pour la visite de la première page (et pour les modales). On avait le même problème sur PDE et sur DS 😁 

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app, configurée avec matomo comme pour l’app de demo
