### PR TITLE
Permet de saisir des numéros de téléphone au format international

### DIFF
--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -34,7 +34,7 @@ label Préférences de notifications
     wrapper: false, \
     **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
   )
-  div.= f.input( \
+  div= f.input( \
     :notify_by_sms,  \
     include_hidden: false, \
     wrapper: false, \

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -12,7 +12,6 @@ import { ShowHidePassword } from 'components/show-hide-password.js';
 import 'components/browser-detection';
 import 'select2/dist/js/select2.min.js';
 import 'select2/dist/js/i18n/fr.js';
-import 'jquery-mask-plugin';
 import { Select2Inputs } from 'components/select2-inputs';
 import 'components/sentry';
 import 'bootstrap';
@@ -24,7 +23,6 @@ new Modal();
 new Select2Inputs();
 
 $(document).on('turbolinks:load', function() {
-  $('input[type="tel"]').mask('00 00 00 00 00')
   Holder.run();
 
   new ShowHidePassword();

--- a/app/webpacker/packs/application_agent.js
+++ b/app/webpacker/packs/application_agent.js
@@ -6,7 +6,6 @@ require("chartkick")
 require("chart.js")
 import 'bootstrap';
 import 'moment/moment.js';
-import 'jquery-mask-plugin';
 import 'moment/locale/fr.js';
 import 'holderjs/holder.min';
 import 'select2/dist/js/select2.full.min.js';
@@ -55,7 +54,6 @@ new ServiceFilterForMotifsSelects();
 global.$ = require('jquery');
 
 $(document).on('shown.bs.modal', '.modal', function(e) {
-  $('input[type="tel"]').mask('00 00 00 00 00')
   new Datetimepicker();
   new AgentUserForm();
 });
@@ -77,7 +75,6 @@ $(document).on('turbolinks:load', function() {
   menu.init();
   new Avatar().init();
 
-  $('input[type="tel"]').mask('00 00 00 00 00')
   $(window).on('resize', function(e) {
     e.preventDefault();
   });

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -47,4 +47,4 @@ fr:
   simple_form:
     hints:
       user:
-        phone_number: Saisissez un numéro français ou outre-mer à 10 chiffres, ou bien un numéro international avec le préfixe du pays.
+        phone_number: Saisissez un numéro à 10 chiffres de France métropole ou d’outre-mer, ou bien un numéro international avec le préfixe du pays.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "holderjs": "^2.9.6",
     "jquery": "^3.4.0",
     "jquery-datetimepicker": "^2.5.21",
-    "jquery-mask-plugin": "^1.14.16",
     "kind-of": ">=6.0.3",
     "minimist": "^1.2.3",
     "moment": "^2.24.0",

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name.upcase }
     phone_number do
       num = ""
-      num = Faker::PhoneNumber.cell_phone until Phonelib.valid?(num)
+      num = Faker::PhoneNumber.cell_phone until Phonelib.parse(num, "FR").valid?
       num
     end
     birth_date { Date.parse("1985-07-20") }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3884,11 +3884,6 @@ jquery-datetimepicker@^2.5.21:
     jquery-mousewheel ">= 3.1.13"
     php-date-formatter "^1.3.4"
 
-jquery-mask-plugin@^1.14.16:
-  version "1.14.16"
-  resolved "https://registry.yarnpkg.com/jquery-mask-plugin/-/jquery-mask-plugin-1.14.16.tgz#9ebb55947d984da5aade45315b2fe6b113e28aae"
-  integrity sha512-reywdHlYEkPbzWjTpcc1fk9XQ3PLvO5dzEAVqy8zI7NTF22tB1HbeU3iboZTLdkBEPaWAqeI2HtEjsGQ4roZKw==
-
 "jquery-mousewheel@>= 3.1.13":
   version "3.1.13"
   resolved "https://registry.yarnpkg.com/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz#06f0335f16e353a695e7206bf50503cb523a6ee5"


### PR DESCRIPTION
Je suis tombé dessus en essayant de comprendre pourquoi je n’arrivais pas à taper de “+” dans les numéros de téléphone des users: en fait c’était fait exprès dans #336. On a mis PhoneLib depuis, donc c’est globalement inutile, et gênant.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
