### PR TITLE
feat(invitations): Redirect user after invitation accepted

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -44,6 +44,6 @@ class Api::V1::UsersController < Api::V1::BaseController
     params.permit(:first_name, :birth_name, :last_name, :email, :address, :phone_number,
                   :birth_date, :responsible_id, :caisse_affiliation, :affiliation_number,
                   :family_situation, :number_of_children, :notify_by_sms, :notify_by_email,
-                  organisation_ids: [])
+                  :after_accept_path, organisation_ids: [])
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -17,6 +17,12 @@ class Users::InvitationsController < Devise::InvitationsController
     super
   end
 
+  def after_accept_path_for(resource)
+    return resource.after_accept_path if resource.after_accept_path.present?
+
+    super
+  end
+
   def edit
     # Reuse prefilled params from the invitation email
     resource.assign_attributes(update_resource_params)

--- a/db/migrate/20210707150348_add_after_accept_path_to_users.rb
+++ b/db/migrate/20210707150348_add_after_accept_path_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAfterAcceptPathToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :after_accept_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_204734) do
+ActiveRecord::Schema.define(version: 2021_07_07_150348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -416,6 +416,7 @@ ActiveRecord::Schema.define(version: 2021_06_09_204734) do
     t.string "created_through"
     t.boolean "logged_once_with_franceconnect"
     t.integer "invite_for"
+    t.string "after_accept_path"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true


### PR DESCRIPTION
Dans cette PR j'ajoute une colonne `after_accept_path` à la table `users` qui, si elle est remplie redirige l'utilisateur vers un chemin spécifique après qu'il ait accepté son invitation.
Je donne également la possibilité de renseigner ce  champ par l'api au moment de la création de l'utilisateur.