### PR TITLE
Indique les noms des usagers dans les notifications en cas d’ambiguïté

### DIFF
--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -25,6 +25,7 @@ module Payloads
           home?: home?,
           phone?: phone?,
           follow_up?: follow_up?,
+          should_display_users_in_sms?: user.relatives.present?,
           reservable_online?: reservable_online?,
           users_full_names: users.map(&:full_name).sort.to_sentence,
           agents_full_names: agents.map(&:full_name).sort.to_sentence,

--- a/app/service_models/transactional_sms/base_concern.rb
+++ b/app/service_models/transactional_sms/base_concern.rb
@@ -52,6 +52,7 @@ module TransactionalSms::BaseConcern
               else
                 "#{rdv.address_complete}\n"
               end
+    message += " pour #{rdv.users_full_names}" if rdv.should_display_users_in_sms?
     message += " avec #{rdv.agents_full_names} " if rdv.follow_up?
     message += "Infos et annulation: #{rdvs_shorten_url(host: ENV['HOST'])}"
     message += " / #{rdv.phone_number}" if rdv.phone_number.present?

--- a/app/services/notifications/rdv/rdv_cancelled_service.rb
+++ b/app/services/notifications/rdv/rdv_cancelled_service.rb
@@ -24,7 +24,7 @@ class Notifications::Rdv::RdvCancelledService < ::BaseService
     return unless @author.is_a? Agent
     return unless @rdv.status == "excused"
 
-    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.payload(:destroy), user.id)
+    SendTransactionalSmsJob.perform_later(:rdv_cancelled, @rdv.payload(:destroy, user), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :cancelled_by_agent)
   end
 end

--- a/app/services/notifications/rdv/rdv_created_service.rb
+++ b/app/services/notifications/rdv/rdv_created_service.rb
@@ -11,7 +11,7 @@ class Notifications::Rdv::RdvCreatedService < ::BaseService
   end
 
   def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.payload(:create), user.id)
+    SendTransactionalSmsJob.perform_later(:rdv_created, @rdv.payload(:create, user), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :created)
   end
 

--- a/app/services/notifications/rdv/rdv_date_updated_service.rb
+++ b/app/services/notifications/rdv/rdv_date_updated_service.rb
@@ -11,7 +11,7 @@ class Notifications::Rdv::RdvDateUpdatedService < ::BaseService
   end
 
   def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:rdv_updated, @rdv.payload(:update), user.id)
+    SendTransactionalSmsJob.perform_later(:rdv_updated, @rdv.payload(:update, user), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :updated)
   end
 

--- a/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
+++ b/app/services/notifications/rdv/rdv_upcoming_reminder_service.rb
@@ -11,7 +11,7 @@ class Notifications::Rdv::RdvUpcomingReminderService < ::BaseService
   end
 
   def notify_user_by_sms(user)
-    SendTransactionalSmsJob.perform_later(:reminder, @rdv.payload, user.id)
+    SendTransactionalSmsJob.perform_later(:reminder, @rdv.payload(nil, user), user.id)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :upcoming_reminder)
   end
 end

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -5,15 +5,14 @@
     span.title Date :
     span.float-right= l(rdv.starts_at, format: (rdv.home? ? :human_approx : :human))
     .clear
-  - if for_role == :agent
-    div.row-result
-      span.title Usager(s) :
-      span.float-right= rdv.users_full_names
-      .clear
-    div.row-result
-      span.title Motif :
-      span.float-right= rdv.motif_name
-      .clear
+  div.row-result
+    span.title Usager(s) :
+    span.float-right= rdv.users_full_names
+    .clear
+  div.row-result
+    span.title Motif :
+    span.float-right= rdv.motif_name
+    .clear
   div.row-result
     span.title Service :
     span.float-right= rdv.motif_service_name


### PR DESCRIPTION
close #1062

* dans les emails, les usagers concerné par le Rdv sont maintenant systématiquement indiqués
* dans les sms, les usagers sont indiqués si besoin: si le destinataire a des `relatives`.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
