### PR TITLE
limite l'accès au bouton de suppression de RDV

### DIFF
--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -36,11 +36,14 @@
           .col
             - if !@rdv.past? && !@rdv.cancelled?
               = link_to "Annuler", admin_organisation_rdv_path(@rdv.organisation, @rdv, rdv: {status: :excused, active_warnings_confirm_decision: true}, agent_id: @agent&.id), method: :put, class: "btn btn-outline-danger mr-1", data: { confirm: "Êtes-vous sûr de vouloir annuler ce rendez-vous ? L'usager recevra une notification de cette annulation."}
-              | ou
-            = link_to "Supprimer ❌", admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), method: :delete, class: "btn btn-link text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
-
           .col.text-right
             = link_to "Modifier", edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
+        - if current_agent.role_in_organisation(current_organisation).admin?
+          .row
+            .col
+              small.text-muted> Vous pouvez aussi
+              = link_to "supprimer", admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), method: :delete, class: "text-danger", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce rendez-vous ? Cette action est définitive et aucune notification ne sera envoyée à #{@rdv.users.map(&:full_name).to_sentence}."}
+              small.text-muted< ce rendez-vous. Il sera complétement supprimer de la base de donnée.
 
   .col-md-6.mb-3
 


### PR DESCRIPTION
close #1043 

Le lien supprimer d'un rendez-vous est visible de toutes et tous. Cette PR le rend visible que des profils admin, et il apparait dans un texte qui évoque ce qu'il va se passer en supprimant le rendez-vous de cette manière.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
