### PR TITLE
crée l'entrée de stats pour le territoire

### DIFF
--- a/app/controllers/admin/territories/stats_controller.rb
+++ b/app/controllers/admin/territories/stats_controller.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
 class Admin::Territories::StatsController < Admin::Territories::BaseController
-
   def index
     @stats = Stat.new(
-      rdvs: Rdv.joins(:organisation).where(organisations: {id: current_territory.organisations.map(&:id)}),
-      agents: Agent.joins(:organisations).where(organisations: {id: current_territory.organisations.map(&:id)}),
-      users: User.joins(:organisations).where(organisations: {id: current_territory.organisations.map(&:id)})
+      rdvs: Rdv.joins(:organisation).where(organisations: { id: current_territory.organisations.map(&:id) }),
+      agents: Agent.joins(:organisations).where(organisations: { id: current_territory.organisations.map(&:id) }),
+      users: User.joins(:organisations).where(organisations: { id: current_territory.organisations.map(&:id) })
     )
   end
 
   def rdvs
     skip_authorization
-    stats = Stat.new(rdvs: policy_scope(Rdv))
+    stats = Stat.new(rdvs: Rdv.joins(:organisation).where(organisations: { id: current_territory.organisations.map(&:id) }))
     stats = if params[:by_service].present?
               stats.rdvs_group_by_service
             elsif params[:by_location_type].present?
@@ -25,6 +24,6 @@ class Admin::Territories::StatsController < Admin::Territories::BaseController
 
   def users
     skip_authorization
-    render json: Stat.new(users: policy_scope(User)).users_group_by_week
+    render json: Stat.new(users: User.joins(:organisations).where(organisations: { id: current_territory.organisations.map(&:id) })).users_group_by_week
   end
 end

--- a/app/controllers/admin/territories/stats_controller.rb
+++ b/app/controllers/admin/territories/stats_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Admin::Territories::StatsController < Admin::Territories::BaseController
+
+  def index
+    @stats = Stat.new(
+      rdvs: Rdv.joins(:organisation).where(organisations: {id: current_territory.organisations.map(&:id)}),
+      agents: Agent.joins(:organisations).where(organisations: {id: current_territory.organisations.map(&:id)}),
+      users: User.joins(:organisations).where(organisations: {id: current_territory.organisations.map(&:id)})
+    )
+  end
+
+  def rdvs
+    skip_authorization
+    stats = Stat.new(rdvs: policy_scope(Rdv))
+    stats = if params[:by_service].present?
+              stats.rdvs_group_by_service
+            elsif params[:by_location_type].present?
+              stats.rdvs_group_by_type
+            else
+              stats.rdvs_group_by_week_fr
+            end
+    render json: stats.chart_json
+  end
+
+  def users
+    skip_authorization
+    render json: Stat.new(users: policy_scope(User)).users_group_by_week
+  end
+end

--- a/app/views/admin/territories/stats/index.html.slim
+++ b/app/views/admin/territories/stats/index.html.slim
@@ -1,0 +1,35 @@
+- content_for(:menu_item) { 'menu-stats' }
+
+- content_for :title do
+  div.mb-0.pb-0 Statistiques #{current_territory.name}
+
+.card.mb-5
+  .card-body
+    = render 'stats/rdv_territory_counters_with_links', rdvs: @stats.rdvs, breadcrumb_page: "territories_stats"
+    p.text-muted.mt-2 Les exports se font dorénavant uniquement depuis les listes de RDVs, suivez les liens ci-dessus pour y accéder
+
+.card.mb-5
+  .card-body
+    = link_to "stats", add_query_string_params_to_url(rdvs_admin_territory_stats_path(current_territory, format: :json), departement: @departement)
+    h4.card-title.mb-3 RDV créés (#{@stats.rdvs.count})
+    = column_chart add_query_string_params_to_url(rdvs_admin_territory_stats_path(current_territory, format: :json), departement: @departement), stacked: true
+
+.card.mb-5
+  .card-body
+    h4.card-title.mb-3 RDV créés par service (#{@stats.rdvs.count})
+    = column_chart add_query_string_params_to_url(rdvs_admin_territory_stats_path(current_territory, format: :json), by_service: true, departement: @departement), stacked: true
+
+.card.mb-5
+  .card-body
+    h4.card-title.mb-3 RDV par type (#{@stats.rdvs.count})
+    = column_chart add_query_string_params_to_url(rdvs_admin_territory_stats_path(current_territory, format: :json), by_location_type: true, departement: @departement), stacked: true
+
+.card.mb-5
+  .card-body
+    h4.card-title.mb-3 Usagers créés (#{@stats.users_active.count})
+    = column_chart add_query_string_params_to_url(users_admin_territory_stats_path(current_territory, format: :json), departement: @departement)
+
+.card.mb-5
+  .card-body
+    h4.card-title.mb-3 Agents créés (#{@stats.agents_for_default_range.count})
+    = column_chart add_query_string_params_to_url(agents_stats_path(format: :json), departement: @departement)

--- a/app/views/layouts/application_agent_departement.html.slim
+++ b/app/views/layouts/application_agent_departement.html.slim
@@ -28,6 +28,11 @@
           span.ml-1 SMS
 
     li.side-nav-item.mb-4.pl-3.pr-2
+      = link_to(admin_territory_stats_path(current_territory), class: ("active" if content_for(:menu_item) == 'menu-organisation-stats')) do
+        i.fa.fa-chart-bar>
+        span.ml-1 Statistiques
+
+    li.side-nav-item.mb-4.pl-3.pr-2
       a.active Sectorisation
       ul.side-nav.list-unstyled.mt-4
         li.side-nav-item.mb-4.pl-3.pr-2

--- a/app/views/stats/_rdv_territory_counters_with_links.html.slim
+++ b/app/views/stats/_rdv_territory_counters_with_links.html.slim
@@ -1,0 +1,31 @@
+- path_params = { agent_id: local_assigns[:agent_id], breadcrumb_page: local_assigns[:breadcrumb_page] }.compact
+
+.row
+  .col-xl-4.col-lg-6
+    - [:seen, :excused, :notexcused].each do |temporal_status|
+      = render "stats/rdv_counter_with_link", \
+        temporal_status: temporal_status, \
+        count: rdvs.status(temporal_status).count,
+        path: admin_territory_rdvs_path(current_territory, status: temporal_status, **path_params)
+  .col-xl-8.col-lg-6
+    .row
+      .col-xl-6
+        = render "stats/rdv_counter_with_link", \
+          temporal_status: :unknown_past, \
+          count: rdvs.status(:unknown_past).count,
+          path: admin_territory_rdvs_path(current_territory, status: :unknown_past, **path_params)
+      .col-xl-6
+        = render "stats/rdv_counter_with_link", \
+          temporal_status: :unknown_future, \
+          count: rdvs.status(:unknown_future).count,
+          path: admin_territory_rdvs_path(current_territory, status: :unknown_future, **path_params)
+
+hr
+
+.row
+  .col-xl-4.col-lg-6
+    = render "stats/rdv_counter_with_link", \
+      label: "Tous", \
+      count: rdvs.count,
+      path: admin_territory_rdvs_path(current_territory, **path_params)
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,13 @@ Rails.application.routes.draw do
     namespace "admin" do
       resources :territories, only: [:update] do
         scope module: "territories" do
+          resources :stats, only: :index do
+            collection do
+              get :rdvs
+              get :users
+            end
+          end
+          resources :rdvs, only: :index
           resources :agent_territorial_roles, only: %i[index new create destroy]
           resource :sms_configuration, only: %i[show edit update]
           resources :zone_imports, only: %i[new create]


### PR DESCRIPTION
close #1077 

Duplique les statistiques au niveau d'un territoire (en assemblant les éléments des organisations du territoire).

Je duplique pour le moment, et il serait intéressant que l'on commence à déplacer les statistiques dans metabase. Une partie pourrait largement être public d'ailleurs... Tant qu'il n'y a pas d'usager dedans ! À voir dans de futurs tickets

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
