### PR TITLE
Add phone number formatted to user blueprint

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -3,8 +3,8 @@
 class UserBlueprint < Blueprinter::Base
   identifier :id
 
-  fields  :first_name, :birth_name, :last_name, :email, :address, :phone_number, :birth_date, :responsible_id,
-          :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :notify_by_sms,
+  fields  :first_name, :birth_name, :last_name, :email, :address, :phone_number, :phone_number_formatted, :birth_date,
+          :responsible_id, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :notify_by_sms,
           :notify_by_email, :invitation_created_at, :invitation_accepted_at, :created_at
   association :responsible, blueprint: UserBlueprint
 


### PR DESCRIPTION
Je rajoute l'attribut `phone_number_formatted ` aux utilisateurs renvoyés par l'API.
Cet attribut nous est utile pour envoyer correctement le SMS d'invitation.