### PR TITLE
retire le nom et prénom usager dans le summary ics

### DIFF
--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -9,7 +9,7 @@ module Payloads
         starts_at: starts_at,
         ends_at: ends_at,
         ical_uid: uuid,
-        summary: "RDV #{user.full_name} <> #{motif&.name}",
+        summary: "RDV #{motif&.name}",
         address: motif.phone? ? nil : address,
         sequence: sequence
       }

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -1,5 +1,5 @@
 - for_role = local_assigns.fetch(:for_role, :user)
-- map_url = "https://maps.google.com?q=#{rdv.address.split(/,?\s/).join('+')}"
+- map_url = rdv.adress.present? && "https://maps.google.com?q=#{rdv.address.split(/,?\s/).join('+')}"
 .overview
   h3.aligncenter Récapitulatif
   div.row-result

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -74,7 +74,7 @@ describe Payloads::Rdv, type: :service do
       let(:user) { build(:user, first_name: "Ethan", last_name: "DUVAL") }
       let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Consultation")) }
 
-      it { expect(rdv.payload[:summary]).to eq("RDV Ethan DUVAL <> Consultation") }
+      it { expect(rdv.payload[:summary]).to eq("RDV Consultation") }
     end
 
     describe ":user_email" do


### PR DESCRIPTION
Close #1587 

Suppression du nom et prénom de l'usager dans le résumé du RDV du fichier ICS

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
