### PR TITLE
Ajoute l'usager d'une autre orga dans l'orga courant et continue le tunnel de prise de rendez-vous

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -25,10 +25,8 @@ class Admin::UsersController < AgentAuthController
   end
 
   def search
-    @users = []
-    if search_params.present? && search_params.length >= 3
-      @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.order_by_last_name.search_by_text(search_params)
-    end
+    @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.order_by_last_name.limit(10)
+    @users = @users.search_by_text(search_params) if search_params
     skip_authorization
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,8 +50,8 @@ class Admin::UsersController < AgentAuthController
     @user.invite! if invite_user?(@user, params)
     prepare_new unless user_persisted
 
-    if params[:return_location].present?
-      redirect_to add_query_string_params_to_url(params[:return_location], 'user_ids[]': @user.id), flash: { notice: "L'usager a été créé." }
+    if from_modal?
+      respond_modal_with @user_form, location: add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id)
     elsif user_persisted
       redirect_to admin_organisation_user_path(@organisation, @user), flash: { notice: "L'usager a été créé." }
     else
@@ -78,7 +78,7 @@ class Admin::UsersController < AgentAuthController
     @user.skip_reconfirmation! if @user.encrypted_password.blank?
     user_updated = @user_form.save
     if from_modal?
-      respond_modal_with @user_form, location: params[:return_modal_location].presence || request.referer
+      respond_modal_with @user_form, location: add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id)
     elsif user_updated
       redirect_to admin_organisation_user_path(current_organisation, @user), flash: { notice: "L'usager a été modifié" }
     else
@@ -112,10 +112,19 @@ class Admin::UsersController < AgentAuthController
     @user = User.find(params.require(:id))
     authorize(current_organisation)
     flash[:notice] = "L'usager a été associé à votre organisation." if @user.add_organisation(current_organisation)
-    redirect_to admin_organisation_user_path(current_organisation, @user)
+
+    if from_modal?
+      respond_modal_with @user_form, location: add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id)
+    else
+      redirect_to admin_organisation_user_path(current_organisation, @user), flash: { notice: "L'usager a été créé." }
+    end
   end
 
   private
+
+  def modal_return_location
+    params[:return_location].presence || request.referer
+  end
 
   def invite_user?(user, params)
     user.persisted? && user.email.present? && (params[:invite_on_create] == "1")

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -51,7 +51,7 @@ class Admin::UsersController < AgentAuthController
     prepare_new unless user_persisted
 
     if from_modal?
-      respond_modal_with @user_form, location: add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id)
+      respond_modal_with @user_form, location: add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id, modal: true)
     elsif user_persisted
       redirect_to admin_organisation_user_path(@organisation, @user), flash: { notice: "L'usager a été créé." }
     else
@@ -160,7 +160,7 @@ class Admin::UsersController < AgentAuthController
       view_locals: {
         current_organisation: current_organisation,
         from_modal: from_modal?,
-        return_location: modal_return_location
+        return_location: params[:return_location]
       }
     )
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -114,7 +114,7 @@ class Admin::UsersController < AgentAuthController
     flash[:notice] = "L'usager a été associé à votre organisation." if @user.add_organisation(current_organisation)
 
     if from_modal?
-      respond_modal_with @user_form, location: add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id)
+      redirect_to add_query_string_params_to_url(modal_return_location, 'user_ids[]': @user.id)
     else
       redirect_to admin_organisation_user_path(current_organisation, @user), flash: { notice: "L'usager a été créé." }
     end
@@ -160,7 +160,7 @@ class Admin::UsersController < AgentAuthController
       view_locals: {
         current_organisation: current_organisation,
         from_modal: from_modal?,
-        request_referer: request.referer
+        return_location: modal_return_location
       }
     )
   end

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -51,8 +51,9 @@ do
         = link_to \
           "Créer un usager", \
           new_admin_organisation_user_path( \
-            current_organisation, return_location: modals_return_location, role: default_service_selection_from(@rdv.motif.service) \
-          )
+              current_organisation, modal: true, return_location: modals_return_location, role: default_service_selection_from(@rdv.motif.service) \
+              ), \
+          data: { modal: true }
 
     .mt-3= f.input :context, as: :text, label: t("activerecord.attributes.rdv.context"), input_html: { rows: 4 }
 

--- a/app/views/admin/users/_duplicate_alert.html.slim
+++ b/app/views/admin/users/_duplicate_alert.html.slim
@@ -1,6 +1,8 @@
-- existing_attributes = attributes.map { t("activerecord.attributes.user.#{_1}") }.map(&:downcase).join(", ")
-- return_location ||= admin_organisation_user_path(current_organisation, user)
-- from_modal ||= false
+ruby:
+  existing_attributes = attributes.map { t("activerecord.attributes.user.#{_1}") }.map(&:downcase).join(", ")
+  return_location ||= admin_organisation_user_path(current_organisation, user)
+  from_modal ||= false
+
 div.flex-grow-1
   p
     span>= "Un usager avec le même #{existing_attributes} existe déjà"

--- a/app/views/admin/users/_duplicate_alert.html.slim
+++ b/app/views/admin/users/_duplicate_alert.html.slim
@@ -1,4 +1,6 @@
 - existing_attributes = attributes.map { t("activerecord.attributes.user.#{_1}") }.map(&:downcase).join(", ")
+- return_location ||= admin_organisation_user_path(current_organisation, user)
+- from_modal ||= false
 div.flex-grow-1
   p
     span>= "Un usager avec le même #{existing_attributes} existe déjà"

--- a/app/views/admin/users/_duplicate_alert.html.slim
+++ b/app/views/admin/users/_duplicate_alert.html.slim
@@ -16,8 +16,8 @@ div.flex-grow-1
   div.text-right
     - if user.organisation_ids.include?(current_organisation.id)
       - if from_modal
-        = link_to "Choisir cet usager", add_query_string_params_to_url(request_referer, "user_ids[]": user.id), class: "btn btn-secondary btn-small"
+        = link_to "Choisir cet usager", add_query_string_params_to_url(return_location, "user_ids[]": user.id), class: "btn btn-secondary btn-small"
       - else
         = link_to "Modifier cet usager", edit_admin_organisation_user_path(current_organisation, user), class: "btn btn-secondary btn-small"
     - else
-      = link_to "Associer cet usager à l'organisation #{current_organisation.name}", link_to_organisation_admin_organisation_user_path(current_organisation, user), class: "btn btn-warning"
+      = link_to "Associer cet usager à l'organisation #{current_organisation.name}", link_to_organisation_admin_organisation_user_path(current_organisation, user, return_location: return_location, modal: from_modal), class: "btn btn-warning"

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -10,9 +10,8 @@
   - f.simple_fields_for :user_profiles, user.profile_for(current_organisation) do |f_user_profile|
     = f_user_profile.input :organisation_id, as: :hidden, wrapper: false
 
-    = hidden_field "", :return_location, value: params[:return_location]
-
     - if from_modal?
+      = hidden_field "", :return_location, value: params[:return_location]
       = hidden_field "", :modal, value: true
     = render "model_errors", model: user_form, f: f
 


### PR DESCRIPTION
Close #1594 

Après la création d'un usager existant dans une autre organisation, nous devrions pouvoir le choisir puis continuer dans le tunnel. Ce n'est pas le cas avant cette PR.

Maintenant, si l'usager créer existe sur une autre organisation, la proposition de l'utiliser (et l'association à l'orga courante) nous renvoie vers le tunnel de prise de rendez-vous avec cet usager sélectionné.


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
