### PR TITLE
Intègre les mécanismes d'appel pour le 92

### DIFF
--- a/app/mailers/admins/grc_92_mailer.rb
+++ b/app/mailers/admins/grc_92_mailer.rb
@@ -3,6 +3,7 @@
 class Admins::Grc92Mailer < ApplicationMailer
   default from: "ne-pas-repondre-grc@hauts-de-seine.fr"
   def send_sms(recipient, phone_number, message)
+    headers["Content-Type"] = "text/plain"
     mail(to: recipient, subject: phone_number) do |format|
       format.text { render plain: "#{message}\n-- RDV-Solidarités" }
     end


### PR DESCRIPTION
Après avoir fait des essais en démonstration, nous avons constaté avec les personnes du 92 qu'il y a un problème.

Notre piste nous amène à penser que c'est lié au format du mail. L'outil de mail2sms mis en place n'accepte pas les messages en HTML. Il faut donc l'envoyer en texte brut.


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
