### PR TITLE
ajoute de tests sur la possibilité de suppression

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,7 +115,7 @@ class User < ApplicationRecord
 
   def can_be_soft_deleted_from_organisation?(organisation)
     Rdv.not_cancelled.future
-      .with_user_in(self_and_relatives_and_responsible)
+      .with_user_in(self_and_relatives)
       .where(organisation: organisation)
       .empty?
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -320,4 +320,26 @@ describe User, type: :model do
       expect(described_class.with_referent(agent)).to eq([user_with_agent])
     end
   end
+
+  describe "#can_be_soft_deleted_from_organisation?" do
+    let(:organisation) { create(:organisation) }
+
+    it "return true when no rdv for self and relatives" do
+      user = create(:user, rdvs: [], organisations: [organisation])
+      expect(user.can_be_soft_deleted_from_organisation?(organisation)).to be true
+    end
+
+    it "return false when rdv for self" do
+      rdv = create(:rdv, organisation: organisation)
+      user = create(:user, rdvs: [rdv], organisations: [organisation])
+      expect(user.can_be_soft_deleted_from_organisation?(organisation)).to be false
+    end
+
+    it "return false when rdv for relatives" do
+      rdv = create(:rdv, organisation: organisation)
+      responsible = create(:user, rdvs: [], organisations: [organisation])
+      relative = create(:user, responsible: responsible, rdvs: [rdv], organisations: [organisation])
+      expect(relative.can_be_soft_deleted_from_organisation?(organisation)).to be false
+    end
+  end
 end


### PR DESCRIPTION
Close #1605 

Réduire le blocage pour la suppression de proche.
Lorsque le proche n'a pas de rendez-vous, pas la peine de le bloquer quand le repsonsable à un rendez-vous

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
