### PR TITLE
Ajustements sur les cartes de Rdv

### DIFF
--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -1,12 +1,13 @@
 .card.mb-3.print-border-bottom.print-border-top
   .card-header
     .d-flex.justify-content-between
-      div
+      .mt-1
         i.fa.fa-fw.fa-calendar>
         = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
       = render "rdv_status_dropdown", rdv: rdv, remote: true
 
   .card-body
+    p.card-text
     - if local_assigns[:show_user_details]
       .row
         .col-md-6.mb-2

--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -1,5 +1,5 @@
-ul.list-unstyled.topbar-right-menu.float-right.mb-0
-  li.dropdown.js-rdv-status-dropdown
+.float-right.mb-0
+  .dropdown.js-rdv-status-dropdown
     a.dropdown-toggle.btn.rdv-status.mr-0.js-current-status[
       class="rdv-status-#{rdv.status}"
       aria-expanded="false"
@@ -9,19 +9,18 @@ ul.list-unstyled.topbar-right-menu.float-right.mb-0
       role="button"
     ]
       = I18n.t("activerecord.attributes.rdv.statuses.#{rdv.temporal_status}")
-    .dropdown-menu.dropdown-menu-right.dropdown-menu-animated.profile-dropdown
-      .dropdown-header.noti-title
-        - rdv_possible_statuses_option_items(rdv).each do |status|
-          = link_to( \
-            status[0], \
-            admin_organisation_rdv_path( \
-              rdv.organisation, \
-              rdv, \
-              rdv: { status: status[1], active_warnings_confirm_decision: true }, \
-              agent_id: local_assigns[:agent]&.id, \
-              format: local_assigns[:remote] ? "json" : "html" \
-            ), \
-            method: :put, \
-            class: "dropdown-item js-change-link", \
-            remote: local_assigns.fetch(:remote, false) \
-          )
+    .dropdown-menu.dropdown-menu-right
+      - rdv_possible_statuses_option_items(rdv).each do |status|
+        = link_to( \
+          status[0], \
+          admin_organisation_rdv_path( \
+            rdv.organisation, \
+            rdv, \
+            rdv: { status: status[1], active_warnings_confirm_decision: true }, \
+            agent_id: local_assigns[:agent]&.id, \
+            format: local_assigns[:remote] ? "json" : "html" \
+          ), \
+          method: :put, \
+          class: "dropdown-item js-change-link", \
+          remote: local_assigns.fetch(:remote, false) \
+        )

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -22,7 +22,7 @@
     .card
       .card-header
         .d-flex.justify-content-between
-          = l(@rdv.starts_at.to_date, format: :human )
+          .mt-1= l(@rdv.starts_at.to_date, format: :human).capitalize
           = render "rdv_status_dropdown", rdv: @rdv, agent: @agent
 
       .card-body

--- a/app/webpacker/stylesheets/components/_dropdown.scss
+++ b/app/webpacker/stylesheets/components/_dropdown.scss
@@ -2,16 +2,6 @@
   box-shadow: $shadow;
 }
 
-
-// Dropdown Animated (Custom)
-.dropdown-menu-animated {
-  display: block;
-  visibility: hidden;
-  opacity: 0;
-  transition: all 300ms ease;
-  margin-top: 20px !important;
-}
-
 .show {
   > .dropdown-menu {
     visibility: visible;

--- a/config/locales/rdvs.fr.yml
+++ b/config/locales/rdvs.fr.yml
@@ -1,4 +1,4 @@
 fr:
   rdvs:
-    title: "le %{starts_at} (durée : %{duration} minutes)"
-    title_time_only: "aujourd'hui à %{starts_at} (durée : %{duration} minutes)"
+    title: "Le %{starts_at} (durée : %{duration} minutes)"
+    title_time_only: "Aujourd’hui à %{starts_at} (durée : %{duration} minutes)"

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -34,7 +34,7 @@ describe "can see users' RDV" do
       expect(page).to have_content("À venir\n1 RDV")
       click_link "Voir tous les rendez-vous de Tanguy LAVERDURE"
       expect_page_title("Liste des RDV")
-      expect(page).to have_content("le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
+      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
     end
   end
 end

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -20,7 +20,7 @@ describe "User views his rdv" do
     before { click_link "Vos rendez-vous" }
 
     it do
-      expect(page).to have_content("le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
+      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
       click_link "Voir vos RDV passés"
       expect_page_with_no_record_text("Vous n'avez pas de RDV passés")
     end
@@ -35,6 +35,6 @@ describe "User views his rdv" do
     click_link "Vos rendez-vous"
     expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
     click_link "Voir vos RDV passés"
-    expect(page).to have_content("le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
+    expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
   end
 end

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -39,14 +39,14 @@ describe RdvsHelper do
   describe "#rdv_title" do
     it "show date, time and duration in minutes" do
       rdv = build(:rdv, starts_at: Time.zone.parse("2020-10-23 12h54"), duration_in_min: 30)
-      expect(rdv_title(rdv)).to eq("le vendredi 23 octobre 2020 à 12h54 (durée : 30 minutes)")
+      expect(rdv_title(rdv)).to eq("Le vendredi 23 octobre 2020 à 12h54 (durée : 30 minutes)")
     end
 
     it "when rdv starts_at today, show only time and duration in minutes" do
       now = Time.zone.parse("2020-10-23 12h54")
       travel_to(now)
       rdv = build(:rdv, starts_at: now + 3.hours, duration_in_min: 30)
-      expect(rdv_title(rdv)).to eq("aujourd'hui à 15h54 (durée : 30 minutes)")
+      expect(rdv_title(rdv)).to eq("Aujourd’hui à 15h54 (durée : 30 minutes)")
       travel_back
     end
   end


### PR DESCRIPTION
Fait en passant pour #1615

Avant:
<img width="687" alt="Capture d’écran 2021-08-05 à 10 22 22" src="https://user-images.githubusercontent.com/139391/128317941-162cdc44-6383-40c0-aac8-e1f62b6283ae.png">

Après
<img width="687" alt="Capture d’écran 2021-08-05 à 10 24 02" src="https://user-images.githubusercontent.com/139391/128317933-621b9920-75ee-4607-8540-60396c85ff22.png">

Le titre est centré verticalement, capitalisé, et les items du menu sont des items (et pas des headers).

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
