### PR TITLE
Corrige les sélecteurs d’usagers dans le tunnel de Rdv

### DIFF
--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -44,7 +44,10 @@ do
       include_blank: "Sélectionner un usager",
       required: false,
       class: "select2-input js-new-rdv-users-select",
-      data: { "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.users.map(&:id)), dataType: "json", delay: 250 }} }
+      data: { \
+        width: "auto", \
+        "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.users.map(&:id)), dataType: "json", delay: 250 }} \
+      }
 
       span.small.text-muted
         | L'usager n'existe pas ?&nbsp;

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -40,7 +40,7 @@ do
 
     .js-add-user-interface.mt-2 class=("d-none" if @rdv.users.any?)
       =  select_tag :status,
-      options_for_select(policy_scope(User).order_by_last_name.map {|u| [ reverse_full_name_and_birthdate(u), u.id ]}),
+      options_for_select([]),
       include_blank: "Sélectionner un usager",
       required: false,
       class: "select2-input js-new-rdv-users-select",

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -72,13 +72,17 @@
                 data-relative-type="existing"
                 class=("active" if initial_relative_type_tab == :existing)
               ]
+                / This is an ajax-backed Select, but we still inline the current value in the html.
                 = f.association( \
                   :responsible, \
-                  collection: policy_scope(User).responsible.order_by_last_name, \
+                  collection: [user.responsible].compact, \
                   label_method: -> { reverse_full_name_and_birthdate(_1) }, \
                   label: false, \
-                  **{input_html: { class: "select2-input" }}.deep_merge(input_opts[:relative_existing]), \
-                  required: true \
+                  **{input_html: { \
+                    class: "select2-input",\
+                    data: { "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation), dataType: "json", delay: 250 }} } \
+                   }}.deep_merge(input_opts[:relative_existing]), \
+                  required: true\
                 )
               - unless user.persisted?
                 .tab-pane[

--- a/app/webpacker/components/select2-inputs.js
+++ b/app/webpacker/components/select2-inputs.js
@@ -27,6 +27,13 @@ class Select2Inputs {
       options = JSON.parse(elt.dataset.selectOptions)
     if (options.disableSearch)
       options.minimumResultsForSearch = Infinity // cf https://select2.org/searching
+
+    // Make sure select2 works correctly inside a modal
+    // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
+    let modal = elt.closest(".modal")
+    if (modal !== undefined)
+      options.dropdownParent = modal
+
     return options
   }
 


### PR DESCRIPTION
Close #1604

* Fix select2 with bootstrap modals
* Widen the main user select
* Use the json ajax query for the responsible select, and avoid inlining all the users in the html.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
