### PR TITLE
Add “blob:” to CSP as per mapbox recommendations

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,9 +10,11 @@ unless Rails.env.test?
   Rails.application.config.content_security_policy do |policy|
     policy.default_src :self
     policy.font_src    :self, :data, "github.com"
-    policy.img_src     :self, :data, "stats.data.gouv.fr", "voxusagers.numerique.gouv.fr"
+    policy.img_src     :self, :data, :blob, "stats.data.gouv.fr", "voxusagers.numerique.gouv.fr"
     policy.object_src  :none
     policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
+    policy.worker_src :blob
+    policy.child_src :blob
 
     if Rails.env.development?
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net",


### PR DESCRIPTION
See https://docs.mapbox.com/mapbox-gl-js/guides/browsers-and-testing/
This fixes this error in Safari “[Error] Refused to load blob:https://demo.rdv-solidarites.fr/e520bb03-70c7-4eff-a43a-8da69bdb0b94 because it appears in neither the child-src directive nor the default-src directive of the Content Security Policy.”
I suspect Safari interprets CSP and blob urls differently, or the default values are different from other browsers.

This makes the sectors map work correctly on Safari.

Close #issue_number

// Description de la fonctionnalité ou du bug

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
