### PR TITLE
expire les absences selon la récurrence

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,7 +80,7 @@ Rails/SkipsModelValidations:
     - 'scripts/agent_et_motif_changent_de_service.rb'
     - 'db/migrate/20210301135256_create_territories.rb'
     - 'app/models/user.rb'
-    - 'app/models/plage_ouverture.rb'
+    - 'app/models/concerns/expiration.rb'
     - 'app/models/motif.rb'
     - 'app/models/agent.rb'
 

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -14,9 +14,10 @@ class Admin::AbsencesController < AgentAuthController
       .includes(:organisation)
       .by_starts_at
       .page(filter_params[:page])
+
     @current_tab = filter_params[:current_tab]
-    @absences = params[:current_tab] == "expired" ? absences.past : absences.future
-    @display_tabs = absences.past.any? || params[:current_tab] == "expired"
+    @absences = params[:current_tab] == "expired" ? absences.expired : absences.not_expired
+    @display_tabs = absences.expired.any? || params[:current_tab] == "expired"
   end
 
   def new

--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -2,10 +2,16 @@
 
 module AbsencesHelper
   def absence_tag(absence)
-    if absence.in_progress?
-      tag.span("En cours", class: "badge badge-info")
-    elsif absence.starts_at.past?
+    if absence.expired?
       tag.span("Passée", class: "badge badge-light")
+    elsif absence.starts_at.today? || an_ocurrence_after_today?(absence)
+      tag.span("En cours", class: "badge badge-info")
     end
+  end
+
+  def an_ocurrence_after_today?(absence)
+    absence.starts_at.past? &&
+      absence.recurrence.presence &&
+      absence.recurrence.lazy.map(&:to_date).select { |d| d > Time.zone.now }.take(1).any?
   end
 end

--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -12,6 +12,6 @@ module AbsencesHelper
   def an_ocurrence_after_today?(absence)
     absence.starts_at.past? &&
       absence.recurrence.presence &&
-      absence.recurrence.lazy.map(&:to_date).select { |d| d > Time.zone.now }.take(1).any?
+      absence.recurrence.lazy.map(&:to_date).any? { |d| d > Time.zone.now }
   end
 end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -55,7 +55,7 @@ class CronJob < ApplicationJob
     self.cron_expression = "0 1 * * *"
 
     def perform
-      PlageOuverture.where(expired_cached: false).each(&:refresh_plage_ouverture_expired_cached)
+      PlageOuverture.where(expired_cached: false).each(&:refresh_expired_cached)
     end
   end
 

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -6,6 +6,7 @@ class Absence < ApplicationRecord
   include IcalHelpers::Ics
   include IcalHelpers::Rrule
   include Payloads::Absence
+  include Expiration
 
   auto_strip_attributes :title
 
@@ -15,18 +16,12 @@ class Absence < ApplicationRecord
   has_many :webhook_endpoints, through: :organisation
 
   before_validation :set_end_day
+
   validates :agent, :organisation, :first_day, :title, presence: true
   validate :ends_at_should_be_after_starts_at
 
   scope :by_starts_at, -> { order(first_day: :desc, start_time: :desc) }
-
-  scope :future, -> { where(end_day: Time.zone.today..) }
-  scope :past, -> { where.not(end_day: Time.zone.today..) } # NOTE: brakeman doesn't support beginless ranges https://github.com/presidentbeef/brakeman/issues/1483
   scope :with_agent, ->(agent) { where(agent_id: agent.id) }
-
-  def in_progress?
-    starts_at.past? && first_occurrence_ends_at.future?
-  end
 
   def ical_uid
     "absence_#{id}@#{BRAND}"

--- a/app/models/concerns/expiration.rb
+++ b/app/models/concerns/expiration.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Pour fonctionner, ce module utilise les champs
+#
+# - `expired_cached (bool)`
+# - `recurrence (Montrose-formatted string)`
+#
+# Pour la récurrence, voir le format de sérialisation de la gem [Montrose](https://rossta.net/montrose/)
+#
+module Expiration
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :refresh_expired_cached
+
+    scope :expired, -> { where(expired_cached: true) }
+    scope :not_expired, -> { where.not(expired_cached: true) }
+  end
+
+  def expired?
+    (recurrence.nil? && first_day < Time.zone.today) ||
+      (recurrence.present? && recurrence.to_hash[:until].present? && recurrence.to_hash[:until].to_date < Time.zone.today)
+  end
+
+  def refresh_expired_cached
+    update_column(:expired_cached, expired?)
+  end
+end

--- a/db/migrate/20210820115346_add_expire_to_absence.rb
+++ b/db/migrate/20210820115346_add_expire_to_absence.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExpireToAbsence < ActiveRecord::Migration[6.0]
+  def change
+    add_column :absences, :expired_cached, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_092811) do
+ActiveRecord::Schema.define(version: 2021_08_20_115346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_092811) do
     t.time "start_time", null: false
     t.date "end_day", null: false
     t.time "end_time", null: false
+    t.boolean "expired_cached", default: false, null: false
     t.index ["agent_id"], name: "index_absences_on_agent_id"
     t.index ["end_day"], name: "index_absences_on_end_day"
     t.index ["organisation_id"], name: "index_absences_on_organisation_id"

--- a/spec/helpers/absences_helper_spec.rb
+++ b/spec/helpers/absences_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe AbsencesHelper do
+  describe "#absence_tag" do
+    it "return En cours when absence is today" do
+      today = Time.zone.parse("2020-12-24 13:56")
+      travel_to(today)
+      absence = build(:absence, first_day: today.beginning_of_day, end_day: today.end_of_day)
+      expect(absence_tag(absence)).to eq("<span class=\"badge badge-info\">En cours</span>")
+    end
+
+    it "return En cours when absence have an ocurrence today" do
+      today = Time.zone.parse("2020-12-24 13:56")
+      travel_to(today)
+      absence = create(:absence,
+                       first_day: today.beginning_of_day - 1.week,
+                       end_day: today.end_of_day - 1.week,
+                       recurrence: Montrose.every(:week, until: today + 1.month, starts: today.beginning_of_day - 1.week))
+
+      expect(absence_tag(absence)).to eq("<span class=\"badge badge-info\">En cours</span>")
+    end
+
+    it "return nil when absence is for the future" do
+      today = Time.zone.parse("2020-12-24 13:56")
+      travel_to(today)
+      absence = build(:absence,
+                      first_day: today.beginning_of_day + 2.days,
+                      end_day: today.end_of_day + 2.days)
+      expect(absence_tag(absence)).to be_nil
+    end
+
+    it "return Passée when absence is expired" do
+      today = Time.zone.parse("2020-12-24 13:56")
+      travel_to(today)
+      absence = build(:absence, first_day: today - 3.days, end_day: today - 3.days)
+      expect(absence_tag(absence)).to eq("<span class=\"badge badge-light\">Passée</span>")
+    end
+  end
+end

--- a/spec/models/concerns/expiration_spec.rb
+++ b/spec/models/concerns/expiration_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe Expiration, type: :concern do
+  shared_examples "expired?" do |element|
+    it "#{element} is expired when end_day before today" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      objet = create(:absence, first_day: today - 5.days, end_day: today - 5.days)
+      expect(objet.expired?).to be true
+    end
+
+    it "#{element} is not past when end_day after today" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      objet = create(:absence, first_day: today + 3.days, end_day: today + 3.days)
+      expect(objet.expired?).to be false
+    end
+
+    it "#{element} is not past when end_day before today with a recurrence after today" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      objet = create(:absence, first_day: today - 1.day, end_day: today - 1.day, recurrence: Montrose.every(:week, until: today + 1.month, starts: today - 1.day))
+      expect(objet.expired?).to be false
+    end
+  end
+
+  it_behaves_like "expired?", :absence, :plage_ouverture
+end


### PR DESCRIPTION
Close #1613 

Affiche dans les présents les absences dont la date de fin est passé, mais pour lesquelles la récurrence est encore valable.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
