### PR TITLE
Fix the select2 dropdown js patch for IE

### DIFF
--- a/app/webpacker/components/select2-inputs.js
+++ b/app/webpacker/components/select2-inputs.js
@@ -30,7 +30,7 @@ class Select2Inputs {
 
     // Make sure select2 works correctly inside a modal
     // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
-    let modal = elt.closest(".modal")
+    let modal = $(elt).closest(".modal")[0]
     if (modal !== undefined)
       options.dropdownParent = modal
 


### PR DESCRIPTION
Followup #1618

`closest()` n’existe pas sur IE11, et si j’en crois sentry c’est encore une bonne part de nos utilisateurs.

Du coup, utilisons jQuery 🥲. J’ai testé sur browserstack, ça a l’air de marcher.

fixes RDV-SOLIDARITES-R9
fixes RDV-SOLIDARITES-RB
fixes RDV-SOLIDARITES-RD
fixes RDV-SOLIDARITES-RE
fixes RDV-SOLIDARITES-QY
fixes RDV-SOLIDARITES-QX

// Description de la fonctionnalité ou du bug

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
