### PR TITLE
CSP: Add stats.data.gouv.fr to connect-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ unless Rails.env.test?
     else
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "data1.gryplex.com", "lb.apicit.net", "tags.clickintext.net",
                         "api.mapbox.com", "blob:"
-      policy.connect_src :self, "api-adresse.data.gouv.fr", "sentry.io", "cdnjs.cloudflare.com", "etalab-tiles.fr"
+      policy.connect_src :self, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "sentry.io", "cdnjs.cloudflare.com", "etalab-tiles.fr"
     end
 
     # Specify URI for violation reports


### PR DESCRIPTION
fixes RDV-SOLIDARITES-QM

Manifestement notre CSP n’est pas configuré correctement pour stats.data.gouv.fr, on a pas mal d’erreurs. Je comprends pas trop pourquoi ça semble marcher 🤷 .

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
