### PR TITLE
Allow changing to noshow as soon as the Rdv is started

### DIFF
--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -10,7 +10,7 @@
       - when "unknown_today"
         = rdv_status_dropdown_item(rdv, agent, "waiting", remote)
         = rdv_status_dropdown_item(rdv, agent, "seen", remote)
-        - if rdv.past? # See issue #1642, I’d rather get rid of `temporal_status` than adding more variants.
+        - if rdv.in_the_past? # See issue #1642, I’d rather get rid of `temporal_status` than adding more variants.
           = rdv_status_dropdown_item(rdv, agent, "noshow", remote)
         .dropdown-divider
         = rdv_status_dropdown_item(rdv, agent, "excused", remote)


### PR DESCRIPTION
At some point we’ll have to get rid of one of these two methods.

Close #issue_number

// Description de la fonctionnalité ou du bug

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
