### PR TITLE
Prevent creating Rdv more than two years in advance

### DIFF
--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -1,12 +1,12 @@
 fr:
   activerecord:
-
     errors:
       models:
         rdv:
           attributes:
             starts_at:
-              must_be_future: "doit être dans le futur"
+              must_be_future: "doit être dans le futur."
+              must_be_within_two_years: "doit être dans moins de deux ans."
     models:
       rdv: Rendez-vous
     attributes:

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 describe Rdv, type: :model do
+  describe "#starts_at_is_plausible" do
+    let(:now) { Time.zone.parse("2021-05-03 14h00") }
+    let(:rdv) { build :rdv, starts_at: starts_at }
+
+    before { travel_to now }
+
+    describe "next week" do
+      let(:starts_at) { now + 1.week }
+
+      it { expect(rdv).to be_valid }
+    end
+
+    describe "last month" do
+      let(:starts_at) { now - 1.month }
+
+      it do
+        expect(rdv).not_to be_valid
+        expect(rdv.errors.details.dig(:starts_at, 0, :error)).to eq :must_be_future
+      end
+    end
+
+    describe "ten years from now week" do
+      let(:starts_at) { now + 10.years }
+
+      it do
+        expect(rdv).not_to be_valid
+        expect(rdv.errors.details.dig(:starts_at, 0, :error)).to eq :must_be_within_two_years
+      end
+    end
+  end
+
   describe "#cancellable?" do
     let(:now) { Time.zone.parse("2021-05-03 14h00") }
 


### PR DESCRIPTION
fixes #1600

WIP: Il faut aussi corriger les quelques Rdv en erreur en production:
```
> Rdv.where(starts_at: Time.zone.now + 2.years..).map{ |rdv| [rdv.id, rdv.starts_at.to_date.iso8601, rdv.created_at.to_date.iso8601, rdv.agents.ids] }.sort
```
* [x] (supprimé) [9175, "202014-08-13", "2020-07-16", [414]]
* [x] (supprimé)  [136660, "202115-05-19", "2021-04-07", [470]]
* [x] (supprimé) [218353, "202114-08-23", "2021-07-05", [1183]]
* [x] (corrigé) [218861, "20211-07-13", "2021-07-05", [1567]]
* [x] (corrigé) [221745, "202110-07-27", "2021-07-07", [1573]]
* [x] (supprimé) [230235, "202115-07-23", "2021-07-19", [2966]]
* [ ] (en cours) [243244, "202110-09-02", "2021-08-02", [2866]]
* [ ] (en cours) [243246, "202110-09-02", "2021-08-02", [2866]]

J’ai prévenu les agents concernés pour les rdv créés cet été, et on peut leur laisser corriger. Concernant les deux plus anciens, je pense qu’on peut les supprimer manuellement.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
