### PR TITLE
replace couleurs de fonds pour les stats public

### DIFF
--- a/app/webpacker/stylesheets/components/_rdv_status.scss
+++ b/app/webpacker/stylesheets/components/_rdv_status.scss
@@ -1,7 +1,8 @@
-a.rdv-status {
+.rdv-status {
   border-radius: 5px;
   border: 1px solid transparent;
 }
+
 a.rdv-status:hover{
   border-color: #000;
   color: inherit;
@@ -20,7 +21,7 @@ $status_colors: (
 );
 
 @each $status, $color in $status_colors {
-  a.rdv-status-#{$status},
+  .rdv-status-#{$status},
   .btn.rdv-status-#{$status} {
     background-color: $color;
     color: #000;


### PR DESCRIPTION
Close #1650 

Lors d'un petit réusinage, nous avons sans doute ajouté un sélecteur sur un lien, alors que dans la page de statistique public, il n'y a pas de lien, c'est uniquement une div.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
