### PR TITLE
Corrige les icônes arrondies dans le menu des status

### DIFF
--- a/app/webpacker/stylesheets/components/_rdv_status.scss
+++ b/app/webpacker/stylesheets/components/_rdv_status.scss
@@ -1,11 +1,8 @@
-.rdv-status {
-  border-radius: 5px;
+a.rdv-status {
   border: 1px solid transparent;
-}
-
-a.rdv-status:hover{
-  border-color: #000;
-  color: inherit;
+  &:hover {
+    border-color: #000;
+  }
 }
 
 $status_colors: (
@@ -21,7 +18,7 @@ $status_colors: (
 );
 
 @each $status, $color in $status_colors {
-  .rdv-status-#{$status},
+  .rdv-status.rdv-status-#{$status},
   .btn.rdv-status-#{$status} {
     background-color: $color;
     color: #000;


### PR DESCRIPTION
Ce sont des `.fa.fa-circle`, mais depuis #1652 on leur donnait la même background-color et color:

<img width="192" alt="image" src="https://user-images.githubusercontent.com/139391/130597514-dc25736d-0fcd-4d84-9fb3-cac2edc2f9e8.png"> 

C’est corrigé:
<img width="261" alt="image" src="https://user-images.githubusercontent.com/139391/130597521-d7a3f0b0-8ffe-477b-a274-b295cf479bf9.png">


J’ai vérifié que ça ne cassait pas l’affichage dans les stats publiques et privés, et dans les petits labels de status (les `rdv_status_tag`). Je crois que c’est bon.