### PR TITLE
recherche un agent dans la page des référents

### DIFF
--- a/app/controllers/admin/referents_controller.rb
+++ b/app/controllers/admin/referents_controller.rb
@@ -5,7 +5,8 @@ class Admin::ReferentsController < AgentAuthController
     @user = policy_scope(User).find(params[:user_id])
     authorize(@user, :update?)
     @referents = policy_scope(@user.agents).distinct.order(:last_name)
-    @agents = policy_scope(Agent).distinct.order(:last_name)
+    @agents = policy_scope(Agent)
+    @agents = @agents.search_by_text(params[:search]) if params[:search].present?
   end
 
   def create

--- a/app/views/admin/referents/index.html.slim
+++ b/app/views/admin/referents/index.html.slim
@@ -10,33 +10,37 @@
       = link_to @user.full_name, admin_organisation_user_path(current_organisation, @user)
     li.breadcrumb-item.active Modifier les référents
 
-.row.justify-content-center
-  .col-md-6
-    .card
-      .card-body
-        table.table
-          thead
-            tr
-              th Nom
-              th Service
-              th Actions
-          tbody
-            - @agents.each do |agent|
-              tr id="agent_#{agent.id}"
-                td
-                  span.mr-2= agent.full_name
-                td
-                  = agent.service&.short_name
-                td
-                  div.mr-3
-                    - if @referents.include?(agent)
-                      = link_to admin_organisation_user_referent_path(current_organisation, @user, agent), method: :delete, class: "btn btn-danger", data: { confirm: "Êtes-vous sûr de vouloir retirer ce référent ?"} do
-                        span> Retirer
-                        i.fa.fa-angle-right
-                    - else
-                      = link_to admin_organisation_user_referents_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary" do
-                        span> Ajouter
-                        i.fa.fa-angle-right
+= simple_form_for "", url: admin_organisation_user_referents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
+  .container-fluid.bg-white.rounded
+    .m-3.d-flex.justify-content-end
+      - search = params[:search].blank? && "d-none"
+      div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
+      = f.input :search, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+      = f.button :submit, t("helpers.search")
 
-        .m-3
-          = link_to "Fiche #{@user.full_name}", admin_organisation_user_path(current_organisation, @user, anchor: "agents-referents"), class: "btn btn-outline-primary"
+    table.table
+      thead
+        tr
+          th Nom
+          th Service
+          th Actions
+      tbody
+        - @agents.order(:last_name).each do |agent|
+          tr id="agent_#{agent.id}"
+            td
+              span.mr-2= agent.reverse_full_name
+            td
+              = agent.service&.short_name
+            td
+              div.mr-3
+                - if @referents.include?(agent)
+                  = link_to admin_organisation_user_referent_path(current_organisation, @user, agent), method: :delete, class: "btn btn-danger", data: { confirm: "Êtes-vous sûr de vouloir retirer ce référent ?"} do
+                    span> Retirer
+                    i.fa.fa-angle-right
+                - else
+                  = link_to admin_organisation_user_referents_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary" do
+                    span> Ajouter
+                    i.fa.fa-angle-right
+
+    .m-3
+      = link_to "Fiche #{@user.full_name}", admin_organisation_user_path(current_organisation, @user, anchor: "agents-referents"), class: "btn btn-outline-primary"

--- a/spec/controllers/admin/referents_controller_spec.rb
+++ b/spec/controllers/admin/referents_controller_spec.rb
@@ -17,6 +17,22 @@ describe Admin::ReferentsController, type: :controller do
       expect(assigns(:agents).sort).to eq([agent, lea].sort)
       expect(assigns(:referents)).to eq([])
     end
+
+    it "assigns matching search agent" do
+      organisation = create(:organisation)
+      user = create(:user, agents: [], organisations: [organisation])
+      service = create(:service)
+      connected_agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
+      agent = create(:agent, basic_role_in_organisations: [organisation], service: service, first_name: "Martine")
+      create(:agent, basic_role_in_organisations: [organisation], service: service)
+      sign_in connected_agent
+
+      get :index, params: { organisation_id: organisation.id, user_id: user.id, search: "Mart" }
+
+      expect(response).to be_successful
+      expect(assigns(:agents)).to eq([agent])
+      expect(assigns(:referents)).to eq([])
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
Close #1622

Ajout d'un champ de recherche dans la page d'ajout de référent. Ça permet de trouver plus simplement l'agent que l'on souhaite ajouter.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
