### PR TITLE
Add active_link_to and use it for all “active” classes in links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem "slim"
 gem "chartkick", "~> 3.4.0"
 gem "groupdate", "~> 4.2"
 gem "rails_autolink"
+gem "active_link_to"
 
 gem "premailer-rails" # Mail formatting
 gem "sib-api-v3-sdk" # SendInBlue (SMS)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     activejob (6.0.3.7)
       activesupport (= 6.0.3.7)
       globalid (>= 0.3.6)
@@ -568,6 +571,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_link_to
   activemodel-caution!
   activerecord-postgres_enum
   administrate!

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -15,7 +15,6 @@ class Admin::AbsencesController < AgentAuthController
       .by_starts_at
       .page(filter_params[:page])
 
-    @current_tab = filter_params[:current_tab]
     @absences = params[:current_tab] == "expired" ? absences.expired : absences.not_expired
     @display_tabs = absences.expired.any? || params[:current_tab] == "expired"
   end

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -19,7 +19,6 @@ class Admin::PlageOuverturesController < AgentAuthController
     @plage_ouvertures = all_plage_ouvertures
       .where(expired_cached: filter_params[:current_tab] == "expired")
       .page(filter_params[:page])
-    @current_tab = filter_params[:current_tab]
     @display_tabs = all_plage_ouvertures.where(expired_cached: true).any? || params[:current_tab] == "expired"
   end
 

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -14,11 +14,9 @@
   - if @display_tabs
     ul.nav.nav-tabs.px-2.mt-2
       li.nav-item
-        - active = @current_tab != "expired" ? "active" : ""
-        = link_to "En cours", admin_organisation_agent_absences_path(current_organisation, @agent.id, current_tab: "not_expired"), class: "nav-link #{active}"
+        = active_link_to "En cours", admin_organisation_agent_absences_path(current_organisation, @agent.id), class: "nav-link", active: :exact
       li.nav-item
-        - active = @current_tab == "expired" ? "active" : ""
-        = link_to "Passées", admin_organisation_agent_absences_path(current_organisation, @agent.id, current_tab: "expired"), class: "nav-link #{active}"
+        = active_link_to "Passées", admin_organisation_agent_absences_path(current_organisation, @agent.id, current_tab: "expired"), class: "nav-link", active: :exact
 
   - if @absences.any?
     table.table

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -14,9 +14,9 @@
   - if @display_tabs
     ul.nav.nav-tabs.px-2.mt-2
       li.nav-item
-        = link_to "En cours", admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, current_tab: "not_expired"), class: "nav-link #{'active' if @current_tab != 'expired'}"
+        = active_link_to "En cours", admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: "nav-link", active: :exact
       li.nav-item
-        = link_to "Passées", admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, current_tab: "expired"), class: "nav-link #{'active' if @current_tab == 'expired'}"
+        = active_link_to "Passées", admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, current_tab: "expired"), class: "nav-link", active: :exact
 
   - if @plage_ouvertures.any?
     table.table

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -35,11 +35,7 @@
           li.my-2
             = link_to "Mes organisations", admin_organisations_path
           li.my-2
-            = link_to( \
-              "Mes statistiques", \
-              admin_organisation_agent_stats_path(current_organisation, current_agent), \
-              class: ("active" if content_for(:menu_item) == "menu-stats") \
-            )
+            = active_link_to "Mes statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
             = rdv_danger_badge(policy_scope(current_agent.rdvs).status("unknown_past").count)
           li.my-2
             = link_to destroy_agent_session_path, method: :delete do
@@ -48,10 +44,7 @@
 
       - if current_organisation.recent?
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to( \
-            admin_organisation_setup_checklist_path(current_organisation), \
-            class: ("active" if content_for(:menu_item) == "menu-setup-checklist") \
-          ) do
+          = active_link_to admin_organisation_setup_checklist_path(current_organisation)
             i.far.fa-calendar>
             span.ml-1 Premiers pas
 
@@ -78,56 +71,35 @@
                 class: "select2-input form-control js-planning-agent-select" \
               )
           li.my-2
-            = link_to "Agenda", \
-              admin_organisation_agent_agenda_path(current_organisation, agent_for_left_menu(@agent)), \
-              class: ("active" if content_for(:menu_item) == "menu-agendas")
+            = active_link_to "Agenda", admin_organisation_agent_agenda_path(current_organisation, agent_for_left_menu(@agent))
           li.my-2
-            = link_to "Plages d'ouverture", \
-              admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu(@agent)), \
-              class: ("active" if content_for(:menu_item) == "menu-plages-ouvertures")
+            = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu(@agent))
           li.my-2
-            = link_to "Absences", \
-              admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu(@agent)), \
-              class: ("active" if content_for(:menu_item) == "menu-absences")
+            = active_link_to "Absences", admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu(@agent))
 
       li.side-nav-item.mb-4.pl-3.pr-2
-        = link_to( \
-            admin_organisation_users_path(current_organisation), \
-            class: ("active" if content_for(:menu_item) == "menu-users") \
-            ) do
-              i.fa.fa-user>
-              span.ml-1 Usagers
+        = active_link_to admin_organisation_users_path(current_organisation)
+          i.fa.fa-user>
+          span.ml-1 Usagers
 
       li.side-nav-item.mb-4.pl-3.pr-2
-        = link_to \
-          admin_organisation_rdvs_path(current_organisation), \
-          class: ("active" if content_for(:menu_item) == "menu-rdvs-list") \
-        do
+        = active_link_to admin_organisation_rdvs_path(current_organisation)
           i.fa.fa-list>
           span.ml-1 Liste des RDV
 
       li.side-nav-item.mb-4.pl-3.pr-2
-        = link_to( \
-          admin_organisation_stats_path(current_organisation), \
-          class: ("active" if content_for(:menu_item) == "menu-organisation-stats") \
-        ) do
+        = active_link_to admin_organisation_stats_path(current_organisation)
           i.fa.fa-chart-bar>
           span.ml-1 Statistiques
           = rdv_danger_badge(policy_scope(current_organisation.rdvs).status("unknown_past").count)
 
       - unless current_agent_role.admin?
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to \
-            admin_organisation_lieux_path(current_organisation), \
-            class: ("active" if content_for(:menu_item) == "menu-lieux") \
-          do
+          = active_link_to admin_organisation_lieux_path(current_organisation)
             i.fa.fa-building>
             span.ml-1 Lieux
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to \
-            admin_organisation_motifs_path(current_organisation), \
-            class: ("active" if content_for(:menu_item) == "menu-motifs") \
-          do
+          = active_link_to admin_organisation_motifs_path(current_organisation)
             i.fa.fa-paste>
             span.ml-1 Motifs
 
@@ -148,33 +120,19 @@
             class=("show" if menu_top_level_item == "settings")
           ]
             li.my-2
-              =link_to "Votre organisation", \
-                admin_organisation_path(current_organisation), \
-                class: ("active" if content_for(:menu_item) == "menu-organisation")
+              = active_link_to "Votre organisation", admin_organisation_path(current_organisation), active: :exact
             li.my-2
-              =link_to "Vos lieux", \
-                admin_organisation_lieux_path(current_organisation), \
-                class: ("active" if content_for(:menu_item) == "menu-lieux")
+              = active_link_to "Vos lieux", admin_organisation_lieux_path(current_organisation)
             li.my-2
-              =link_to "Vos agents", \
-                admin_organisation_agents_path(current_organisation), \
-                class: ("active" if content_for(:menu_item) == "menu-agents")
+              = active_link_to "Vos agents", admin_organisation_agents_path(current_organisation)
             li.my-2
-              =link_to "Vos invitations", \
-                admin_organisation_invitations_path(current_organisation), \
-                class: ("active" if content_for(:menu_item) == "menu-invitations")
+              = active_link_to "Vos invitations", admin_organisation_invitations_path(current_organisation)
             li.my-2
-              = link_to "Vos motifs", \
-                admin_organisation_motifs_path(current_organisation), \
-                class: ("active" if content_for(:menu_item) == "menu-motifs")
+              = active_link_to "Vos motifs", admin_organisation_motifs_path(current_organisation)
             - if current_agent_role.admin? && policy_scope(Organisation).count == 1
               li.my-2
-                = link_to "Sectorisation #{current_organisation.territory}", \
-                  admin_territory_setup_checklist_path(current_organisation.territory)
+                = active_link_to "Sectorisation #{current_organisation.territory}", admin_territory_setup_checklist_path(current_organisation.territory)
       li.side-nav-item.pl-3.pr-2
-        = link_to \
-          admin_organisation_support_path(current_organisation), \
-          class: ("active" if content_for(:menu_item) == "menu-support") \
-        do
+        = active_link_to admin_organisation_support_path(current_organisation)
           i.fa.fa-question-circle>
           span.ml-1 Support

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -43,4 +43,3 @@ html lang="fr"
               = link_to "https://doc.rdv-solidarites.fr/politique-de-confidentialite" do
                 span> Politique de confidentialité
                 i.fa.fa-external-link-alt
-    input type="hidden" id="js-current-menu-item" value=content_for(:menu_item)

--- a/app/views/layouts/application_agent_departement.html.slim
+++ b/app/views/layouts/application_agent_departement.html.slim
@@ -3,23 +3,23 @@
     li.side-nav-title.pl-3.mb-4= current_territory
 
     li.side-nav-item.mb-4.pl-3.pr-2
-      = link_to admin_territory_setup_checklist_path(current_territory), class: ("active" if content_for(:menu_item) == "menu-departement-setup-checklist")
+      = active_link_to admin_territory_setup_checklist_path(current_territory)
         i.fa.fa-info>
         span.ml-1 Instructions
 
     li.side-nav-item.mb-4.pl-3.pr-2
-      = link_to admin_territory_agent_territorial_roles_path(current_territory), class: ("active" if content_for(:menu_item) == "menu-departement-agents")
+      = active_link_to admin_territory_agent_territorial_roles_path(current_territory)
         i.fa.fa-users>
         span.ml-1 Administration
 
       li.side-nav-item.mb-4.pl-3.pr-2
-        = link_to admin_territory_webhook_endpoints_path(current_territory)
+        = active_link_to admin_territory_webhook_endpoints_path(current_territory)
           i.fa.fa-network-wired>
           span.ml-1 Webhook
 
     - if current_territory.has_own_sms_provider?
       li.side-nav-item.mb-4.pl-3.pr-2
-        = link_to admin_territory_sms_configuration_path(current_territory)
+        = active_link_to admin_territory_sms_configuration_path(current_territory)
           i.fa.fa-mobile-alt>
           span.ml-1 SMS
 
@@ -27,22 +27,22 @@
       a.active Sectorisation
       ul.side-nav.list-unstyled.mt-4
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to admin_territory_sectors_path(current_territory), class: ("active" if content_for(:menu_item) == "menu-departement-sectors")
+          = active_link_to admin_territory_sectors_path(current_territory)
             i.fa.fa-table>
             span.ml-1 Secteurs
 
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to admin_territory_sectors_path(current_territory, view: "map"), class: ("active" if content_for(:menu_item) == "menu-departement-sectors-map")
+          = active_link_to admin_territory_sectors_path(current_territory, view: "map"), active: :exact
             i.fa.fa-map>
             span.ml-1 Carte
 
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to admin_territory_sectorisation_test_path(current_territory), class: ("active" if content_for(:menu_item) == "menu-departement-sectorisation-test")
+          = active_link_to admin_territory_sectorisation_test_path(current_territory)
             i.fa.fa-cogs>
             span.ml-1 Tests
 
         li.side-nav-item.mb-4.pl-3.pr-2
-          = link_to new_admin_territory_zone_import_path(current_territory), class: ("active" if content_for(:menu_item) == "menu-departement-zone-imports")
+          = active_link_to new_admin_territory_zone_import_path(current_territory)
             i.fa.fa-download>
             span.ml-1 Importer fichier
 

--- a/app/webpacker/stylesheets/_variables.scss
+++ b/app/webpacker/stylesheets/_variables.scss
@@ -441,7 +441,7 @@ $bg-topnav:             linear-gradient(to bottom, #8f75da, #727cf5);
 $leftbar-width:         250px;
 
 //Menu item colors (Default-dark)
-$menu-item:          #cedce4;
+$menu-item:          #cbdae2;
 $menu-item-hover:    #ffffff;
 $menu-item-active:   #ffffff;
 


### PR DESCRIPTION
Le lien est `active` si le path de la page visitée contient celui du lien. A priori, ça marche à peu près partout, peut-être qu’il reste des endroits où on a fait des choses compliquées avec les routes, mais ça devrait aller. Ça simplifie pas mal certains trucs inutiles.

La prochaine fois je retirerai les `content_for(:menu_item)` :)


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
