### PR TITLE
Affiche les services disponible sur l'accueil usager

### DIFF
--- a/app/views/welcome/welcome_departement.html.slim
+++ b/app/views/welcome/welcome_departement.html.slim
@@ -9,7 +9,7 @@
             br
             | avec votre département le&nbsp;
             span.text-secondary #{@departement}
-          h3.text-white.mb-4 en PMI, CPEF, Service Social
+          h3.text-white.mb-4 en PMI, CPEF, Service Social, MDPH
 
           .mb-5= render "common/search_form"
       h3.text-white.text-center Comment ça marche ?

--- a/app/views/welcome/welcome_departement.html.slim
+++ b/app/views/welcome/welcome_departement.html.slim
@@ -9,7 +9,8 @@
             br
             | avec votre département le&nbsp;
             span.text-secondary #{@departement}
-          h3.text-white.mb-4 en PMI, CPEF, Service Social, MDPH
+
+            h3.text-white.mb-4 = t(".open_services", count: @services.count, services_names: @services.map(&:short_name).join(", "))
 
           .mb-5= render "common/search_form"
       h3.text-white.text-center Comment ça marche ?

--- a/app/views/welcome/welcome_departement.html.slim
+++ b/app/views/welcome/welcome_departement.html.slim
@@ -10,7 +10,7 @@
             | avec votre département le&nbsp;
             span.text-secondary #{@departement}
 
-            h3.text-white.mb-4 = t(".open_services", count: @services.count, services_names: @services.map(&:short_name).join(", "))
+          h3.text-white.mb-4 = t(".open_services", count: @services.count, services_names: @services.map(&:short_name).join(", "))
 
           .mb-5= render "common/search_form"
       h3.text-white.text-center Comment ça marche ?

--- a/config/locales/views/welcome.fr.yml
+++ b/config/locales/views/welcome.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  welcome:
+    welcome_departement:
+      open_services:
+        zero: dans les services des solidarités
+        other: "en %{services_names}"
+

--- a/config/locales/views/welcome.fr.yml
+++ b/config/locales/views/welcome.fr.yml
@@ -3,5 +3,6 @@ fr:
     welcome_departement:
       open_services:
         zero: dans les services des solidarités
+        one: "en %{services_names}"
         other: "en %{services_names}"
 


### PR DESCRIPTION
Close #1701 

Affiche uniquement les services disponible (issue de la liste affichée pour les filtres) dans le titre de la page de recherche des usagers.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
