### PR TITLE
Always display the instance name banner, regardless of width

### DIFF
--- a/app/webpacker/stylesheets/components/_rdv_solidarites_instance_name.scss
+++ b/app/webpacker/stylesheets/components/_rdv_solidarites_instance_name.scss
@@ -38,9 +38,3 @@
     }
   }
 }
-
-@media (max-width: 768px) {
-  .rdv-solidarites-instance-name-wrapper {
-    display: none;
-  }
-}


### PR DESCRIPTION
This broke the banner in emails: the html for the emails are rendered in a job, and the css styles are inlined, which means the media queries are resolved in a weird context. In practice, this meant the banner had a `display: none` style in emails. 🙈