### PR TITLE
correction du script de migration

### DIFF
--- a/scripts/agent_et_motif_changent_de_service.rb
+++ b/scripts/agent_et_motif_changent_de_service.rb
@@ -38,7 +38,7 @@ Agent.transaction do
   end
 
   puts "Déplacement des agents:"
-  organisation.agents.each do |agent|
+  organisation.agents.where(service: services_source).each do |agent|
     puts agent.full_name.to_s
     agent.update_column(:service_id, ID_SERVICE_DESTINATION)
   end


### PR DESCRIPTION
Durant la migration de service des agents de la Somme, nous avons découvert un cas non couvert (et non détecté lors de la première utilisation). Le script migre tous les agents d'une organisation vers l'autre service.

Dans la première exécution du script (pour le 92) c'était ce que nous voulions... Là, ce n'étais pas le cas.