### PR TITLE
Ajoute zone de pagination en bas de page motifs

### DIFF
--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -44,11 +44,5 @@ module SuperAdmins
     def sign_in_as_allowed?
       ENV.fetch("SIGN_IN_AS_ALLOWED", false)
     end
-
-    # Override this value to specify the number of elements to display at a time
-    # on index pages. Defaults to 20.
-    # def records_per_page
-    #   params[:per_page] || 20
-    # end
   end
 end

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -44,7 +44,7 @@
       tbody
         - if @motifs.any?
           = render @motifs
-          .d-flex.justify-content-center id="users-pagination"
+          .d-flex.justify-content-center
             = paginate @motifs, theme: "twitter-bootstrap-4"
         - else
           tr
@@ -64,7 +64,7 @@
                       = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
 
     - if @motifs.any?
-      .d-flex.justify-content-center id="users-pagination"
+      .d-flex.justify-content-center
         = paginate @motifs, theme: "twitter-bootstrap-4"
       - if current_agent_can?(:create, Motif)
         .text-center.m-3

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -63,6 +63,9 @@
                     .text-center.m-3
                       = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
 
-    - if @motifs.any? && current_agent_can?(:create, Motif)
-      .text-center.m-3
-        = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
+    - if @motifs.any?
+      .d-flex.justify-content-center id="users-pagination"
+        = paginate @motifs, theme: "twitter-bootstrap-4"
+      - if current_agent_can?(:create, Motif)
+        .text-center.m-3
+          = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"


### PR DESCRIPTION
Close #1726 

Ajoute une zone de pagination en bas de la page des motifs

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
