### PR TITLE
Sécurise l'ouverture du fichier

### DIFF
--- a/scripts/import_motifs_libelles.rb
+++ b/scripts/import_motifs_libelles.rb
@@ -7,7 +7,7 @@ url = ARGV[0]
 puts "import from `#{url}`"
 puts "#{MotifLibelle.count} libellé de motif avant import"
 
-CSV.foreach(URI.open(url)) do |row|
+CSV.foreach(URI.parse(url).open) do |row|
   MotifLibelle.find_or_create_by(name: row[2], service_id: row[3])
 end
 


### PR DESCRIPTION
Pour corriger l'alerte linter que je n'avais pas vu en forçant le passage la première fois.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
