### PR TITLE
Remove the “display: none” for the page title on small screens

### DIFF
--- a/app/webpacker/stylesheets/structure/_page-head.scss
+++ b/app/webpacker/stylesheets/structure/_page-head.scss
@@ -13,27 +13,3 @@
     padding-top: 8px;
   }
 }
-
-@include media-breakpoint-down(sm) {
-  .page-title-box {
-    .page-title {
-      display: block;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      line-height: 70px;
-    }
-    .breadcrumb {
-      display: none;
-    }
-    .page-title-right {
-      display: none;
-    }
-  }
-}
-
-@media (max-width: 419px) {
-  .page-title-box .breadcrumb {
-    display: none;
-  }
-}


### PR DESCRIPTION
fixes #1674

L’alternative serait de garder ce css mais de mettre le bouton “trouver un créneau” ailleurs, mais franchement, quand je peux fixer un bug en supprimant du code… (Je trouve ça vraiment contre-intuitif de mettre des “display: none” pour des portions de l’interface.)

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
