### PR TITLE
Prevent a crash in ReminderJob

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -45,7 +45,7 @@ class CronJob < ApplicationJob
 
     def perform
       Rdv.not_cancelled.day_after_tomorrow.each do |rdv|
-        Notifications::Rdv::RdvUpcomingReminderService.perform_with(rdv)
+        Notifications::Rdv::RdvUpcomingReminderService.perform_with(rdv, nil)
       end
     end
   end

--- a/spec/jobs/cron_job/reminder_job_spec.rb
+++ b/spec/jobs/cron_job/reminder_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CronJob::ReminderJob, type: :job do
     let!(:rdv1) { create(:rdv, starts_at: 2.days.from_now) }
 
     it "calls notification service" do
-      expect(Notifications::Rdv::RdvUpcomingReminderService).to receive(:perform_with).with(rdv1)
+      expect(Notifications::Rdv::RdvUpcomingReminderService).to receive(:perform_with).with(rdv1, nil)
       subject
     end
   end
@@ -25,9 +25,9 @@ RSpec.describe CronJob::ReminderJob, type: :job do
     let!(:rdv3) { create(:rdv, starts_at: 1.day.from_now) }
 
     it "calls notification service" do
-      expect(Notifications::Rdv::RdvUpcomingReminderService).to receive(:perform_with).with(rdv1)
-      expect(Notifications::Rdv::RdvUpcomingReminderService).to receive(:perform_with).with(rdv2)
-      expect(Notifications::Rdv::RdvUpcomingReminderService).not_to receive(:perform_with).with(rdv3)
+      expect(Notifications::Rdv::RdvUpcomingReminderService).to receive(:perform_with).with(rdv1, nil)
+      expect(Notifications::Rdv::RdvUpcomingReminderService).to receive(:perform_with).with(rdv2, nil)
+      expect(Notifications::Rdv::RdvUpcomingReminderService).not_to receive(:perform_with).with(rdv3, nil)
       subject
     end
   end


### PR DESCRIPTION
Followup ruby 3 #1712

fixes #1749

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
