### PR TITLE
feat(api): Add rdvs index endpoint

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Api::V1::RdvsController < Api::V1::BaseController
+  def index
+    rdvs = policy_scope(Rdv)
+    render_collection(rdvs)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
       resources :organisations, only: %i[index] do
         resources :users, only: %i[index]
         resources :motifs, only: %i[index]
+        resources :rdvs, only: %i[index]
       end
     end
   end

--- a/spec/requests/api/v1/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/rdvs_request_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe "api/v1/rdvs requests", type: :request do
+  let!(:organisation) { create(:organisation) }
+  let!(:service) { create(:service) }
+  let!(:motif) { create(:motif, service: service) }
+  let!(:rdv) { create(:rdv, organisation: organisation, motif: motif) }
+
+  describe "GET api/v1/organisations/:id/rdvs" do
+    context "multiple organisations and motifs" do
+      let!(:organisation2) { create(:organisation) }
+      let!(:rdv2) { create(:rdv, organisation: organisation2, motif: motif) }
+      let!(:service2) { create(:service) }
+      let!(:motif2) { create(:motif, service: service2) }
+      let!(:rdv3) { create(:rdv, organisation: organisation, motif: motif2) }
+
+      context "basic role" do
+        let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+
+        it "returns policy scoped rdvs" do
+          get api_v1_organisation_rdvs_path(organisation), headers: api_auth_headers_for_agent(agent)
+          expect(response.status).to eq(200)
+          response_parsed = JSON.parse(response.body)
+          expect(response_parsed["rdvs"].pluck("id")).to contain_exactly(rdv.id)
+        end
+      end
+
+      context "admin role" do
+        let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+
+        it "returns policy scoped rdvs" do
+          get api_v1_organisation_rdvs_path(organisation), headers: api_auth_headers_for_agent(agent)
+          expect(response.status).to eq(200)
+          response_parsed = JSON.parse(response.body)
+          expect(response_parsed["rdvs"].pluck("id")).to contain_exactly(rdv.id, rdv3.id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
J'ajoute ici un endpoint permettant de récupérer les rdvs d'une organisation, endpoint dont on aura besoin de manière sporadique côté RDV Insertion.
À noter que je n'ai pas ajouté la route `GET api/v1/rdvs` non scopée à une organisation pour être homogène car au vu de [la policy actuelle](https://github.com/betagouv/rdv-solidarites.fr/blob/863f217b24a955d4e01d2e7df4c8a8e73a3d2289/app/policies/agent/rdv_policy.rb#L9) ça ne renverrait rien.