### PR TITLE
🚀 [perf] Faster rdv search form

### DIFF
--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -7,7 +7,24 @@
             label_method: :reverse_full_name, \
             input_html: { class: "select2-input" }, \
             wrapper: "horizontal_form"
-      = f.input :user_id, collection: policy_scope(User), label: "Usager", label_method: :reverse_full_name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
+
+      = f.input :user_id, collection: [],
+              label: "Usager",
+              label_method: :reverse_full_name,
+              input_html: { \
+                class: "select2-input", \
+                data: {\
+                  "select-options": {\
+                    ajax: {\
+                      url: search_admin_organisation_users_path(current_organisation),
+                      dataType: "json",
+                      delay: 250\
+                    }\
+                  }\
+                }\
+              },
+              wrapper: "horizontal_form"
+
       = f.input :lieu_id, collection: policy_scope(Lieu), label: "Lieu", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
       = f.input :show_user_details, as: :boolean, wrapper: "horizontal_form", label: "Détails usagers"
     .col-md-6

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -1,0 +1,17 @@
+= simple_form_for(form, method: "GET", url: url_for({}), as: "") do |f|
+  .row
+    .col-md-6
+      = f.input :agent_id, \
+            collection: policy_scope(Agent).joins(:organisations).where(organisations: { id: current_organisation.id }), \
+            label: "Agent", \
+            label_method: :reverse_full_name, \
+            input_html: { class: "select2-input" }, \
+            wrapper: "horizontal_form"
+      = f.input :user_id, collection: policy_scope(User), label: "Usager", label_method: :reverse_full_name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
+      = f.input :lieu_id, collection: policy_scope(Lieu), label: "Lieu", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
+      = f.input :show_user_details, as: :boolean, wrapper: "horizontal_form", label: "Détails usagers"
+    .col-md-6
+      = f.input :status, collection: Rdv.statuses.keys - ["unknown"] + ["unknown_past", "unknown_future"], label_method: -> { ::Rdv.human_enum_name(:status, _1) }, label: "Statut", wrapper: "horizontal_form", input_html: { class: "select2-input" }
+      = date_input(f, :start, label = "Période - Début", wrapper: "horizontal_form")
+      = date_input(f, :end, label = "Période - Fin", wrapper: "horizontal_form")
+  input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste"

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -34,23 +34,7 @@
 .card.border-info
   .card-header ⚙️ Filtres et options
   .card-body
-    = simple_form_for(@form, method: "GET", url: url_for({}), as: "") do |f|
-      .row
-        .col-md-6
-          = f.input :agent_id, \
-            collection: policy_scope(Agent).joins(:organisations).where(organisations: { id: current_organisation.id }), \
-            label: "Agent", \
-            label_method: :reverse_full_name, \
-            input_html: { class: "select2-input" }, \
-            wrapper: "horizontal_form"
-          = f.input :user_id, collection: policy_scope(User), label: "Usager", label_method: :reverse_full_name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
-          = f.input :lieu_id, collection: policy_scope(Lieu), label: "Lieu", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
-          = f.input :show_user_details, as: :boolean, wrapper: "horizontal_form", label: "Détails usagers"
-        .col-md-6
-          = f.input :status, collection: Rdv.statuses.keys - ["unknown"] + ["unknown_past", "unknown_future"], label_method: -> { ::Rdv.human_enum_name(:status, _1) }, label: "Statut", wrapper: "horizontal_form", input_html: { class: "select2-input" }
-          = date_input(f, :start, label = "Période - Début", wrapper: "horizontal_form")
-          = date_input(f, :end, label = "Période - Fin", wrapper: "horizontal_form")
-      input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste"
+    = render "rdv_search_form", form: @form
   - if @rdvs.any?
     .card-footer
       div.d-flex.justify-content-end


### PR DESCRIPTION
refs #1754

Utiliser le service de recherche js plutôt que de mettre les milliers d’usagers dans le select.
* Il faut faire la même chose avec les agents, même si en principe c’est moins grave, il y en a moins. C’est le point d’après, parce que ce service de recherche n’existe pas; il faut aussi le créer pour le left_menu.
* Je craignais qu’il faille attendre que les colonnes `tsvector` soit implémentées pour mettre ça en prod, parce que ça pourrait augmenter le nombre de recherches full text. Cependant, `Admin::UsersController#search` limite le nombre de résultats à 10, donc en fait ça va très bien.

Benchmark rapide, meilleur temps sur une quinzaine de rechargements de la page:

Avant:
```
16:29:22 web.1     | Started GET "/admin/organisations/443/rdvs" for 127.0.0.1 at 2021-09-29 16:29:22 +0200
16:29:22 web.1     | Processing by Admin::RdvsController#index as HTML
...
16:29:23 web.1     | Completed 200 OK in 1207ms (Views: 1153.7ms | ActiveRecord: 45.4ms | Allocations: 1282348)
```

Après:

```
16:28:03 web.1     | Started GET "/admin/organisations/443/rdvs" for 127.0.0.1 at 2021-09-29 16:28:03 +0200
16:28:03 web.1     | Processing by Admin::RdvsController#index as HTML
...
16:28:03 web.1     | Completed 200 OK in 205ms (Views: 180.3ms | ActiveRecord: 17.3ms | Allocations: 160423)
```

(On gagne beaucoup en temps et en mémoire.)

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
