### PR TITLE
utilise le script shell sans appeler ruby

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: bundle exec bin/start_web_server
+web: ./bin/start_web_server
 jobs: bundle exec bin/delayed_job run
 postdeploy: bundle exec rake db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bundle exec bin/start_web_server
+web: ./bin/start_web_server
 worker: bin/rake jobs:work
 webpack: bin/webpack-dev-server

--- a/bin/start_web_server
+++ b/bin/start_web_server
@@ -2,4 +2,4 @@ export RDV_SOLIDARITES_VERSION=v1.`date +"%y%m%d%H%M"`
 if [[ -z "${CONTAINER_VERSION}" ]]; then
   export CONTAINER_VERSION=`git rev-parse HEAD`
 fi
-puma
+bundle exec puma


### PR DESCRIPTION
En explorant un problème, nous avons découvert (avec @rebeccadumazert) que le `Procfile` appel `bundle exec bin/start_web_server` comme si c'était un script ruby alors qu'en fait, c’est un script shell... 

