### PR TITLE
Bugfix pour external invitations

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -27,7 +27,7 @@
             .col-md-4.text-right
               = link_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white"
 
-        - if @user.invited_through == "external" && invitation_accepted_at.nil?
+        - if @user.invited_through == "external" && @user.invitation_accepted_at.nil?
           .row.bg-info.text-white.p-2.mb-3
             .col-md-8
               | Cet usager a reçu une invitation via un partenaire de RDV-Solidarités, mais il ne l’a pas encore acceptée.


### PR DESCRIPTION
La page show des utilisateurs invités via rdv-insertion n'était plus accessible à cause d'une erreur dans le code (my bad).