### PR TITLE
mise à jour de la gem FFI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    ffi (1.15.3)
+    ffi (1.15.4)
     globalid (0.5.2)
       activesupport (>= 5.0)
     groupdate (4.3.0)


### PR DESCRIPTION
Ce matin, j'ai eu un petit souci avec la gem FFI.

Je ne sais pas trop pourquoi. En cherchant des solutions, je suis tombé sur pas mal d'article qui parlaient de plateforme et de supprimer le `Gemfile.lock` pour refaire un `bundle install`

C'est ce que j'ai fait dans cette PR. Ceci étant, il y a un changement de plateforme dans le fichier `Gemfile.lock`, je trouve ça génant... (et en même temps, c'est sans doute ce qui fait que ça fonctionne sur mon environnement à nouveau).


J'ai trouvé un article qui permet d'ajouter une autre plateforme.

Il faut peut-être en discuter. Mon problème peut peut-être être résolu autrement ?
https://prathamesh.tech/2021/04/18/bundler-2-2-3-and-deployment-of-ruby-apps/
