### PR TITLE
Réactive le “danger badge”, avec une clé de cache raisonnable

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -42,7 +42,7 @@ module RdvsHelper
   end
 
   def rdv_danger_badge(rdvs)
-    Rails.cache.fetch(["rdv_danger_badge", rdvs]) do
+    Rails.cache.fetch(["rdv_danger_badge", rdvs.to_sql.hash], expires_in: 2.minutes) do
       count = rdvs.status("unknown_past").count
       tag.span(count, class: "badge badge-danger") if count.positive?
     end


### PR DESCRIPTION
🙈

Quand on utilise une ActiveRecord::Relation comme clé de cache, AR appelle en fait .cache_key_with_version, ce qui fait en fait un `SELECT COUNT (*), MAX(UPDATED_AT)`. C’est pas forcément un problème en général, sauf que en définitive, ce n’est même pas une requête SQL plus simple que celle dont on essaye de garder le résultat en cache.

En utilisant `.to_sql.hash` avec une expiration à deux minutes, on garantit que les requêtes pour un même jeu de rdvs ne seront pas faites à nouveau pendant deux minutes; d’un autre côté, le compteur peut ne pas être à jour pendant deux minutes.

Followup #1794

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
