### PR TITLE
refactor(policy): Change user invite policy

### DIFF
--- a/app/policies/agent/user_policy.rb
+++ b/app/policies/agent/user_policy.rb
@@ -17,7 +17,7 @@ class Agent::UserPolicy < DefaultAgentPolicy
   end
 
   def invite?
-    create?
+    same_org?
   end
 
   def update?


### PR DESCRIPTION
Cette PR a pour but de faire en sorte qu'un agent puisse inviter un utilisateur sur RDV-Solidarités même si celui-ci appartient à d'autres organisation en + de celle de l'agent (https://mattermost.incubateur.net/betagouv/pl/tud8ysbsjbbh7nwz16tocsxq3c).  