### PR TITLE
Use redis cache store in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem "administrate", git: "https://github.com/thoughtbot/administrate.git", ref: 
 gem "administrate-field-belongs_to_search"
 gem "paper_trail"
 gem "activerecord-postgres_enum"
+gem "redis"
+gem "hiredis"
+
 
 # Devise / auth
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,7 @@ GEM
     groupdate (4.3.0)
       activesupport (>= 5)
     hashie (4.1.0)
+    hiredis (0.6.3)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     i18n (1.8.10)
@@ -413,6 +414,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.5.1)
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -602,6 +604,7 @@ DEPENDENCIES
   factory_bot
   faker
   groupdate (~> 4.2)
+  hiredis
   icalendar (~> 2.5)
   image_processing (~> 1.8)
   jbuilder
@@ -626,6 +629,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rails_autolink
+  redis
   rspec-rails
   rspec_junit_formatter
   rubocop

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: "#{ENV['REDIS_URL']}/0:#{ENV['SOURCE_VERSION'] || ENV['CONTAINER_VERSION']}" }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   config.active_job.queue_adapter = :delayed_job


### PR DESCRIPTION
refs #1806

A Redis addon is setup on Scalingo. To experiment, I started with the free plan (64MB). Scalingo sets the SCALINGO_REDIS_URL and aliases it as REDIS_URL. Additionally, in the Scalingo Redis Dashboard, in the advanced section, “Cache Mode” is enabled.

Links:
https://doc.scalingo.com/databases/redis/start#cache-mode
https://doc.scalingo.com/languages/ruby/rails/redis-cache
https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore

Close #issue_number

// Description de la fonctionnalité ou du bug

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
