### PR TITLE
Fix Rdv duration update from FileAttente 🚀 

### DIFF
--- a/app/controllers/users/creneaux_controller.rb
+++ b/app/controllers/users/creneaux_controller.rb
@@ -21,7 +21,7 @@ class Users::CreneauxController < UserAuthController
   end
 
   def update
-    @rdv.update(starts_at: @creneau.starts_at, agent_ids: [@creneau.agent_id], created_by: :file_attente)
+    @rdv.update(starts_at: @creneau.starts_at, ends_at: @creneau.starts_at + @rdv.duration_in_min.minutes, agent_ids: [@creneau.agent_id], created_by: :file_attente)
     Notifications::Rdv::RdvDateUpdatedService.perform_with(@rdv, current_user)
   end
 


### PR DESCRIPTION
fixes #1826

Direct en production: ça fait un peu de bruit d’erreurs 500 qui bloquent le calendrier des agents concernés.

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
