### PR TITLE
Fix search results ordering in controllers

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -7,8 +7,8 @@ class Admin::AgentsController < AgentAuthController
     agents = policy_scope(Agent)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .active.order_by_last_name
-    @invited_agents = agents.invitation_not_accepted.created_by_invite
-    @complete_agents = index_params[:search].present? ? agents.search_by_text(index_params[:search]) : agents
+    @invited_agents = agents.invitation_not_accepted.created_by_invite.order_by_last_name
+    @complete_agents = index_params[:search].present? ? agents.search_by_text(index_params[:search]) : agents.order_by_last_name
     @complete_agents = @complete_agents.complete
       .includes(:service, :roles, :organisations)
       .page(params[:page])
@@ -17,9 +17,8 @@ class Admin::AgentsController < AgentAuthController
   def search
     agents = policy_scope(Agent)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
-      .active.order_by_last_name.complete
-    agents = agents.order_by_last_name.limit(10)
-    @agents = agents.search_by_text(search_params[:term]) if search_params[:term].present?
+      .active.complete.limit(10)
+    @agents = search_params[:term].present? ? agents.search_by_text(search_params[:term]) : agents.order_by_last_name
     skip_authorization
   end
 

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -6,9 +6,8 @@ class Admin::InvitationsController < AgentAuthController
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .invitation_not_accepted
       .created_by_invite
-      .order(invitation_sent_at: :desc)
       .page(params[:page])
-    @invited_agents = @invited_agents.search_by_text(index_params[:search]) if index_params[:search].present?
+    @invited_agents = index_params[:search].present? ? @invited_agents.search_by_text(index_params[:search]) : @invited_agents.order(invitation_sent_at: :desc)
   end
 
   def reinvite

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -8,9 +8,9 @@ class Admin::MotifsController < AgentAuthController
 
   def index
     @unfiltered_motifs = policy_scope(Motif).active
-    @motifs = params[:search].present? ? @unfiltered_motifs.search_by_text(params[:search]) : @unfiltered_motifs
+    @motifs = params[:search].present? ? @unfiltered_motifs.search_by_text(params[:search]) : @unfiltered_motifs.ordered_by_name
     @motifs = filtered(@motifs, params)
-    @motifs = @motifs.includes(:organisation).includes(:service).ordered_by_name.page(params[:page])
+    @motifs = @motifs.includes(:organisation).includes(:service).page(params[:page])
 
     @sectors_attributed_to_organisation_count = Sector.attributed_to_organisation(current_organisation).count
     @sectorisation_level_agent_counts_by_service = SectorAttribution.level_agent_grouped_by_service(current_organisation)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,8 +26,8 @@ class Admin::UsersController < AgentAuthController
   end
 
   def search
-    @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.order_by_last_name.limit(10)
-    @users = @users.search_by_text(search_params[:term]) if search_params[:term].present?
+    @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.limit(10)
+    @users = search_params[:term].present? ? @users.search_by_text(search_params[:term]) : @users.order_by_last_name
     skip_authorization
   end
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -34,13 +34,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "d47b97da06b485e3b3e6da6d8056f1fb1f0beb9a247bc81f90ae0947d5f4d584",
+      "fingerprint": "d8dbbc60b51eb0beb5bc2f943b01142aad77a449260029dedf5a293e96f074a8",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
       "line": 46,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active), params).includes(:organisation).includes(:service).ordered_by_name.page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
@@ -65,13 +65,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "d47b97da06b485e3b3e6da6d8056f1fb1f0beb9a247bc81f90ae0947d5f4d584",
+      "fingerprint": "d8dbbc60b51eb0beb5bc2f943b01142aad77a449260029dedf5a293e96f074a8",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
       "line": 72,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active), params).includes(:organisation).includes(:service).ordered_by_name.page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
@@ -125,6 +125,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-10-26 16:11:40 +0200",
+  "updated": "2021-10-28 18:42:02 +0200",
   "brakeman_version": "5.1.1"
 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -223,6 +223,12 @@ describe User, type: :model do
       create(:user, phone_number: "01 31 34 34 34")
       expect(described_class.search_by_text("+3313030")).to eq([jean])
     end
+
+    it "orders results by relevance" do
+      durand = create(:user, first_name: "Louis", last_name: "Durand")
+      dupont = create(:user, first_name: "Louis", last_name: "Dupont")
+      expect(described_class.search_by_text("Louis Durand")).to eq([durand, dupont])
+    end
   end
 
   describe "#notes_for" do


### PR DESCRIPTION
fixes #1836

En fait, la recherche pg fonctionne déjà bien; simplement, dans la plupart des cas, on forçait le tri par last_name. 🤷 

(Le nouveau test n’est pas tellement utile: il ne teste que le tri des résultat dans `search_by_text`, mais pas le comportement des controllers.)

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
