### PR TITLE
Fix a 500 in /rdvs when coming from another counter

### DIFF
--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -14,7 +14,7 @@
     ol.breadcrumb.m-0
       li.breadcrumb-item
           = link_to "Vos statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
-      li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status)&.downcase }
+      li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase }
 
   - if @breadcrumb_page == "user" && @form.user.present?
     ol.breadcrumb.m-0
@@ -22,14 +22,14 @@
         = link_to "Vos usagers", admin_organisation_users_path(current_organisation), class: "text-white"
       li.breadcrumb-item
         = link_to @form.user.full_name, admin_organisation_user_path(current_organisation, @form.user)
-      li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status)&.downcase }
+      li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase }
 
   - if @breadcrumb_page == "organisation_stats"
     ol.breadcrumb.m-0
       li.breadcrumb-item
         = link_to "Statistiques de l'organisation", admin_organisation_stats_path(current_organisation), class: "text-white"
       - if @form.status.present?
-        li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status)&.downcase }
+        li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase }
 
 .card.border-info
   .card-header ⚙️ Filtres et options


### PR DESCRIPTION
followup #1820

Fix an error 500 when displaying `/admin/organisation/:id/rdvs` when coming from another page and a `:breadcrumb_page` param is passed. The passed `:status` may be a “temporal status” which is not a real valid `status` enum, and it breaks when casting inside `human_attribute_value`.

fixes RDV-SOLIDARITES-WG

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
