### PR TITLE
Change the default puma port for development, because of macOS 12

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 # Rails configuration
-HOST=http://localhost:5000
+HOST=http://localhost:3000
 CSP_REPORT_URI=change_me
 
 # Feature flags and App configuration

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: "localhost:5000", utm_source: "dev", utm_medium: "email", utm_campaign: "default" }
+  config.action_mailer.default_url_options = { host: ENV["HOST"].sub(%r{^https?://}, ""), utm_source: "dev", utm_medium: "email", utm_campaign: "default" }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   if ENV["DEVELOPMENT_SMTP_USER_NAME"].present?
@@ -48,7 +48,7 @@ Rails.application.configure do
   else
     config.action_mailer.delivery_method = :letter_opener_web
   end
-  config.action_mailer.asset_host = "http://localhost:5000"
+  config.action_mailer.asset_host = ENV["HOST"]
 
   config.active_job.queue_adapter = :delayed_job
 

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -42,10 +42,10 @@ rails runner scripts/export_sectors.rb 64
 
 ## Liens utiles
 
-- http://localhost:5000/letter_opener
-- http://localhost:5000/rails/mailers
-- http://localhost:5000/rails/info/routes
-- http://localhost:5000/rails/info/properties
+- http://localhost:3000/letter_opener
+- http://localhost:3000/rails/mailers
+- http://localhost:3000/rails/info/routes
+- http://localhost:3000/rails/info/properties
 
 
 #### Tester une WebHook


### PR DESCRIPTION
See https://developer.apple.com/forums/thread/682332. The default configuration in macOS 12 (Monterey) runs the Airplay Server on the port 5000. This is unfortunate, but there’s not much we can do about it.

Also, use ENV["HOST"] in relevant places.

Again: this is only for the development environment.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
