### PR TITLE
Cache rdvs in index and show

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -13,7 +13,6 @@ class Admin::RdvsController < AgentAuthController
       **params.permit(:organisation_id, :agent_id, :user_id, :lieu_id, :status)
     )
     @rdvs = policy_scope(Rdv).merge(@form.rdvs)
-      .includes(:organisation, :users, :lieu, :motif, agents: :service)
     @breadcrumb_page = params[:breadcrumb_page]
     respond_to do |format|
       format.xls { send_data(RdvExporter.export(@rdvs.order(starts_at: :desc)), filename: "rdvs.xls", type: "application/xls") }

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -19,6 +19,8 @@ class Motif < ApplicationRecord
   has_many :rdvs, dependent: :restrict_with_exception
   has_and_belongs_to_many :plage_ouvertures, -> { distinct }
 
+  after_update -> { rdvs.touch_all }
+
   VISIBLE_AND_NOTIFIED = "visible_and_notified"
   VISIBLE_AND_NOT_NOTIFIED = "visible_and_not_notified"
   INVISIBLE = "invisible"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,10 @@ class User < ApplicationRecord
   has_many :relatives, foreign_key: "responsible_id", class_name: "User", inverse_of: :responsible, dependent: :nullify
   has_many :file_attentes, dependent: :destroy
 
+  before_save :set_email_to_null_if_blank
+  before_save :normalize_account
+  after_update -> { rdvs.touch_all }
+
   enum caisse_affiliation: { aucune: 0, caf: 1, msa: 2 }
   enum family_situation: { single: 0, in_a_relationship: 1, divorced: 2 }
   enum created_through: { agent_creation: "agent_creation", user_sign_up: "user_sign_up",
@@ -66,9 +70,6 @@ class User < ApplicationRecord
   scope :with_referent, lambda { |agent|
     joins(:agents_users).where(agents_users: { agent_id: agent.id })
   }
-
-  before_save :set_email_to_null_if_blank
-  before_save :normalize_account
 
   include User::ResponsabilityConcern
 

--- a/app/views/admin/rdvs/_short_rdv.html.slim
+++ b/app/views/admin/rdvs/_short_rdv.html.slim
@@ -1,0 +1,11 @@
+li.card-body.py-2
+  strong= link_to rdv_title(short_rdv), admin_organisation_rdv_path(current_organisation, short_rdv)
+  = rdv_status_tag(short_rdv)
+  div
+    = short_rdv.motif.name
+    div
+      - if short_rdv.context.blank?
+        .text-muted Pas de contexte renseigné
+      - else
+        .text-muted Contexte :
+        .border-left.pl-2= simple_format(short_rdv.context)

--- a/app/views/admin/rdvs/_short_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_short_rdvs_list.html.slim
@@ -3,15 +3,6 @@
     .text-muted aucun RDV
 - else
   ul.list-unstyled.horizontal-border-between-items
-    - rdvs.includes(:motif).each do |rdv|
-      li.card-body.py-2
-        strong= link_to rdv_title(rdv), admin_organisation_rdv_path(current_organisation, rdv)
-        = rdv_status_tag(rdv)
-        div
-          = rdv.motif.name
-          div
-            - if rdv.context.blank?
-              .text-muted Pas de contexte renseigné
-            - else
-              .text-muted Contexte :
-              .border-left.pl-2= simple_format(rdv.context)
+    = render partial: "admin/rdvs/short_rdv",
+            collection: rdvs.includes(:motif),
+            cached: ->(rdv) { [rdv, rdv.motif] }

--- a/app/views/admin/rdvs/_short_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_short_rdvs_list.html.slim
@@ -5,4 +5,4 @@
   ul.list-unstyled.horizontal-border-between-items
     = render partial: "admin/rdvs/short_rdv",
             collection: rdvs.includes(:motif),
-            cached: ->(rdv) { [rdv, rdv.motif] }
+            cached: true

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -47,11 +47,10 @@
   div class=(@form.show_user_details ? "col-md-12" : "col-md-6")
     - if @rdvs.any?
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
-      = render( \
-        partial: "admin/rdvs/rdv", \
-        collection: @rdvs, \
-        locals: { show_user_details: @form.show_user_details} \
-      )
+      = render(partial: "admin/rdvs/rdv",
+              collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service),
+              locals: {show_user_details: @form.show_user_details},
+              cached: ->(rdv) { [rdv, rdv.motif, rdv.agents, rdv.users] })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
     - else
       .card

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -50,7 +50,7 @@
       = render(partial: "admin/rdvs/rdv",
               collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service),
               locals: {show_user_details: @form.show_user_details},
-              cached: ->(rdv) { [rdv, rdv.motif, rdv.agents, rdv.users] })
+              cached: true)
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
     - else
       .card


### PR DESCRIPTION
refs #1754

Sur skylight, à part la recherche de créneau, les pages les plus coûteuses sont les index et show de Rdv et User. En principe tout ça se garde assez bien en cache, pour peu que les `updated_at` soient tenus à jour proprement. Il y a peut-être quelques pièges sur des objets liés qui sont affichés 🤔. 

Sur rdvs/index, avant :
```
  Rendered collection of admin/rdvs/_rdv.html.slim [0 / 25 cache hits] (Duration: 944.2ms | Allocations: 674007)
...
Completed 200 OK in 1090ms (Views: 1025.3ms | ActiveRecord: 48.6ms | Allocations: 756157)
```

Après:
```
  Rendered collection of admin/rdvs/_rdv.html.slim [25 / 25 cache hits] (Duration: 2.0ms | Allocations: 1140)
...
Completed 200 OK in 126ms (Views: 100.7ms | ActiveRecord: 14.4ms | Allocations: 81435)
```


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
