### PR TITLE
feat(script): change service swap script

### DIFF
--- a/scripts/agent_et_motif_changent_de_service.rb
+++ b/scripts/agent_et_motif_changent_de_service.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
-# rails runner scripts/agent-et-motif-changent-de-service.rb
+# rails runner scripts/agent_et_motif_changent_de_service.rb ID_ORGA ID_SERVICE_SOURCE ID_DESTINATION
 
-ID_ORGANISATION = 100
-IDS_SERVICE_SOURCE = [6, 7].freeze
-ID_SERVICE_DESTINATION = 22
+ID_ORGANISATION = ARGV[0]
+ID_SERVICE_SOURCE = ARGV[1]
+ID_SERVICE_DESTINATION = ARGV[2]
+dry_run = ARGV[3].blank?
 
-services_source = Service.where(id: IDS_SERVICE_SOURCE)
+service_source = Service.find(ID_SERVICE_SOURCE)
 service_destination = Service.find(ID_SERVICE_DESTINATION)
 organisation = Organisation.find(ID_ORGANISATION)
 
 puts "Hello !"
-puts "Déplace les agents et les motifs des services #{services_source.map(&:name).join(', ')} vers le service #{service_destination.name}"
+puts "Running in dry run!" if dry_run
+puts "Déplace les agents et les motifs du service #{service_source.name} vers le service #{service_destination.name}"
 
 Agent.transaction do
   puts "Déplacement des motifs:"
-  Motif.where(organisation_id: ID_ORGANISATION, service: services_source).each do |motif|
+  Motif.where(organisation_id: ID_ORGANISATION, service: service_source).each do |motif|
     puts motif.name.to_s
     new_motif = motif.dup
     new_motif.organisation_id = ID_ORGANISATION
     new_motif.service_id = ID_SERVICE_DESTINATION
+
+    next if dry_run
 
     unless new_motif.save
       puts "Erreur: #{new_motif.errors.full_messages.to_sentence}. Essayons en changeant le nom."
@@ -27,19 +31,26 @@ Agent.transaction do
       new_motif.save!
     end
 
-    puts " avant - PO nouveau: #{new_motif.plage_ouvertures.count} - PO ancien #{motif.plage_ouvertures.count}"
+    puts " avant - PO nouveau motif: #{new_motif.plage_ouvertures.count} - PO ancien motif: #{motif.plage_ouvertures.count}"
     new_motif.plage_ouvertures = motif.plage_ouvertures
     motif.plage_ouvertures = []
-    puts " après - PO nouveau: #{new_motif.plage_ouvertures.count} - PO ancien #{motif.plage_ouvertures.count}"
+    puts " après - PO nouveau motif: #{new_motif.plage_ouvertures.count} - PO ancien motif: #{motif.plage_ouvertures.count}"
 
-    puts "RDV nouveau: #{new_motif.rdvs.count} - RDV ancien #{motif.rdvs.count}"
-    new_motif.rdvs = motif.rdvs
-    puts "RDV nouveau: #{new_motif.rdvs.count} - RDV ancien #{motif.rdvs.count}"
+    puts "RDV nouveau motif: #{new_motif.rdvs.count} - RDV ancien motif: #{motif.rdvs.count}"
+    motif.rdvs.each do |rdv|
+      rdv.update_column(:motif_id, new_motif.id)
+    end
+    puts "RDV nouveau motif: #{new_motif.rdvs.count} - RDV ancien motif: #{motif.rdvs.count}"
+
+    puts "soft deleting motif"
+    motif.soft_delete
   end
 
   puts "Déplacement des agents:"
-  organisation.agents.where(service: services_source).each do |agent|
+  organisation.agents.where(service: service_source).each do |agent|
     puts agent.full_name.to_s
+    next if dry_run
+
     agent.update_column(:service_id, ID_SERVICE_DESTINATION)
   end
   puts "Terminé"


### PR DESCRIPTION
Avec RDV Insertion nous commençons à embarquer des départements utilisant déjà RDV-Solidarités tels que l'Aveyron.
Ces organisations utilisent déjà RDV-Solidarités pour le RSA mais sous le service social au lieu du service RSA (car celui-ci n'existait pas il me semble).
Je modifie donc le script de changement de service des motifs et des agents d'une organisation en:

* ajoutant la possibilité de passer les ids des services et de l'orga concernée au script
* ajoutant un "dry run" mode
* soft deletant les motifs changés pour éviter d'avoir des motifs identiques qui s'affichent dans la liste de motifs

J'ai juste un doute sur l'utilisation de ce script si des agents sont liés au service social n'ont pas **que** des motifs de rdvs liés au RSA: en utilisant ce script des motifs de rdvs non liés aux RSA seront liés au service RSA (ainsi que potentiellement des agents non liés au RSA).

