### PR TITLE
feat(api): Filter motifs on services

### DIFF
--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -3,5 +3,5 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :reservable_online
+  fields :name, :location_type, :deleted_at, :reservable_online, :service_id
 end

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -7,6 +7,8 @@ class Api::V1::MotifsController < Api::V1::BaseController
 
     motifs = motifs.where(reservable_online: params[:reservable_online].to_b) unless params[:reservable_online].nil?
 
+    motifs = motifs.where(service_id: params[:service_id]) if params[:service_id].present?
+
     render_collection(motifs.order(:id))
   end
 end

--- a/spec/requests/api/v1/motifs_request_spec.rb
+++ b/spec/requests/api/v1/motifs_request_spec.rb
@@ -97,5 +97,24 @@ describe "api/v1/motifs requests", type: :request do
         end
       end
     end
+
+    context "filtered on service" do
+      let!(:agent) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }
+      let!(:another_service) { create(:service) }
+
+      let!(:motif1) { create(:motif, organisation: organisation, service: service) }
+      let!(:motif2) { create(:motif, organisation: organisation, service: another_service) }
+
+      it "returns the service specific motifs" do
+        get(
+          api_v1_organisation_motifs_path(organisation),
+          headers: api_auth_headers_for_agent(agent),
+          params: { service_id: service.id }
+        )
+        expect(response.status).to eq(200)
+        response_parsed = JSON.parse(response.body)
+        expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif1.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
Dans cette PR j'ajoute la possibilité de filtrer les motifs par service quand on récupère les motifs par l'API. 
En effet nous nous ne voulons récupérer que les motifs liés aux RSA.
J'ajoute également le `service_id` au blueprint qui pourrait nous être utile.