### PR TITLE
Make fragment caching locale-aware

### DIFF
--- a/app/helpers/i18n_cache_helper.rb
+++ b/app/helpers/i18n_cache_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module I18nCacheHelper
+  # Make the fragment cache locale-dependent,
+  # and make sure to invalidate cache when the i18n dictionary changes.
+  def cache(name = {}, options = {}, &block)
+    name_with_locale = [name, locale_cache_key].flatten
+    super(name_with_locale, options, &block)
+  end
+
+  # A cache key depending on the actual translations for the current locale
+  def locale_cache_key
+    if Rails.env.production?
+      # In production, we’re sure the translations wont change until a restart
+      @locale_cache_key ||= locale_translations_hash
+    else
+      # In development, we want to take live changes to the yml files into account.
+      locale_translations_hash
+    end
+  end
+
+  def locale_translations_hash
+    I18n.backend.translations[I18n.locale].hash
+  end
+end

--- a/app/views/admin/rdvs/_short_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_short_rdvs_list.html.slim
@@ -5,4 +5,4 @@
   ul.list-unstyled.horizontal-border-between-items
     = render partial: "admin/rdvs/short_rdv",
             collection: rdvs.includes(:motif),
-            cached: true
+            cached: ->(rdv) { [rdv, locale_cache_key] }

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -50,7 +50,7 @@
       = render(partial: "admin/rdvs/rdv",
               collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service),
               locals: {show_user_details: @form.show_user_details},
-              cached: true)
+              cached: ->(rdv) { [rdv, locale_cache_key] })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
     - else
       .card


### PR DESCRIPTION
Followup #1847. Make sure the fragments cached are invalidated when the translations change.

WIP: Merge #1847 d’abord

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
