### PR TITLE
Ne pas afficher la liste complète des agents dans le formulaire de recherche des Users

### DIFF
--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -15,7 +15,23 @@
         .col-md-6
           = f.input :search, placeholder: "Prénom, Nom, Email, Téléphone", label: "Recherche", input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
         .col-md-6
-          = f.input :agent_id, collection: policy_scope(Agent).within_organisation(current_organisation), label: "Agent référent", label_method: :reverse_full_name, input_html: { class: "select2-input" }
+          = f.input :agent_id,
+                  collection: [],
+                  label: "Agent référent",
+                  label_method: :reverse_full_name,
+                  input_html: { \
+                    class: "select2-input",\
+                    data: {\
+                      "select-options": {\
+                        ajax: {\
+                          url: search_admin_organisation_agents_path(current_organisation),
+                          dataType: "json",
+                          delay: 250\
+                        }\
+                      }\
+                    }\
+                  }
+
       input.btn.btn-primary.d-print-none type="submit" value="Rechercher"
 
 .card


### PR DESCRIPTION
Encore un fix de performances en passant. Je ne sais pas combien de liste complète d’agents et d’usagers on affichait dans l’interface 🙈

J’aimerais bien faire un helper à la place de ce bout de code vraiment pas élégant, mais à chaque fois qu’on le duplique il y a une variante quelque part, je ne vois pas trop comment faire bien. En attendant, je duplique…

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
