### PR TITLE
🧹 Self-restart all Scalingo containers everynight at 2AM

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,10 @@ MAINTENANCE_PAGE_URL=
 SCALINGO_STOPPED_PAGE_URL=
 SCALINGO_NO_FRONT_ERROR_URL=
 
+# Scalingo auto-restart job
+SCALINGO_RESTARTER_API_TOKEN=
+SCALINGO_RESTARTER_APP_ID=production-rdv-solidarites
+
 # Third-party tools
 ## Monitoring
 SENTRY_DSN_RAILS=change_me

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -70,4 +70,16 @@ class CronJob < ApplicationJob
       Admins::SystemMailer.rdv_events_stats.deliver_later
     end
   end
+
+  class ScalingoAppRestarterJob < CronJob
+    # At 2:00 every day
+    self.cron_expression = "0 2 * * *"
+
+    def perform
+      # Avoid restarting recette many times from review apps
+      return if ENV["RDV_SOLIDARITES_IS_REVIEW_APP"] == "true"
+
+      ScalingoAppRestarter.perform_with(ENV["SCALINGO_RESTARTER_APP_ID"], ENV["SCALINGO_RESTARTER_API_TOKEN"])
+    end
+  end
 end

--- a/app/services/scalingo_app_restarter.rb
+++ b/app/services/scalingo_app_restarter.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ScalingoAppRestarter < BaseService
+  class ApiError < StandardError; end
+
+  # Restarts all the containers of the target app.
+  # See https://github.com/betagouv/rdv-solidarites.fr/issues/1866
+  def initialize(app_id, api_token)
+    @app_id = app_id
+    @api_token = api_token
+  end
+
+  def perform
+    # https://developers.scalingo.com/apps#restart-an-application
+    # First get a bearer token from the API token
+    token_response = Typhoeus::Request.post(
+      "https://auth.scalingo.com/v1/tokens/exchange",
+      userpwd: ":#{@api_token}",
+      headers: { "Content-Type": "application/json",
+                 Accept: "application/json" }
+    )
+
+    raise ApiError, "Token request failed: #{token_response.code}" unless token_response.success?
+
+    json = JSON.parse(token_response.body)
+    bearer_token = json["token"]
+
+    # Then perform the actual restart
+    api_host = "api.osc-secnum-fr1.scalingo.com"
+    restart_response = Typhoeus::Request.post(
+      "https://#{api_host}/v1/apps/#{@app_id}/restart",
+      headers: { "Content-Type": "application/json",
+                 Accept: "application/json",
+                 Authorization: "Bearer #{bearer_token}" }
+    )
+
+    raise ApiError, "Restart request failed: #{restart_response.code}" unless restart_response.success?
+  end
+end

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -16,6 +16,7 @@ L’accès à /super_admins se fait:
 
 * `auto_generate_diagram` est ajouté à `db:migrate` pour tenir à jour docs/domain_model.png.
 * `schedule_jobs` tourne après chaque `db:migrate` et`db:schema:load` pour ajouter automatiquement les “cron jobs”.
+* Dans `cron_job.rb`, outre les tâches métiers (c’est-à-dire les envois de mail et la gestion de file d’attente), il y a un job de gestion de production, `ScalingoAppRestarterJob` dont le rôle est de redémarrer les instances Scalingo chaque nuit. 
 
 ## Restore production
 


### PR DESCRIPTION
fixes #1866

🧹 Ne pas oublier de mettre les variables d’environnement avant de déployer en prod. Il faut créer un token d’api sur l’un de nos comptes.

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app
