### PR TITLE
affiche la page sans current_orga

### DIFF
--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -1,5 +1,5 @@
 - if organisation.present? && agent && agent.unknow_past_rdv_count > 0
-  = link_to  admin_organisation_rdvs_path(current_organisation, status: "unknown_past", agent_id: agent.id)
+  = link_to admin_organisation_rdvs_path(organisation, status: "unknown_past", agent_id: agent.id)
     .navbar.alert-warning.p-2
       div
         .fa.fa-exclamation-triangle.alert-link>

--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -1,4 +1,4 @@
-- if defined?(current_organisation) && agent && agent.unknow_past_rdv_count > 0
+- if organisation.present? && agent && agent.unknow_past_rdv_count > 0
   = link_to  admin_organisation_rdvs_path(current_organisation, status: "unknown_past", agent_id: agent.id)
     .navbar.alert-warning.p-2
       div

--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -1,4 +1,4 @@
-- if agent && agent.unknow_past_rdv_count > 0
+- if defined?(current_organisation) && agent && agent.unknow_past_rdv_count > 0
   = link_to  admin_organisation_rdvs_path(current_organisation, status: "unknown_past", agent_id: agent.id)
     .navbar.alert-warning.p-2
       div

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -10,7 +10,7 @@ html lang="fr"
       = render "layouts/left_menu"
       .content-page
         .content
-          = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: current_organisation
+          = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: defined?(current_organisation) ? current_organisation : nil
           .container-fluid
             - if content_for :title
               .row.bg-dark.pb-5.justify-content-md-center

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -10,7 +10,7 @@ html lang="fr"
       = render "layouts/left_menu"
       .content-page
         .content
-          = render "layouts/rdv_a_renseigner", agent: current_agent
+          = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: current_organisation
           .container-fluid
             - if content_for :title
               .row.bg-dark.pb-5.justify-content-md-center


### PR DESCRIPTION
Correction d'un petit pépin lié au bandeau pour les RDV à renseigner.

Tel que c'est fait, nous ne pouvons plus aller sur la page d'administration d'un territoire.

Ceci est un patch rapide où j'ajoute à la condition d'affichage du bandeau une vérification sur le fait que `current_organisation` est définie. Quand je vois le code des layouts, je me dis qu'il y a un sacré remaniement à y faire. Mais là, je n'ai pas l'énergie pour ça. Trop d'autres trucs sur le feu.
