### PR TITLE
Ajoute script andi

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,20 +10,22 @@ unless Rails.env.test?
   Rails.application.config.content_security_policy do |policy|
     policy.default_src :self
     policy.font_src    :self, :data, "github.com"
-    policy.img_src     :self, :data, :blob, "stats.data.gouv.fr", "voxusagers.numerique.gouv.fr"
     policy.object_src  :none
-    policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
     policy.worker_src :blob
     policy.child_src :blob, :self
 
     if Rails.env.development?
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net",
-                        "tags.clickintext.net", "api.mapbox.com", "blob:"
+                        "tags.clickintext.net", "api.mapbox.com", "blob:", "www.ssa.gov", "ajax.googleapis.com"
       policy.connect_src :self, "api-adresse.data.gouv.fr", "sentry.io", "localhost:3035", "ws://localhost:3035", "etalab-tiles.fr"
+      policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com", "www.ssa.gov"
+      policy.img_src     :self, :data, :blob, "stats.data.gouv.fr", "voxusagers.numerique.gouv.fr", "www.ssa.gov"
     else
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "data1.gryplex.com", "lb.apicit.net", "tags.clickintext.net",
                         "api.mapbox.com", "blob:"
       policy.connect_src :self, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "sentry.io", "cdnjs.cloudflare.com", "etalab-tiles.fr"
+      policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
+      policy.img_src     :self, :data, :blob, "stats.data.gouv.fr", "voxusagers.numerique.gouv.fr"
     end
 
     # Specify URI for violation reports

--- a/docs/5-decisions-techniques.md
+++ b/docs/5-decisions-techniques.md
@@ -16,11 +16,9 @@ Nous aurions pu utiliser une table spécifique pour chaque fournisseur, en créa
 
 Nous préférons utiliser la sérialisation en JSON. Ajout d'une colonne pour connaitre le fournisseur \(et donc quel programme exécuter pour l'envoi de message et pour savoir comment sérialiser/désérialiser le JSON\), et une colonne JSON contenant la configuration sérialisée. N'ayant pas de requête à faire dessus, cela semble pertinent pour offrir la flexibilité nécessaire.
 
-
-
 ## 2021-05-06 Enum dans rails
 
-Il existe dans l'application deux façons de gérer les Enums. 
+Il existe dans l'application deux façons de gérer les Enums.
 
 La façon apportée par Rails depuis la version 5 \(?\)
 
@@ -53,5 +51,8 @@ L'idée est d'utiliser VOX Usager pour la récole de feedback usage
 
 Nous décidons de mettre en place un lien vers vox-usager pour récolter du feedback
 
+## Faciliter l'accessibilité du site
 
+Afin d'aider les contributrices/contributeurs ainsi que les membres de l'équipe qui souhaiteraient développer de sorte à ce que RDV-Solidarité soit accessible, le script ANDI a été ajouté au fichier content_security_policy.rb.
 
+ANDI est un outil qui permet de tester une partie de l'accessibilité d'une application web. Pour celles et ceux qui souhaiteraient utiliser cet outil, il faudra installer ANDI dans son navigateur [https://www.ssa.gov/accessibility/andi/help/install.html].


### PR DESCRIPTION
Close #1877 

En vue de rendre RDV-Solidarité accessible, le script ANDI a été ajouté au content security policy afin que les personnes qui travaillent, ou participent de manière ponctuelle, sur le projet puisse utiliser l'outil ANDI. Il n'est cependant accessible que depuis l'environnement de développement.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
