### PR TITLE
Fix a crash in /rdvs from stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,7 @@ end
 group :development do
   gem "listen" # Needed for ActiveSupport::EventedFileUpdateChecker. See config/environment/development.rb
   gem "better_errors" # Better error page than the Rails default
+  gem "binding_of_caller" # Enable the REPL in better_errors
   gem "letter_opener_web" # Saves sent emails and serves them on /letter_opener
   gem "rails-erd" # Keeps docs/domain_model.png up-to-date. See .erdconfig
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
     bindata (2.4.10)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     blueprinter (0.25.3)
     bootsnap (1.7.7)
       msgpack (~> 1.0)
@@ -160,6 +162,7 @@ GEM
     database_cleaner-core (2.0.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
+    debug_inspector (1.1.0)
     delayed_cron_job (0.7.4)
       delayed_job (>= 4.1)
     delayed_job (4.1.9)
@@ -581,6 +584,7 @@ DEPENDENCIES
   administrate-field-belongs_to_search
   auto_strip_attributes
   better_errors
+  binding_of_caller
   blueprinter
   bootsnap
   bootstrap4-kaminari-views

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -14,7 +14,7 @@
     ol.breadcrumb.m-0
       li.breadcrumb-item
         = link_to "Vos statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
-      li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status)&.downcase }
+      li.breadcrumb-item.active RDVs #{ Rdv.human_attribute_value(:status, @form.status, disable_cast: true)&.downcase }
 
   - if @breadcrumb_page == "user" && @form.user.present?
     ol.breadcrumb.m-0


### PR DESCRIPTION
En cliquant sur “à renseigner” depuis “Mes statistiques”. On devrait retirer ce concept de breadcrumb, je pense.

fixes [RDV-SOLIDARITES-WG](https://sentry.io/organizations/rdv-solidarites/issues/2762864691/?environment=production&project=1811205&query=is%3Aunresolved).