### PR TITLE
distingue agents lors proposition creneaux

### DIFF
--- a/app/helpers/creneaux_helper.rb
+++ b/app/helpers/creneaux_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CreneauxHelper
+  COLORS = %w[
+    color-scheme-bleu
+    color-scheme-red
+    color-scheme-green
+    color-scheme-yellow
+    color-scheme-pink
+    color-scheme-purple
+    color-scheme-grey
+    color-scheme-beige
+    color-scheme-apple-green
+    color-scheme-burgundy
+    color-scheme-duck-green
+    color-scheme-light-blue
+    color-scheme-light-grey
+    color-scheme-light-purple
+    color-scheme-strong-green
+    color-scheme-strong-blue
+    color-scheme-strong-grey
+    color-scheme-strong-red
+    color-scheme-strong-pink
+    color-scheme-strong-purple
+  ].freeze
+  def agent_color(color_index)
+    COLORS[color_index % COLORS.length]
+  end
+end

--- a/app/helpers/creneaux_helper.rb
+++ b/app/helpers/creneaux_helper.rb
@@ -3,25 +3,16 @@
 module CreneauxHelper
   COLORS = %w[
     color-scheme-bleu
-    color-scheme-red
-    color-scheme-green
-    color-scheme-yellow
-    color-scheme-pink
+    color-scheme-turquoise
+    color-scheme-indigo
     color-scheme-purple
-    color-scheme-grey
-    color-scheme-beige
-    color-scheme-apple-green
-    color-scheme-burgundy
-    color-scheme-duck-green
-    color-scheme-light-blue
-    color-scheme-light-grey
-    color-scheme-light-purple
-    color-scheme-strong-green
-    color-scheme-strong-blue
-    color-scheme-strong-grey
-    color-scheme-strong-red
-    color-scheme-strong-pink
-    color-scheme-strong-purple
+    color-scheme-pink
+    color-scheme-yellow
+    color-scheme-red
+    color-scheme-orange
+    color-scheme-green
+    color-scheme-teal
+    color-scheme-lightturquoise
   ].freeze
   def agent_color(color_index)
     COLORS[color_index % COLORS.length]

--- a/app/views/admin/creneaux/agent_searches/_creneaux.html.slim
+++ b/app/views/admin/creneaux/agent_searches/_creneaux.html.slim
@@ -30,10 +30,11 @@ div.js-creneaux-list.collapsed id="creneaux-lieu-#{lieu.id}"
               - creneaux_for_date = creneaux.select { |c| c.starts_at.to_date == date }.sort_by(&:starts_at)
               - creneaux_for_date.first(5).each do |creneau|
                 = link_to(new_admin_organisation_rdv_wizard_step_path(build_link_to_rdv_wizard_params(creneau, form)),
-                  class: "creneau #{agent_color(creneau.agent_id)} d-block w-100 text-center p-1 mb-1 rounded") do
-                  div
-                    span= l(creneau.starts_at, format: "%H:%M")
+                  class: "creneau bg-light d-block w-100 text-center p-1 mb-1 rounded") do
+                  .text-left.m-1
+                    span.strong.font-weight-bold= l(creneau.starts_at, format: "%H:%M")
                     br
+                    i class= "mr-1 fa fa-user-alt #{agent_color(creneau.agent_id)}"
                     small.text-dark= creneau.agent_name
 
               - if creneaux_for_date.size > 5

--- a/app/views/admin/creneaux/agent_searches/_creneaux.html.slim
+++ b/app/views/admin/creneaux/agent_searches/_creneaux.html.slim
@@ -30,7 +30,7 @@ div.js-creneaux-list.collapsed id="creneaux-lieu-#{lieu.id}"
               - creneaux_for_date = creneaux.select { |c| c.starts_at.to_date == date }.sort_by(&:starts_at)
               - creneaux_for_date.first(5).each do |creneau|
                 = link_to(new_admin_organisation_rdv_wizard_step_path(build_link_to_rdv_wizard_params(creneau, form)),
-                  class: "creneau bg-light d-block w-100 text-center p-1 mb-1 rounded") do
+                  class: "creneau #{agent_color(creneau.agent_id)} d-block w-100 text-center p-1 mb-1 rounded") do
                   div
                     span= l(creneau.starts_at, format: "%H:%M")
                     br

--- a/app/webpacker/stylesheets/components/_creneaux.scss
+++ b/app/webpacker/stylesheets/components/_creneaux.scss
@@ -42,70 +42,35 @@
 }
 
 .color-scheme-bleu{
-  background-color: #CBD1D8;
+  color: $blue;
 }
-.color-scheme-red{
-  background-color: #FFC1C3;
+.color-scheme-turquoise{
+  color: $turquoise;
 }
-.color-scheme-green{
-  background-color: #CBFFC1;
-}
-.color-scheme-yellow{
-  background-color: #FFF4C1;
-}
-.color-scheme-pink{ 
-  background-color: #FFC1F1;
-}
-.color-scheme-apple-green{ 
-  background-color: #B5FF5F;
-}
-.color-scheme-beige{ 
-  background-color: #EFE095;
-}
-.color-scheme-grey{ 
-  background-color: #404444;
-  color: white
-}
-.color-scheme-burgundy{ 
-  background-color: #7C0040;
-  color: white
-}
-.color-scheme-duck-green{ 
-  background-color: #284843;
-  color: white
-}
-.color-scheme-light-purple{ 
-  background-color: #C4C1FF;
-}
-.color-scheme-light-blue{ 
-  background-color: #C1FFEC;
-}
-.color-scheme-light-grey{ 
-  background-color: #DEEAE8;
+.color-scheme-indigo{
+  color: $indigo;
 }
 .color-scheme-purple{ 
-  background-color: #9599FD;
+  color: $purple;
 }
-.color-scheme-strong-blue{ 
-  background-color: #1D1F4B;
-  color: white
+.color-scheme-pink{ 
+  color: $pink;
 }
-.color-scheme-strong-green{ 
-  background-color: #2B592E;
-  color: white
+.color-scheme-yellow{
+  color: $yellow;
 }
-.color-scheme-strong-grey{ 
-  background-color: #101010;
-  color: white
+.color-scheme-red{ 
+  color: $red;
 }
-.color-scheme-strong-red{ 
-  background-color: #822B2A;
-  color: white
+.color-scheme-orange{ 
+  color: $orange;
 }
-.color-scheme-strong-pink{ 
-  background-color: #FF5FA1;
+.color-scheme-green{ 
+  color: $green;
 }
-.color-scheme-strong-purple{ 
-  background-color: #00037C;
-  color: white
+.color-scheme-teal{ 
+  color: $teal;
+}
+.color-scheme-lightturquoise{ 
+  color: $lightturquoise;
 }

--- a/app/webpacker/stylesheets/components/_creneaux.scss
+++ b/app/webpacker/stylesheets/components/_creneaux.scss
@@ -28,7 +28,7 @@
 
 .collapsed .creneau:nth-child(6){
   position: relative;
-
+  
   &::before {
     content: '';
     position: absolute;
@@ -39,4 +39,73 @@
     border: none;
     background: linear-gradient(to top, rgb(255, 255, 255), rgba(226, 234, 238, 0.5));
   }
+}
+
+.color-scheme-bleu{
+  background-color: #CBD1D8;
+}
+.color-scheme-red{
+  background-color: #FFC1C3;
+}
+.color-scheme-green{
+  background-color: #CBFFC1;
+}
+.color-scheme-yellow{
+  background-color: #FFF4C1;
+}
+.color-scheme-pink{ 
+  background-color: #FFC1F1;
+}
+.color-scheme-apple-green{ 
+  background-color: #B5FF5F;
+}
+.color-scheme-beige{ 
+  background-color: #EFE095;
+}
+.color-scheme-grey{ 
+  background-color: #404444;
+  color: white
+}
+.color-scheme-burgundy{ 
+  background-color: #7C0040;
+  color: white
+}
+.color-scheme-duck-green{ 
+  background-color: #284843;
+  color: white
+}
+.color-scheme-light-purple{ 
+  background-color: #C4C1FF;
+}
+.color-scheme-light-blue{ 
+  background-color: #C1FFEC;
+}
+.color-scheme-light-grey{ 
+  background-color: #DEEAE8;
+}
+.color-scheme-purple{ 
+  background-color: #9599FD;
+}
+.color-scheme-strong-blue{ 
+  background-color: #1D1F4B;
+  color: white
+}
+.color-scheme-strong-green{ 
+  background-color: #2B592E;
+  color: white
+}
+.color-scheme-strong-grey{ 
+  background-color: #101010;
+  color: white
+}
+.color-scheme-strong-red{ 
+  background-color: #822B2A;
+  color: white
+}
+.color-scheme-strong-pink{ 
+  background-color: #FF5FA1;
+}
+.color-scheme-strong-purple{ 
+  background-color: #00037C;
+  color: white
 }


### PR DESCRIPTION
Close #1848

Ajoute couleurs sur les créneaux disponibles afin de distinguer les différents agents dispos.
Avant : 

![agents](https://user-images.githubusercontent.com/44778533/143596761-deaf8ad1-a6e9-4dba-9e3a-5c5033c58314.png)

Après: 

![image](https://user-images.githubusercontent.com/44778533/143596837-75c1538d-3415-4eeb-8cc9-effef1cb64e6.png)


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
