### PR TITLE
Recompte les « à renseigner » pour un RDV passé

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -60,7 +60,7 @@ class Rdv < ApplicationRecord
   scope :visible, -> { joins(:motif).where(motifs: { visibility_type: [Motif::VISIBLE_AND_NOTIFIED, Motif::VISIBLE_AND_NOT_NOTIFIED] }) }
 
   after_save :associate_users_with_organisation
-  after_commit :update_unknow_past_rdv_count, if: -> { (status_previously_changed? || new_record? || destroyed?) && past? }
+  after_commit :update_unknow_past_rdv_count, if: -> { past? }
   after_commit :reload_uuid, on: :create
 
   def self.ongoing(time_margin: 0.minutes)


### PR DESCRIPTION
Close #1896 

C'est en fait plus large qu'évoqué sur le ticket.

Le problème vient du callback utilisé : `after_commit`. À ce stade, l'objet n'est plus considéré comme un `new_record` (et peut-être pas comme un `destroyed` mais je n'ai pas vérifié).

J'ai l'impression qu'au niveau performance, c'est à peu près correct de refaire le calcul chaque fois qu'un RDV du passé est modifié, créé ou supprimé.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
