### PR TITLE
Fix links color in breadcrumbs

### DIFF
--- a/app/webpacker/stylesheets/components/_breadcrumb.scss
+++ b/app/webpacker/stylesheets/components/_breadcrumb.scss
@@ -1,5 +1,4 @@
 .breadcrumb-item {
-  a {@extend .text-white}
   +.breadcrumb-item {
     &::before {
       font-family: "Font Awesome 5 Free"; font-weight: 900; content: "\f054";


### PR DESCRIPTION
followup #1883

Avant:
<img width="419" alt="Capture d’écran 2021-12-02 à 15 19 38" src="https://user-images.githubusercontent.com/139391/144439811-11ed19d3-2df9-489e-a9eb-a441249f5642.png">

Après
<img width="413" alt="image" src="https://user-images.githubusercontent.com/139391/144439784-8d2797fd-3c62-4482-85e4-44107d381121.png">

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
