### PR TITLE
:rocket: Prend en compte le cas de la date de fin d'absence or récurrence

### DIFF
--- a/app/models/concerns/expiration.rb
+++ b/app/models/concerns/expiration.rb
@@ -18,11 +18,24 @@ module Expiration
   end
 
   def expired?
-    (recurrence.nil? && first_day < Time.zone.today) ||
-      (recurrence.present? && recurrence.to_hash[:until].present? && recurrence.to_hash[:until].to_date < Time.zone.today)
+    return false if absence_end_day_in_future? || first_day_in_future? || recurrence_ends_at_in_future?
+
+    true
   end
 
   def refresh_expired_cached
     update_column(:expired_cached, expired?)
+  end
+
+  def absence_end_day_in_future?
+    recurrence.nil? && instance_of?(Absence) && end_day >= Time.zone.today
+  end
+
+  def first_day_in_future?
+    recurrence.nil? && first_day >= Time.zone.today
+  end
+
+  def recurrence_ends_at_in_future?
+    recurrence.present? && (recurrence_ends_at.nil? || recurrence_ends_at >= Time.zone.today)
   end
 end

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -40,4 +40,35 @@ describe Absence, type: :model do
       end
     end
   end
+
+  describe "expired?" do
+    # cas particulier de l'absence qui a une date de fin à prendre ne compte
+    it "return false when end_day after today" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      absence = build(:absence, first_day: today - 3.days, end_day: today + 3.days)
+      expect(absence.expired?).to be false
+    end
+
+    it "return true when end_day before today" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      absence = build(:absence, first_day: today - 3.days, end_day: today - 1.day, recurrence: nil)
+      expect(absence.expired?).to be true
+    end
+
+    it "return true when first_day before today without end_day" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      absence = build(:absence, first_day: today - 3.days, end_day: today - 3.days)
+      expect(absence.expired?).to be true
+    end
+
+    it "return stil works for plage_ouverture" do
+      today = Time.zone.parse("20210323 13:45")
+      travel_to(today)
+      plage_ouverture = build(:plage_ouverture, first_day: today - 3.days)
+      expect(plage_ouverture.expired?).to be true
+    end
+  end
 end

--- a/spec/models/concerns/expiration_spec.rb
+++ b/spec/models/concerns/expiration_spec.rb
@@ -5,21 +5,21 @@ describe Expiration, type: :concern do
     it "#{element} is expired when end_day before today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)
-      objet = create(:absence, first_day: today - 5.days, end_day: today - 5.days)
+      objet = build(element, first_day: today - 5.days, end_day: today - 5.days)
       expect(objet.expired?).to be true
     end
 
     it "#{element} is not past when end_day after today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)
-      objet = create(:absence, first_day: today + 3.days, end_day: today + 3.days)
+      objet = build(element, first_day: today + 3.days, end_day: today + 3.days)
       expect(objet.expired?).to be false
     end
 
     it "#{element} is not past when end_day before today with a recurrence after today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)
-      objet = create(:absence, first_day: today - 1.day, end_day: today - 1.day, recurrence: Montrose.every(:week, until: today + 1.month, starts: today - 1.day))
+      objet = build(element, first_day: today - 1.day, end_day: today - 1.day, recurrence: Montrose.every(:week, until: today + 1.month, starts: today - 1.day))
       expect(objet.expired?).to be false
     end
   end


### PR DESCRIPTION
Les absences, contrairement aux plages d'ouverture, ont une date de fin en dehors de la récurrence. Il faut la prendre en compte dans le calcul d'expiration.

Pour être plus cohérent, nous pourrions la supprimer. Cela dit, il faudra prévoir un script pour créer les récurrences correspondantes aux absences que nous modifierions ainsi... À voir plus tard. Peut-être que nous pourrions aussi simplement supprimer les absences ? :smiling_imp: 


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
