### PR TITLE
Améliorer les performances dans superadmin

### DIFF
--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -52,7 +52,6 @@ class OrganisationDashboard < Administrate::BaseDashboard
     name
     horaires
     phone_number
-    agents
     human_id
   ].freeze
 

--- a/app/dashboards/service_dashboard.rb
+++ b/app/dashboards/service_dashboard.rb
@@ -49,7 +49,6 @@ class ServiceDashboard < Administrate::BaseDashboard
     name
     short_name
     motifs
-    agents
   ].freeze
 
   def display_resource(service)

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -70,7 +70,6 @@ class UserDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     organisations
     responsible
-    relatives
     first_name
     last_name
     birth_name


### PR DESCRIPTION
Et éviter les consommations dramatyiques de mémoire. Ça semble être une cause de #1912 et d’autres problèmes de performance: lors du chargement d’un formulaire d’usager dans Administrate, on voit un pic mémoire de 1 go (!!!), parce que Administrate charge l’intégralité des objets pour le champ “HasMany”.

![Image collée à 2021-12-7 17-42](https://user-images.githubusercontent.com/139391/145082853-269c8172-5301-463f-b854-be5b9e161efe.png)

C’est a priori un problème existant: https://github.com/thoughtbot/administrate/issues/1464

Le symptôme chez nous était donc: quand un superadmin affiche le formulaire d’un User ou d’une Organisation avec beaucoup d’agents dans superadmin, la consommation mémoire du container qui a répondu double et le container commence à swapper, et les performances tombent.

Cette PR supprime les champ HasMany vers des User ou des Agents dans les dashboards correspondants.

😩😩😩😩😩 

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
