### PR TITLE
feat(api): Retrieve geolocated organisations

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -3,6 +3,21 @@
 class Api::V1::OrganisationsController < Api::V1::BaseController
   def index
     organisations = policy_scope(Organisation)
+    organisations = organisations.merge(organisations_attributed_to_sector) if geo_params?
     render_collection(organisations.order(:id))
+  end
+
+  private
+
+  def organisations_attributed_to_sector
+    Users::GeoSearch.new(
+      departement: params[:departement_number],
+      city_code: params[:city_code],
+      street_ban_id: params[:street_ban_id]
+    ).attributed_organisations
+  end
+
+  def geo_params?
+    [params[:city_code], params[:street_ban_id]].any?(&:present?)
   end
 end

--- a/app/views/search/_banner.html.slim
+++ b/app/views/search/_banner.html.slim
@@ -3,7 +3,7 @@ section#hero.hero.hero-home.py-2
     .col-lg-12.justify-content-md-center
       h1.text-white
         - if context.invitation?
-          | Vous avez été invité à prendre&nbsp;
+          | Vous avez été invité(e) à prendre&nbsp;
           span.text-secondary rendez-vous
         - else
           | Prenez&nbsp;

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -31,5 +31,36 @@ describe "api/v1/organisations requests", type: :request do
           contain_exactly(organisation1.id, organisation2.id)
       end
     end
+
+    context "when geolocalisation parameters are passed" do
+      subject do
+        get api_v1_organisations_path(departement_number: departement_number, city_code: city_code),
+            headers: api_auth_headers_for_agent(agent)
+      end
+
+      let!(:organisation1) { create(:organisation) }
+      let!(:organisation2) { create(:organisation) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation1, organisation2]) }
+      let(:departement_number) { "26" }
+      let!(:city_code) { "26323" }
+      let(:geo_search) do
+        instance_double(Users::GeoSearch, attributed_organisations: Organisation.where(id: organisation2.id))
+      end
+
+      before do
+        allow(Users::GeoSearch).to receive(:new)
+          .with(departement: departement_number, city_code: city_code, street_ban_id: nil)
+          .and_return(geo_search)
+      end
+
+      it "returns the organisations attributed to the sector" do
+        subject
+        expect(response.status).to eq(200)
+        result = JSON.parse(response.body)
+        expect(result["organisations"].count).to eq(1)
+        expect(result["organisations"].pluck("id")).to \
+          contain_exactly(organisation2.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sur RDV-Insertion, on veut permettre à un agent qui appartiendrait à toutes les organisations d'un territoire de pouvoir créer/inviter une personne au niveau du territoire.
Pour cela on cherche à identifier l'organisation lié au secteur dans lequel se trouve l'allocataire, afin de le créer/inviter sur cette organisation.
Pour se faire, nous géolocalisons l'adresse de l'allocataire côté RDV-I, et on aimerait donc savoir quels secteurs sont attribués à cet allocataire sur RDV-Solidarités (en supposant bien entendu que des secteurs ait été attribué à des organisations au préalable). 
Cette PR rajoute cette possibilité de filtrer les organisations sur l'endpoint `GET api/v1/organisations`.

Je profite de cette PR pour glisser un fix sur le texte d'invitation dans les nouvelles vues 👀 .