### PR TITLE
affiche la checklist que pour les agents admin

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -49,7 +49,7 @@ class Admin::OrganisationsController < AgentAuthController
     )
     authorize(@organisation)
     if @organisation.save
-      redirect_to organisation_home_path(@organisation), flash: { success: "Organisation créée !" }
+      redirect_to organisation_home_path(@organisation, current_agent), flash: { success: "Organisation créée !" }
     else
       render :new, layout: "registration"
     end
@@ -77,6 +77,6 @@ class Admin::OrganisationsController < AgentAuthController
   def follow_unique
     return if params[:follow_unique].blank? || policy_scope(Organisation).count != 1
 
-    redirect_to organisation_home_path(policy_scope(Organisation).first)
+    redirect_to organisation_home_path(policy_scope(Organisation).first, current_agent)
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 module OrganisationsHelper
-  def organisation_home_path(organisation)
-    if organisation.recent?
+  def show_checklist?(organisation, agent)
+    1.week.ago < organisation.created_at && agent.admin_in_organisation?(organisation)
+  end
+
+  def organisation_home_path(organisation, agent)
+    if show_checklist?(organisation, agent)
       admin_organisation_setup_checklist_path(organisation)
     else
-      admin_organisation_agent_agenda_path(organisation, current_agent)
+      admin_organisation_agent_agenda_path(organisation, agent)
     end
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -62,8 +62,4 @@ class Organisation < ApplicationRecord
 
     Admins::OrganisationMailer.organisation_created(agents.first, self).deliver_later
   end
-
-  def recent?
-    1.week.ago < created_at
-  end
 end

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -41,7 +41,7 @@
               i.fa.fa-sign-out
               span Me déconnecter
 
-      - if current_organisation.recent?
+      - if show_checklist?(current_organisation, current_agent)
         li.side-nav-item.mb-4.pl-3.pr-2
           = active_link_to admin_organisation_setup_checklist_path(current_organisation)
             i.far.fa-calendar>

--- a/app/views/layouts/application_agent_departement.html.slim
+++ b/app/views/layouts/application_agent_departement.html.slim
@@ -54,7 +54,7 @@
       - else
         - organisation = policy_scope([:agent, Organisation]).first
         - if organisation.present?
-          = link_to organisation_home_path(organisation), class: "side-nav-link"
+          = link_to organisation_home_path(organisation, current_agent), class: "side-nav-link"
               span>= organisation.name
               i.fa.fa-sign-out-alt>
 

--- a/spec/features/users/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/user_signs_up_and_signs_in_spec.rb
@@ -62,7 +62,7 @@ describe "User signs up and signs in" do
           fill_in :password, with: agent.password
           click_on "Se connecter"
         end
-        expect(page).to have_current_path(admin_organisation_setup_checklist_path(agent.organisations.first), ignore_query: true)
+        expect(page).to have_current_path(admin_organisation_agent_agenda_path(agent.organisations.first, agent), ignore_query: true)
       end
     end
   end

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe OrganisationsHelper do
+  describe "#show_checklist?" do
+    context "for agent with admin access" do
+      it "returns true with a 4 days old organisation" do
+        now = Time.zone.parse("2021-11-23 10:56")
+        travel_to(now)
+        organisation = create(:organisation, created_at: now - 4.days)
+        agent = create(:agent, admin_role_in_organisations: [organisation])
+        expect(show_checklist?(organisation, agent)).to be_truthy
+      end
+
+      it "returns false with an 8 days old organisation" do
+        now = Time.zone.parse("2021-11-23 10:56")
+        travel_to(now)
+        organisation = create(:organisation, created_at: now - 8.days)
+        agent = create(:agent, admin_role_in_organisations: [organisation])
+        expect(show_checklist?(organisation, agent)).to be_falsy
+      end
+    end
+
+    it "returns false for agent without admin access" do
+      now = Time.zone.parse("2021-11-23 10:56")
+      travel_to(now)
+      organisation = create(:organisation, created_at: now - 8.days)
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      expect(show_checklist?(organisation, agent)).to be_falsy
+    end
+  end
+
+  describe "#organisation_home_path" do
+    it "returns first steps page if show checklist" do
+      now = Time.zone.parse("2021-11-23 10:56")
+      travel_to(now)
+      organisation = create(:organisation, created_at: now - 4.days)
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      expect(organisation_home_path(organisation, agent)).to eq(admin_organisation_setup_checklist_path(organisation))
+    end
+
+    it "returns agenda page if not show checklist" do
+      now = Time.zone.parse("2021-11-23 10:56")
+      travel_to(now)
+      organisation = create(:organisation, created_at: now - 8.days)
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      expect(organisation_home_path(organisation, agent)).to eq(admin_organisation_agent_agenda_path(organisation, agent))
+    end
+  end
+end


### PR DESCRIPTION
Pour faire suite au message d'Irène (83), et à des réflexions dans l'équipe, cette PR permet d'afficher la page de checklist que pour les agents admin (et toujours uniquement la première semaine)

Avant, un agent non admin avait la page de checklist 

![Screenshot_2021-12-09 Votre installation - RDV Solidarités](https://user-images.githubusercontent.com/42057/145369565-96d17334-2cb9-43b3-912d-abf133043a03.png)


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
