### PR TITLE
ajoute l'agent sur le lien pour l'accueil agent

### DIFF
--- a/app/views/admin/organisations/index.html.slim
+++ b/app/views/admin/organisations/index.html.slim
@@ -13,7 +13,7 @@
       ul.list-group.list-group-flush
         - agent_roles.each do |agent_role|
           li.list-group-item
-            span>= link_to agent_role.organisation.name, organisation_home_path(agent_role.organisation)
+            span>= link_to agent_role.organisation.name, organisation_home_path(agent_role.organisation, agent_role.agent)
             - if agent_role.admin?
               i.fa.fa-user-cog.text-muted[title="Vous êtes administrateur de cette organisation"]
       - if policy([:agent, Organisation.new(territory: territory)]).new?


### PR DESCRIPTION
refs #1922 

Il manque un paramètre sur un appel au helper de lien pour l'accueil agent sur les organisations.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
