### PR TITLE
Supprime les attributions de secteur avec l'agent

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -40,6 +40,7 @@ class Agent < ApplicationRecord
   has_many :territorial_roles, class_name: "AgentTerritorialRole", dependent: :destroy
   has_many :territories, through: :territorial_roles
   has_many :organisations_of_territorial_roles, source: :organisations, through: :territories
+  has_many :sector_attributions, dependent: :destroy
 
   has_and_belongs_to_many :users
 
@@ -96,6 +97,7 @@ class Agent < ApplicationRecord
   def soft_delete
     raise SoftDeleteError, "agent still has attached resources" if organisations.any? || plage_ouvertures.any? || absences.any?
 
+    sector_attributions.delete_all
     update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email, uid: deleted_email)
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -97,7 +97,7 @@ class Agent < ApplicationRecord
   def soft_delete
     raise SoftDeleteError, "agent still has attached resources" if organisations.any? || plage_ouvertures.any? || absences.any?
 
-    sector_attributions.delete_all
+    sector_attributions.destroy_all
     update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email, uid: deleted_email)
   end
 

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -40,6 +40,13 @@ describe Agent, type: :model do
       agent.soft_delete
       expect(agent.uid).to eq("agent_#{agent.id}@deleted.rdv-solidarites.fr")
     end
+
+    it "delete sector attributions" do
+      agent = create(:agent, basic_role_in_organisations: [])
+      create(:sector_attribution, agent: agent)
+      agent.soft_delete
+      expect(agent.sector_attributions).to be_empty
+    end
   end
 
   describe "#available_referents_for" do


### PR DESCRIPTION
Close #1893 

Ajout d'un `has_many` et de la suppression des attributions dans le `soft_delete`. Les attributions n'ont pas d'intérêt à être gardées.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
