### PR TITLE
fix(api): Use validate token endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,8 +47,6 @@ class ApplicationController < ActionController::Base
       role: user&.class&.name || "Guest",
       email: user&.email
     }.compact
-  rescue StandardError
-    {}
   end
 
   def authenticate_inviter!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,6 +47,8 @@ class ApplicationController < ActionController::Base
       role: user&.class&.name || "Guest",
       email: user&.email
     }.compact
+  rescue StandardError
+    {}
   end
 
   def authenticate_inviter!

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -152,4 +152,11 @@ class Agent < ApplicationRecord
   def update_unknown_past_rdv_count!
     update_column(:unknown_past_rdv_count, rdvs.status(:unknown_past).count)
   end
+
+  # This method is called when calling #current_agent on a controller action that is automatically generated
+  # by the devise_token_auth gem. It can happen since these actions inherits from ApplicationController (see PR #1933).
+  # We monkey-patch it for it not to raise.
+  def self.dta_find_by(_attrs = {})
+    nil
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,6 +178,13 @@ class User < ApplicationRecord
     I18n.transliterate([last_name, email, birth_name, phone_number_formatted, first_name].compact.join(" "))
   end
 
+  # This method is called when calling #current_user on a controller action that is automatically generated
+  # by the devise_token_auth gem. It can happen since these actions inherits from ApplicationController (see PR #1933).
+  # We monkey-patch it for it not to raise.
+  def self.dta_find_by(_attrs = {})
+    nil
+  end
+
   protected
 
   def compute_invitation_due_at

--- a/spec/requests/api_authentication_spec.rb
+++ b/spec/requests/api_authentication_spec.rb
@@ -73,4 +73,16 @@ describe "API auth", type: :request do
       expect(JSON.parse(response.body)["absences"].count).to eq(1)
     end
   end
+
+  describe "GET api/v1/auth/validate_token" do
+    subject { get api_v1_auth_validate_token_path, headers: api_auth_headers_for_agent(agent) }
+
+    let!(:agent) { create(:agent, email: "amine.dhobb@beta.gouv.fr") }
+
+    it "returns the agent credentials" do
+      subject
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)["data"]["email"]).to eq("amine.dhobb@beta.gouv.fr")
+    end
+  end
 end


### PR DESCRIPTION
Côté RDV-Insertion il faudrait que l'on puisse à certains moments vérifier que les identifiants de session RDV-Solidarités sont valides.
Pour cela on veut utiliser l'endpoint généré par `devise_token_auth` `GET api/v1/auth/validate_token`.
Cependant le controller responsable de cette action hérite de `DeviseController`, ce qu'il fait que la requête passe par l'`ApplicationController` et la méthode `sentry_user` raise à l'appel de l'expression `current_agent || current_user` (voir https://github.com/lynndylanhurley/devise_token_auth/issues/1286).
Du coup je `rescue` cette méthode en cas d'erreur et j'ai ajouté un test à cet endpoint.
