### PR TITLE
🚀  Fix errors not being displayed properly in step2 of rdv wizard

### DIFF
--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -16,6 +16,7 @@ module Admin::RdvWizardFormConcern
     delegate :motif, :organisation, :agents, :users, to: :rdv
 
     delegate :errors, to: :rdv
+    delegate :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :rdv
 
     def initialize(agent_author, organisation, attributes)
       rdv_attributes = attributes.to_h.symbolize_keys.except(:service_id)


### PR DESCRIPTION
When a rdv was being created for a “phone” motif, with a user without a phone number.

followup #1932

fixes RDV-SOLIDARITES-ZG
