### PR TITLE
:rocket: Affiche les pages de créneaux seulement s'il y en a

### DIFF
--- a/app/services/creneaux_builder_service.rb
+++ b/app/services/creneaux_builder_service.rb
@@ -34,7 +34,7 @@ class CreneauxBuilderService < BaseService
       .not_expired
       .for_motif(@motif_name, @lieu.organisation_id)
       .includes(:agent)
-      .where(({ agent_id: @agent_ids } unless @agent_ids.nil?))
+      .where(({ agent_id: @agent_ids } if @agent_ids.present?))
       .where(({ motifs: { location_type: @motif_location_type } } if @motif_location_type.present?))
       .where(({ motifs: { service: @service } } if @service.present?))
   end

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -12,8 +12,10 @@ class SearchCreneauxForAgentsService < BaseService
   private
 
   def build_result(lieu)
-    next_availability = FindAvailabilityService.perform_with(@form.motif.name, lieu, Time.zone.today, for_agents: true, agent_ids: @form.agent_ids, motif_location_type: @form.motif.location_type, service: @form.service)
-    creneaux = CreneauxBuilderService.perform_with(@form.motif.name, lieu, @form.date_range, for_agents: true, agent_ids: @form.agent_ids, motif_location_type: @form.motif.location_type, service: @form.service)
+    next_availability = FindAvailabilityService.perform_with(@form.motif.name, lieu, Time.zone.today, for_agents: true, agent_ids: @form.agent_ids, motif_location_type: @form.motif.location_type,
+                                                                                                      service: @form.service)
+    creneaux = CreneauxBuilderService.perform_with(@form.motif.name, lieu, @form.date_range, for_agents: true, agent_ids: @form.agent_ids, motif_location_type: @form.motif.location_type,
+                                                                                             service: @form.service)
 
     return nil if creneaux.empty? && next_availability.nil?
 

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -15,7 +15,7 @@ class SearchCreneauxForAgentsService < BaseService
     next_availability = FindAvailabilityService.perform_with(@form.motif.name, lieu, Time.zone.today, for_agents: true, agent_ids: @form.agent_ids, motif_location_type: @form.motif.location_type, service: @form.service)
     creneaux = CreneauxBuilderService.perform_with(@form.motif.name, lieu, @form.date_range, for_agents: true, agent_ids: @form.agent_ids, motif_location_type: @form.motif.location_type, service: @form.service)
 
-    return nil if creneaux.empty? & next_availability.nil?
+    return nil if creneaux.empty? && next_availability.nil?
 
     OpenStruct.new(lieu: lieu, next_availability: next_availability, creneaux: creneaux)
   end

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -42,12 +42,13 @@
           = f.input :agent_ids, collection: @agents, label: "Agent(s)", label_method: :full_name, input_html: { multiple: true, class: "select2-input" }
         .col-md-4
           = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
-      = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
+      = f.submit "Afficher les lieux disponible", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
 
 #creneaux
   .text-center
-    - if @form.motif.blank?
-      | Sélectionnez un motif pour afficher les créneaux disponibles.
+    - if @form.motif.blank? || @search_results.nil?
+      | Selectionnez vos filtres pour demander l'affichage de la liste des lieux où il y a des créneaux disponible
+    - elsif @search_results.nil?
     - elsif @form.errors.any?
       | Nous ne reconnaissons pas certains éléments du formulaire, pouvez-vous vérifier ?
     - elsif @search_results.empty?

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -42,40 +42,36 @@
           = f.input :agent_ids, collection: @agents, label: "Agent(s)", label_method: :full_name, input_html: { multiple: true, class: "select2-input" }
         .col-md-4
           = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
-      = f.submit "Afficher les lieux disponible", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
+      = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
 
 #creneaux
-  .text-center
-    - if @form.motif.blank? || @search_results.nil?
-      | Selectionnez vos filtres pour demander l'affichage de la liste des lieux où il y a des créneaux disponible
-    - elsif @search_results.nil?
-    - elsif @form.errors.any?
-      | Nous ne reconnaissons pas certains éléments du formulaire, pouvez-vous vérifier ?
-    - elsif @search_results.empty?
-      | Il n'y a pour l'instant aucune disponibilité pour le motif #{@form.motif.name}
-    - else
-      - available_places = @search_results.map(&:lieu)
-      .container
-          h3.font-weight-bold Résultats de votre recherche
-          p.font-weight-bold= t(".available_places_with_slots", count: available_places.length.to_s)
-          - available_places.each do |lieu|
-            - next_availability = @search_results.find {|s| s.lieu == lieu }&.next_availability
-            .card.mb-3 class=("card-hoverable" if next_availability)
-              .card-body
-                .row
-                  .col-md
-                    h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-                    h6.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
-                    h6.card-subtitle.text-black-50= lieu.address
-                  .col-md.align-self-center.pt-3.pt-md-0.position-static
-                    - if next_availability
-                      = link_to admin_organisation_slots_path(current_organisation, service_id: @form.service_id, motif_id: @form.motif.id, from_date: @form.from_date, agent_ids: @form.agent_ids, lieu_id: lieu.id, user_ids: @form.user_ids), class: "d-block stretched-link" do
-                        .row
-                          .col
-                            | Prochaine disponibilité le
-                            br
-                            strong= l(next_availability.starts_at, format: :human)
-                          .col-auto.align-self-center
-                            i.fa.fa-chevron-right
-                    - else
-                      em Aucune disponibilité
+  - if @search_results.present?
+    .text-center
+      - if @search_results.empty?
+        | Il n'y a pour l'instant aucune disponibilité pour le motif #{@form.motif.name}
+      - else
+        - available_places = @search_results.map(&:lieu)
+        .container
+            h3.font-weight-bold Résultats de votre recherche
+            p.font-weight-bold= t(".available_places_with_slots", count: available_places.length.to_s)
+            - available_places.each do |lieu|
+              - next_availability = @search_results.find {|s| s.lieu == lieu }&.next_availability
+              .card.mb-3 class=("card-hoverable" if next_availability)
+                .card-body
+                  .row
+                    .col-md
+                      h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
+                      h6.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
+                      h6.card-subtitle.text-black-50= lieu.address
+                    .col-md.align-self-center.pt-3.pt-md-0.position-static
+                      - if next_availability
+                        = link_to admin_organisation_slots_path(current_organisation, service_id: @form.service_id, motif_id: @form.motif.id, from_date: @form.from_date, agent_ids: @form.agent_ids, lieu_id: lieu.id, user_ids: @form.user_ids), class: "d-block stretched-link" do
+                          .row
+                            .col
+                              | Prochaine disponibilité le
+                              br
+                              strong= l(next_availability.starts_at, format: :human)
+                            .col-auto.align-self-center
+                              i.fa.fa-chevron-right
+                      - else
+                        em Aucune disponibilité

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -6,13 +6,7 @@
         h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
         = t(".place_informations_html", place_name: search_result.lieu.name, place_address: search_result.lieu.address)
       span
-        = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,
-            service_id: @form.service_id,
-            motif_id: @form.motif_id,
-            from_date: @form.from_date,
-            user_ids: @form.user_ids,
-            agent_ids: @form.agent_ids,
-            commit: "reload"), class: "btn btn-outline-primary m-2"
+        = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation), class: "btn btn-outline-primary m-2"
 
   .card-body
 

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -6,7 +6,12 @@
         h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
         = t(".place_informations_html", place_name: search_result.lieu.name, place_address: search_result.lieu.address)
       span
-        = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation), class: "btn btn-outline-primary m-2"
+        = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,
+            service_id: @form.service_id,
+            motif_id: @form.motif_id,
+            from_date: @form.from_date,
+            user_ids: @form.user_ids,
+            agent_ids: @form.agent_ids), class: "btn btn-outline-primary m-2"
 
   .card-body
 

--- a/spec/services/creneaux_builder_service_spec.rb
+++ b/spec/services/creneaux_builder_service_spec.rb
@@ -245,18 +245,6 @@ describe CreneauxBuilderService, type: :service do
         end
       end
 
-      context "when the result is filtered with an empty agents set" do
-        let(:options) { { agent_ids: [] } }
-
-        it { is_expected.to be_empty }
-      end
-
-      context "when the result is filtered with an empty agents set, for agents" do
-        let(:options) { { for_agents: true, agent_ids: [] } }
-
-        it { is_expected.to be_empty }
-      end
-
       context "when there is another motif with the same name but a different location_type" do
         let!(:motif_home) { create(:motif, name: "Vaccination", default_duration_in_min: 30, organisation: organisation, location_type: :home) }
         let!(:plage_ouverture) do


### PR DESCRIPTION
~~J'imagine que c'est mieux direct en prod, mais ce n'est pas si urgent que ça non plus. Ce n'est pas un bug à proprement parlé, plutôt un inconfort.~~

Nous affichions la page des créneaux avec les dates alors qu'il n'y a aucune disponibilité (dans certains cas). Autant faire en sorte de ne pas afficher cette page.
