### PR TITLE
:rocket:  récupère toutes les absences

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -23,6 +23,15 @@ class Absence < ApplicationRecord
   scope :by_starts_at, -> { order(first_day: :desc, start_time: :desc) }
   scope :with_agent, ->(agent) { where(agent_id: agent.id) }
 
+  scope :in_range, lambda { |range|
+    return all if range.nil?
+
+    not_recurring_start_in_range = where(recurrence: nil).where("first_day < ?", range.end).where("end_day > ?", range.begin)
+    recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+
+    not_recurring_start_in_range.or(recurring_in_range)
+  }
+
   def ical_uid
     "absence_#{id}@#{BRAND}"
   end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -18,15 +18,6 @@ module RecurrenceConcern
 
     scope :exceptionnelles, -> { where(recurrence: nil) }
     scope :regulieres, -> { where.not(recurrence: nil) }
-
-    scope :in_range, lambda { |range|
-      return all if range.nil?
-
-      not_recurring_in_range = where(recurrence: nil).where(first_day: range)
-      recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
-
-      not_recurring_in_range.or(recurring_in_range)
-    }
   end
 
   def starts_at

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -21,6 +21,15 @@ class PlageOuverture < ApplicationRecord
 
   has_many :webhook_endpoints, through: :organisation
 
+  scope :in_range, lambda { |range|
+    return all if range.nil?
+
+    not_recurring_start_in_range = where(recurrence: nil).where(first_day: range)
+    recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+
+    not_recurring_start_in_range.or(recurring_in_range)
+  }
+
   def ical_uid
     "plage_ouverture_#{id}@#{BRAND}"
   end

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -96,6 +96,18 @@ describe RecurrenceConcern do
               create(element, first_day: Date.new(2021, 9, 26), recurrence: nil)
               expect(element_class.in_range(range)).to eq([])
             end
+
+            if element.is_a?(Absence)
+              it "returns #{element} when last_day in range" do
+                object = create(element, first_day: Date.new(2021, 9, 26), end_day: Date.new(2021, 10, 27), recurrence: nil)
+                expect(element_class.in_range(range)).to eq([object])
+              end
+
+              it "returns #{element} when start_day before range and last_day after range" do
+                object = create(element, first_day: Date.new(2021, 9, 26), end_day: Date.new(2021, 10, 30), recurrence: nil)
+                expect(element_class.in_range(range)).to eq([object])
+              end
+            end
           end
 
           context "with recurrence" do


### PR DESCRIPTION
Patch en urgence pour réglé un problème de créneau qui s'affiche alors qu'il y a des absences à ce moment là.

Le in_range ne prennais pas en compte certaines absences !

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
