### PR TITLE
selection les jours fériées concernés

### DIFF
--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -129,7 +129,7 @@ module SlotBuilder
 
         busy_times = busy_times_from_rdvs(range, plage_ouverture)
         busy_times += busy_times_from_absences(range, plage_ouverture)
-        busy_times += busy_times_from_off_days(off_days)
+        busy_times += busy_times_from_off_days(off_days.select { |off_day| range.cover?(off_day) })
 
         # Le tri est nécessaire, surtout pour les surcharges.
         busy_times.sort_by(&:starts_at)

--- a/spec/services/slot_builder/busy_time_spec.rb
+++ b/spec/services/slot_builder/busy_time_spec.rb
@@ -78,5 +78,10 @@ describe SlotBuilder::BusyTime, type: :service do
       expect(described_class.busy_times_for(range, plage_ouverture, off_days).first.starts_at).to eq(Time.zone.parse("20211027 0:00"))
       expect(described_class.busy_times_for(range, plage_ouverture, off_days).first.ends_at).to be_within(1.second).of(Time.zone.parse("20211027 23:59:59"))
     end
+
+    it "returns off_day that in given range only" do
+      off_days = [Date.new(2021, 10, 30)]
+      expect(described_class.busy_times_for(range, plage_ouverture, off_days)).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Encore un « bug » découvert en faisant une comparaison entre ce qui est proposé aujourd'hui en production et ce que nous avons avec le nouveau moteur de calcul...

Ici, c'est le cas des jours fériés. Nous sélectionnons ceux qui sont dans le grand range, mais, au moment de faire le calcul des indisponibilités sur un range plus réduit (une journée), le jour férié qui à lieu un autre jour viens perturber le calcul. Nous avons donc ajouté un filtre dans cette PR


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
