### PR TITLE
Harmonise la fin du message de template

### DIFF
--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -18,8 +18,6 @@ html
                   table width="100%"
                     tbody
                       = yield
-                      p À bientôt,
-                      p L'équipe RDV Solidarités
             .footer
               table width="100%"
                 tr

--- a/app/views/mailers/admins/organisation_mailer/organisation_created.html.slim
+++ b/app/views/mailers/admins/organisation_mailer/organisation_created.html.slim
@@ -14,3 +14,5 @@ p
   ' Accédez à
   = link_to "la fiche agent", super_admins_agent_url(@agent)
   |  de l'interface d'administration pour envoyer une invitation ou bien prenez contact avec la personne pour avoir plus d'informations.
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_created.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_created.html.slim
@@ -1,2 +1,5 @@
 p = t("mailers.common.hello")
+
 = t(".description_html")
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
@@ -1,2 +1,4 @@
 p = t("mailers.common.hello")
 = t(".description_html")
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
@@ -1,2 +1,4 @@
 p = t("mailers.common.hello")
 = t(".description_html")
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_created.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_created.html.slim
@@ -2,3 +2,5 @@ p Bonjour,
 
 p Vous venez de créer une plage d'ouverture sur votre planning de RDV Solidarités.
 p Vous pouvez synchroniser cette plage sur votre calendrier en ouvrant la pièce-jointe de cet email.
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_destroyed.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_destroyed.html.slim
@@ -2,3 +2,5 @@ p Bonjour,
 
 p Une de vos plages d'ouvertures a été supprimée.
 p Vous pouvez supprimer l'événement correspondant de votre logiciel de calendrier externe (Outlook, Zimbra, Thunderbird etc) en ouvrant la pièce jointe
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_updated.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_updated.html.slim
@@ -2,3 +2,5 @@ p Bonjour,
 
 p Une de vos plages d'ouvertures a été modifiée.
 p Vous pouvez synchroniser cette plage sur votre calendrier en ouvrant la pièce-jointe de cet email.
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_cancelled.html.slim
@@ -14,3 +14,6 @@ div
 
   p.aligncenter
     = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation_id, @agent),  class: "btn btn-primary"
+
+  br
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
@@ -6,3 +6,6 @@ div
 
   p.aligncenter
     = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation_id, @agent),  class: "btn btn-primary"
+
+  br
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/rdv_mailer/rdv_date_updated.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_date_updated.html.slim
@@ -6,3 +6,6 @@ div
 
   p.aligncenter
     = link_to "Voir sur RDV-Solidarités", admin_organisation_agent_url(@rdv.organisation_id , @agent),  class: "btn btn-primary"
+
+  br
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/common/_rdv_cancellable.html.slim
+++ b/app/views/mailers/common/_rdv_cancellable.html.slim
@@ -9,4 +9,3 @@ p[style="margin-top:12px;"]
 .btn-wrapper
   = link_to "Annuler ce rendez-vous", users_rdvs_url, class:"btn btn-primary"
 
-= t("mailers.common.farewell_html")

--- a/app/views/mailers/common/_rdv_cancellable.html.slim
+++ b/app/views/mailers/common/_rdv_cancellable.html.slim
@@ -8,3 +8,5 @@ p[style="margin-top:12px;"]
 
 .btn-wrapper
   = link_to "Annuler ce rendez-vous", users_rdvs_url, class:"btn btn-primary"
+
+= t("mailers.common.farewell_html")

--- a/app/views/mailers/common/_rdv_cancellable.html.slim
+++ b/app/views/mailers/common/_rdv_cancellable.html.slim
@@ -8,4 +8,3 @@ p[style="margin-top:12px;"]
 
 .btn-wrapper
   = link_to "Annuler ce rendez-vous", users_rdvs_url, class:"btn btn-primary"
-

--- a/app/views/mailers/users/file_attente_mailer/new_creneau_available.html.slim
+++ b/app/views/mailers/users/file_attente_mailer/new_creneau_available.html.slim
@@ -5,3 +5,5 @@ div
   p Vous pouvez avancer la date de votre RDV en cliquant sur le lien ci-dessous.
   .btn-wrapper
     = link_to "Vérifier la disponibilité", users_creneaux_index_url(rdv_id: @rdv.id), class:"btn btn-primary"
+
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -20,3 +20,6 @@ div
         service: @rdv.motif_service_id, \
         where: @rdv.address \
       }), class:"btn btn-primary"
+
+  br
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/users/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_created.html.slim
@@ -8,3 +8,4 @@ div
 
   = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :user
   = render "mailers/common/rdv_cancellable", rdv: @rdv
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/users/rdv_mailer/rdv_date_updated.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_date_updated.html.slim
@@ -6,3 +6,5 @@ div
       Nouveau RDV : #{l(@rdv.starts_at, format: (@rdv.home? ?   :human_approx : :human))}.
   = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :user
   = render "mailers/common/rdv_cancellable", rdv: @rdv
+
+  = t("mailers.common.farewell_html")

--- a/app/views/mailers/users/rdv_mailer/rdv_upcoming_reminder.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_upcoming_reminder.html.slim
@@ -8,3 +8,4 @@ div
 
   = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :user
   = render "mailers/common/rdv_cancellable", rdv: @rdv
+  = t("mailers.common.farewell_html")

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -7,7 +7,6 @@ fr:
   mailers:
     common:
       hello: Bonjour,
-      farewell: "Belle journée, L'équipe RDV-Solidarités"
       farewell_html: "<p>À bientôt,<br>L’équipe RDV-Solidarités</p>"
 
   agents:

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -8,7 +8,7 @@ fr:
     common:
       hello: Bonjour,
       farewell: "Belle journée, L'équipe RDV-Solidarités"
-      farewell_html: "<p>Belle journée,<br>L'équipe RDV-Solidarités</p>"
+      farewell_html: "<p>À bientôt,<br>L’équipe RDV-Solidarités</p>"
 
   agents:
     absence_mailer:

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -7,6 +7,8 @@ fr:
   mailers:
     common:
       hello: Bonjour,
+      farewell: "Belle journée, L'équipe RDV-Solidarités"
+      farewell_html: "<p>Belle journée,<br>L'équipe RDV-Solidarités</p>"
 
   agents:
     absence_mailer:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_12_16_141613) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"


### PR DESCRIPTION
Il est surprenant d'avoir un morceau du corps de message dans le layout. Cette PR propose de placer la fin du message dans le corps des messages, comme pour le bonjour.

Cela fait de la duplication, mais il faut sans doute avoir une autre approche que celle de mettre les morceaux dans le layout

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
