### PR TITLE
feat(webhooks): send webhook on organisations updates

### DIFF
--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -3,5 +3,5 @@
 class OrganisationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name
+  fields :name, :phone_number, :email
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Organisation < ApplicationRecord
+  include WebhookDeliverable
+
   has_paper_trail
 
   auto_strip_attributes :email, :name

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -7,5 +7,5 @@ class WebhookEndpoint < ApplicationRecord
   validates :target_url, presence: true
   validates :secret, presence: true
 
-  ALL_SUBSCRIPTIONS = %w[rdv absence plage_ouverture user user_profile].freeze
+  ALL_SUBSCRIPTIONS = %w[rdv absence plage_ouverture user user_profile organisation].freeze
 end


### PR DESCRIPTION
Pour le bon fonctionnement de RDV-Insertion nous avons besoin des infos relatives aux organisations, notamment le numéro de téléphone et l'adresse email.
Cette PR configure l'envoi de webhooks au moment des changements sur une organisation (sur `/admin/organisations/:id/edit`) pour que l'on puisse mettre à jour instantanément les infos de l'organisations sur RDV-Insertion.