### PR TITLE
Install foreman in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -15,6 +15,7 @@ FileUtils.chdir APP_ROOT do
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
+  system! 'gem install foreman --conservative'
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies


### PR DESCRIPTION
We use foreman for `make run` but it’s not installed by default.

We _could_ add it to the :development section of the Gemfile and it probably would work, however the foreman developers [explicitly advise against it](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman).

