### PR TITLE
Fix Range#include? being deprecated for date time ranges

### DIFF
--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -66,13 +66,13 @@ module SlotBuilder
     end
 
     def first_range(range, busy_time)
-      return [range.begin..busy_time.starts_at] if range.begin < busy_time.starts_at && range.include?(busy_time.range)
+      return [range.begin..busy_time.starts_at] if range.begin < busy_time.starts_at && range.cover?(busy_time.range)
 
       []
     end
 
     def remaining_range(range, busy_time)
-      return busy_time.ends_at..range.end if range.include?(busy_time.range)
+      return busy_time.ends_at..range.end if range.cover?(busy_time.range)
       return range.begin..busy_time.starts_at if range.cover?(busy_time.starts_at)
       return busy_time.ends_at..range.end if range.cover?(busy_time.ends_at)
     end


### PR DESCRIPTION
@yaf est-ce que tu sais pourquoi ligne 75 on utilisait `include?`, mais lignes 76 et 77 on utilisait `cover?`?

----

```
DEPRECATION WARNING: Using `Range#include?` to check the inclusion of a value in a date time range is deprecated. It is recommended to use `Range#cover?` instead of `Range#include?` to check the inclusion of a value in a date time range. (called from first_range at /Users/nicolas/Documents/rdv-solidarites.fr/app/services/slot_builder.rb:69)

DEPRECATION WARNING: Using `Range#include?` to check the inclusion of a value in a date time range is deprecated. It is recommended to use `Range#cover?` instead of `Range#include?` to check the inclusion of a value in a date time range. (called from remaining_range at /Users/nicolas/Documents/rdv-solidarites.fr/app/services/slot_builder.rb:75)
```

See https://github.com/rails/rails/pull/38186.

Basically, `include?` calls `cover?` under the hood when relevant, but that extension in Rails was confusing, so it’s being.
