### PR TITLE
Fix uses of shared examples in specs

### DIFF
--- a/spec/lib/phone_number_validation_spec.rb
+++ b/spec/lib/phone_number_validation_spec.rb
@@ -49,8 +49,8 @@ describe PhoneNumberValidation do
     end
   end
 
-  describe "has phone number concern" do
-    shared_examples "has phone number concern" do |factory|
+  describe "HasPhoneNumber" do
+    shared_examples "HasPhoneNumber" do
       describe "validation hooks" do
         it "is invalid when number is wrong" do
           object = build(factory, phone_number: "invalid value")
@@ -92,6 +92,12 @@ describe PhoneNumberValidation do
       end
     end
 
-    it_behaves_like "has phone number concern", :user, :rdv
+    [User, Territory, Lieu].each do |klass|
+      describe(klass) do
+        let(:factory) { described_class.name.underscore }
+
+        include_examples "HasPhoneNumber"
+      end
+    end
   end
 end

--- a/spec/models/concerns/expiration_spec.rb
+++ b/spec/models/concerns/expiration_spec.rb
@@ -2,6 +2,12 @@
 
 describe Expiration, type: :concern do
   shared_examples "#expired?" do
+    def build(factory, params)
+      # Absence has a :end_day attribute, but not PlageOuverture
+      params.delete(:end_day) if described_class != Absence
+      super(factory, **params)
+    end
+
     it "is expired when end_day before today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)

--- a/spec/models/concerns/expiration_spec.rb
+++ b/spec/models/concerns/expiration_spec.rb
@@ -1,28 +1,34 @@
 # frozen_string_literal: true
 
 describe Expiration, type: :concern do
-  shared_examples "expired?" do |element|
-    it "#{element} is expired when end_day before today" do
+  shared_examples "#expired?" do
+    it "is expired when end_day before today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)
-      objet = build(element, first_day: today - 5.days, end_day: today - 5.days)
+      objet = build(factory, first_day: today - 5.days, end_day: today - 5.days)
       expect(objet.expired?).to be true
     end
 
-    it "#{element} is not past when end_day after today" do
+    it "is not past when end_day after today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)
-      objet = build(element, first_day: today + 3.days, end_day: today + 3.days)
+      objet = build(factory, first_day: today + 3.days, end_day: today + 3.days)
       expect(objet.expired?).to be false
     end
 
-    it "#{element} is not past when end_day before today with a recurrence after today" do
+    it "is not past when end_day before today with a recurrence after today" do
       today = Time.zone.parse("20210323 13:45")
       travel_to(today)
-      objet = build(element, first_day: today - 1.day, end_day: today - 1.day, recurrence: Montrose.every(:week, until: today + 1.month, starts: today - 1.day))
+      objet = build(factory, first_day: today - 1.day, end_day: today - 1.day, recurrence: Montrose.every(:week, until: today + 1.month, starts: today - 1.day))
       expect(objet.expired?).to be false
     end
   end
 
-  it_behaves_like "expired?", :absence, :plage_ouverture
+  [Absence, PlageOuverture].each do |klass|
+    describe(klass) do
+      let(:factory) { described_class.name.underscore }
+
+      include_examples "#expired?"
+    end
+  end
 end

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -1,192 +1,175 @@
 # frozen_string_literal: true
 
 describe RecurrenceConcern do
-  describe "#all_occurrences_for" do
-    shared_examples "occurrences for" do |*elements|
-      elements.each do |element|
-        element_class = element.to_s.classify.constantize
+  shared_examples "#all_occurrences_for" do
+    def expect_first_occurrence_to_match(occurrences, expected_boundaries)
+      first_occurrence = occurrences.first.second
+      expect(first_occurrence.starts_at).to eq(expected_boundaries[:starts_at])
+      expect(first_occurrence.ends_at).to eq(expected_boundaries[:ends_at])
+    end
 
-        context element.to_s do
-          it "return given #{element} as first entry of each entry" do
-            first_day = Date.new(2019, 8, 15)
-            object = create(element, first_day: first_day)
-            second_object = create(element, first_day: first_day + 1)
-            period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
+    it "return given element as first entry of each entry" do
+      first_day = Date.new(2019, 8, 15)
+      object = create(factory, first_day: first_day)
+      second_object = create(factory, first_day: first_day + 1)
+      period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
 
-            first_entry_of_each_entries = element_class.all_occurrences_for(period).map(&:first)
+      first_entry_of_each_entries = described_class.all_occurrences_for(period).map(&:first)
 
-            expect(first_entry_of_each_entries).to eq([object, second_object])
-          end
+      expect(first_entry_of_each_entries).to eq([object, second_object])
+    end
 
-          it "returns starts_at from given first_day" do
-            starts_at = Time.zone.parse("2019-08-15 10h00:00")
-            create(element, first_day: starts_at.to_date, start_time: starts_at.to_time)
-            period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
+    it "returns starts_at from given first_day" do
+      starts_at = Time.zone.parse("2019-08-15 10h00:00")
+      create(factory, first_day: starts_at.to_date, start_time: starts_at.to_time)
+      period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
 
-            occurrences = element_class.all_occurrences_for(period)
-            expect(occurrences.first.second.starts_at).to eq(starts_at)
-          end
+      occurrences = described_class.all_occurrences_for(period)
+      expect(occurrences.first.second.starts_at).to eq(starts_at)
+    end
 
-          it "returns august 14th from 8h to 12h when recurrence interval for 2 weeks, and start on july 17th" do
-            first_day = Date.new(2019, 7, 17)
-            recurrence = Montrose.every(:week, interval: 2, starts: first_day)
-            create(element, \
-                   recurrence: recurrence, \
-                   first_day: first_day, \
-                   start_time: Time.zone.parse("8h00"), \
-                   end_time: Time.zone.parse("12h00"))
-            period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
+    it "returns august 14th from 8h to 12h when recurrence interval for 2 weeks, and start on july 17th" do
+      first_day = Date.new(2019, 7, 17)
+      recurrence = Montrose.every(:week, interval: 2, starts: first_day)
+      create(factory, \
+             recurrence: recurrence, \
+             first_day: first_day, \
+             start_time: Time.zone.parse("8h00"), \
+             end_time: Time.zone.parse("12h00"))
+      period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
 
-            expect_first_occurrence_to_match(element_class.all_occurrences_for(period), \
-                                             starts_at: Time.zone.parse("2019-08-14 8h00"), \
-                                             ends_at: Time.zone.parse("2019-08-14 12h00"))
-          end
+      expect_first_occurrence_to_match(described_class.all_occurrences_for(period), \
+                                       starts_at: Time.zone.parse("2019-08-14 8h00"), \
+                                       ends_at: Time.zone.parse("2019-08-14 12h00"))
+    end
 
-          it "returns july 31th without recurrence, only first day and time period" do
-            first_day = Date.new(2019, 7, 31)
-            create(element, \
-                   recurrence: nil, \
-                   first_day: first_day, \
-                   start_time: Time.zone.parse("8h00"), \
-                   end_time: Time.zone.parse("12h00"))
-            period = Date.new(2019, 7, 29)..Date.new(2019, 8, 4)
+    it "returns july 31th without recurrence, only first day and time period" do
+      first_day = Date.new(2019, 7, 31)
+      create(factory, \
+             recurrence: nil, \
+             first_day: first_day, \
+             start_time: Time.zone.parse("8h00"), \
+             end_time: Time.zone.parse("12h00"))
+      period = Date.new(2019, 7, 29)..Date.new(2019, 8, 4)
 
-            expect_first_occurrence_to_match(element_class.all_occurrences_for(period), \
-                                             starts_at: Time.zone.parse("2019-07-31 8h00"), \
-                                             ends_at: Time.zone.parse("2019-07-31 12h00"))
-          end
+      expect_first_occurrence_to_match(described_class.all_occurrences_for(period), \
+                                       starts_at: Time.zone.parse("2019-07-31 8h00"), \
+                                       ends_at: Time.zone.parse("2019-07-31 12h00"))
+    end
+  end
+
+  shared_examples "#in_range" do
+    let(:monday) { Date.new(2021, 10, 4) }
+    let(:range) { Date.new(2021, 10, 25)..Date.new(2021, 10, 29) }
+
+    before do
+      travel_to(monday)
+    end
+
+    context "without recurrence" do
+      it "returns element when first_day in range" do
+        object = create(factory, first_day: Date.new(2021, 10, 26), recurrence: nil)
+        expect(described_class.in_range(range)).to eq([object])
+      end
+
+      it "doesnt return element when first_day after range" do
+        create(factory, first_day: Date.new(2021, 11, 26), recurrence: nil)
+        expect(described_class.in_range(range)).to eq([])
+      end
+
+      it "doesnt return element when first_day before range" do
+        create(factory, first_day: Date.new(2021, 9, 26), recurrence: nil)
+        expect(described_class.in_range(range)).to eq([])
+      end
+
+      if described_class == Absence
+        it "returns element when last_day in range" do
+          object = create(factory, first_day: Date.new(2021, 9, 26), end_day: Date.new(2021, 10, 27), recurrence: nil)
+          expect(described_class.in_range(range)).to eq([object])
+        end
+
+        it "returns element when start_day before range and last_day after range" do
+          object = create(factory, first_day: Date.new(2021, 9, 26), end_day: Date.new(2021, 10, 30), recurrence: nil)
+          expect(described_class.in_range(range)).to eq([object])
         end
       end
     end
 
-    it_behaves_like "occurrences for", :absence, :plage_ouverture
-  end
+    context "with recurrence" do
+      it "returns element when start in range" do
+        first_day = Date.new(2021, 9, 26)
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
+        expect(described_class.in_range(range)).to eq([object])
+      end
 
-  def expect_first_occurrence_to_match(occurrences, expected_boundaries)
-    first_occurrence = occurrences.first.second
-    expect(first_occurrence.starts_at).to eq(expected_boundaries[:starts_at])
-    expect(first_occurrence.ends_at).to eq(expected_boundaries[:ends_at])
-  end
+      it "returns element when ends in range" do
+        first_day = range.begin - 1.month
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end - 2.days))
+        expect(described_class.in_range(range)).to eq([object])
+      end
 
-  describe "#in_range" do
-    shared_examples "in range" do |*elements|
-      elements.each do |element|
-        element_class = element.to_s.classify.constantize
+      it "returns element when start before range and end after range" do
+        first_day = range.begin - 1.day
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end + 2.days))
+        expect(described_class.in_range(range)).to eq([object])
+      end
 
-        context element.to_s do
-          let(:monday) { Date.new(2021, 10, 4) }
-          let(:range) { Date.new(2021, 10, 25)..Date.new(2021, 10, 29) }
+      it "returns element when one occurrence start in range without until day" do
+        range = Date.new(2021, 10, 25)..Date.new(2021, 10, 29)
+        first_day = monday - 14.days
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
+        expect(described_class.in_range(range)).to eq([object])
+      end
 
-          before do
-            travel_to(monday)
-          end
+      it "doesnt return element when end before range" do
+        first_day = range.begin - 2.months
+        create(factory, first_day: first_day,
+                        recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin - 3.days))
+        expect(described_class.in_range(range)).to eq([])
+      end
 
-          context "without recurrence" do
-            it "returns #{element} when first_day in range" do
-              object = create(element, first_day: Date.new(2021, 10, 26), recurrence: nil)
-              expect(element_class.in_range(range)).to eq([object])
-            end
-
-            it "dont returns #{element} when first_day after range" do
-              create(element, first_day: Date.new(2021, 11, 26), recurrence: nil)
-              expect(element_class.in_range(range)).to eq([])
-            end
-
-            it "dont returns #{element} when first_day before range" do
-              create(element, first_day: Date.new(2021, 9, 26), recurrence: nil)
-              expect(element_class.in_range(range)).to eq([])
-            end
-
-            if element.is_a?(Absence)
-              it "returns #{element} when last_day in range" do
-                object = create(element, first_day: Date.new(2021, 9, 26), end_day: Date.new(2021, 10, 27), recurrence: nil)
-                expect(element_class.in_range(range)).to eq([object])
-              end
-
-              it "returns #{element} when start_day before range and last_day after range" do
-                object = create(element, first_day: Date.new(2021, 9, 26), end_day: Date.new(2021, 10, 30), recurrence: nil)
-                expect(element_class.in_range(range)).to eq([object])
-              end
-            end
-          end
-
-          context "with recurrence" do
-            it "returns #{element} when start in range" do
-              first_day = Date.new(2021, 9, 26)
-              object = create(element, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
-              expect(element_class.in_range(range)).to eq([object])
-            end
-
-            it "returns #{element} when ends in range" do
-              first_day = range.begin - 1.month
-              object = create(element, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end - 2.days))
-              expect(element_class.in_range(range)).to eq([object])
-            end
-
-            it "returns #{element} when start before range and end after range" do
-              first_day = range.begin - 1.day
-              object = create(element, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end + 2.days))
-              expect(element_class.in_range(range)).to eq([object])
-            end
-
-            it "returns #{element} when one occurrence start in range without until day" do
-              range = Date.new(2021, 10, 25)..Date.new(2021, 10, 29)
-              first_day = monday - 14.days
-              object = create(element, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
-              expect(element_class.in_range(range)).to eq([object])
-            end
-
-            it "dont returns #{element} when end before range" do
-              first_day = range.begin - 2.months
-              create(element, first_day: first_day,
-                              recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin - 3.days))
-              expect(element_class.in_range(range)).to eq([])
-            end
-
-            it "dont returns #{element} with recurrence start after range" do
-              first_day = range.end + 4.days
-              create(element, first_day: first_day,
-                              recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
-              expect(element_class.in_range(range)).to eq([])
-            end
-          end
-        end
+      it "doesnt return element with recurrence start after range" do
+        first_day = range.end + 4.days
+        create(factory, first_day: first_day,
+                        recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
+        expect(described_class.in_range(range)).to eq([])
       end
     end
-    it_behaves_like "in range", :absence, :plage_ouverture
   end
 
-  describe "#recurrence_ends_after_first_day" do
-    shared_examples "recurrence ends after first day" do |*elements|
-      elements.each do |element|
-        context element.to_s do
-          it "valid #{element} when recurrence ends after first_day" do
-            starts = Date.new(2021, 10, 27)
-            recurring_object = build(element, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts + 1.week))
-            expect(recurring_object).to be_valid
-          end
-
-          it "valid #{element} when recurrence ends is nil" do
-            starts = Date.new(2021, 10, 27)
-            recurring_object = build(element, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: nil))
-            expect(recurring_object).to be_valid
-          end
-
-          it "invalid #{element} when recurrence ends at first_day" do
-            starts = Date.new(2021, 10, 27)
-            recurring_object = build(element, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts))
-            expect(recurring_object).to be_invalid
-          end
-
-          it "invalid #{element} when recurrence ends before first_day" do
-            starts = Date.new(2021, 10, 27)
-            recurring_object = build(element, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts - 1.week))
-            expect(recurring_object).to be_invalid
-          end
-        end
-      end
+  shared_examples "#recurrence_ends_after_first_day" do
+    it "valid element when recurrence ends after first_day" do
+      starts = Date.new(2021, 10, 27)
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts + 1.week))
+      expect(recurring_object).to be_valid
     end
 
-    it_behaves_like "recurrence ends after first day", :absence, :plage_ouverture
+    it "valid element when recurrence ends is nil" do
+      starts = Date.new(2021, 10, 27)
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: nil))
+      expect(recurring_object).to be_valid
+    end
+
+    it "invalid element when recurrence ends at first_day" do
+      starts = Date.new(2021, 10, 27)
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts))
+      expect(recurring_object).to be_invalid
+    end
+
+    it "invalid element when recurrence ends before first_day" do
+      starts = Date.new(2021, 10, 27)
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts - 1.week))
+      expect(recurring_object).to be_invalid
+    end
+  end
+
+  [Absence, PlageOuverture].each do |klass|
+    describe(klass) do
+      let(:factory) { described_class.name.underscore }
+
+      include_examples "#all_occurrences_for"
+      include_examples "#in_range"
+      include_examples "#recurrence_ends_after_first_day"
+    end
   end
 end


### PR DESCRIPTION
⚠️ Merge #1966 first. It’s not directly related, but it would conflict. The first commit is the same; it’s better to only review the other two commits.

We sometimes used shared_examples wrongly in rspec, along with `it_behaves_like`. `it_behaves_like` doesn't support multiple contexts in one call; it needs to be called once for each class. `RecurrenceConcernSpec` did run the multiple contexte internally, but `ExpirationSpec` and `PhoneNumberValidationSpec` only ran the tests for the first class. Additionally ExpirationSpec did fail for PlageOuverture.


Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app
