### PR TITLE
Fix dont display agent name

### DIFF
--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -24,7 +24,7 @@ div id="creneaux-lieu-#{lieu.id}"
                   - if creneau.motif.restriction_for_rdv.blank?
                     = link_to new_users_rdv_wizard_step_path(query.merge(starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100" do
                       = l(creneau.starts_at, format: "%H:%M")
-                      - if creneau.agent.short_name
+                      - if creneau.motif.follow_up?
                         br
                         small= creneau.agent.short_name
                   - else


### PR DESCRIPTION
Limite l'affichage des noms d'agents dans l'affichage de créneau coté usager.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
