### PR TITLE
Corrige des warnings de rake assets:precompile

### DIFF
--- a/app/webpacker/stylesheets/_variables.scss
+++ b/app/webpacker/stylesheets/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Bootstrap Variables
 
 //
@@ -406,7 +408,7 @@ $list-group-active-bg:              $component-active-bg;
 
 // Breadcrumbs
 
-$breadcrumb-padding-y:              $spacer/1.5;
+$breadcrumb-padding-y:              math.div($spacer, 1.5);
 $breadcrumb-padding-x:              0;
 $breadcrumb-item-padding:           .5rem;
 

--- a/app/webpacker/stylesheets/administrate/base/_forms.scss
+++ b/app/webpacker/stylesheets/administrate/base/_forms.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 fieldset {
   background-color: transparent;
   border: 0;
@@ -85,7 +87,7 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $small-spacing / 2;
+  margin-right: math.div($small-spacing, 2);
 }
 
 [type="file"] {

--- a/app/webpacker/stylesheets/administrate/components/_flashes.scss
+++ b/app/webpacker/stylesheets/administrate/components/_flashes.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $base-spacing: 1.5em !default;
 $flashes: (
   "alert": #fff6bf,
@@ -11,8 +13,8 @@ $flashes: (
     background-color: $color;
     color: mix($black, $color, 60%);
     display: block;
-    margin-bottom: $base-spacing / 2;
-    padding: $base-spacing / 2;
+    margin-bottom: math.div($base-spacing, 2);
+    padding: math.div($base-spacing, 2);
     text-align: center;
 
     a {

--- a/app/webpacker/stylesheets/administrate/library/_variables.scss
+++ b/app/webpacker/stylesheets/administrate/library/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Typography
 $base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
   "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
@@ -14,7 +16,7 @@ $heading-line-height: 1.2 !default;
 // Other Sizes
 $base-border-radius: 4px !default;
 $base-spacing: $base-line-height * 1em !default;
-$small-spacing: $base-spacing / 2 !default;
+$small-spacing: math.div($base-spacing, 2) !default;
 
 // Colors
 $white: #fff !default;

--- a/babel.config.js
+++ b/babel.config.js
@@ -54,6 +54,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-property-in-object',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-proposal-object-rest-spread',
         {
           useBuiltIns: true


### PR DESCRIPTION
Corrige des warnings lors de la précompilation js et css:

Sass:
```
DEPRECATION WARNING: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($fa-li-width * 5, 4) or calc($fa-li-width * 5 / 4)

More info and automated migrator: https://sass-lang.com/d/slash-div
```
Il en reste une partie dans FontAwesome, qui sera corrigée dans une mise à jour future

Babel:
```
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
  ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
  to the "plugins" section of your Babel config.
  Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.
```
ok 🤷 

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
