### PR TITLE
Save notifications changes in rdv paper_trail versions

### DIFF
--- a/app/helpers/paper_trail_helper.rb
+++ b/app/helpers/paper_trail_helper.rb
@@ -34,4 +34,17 @@ module PaperTrailHelper
   def paper_trail__service_id(value)
     ::Service.find_by(id: value)&.name
   end
+
+  def paper_trail__rdvs_users(values)
+    values.map do |value|
+      user = User.find_by(id: value["user_id"])
+      next if user.nil?
+
+      name = user.full_name
+      lifecycle = RdvsUser.human_attribute_value(:send_lifecycle_notifications, value["send_lifecycle_notifications"])
+      reminder = RdvsUser.human_attribute_value(:send_reminder_notification, value["send_reminder_notification"])
+
+      "#{name}: #{lifecycle}, #{reminder}"
+    end.compact.join("\n")
+  end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -204,7 +204,13 @@ class Rdv < ApplicationRecord
   end
 
   def virtual_attributes_for_paper_trail
-    { user_ids: users&.pluck(:id), agent_ids: agents&.pluck(:id) }
+    {
+      user_ids: users.ids,
+      agent_ids: agents.ids,
+      rdvs_users: rdvs_users.map do |rdvs_user|
+        rdvs_user.slice(:user_id, :send_lifecycle_notifications, :send_reminder_notification)
+      end
+    }
   end
 
   def associate_users_with_organisation

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -60,4 +60,4 @@
               "Voir les #{rdv_user_presenter.previous_rdvs_count} RDVs précédents…", \
               admin_organisation_rdvs_path(current_organisation, user_id: rdv_user.user.id, end: @rdv.starts_at)
 
-= render "admin/versions/resource_versions_row", resource: @rdv, attributes_allowlist: ["user_ids", "agent_ids", "status", "starts_at", "ends_at", "lieu_id", "notes", "location", "context"]
+= render "admin/versions/resource_versions_row", resource: @rdv, attributes_allowlist: ["user_ids", "agent_ids", "status", "starts_at", "ends_at", "lieu_id", "notes", "location", "context", "rdvs_users"]

--- a/app/views/admin/versions/_version.html.slim
+++ b/app/views/admin/versions/_version.html.slim
@@ -8,13 +8,13 @@
     th{rowspan: =length }= version.whodunnit
     - property, change = changes.shift
     td= version.version.item.class.human_attribute_name(property)
-    td= paper_trail_change_value(property, change.first)
-    td= paper_trail_change_value(property, change.last)
+    td= simple_format(paper_trail_change_value(property, change.first))
+    td= simple_format(paper_trail_change_value(property, change.last))
 
   - changes.to_h.each do |attribute,change|
     tr
       td
       td
       td= version.version.item.class.human_attribute_name(attribute)
-      td= paper_trail_change_value(attribute, change.first)
-      td= paper_trail_change_value(attribute, change.last)
+      td= simple_format(paper_trail_change_value(attribute, change.first))
+      td= simple_format(paper_trail_change_value(attribute, change.last))

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -17,6 +17,7 @@ fr:
         motif: Motif
         user_ids: Usagers
         users: Usagers
+        rdvs_users: Participations
         agents: Agents
         agent_ids: Agents
         location: Lieu

--- a/config/locales/models/rdvs_user.fr.yml
+++ b/config/locales/models/rdvs_user.fr.yml
@@ -9,6 +9,6 @@ fr:
       rdvs_user/send_lifecycle_notifications:
         true: Notifications de création et modification activées
         false: Notifications de création et modification désactivées
-      rdvs_user/send_reminder_notification:
+      rdvs_user/send_reminder_notifications:
         true: Notification de rappel activée
         false: Notification de rappel désactivée


### PR DESCRIPTION
fixes #1970

Je suis assez mal à l’aise avec `paper_trail_helper` (et dans une moindre mesure `PaperTrailAugmentedVersion`). Je ne suis pas certain de ce qui me dérange, j’ai l’impression que c’est un peu un hack.

Ça ressemble à ça:
![notifs-papertrail](https://user-images.githubusercontent.com/139391/148971123-14eda7e2-c825-4881-86ad-d3ca0bb46a25.png)


Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
