### PR TITLE
Remove useless scopes

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -58,11 +58,9 @@ class Rdv < ApplicationRecord
       where(status: status)
     end
   }
-  scope :with_agent, ->(agent) { joins(:agents).where(agents: { id: agent.id }) }
-  scope :with_agent_among, ->(agents) { agents.map { with_agent(_1) }.reduce(:or) }
-  scope :with_user, ->(user) { joins(:rdvs_users).where(rdvs_users: { user_id: user.id }) }
-  scope :with_user_in, ->(users) { joins(:rdvs_users).where(rdvs_users: { user_id: users.pluck(:id) }).distinct }
-  scope :with_lieu, ->(lieu) { joins(:lieu).where(lieux: { id: lieu.id }) }
+  scope :with_agent, ->(agents) { joins(:agents).where(agents: agents) }
+  scope :with_user, ->(users) { joins(:users).where(users: users).distinct }
+  scope :with_lieu, ->(lieux) { joins(:lieu).where(lieux: lieux) }
   scope :visible, -> { joins(:motif).where(motifs: { visibility_type: [Motif::VISIBLE_AND_NOTIFIED, Motif::VISIBLE_AND_NOT_NOTIFIED] }) }
 
   after_save :associate_users_with_organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,7 +147,7 @@ class User < ApplicationRecord
   end
 
   def rdvs_for_organisation(organisation)
-    Rdv.where(organisation: organisation).with_user(self)
+    rdvs.where(organisation: organisation)
   end
 
   def email_tld

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
 
   def can_be_soft_deleted_from_organisation?(organisation)
     Rdv.not_cancelled.future
-      .with_user_in(self_and_relatives)
+      .with_user(self_and_relatives)
       .where(organisation: organisation)
       .empty?
   end
@@ -147,7 +147,7 @@ class User < ApplicationRecord
   end
 
   def rdvs_for_organisation(organisation)
-    Rdv.where(organisation: organisation).with_user_in([self])
+    Rdv.where(organisation: organisation).with_user(self)
   end
 
   def email_tld

--- a/app/services/rdv_start_coherence.rb
+++ b/app/services/rdv_start_coherence.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RdvStartCoherence
-  delegate :starts_at, :duration_in_min, :agents, to: :rdv
+  delegate :starts_at, :duration_in_min, to: :rdv
   attr_reader :rdv
 
   THRESHOLD = 1.minute
@@ -33,7 +33,10 @@ class RdvStartCoherence
   end
 
   def all_rdvs_ending_before
-    return Rdv.none if starts_at.blank? || duration_in_min.blank? || agents.blank?
+    return Rdv.none if starts_at.blank? || duration_in_min.blank?
+
+    agents = rdv.agents
+    agents = agents.to_a if rdv.new_record?
 
     @all_rdvs_ending_before ||= Rdv
       .not_cancelled

--- a/app/services/rdv_start_coherence.rb
+++ b/app/services/rdv_start_coherence.rb
@@ -38,7 +38,7 @@ class RdvStartCoherence
     @all_rdvs_ending_before ||= Rdv
       .not_cancelled
       .future
-      .with_agent_among(agents)
+      .with_agent(agents)
       .where(ends_at: (starts_at - 46.minutes)..starts_at)
       .order(:ends_at)
       .to_a

--- a/app/services/rdvs_overlapping.rb
+++ b/app/services/rdvs_overlapping.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RdvsOverlapping
-  delegate :starts_at, :ends_at, :duration_in_min, :agents, to: :rdv
+  delegate :starts_at, :ends_at, :duration_in_min, to: :rdv
   attr_reader :rdv
 
   def initialize(rdv)
@@ -10,6 +10,9 @@ class RdvsOverlapping
 
   def rdvs_overlapping_rdv
     return Rdv.none if starts_at.nil? || ends_at.nil? || starts_at > ends_at
+
+    agents = rdv.agents
+    agents = agents.to_a if rdv.new_record?
 
     Rdv.where.not(id: @rdv.id)
       .not_cancelled

--- a/app/services/rdvs_overlapping.rb
+++ b/app/services/rdvs_overlapping.rb
@@ -14,7 +14,7 @@ class RdvsOverlapping
     Rdv.where.not(id: @rdv.id)
       .not_cancelled
       .future
-      .with_agent_among(agents)
+      .with_agent(agents)
       .where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", starts_at, ends_at)
       .order(:ends_at)
   end

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -30,27 +30,6 @@ describe Admin::RdvSearchForm do
   end
 
   describe "#rdvs" do
-    it "call Rdv.with_lieu with given lieu" do
-      lieu = create(:lieu)
-      agent_rdv_search_form = described_class.new(lieu_id: lieu.id)
-      expect(Rdv).to receive(:with_lieu).with(lieu)
-      agent_rdv_search_form.rdvs
-    end
-
-    it "call Rdv.with_agent with given agent" do
-      agent = create(:agent)
-      agent_rdv_search_form = described_class.new(agent_id: agent.id)
-      expect(Rdv).to receive(:with_agent).with(agent)
-      agent_rdv_search_form.rdvs
-    end
-
-    it "call Rdv.with_user with given user" do
-      user = create(:user)
-      agent_rdv_search_form = described_class.new(user_id: user.id)
-      expect(Rdv).to receive(:with_user).with(user)
-      agent_rdv_search_form.rdvs
-    end
-
     it "return rdvs that starts_at is in window" do
       now = Time.zone.parse("20/07/2019 15:00")
       travel_to(now)


### PR DESCRIPTION
Encore du nettoyage, mais sujet à débat. En gros, la plupart de ces scopes (il y en a d’autres un peu partout, par exemple `User#within_organisation`) peuvent être remplacés par un `join/where` ou un `merge` à l’appel. Je pense qu’ils n’apportent pas grand chose, sinon du bruit et des bugs.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
