### PR TITLE
feat(geosearch): Retrieve most relevant organisations

### DIFF
--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -3,18 +3,18 @@
 class Api::V1::OrganisationsController < Api::V1::BaseController
   def index
     organisations = policy_scope(Organisation)
-    organisations = organisations.merge(organisations_attributed_to_sector) if geo_params?
+    organisations = organisations.where(id: organisations_relevant_to_sector.pluck(:id)) if geo_params?
     render_collection(organisations.order(:id))
   end
 
   private
 
-  def organisations_attributed_to_sector
+  def organisations_relevant_to_sector
     Users::GeoSearch.new(
       departement: params[:departement_number],
       city_code: params[:city_code],
       street_ban_id: params[:street_ban_id]
-    ).attributed_organisations
+    ).most_relevant_organisations
   end
 
   def geo_params?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -41,14 +41,14 @@ class Organisation < ApplicationRecord
   accepts_nested_attributes_for :agent_roles
   accepts_nested_attributes_for :territory
 
-  scope :attributed_to_sectors, lambda { |sectors, most_pertinent = false|
+  scope :attributed_to_sectors, lambda { |sectors:, most_relevant: false|
     attributions = SectorAttribution
       .level_organisation
       .where(sector_id: sectors.pluck(:id))
 
-    # if most pertinent we take the attributions from the sectors with the least
+    # if most relevant we take the attributions from the sector with the least
     # attributed organisations
-    if most_pertinent
+    if most_relevant
       attributions = attributions
         .group_by(&:sector_id)
         .min_by(1) { |_sector_id, attrs| attrs.length }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -41,24 +41,21 @@ class Organisation < ApplicationRecord
   accepts_nested_attributes_for :agent_roles
   accepts_nested_attributes_for :territory
 
-  scope :attributed_to_sectors, lambda { |sectors|
-    where(
-      id: SectorAttribution
-        .level_organisation
-        .where(sector_id: sectors.pluck(:id))
-        .select(:organisation_id)
-    )
-  }
-  scope :most_relevant_to_sectors, lambda { |sectors|
-    where(
-      id: SectorAttribution
-            .level_organisation
-            .where(sector_id: sectors.pluck(:id))
-            .group_by(&:sector_id)
-            .min_by(1) { |_sector_id, attributions| attributions.length }
-            .flat_map(&:last)
-            .pluck(:organisation_id)
-    )
+  scope :attributed_to_sectors, lambda { |sectors, most_pertinent = false|
+    attributions = SectorAttribution
+      .level_organisation
+      .where(sector_id: sectors.pluck(:id))
+
+    # if most pertinent we take the attributions from the sectors with the least
+    # attributed organisations
+    if most_pertinent
+      attributions = attributions
+        .group_by(&:sector_id)
+        .min_by(1) { |_sector_id, attrs| attrs.length }
+        .flat_map(&:last)
+    end
+
+    where(id: attributions.pluck(:organisation_id))
   }
   scope :order_by_name, -> { order(Arel.sql("LOWER(name)")) }
   scope :contactable, lambda {

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -49,6 +49,17 @@ class Organisation < ApplicationRecord
         .select(:organisation_id)
     )
   }
+  scope :most_relevant_to_sectors, lambda { |sectors|
+    where(
+      id: SectorAttribution
+            .level_organisation
+            .where(sector_id: sectors.pluck(:id))
+            .group_by(&:sector_id)
+            .min_by(1) { |_sector_id, attributions| attributions.length }
+            .flat_map(&:last)
+            .pluck(:organisation_id)
+    )
+  }
   scope :order_by_name, -> { order(Arel.sql("LOWER(name)")) }
   scope :contactable, lambda {
     where.not(phone_number: ["", nil])

--- a/app/services/users/geo_search.rb
+++ b/app/services/users/geo_search.rb
@@ -15,6 +15,10 @@ class Users::GeoSearch
     @departement_organisations ||= Organisation.joins(:territory).where(territories: { departement_number: @departement })
   end
 
+  def most_relevant_organisations
+    @most_relevant_organisations ||= Organisation.most_relevant_to_sectors(matching_sectors)
+  end
+
   def attributed_agents_by_organisation
     @attributed_agents_by_organisation ||= matching_sectors
       .map { |sector| sector.attributions.level_agent.includes(:agent).to_a }

--- a/app/services/users/geo_search.rb
+++ b/app/services/users/geo_search.rb
@@ -16,7 +16,7 @@ class Users::GeoSearch
   end
 
   def most_relevant_organisations
-    @most_relevant_organisations ||= Organisation.most_relevant_to_sectors(matching_sectors)
+    @most_relevant_organisations ||= Organisation.attributed_to_sectors(matching_sectors, true)
   end
 
   def attributed_agents_by_organisation

--- a/app/services/users/geo_search.rb
+++ b/app/services/users/geo_search.rb
@@ -8,7 +8,7 @@ class Users::GeoSearch
   end
 
   def attributed_organisations
-    @attributed_organisations ||= Organisation.attributed_to_sectors(matching_sectors)
+    @attributed_organisations ||= Organisation.attributed_to_sectors(sectors: matching_sectors)
   end
 
   def departement_organisations
@@ -16,7 +16,7 @@ class Users::GeoSearch
   end
 
   def most_relevant_organisations
-    @most_relevant_organisations ||= Organisation.attributed_to_sectors(matching_sectors, true)
+    @most_relevant_organisations ||= Organisation.attributed_to_sectors(sectors: matching_sectors, most_relevant: true)
   end
 
   def attributed_agents_by_organisation

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -44,7 +44,7 @@ describe "api/v1/organisations requests", type: :request do
       let(:departement_number) { "26" }
       let!(:city_code) { "26323" }
       let(:geo_search) do
-        instance_double(Users::GeoSearch, attributed_organisations: Organisation.where(id: organisation2.id))
+        instance_double(Users::GeoSearch, most_relevant_organisations: Organisation.where(id: organisation2.id))
       end
 
       before do

--- a/spec/services/users/geo_search_spec.rb
+++ b/spec/services/users/geo_search_spec.rb
@@ -124,6 +124,45 @@ describe Users::GeoSearch, type: :service_model do
     end
   end
 
+  describe "#most_relevant_organisations" do
+    subject { described_class.new(departement: "64", city_code: "64110").most_relevant_organisations }
+
+    let!(:territory64) { create(:territory, departement_number: "64") }
+
+    context "no matching sectors" do
+      it { is_expected.to be_empty }
+    end
+
+    context "one sector attributed to multiple organisations" do
+      let!(:sector_pau) { create(:sector, territory: territory64, name: "Secteur entier Pau agglo") }
+      let!(:organisation1) { create(:organisation, territory: territory64, name: "Pau 1: Site de Jurancon") }
+      let!(:organisation2) { create(:organisation, territory: territory64, name: "Pau 2: Site de Bonnard") }
+      let!(:zone_jurancon_pau_agglo) { create(:zone, level: "city", city_code: "64110", city_name: "Jurancon", sector: sector_pau) }
+      let!(:attribution_organisation_pau1) { SectorAttribution.create(level: "organisation", sector: sector_pau, organisation: organisation1) }
+      let!(:attribution_organisation_pau2) { SectorAttribution.create(level: "organisation", sector: sector_pau, organisation: organisation2) }
+
+      it { is_expected.to contain_exactly(organisation1, organisation2) }
+    end
+
+    context "multiple sectors attributed to multiple organisations" do
+      let!(:sector_pau) { create(:sector, territory: territory64, name: "Secteur entier Pau agglo") }
+      let!(:organisation1) { create(:organisation, territory: territory64, name: "Pau 1: Site de Jurancon") }
+      let!(:organisation2) { create(:organisation, territory: territory64, name: "Pau 2: Site de Bonnard") }
+      let!(:zone_jurancon_pau_agglo) { create(:zone, level: "city", city_code: "64110", city_name: "Jurancon", sector: sector_pau) }
+      let!(:attribution_organisation_pau1) { SectorAttribution.create(level: "organisation", sector: sector_pau, organisation: organisation1) }
+      let!(:attribution_organisation_pau2) { SectorAttribution.create(level: "organisation", sector: sector_pau, organisation: organisation2) }
+      let!(:sector_jurancon) { create(:sector, territory: territory64, name: "Secteur Jurancon") }
+      let!(:zone_jurancon) { create(:zone, level: "city", city_code: "64110", city_name: "Jurancon", sector: sector_jurancon) }
+      let!(:attribution_organisation_jurancon) { SectorAttribution.create(level: "organisation", sector: sector_jurancon, organisation: organisation1) }
+      let!(:agent1) { create(:agent, basic_role_in_organisations: [organisation1]) }
+      let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation1]) }
+      let!(:attribution_agent_jurancon1) { SectorAttribution.create(level: "agent", sector: sector_jurancon, organisation: organisation1, agent: agent1) }
+      let!(:attribution_agent_jurancon2) { SectorAttribution.create(level: "agent", sector: sector_jurancon, organisation: organisation1, agent: agent2) }
+
+      it { is_expected.to contain_exactly(organisation1) }
+    end
+  end
+
   describe "#attributed_agents_by_organisation" do
     subject { described_class.new(departement: "62", city_code: "62100").attributed_agents_by_organisation }
 


### PR DESCRIPTION
## Contexte

Lorsque l'on passe une adresse (département, ville et/ou rue) au service `GeoSearch`, on pouvait jusqu'à présent récupérer [les organisations attribués aux secteurs](https://github.com/betagouv/rdv-solidarites.fr/blob/0c2de800b23162f4149677eaa82c51ebcb130a10/app/services/users/geo_search.rb#L10) qui comprennent la zone de l'adresse. 
Cependant on récupère toutes les organisations attribués à tous les secteurs qui comprennent cette zone, sans distinction de pertinence sur ces organisations.  Cette PR ajoute cette distinction.

(NB: cette feature n'est pas en lien avec [les nouveaux problèmes rencontrés par le 64 sur la sectorisation](https://mattermost.incubateur.net/betagouv/pl/igicn7zn57n58jn7ifrqo6mgbh))

## Exemple concret

Un exemple concret est plus parlant, ici nous prenons le cas du 64 (ce cas est repris dans les tests implémentés):

Disons qu'un usager habite à Jurançon (petite ville à côté de Pau). Jurançon fait partie du secteur "Secteur entier de Pau agglo" qui regroupe Pau et son agglomération. Les 6 organisations de Pau Agglo sont attribués à ce secteur (pour qu'un usager qui habite à Pau et ses alentours ait le choix entre les 6 orgas pour ses rdvs).
Or il existe également un secteur "secteur PAU Agglo JURANCON" qui ne comprend que Jurançon et les communes limitrophe. Attribuons l'organisation "SDSEI Pau Agglo Jurancon" à ce secteur.

Si nous récupérons les organisations attribués aux secteurs qui matchent, on récupère les 6 organisations de Pau agglo (car le secteur "Secteur entier de Pau agglo" est un des secteurs qui comprend la commune de Jurançon). 
Dans cette PR, j'apporte la possibilité de récupérer également les organisations les plus pertinentes sur ces secteurs, **soit les organisations du secteur qui a le moins d'organisations attribuées**. Dans notre exemple, on récupèrera donc l'organisation "SDSEI Pau agglo Jurançon".

## Utilisation

Nous utiliserons cette distinction pour attribuer à chaque allocataire l'organisation la plus pertinente en fonction de son adresse au moment de la création de sa fiche depuis RDV-Insertion.
