### PR TITLE
:rocket: Inclut la fin de récurrence

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -27,7 +27,7 @@ class Absence < ApplicationRecord
     return all if range.nil?
 
     not_recurring_start_in_range = where(recurrence: nil).where("first_day <= ?", range.end).where("end_day >= ?", range.begin)
-    recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+    recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[]') && tsrange(?, ?)", range.begin, range.end)
 
     not_recurring_start_in_range.or(recurring_in_range)
   }

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -25,7 +25,7 @@ class PlageOuverture < ApplicationRecord
     return all if range.nil?
 
     not_recurring_start_in_range = where(recurrence: nil).where(first_day: range)
-    recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+    recurring_in_range = where.not(recurrence: nil).where("tsrange(first_day, recurrence_ends_at, '[]') && tsrange(?, ?)", range.begin, range.end)
 
     not_recurring_start_in_range.or(recurring_in_range)
   }

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -136,6 +136,13 @@ describe RecurrenceConcern do
               expect(element_class.in_range(range)).to eq([object])
             end
 
+            it "returns element when first day of range at the until day" do
+              range = Time.zone.parse("2021-10-25 0:00")..Time.zone.parse("2021-10-29 23:59:59.99")
+              first_day = monday - 14.days
+              object = create(element, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin.to_date))
+              expect(element_class.in_range(range)).to eq([object])
+            end
+
             it "dont returns #{element} when end before range" do
               first_day = range.begin - 2.months
               create(element, first_day: first_day,


### PR DESCRIPTION
Close https://sentry.io/organizations/rdv-solidarites/issues/2872600804/?project=1811205&query=is%3Aunresolved

Il y avait un fonctionnement en erreur : 
- affichage d'un créneau disponible dans plusieurs mois
- erreur 500 en cliquant dessus

![Screenshot 2022-01-18 at 16-47-39 RDV Solidarités](https://user-images.githubusercontent.com/42057/149970652-4978d62e-ee98-463e-bb87-6ac8ebb898b4.png)

![Screenshot 2022-01-18 at 16-47-57 RDV Solidarités 500 - Page non trouvée](https://user-images.githubusercontent.com/42057/149970675-3a9ee355-5bc5-4442-a5a5-91538a02ff99.png)


Lorsque l'on cherche un créneau avec comme date de début de _range_ la date de fin d'une récurrence sur une plage d'ouverture, cette plage n'est pas prise en compte.

Cette PR inclue la plage pour le calcul de créneau.

Directement en production, car ça crée des difficultés pour certains agents pour la prise de RDV.

Nous aurions sans doute gagné à mieux lire [la doc sur la gestion des bordures dans les requêtes de TSRange](https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO)


Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
