### PR TITLE
search territory agents without duplicate

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -7,7 +7,7 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
   end
 
   def search
-    agents = policy_scope_admin(Agent)
+    agents = policy_scope_admin(Agent).distinct
       .joins(:organisations).where(organisations: { id: current_territory.organisations.map(&:id) })
       .active.complete.limit(10)
     @agents = search_params[:term].present? ? agents.search_by_text(search_params[:term]) : agents.order_by_last_name

--- a/spec/controllers/admin/territories/agents_controller_spec.rb
+++ b/spec/controllers/admin/territories/agents_controller_spec.rb
@@ -68,5 +68,12 @@ RSpec.describe Admin::Territories::AgentsController, type: :controller do
       get :search, params: { territory_id: territory.id, term: "bla", format: "json" }
       expect(assigns(:agents)).to eq([agent])
     end
+
+    it "assigns agents without duplicate" do
+      agent = create(:agent, admin_role_in_organisations: [organisation, create(:organisation, territory: territory)], role_in_territories: [territory], last_name: "Bladubar")
+      sign_in agent
+      get :search, params: { territory_id: territory.id, term: "bla", format: "json" }
+      expect(assigns(:agents)).to eq([agent])
+    end
   end
 end


### PR DESCRIPTION
Corrige un des retours du 18 janvier à propos de doublon dans la liste des agents sur le formulaire de création d'équipe.

https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-referent/reunions-referentes/reunion-referentes-du-18-janvier-2022#en-production-jeudi-20


Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
