### PR TITLE
combine agents et équipes pour la recherche

### DIFF
--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -3,7 +3,7 @@
 class AgentCreneauxSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :service_id, :motif_id, :team_ids, :user_ids, :lieu_ids, :context
+  attr_accessor :organisation_id, :service_id, :motif_id, :agent_ids, :team_ids, :user_ids, :lieu_ids, :context
   attr_writer :from_date
 
   validates :organisation_id, :motif_id, presence: true

--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -3,8 +3,8 @@
 class AgentCreneauxSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :service_id, :motif_id, :agent_ids, :team_ids, :user_ids, :lieu_ids, :context
-  attr_writer :from_date
+  attr_accessor :organisation_id, :service_id, :motif_id, :team_ids, :user_ids, :lieu_ids, :context
+  attr_writer :from_date, :agent_ids
 
   validates :organisation_id, :motif_id, presence: true
 

--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -3,7 +3,7 @@
 class AgentCreneauxSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :service_id, :motif_id, :agent_ids, :team_ids, :user_ids, :lieu_ids, :context
+  attr_accessor :organisation_id, :service_id, :motif_id, :team_ids, :user_ids, :lieu_ids, :context
   attr_writer :from_date
 
   validates :organisation_id, :motif_id, presence: true
@@ -26,6 +26,15 @@ class AgentCreneauxSearchForm
 
   def teams
     organisation.territory.teams.where(id: team_ids)
+  end
+
+  def agent_ids
+    id_list = @agent_ids || []
+    if @team_ids
+      teams = @team_ids.map { |d| Team.find(d) }
+      id_list += teams.flat_map(&:agents).map(&:id)
+    end
+    id_list
   end
 
   def date_range

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2022_01_18_161355) do
-=======
-ActiveRecord::Schema.define(version: 2022_01_10_132442) do
->>>>>>> 3dc83895 (update schema)
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2022_01_18_161355) do
+=======
+ActiveRecord::Schema.define(version: 2022_01_10_132442) do
+>>>>>>> 3dc83895 (update schema)
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/form_models/agent_creneaux_search_form_spec.rb
+++ b/spec/form_models/agent_creneaux_search_form_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe AgentCreneauxSearchForm, type: :form do
+  describe "#agent_ids" do
+    it "return empty array without agent or teams" do
+      form = described_class.new
+      expect(form.agent_ids).to be_empty
+    end
+
+    it "return [1] with one agent given" do
+      agent = create(:agent)
+      form = described_class.new(agent_ids: [agent.id])
+      expect(form.agent_ids).to contain_exactly(agent.id)
+    end
+
+    it "return [1, 2] with team given" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      other_agent = create(:agent, basic_role_in_organisations: [organisation])
+      team = create(:team, agents: [agent, other_agent])
+      form = described_class.new(team_ids: [team.id])
+      expect(form.agent_ids).to contain_exactly(agent.id, other_agent.id)
+    end
+
+    it "return [1, 2, 3] with team and agent given" do
+      organisation = create(:organisation)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      other_agent = create(:agent, basic_role_in_organisations: [organisation])
+      agent_alone = create(:agent, basic_role_in_organisations: [organisation])
+      team = create(:team, agents: [agent, other_agent])
+      form = described_class.new(team_ids: [team.id], agent_ids: [agent_alone.id])
+      expect(form.agent_ids).to contain_exactly(agent.id, other_agent.id, agent_alone.id)
+    end
+  end
+end


### PR DESCRIPTION
Corrige un des retours du 18 janvier à propos de la recherche de créneau en combinant les agents et les équipes dans les filtres


https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-referent/reunions-referentes/reunion-referentes-du-18-janvier-2022#en-production-jeudi-20

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
