### PR TITLE
refactor(invitations): Update search context logic

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,8 @@ class SearchController < ApplicationController
   def search_params
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
-      :organisation_id, :service_id, :motif_id, :lieu_id, :date, :invitation_token
+      :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type,
+      :invitation_token, organisation_ids: []
     )
   end
 end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class SearchContext
-  attr_reader :errors, :query, :departement, :address, :city_code, :street_ban_id, :latitude, :longitude
+  attr_reader :errors, :query, :departement, :address, :city_code, :street_ban_id, :latitude, :longitude,
+              :motif_name_with_location_type
 
   def initialize(current_user, query = {})
     @current_user = current_user
@@ -13,9 +14,10 @@ class SearchContext
     @city_code = query[:city_code]
     @departement = query[:departement]
     @street_ban_id = query[:street_ban_id]
-    @organisation_id = query[:organisation_id]
+    @organisation_ids = query[:organisation_ids]
+    @motif_search_terms = query[:motif_search_terms]
+    @motif_name_with_location_type = query[:motif_name_with_location_type]
     @service_id = query[:service_id]
-    @motif_id = query[:motif_id]
     @lieu_id = query[:lieu_id]
     @start_date = query[:date]
     @errors = []
@@ -24,9 +26,10 @@ class SearchContext
   # *** Method that outputs the next step for the user to complete its rdv journey ***
   # *** It is used in #to_partial_parth to render the matching partial view ***
   def current_step
+    # byebug
     if address.blank?
       :address_selection
-    elsif motif.nil?
+    elsif !motif_selected?
       :motif_selection
     elsif lieu.nil?
       :lieu_selection
@@ -52,19 +55,19 @@ class SearchContext
   end
 
   def unique_motifs_by_name_and_location_type
-    @unique_motifs_by_name_and_location_type ||= available_motifs.uniq { [_1.name, _1.location_type] }
+    @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq { [_1.name, _1.location_type] }
   end
 
-  def organisation
-    @organisation ||= @organisation_id.blank? ? nil : Organisation.find(@organisation_id)
+  def selected_motif_name
+    motif_selected? ? unique_motifs_by_name_and_location_type.first.name : nil
+  end
+
+  def motif_selected?
+    unique_motifs_by_name_and_location_type.length == 1
   end
 
   def service
     @service ||= @service_id.blank? ? nil : Service.find(@service_id)
-  end
-
-  def motif
-    @motif ||= @motif_id.blank? ? nil : Motif.find(@motif_id)
   end
 
   def lieu
@@ -73,12 +76,10 @@ class SearchContext
 
   def lieux
     @lieux ||= \
-      if motif.nil?
-        Lieu.none
-      else
-        Lieu.for_motif(motif).includes(:organisation)
-          .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
-      end
+      Lieu
+        .with_open_slots_for_motifs(@matching_motifs)
+        .includes(:organisation)
+        .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
   end
 
   def next_availability_by_lieux
@@ -98,6 +99,10 @@ class SearchContext
     start_date..(start_date + 6.days)
   end
 
+  def max_booking_delay
+    matching_motifs.maximum("max_booking_delay")
+  end
+
   def creneaux
     @creneaux ||= creneaux_search.creneaux
   end
@@ -114,12 +119,24 @@ class SearchContext
 
   def creneaux_search_for(lieu, date_range)
     Users::CreneauxSearch.new(
-      user: @current_user,
-      motif: motif,
+      user: @current_user || invited_user,
+      motif: matching_motifs.where(organisation: lieu.organisation).first,
       lieu: lieu,
       date_range: date_range,
       geo_search: geo_search
     )
+  end
+
+  def matching_motifs
+    @matching_motifs ||= begin
+      motifs = if @motif_name_with_location_type.present?
+                 available_motifs.search_by_name_with_location_type(@motif_name_with_location_type)
+               else
+                 available_motifs
+               end
+      motifs = motifs.where(organisation: lieu.organisation) if lieu.present?
+      motifs
+    end
   end
 
   def available_motifs
@@ -127,8 +144,21 @@ class SearchContext
   end
 
   def available_motifs_for_invitation
-    geo_search.available_motifs.where(organisation: organisation, service: service).presence ||
-      Motif.available_with_plages_ouvertures.where(organisation: organisation, service: service)
+    # we retrieve the geolocalised available motifs, if there are none we fallback
+    # on the availabe motifs for the organisations passed in the query
+    invitation_geo_search_motifs.presence || invitation_organisations_motifs
+  end
+
+  def invitation_geo_search_motifs
+    motifs = geo_search.available_motifs
+    motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
+    motifs
+  end
+
+  def invitation_organisations_motifs
+    motifs = Motif.available_with_plages_ouvertures.where(organisation_id: @organisation_ids)
+    motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
+    motifs
   end
 
   def invited_user
@@ -139,7 +169,7 @@ class SearchContext
   end
 
   def invitation_valid?
-    token_valid? && current_user_is_invited_user? && user_belongs_to_current_organsation?
+    token_valid? && current_user_is_invited_user?
   end
 
   def token_valid?
@@ -154,13 +184,6 @@ class SearchContext
     return true if @current_user == invited_user
 
     @errors << I18n.t("devise.invitations.current_user_mismatch")
-    false
-  end
-
-  def user_belongs_to_current_organsation?
-    return true if invited_user.organisation_ids.include?(organisation.id)
-
-    @errors << I18n.t("devise.invitations.organisation_mismatch")
     false
   end
 end

--- a/app/views/search/_banner.html.slim
+++ b/app/views/search/_banner.html.slim
@@ -13,7 +13,5 @@ section#hero.hero.hero-home.py-2
           - if context.departement.present?
             | le &nbsp;
             span.text-secondary #{context.departement}
-      - if context.motif.present?
-        h3.text-white.mb-4 #{context.motif.name}
-      - elsif context.service.present?
-        h3.text-white.mb-4 en #{context.service.name}
+      - if context.selected_motif_name.present?
+        h3.text-white.mb-4 #{context.selected_motif_name}

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -4,7 +4,7 @@ section.bg-light.p-4
       .card-body
         h5.card-title= context.lieu.name
         h6.card-subtitle.mb-3= context.lieu.address
-        - if context.motif.present?
-          = render "creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_booking_delay: context.motif.max_booking_delay, city_code: context.city_code, motif: context.motif, service: context.service, organisation: context.organisation, next_availability: context.next_availability, query: context.query
+        - if context.unique_motifs_by_name_and_location_type.present?
+          = render "creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_booking_delay: context.max_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query: context.query
         - else
-          .alert.alert-warning= "Le motif <b>#{context.motif.name_with_location_type}</b> n'est plus disponible à la réservation à <b>#{context.lieu.name}</b>".html_safe
+          .alert.alert-warning= "Le motif <b>#{context.selected_motif_name}</b> n'est plus disponible à la réservation à <b>#{context.lieu.name}</b>".html_safe

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -22,7 +22,7 @@ div id="creneaux-lieu-#{lieu.id}"
               - creneaux_for_date.each do |date, creneaux|
                 - creneaux.sort_by(&:starts_at).each do |creneau|
                   - if creneau.motif.restriction_for_rdv.blank?
-                    = link_to new_users_rdv_wizard_step_path(query.merge(starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100" do
+                    = link_to new_users_rdv_wizard_step_path(query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100" do
                       = l(creneau.starts_at, format: "%H:%M")
                       - if creneau.motif.follow_up?
                         br
@@ -34,8 +34,8 @@ div id="creneaux-lieu-#{lieu.id}"
                         br
                         small= creneau.agent.short_name
 
-                    =  render "/common/modal", id: "js-rdv-restriction-motif#{creneau.starts_at.to_i}" , title: "À lire avant de prendre un rendez-vous", confirm_path: new_users_rdv_wizard_step_path(query.merge(starts_at: creneau.starts_at)) do
-                      = ActionController::Base.helpers.auto_link(simple_format(motif.restriction_for_rdv), html: { target: "_blank"})
+                    =  render "/common/modal", id: "js-rdv-restriction-motif#{creneau.starts_at.to_i}" , title: "À lire avant de prendre un rendez-vous", confirm_path: new_users_rdv_wizard_step_path(query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)) do
+                      = ActionController::Base.helpers.auto_link(simple_format(creneau.motif.restriction_for_rdv), html: { target: "_blank"})
             - elsif date >= (Time.now + max_booking_delay.seconds).to_date
               p.text-center.text-muted
                 | Date fermée à la reservation

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -9,7 +9,7 @@ section.bg-light.p-4
           .row
             .col-md
               h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-              h6.card-subtitle.text-black-50.mb-2= context.motif.service.name
+              h6.card-subtitle.text-black-50.mb-2= context.unique_motifs_by_name_and_location_type.first.service.name
               h6.card-subtitle.text-black-50= lieu.address
             .col-md.align-self-center.pt-3.pt-md-0.position-static
               - if next_availability

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -17,7 +17,7 @@ section.bg-light.p-4
       h4.font-weight-bold Sélectionnez le motif de votre RDV:
       - context.unique_motifs_by_name_and_location_type.each do |motif|
         .card.mb-3
-          = link_to prendre_rdv_path(context.query.merge(motif_id: motif.id))
+          = link_to prendre_rdv_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))
             .card-body
               .row
                 .col-md

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -13,87 +13,26 @@ describe "User can be invited" do
     user.raw_invitation_token
   end
   let!(:agent) { create(:agent) }
-  let!(:territory26) { create(:territory, departement_number: "26") }
+  let!(:departement_number) { "26" }
+  let!(:city_code) { "26000" }
+  let!(:territory26) { create(:territory, departement_number: departement_number) }
   let!(:organisation) { create(:organisation, territory: territory26) }
-  let!(:service) { create(:service) }
-  let!(:motif) { create(:motif, service: service, name: "RDV RSA sur site", reservable_online: true, organisation: organisation) }
+  let!(:motif) { create(:motif, name: "RSA orientation sur site", reservable_online: true, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
 
-  before do
-    travel_to(now)
-  end
-
-  describe "invitaton to lieu selection old path" do
-    before do
-      visit lieux_path(
-        search: {
-          departement: "26", where: "Drôme, Auvergne-Rhône-Alpes",
-          service: service.id,
-          motif_name_with_location_type: motif.name_with_location_type
-        },
-        invitation_token: invitation_token
-      )
-    end
-
-    it "default", js: true do
-      # Step 4
-      expect(page).to have_content(lieu.name)
-
-      # Step 5
-      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
-      expect(page).to have_content(lieu.name)
-      first(:link, "11:00").click
-
-      # Restriction Page
-      expect(page).to have_content("À lire avant de prendre un rendez-vous")
-      expect(page).to have_content(motif.restriction_for_rdv)
-      click_link("Accepter")
-
-      # Invitation page
-      expect(page).to have_content("Inscription")
-      expect(page).to have_field("Prénom", with: user.first_name)
-      expect(page).to have_field("Nom d’usage", with: user.last_name)
-      expect(page).to have_field("Email", disabled: true, with: user.email)
-      expect(page).to have_field("Téléphone", with: user.phone_number)
-
-      fill_in(:password, with: "12345678")
-      click_button("Enregistrer")
-
-      # Redirects to rdv informations
-      expect(page).to have_content("Votre mot de passe a correctement été enregistré. Vous êtes maintenant connecté.")
-      expect(page).to have_content("Vos informations")
-      expect(page).to have_field("Date de naissance", with: "20/12/1988")
-      expect(page).to have_field("Adresse", with: user.address)
-      click_button("Continuer")
-
-      # Choix de l'usager
-      expect(page).to have_content("Choix de l'usager")
-      expect(page).to have_content(user.full_name)
-      click_button("Continuer")
-
-      # Confirmation
-      expect(page).to have_content("Informations de contact")
-      expect(page).to have_content("johndoe@gmail.com")
-      expect(page).to have_content("0682605955")
-      click_link("Confirmer mon RDV")
-
-      # RDV page
-      expect(page).to have_content("Vos rendez-vous")
-      expect(page).to have_content(motif.name)
-      expect(page).to have_content(lieu.address)
-      expect(page).to have_content("11h00")
-    end
-  end
+  let!(:organisation2) { create(:organisation) }
 
   describe "invitation to lieu selection new path" do
+    let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id])) }
+
     before do
+      travel_to(now)
+      allow(Users::GeoSearch).to receive(:new).and_return(geo_search)
+
       visit prendre_rdv_path(
-        departement: "26", address: "Drôme, Auvergne-Rhône-Alpes",
-        organisation_id: organisation.id,
-        service_id: motif.service_id,
-        motif_id: motif.id,
-        invitation_token: invitation_token
+        departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+        address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
       )
     end
 
@@ -148,18 +87,95 @@ describe "User can be invited" do
   end
 
   describe "invitation to motifs selection" do
+    let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
+    let!(:motif2) { create(:motif, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
+
     before do
+      travel_to(now)
+      allow(Users::GeoSearch).to receive(:new).and_return(geo_search)
+
       visit prendre_rdv_path(
-        departement: "26", address: "Drôme, Auvergne-Rhône-Alpes",
-        organisation_id: organisation.id,
-        service_id: motif.service_id,
-        invitation_token: invitation_token
+        departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+        address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
       )
     end
 
     it "default", js: true do
       # Step 3
       expect(page).to have_content(motif.name)
+      expect(page).to have_content(motif2.name)
+      find(".card-title", text: /#{motif.name}/).click
+
+      # Step 4
+      expect(page).to have_content(lieu.name)
+      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
+
+      # Step 5
+      expect(page).to have_content(lieu.name)
+      first(:link, "11:00").click
+
+      # Restriction Page
+      expect(page).to have_content("À lire avant de prendre un rendez-vous")
+      expect(page).to have_content(motif.restriction_for_rdv)
+      click_link("Accepter")
+
+      # Invitation page
+      expect(page).to have_content("Inscription")
+      expect(page).to have_field("Prénom", with: user.first_name)
+      expect(page).to have_field("Nom d’usage", with: user.last_name)
+      expect(page).to have_field("Email", disabled: true, with: user.email)
+      expect(page).to have_field("Téléphone", with: user.phone_number)
+
+      fill_in(:password, with: "12345678")
+      click_button("Enregistrer")
+
+      # Redirects to rdv informations
+      expect(page).to have_content("Votre mot de passe a correctement été enregistré. Vous êtes maintenant connecté.")
+      expect(page).to have_content("Vos informations")
+      expect(page).to have_field("Date de naissance", with: "20/12/1988")
+      expect(page).to have_field("Adresse", with: user.address)
+      click_button("Continuer")
+
+      # Choix de l'usager
+      expect(page).to have_content("Choix de l'usager")
+      expect(page).to have_content(user.full_name)
+      click_button("Continuer")
+
+      # Confirmation
+      expect(page).to have_content("Informations de contact")
+      expect(page).to have_content("johndoe@gmail.com")
+      expect(page).to have_content("0682605955")
+      click_link("Confirmer mon RDV")
+
+      # RDV page
+      expect(page).to have_content("Vos rendez-vous")
+      expect(page).to have_content(motif.name)
+      expect(page).to have_content(lieu.address)
+      expect(page).to have_content("11h00")
+    end
+  end
+
+  describe "when no motifs found through geo search" do
+    let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.none) }
+    let!(:motif2) { create(:motif, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
+
+    before do
+      travel_to(now)
+      allow(Users::GeoSearch).to receive(:new).and_return(geo_search)
+
+      visit prendre_rdv_path(
+        departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+        address: "16 rue de la résistance", motif_search_terms: "RSA orientation",
+        organisation_ids: [organisation.id, organisation2.id]
+      )
+    end
+
+    it "default", js: true do
+      # Step 3
+      expect(page).to have_content(motif.name)
+      expect(page).to have_content(motif2.name)
       find(".card-title", text: /#{motif.name}/).click
 
       # Step 4

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -10,7 +10,8 @@ describe SearchContext, type: :service do
   end
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
-  let!(:motif) { create(:motif, organisation: organisation, service: service) }
+  let!(:motif) { create(:motif, name: "RSA orientation sur site", organisation: organisation) }
+  let!(:motif2) { create(:motif, name: "RSA orientation téléphonique", organisation: organisation) }
   let!(:departement_number) { "75" }
   let!(:address) { "20 avenue de Ségur 75007 Paris" }
   let!(:city_code) { "75007" }
@@ -18,7 +19,7 @@ describe SearchContext, type: :service do
   let!(:longitude) { "55.5" }
   let!(:search_query) do
     {
-      organisation_id: organisation.id, service_id: service.id, departement: departement_number, city_code: city_code,
+      organisation_ids: [organisation.id], departement: departement_number, city_code: city_code,
       latitude: latitude, longitude: longitude
     }
   end
@@ -40,8 +41,9 @@ describe SearchContext, type: :service do
       end
     end
 
-    context "with an address but no motif" do
-      let!(:search_query) { { address: address } }
+    context "with an address but several motifs available" do
+      let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
+      let!(:search_query) { { address: address, departement: departement_number, city_code: city_code } }
 
       it "current step is motif selection" do
         expect(subject.current_step).to eq(:motif_selection)
@@ -49,7 +51,7 @@ describe SearchContext, type: :service do
     end
 
     context "with a motif and an address" do
-      let!(:search_query) { { address: address, motif_id: motif.id } }
+      let!(:search_query) { { address: address, departement: departement_number, city_code: city_code } }
 
       it "current step is lieu selection" do
         expect(subject.current_step).to eq(:lieu_selection)
@@ -93,15 +95,6 @@ describe SearchContext, type: :service do
           expect(subject.errors).to eq(["L’utilisateur connecté ne correspond pas à l’utilisateur invité. Déconnectez-vous et réessayez."])
         end
       end
-
-      context "when invited user does not belong to the organisation" do
-        let!(:user) { create(:user, organisations: []) }
-
-        it "is not valid" do
-          expect(subject.valid?).to eq(false)
-          expect(subject.errors).to eq(["L’utilisateur concerné n’appartient pas à cette organisation."])
-        end
-      end
     end
   end
 
@@ -111,9 +104,10 @@ describe SearchContext, type: :service do
     end
 
     context "for an invitation" do
-      let!(:motif_list) { double }
-
-      before { search_query[:invitation_token] = invitation_token }
+      before do
+        search_query[:invitation_token] = invitation_token
+        search_query[:motif_search_terms] = "RSA orientation"
+      end
 
       context "when there are geo search available motifs for the org and service" do
         it "is the geo available_motifs" do
@@ -122,16 +116,15 @@ describe SearchContext, type: :service do
       end
 
       context "when there are no geo search available motifs" do
-        let!(:some_motif) { create(:motif, organisation: organisation, service: service) }
         let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.none) }
 
         before do
           allow(Motif).to receive(:available_with_plages_ouvertures)
-            .and_return(Motif.where(id: some_motif.id))
+            .and_return(Motif.where(id: motif2.id))
         end
 
         it "is the organisation available motif" do
-          expect(subject.send(:available_motifs)).to eq([some_motif])
+          expect(subject.send(:available_motifs)).to eq([motif2])
         end
       end
     end


### PR DESCRIPTION
Dans cette PR je change le fonctionnement du `SearchContext` pour me rapprocher de ce qui se fait actuellement sur la search "native" de RDV-Solidarités.

Lorsqu'on est invité, on récupère les motifs disponibles pour les coordonnées géographiques présentes dans l'url (lorsque celles-ci sont présentes). Lorsqu'aucun motif n'est disponible (ce qui peut notamment arriver lorsque les coordonnées géographiques n'ont pas pu être retrouvées et placées dans l'url), on fallback sur tous les motifs de toutes les organisations sur lesquelles on a invité l'utilisateur (un array d'organisation ids est passé en ce sens dans l'URL).

J'ajoute également la possibilité de filtrer les motifs en envoyant un paramètre `motif_search_terms` qui cherchera ce terme dans les motifs disponibles (dans le but de récupérer que les motifs qui nous intéresse dans le contexte de l'invitation).
