### PR TITLE
masque le filtre équipe si aucune équipe

### DIFF
--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -38,20 +38,21 @@
         .col-md-4
           = date_input(f, :from_date, label = "À partir du", required: true)
       .row
-        .col-md-4
-          = f.input :team_ids, collection: @teams, label: t(".teams"), label_method: :name, input_html: { \
-              multiple: true, \
-              class: "select2-input",\
-              data: {\
-                "select-options": {\
-                  ajax: {\
-                    url: search_admin_territory_teams_path(current_organisation.territory),
-                    dataType: "json",
-                    delay: 250\
+        - if @teams.any?
+          .col-md-4
+            = f.input :team_ids, collection: @teams, label: t(".teams"), label_method: :name, input_html: { \
+                multiple: true, \
+                class: "select2-input",\
+                data: {\
+                  "select-options": {\
+                    ajax: {\
+                      url: search_admin_territory_teams_path(current_organisation.territory),
+                      dataType: "json",
+                      delay: 250\
+                    }\
                   }\
                 }\
-              }\
-            }
+              }
 
         .col-md-4
           = f.input :agent_ids, collection: @agents, label: t(".agents"), label_method: :reverse_full_name, input_html: { \


### PR DESCRIPTION
Corrige un des retours du 18 janvier à propos de l'affichage du filtre des équipes lorsqu'il n'y en a aucune de configurée

https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-referent/reunions-referentes/reunion-referentes-du-18-janvier-2022#en-production-jeudi-20

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
