### PR TITLE
🚀 Prevent duplicate assignment in rdv edit form

### DIFF
--- a/app/form_models/admin/edit_rdv_form.rb
+++ b/app/form_models/admin/edit_rdv_form.rb
@@ -12,9 +12,7 @@ class Admin::EditRdvForm
   end
 
   def update(**rdv_attributes)
-    # assigning attributes on rdv in order to validate this form object
-    @rdv.assign_attributes(rdv_attributes)
-    valid? && RdvUpdater.update(agent_context.agent, rdv, rdv_attributes)
+    RdvUpdater.update(agent_context.agent, rdv, rdv_attributes)
   end
 
   def save


### PR DESCRIPTION
refs #2028

La bonne façon de faire nécessite d’ajouter une validation d’unicité sur RdvsUsers (et sur AgentsRdvs, tant qu’à faire), d’abord dans ActiveRecord, et surtout en base. Par contre:

* la validation d’unicité dans ActiveRecord ne fonctionne pas de façon satisfaisante, c’est un problème connu de Rails. En gros, il faut se baser sur la contrainte en base et faire du code autour :)
* il faut nettoyer la baddata en base avant de rajouter la contrainte
* mais vu ce bug, on a quelques centaines d’erreurs en base, et ça continue d’arriver; je ne peux donc pas nettoyer à la main puis mettre le fix et la migration en prod en même temps. Cette PR consiste donc à fermer le robinet à baddata.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
