### PR TITLE
feat(invitations): Precise location type when a motif is selected

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -26,7 +26,6 @@ class SearchContext
   # *** Method that outputs the next step for the user to complete its rdv journey ***
   # *** It is used in #to_partial_parth to render the matching partial view ***
   def current_step
-    # byebug
     if address.blank?
       :address_selection
     elsif !motif_selected?
@@ -58,8 +57,10 @@ class SearchContext
     @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq { [_1.name, _1.location_type] }
   end
 
-  def selected_motif_name
-    motif_selected? ? unique_motifs_by_name_and_location_type.first.name : nil
+  def selected_motif
+    return unless motif_selected?
+
+    unique_motifs_by_name_and_location_type.first
   end
 
   def motif_selected?

--- a/app/views/search/_banner.html.slim
+++ b/app/views/search/_banner.html.slim
@@ -14,4 +14,4 @@ section#hero.hero.hero-home.py-2
             | le &nbsp;
             span.text-secondary #{context.departement}
       - if context.selected_motif.present?
-        h3.text-white.mb-4 #{context.selected_motif.name} (#{I18n.t(context.selected_motif.location_type)})
+        h3.text-white.mb-4 #{motif_name_with_location_type(context.selected_motif)}

--- a/app/views/search/_banner.html.slim
+++ b/app/views/search/_banner.html.slim
@@ -13,5 +13,5 @@ section#hero.hero.hero-home.py-2
           - if context.departement.present?
             | le &nbsp;
             span.text-secondary #{context.departement}
-      - if context.selected_motif_name.present?
-        h3.text-white.mb-4 #{context.selected_motif_name}
+      - if context.selected_motif.present?
+        h3.text-white.mb-4 #{context.selected_motif.name} (#{I18n.t(context.selected_motif.location_type)})

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -7,4 +7,4 @@ section.bg-light.p-4
         - if context.unique_motifs_by_name_and_location_type.present?
           = render "creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_booking_delay: context.max_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query: context.query
         - else
-          .alert.alert-warning= "Le motif <b>#{context.selected_motif_name}</b> n'est plus disponible à la réservation à <b>#{context.lieu.name}</b>".html_safe
+          .alert.alert-warning= "Le motif <b>#{context.selected_motif.name}</b> n'est plus disponible à la réservation à <b>#{context.lieu.name}</b>".html_safe

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -9,7 +9,7 @@ section.bg-light.p-4
           .row
             .col-md
               h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-              h6.card-subtitle.text-black-50.mb-2= context.unique_motifs_by_name_and_location_type.first.service.name
+              h6.card-subtitle.text-black-50.mb-2= context.selected_motif.service.name
               h6.card-subtitle.text-black-50= lieu.address
             .col-md.align-self-center.pt-3.pt-md-0.position-static
               - if next_availability

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -9,8 +9,8 @@ section.bg-light.p-4
           .row
             .col-md
               h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-              h6.card-subtitle.text-black-50.mb-2= context.selected_motif.service.name
-              h6.card-subtitle.text-black-50= lieu.address
+              h5.card-subtitle.text-black-50.mb-2= lieu.address
+              h6.card-subtitle.text-black-50= context.selected_motif.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
               - if next_availability
                 = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id)), class: "d-block stretched-link" do

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -22,5 +22,5 @@ section.bg-light.p-4
               .row
                 .col-md
                   h4.card-title.mb-3.mt-0.text-success.font-weight-bold= motif.name
-                  h6.card-subtitle.text-black-50.mb-2= "RDV #{I18n.t(motif.location_type)}."
+                  h5.card-subtitle.text-black-50.mb-2= motif.human_attribute_value(:location_type)
                   h6.card-subtitle.text-black-50.mb-2= motif.service.name

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -22,4 +22,5 @@ section.bg-light.p-4
               .row
                 .col-md
                   h4.card-title.mb-3.mt-0.text-success.font-weight-bold= motif.name
+                  h6.card-subtitle.text-black-50.mb-2= "RDV #{I18n.t(motif.location_type)}."
                   h6.card-subtitle.text-black-50.mb-2= motif.service.name


### PR DESCRIPTION
Je précise le type de motif (sur place ou par téléphone) quand un motif est choisi.
Pour l'instant si la personne est redirigé vers la sélection du lieu directement et que le motif est `RSA Orientation`, elle n'a aucun moyen de savoir s'il s'agit d'un RDV sur place ou téléphonique.

