### PR TITLE
🚀 Prevent RdvsUsers and AgentsRdvs duplicates with DB constraints

### DIFF
--- a/app/models/agents_rdv.rb
+++ b/app/models/agents_rdv.rb
@@ -4,6 +4,10 @@ class AgentsRdv < ApplicationRecord
   belongs_to :rdv, touch: true
   belongs_to :agent
 
+  # Uniqueness validation doesn’t work with nested_attributes, see https://github.com/rails/rails/issues/4568
+  # We do have on a DB constraint.
+  validates :agent_id, uniqueness: { scope: :rdv_id }
+
   after_commit :update_unknown_past_rdv_count
 
   def update_unknown_past_rdv_count

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -4,6 +4,10 @@ class RdvsUser < ApplicationRecord
   belongs_to :rdv, touch: true, inverse_of: :rdvs_users
   belongs_to :user
 
+  # Uniqueness validation doesn’t work with nested_attributes, see https://github.com/rails/rails/issues/4568
+  # We do have on a DB constraint.
+  validates :user_id, uniqueness: { scope: :rdv_id }
+
   after_initialize :set_default_notifications_flags
   before_validation :set_default_notifications_flags
 

--- a/db/migrate/20220124110241_make_rdvs_users_unique.rb
+++ b/db/migrate/20220124110241_make_rdvs_users_unique.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class MakeRdvsUsersUnique < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rdvs_users, %i[rdv_id user_id], unique: true
+    add_index :agents_rdvs, %i[agent_id rdv_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_18_161355) do
+ActiveRecord::Schema.define(version: 2022_01_24_110241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,6 +191,7 @@ ActiveRecord::Schema.define(version: 2022_01_18_161355) do
   create_table "agents_rdvs", force: :cascade do |t|
     t.bigint "agent_id"
     t.bigint "rdv_id"
+    t.index ["agent_id", "rdv_id"], name: "index_agents_rdvs_on_agent_id_and_rdv_id", unique: true
     t.index ["agent_id"], name: "index_agents_rdvs_on_agent_id"
     t.index ["rdv_id"], name: "index_agents_rdvs_on_rdv_id"
   end
@@ -362,6 +363,7 @@ ActiveRecord::Schema.define(version: 2022_01_18_161355) do
     t.bigint "user_id"
     t.boolean "send_lifecycle_notifications", null: false
     t.boolean "send_reminder_notification", null: false
+    t.index ["rdv_id", "user_id"], name: "index_rdvs_users_on_rdv_id_and_user_id", unique: true
     t.index ["rdv_id"], name: "index_rdvs_users_on_rdv_id"
     t.index ["user_id"], name: "index_rdvs_users_on_user_id"
   end


### PR DESCRIPTION
followup #2034, fixes #2028

Concrètement, la validation en ruby ne sert pas à grand chose: Rails ne gère par correctement la validation d’unicité avec les `nested_attributes`. L’intérêt de faire passer cette PR en 🚀 est surtout de faire passer la migration (et de s’assurer qu’elle n’échoue pas) indépendamment du reste de la recette.

Vu que la validation est sur une contrainte de DB, s’il y a une erreur, ce sera une 500; cependant côté frontend, en principe, on ne peut pas envoyer ce genre de données. C’est acceptable pour le moment. J’ai bien envie d’améliorer le formulaire de modification (et un jour de création) de Rdv, de toute façon.

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app
