### PR TITLE
annule un RDV passé sans message de confirmation

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -75,15 +75,12 @@ module RdvsHelper
   end
 
   def change_status_confirmation_message(rdv, status)
-    if cancel_rdv_to_not_notify?(rdv, status)
-      I18n.t("admin.rdvs.message.confirm.simple_cancel")
-    elsif cancel_rdv_to_notify?(rdv, status)
-      I18n.t("admin.rdvs.message.confirm.cancel_with_notification")
-    elsif reset_futur_rdv?(rdv, status)
-      I18n.t("admin.rdvs.message.confirm.reinit_status")
-    else
-      ""
-    end
+    return "" if rdv.past?
+    return I18n.t("admin.rdvs.message.confirm.simple_cancel") if cancel_rdv_to_not_notify?(rdv, status)
+    return I18n.t("admin.rdvs.message.confirm.cancel_with_notification") if cancel_rdv_to_notify?(rdv, status)
+    return I18n.t("admin.rdvs.message.confirm.reinit_status") if reset_futur_rdv?(rdv, status)
+
+    ""
   end
 
   def cancel_rdv_to_not_notify?(rdv, status)

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -115,9 +115,9 @@ describe RdvsHelper do
     end
 
     context "with a past's RDV" do
-      it "returns reinit confirm message for unknown" do
+      it "returns empty confirm message for unknown" do
         rdv = build(:rdv, starts_at: now - 2.days)
-        expect(change_status_confirmation_message(rdv, "unknown")).to eq("")
+        expect(change_status_confirmation_message(rdv, :unknown)).to eq("")
       end
     end
 


### PR DESCRIPTION
À l'annulation d'un RDV passé, nous affichons aujourd'hui un message de confirmation. Ce n'est pas nécessaire

![Capture d’écran de 2022-01-25 14-07-12](https://user-images.githubusercontent.com/42057/150982439-0994d5b5-f806-427e-b71d-eb5705b00278.png)

Cette PR permet de modifier un RDV passé sans avoir de message de confirmation.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
