### PR TITLE
:rocket: Duplique le contexte d'un RDV

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -15,7 +15,8 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
                                                 from_date: @form.from_date,
                                                 agent_ids: @form.agent_ids,
                                                 user_ids: @form.user_ids,
-                                                lieu_id: @search_results.first.lieu.id),
+                                                lieu_id: @search_results.first.lieu.id,
+                                                context: @form.context),
                   class: "d-block stretched-link"
     else
       @motifs = policy_scope(Motif).active.ordered_by_name

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,7 +5,7 @@ fr:
       message:
         confirm:
           simple_cancel: Annuler le rendez-vous ?
-          cancel_with_notification: Annuler le rendez-vous ? Les usagers seront notifiés de cette annulation.
+          cancel_with_notification: Annuler le rendez-vous ? Les usagers seront informés de cette annulation.
           reinit_status: Réinitialiser l’état du rendez-vous ?
       show:
         update: Modifier

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,11 @@
 fr:
   admin:
     rdvs:
+      message:
+        confirm:
+          simple_cancel: Annuler le rendez-vous ?
+          cancel_with_notification: Annuler le rendez-vous ? Les usagers seront notifiés de cette annulation.
+          reinit_status: Réinitialiser l’état du rendez-vous ?
       show:
         update: Modifier
         duplicate: Dupliquer…

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -54,13 +54,6 @@ fr:
         excused: L’usager a pu prévenir de son absence. Une notification de confirmation lui sera envoyée.
         revoked: Le rendez-vous a du être annulé par le service, par exemple pour une raison administrative. Une notification sera envoyée à l’usager.
         noshow: L’usager ne s’est pas présenté a son rendez-vous.
-      rdv/statuses/confirm:
-        unknown: Réinitialiser l’état du rendez-vous ?
-        waiting: ""
-        seen: ""
-        excused: Annuler le rendez-vous ? Si le ou les usagers ont configuré leur email ou numéro de téléphone, une confirmation leur sera envoyée.
-        revoked: Annuler le rendez-vous ? Si le ou les usagers ont configuré leur email ou numéro de téléphone, une notification leur sera envoyée.
-        noshow: ""
   activemodel:
     warnings:
       models:

--- a/config/locales/models/rdvs_user.fr.yml
+++ b/config/locales/models/rdvs_user.fr.yml
@@ -9,6 +9,6 @@ fr:
       rdvs_user/send_lifecycle_notifications:
         true: Notifications de création et modification activées
         false: Notifications de création et modification désactivées
-      rdvs_user/send_reminder_notifications:
+      rdvs_user/send_reminder_notification:
         true: Notification de rappel activée
         false: Notification de rappel désactivée


### PR DESCRIPTION
Close #2020

Dans la modification sur l'affichage des créneaux (#1891 ?) nous avons cassé le transport du contexte lors de la duplication d'un RDV. Cette PR le répare.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
