### PR TITLE
:rocket: Duplique le contexte d'un RDV

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -15,7 +15,8 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
                                                 from_date: @form.from_date,
                                                 agent_ids: @form.agent_ids,
                                                 user_ids: @form.user_ids,
-                                                lieu_id: @search_results.first.lieu.id),
+                                                lieu_id: @search_results.first.lieu.id,
+                                                context: @form.context),
                   class: "d-block stretched-link"
     else
       @motifs = policy_scope(Motif).active.ordered_by_name


### PR DESCRIPTION
Close #2020 

Lors de la modification sur l'affichage des créneaux coté agent, nous avons cassé la duplication de RDV. Cette PR répare cette duplication pour qu'elle copie aussi le contexte.

Checklist avant review:
- [x] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [x] Tester la fonctionnalité sur la review app
