### PR TITLE
Fix duplicates in admin/territories/:id/agents

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -7,6 +7,7 @@ class Territory < ApplicationRecord
 
   has_many :teams, dependent: :destroy
   has_many :organisations, dependent: :destroy
+  has_many :organisations_agents, through: :organisations, source: :agents
   has_many :roles, class_name: "AgentTerritorialRole", dependent: :delete_all
   has_many :agents, through: :roles
 

--- a/app/views/admin/territories/agents/index.html.slim
+++ b/app/views/admin/territories/agents/index.html.slim
@@ -6,7 +6,7 @@
     .m-3.d-flex.justify-content-end
       - search = params[:search].blank? ? "d-none" : ""
       div= link_to t(".reset"), admin_territory_agents_path(current_territory), class: "btn btn-link #{search}"
-      = f.input :search, placeholder: t(".search_placeholder"), label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+      = f.input :q, placeholder: t(".search_placeholder"), label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:q] }, required: false
       = f.button :submit, t(".search")
 
     table.table

--- a/spec/controllers/admin/territories/agents_controller_spec.rb
+++ b/spec/controllers/admin/territories/agents_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Admin::Territories::AgentsController, type: :controller do
       create(:agent, last_name: "Blot", basic_role_in_organisations: [organisation])
       sign_in agent
 
-      get :index, params: { territory_id: territory.id, search: "zarg" }
+      get :index, params: { territory_id: territory.id, q: "zarg" }
       expect(assigns(:agents)).to eq([agent])
     end
   end


### PR DESCRIPTION
fixes #2021

Also make sure Admin::Territories::AgentsController#index and #search are consistent.

ℹ️ I’m starting to use `q` instead of `term` or `search_term`; it’s the [same thing in select2](https://select2.org/data-sources/ajax), and I find it looks better when using #index.

Checklist avant review:
- [ ] reparcourir le code rapidement pour voir les problèmes évidents (fichiers touchés inutilement, debug logs qui trainent…).
- [ ] Tester la fonctionnalité sur la review app
