### PR TITLE
refactor(invitations): Link invitation matching motifs to lieu

### DIFF
--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -7,6 +7,7 @@ class Lieu < ApplicationRecord
 
   belongs_to :organisation
   has_many :plage_ouvertures, dependent: :restrict_with_error
+  has_many :motifs, through: :plage_ouvertures
   has_many :rdvs, dependent: :restrict_with_error
   validates :name, :address, :latitude, :longitude, presence: true
 

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -78,6 +78,9 @@ class Motif < ApplicationRecord
     joins(organisation: :territory)
       .where(organisations: { territories: { departement_number: departement_number } })
   }
+  scope :for_lieu, lambda { |lieu|
+    joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: lieu.id })
+  }
 
   def to_s
     name

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -16,6 +16,7 @@ class Motif < ApplicationRecord
   belongs_to :service
   has_many :rdvs, dependent: :restrict_with_exception
   has_and_belongs_to_many :plage_ouvertures, -> { distinct }
+  has_many :lieux, through: :plage_ouvertures
 
   after_update -> { rdvs.touch_all }
 
@@ -77,9 +78,6 @@ class Motif < ApplicationRecord
   scope :in_departement, lambda { |departement_number|
     joins(organisation: :territory)
       .where(organisations: { territories: { departement_number: departement_number } })
-  }
-  scope :for_lieu, lambda { |lieu|
-    joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: lieu.id })
   }
 
   def to_s

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -136,7 +136,7 @@ class SearchContext
                  available_motifs
                end
       motifs = motifs.where(service: service) if service.present?
-      motifs = motifs.for_lieu(lieu) if lieu.present?
+      motifs = motifs.joins(:lieux).where(lieux: lieu) if lieu.present?
       motifs
     end
   end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -136,7 +136,7 @@ class SearchContext
                  available_motifs
                end
       motifs = motifs.where(service: service) if service.present?
-      motifs = motifs.where(organisation: lieu.organisation) if lieu.present?
+      motifs = motifs.for_lieu(lieu) if lieu.present?
       motifs
     end
   end


### PR DESCRIPTION
On va laisser la possibilité de passer un `lieu_id` dans l'url d'invitation d'un usager.
Lorsque celui-ci est présent, les motifs disponibles ne doivent correspondre qu'aux motifs qui sont rattachés à ce lieu par des plages d'ouvertures. Cette PR fait ce lien, qui était jusqu'à présent fait seulement sur l'organisation du lieu.