### PR TITLE
Respecter le tri de la recherche texte dans les résultats

### DIFF
--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -67,9 +67,13 @@ describe TextSearch, type: :concern do
     end
 
     it "orders results by relevance" do
-      durand = create(:user, first_name: "Louis", last_name: "Durand")
-      dupont = create(:user, first_name: "Louis", last_name: "Dupont")
-      expect(described_class.search_by_text("Louis Durand")).to eq([durand, dupont])
+      create(:user, first_name: "Marie", last_name: "Petit")
+      create(:user, first_name: "Gabrielle", last_name: "Petit")
+      create(:user, first_name: "Pauline", last_name: "Martin")
+      create(:user, first_name: "Jeanne", last_name: "Durand")
+      jean_paul = create(:user, first_name: "Jean-Paul", last_name: "Petit")
+      expect(described_class.search_by_text("Jean Paul Petit").count).to eq(5)
+      expect(described_class.search_by_text("Jean Paul Petit").first).to eq(jean_paul)
     end
   end
 end


### PR DESCRIPTION
fixes #2047. On ne peut pas combiner la recherche sur la colonne `:email` avec la recherche full-text, puisque ça perd le `ranking`.

Par ailleurs, ce changement signifie qu’on ne peut plus rechercher un `@` qui serait dans un champ autre que l’email.

#2047 was introduced in 120ce67a95358d82a623d814921601e66f57ce03

Avant:
<img width="394" alt="avant" src="https://user-images.githubusercontent.com/139391/151157122-241a9616-fbce-40f1-a5e6-094d229ff31a.png">

Après:
<img width="394" alt="après" src="https://user-images.githubusercontent.com/139391/151157112-aaa04100-41bb-46c0-b64a-f0e0f2e35d13.png">


AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
