### PR TITLE
:rocket: Précise la fin de journée pour la fin de récursion

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -102,7 +102,7 @@ module RecurrenceConcern
   end
 
   def set_recurrence_ends_at
-    self.recurrence_ends_at = recurrence&.ends_at
+    self.recurrence_ends_at = recurrence&.ends_at&.end_of_day
   end
 
   def clear_empty_recurrence

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 describe RecurrenceConcern do
+  shared_examples "#set_recurrence_ends_at" do
+    it "set to ends of day of last occurrence" do
+      first_day = Date.new(2019, 8, 15)
+      recurrence = Montrose.every(:week, interval: 2, starts: first_day, until: first_day + 7.days)
+      object = build(factory, first_day: first_day, recurrence: recurrence)
+      object.save!
+      expect(object.reload.recurrence_ends_at).to be_within(1.second).of(Time.zone.parse("20190822 23:59:59"))
+    end
+  end
+
   shared_examples "#all_occurrences_for" do
     def expect_first_occurrence_to_match(occurrences, expected_boundaries)
       first_occurrence = occurrences.first.second
@@ -177,6 +187,7 @@ describe RecurrenceConcern do
       include_examples "#all_occurrences_for"
       include_examples "#in_range"
       include_examples "#recurrence_ends_after_first_day"
+      include_examples "#set_recurrence_ends_at"
     end
   end
 end


### PR DESCRIPTION
Close #2055 

La dernière occurrence d'une absence récurrente n'était pas prise en compte dans le calcul de créneau. La méthode `in_range` prend un format `DateTime` et la fin d'occurrence était calculé sur le début de la dernière journée.

Cette PR précise qu'il la fin de journée, pour inclure cette journée dans la liste des occurrences.

AVANT LA REVUE
- [ ] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
