### PR TITLE
:rocket: fix le bug du créneau suivant

### DIFF
--- a/app/controllers/admin/slots_controller.rb
+++ b/app/controllers/admin/slots_controller.rb
@@ -3,7 +3,13 @@
 class Admin::SlotsController < AgentAuthController
   def index
     @form = build_agent_creneaux_search_form
-    @search_results = SearchCreneauxForAgentsService.perform_with(@form)
+
+    # Dans ce cadre là, nous n'avons qu'un lieu, et donc une structure en résultat de l'appel à ce service.
+    # TODO reprendre le service pour le sortir du format `background_job` et proposer 2 méthodes publiques
+    # - une pour construire la liste des lieux
+    # - une pour le cas où nous avons déjà un lieu
+    # À terme, ça pourrait également être un calcul plus réduit. Dans le cas de la recherche sur plusieurs lieux, nous avons besoin de connaitre la prochaine dispo, pas TOUTES les dispo
+    @search_result = SearchCreneauxForAgentsService.perform_with(@form).first
 
     @motifs = policy_scope(Motif).active.ordered_by_name
     @services = policy_scope(Service)

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -13,7 +13,8 @@ class SearchCreneauxForAgentsService < BaseService
 
   def build_result(lieu)
     # utiliser les ids des agents pour ne pas faire de requêtes supplémentaire
-    next_availability = NextAvailabilityService.find(@form.motif, lieu, @form.date_range.begin, @form.agent_ids)
+    # Utilise le date_range.end + 1 pour chercher la date suivante du créneau affiché
+    next_availability = NextAvailabilityService.find(@form.motif, lieu, @form.date_range.end + 1.day, @form.agent_ids)
     creneaux = SlotBuilder.available_slots(@form.motif, lieu, @form.date_range, OffDays.all_in_date_range(@form.date_range), @form.agent_ids)
     return nil if creneaux.empty? && next_availability.nil?
 

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -79,22 +79,23 @@
       - if @search_results.empty?
         | Il n'y a pour l'instant aucune disponibilité pour le motif #{@form.motif.name}
       - else
-        - available_places = @search_results.map(&:lieu)
         .container
             h3.font-weight-bold Résultats de votre recherche
-            p.font-weight-bold= t(".available_places_with_slots", count: available_places.length.to_s)
-            - available_places.each do |lieu|
-              - next_availability = @search_results.find {|s| s.lieu == lieu }&.next_availability
+            p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
+            - @search_results.each do |search_result|
+              / Ici ce qui nous intéresse, c'est le prochain créneau disponible.
+              / next_availability du `@search_results` contient le premier créneau suivant la période analysé
+              - next_availability = search_result.creneaux.min_by(&:starts_at)
               .card.mb-3 class=("card-hoverable" if next_availability)
                 .card-body
                   .row
                     .col-md
-                      h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-                      h6.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
-                      h6.card-subtitle.text-black-50= lieu.address
+                      h4.card-title.mb-3.mt-0.text-success.font-weight-bold= search_result.lieu.name
+                      h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
+                      h6.card-subtitle.text-black-50= search_result.lieu.address
                     .col-md.align-self-center.pt-3.pt-md-0.position-static
                       - if next_availability
-                        = link_to admin_organisation_slots_path(current_organisation, service_id: @form.service_id, motif_id: @form.motif.id, from_date: @form.from_date, agent_ids: @form.agent_ids, lieu_id: lieu.id, user_ids: @form.user_ids), class: "d-block stretched-link" do
+                        = link_to admin_organisation_slots_path(current_organisation, service_id: @form.service_id, motif_id: @form.motif.id, from_date: @form.from_date, agent_ids: @form.agent_ids, lieu_id: search_result.lieu.id, user_ids: @form.user_ids), class: "d-block stretched-link" do
                           .row
                             .col
                               | Prochaine disponibilité le

--- a/app/views/admin/slots/_slots.html.slim
+++ b/app/views/admin/slots/_slots.html.slim
@@ -32,7 +32,7 @@ div id="creneaux-lieu-#{lieu.id}"
                     small.text-dark= creneau.agent.short_name
 
     - if next_availability
-      - if form.date_range.end < next_availability.starts_at.to_date
+      - if form.date_range.end < next_availability.starts_at.to_date && creneaux.empty?
         .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center
           = link_to admin_organisation_slots_path(from_date: next_availability.starts_at.to_date, **path_opts),
               class: "btn btn-light" do

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -1,10 +1,9 @@
-- search_result = @search_results.first
 .card
   .card-header
     .d-flex.justify-content-between.flex-wrap
       span
         h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
-        = t(".place_informations_html", place_name: search_result.lieu.name, place_address: search_result.lieu.address)
+        = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
       span
         = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,
             service_id: @form.service_id,
@@ -16,7 +15,7 @@
   .card-body
 
     = render "/admin/slots/slots", \
-      lieu: search_result.lieu, \
-      creneaux: search_result.creneaux, \
+      lieu: @search_result.lieu, \
+      creneaux: @search_result.creneaux, \
       form: @form, \
-      next_availability: search_result.next_availability
+      next_availability: @search_result.next_availability

--- a/spec/controllers/admin/slots_controller_spec.rb
+++ b/spec/controllers/admin/slots_controller_spec.rb
@@ -26,7 +26,7 @@ describe Admin::SlotsController, type: :controller do
         lieu_id: lieu
       }
 
-      expect(assigns(:search_results)).not_to be_nil
+      expect(assigns(:search_result)).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
fix https://sentry.io/organizations/rdv-solidarites/issues/2872600804/?project=1811205&query=is%3Aunresolved

Dans cette PR, je commence à modifier la notion de `next_availability` pour que ça corresponde au prochain créneau après la période analysée.

J'ai également ajouté quelques commentaires pour expliquer ce qu'il se passe à certains endroits et suggéré des évolutions.


AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
