### PR TITLE
:rocket: Affiche le premier prochain créneau

### DIFF
--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -83,9 +83,11 @@
             h3.font-weight-bold Résultats de votre recherche
             p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
             - @search_results.each do |search_result|
-              / Ici ce qui nous intéresse, c'est le prochain créneau disponible.
+              / Ici ce qui nous intéresse, c'est le « premier » prochain créneau disponible.
               / next_availability du `@search_results` contient le premier créneau suivant la période analysé
-              - next_availability = search_result.creneaux.min_by(&:starts_at)
+              / les creneaux sont ceux de la période analysé
+              / la période analysé est la semaine qui commence à la date saisi dans les filtres
+              - next_availability = search_result.creneaux.min_by(&:starts_at) || search_result.next_availability
               .card.mb-3 class=("card-hoverable" if next_availability)
                 .card-body
                   .row


### PR DESCRIPTION
Avec les changements apportés par #2103 , il y a des cas où les prochains créneaux ne sont plus affichés

![Screenshot 2022-01-31 at 22-06-46 RDV Solidarités](https://user-images.githubusercontent.com/42057/151878702-1aa3507c-df3c-4a69-a102-e84a0d4b6a75.png)
![Screenshot 2022-01-31 at 22-06-31 RDV Solidarités](https://user-images.githubusercontent.com/42057/151878703-89c71429-67a1-477b-904c-a01fecd8c673.png)

Les modifications nous font utiliser uniquement les créneaux calculés sur la semaine commençant à la date saisie. Parfois, le prochain créneau est plus éloigné.
Ce bug n'est pas visible s'il n'y a qu'un lieu qui propose ce motif. C'est visible seulement dans cette page où on liste les lieux.

Après la correction : 

![Screenshot 2022-01-31 at 22-52-16 RDV Solidarités](https://user-images.githubusercontent.com/42057/151879185-a6a40dfd-b20b-4cc7-84fa-d9d3360e8beb.png)


AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
