### PR TITLE
🚀 Corrige l’affichage des notifications par usager dans l’historique Rdv

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -83,7 +83,7 @@ module ApplicationHelper
 
   def boolean_attribute_tag(object, attribute_name)
     value = object.send(attribute_name)
-    boolean_tag(value) { object.class.human_attribute_name("#{attribute_name}.#{value}") }
+    boolean_tag(value) { object.class.human_attribute_value(attribute_name, value) }
   end
 
   def admin_link_to_if_permitted(organisation, object, name = object.to_s)

--- a/config/locales/models/rdvs_user.fr.yml
+++ b/config/locales/models/rdvs_user.fr.yml
@@ -9,6 +9,6 @@ fr:
       rdvs_user/send_lifecycle_notifications:
         true: Notifications de création et modification activées
         false: Notifications de création et modification désactivées
-      rdvs_user/send_reminder_notification:
+      rdvs_user/send_reminder_notifications:
         true: Notification de rappel activée
         false: Notification de rappel désactivée


### PR DESCRIPTION
Suite de #2039:

Dans `paper_trail_helper.rb`, on utilise pour les `rdv_users` `human_attribute_value`, qui a besoin que la clé de localisation (dans le `.yml`) soit au pluriel. Par cohérence, autant utiliser `human_attribute_value` aussi dans `boolean_attribute_tag`.

`boolean_attribute_tag` n’est utilisé que dans _notification_overrides.html.slim, ça ne devrait donc rien casser ailleurs.

Demande de C. Beauvois, 1 févr. 2022 à 09:46
Avant:
![avant](https://user-images.githubusercontent.com/139391/151959351-38e1f780-4f41-4f0f-9c1a-9e8006e36e4e.png)

Après:
![après](https://user-images.githubusercontent.com/139391/151959352-9cda01db-7a89-416a-b9d8-78d4457a63ce.png)

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local

