### PR TITLE
🚀 Remove unneeded css class js-search-and-filter-form

### DIFF
--- a/app/views/admin/territories/agents/index.html.slim
+++ b/app/views/admin/territories/agents/index.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for "", url: admin_territory_agents_path(current_territory), html: { method: :get, class: "form-inline js-search-and-filter-form" }, wrapper: :inline_form do |f|
+= simple_form_for "", url: admin_territory_agents_path(current_territory), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
 
   .container-fluid.bg-white.rounded.m-2.p-2
     h2.text-center = t(".territory_agents_title")

--- a/app/views/admin/territories/teams/index.html.slim
+++ b/app/views/admin/territories/teams/index.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for "", url: admin_territory_teams_path(current_territory), html: { method: :get, class: "form-inline js-search-and-filter-form" }, wrapper: :inline_form do |f|
+= simple_form_for "", url: admin_territory_teams_path(current_territory), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
 
   .container-fluid.bg-white.rounded.m-2.p-2
     h2.text-center = t(".teams_title")


### PR DESCRIPTION
It’s used in motif filters, not anywhere else

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
