### PR TITLE
feat(user): generalize short invitation token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,14 +185,12 @@ class User < ApplicationRecord
   end
 
   def generate_invitation_token
-    # we generate short invitations token to allow paper mail invitation
     key = Devise.token_generator.send(:key_for, :invitation_token)
     loop do
-      raw = SecureRandom.send(:choose, [*"A".."Z", *"0".."9"], 8)
-      enc = OpenSSL::HMAC.hexdigest("SHA256", key, raw)
+      raw, enc = TokenGenerator.perform_with(key)
       @raw_invitation_token = raw
       self.invitation_token = enc
-      break [raw, enc] unless User.where(invitation_token: enc).size.positive?
+      break unless User.where(invitation_token: enc).size.positive?
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,14 +185,7 @@ class User < ApplicationRecord
   end
 
   def generate_invitation_token
-    if email.present?
-      super
-    else
-      generate_short_invitation_token # users without emails are invited to manually type it on rdv-solidarites.fr/invitation (Issue #1472)
-    end
-  end
-
-  def generate_short_invitation_token
+    # we generate short invitations token to allow paper mail invitation
     key = Devise.token_generator.send(:key_for, :invitation_token)
     loop do
       raw = SecureRandom.send(:choose, [*"A".."Z", *"0".."9"], 8)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -190,7 +190,7 @@ class User < ApplicationRecord
       raw, enc = TokenGenerator.perform_with(key)
       @raw_invitation_token = raw
       self.invitation_token = enc
-      break unless User.where(invitation_token: enc).size.positive?
+      break [raw, enc] unless User.where(invitation_token: enc).size.positive?
     end
   end
 

--- a/app/services/token_generator.rb
+++ b/app/services/token_generator.rb
@@ -1,5 +1,6 @@
-class TokenGenerator < BaseService
+# frozen_string_literal: true
 
+class TokenGenerator < BaseService
   def initialize(key)
     @key = key
   end
@@ -13,6 +14,6 @@ class TokenGenerator < BaseService
   def generate_token
     raw = SecureRandom.send(:choose, [*"A".."Z", *"0".."9"], 8)
     enc = OpenSSL::HMAC.hexdigest("SHA256", @key, raw)
-    return [raw, enc]
+    [raw, enc]
   end
 end

--- a/app/services/token_generator.rb
+++ b/app/services/token_generator.rb
@@ -1,0 +1,18 @@
+class TokenGenerator < BaseService
+
+  def initialize(key)
+    @key = key
+  end
+
+  def perform
+    generate_token
+  end
+
+  private
+
+  def generate_token
+    raw = SecureRandom.send(:choose, [*"A".."Z", *"0".."9"], 8)
+    enc = OpenSSL::HMAC.hexdigest("SHA256", @key, raw)
+    return [raw, enc]
+  end
+end


### PR DESCRIPTION
Dans cette PR, je généralise l'utilisation de tokens d'invitations de 8 caractères alphanumériques pour que la possibilité d'inviter les utilisateurs par courrier ne soit pas limitée aux utilisateurs sans emails (un critère qui n'était de toute façon plus forcément pertinent puisque nous invitons aussi via SMS sur rdv-i : les utilisateurs sans email invités par SMS recevaient donc déjà également un short token). 

Côté sécurité, cela laisse plusieurs centaines de milliers de millards de combinaisons différentes, donc ça me semble acceptable.
