### PR TITLE
Empêche les doublons dans les listes d’agents pour les secrétaires

### DIFF
--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -33,7 +33,7 @@ class Agent::AgentPolicy < ApplicationPolicy
 
     def resolve
       if current_agent.service.secretariat?
-        scope.joins(:organisations).merge(current_agent.organisations)
+        scope.where(id: AgentRole.where(organisation_id: current_agent.organisations).select(:agent_id))
       else
         agents_of_territories_i_admin = scope.joins(:organisations).merge(current_agent.organisations_of_territorial_roles)
 

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -85,6 +85,17 @@ describe Agent::AgentPolicy::Scope, type: :policy do
       end
     end
 
+    context "agent is in secrétariat" do
+      let!(:service_secretariat) { create(:service, :secretariat) }
+      let!(:other_service) { create :service }
+      let!(:services) { create_list(:service, 2) }
+      let!(:organisations) { create_list(:organisation, 2) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: organisations, service: service_secretariat) }
+      let!(:other_agent_same_orgas) { create(:agent, basic_role_in_organisations: organisations, service: other_service) }
+
+      it { is_expected.to match_array([agent, other_agent_same_orgas]) }
+    end
+
     context "admin agent, misc state" do
       let!(:organisations) { create_list(:organisation, 4) }
       let!(:agent) do


### PR DESCRIPTION
Les policies des agents des services secrétariats sont gérés différemment des autres.

J’ai hésité à faire une subquery de la query telle qu’elle était écrite précédemment, je trouve ça dommage de référencer la table de jointure. Idéalement, je voudrais écrire quelque chose du genre `Agents.where(organisations: current_agent.organisations)`.

D’un autre côté, c’est plus performant comme ça, et comme c’est une policy utilisée à beaucoup d’endroits par tous les agents de secrétariat, on y gagne. Je crois.

Close #1998

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
