### PR TITLE
Gestion de l’historique pour Absence, Lieu, PlageOuverture

### DIFF
--- a/app/helpers/paper_trail_helper.rb
+++ b/app/helpers/paper_trail_helper.rb
@@ -2,6 +2,7 @@
 
 module PaperTrailHelper
   def paper_trail_change_value(property_name, value)
+    # TODO: use human_attribute_value instead of these custom helpers
     return "N/A" if value.blank?
     return I18n.l(value, format: :dense) if value.is_a? Time
 
@@ -14,6 +15,12 @@ module PaperTrailHelper
   end
 
   private
+
+  def paper_trail__recurrence(value)
+    # NOTE: We can't use the display methods in plage_ouverture_helper because they need the whole plage_ouverture,
+    # and we only have the attribute value here.
+    value.to_hash.to_s
+  end
 
   def paper_trail__user_ids(value)
     ::User.where(id: value).order_by_last_name.map(&:full_name).join(", ")

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -2,6 +2,7 @@
 
 class Absence < ApplicationRecord
   # Mixins
+  has_paper_trail
   include WebhookDeliverable
   include RecurrenceConcern
   include IcalHelpers::Ics

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -3,9 +3,11 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  has_paper_trail
-
   # Mixins
+  has_paper_trail(
+    only: %w[email first_name last_name starts_at service_id invitation_sent_at invitation_accepted_at]
+  )
+
   include DeviseInvitable::Inviter
   include FullNameConcern
   include TextSearch

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -2,6 +2,7 @@
 
 class Lieu < ApplicationRecord
   # Mixins
+  has_paper_trail
   include PhoneNumberValidation::HasPhoneNumber
 
   # Attributes

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,7 @@ class Organisation < ApplicationRecord
   # Mixins
   has_paper_trail
   include WebhookDeliverable
+  include WebhookDeliverable
 
   # Attributes
   auto_strip_attributes :email, :name

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -2,6 +2,7 @@
 
 class PlageOuverture < ApplicationRecord
   # Mixins
+  has_paper_trail
   include RecurrenceConcern
   include WebhookDeliverable
   include IcalHelpers::Ics

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -3,8 +3,10 @@
 class Rdv < ApplicationRecord
   # Mixins
   has_paper_trail(
+    only: %w[user_ids agent_ids status starts_at ends_at lieu_id notes location context rdvs_users],
     meta: { virtual_attributes: :virtual_attributes_for_paper_trail }
   )
+
   include WebhookDeliverable
   include Rdv::AddressConcern
   include IcalHelpers::Ics

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,6 +2,7 @@
 
 class Team < ApplicationRecord
   # Mixins
+  has_paper_trail
   include TextSearch
   def self.search_keys = %i[name]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,14 @@
 
 class User < ApplicationRecord
   # Mixins
-  has_paper_trail
+  has_paper_trail(
+    only: %w[
+      email first_name last_name birth_name created_at confirmed_at invitation_accepted_at invited_through
+      created_through address phone_number birth_date caisse_affiliation affiliation_number family_situation
+      number_of_children notify_by_sms notify_by_email city_code post_code city_name
+    ]
+  )
+
   include PgSearch::Model
   include FullNameConcern
   include User::FranceconnectFrozenFieldsConcern

--- a/app/policies/agent/absence_policy.rb
+++ b/app/policies/agent/absence_policy.rb
@@ -18,6 +18,7 @@ class Agent::AbsencePolicy < ApplicationPolicy
   alias update? same_agent_or_has_access?
   alias edit? same_agent_or_has_access?
   alias destroy? same_agent_or_has_access?
+  alias versions? same_agent_or_has_access?
 
   private
 

--- a/app/policies/agent/admin_policy.rb
+++ b/app/policies/agent/admin_policy.rb
@@ -17,6 +17,10 @@ class Agent::AdminPolicy < DefaultAgentPolicy
     admin_and_same_org?
   end
 
+  def versions?
+    admin_and_same_org?
+  end
+
   class Scope < Scope
     def resolve
       scope.where(organisation_id: current_organisation.id)

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -5,10 +5,6 @@ class Agent::MotifPolicy < Agent::AdminPolicy
     admin_and_same_org? || same_agent_or_has_access?
   end
 
-  def versions?
-    admin_and_same_org?
-  end
-
   class Scope < Scope
     def resolve
       if context.can_access_others_planning?

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -5,10 +5,6 @@ class Agent::RdvPolicy < DefaultAgentPolicy
     same_agent_or_has_access?
   end
 
-  def versions?
-    same_agent_or_has_access?
-  end
-
   class Scope < Scope
     def resolve
       if context.can_access_others_planning?

--- a/app/policies/default_agent_policy.rb
+++ b/app/policies/default_agent_policy.rb
@@ -37,6 +37,10 @@ class DefaultAgentPolicy < ApplicationPolicy
     same_agent_or_has_access?
   end
 
+  def versions?
+    same_agent_or_has_access?
+  end
+
   def same_org?
     return false if current_organisation.nil?
 

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -22,3 +22,5 @@
     .card
       .card-body
         = render "form", absence: @absence, agent: @agent
+
+= render "admin/versions/resource_versions_row", resource: @absence

--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -37,4 +37,4 @@
             .col.text-right
               = f.button :submit
 
-= render "admin/versions/resource_versions_row", resource: @agent_role.agent, attributes_allowlist: ["email", "first_name", "last_name", "starts_at", "service_id", "invitation_sent_at", "invitation_accepted_at"]
+= render "admin/versions/resource_versions_row", resource: @agent_role.agent

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -13,4 +13,6 @@
   .col-md-6
     .card
       .card-body
-          = render "form", lieu: @lieu
+        = render "form", lieu: @lieu
+
+= render "admin/versions/resource_versions_row", resource: @lieu

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -80,3 +80,5 @@
             edit_admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture), \
             class: "btn btn-primary" \
           )
+
+= render "admin/versions/resource_versions_row", resource: @plage_ouverture

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -60,4 +60,4 @@
               "Voir les #{rdv_user_presenter.previous_rdvs_count} RDVs précédents…", \
               admin_organisation_rdvs_path(current_organisation, user_id: rdv_user.user.id, end: @rdv.starts_at)
 
-= render "admin/versions/resource_versions_row", resource: @rdv, attributes_allowlist: ["user_ids", "agent_ids", "status", "starts_at", "ends_at", "lieu_id", "notes", "location", "context", "rdvs_users"]
+= render "admin/versions/resource_versions_row", resource: @rdv

--- a/app/views/admin/territories/teams/edit.html.slim
+++ b/app/views/admin/territories/teams/edit.html.slim
@@ -2,3 +2,5 @@
   h2.text-center = t(".territory_teams_title")
 
   = render "form", team: @team, url: admin_territory_team_path(current_territory, @team)
+
+= render "admin/versions/resource_versions_row", resource: @team

--- a/app/views/admin/territories/teams/edit.html.slim
+++ b/app/views/admin/territories/teams/edit.html.slim
@@ -2,5 +2,3 @@
   h2.text-center = t(".territory_teams_title")
 
   = render "form", team: @team, url: admin_territory_team_path(current_territory, @team)
-
-= render "admin/versions/resource_versions_row", resource: @team

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -141,9 +141,4 @@
                 count: @rdvs.status(temporal_status).count,
                 path: admin_organisation_rdvs_path(current_organisation, status: temporal_status, user_id: @user.id, breadcrumb_page: "user")
 
-= render "admin/versions/resource_versions_row", resource: @user,
-  attributes_allowlist: ["email", "first_name", "last_name", "birth_name",
-    "created_at", "confirmed_at", "invitation_accepted_at", "invited_through", "created_through",
-    "address", "phone_number", "birth_date",
-    "caisse_affiliation", "affiliation_number", "family_situation", "number_of_children",
-    "notify_by_sms", "notify_by_email", "city_code", "post_code", "city_name"]
+= render "admin/versions/resource_versions_row", resource: @user

--- a/app/views/admin/versions/_resource_versions_row.html.slim
+++ b/app/views/admin/versions/_resource_versions_row.html.slim
@@ -9,7 +9,6 @@
               = t("admin.versions.title")
         .collapse.hide#history-collapse
           .card-body
-            - attributes_allowlist = local_assigns[:attributes_allowlist]
-            = cache [resource, attributes_allowlist] do
-              - versions = PaperTrailAugmentedVersion.for_resource(resource, attributes_allowlist: local_assigns[:attributes_allowlist])
+            = cache [resource, resource.class.paper_trail_options[:only]] do
+              - versions = PaperTrailAugmentedVersion.for_resource(resource)
               = render "admin/versions/versions", versions: versions.reverse


### PR DESCRIPTION
Il n’y a pas d’issue! C’est suite à une discussion d’hier, et un peu de nettoyage en passant. Cela dit, ça touche du doigt les réécritures des policies (argh) et la suite de #2114 pour les retouches de design sur la page de détail des Usagers.

fixes #2144

![Screen Shot 2022-02-14 at 11 16 50](https://user-images.githubusercontent.com/139391/153845069-d7b87cca-87d5-4418-a43d-1ead2aaccd7e.png)

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
