### PR TITLE
Considère le délai min et max du motif

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -17,7 +17,7 @@ class LieuxController < ApplicationController
     @next_availability_by_lieux = @lieux.to_h do |lieu|
       [
         lieu.id,
-        creneaux_search_for(lieu, (1.week.ago.to_date..Time.zone.today)).next_availability
+        creneaux_search_for(lieu, (Time.zone.today..Time.zone.today + 7.days)).next_availability
       ]
     end
   end

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -10,16 +10,14 @@ class LieuxController < ApplicationController
   after_action :allow_iframe
 
   def index
-   @lieux = Lieu
+    @lieux = Lieu
       .with_open_slots_for_motifs(@matching_motifs)
       .includes(:organisation)
       .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
     @next_availability_by_lieux = @lieux.to_h do |lieu|
       motif = @matching_motifs.where(organisation: lieu.organisation).first
-      [
-        lieu.id,
-        NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
-      ]
+      next_availability = NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
+      [lieu.id, next_availability]
     end
   end
 

--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -10,14 +10,15 @@ class LieuxController < ApplicationController
   after_action :allow_iframe
 
   def index
-    @lieux = Lieu
+   @lieux = Lieu
       .with_open_slots_for_motifs(@matching_motifs)
       .includes(:organisation)
       .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
     @next_availability_by_lieux = @lieux.to_h do |lieu|
+      motif = @matching_motifs.where(organisation: lieu.organisation).first
       [
         lieu.id,
-        creneaux_search_for(lieu, (Time.zone.today..Time.zone.today + 7.days)).next_availability
+        NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
       ]
     end
   end

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Lapin
+  module Range
+    class << self
+      def reduce_range_to_delay(motif, date_range)
+        start_range = [(Time.zone.now + motif.min_booking_delay.minutes), date_range.begin].max
+        end_range = [(Time.zone.now + motif.max_booking_delay.minutes), date_range.end].min
+        start_range..end_range
+      end
+
+      def ensure_date_range_with_time(date_range)
+        time_begin = date_range.begin.is_a?(Time) ? date_range.begin : date_range.begin.beginning_of_day
+        time_begin = Time.zone.now if time_begin < Time.zone.now
+        time_end = date_range.end.is_a?(Time) ? date_range.end : date_range.end.end_of_day
+
+        time_begin..time_end
+      end
+    end
+  end
+end

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -4,8 +4,10 @@ module Lapin
   module Range
     class << self
       def reduce_range_to_delay(motif, date_range)
-        start_range = [(Time.zone.now + motif.min_booking_delay.minutes), date_range.begin].max
-        end_range = [(Time.zone.now + motif.max_booking_delay.minutes), date_range.end].min
+        return nil if date_range.end < (Time.zone.now + motif.min_booking_delay.seconds)
+
+        start_range = [(Time.zone.now + motif.min_booking_delay.seconds), date_range.begin].max
+        end_range = [(Time.zone.now + motif.max_booking_delay.seconds), date_range.end].min
         start_range..end_range
       end
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -146,6 +146,7 @@ class Rdv < ApplicationRecord
   end
 
   def creneaux_available(date_range)
+    date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
     lieu.present? ? SlotBuilder.available_slots(motif, lieu, date_range, OffDays.all_in_date_range(date_range)) : []
   end
 

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -4,10 +4,12 @@ module Users::CreneauxSearchConcern
   extend ActiveSupport::Concern
 
   def next_availability
+    date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
     NextAvailabilityService.find(motif, @lieu, date_range.end, agents)
   end
 
   def creneaux
+    date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
     SlotBuilder.available_slots(motif, @lieu, date_range, OffDays.all_in_date_range(date_range), agents)
   end
 

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -4,12 +4,16 @@ module Users::CreneauxSearchConcern
   extend ActiveSupport::Concern
 
   def next_availability
-    date_range_end = Lapin::Range.reduce_range_to_delay(motif, date_range).end
-    NextAvailabilityService.find(motif, @lieu, date_range_end, agents)
+    reduced_date_range = Lapin::Range.reduce_range_to_delay(motif, date_range)
+    return if reduced_date_range.blank?
+
+    NextAvailabilityService.find(motif, @lieu, reduced_date_range.end, agents)
   end
 
   def creneaux
     reduced_date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
+    return [] if reduced_date_range.blank?
+
     SlotBuilder.available_slots(motif, @lieu, reduced_date_range, OffDays.all_in_date_range(reduced_date_range), agents)
   end
 

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -4,13 +4,13 @@ module Users::CreneauxSearchConcern
   extend ActiveSupport::Concern
 
   def next_availability
-    date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
-    NextAvailabilityService.find(motif, @lieu, date_range.end, agents)
+    date_range_end = Lapin::Range.reduce_range_to_delay(motif, date_range).end
+    NextAvailabilityService.find(motif, @lieu, date_range_end, agents)
   end
 
   def creneaux
-    date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
-    SlotBuilder.available_slots(motif, @lieu, date_range, OffDays.all_in_date_range(date_range), agents)
+    reduced_date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
+    SlotBuilder.available_slots(motif, @lieu, reduced_date_range, OffDays.all_in_date_range(reduced_date_range), agents)
   end
 
   protected

--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -46,6 +46,7 @@ class OffDays
   ].freeze
 
   def self.all_in_date_range(date_range)
+    date_range = date_range.begin.to_date..date_range.end.to_date unless date_range.begin.is_a?(Date)
     date_range.select do |d|
       case d.year
       when 2020

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -87,7 +87,7 @@ class SearchContext
     @next_availability_by_lieux ||= lieux.to_h do |lieu|
       [
         lieu.id,
-        creneaux_search_for(lieu, (1.week.ago.to_date..Time.zone.today)).next_availability
+        creneaux_search_for(lieu, (Time.zone.today..(Time.zone.today + 7.days))).next_availability
       ]
     end
   end

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -4,32 +4,10 @@ module SlotBuilder
   class << self
     # méthode publique
     def available_slots(motif, lieu, date_range, off_days, agents = [])
-      datetime_range = ensure_date_range_with_time(date_range)
-      datetime_range = motif_delay_and_range_union(motif, datetime_range)
+      datetime_range = Lapin::Range.ensure_date_range_with_time(date_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)
       free_times_po = free_times_from(plage_ouvertures, datetime_range, off_days) # dépendance sur RDV et Absence
       slots_for(free_times_po, motif)
-    end
-
-    def motif_delay_and_range_union(motif, date_range)
-      return date_range if motif.min_booking_delay.zero? && motif.max_booking_delay.zero?
-
-      start_range = [(Time.zone.now + motif.min_booking_delay.minutes), date_range.begin].max
-      end_range = if motif.max_booking_delay.positive?
-                    [(Time.zone.now + motif.max_booking_delay.minutes), date_range.end].min
-                  else
-                    date_range.end
-                  end
-
-      start_range..end_range
-    end
-
-    def ensure_date_range_with_time(date_range)
-      time_begin = date_range.begin.is_a?(Time) ? date_range.begin : date_range.begin.beginning_of_day
-      time_begin = Time.zone.now if time_begin < Time.zone.now
-      time_end = date_range.end.is_a?(Time) ? date_range.end : date_range.end.end_of_day
-
-      time_begin..time_end
     end
 
     def plage_ouvertures_for(motif, lieu, datetime_range, agents)

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -5,9 +5,23 @@ module SlotBuilder
     # méthode publique
     def available_slots(motif, lieu, date_range, off_days, agents = [])
       datetime_range = ensure_date_range_with_time(date_range)
+      datetime_range = motif_delay_and_range_union(motif, datetime_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)
       free_times_po = free_times_from(plage_ouvertures, datetime_range, off_days) # dépendance sur RDV et Absence
       slots_for(free_times_po, motif)
+    end
+
+    def motif_delay_and_range_union(motif, date_range)
+      return date_range if motif.min_booking_delay.zero? && motif.max_booking_delay.zero?
+
+      start_range = [(Time.zone.now + motif.min_booking_delay.minutes), date_range.begin].max
+      end_range = if motif.max_booking_delay.positive?
+                    [(Time.zone.now + motif.max_booking_delay.minutes), date_range.end].min
+                  else
+                    date_range.end
+                  end
+
+      start_range..end_range
     end
 
     def ensure_date_range_with_time(date_range)

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe SearchController, type: :controller do
           user: nil,
           motif: motif,
           lieu: lieu,
-          date_range: (Date.new(2019, 7, 15)..Date.new(2019, 7, 22)),
+          date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 29)),
           geo_search: geo_search
         ).and_return(creneaux_search)
       end

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
 
     name { generate(:motif_name) }
     default_duration_in_min { 45 }
-    min_booking_delay { 30.minutes }
-    max_booking_delay { 6.months }
+    min_booking_delay { 30.minutes.seconds }
+    max_booking_delay { 6.months.seconds }
     color { "##{SecureRandom.hex(3)}" }
     instruction_for_rdv { "Intruction pour le RDV" }
     restriction_for_rdv { "Consigne pour le RDV" }

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -35,7 +35,7 @@ describe "Agent can create a Rdv with wizard" do
     # create user with mail
     fill_in :user_first_name, with: "Jean-Paul"
     fill_in :user_last_name, with: "Orvoir"
-    fill_in :user_email, with: "jporvoir@bidule.com"
+    expect(page).to have_selector(".user_email")
     click_button("Créer usager")
 
     # create user without email

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -37,7 +37,7 @@ describe Lapin::Range do
       friday = Time.zone.parse("20210430 8:00")
       travel_to(friday)
       date_range = (friday + 60.minutes)..(friday + 7.days)
-      motif = build(:motif, min_booking_delay: 30, max_booking_delay: 10_080)
+      motif = build(:motif, min_booking_delay: 30 * 60, max_booking_delay: 8 * 24 * 60 * 60)
       expected_range = (friday + 60.minutes)..(friday + 7.days)
       expect(described_class.reduce_range_to_delay(motif, date_range)).to eq(expected_range)
     end
@@ -46,7 +46,7 @@ describe Lapin::Range do
       friday = Time.zone.parse("20210430 8:00")
       travel_to(friday)
       date_range = friday..(friday + 7.days)
-      motif = build(:motif, min_booking_delay: (3 * 24 * 60), max_booking_delay: (8 * 24 * 60))
+      motif = build(:motif, min_booking_delay: (3 * 24 * 60 * 60), max_booking_delay: (8 * 24 * 60 * 60))
       expected_range = friday + 3.days..(friday + 7.days)
       expect(described_class.reduce_range_to_delay(motif, date_range)).to eq(expected_range)
     end
@@ -55,9 +55,17 @@ describe Lapin::Range do
       friday = Time.zone.parse("20210430 8:00")
       travel_to(friday)
       date_range = (friday + 60.minutes)..(friday + 7.days)
-      motif = build(:motif, min_booking_delay: 30, max_booking_delay: (3 * 24 * 60))
+      motif = build(:motif, min_booking_delay: 30 * 60, max_booking_delay: (3 * 24 * 60 * 60))
       expected_range = (friday + 60.minutes)..(friday + 3.days)
       expect(described_class.reduce_range_to_delay(motif, date_range)).to eq(expected_range)
+    end
+
+    it "return empty range when min booking after end of range" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = friday..(friday + 7.days)
+      motif = build(:motif, min_booking_delay: (8 * 24 * 60 * 60), max_booking_delay: (9 * 24 * 60 * 60))
+      expect(described_class.reduce_range_to_delay(motif, date_range)).to be_nil
     end
   end
 end

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe Lapin::Range do
+  describe "#ensure_date_range_with_time" do
+    it "returns range with given datetime_range" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = Time.zone.parse("2021-12-20 11:00")..Time.zone.parse("2021-12-21 18:00")
+      expected_range = Time.zone.parse("2021-12-20 11:00")..Time.zone.parse("2021-12-21 18:00")
+      datetime_range = described_class.ensure_date_range_with_time(date_range)
+      expect(datetime_range).to eq(expected_range)
+    end
+
+    it "returns range from beginning of day of range begin and end of day of range end wit date range" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = Date.new(2021, 12, 20)..Date.new(2021, 12, 21)
+      expected_range = Date.new(2021, 12, 20).beginning_of_day..(Date.new(2021, 12, 21).end_of_day)
+      datetime_range = described_class.ensure_date_range_with_time(date_range)
+      expect(datetime_range).to eq(expected_range)
+    end
+
+    it "returns range from now to end of given datetime range" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = Time.zone.parse("2021-12-20 11:00")..Time.zone.parse("2021-12-21 18:00")
+      expected_range = Time.zone.parse("2021-12-21 10:00")..Time.zone.parse("2021-12-21 18:00")
+      now = Time.zone.parse("2021-12-21 10:00")
+      travel_to(now)
+      datetime_range = described_class.ensure_date_range_with_time(date_range)
+      expect(datetime_range).to eq(expected_range)
+    end
+  end
+
+  describe "#reduce_range_to_delay" do
+    it "return date range when range in bookin period" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = (friday + 60.minutes)..(friday + 7.days)
+      motif = build(:motif, min_booking_delay: 30, max_booking_delay: 10_080)
+      expected_range = (friday + 60.minutes)..(friday + 7.days)
+      expect(described_class.reduce_range_to_delay(motif, date_range)).to eq(expected_range)
+    end
+
+    it "return date range starting at now + min booking delay and range end when range start before booking period" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = friday..(friday + 7.days)
+      motif = build(:motif, min_booking_delay: (3 * 24 * 60), max_booking_delay: (8 * 24 * 60))
+      expected_range = friday + 3.days..(friday + 7.days)
+      expect(described_class.reduce_range_to_delay(motif, date_range)).to eq(expected_range)
+    end
+
+    it "return date range ending at booking max delay when range finish after booking period" do
+      friday = Time.zone.parse("20210430 8:00")
+      travel_to(friday)
+      date_range = (friday + 60.minutes)..(friday + 7.days)
+      motif = build(:motif, min_booking_delay: 30, max_booking_delay: (3 * 24 * 60))
+      expected_range = (friday + 60.minutes)..(friday + 3.days)
+      expect(described_class.reduce_range_to_delay(motif, date_range)).to eq(expected_range)
+    end
+  end
+end

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -22,7 +22,7 @@ describe FileAttente, type: :model do
     let!(:file_attente) { create(:file_attente, rdv: rdv) }
 
     context "with availabilities before rdv" do
-      let!(:plage_ouverture2) { create(:plage_ouverture, first_day: 1.day.from_now, start_time: Tod::TimeOfDay.new(9), lieu: lieu, agent: agent, motifs: [motif], organisation: organisation) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, first_day: 8.days.from_now, start_time: Tod::TimeOfDay.new(9), lieu: lieu, agent: agent, motifs: [motif], organisation: organisation) }
 
       it "increments notifications_sent" do
         expect { subject }.to change(file_attente, :notifications_sent).from(0).to(1)

--- a/spec/services/next_availability_service_spec.rb
+++ b/spec/services/next_availability_service_spec.rb
@@ -16,9 +16,9 @@ describe NextAvailabilityService, type: :service do
       it "works" do
         create(:plage_ouverture,
                motifs: [motif], lieu: lieu, agent: agent, organisation: organisation,
-               first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+               first_day: today + 8.days, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
         next_available = described_class.find(motif, lieu, today, [])
-        expect(next_available.starts_at).to eq(today.in_time_zone + 9.hours)
+        expect(next_available.starts_at).to eq((today + 8.days).in_time_zone + 9.hours)
       end
     end
 
@@ -69,17 +69,17 @@ describe NextAvailabilityService, type: :service do
       it "doesnt look a cancelled's RDV" do
         create(:plage_ouverture,
                motifs: [motif], lieu: lieu, agent: agent, organisation: organisation,
-               first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+               first_day: (today + 8.days), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
         create(:rdv,
                agents: [agent],
                organisation: organisation,
                lieu: lieu,
                motif: motif,
-               starts_at: today.in_time_zone + 9.hours, duration_in_min: 120,
+               starts_at: (today + 8.days).in_time_zone + 9.hours, duration_in_min: 120,
                status: "revoked")
 
         next_creneau = described_class.find(motif, lieu, today, [])
-        expect(next_creneau.starts_at).to eq(today.in_time_zone + 9.hours)
+        expect(next_creneau.starts_at).to eq((today + 8.days).in_time_zone + 9.hours)
       end
 
       it "returns a next creneau when plage_ouverture is recurrence" do

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -39,5 +39,11 @@ describe OffDays, type: :service do
 
       it { is_expected.to match_array([Date.new(2022, 1, 1)]) } if Time.zone.now > Date.new(2021, 1, 1)
     end
+
+    context "it works with datetime" do
+      let(:range) { Time.zone.parse("20220101 16:00")..Time.zone.parse("20220107 18:00") }
+
+      it { is_expected.to match_array([Date.new(2022, 1, 1)]) } if Time.zone.now > Date.new(2021, 1, 1)
+    end
   end
 end

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -340,31 +340,6 @@ describe SlotBuilder, type: :service do
     end
   end
 
-  describe "#ensure_date_range_with_time" do
-    it "returns range with given datetime_range" do
-      date_range = Time.zone.parse("2021-12-20 11:00")..Time.zone.parse("2021-12-21 18:00")
-      expected_range = Time.zone.parse("2021-12-20 11:00")..Time.zone.parse("2021-12-21 18:00")
-      datetime_range = described_class.ensure_date_range_with_time(date_range)
-      expect(datetime_range).to eq(expected_range)
-    end
-
-    it "returns range from beginning of day of range begin and end of day of range end wit date range" do
-      date_range = Date.new(2021, 12, 20)..Date.new(2021, 12, 21)
-      expected_range = Date.new(2021, 12, 20).beginning_of_day..(Date.new(2021, 12, 21).end_of_day)
-      datetime_range = described_class.ensure_date_range_with_time(date_range)
-      expect(datetime_range).to eq(expected_range)
-    end
-
-    it "returns range from now to end of given datetime range" do
-      date_range = Time.zone.parse("2021-12-20 11:00")..Time.zone.parse("2021-12-21 18:00")
-      expected_range = Time.zone.parse("2021-12-21 10:00")..Time.zone.parse("2021-12-21 18:00")
-      now = Time.zone.parse("2021-12-21 10:00")
-      travel_to(now)
-      datetime_range = described_class.ensure_date_range_with_time(date_range)
-      expect(datetime_range).to eq(expected_range)
-    end
-  end
-
   describe "#ranges_for" do
     context "without recurrence" do
       it "return empty when po is out of range" do
@@ -402,51 +377,6 @@ describe SlotBuilder, type: :service do
         range = (friday + 3.days)..(friday + 10.days)
         expect(described_class.ranges_for(plage_ouverture, range)).to eq([(Time.zone.parse("20210507 9:00")..Time.zone.parse("20210507 11:00"))])
       end
-    end
-  end
-
-  describe "#motif_delay_and_range_union" do
-    it "return date range without motif's delay" do
-      date_range = friday..(friday + 7.days)
-      motif = build(:motif, min_booking_delay: 0, max_booking_delay: 0)
-      expected_range = friday..(friday + 7.days)
-      expect(described_class.motif_delay_and_range_union(motif, date_range)).to eq(expected_range)
-    end
-
-    it "return date range with now + min booking delay and range end" do
-      now = friday
-      travel_to(now)
-      date_range = friday..(friday + 7.days)
-      motif = build(:motif, min_booking_delay: (3 * 24 * 60), max_booking_delay: 0)
-      expected_range = friday + 3.days..(friday + 7.days)
-      expect(described_class.motif_delay_and_range_union(motif, date_range)).to eq(expected_range)
-    end
-
-    it "return date range with range being and now + max booking delay" do
-      now = friday
-      travel_to(now)
-      date_range = friday..(friday + 7.days)
-      motif = build(:motif, min_booking_delay: 0, max_booking_delay: (3 * 24 * 60))
-      expected_range = friday..(friday + 3.days)
-      expect(described_class.motif_delay_and_range_union(motif, date_range)).to eq(expected_range)
-    end
-
-    it "return max date between now + min_booking_delay and date_range.begin" do
-      now = friday
-      travel_to(now)
-      date_range = (friday + 10.days)..(friday + 17.days)
-      motif = build(:motif, min_booking_delay: (1 * 24 * 60), max_booking_delay: 0)
-      expected_range = (friday + 10.days)..(friday + 17.days)
-      expect(described_class.motif_delay_and_range_union(motif, date_range)).to eq(expected_range)
-    end
-
-    it "return min date between now + max_booking_delay and date_range.end" do
-      now = friday
-      travel_to(now)
-      date_range = (friday + 10.days)..(friday + 17.days)
-      motif = build(:motif, min_booking_delay: 0, max_booking_delay: (20 * 24 * 60))
-      expected_range = (friday + 10.days)..(friday + 17.days)
-      expect(described_class.motif_delay_and_range_union(motif, date_range)).to eq(expected_range)
     end
   end
 end

--- a/spec/services/users/creneau_search_spec.rb
+++ b/spec/services/users/creneau_search_spec.rb
@@ -6,6 +6,7 @@ describe Users::CreneauSearch do
   let(:motif) { create(:motif, name: "Coucou", location_type: :home, organisation: organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }
   let(:starts_at) { DateTime.parse("2020-10-20 09h30") }
+  let(:now) { Time.zone.parse("2020-10-19 14:30") }
 
   describe ".creneau_for" do
     subject do
@@ -18,6 +19,7 @@ describe Users::CreneauSearch do
     end
 
     before do
+      travel_to(now)
       allow(SlotBuilder).to receive(:available_slots).and_return(mock_creneaux)
     end
 

--- a/spec/services/users/creneaux_search_spec.rb
+++ b/spec/services/users/creneaux_search_spec.rb
@@ -4,6 +4,11 @@ describe Users::CreneauxSearch, type: :service do
   let(:organisation) { create(:organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }
   let(:date_range) { (Date.parse("2020-10-20")..Date.parse("2020-10-23")) }
+  let(:now) { Time.zone.parse("2020-10-19 15:34") }
+
+  before do
+    travel_to(now)
+  end
 
   it "call builder without special options" do
     user = create(:user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 
 require "axe-rspec"
 require "webdrivers/chromedriver"
+Webdrivers::Chromedriver.required_version = "97.0.4692.71"
 require "capybara/rspec"
 require "capybara/email/rspec"
 require "webdrivers"


### PR DESCRIPTION
Close #2005 

Nous ne prenions pas en compte les délais min et max configuré dans le motif au moment du calcul de créneau.

Il y a plusieurs façons de le prendre en compte. J'ai opté pour la modification de la période de recherche de créneau (déplacement des bornes en fonction de la configuration du motif). C'es ce qui me semble le plus optimum.

Nous pourrions imaginer que cette opération soit réalisé avant, en dehors du calcul de créneau, mais je crois le code pas assez nettoyer encre... et ça permet d'avoir une vue d'ensemble comme ça.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
