### PR TITLE
Rails 6.1: Activer annotate_rendered_view_with_filenames en development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.


### PR DESCRIPTION
Ça ressemble à ça:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/139391/153165709-08752890-945f-4a0a-836d-fe345de7ec7b.png">

Par contre! Ça ne fonctionne qu’avec les templates `.erb`. Il y a une PR en cours pour les `.slim`, mais manifestement ce n’est pas urgent. Cela dit, ça ne coûte rien.

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
