### PR TITLE
Accélération du lancement des specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,8 @@ group :development, :test do
   gem "slim_lint", require: false
   gem "axe-core-rspec"
   gem "selenium-webdriver"
+  gem "spring", require: false
+  gem "spring-commands-rspec"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -543,6 +543,9 @@ GEM
       slim (>= 3.0, < 5.0)
     spreadsheet (1.3.0)
       ruby-ole
+    spring (3.0.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -676,6 +679,8 @@ DEPENDENCIES
   slim
   slim_lint
   spreadsheet
+  spring
+  spring-commands-rspec
   sprockets-rails
   tod (~> 2.2)
   turbolinks (~> 5)

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ lint_brakeman: ## Security Checker
 test: test_unit test_features ## Run all tests
 
 test_unit:  ## Run unit tests in parallel
-	RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)']
+	RAILS_ENV=test bundle exec spring rake parallel:spec['spec\/(?!features)']
 
 test_features:  ## Run feature tests
-	bundle exec rspec spec/features
+	bundle exec spring rspec spec/features
 
 autocorrect: ## Fix autocorrectable lint issues
 	bundle exec rubocop --auto-correct-all

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
On peut maintenant faire `bundle exec spring rspec` pour que les specs démarrent plus vite. Sur ma machine, le temps pour lancer un test passe d'environ 3s à 0.4s. ⚡ 

Dans certains cas très rares (ça fait quelques années que j'ai pas vu ça), il se peut que le rechargement se passe mal, et que les specs se mettent à se comporter de manière bizarre. Dans ce cas il faut faire un `spring stop` pour que les choses redeviennent normales. Dans la pratique, ça arrive surtout si on modifie des objets globaux (classes, constantes) de manière inhabituelle dans le code.


REVUE
- [x] Relecture du code
- [x] ~~Test sur la review app / en local~~
