### PR TITLE
affiche les warnings et erreur correctement

### DIFF
--- a/app/models/concerns/benign_errors.rb
+++ b/app/models/concerns/benign_errors.rb
@@ -25,7 +25,7 @@ module BenignErrors
 
   def not_benign_errors
     # I would like to use ActiveModel::Errors#slice! here, but it relies on making a copy of the Errors.
-    errors.filter { |k, _| k != :_benign } # rubocop:disable Style/HashExcept
+    errors.filter { |k, _| k.attribute != :_benign }
   end
 
   def errors_are_all_benign?

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -25,4 +25,4 @@
   .alert.alert-danger.fade.show
     ul.m-0
       - errors_full_messages(model).each do |msg|
-        li= msg
+        li= msg.html_safe


### PR DESCRIPTION
Il y a un problème d'affichage actuellement lorsque l'on cré un usager avec le même prénom, nom et date de naissance ET avec la même adresse email. L'email est un élément discriminant, il est unique. Ce n'est pas nécessaire d'afficher le warning en même temps. De plus, il manquait un `html_safe` sur l'affichage du warning.

Avant :
![Screenshot 2022-02-13 at 18-46-50 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/153767773-85fa023e-4f8a-4598-9aa8-32525e331adc.png)

Après (avec uniquement l'alerte sur le mail existant, même si le nom, prénom et date de naissance sont aussi identitque) 
![Screenshot 2022-02-13 at 18-47-41 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/153767772-71d74640-fad8-4217-b926-1b65ef9026d3.png)

Après (avec uniquement le warning sur le nom, prénom et date de naissance)
![Screenshot 2022-02-13 at 18-47-56 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/153767770-bbd5760b-3d10-49da-ab49-7be779e7e308.png)


AVANT LA REVUE
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
