### PR TITLE
Add job workers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
+  self.deliver_later_queue_name = :mailers
+
   prepend IcsMultipartAttached
 
   default from: "contact@rdv-solidarites.fr"

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CustomDeviseMailer < Devise::Mailer
+  self.deliver_later_queue_name = :devise
+
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application

--- a/app/services/notifiers/rdv_upcoming_reminder.rb
+++ b/app/services/notifiers/rdv_upcoming_reminder.rb
@@ -8,12 +8,12 @@ class Notifiers::RdvUpcomingReminder < Notifiers::RdvBase
   end
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_upcoming_reminder(@rdv.payload(nil, user), user).deliver_later
+    Users::RdvMailer.rdv_upcoming_reminder(@rdv.payload(nil, user), user).deliver_later(queue: :mailers_low)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :upcoming_reminder)
   end
 
   def notify_user_by_sms(user)
-    Users::RdvSms.rdv_upcoming_reminder(@rdv, user).deliver_later
+    Users::RdvSms.rdv_upcoming_reminder(@rdv, user).deliver_later(queue: :sms_low)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_SMS, event_name: :upcoming_reminder)
   end
 end

--- a/app/sms/application_sms.rb
+++ b/app/sms/application_sms.rb
@@ -47,10 +47,10 @@ class ApplicationSms
 
   # Enqueue a DelayedJob with the sms
   # Note: the stored parameter in the delayed_jobs table is the ApplicationSms instance.
-  def deliver_later
+  def deliver_later(queue: :sms)
     raise InvalidMobilePhoneNumberError, "#{phone_number} is not a valid mobile phone number" unless PhoneNumberValidation.number_is_mobile?(phone_number)
 
-    SmsSender.delay(queue: :sms).perform_with(phone_number, content, tags, provider, key)
+    SmsSender.delay(queue: queue).perform_with(phone_number, content, tags, provider, key)
   end
 
   private

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# We declare the following queues in the code:
+# :cron     used in CronJob
+# :webhook  used in WebhookJob
+# :mailers  used in ApplicationMailer
+# :devise   used in CustomDeviseMailer
+# :sms      used in ApplicationSms
+#
+# Additionally, we declare the two following queues for lower priority jobs (e.g. Reminders)
+# :mailers_low
+# :sms_low
+Delayed::Worker.queue_attributes = {
+  mailers_low: { priority: 10 }, # Higher numbers have lower priority.
+  sms_low: { priority: 10 }
+}


### PR DESCRIPTION
refs #2154

~~à tester sur la review app: ~~
~~* est-ce que les jobs sont bien dépilés en parallèle?~~
~~* est-ce que ça consomme plus de mémoire?~~

Par ailleurs, il y a de mémoire un problème pour l’accès au dashboard de super_admin/delayed_jobs sur les review apps, il va peut-être falloir régler ça en premier.

Edit: je n’ai pas réussi à faire marcher delayed_job avec plusieurs workers; une autre piste sera de faire tourner plusieurs instances scalingo, chacune par queue. En attendant, on peut aussi faire tourner plusieurs instances de `jobs`, tout simplement.

Ce n’est pas (plus) ce que tente de faire cette PR: j’ajoute simplement deux autres noms de queues, `:sms_low` et `:mailers_low`, avec une moindre priorité. En principe, ça devrait permettre aux autres jobs de ne pas attendre 20 minutes, le matin à 20 heures pendant que les notifications de rappel sont envoyées.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
