### PR TITLE
Fix asset-precompile in production

### DIFF
--- a/app/webpacker/stylesheets/components/_lieux.scss
+++ b/app/webpacker/stylesheets/components/_lieux.scss
@@ -1,3 +1,5 @@
+@import "~bootstrap/scss/bootstrap";
+
 .lieux-search-results{
   h1, h2{
     color: $blue
@@ -29,4 +31,4 @@
     @extend .pt-md-0;
     @extend .position-static;
   }
-} 
+}


### PR DESCRIPTION
Les derniers déploiements en production ont échoué (`rake assets:precompile` en RAILS_ENV=production, je ne sais pas trop pourquoi ça passe en développement.)

Followup #2125

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
