### PR TITLE
Regroupe interface agent

### DIFF
--- a/app/controllers/admin/territories/agent_territorial_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_territorial_roles_controller.rb
@@ -13,12 +13,12 @@ class Admin::Territories::AgentTerritorialRolesController < Admin::Territories::
       .includes(:territories)
       .to_a
       .reject { _1.territorial_admin_in?(current_territory) }
-    authorize_admin(@role)
+    authorize @role
   end
 
   def create
     @role = AgentTerritorialRole.new(agent_territorial_role_params)
-    authorize_admin(@role)
+    authorize @role
     if @role.save
       redirect_to(
         admin_territory_agent_territorial_roles_path(current_territory),
@@ -31,7 +31,7 @@ class Admin::Territories::AgentTerritorialRolesController < Admin::Territories::
 
   def destroy
     role = AgentTerritorialRole.find(params[:id])
-    authorize_admin(role)
+    authorize role
     if role.destroy
       flash[:success] = "#{role.agent.full_name} n'a plus le rôle d'administrateur du #{current_territory}"
     else

--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -2,20 +2,17 @@
 
 class Admin::Territories::AgentsController < Admin::Territories::BaseController
   def index
-    @agents = find_agents(params[:q])
-      .page(params[:page])
+    @agents = find_agents(params[:q]).page(params[:page])
   end
 
   def show
-    skip_authorization
     @agent = Agent.find(params[:id])
+    authorize @agent
   end
 
   def search
-    skip_authorization
-
-    @agents = find_agents(params[:q])
-      .limit(10)
+    @agents = find_agents(params[:q]).limit(10)
+    authorize @agent
   end
 
   def find_agents(search_term)
@@ -34,10 +31,12 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
 
   def edit
     @agent = Agent.find(params[:id])
+    authorize @agent
   end
 
   def update
     @agent = Agent.find(params[:id])
+    authorize @agent
     if @agent.update(agent_params)
       redirect_to admin_territory_agents_path(current_territory)
     else

--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -6,6 +6,11 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
       .page(params[:page])
   end
 
+  def show
+    skip_authorization
+    @agent = Agent.find(params[:id])
+  end
+
   def search
     skip_authorization
 

--- a/app/controllers/admin/territories/base_controller.rb
+++ b/app/controllers/admin/territories/base_controller.rb
@@ -6,6 +6,8 @@ class Admin::Territories::BaseController < ApplicationController
   layout "application_configuration"
 
   before_action :set_territory
+  after_action :verify_authorized, except: :index
+  after_action :verify_policy_scoped, only: :index
 
   def current_territory
     @territory
@@ -13,7 +15,12 @@ class Admin::Territories::BaseController < ApplicationController
   helper_method :current_territory
 
   def pundit_user
-    AgentContext.new(current_agent)
+    AgentTerritorialContext.new(current_agent, current_territory)
+  end
+  helper_method :pundit_user
+
+  def authorize(record, *args)
+    super([:configuration, record], *args)
   end
 
   private

--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -2,19 +2,22 @@
 
 class Admin::Territories::TeamsController < Admin::Territories::BaseController
   def index
-    @teams = current_territory.teams.page(params[:page])
+    @teams = policy_scope(Team).page(params[:page])
     @teams = params[:search].present? ? @teams.search_by_text(params[:search]) : @teams.order(:name)
   end
 
   def new
     @team = Team.new
+    authorize Team
   end
 
   def show
     @team = Team.find(params[:id])
+    authorize @team
   end
 
   def create
+    authorize Team
     if (@team = Team.create(team_params.merge(territory: current_territory)))
       redirect_to admin_territory_teams_path(current_territory)
     else
@@ -24,10 +27,12 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
 
   def edit
     @team = Team.find(params[:id])
+    authorize @team
   end
 
   def update
     @team = Team.find(params[:id])
+    authorize @team
     if @team.update(team_params)
       redirect_to admin_territory_teams_path(current_territory)
     else
@@ -37,6 +42,7 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
 
   def destroy
     team = Team.find(params[:id])
+    authorize team
     team.destroy!
     redirect_to admin_territory_teams_path(current_territory)
   end

--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -10,6 +10,10 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
     @team = Team.new
   end
 
+  def show
+    @team = Team.find(params[:id])
+  end
+
   def create
     if (@team = Team.create(team_params.merge(territory: current_territory)))
       redirect_to admin_territory_teams_path(current_territory)

--- a/app/controllers/admin/territories_controller.rb
+++ b/app/controllers/admin/territories_controller.rb
@@ -10,7 +10,7 @@ class Admin::TerritoriesController < Admin::Territories::BaseController
 
   def update
     @territory = Territory.find(params[:id])
-    authorize_admin(@territory)
+    authorize @territory
     flash[:success] = "Mise à jour réussie !" if @territory.update(territory_params)
     render "admin/territories/agent_territorial_roles/index"
   end

--- a/app/controllers/admin/territories_controller.rb
+++ b/app/controllers/admin/territories_controller.rb
@@ -5,6 +5,7 @@ class Admin::TerritoriesController < Admin::Territories::BaseController
 
   def show
     @territory = Territory.find(params[:id])
+    authorize @territory
   end
 
   def update

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -23,6 +23,10 @@ class Agent::AgentPolicy < ApplicationPolicy
   alias reinvite? current_agent_or_admin_in_record_organisation?
   alias versions? current_agent_or_admin_in_record_organisation?
 
+  def edit?
+    @agent.territorial_admin_in?(@territory)
+  end
+
   def destroy?
     # Even admins cannot destroy themselves
     admin_in_record_organisation? && record != current_agent

--- a/app/policies/agent_territorial_context.rb
+++ b/app/policies/agent_territorial_context.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AgentTerritorialContext
+  attr_reader :agent, :territory
+
+  def initialize(agent, territory)
+    @agent = agent
+    @territory = territory
+  end
+end

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Configuration::AgentPolicy
-
   def initialize(context, agent)
     @context = context
     @agent = agent
@@ -14,5 +13,4 @@ class Configuration::AgentPolicy
   alias edit? territorial_admin?
   alias show? territorial_admin?
   alias update? territorial_admin?
-
 end

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Configuration::AgentPolicy
+
+  def initialize(context, agent)
+    @context = context
+    @agent = agent
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias edit? territorial_admin?
+  alias show? territorial_admin?
+  alias update? territorial_admin?
+
+end

--- a/app/policies/configuration/agent_territorial_role_policy.rb
+++ b/app/policies/configuration/agent_territorial_role_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Configuration::AgentTerritorialRolePolicy
+  def initialize(context, role)
+    @context = context
+    @role = role
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias destroy? territorial_admin?
+end

--- a/app/policies/configuration/team_policy.rb
+++ b/app/policies/configuration/team_policy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Configuration::TeamPolicy
+
+  def initialize(context, team)
+    @context = context
+    @team = team
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      puts "init scop team ?"
+      @context  = context
+    end
+
+    def resolve
+      puts "resolve scop team ?"
+      puts @context.territory.inspect
+      @context.territory.teams
+    end
+  end
+end

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Configuration::TerritoryPolicy
+
+  def initialize(context, territory)
+    @context = context
+    @territory = territory
+  end
+
+  def show?
+    @context.agent.territorial_admin_in?(@territory)
+  end
+
+end
+

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class Configuration::TerritoryPolicy
-
   def initialize(context, territory)
     @context = context
     @territory = territory
   end
 
-  def show?
-    @context.agent.territorial_admin_in?(@territory)
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
   end
 
+  alias show? territorial_admin?
+  alias update? territorial_admin?
 end
-

--- a/app/views/admin/territories/agents/index.html.slim
+++ b/app/views/admin/territories/agents/index.html.slim
@@ -12,17 +12,19 @@
     table.table
       thead
         tr
-          th = t(".last_name")
-          th = t(".first_name")
-          th = t(".email")
+          th= Agent.human_attribute_name(:name)
+          th= Agent.human_attribute_name(:email)
+          th= Agent.human_attribute_name(:service)
           th = t(".teams")
           th = t(".actions")
       tbody
         - @agents.each do |agent|
           tr
-            td = agent.last_name
-            td = agent.first_name
+            td
+              = link_to agent.reverse_full_name, admin_territory_agent_path(current_territory, agent), class: "mr-2"
+              = me_tag(agent)
             td = agent.email
+            td = agent.service.name
             td = agent.teams.count
 
             td

--- a/app/views/admin/territories/agents/show.html.slim
+++ b/app/views/admin/territories/agents/show.html.slim
@@ -25,5 +25,3 @@
     .card-footer
       .d-flex.justify-content-end
         div= link_to "Modifier les équipes", edit_admin_territory_agent_path(current_territory, @agent), class: "btn btn-primary w-100"
-
-

--- a/app/views/admin/territories/agents/show.html.slim
+++ b/app/views/admin/territories/agents/show.html.slim
@@ -1,7 +1,6 @@
 = territory_navigation(t(".title", name: @agent.full_name), [link_to("Agents du territoire", admin_territory_agents_path(current_territory))])
 
 .container-fluid.bg-white.rounded.m-2
-
   .card
     .card-header
       h2 = @agent.full_name
@@ -14,3 +13,17 @@
         | Email
         br
         = mail_to @agent.email
+      .m-2
+        | Droit sur le territoire
+        br
+        = @agent.territorial_role_in(current_territory) ? "admin de territoire" : "agent"
+      .m-2
+        | Équipes
+        br
+        - @agent.teams.each do |team|
+          = link_to team.name, admin_territory_team_path(current_territory)
+    .card-footer
+      .d-flex.justify-content-end
+        div= link_to "Modifier les équipes", edit_admin_territory_agent_path(current_territory, @agent), class: "btn btn-primary w-100"
+
+

--- a/app/views/admin/territories/agents/show.html.slim
+++ b/app/views/admin/territories/agents/show.html.slim
@@ -1,0 +1,16 @@
+= territory_navigation(t(".title", name: @agent.full_name), [link_to("Agents du territoire", admin_territory_agents_path(current_territory))])
+
+.container-fluid.bg-white.rounded.m-2
+
+  .card
+    .card-header
+      h2 = @agent.full_name
+    .card-body
+      .m-2
+        | Service
+        br
+        = @agent.service.name
+      .m-2
+        | Email
+        br
+        = mail_to @agent.email

--- a/app/views/admin/territories/teams/index.html.slim
+++ b/app/views/admin/territories/teams/index.html.slim
@@ -21,7 +21,7 @@
       tbody
         - @teams.each do |team|
           tr id="team_#{team.id}"
-            td = team.name
+            td = link_to team.name, admin_territory_team_path(current_territory, team)
             td = team.agents.count
             td
               .d-flex

--- a/app/views/admin/territories/teams/show.html.slim
+++ b/app/views/admin/territories/teams/show.html.slim
@@ -18,5 +18,3 @@
     .card-footer
       .d-flex.justify-content-end
         div= link_to "Éditer", edit_admin_territory_team_path(current_territory, @team), class: "btn btn-primary w-100"
-
-

--- a/app/views/admin/territories/teams/show.html.slim
+++ b/app/views/admin/territories/teams/show.html.slim
@@ -1,0 +1,22 @@
+= territory_navigation(t(".title", name: @team.name), [link_to("Équipes", admin_territory_teams_path(current_territory))])
+
+.container-fluid.bg-white.rounded.m-2
+  .card
+    .card-header
+      h2 = @team.name
+    .card-body
+      - if @team.agents.any?
+        .m-2
+          | Liste des agents de l'équipe
+          br
+          - @team.agents.each do |agent|
+            = link_to agent.name, admin_territory_agent_path(current_territory, agent)
+      - else
+        .m-2
+          | Aucun agent dans cette équipe
+
+    .card-footer
+      .d-flex.justify-content-end
+        div= link_to "Éditer", edit_admin_territory_team_path(current_territory, @team), class: "btn btn-primary w-100"
+
+

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -84,6 +84,8 @@ fr:
           territory_teams_title: Créer une équipe
           title: Ajouter une équipe
       agents:
+        show:
+          title: Agent %{name}
         edit:
           agent_title: Modification agent %{name}
           territory_agents_title: Agents du territoire

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -73,6 +73,8 @@ fr:
           sectorization_title: Sectorisation
           title: Carte des secteurs
       teams:
+        show:
+          title: Équipe %{name}
         edit:
           territory_teams_title: Équipes du territoire
           title: Modifier l'équipe %{name}

--- a/spec/controllers/admin/territories/agents_controller_spec.rb
+++ b/spec/controllers/admin/territories/agents_controller_spec.rb
@@ -76,4 +76,21 @@ describe Admin::Territories::AgentsController, type: :controller do
       expect(assigns(:agents)).to eq([agent])
     end
   end
+
+  describe "#show" do
+
+    it "respond successfull" do
+      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
+      sign_in agent
+      get :show, params: { territory_id: territory.id, id: agent.id }
+      expect(response).to be_successful
+    end
+
+    it "assigns agent" do
+      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
+      sign_in agent
+      get :show, params: { territory_id: territory.id, id: agent.id }
+      expect(assigns(:agent)).to eq(agent)
+    end
+  end
 end

--- a/spec/controllers/admin/territories/agents_controller_spec.rb
+++ b/spec/controllers/admin/territories/agents_controller_spec.rb
@@ -78,7 +78,6 @@ describe Admin::Territories::AgentsController, type: :controller do
   end
 
   describe "#show" do
-
     it "respond successfull" do
       agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
       sign_in agent

--- a/spec/policies/configuration/agent_policy_spec.rb
+++ b/spec/policies/configuration/agent_policy_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Configuration::AgentPolicy, type: :policy do
+
+  [:edit?, :show?, :update?].each do |action|
+    describe action do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(Configuration::AgentPolicy.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(Configuration::AgentPolicy.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+
+end

--- a/spec/policies/configuration/agent_territorial_role_policy_spec.rb
+++ b/spec/policies/configuration/agent_territorial_role_policy_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-describe Configuration::AgentPolicy, type: :policy do
-  %i[edit? show? update?].each do |action|
+describe Configuration::AgentTerritorialRolePolicy, type: :policy do
+  %i[new? create? destroy?].each do |action|
     describe "##{action}" do
       it "returns false with agent without admin access to this territory" do
         territory = create(:territory)
         agent = create(:agent, role_in_territories: [])
         agent_territorial_context = AgentTerritorialContext.new(agent, territory)
-        expect(described_class.new(agent_territorial_context, territory).show?).to be false
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
       end
 
       it "returns true with agent with admin access to this territory" do

--- a/spec/policies/configuration/territory_policy_spec.rb
+++ b/spec/policies/configuration/territory_policy_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Configuration::TerritoryPolicy, type: :policy do
+
+  describe "show?" do
+    it "returns false with agent without admin access to this territory" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [])
+      agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+      expect(described_class.new(agent_territorial_context, territory).show?).to be false
+    end
+
+    it "returns true with agent with admin access to this territory" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [territory])
+      agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+      expect(described_class.new(agent_territorial_context, territory).show?).to be true
+    end
+  end
+
+end
+
+

--- a/spec/policies/configuration/territory_policy_spec.rb
+++ b/spec/policies/configuration/territory_policy_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe Configuration::TerritoryPolicy, type: :policy do
-
   describe "show?" do
     it "returns false with agent without admin access to this territory" do
       territory = create(:territory)
@@ -17,7 +16,4 @@ describe Configuration::TerritoryPolicy, type: :policy do
       expect(described_class.new(agent_territorial_context, territory).show?).to be true
     end
   end
-
 end
-
-


### PR DESCRIPTION
refs #2032

_À fusionner après #2151_

Pour préparer le terrain, j'ai ajouté une vue de visualisation dans laquelle j'affiche l'information sur le niveau d'admin de territoire.

J'ai également commencé à ajouter des `policies` pour le module de configuration.



AVANT LA REVUE
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
