### PR TITLE
Segmentation des cnfs dans des organisations différentes

### DIFF
--- a/scripts/migrate_cnfs_to_different_organisations.rb
+++ b/scripts/migrate_cnfs_to_different_organisations.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# rails runner scripts/migrate_cnfs_to_different_organisations.rb
+# rubocop:disable Rails/SkipsModelValidations
+
+old_organisation = Organisation.find(340)
+
+agent_ids_by_organisation_id = {
+  347 => [5975], # Médiathèque Jean Carmin
+  348 => [5983], # La Bâtie-Neuve
+  349 => [5976, 5977, 5978], # Grand Cognac
+  350 => [5982], # Espace de la porte St Jacques, Troyes
+  351 => [5974], # France Services Thenon
+  352 => [5981] # Tremblay-en-France
+}
+
+class MotifsPlageOuverture < ApplicationRecord
+end
+
+ActiveRecord::Base.transaction do
+  agent_ids_by_organisation_id.each do |organisation_id, agent_ids|
+    new_organisation = Organisation.find(organisation_id)
+
+    # migrer les plages d'ouverture
+    plage_ouvertures_for_organisation = PlageOuverture.where(agent_id: agent_ids)
+    plage_ouvertures_for_organisation.where(organisation: old_organisation).update_all(organisation_id: new_organisation.id)
+
+    # creer des duplicatas de motifs, et y associer les plages d'ouvertures, et les rdvs
+    Motif.joins(rdvs: :agents_rdvs).where(agents_rdvs: { agent_id: agent_ids }).find_each do |old_motif|
+      new_motif = old_motif.dup
+      new_motif.organisation = new_organisation
+      new_motif.save
+
+      MotifsPlageOuverture.where(motif_id: old_motif, plage_ouverture_id: plage_ouvertures_for_organisation).update_all(motif_id: new_motif.id)
+
+      Rdv.joins(:agents_rdvs).where(agents_rdvs: { agent_id: agent_ids }, motif: old_motif).update_all(motif_id: new_motif.id)
+    end
+
+    # migrer les rdv dans les nouveaux
+    Rdv.joins(:agents_rdvs).where(agents_rdvs: { agent_id: agent_ids }).update_all(organisation_id: new_organisation.id)
+
+    # migrer les lieux (en espérant qu'il n'y ai pas de lieux utilisés par plusieurs organisations différentes)
+    Lieu.joins(rdvs: :agents_rdvs).where(agents_rdvs: { agent_id: agent_ids }).where(organisation: old_organisation).update_all(organisation_id: new_organisation.id)
+
+    # migrer les absence
+    Absence.where(agent_id: agent_ids).where(organisation: old_organisation).update_all(organisation_id: new_organisation.id)
+
+    # et ajouter les usagers
+    User.joins(rdvs_users: { rdv: :agents_rdvs }).where(agents_rdvs: { agent_id: agent_ids }).find_each do |user|
+      user.add_organisation(new_organisation)
+    end
+  end
+
+  # Des lieux supplémentaires ont été créés pour le grand cognac
+  Lieu.where("address LIKE '%16, Charente, Nouvelle-Aquitaine'").where(organisation: old_organisation).update_all(organisation_id: 349)
+end
+
+# rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
Il y a un besoin assez fort pour l'expérimentation des cnfs de segmenter les données : c'est ressorti dans quasiment tous les entretiens que les cnfs n'étaient pas à l'aise que les données personnelles des usagers soient accessibles pour tous les cnfs de l'expérimentation. Par ailleurs, ça nous a confirmé que pour le vrai lancement, on voudra une organisation rdv solidarité par structure cnfs (qui sont généralement des petites équipes, et souvent un seul cnfs).

Pour que l'expérience se passe bien, on a aussi besoin de continuité des données : certaines cnfs ont entré de nombreux lieux, et veulent pouvoir continuer à les utiliser, d'autres ont des plages d'ouvertures très détaillées, et elles veulent aussi garder leur historique de rdev

J'ai manuellement créé les nouvelles organisations, et j'y ai invité les cnfs.

Je suis tenté d'utiliser ce script en production pour déplacer dans les bonnes organisations les données des cnfs pour l'expérimentation, mais je suis pas complètement serein : je me dis que ça peut poser des problèmes pour les versions papertrail, et c'est pas évident à tester en local.

J'ai l'impression que c'est raisonnable de faire un test en local en changeant les id. J'ai aussi scopé autant que possible les requêtes par organisation_id pour être sûr de ne toucher que à l'expérience cnfs.

Qu'est-ce que vous en pensez ?

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
