### PR TITLE
Ajoute des policies pour le module configuration

### DIFF
--- a/app/controllers/admin/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/agents/plage_ouvertures_controller.rb
@@ -17,7 +17,7 @@ class Admin::Agents::PlageOuverturesController < ApplicationController
 
   # TODO: custom policy waiting for policies refactoring
   def custom_policy
-    context = AgentContext.new(current_agent, @organisation)
+    context = AgentOrganisationContext.new(current_agent, @organisation)
     Agent::PlageOuverturePolicy::DepartementScope.new(context, PlageOuverture)
       .resolve
   end

--- a/app/controllers/admin/agents/rdvs_controller.rb
+++ b/app/controllers/admin/agents/rdvs_controller.rb
@@ -18,7 +18,7 @@ class Admin::Agents::RdvsController < ApplicationController
 
   # TODO: custom policy waiting for policies refactoring
   def custom_policy
-    context = AgentContext.new(current_agent, @organisation)
+    context = AgentOrganisationContext.new(current_agent, @organisation)
     Agent::RdvPolicy::DepartementScope.new(context, Rdv)
       .resolve
   end

--- a/app/controllers/admin/invitations_devise_controller.rb
+++ b/app/controllers/admin/invitations_devise_controller.rb
@@ -42,7 +42,7 @@ class Admin::InvitationsDeviseController < Devise::InvitationsController
   protected
 
   def pundit_user
-    AgentContext.new(current_agent, current_organisation)
+    AgentOrganisationContext.new(current_agent, current_organisation)
   end
 
   def current_organisation

--- a/app/controllers/admin/territories/agent_territorial_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_territorial_roles_controller.rb
@@ -2,23 +2,22 @@
 
 class Admin::Territories::AgentTerritorialRolesController < Admin::Territories::BaseController
   def index
-    @roles = policy_scope_admin(AgentTerritorialRole)
-      .where(territory: current_territory)
+    @roles = policy_scope(AgentTerritorialRole).where(territory: current_territory)
     @territory = current_territory
   end
 
   def new
     @role = AgentTerritorialRole.new(territory: current_territory)
-    @possible_agents = policy_scope_admin(Agent)
+    @possible_agents = policy_scope(Agent)
       .includes(:territories)
       .to_a
       .reject { _1.territorial_admin_in?(current_territory) }
-    authorize_admin(@role)
+    authorize @role
   end
 
   def create
     @role = AgentTerritorialRole.new(agent_territorial_role_params)
-    authorize_admin(@role)
+    authorize @role
     if @role.save
       redirect_to(
         admin_territory_agent_territorial_roles_path(current_territory),
@@ -31,7 +30,7 @@ class Admin::Territories::AgentTerritorialRolesController < Admin::Territories::
 
   def destroy
     role = AgentTerritorialRole.find(params[:id])
-    authorize_admin(role)
+    authorize role
     if role.destroy
       flash[:success] = "#{role.agent.full_name} n'a plus le rôle d'administrateur du #{current_territory}"
     else

--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 class Admin::Territories::AgentsController < Admin::Territories::BaseController
+  before_action :set_agent, only: %i[edit update]
+  before_action :authorize_agent, only: %i[edit update]
+
   def index
-    @agents = find_agents(params[:q])
-      .page(params[:page])
+    @agents = find_agents(params[:q]).page(params[:page])
   end
 
   def search
-    skip_authorization
-
-    @agents = find_agents(params[:q])
-      .limit(10)
+    @agents = find_agents(params[:q]).limit(10)
   end
 
   def find_agents(search_term)
-    organisation_agents = policy_scope_admin(Agent)
+    organisation_agents = policy_scope(Agent)
       .merge(current_territory.organisations_agents)
       .active
       .complete
@@ -27,17 +26,24 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
     end
   end
 
-  def edit
-    @agent = Agent.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @agent = Agent.find(params[:id])
     if @agent.update(agent_params)
       redirect_to admin_territory_agents_path(current_territory)
     else
       render :edit
     end
+  end
+
+  private
+
+  def set_agent
+    @agent = Agent.find(params[:id])
+  end
+
+  def authorize_agent
+    authorize @agent
   end
 
   def agent_params

--- a/app/controllers/admin/territories/base_controller.rb
+++ b/app/controllers/admin/territories/base_controller.rb
@@ -7,13 +7,29 @@ class Admin::Territories::BaseController < ApplicationController
 
   before_action :set_territory
 
+  # rubocop:disable Rails/LexicallyScopedActionFilter
+  after_action :verify_authorized, except: %i[index search]
+  after_action :verify_policy_scoped, only: %i[index search]
+  # rubocop:enable Rails/LexicallyScopedActionFilter
+
   def current_territory
     @territory
   end
   helper_method :current_territory
 
   def pundit_user
-    AgentContext.new(current_agent)
+    AgentTerritorialContext.new(current_agent, current_territory)
+  end
+  helper_method :pundit_user
+
+  def authorize(record, *args)
+    # Utilisation d'un namespace `configuration` pour éviter les confusions avec les policies d'un RDV usager, d'un RDV agent ou d'un RDV en configuration.
+    super([:configuration, record], *args)
+  end
+
+  def policy_scope(record, *args)
+    # Utilisation d'un namespace `configuration` pour éviter les confusions avec les policies d'un RDV usager, d'un RDV agent ou d'un RDV en configuration.
+    super([:configuration, record], *args)
   end
 
   private

--- a/app/controllers/admin/territories/sector_attributions_controller.rb
+++ b/app/controllers/admin/territories/sector_attributions_controller.rb
@@ -6,12 +6,12 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
   def new
     @sector_attribution = SectorAttribution.new(**sector_attribution_params_get, sector: @sector)
     prepare_available_organisations_and_agents
-    authorize_admin(@sector_attribution)
+    authorize @sector_attribution
   end
 
   def create
     @sector_attribution = SectorAttribution.new(**sector_attribution_params, sector: @sector)
-    authorize_admin(@sector_attribution)
+    authorize @sector_attribution
     if @sector_attribution.save
       redirect_to admin_territory_sector_path(current_territory, @sector), flash: { success: "Attribution ajoutée" }
     else
@@ -22,7 +22,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
 
   def destroy
     sector_attribution = SectorAttribution.find(params[:id])
-    authorize_admin(sector_attribution)
+    authorize sector_attribution
     if sector_attribution.destroy
       redirect_to admin_territory_sector_path(current_territory, @sector), flash: { success: "Attribution retirée" }
     else
@@ -33,7 +33,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
   private
 
   def prepare_available_organisations_and_agents
-    @available_organisations = policy_scope_admin(Organisation)
+    @available_organisations = Organisation
       .where(territory: current_territory)
       .where.not(id: excluded_organisation_ids)
       .order_by_name
@@ -43,7 +43,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
       .attributions
       .level_agent
       .where(organisation: @sector_attribution.organisation)
-    @available_agents = policy_scope_admin(Agent)
+    @available_agents = policy_scope(Agent)
       .merge(@sector_attribution.organisation.agents)
       .where.not(id: existing_agent_attributions.pluck(:agent_id))
   end
@@ -57,7 +57,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
   end
 
   def set_sector
-    @sector = policy_scope_admin(Sector).find(params[:sector_id])
+    @sector = policy_scope(Sector).find(params[:sector_id])
   end
 
   def sector_attribution_params

--- a/app/controllers/admin/territories/sectorisation_tests_controller.rb
+++ b/app/controllers/admin/territories/sectorisation_tests_controller.rb
@@ -2,11 +2,7 @@
 
 class Admin::Territories::SectorisationTestsController < Admin::Territories::BaseController
   def search
-    authorize_admin(
-      policy_scope_admin(Organisation).where(territory: current_territory).first,
-      :show?
-    )
-    @sectorisation_test_form = Admin::SectorisationTestForm.new(current_territory: current_territory, **sectorisation_test_params)
+    @sectorisation_test_form = policy_scope(Admin::SectorisationTestForm.new(current_territory: current_territory, **sectorisation_test_params))
     @sectorisation_test_form.valid? if sectorisation_test_params.present?
   end
 

--- a/app/controllers/admin/territories/sms_configurations_controller.rb
+++ b/app/controllers/admin/territories/sms_configurations_controller.rb
@@ -2,6 +2,7 @@
 
 class Admin::Territories::SmsConfigurationsController < Admin::Territories::BaseController
   before_action :check_allowed_departement, only: %i[update edit]
+  before_action :authorize_current_territory
 
   def show; end
 
@@ -13,6 +14,10 @@ class Admin::Territories::SmsConfigurationsController < Admin::Territories::Base
   end
 
   private
+
+  def authorize_current_territory
+    authorize current_territory
+  end
 
   def check_allowed_departement
     return if current_territory.has_own_sms_provider?

--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
 class Admin::Territories::TeamsController < Admin::Territories::BaseController
+  before_action :set_team, only: %i[show edit update destroy]
+
   def index
-    @teams = current_territory.teams.page(params[:page])
+    @teams = policy_scope(Team).page(params[:page])
     @teams = params[:search].present? ? @teams.search_by_text(params[:search]) : @teams.order(:name)
   end
 
   def new
     @team = Team.new
+    authorize @team
+  end
+
+  def show
+    authorize @team
   end
 
   def create
+    authorize Team
     if (@team = Team.create(team_params.merge(territory: current_territory)))
       redirect_to admin_territory_teams_path(current_territory)
     else
@@ -19,11 +27,11 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
   end
 
   def edit
-    @team = Team.find(params[:id])
+    authorize @team
   end
 
   def update
-    @team = Team.find(params[:id])
+    authorize @team
     if @team.update(team_params)
       redirect_to admin_territory_teams_path(current_territory)
     else
@@ -32,13 +40,13 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
   end
 
   def destroy
-    team = Team.find(params[:id])
-    team.destroy!
+    authorize @team
+    @team.destroy!
     redirect_to admin_territory_teams_path(current_territory)
   end
 
   def search
-    teams = TeamPolicy::Scope.new(current_territory, Team).resolve.limit(10)
+    teams = policy_scope(Team).limit(10)
     @teams = search_params[:term].present? ? teams.search_by_text(search_params[:term]) : teams.order(:name)
   end
 
@@ -50,5 +58,9 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
 
   def team_params
     params.require(:team).permit(:name, agent_ids: [])
+  end
+
+  def set_team
+    @team = Team.find(params[:id])
   end
 end

--- a/app/controllers/admin/territories/user_fields_controller.rb
+++ b/app/controllers/admin/territories/user_fields_controller.rb
@@ -2,11 +2,11 @@
 
 class Admin::Territories::UserFieldsController < Admin::Territories::BaseController
   def edit
-    authorize_admin(current_territory)
+    authorize current_territory
   end
 
   def update
-    authorize_admin(current_territory)
+    authorize current_territory
     current_territory.update!(user_fields_params)
 
     flash[:alert] = "Configuration enregistrée"

--- a/app/controllers/admin/territories/webhook_endpoints_controller.rb
+++ b/app/controllers/admin/territories/webhook_endpoints_controller.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 class Admin::Territories::WebhookEndpointsController < Admin::Territories::BaseController
+  before_action :set_webhook_endpoint, only: %i[edit update destroy]
+
   def index
-    @webhooks = policy_scope_admin(WebhookEndpoint).where(organisation: current_territory.organisations)
+    @webhooks = policy_scope(WebhookEndpoint).where(organisation: current_territory.organisations)
   end
 
   def new
     @webhook = WebhookEndpoint.new
-    skip_authorization
+    authorize @webhook
   end
 
   def create
     @webhook = WebhookEndpoint.new(webhook_endpoint_params)
-    authorize_admin(@webhook)
+    authorize @webhook
     if @webhook.save
       redirect_to admin_territory_webhook_endpoints_path(current_territory)
     else
@@ -21,13 +23,11 @@ class Admin::Territories::WebhookEndpointsController < Admin::Territories::BaseC
   end
 
   def edit
-    @webhook = WebhookEndpoint.find(params[:id])
-    authorize_admin(@webhook)
+    authorize @webhook
   end
 
   def update
-    @webhook = WebhookEndpoint.find(params[:id])
-    authorize_admin(@webhook)
+    authorize @webhook
     if @webhook.update(webhook_endpoint_params)
       redirect_to admin_territory_webhook_endpoints_path(current_territory)
     else
@@ -36,7 +36,8 @@ class Admin::Territories::WebhookEndpointsController < Admin::Territories::BaseC
   end
 
   def destroy
-    policy_scope_admin(WebhookEndpoint).find(params[:id]).destroy
+    authorize @webhook
+    @webhook.destroy
     redirect_to admin_territory_webhook_endpoints_path(current_territory)
   end
 
@@ -46,5 +47,9 @@ class Admin::Territories::WebhookEndpointsController < Admin::Territories::BaseC
     params.require(:webhook_endpoint).permit(
       :target_url, :secret, :organisation_id, subscriptions: []
     )
+  end
+
+  def set_webhook_endpoint
+    @webhook = WebhookEndpoint.find(params[:id])
   end
 end

--- a/app/controllers/admin/territories/zone_imports_controller.rb
+++ b/app/controllers/admin/territories/zone_imports_controller.rb
@@ -2,12 +2,12 @@
 
 class Admin::Territories::ZoneImportsController < Admin::Territories::BaseController
   def new
-    authorize_admin(Zone.new(sector: Sector.new(territory: current_territory)))
+    authorize Zone.new(sector: Sector.new(territory: current_territory))
     @form = ZoneImportForm.new
   end
 
   def create
-    authorize_admin(Zone.new(sector: Sector.new(territory: current_territory)))
+    authorize Zone.new(sector: Sector.new(territory: current_territory))
     @form = ZoneImportForm.new(import_params)
     if @form.valid?
       @res = ImportZoneRowsService.perform_with(

--- a/app/controllers/admin/territories_controller.rb
+++ b/app/controllers/admin/territories_controller.rb
@@ -5,13 +5,18 @@ class Admin::TerritoriesController < Admin::Territories::BaseController
 
   def show
     @territory = Territory.find(params[:id])
+    authorize @territory
   end
 
   def update
     @territory = Territory.find(params[:id])
-    authorize_admin(@territory)
-    flash[:success] = "Mise à jour réussie !" if @territory.update(territory_params)
-    render "admin/territories/agent_territorial_roles/index"
+    authorize @territory
+    if @territory.update(territory_params)
+      flash[:success] = "Mise à jour réussie !"
+    else
+      flash[:error] = "Erreur durant la mise à jour"
+    end
+    redirect_to admin_territory_agent_territorial_roles_path(current_territory)
   end
 
   private

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -13,7 +13,7 @@ class AgentAuthController < ApplicationController
   private
 
   def pundit_user
-    AgentContext.new(current_agent, current_organisation)
+    AgentOrganisationContext.new(current_agent, current_organisation)
   end
   helper_method :pundit_user
 

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BaseController < ActionController::Base
   before_action :authenticate_api_v1_agent_with_token_auth!
 
   def pundit_user
-    AgentContext.new(current_agent, current_organisation)
+    AgentOrganisationContext.new(current_agent, current_organisation)
   end
 
   def current_organisation

--- a/app/form_models/admin/rdv_wizard_form/step3.rb
+++ b/app/form_models/admin/rdv_wizard_form/step3.rb
@@ -11,6 +11,6 @@ class Admin::RdvWizardForm::Step3
   protected
 
   def agent_context
-    AgentContext.new(@agent_author, @organisation)
+    AgentOrganisationContext.new(@agent_author, @organisation)
   end
 end

--- a/app/policies/agent/user_policy.rb
+++ b/app/policies/agent/user_policy.rb
@@ -6,14 +6,10 @@ class Agent::UserPolicy < DefaultAgentPolicy
   end
 
   def create?
-    # for the creation we want to make sure that all organisation IDs are
-    # authorized for the current context (orga or agent)
-    return false if @record.user_profiles.empty?
-
-    (
-      @record.user_profiles.map(&:organisation_id) -
-      (current_organisation.present? ? [current_organisation.id] : current_agent.organisation_ids)
-    ).empty?
+    # Un agent est toujours authorisé à créer un usager.
+    # Il y a des contraintes sur l'association à une organisation,c'est sur le `user_profile`,
+    # lié au système d'erreur et de contrainte `ActiveRecord`, et non aux authorisation.
+    true
   end
 
   def invite?

--- a/app/policies/agent_context.rb
+++ b/app/policies/agent_context.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class AgentContext
-  attr_reader :agent, :organisation, :agent_role
+  attr_reader :agent
 
-  delegate :can_access_others_planning?, to: :agent_role, allow_nil: true
-
-  def initialize(agent, organisation = nil)
+  def initialize(agent)
     @agent = agent
-    @organisation = organisation
-    @agent_role = AgentRole.find_by(agent: @agent, organisation: @organisation) if @organisation.present?
   end
 end

--- a/app/policies/agent_organisation_context.rb
+++ b/app/policies/agent_organisation_context.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# TODO: supprimer ce context, nous devrions pouvoir utiliser l'organisation de l'objet sur lequel on vérifier l'accès
+class AgentOrganisationContext
+  attr_reader :agent, :organisation, :agent_role
+
+  delegate :can_access_others_planning?, to: :agent_role, allow_nil: true
+
+  def initialize(agent, organisation)
+    @agent = agent
+    @organisation = organisation
+    @agent_role = AgentRole.find_by(agent: @agent, organisation: @organisation)
+  end
+end

--- a/app/policies/agent_territorial_context.rb
+++ b/app/policies/agent_territorial_context.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# TODO: supprimer ce context, nous devrions pouvoir utiliser le territoire de l'objet sur lequel on vérifier l'accès
+class AgentTerritorialContext
+  attr_reader :agent, :territory
+
+  def initialize(agent, territory)
+    @agent = agent
+    @territory = territory
+  end
+end

--- a/app/policies/configuration/admin/sectorisation_test_form_policy.rb
+++ b/app/policies/configuration/admin/sectorisation_test_form_policy.rb
@@ -2,8 +2,7 @@
 
 class Configuration::Admin::SectorisationTestFormPolicy
   class Scope
-    def initialize(context, scope)
-      @context = context
+    def initialize(_context, scope)
       @scope = scope
     end
 

--- a/app/policies/configuration/admin/sectorisation_test_form_policy.rb
+++ b/app/policies/configuration/admin/sectorisation_test_form_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Configuration::Admin::SectorisationTestFormPolicy
+  class Scope
+    def initialize(context, scope)
+      @context = context
+      @scope = scope
+    end
+
+    def resolve
+      @scope
+    end
+  end
+end

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::AgentPolicy
   def initialize(context, agent)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @agent = agent
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias edit? territorial_admin?
@@ -15,11 +16,11 @@ class Configuration::AgentPolicy
 
   class Scope
     def initialize(context, _scope)
-      @context = context
+      @current_territory = context.territory
     end
 
     def resolve
-      Agent.where(roles: AgentRole.where(organisation: @context.territory.organisations))
+      Agent.where(roles: AgentRole.where(organisation: @current_territory.organisations))
     end
   end
 end

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Configuration::AgentPolicy
+  def initialize(context, agent)
+    @context = context
+    @agent = agent
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias edit? territorial_admin?
+  alias update? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      @context = context
+    end
+
+    def resolve
+      Agent.where(roles: AgentRole.where(organisation: @context.territory.organisations))
+    end
+  end
+end

--- a/app/policies/configuration/agent_territorial_role_policy.rb
+++ b/app/policies/configuration/agent_territorial_role_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::AgentTerritorialRolePolicy
   def initialize(context, role)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @role = role
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias new? territorial_admin?
@@ -16,11 +17,11 @@ class Configuration::AgentTerritorialRolePolicy
 
   class Scope
     def initialize(context, _scope)
-      @context = context
+      @current_territory = context.territory
     end
 
     def resolve
-      AgentTerritorialRole.where(territory: @context.territory)
+      AgentTerritorialRole.where(territory: @current_territory)
     end
   end
 end

--- a/app/policies/configuration/agent_territorial_role_policy.rb
+++ b/app/policies/configuration/agent_territorial_role_policy.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Configuration::AgentTerritorialRolePolicy
+  def initialize(context, role)
+    @context = context
+    @role = role
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias destroy? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      @context = context
+    end
+
+    def resolve
+      AgentTerritorialRole.where(territory: @context.territory)
+    end
+  end
+end

--- a/app/policies/configuration/sector_attribution_policy.rb
+++ b/app/policies/configuration/sector_attribution_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Configuration::SectorAttributionPolicy
+  def initialize(context, agent)
+    @context = context
+    @agent = agent
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias destroy? territorial_admin?
+end

--- a/app/policies/configuration/sector_attribution_policy.rb
+++ b/app/policies/configuration/sector_attribution_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::SectorAttributionPolicy
   def initialize(context, agent)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @agent = agent
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias new? territorial_admin?

--- a/app/policies/configuration/sector_policy.rb
+++ b/app/policies/configuration/sector_policy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Configuration::SectorPolicy
+  def initialize(context, agent)
+    @context = context
+    @agent = agent
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias show? territorial_admin?
+  alias edit? territorial_admin?
+  alias update? territorial_admin?
+  alias destroy? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      @context = context
+    end
+
+    def resolve
+      Sector.where(territory: @context.territory)
+    end
+  end
+end

--- a/app/policies/configuration/sector_policy.rb
+++ b/app/policies/configuration/sector_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::SectorPolicy
   def initialize(context, agent)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @agent = agent
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias new? territorial_admin?
@@ -19,11 +20,11 @@ class Configuration::SectorPolicy
 
   class Scope
     def initialize(context, _scope)
-      @context = context
+      @current_territory = context.territory
     end
 
     def resolve
-      Sector.where(territory: @context.territory)
+      Sector.where(territory: @current_territory)
     end
   end
 end

--- a/app/policies/configuration/team_policy.rb
+++ b/app/policies/configuration/team_policy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Configuration::TeamPolicy
+  def initialize(context, team)
+    @context = context
+    @team = team
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias destroy? territorial_admin?
+  alias edit? territorial_admin?
+  alias update? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      @context = context
+    end
+
+    def resolve
+      @context.territory.teams
+    end
+  end
+end

--- a/app/policies/configuration/team_policy.rb
+++ b/app/policies/configuration/team_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::TeamPolicy
   def initialize(context, team)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @team = team
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias new? territorial_admin?
@@ -18,11 +19,11 @@ class Configuration::TeamPolicy
 
   class Scope
     def initialize(context, _scope)
-      @context = context
+      @current_territory = context.territory
     end
 
     def resolve
-      @context.territory.teams
+      @current_territory.teams
     end
   end
 end

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::TerritoryPolicy
   def initialize(context, territory)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @territory = territory
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias show? territorial_admin?

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Configuration::TerritoryPolicy
+  def initialize(context, territory)
+    @context = context
+    @territory = territory
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias show? territorial_admin?
+  alias update? territorial_admin?
+  alias edit? territorial_admin?
+end

--- a/app/policies/configuration/webhook_endpoint_policy.rb
+++ b/app/policies/configuration/webhook_endpoint_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::WebhookEndpointPolicy
   def initialize(context, agent)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @agent = agent
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias new? territorial_admin?
@@ -18,11 +19,11 @@ class Configuration::WebhookEndpointPolicy
 
   class Scope
     def initialize(context, _scope)
-      @context = context
+      @current_territory = context.territory
     end
 
     def resolve
-      WebhookEndpoint.where(organisation: @context.territory.organisations)
+      WebhookEndpoint.where(organisation: @current_territory.organisations)
     end
   end
 end

--- a/app/policies/configuration/webhook_endpoint_policy.rb
+++ b/app/policies/configuration/webhook_endpoint_policy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Configuration::WebhookEndpointPolicy
+  def initialize(context, agent)
+    @context = context
+    @agent = agent
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias edit? territorial_admin?
+  alias update? territorial_admin?
+  alias destroy? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      @context = context
+    end
+
+    def resolve
+      WebhookEndpoint.where(organisation: @context.territory.organisations)
+    end
+  end
+end

--- a/app/policies/configuration/zone_policy.rb
+++ b/app/policies/configuration/zone_policy.rb
@@ -2,12 +2,13 @@
 
 class Configuration::ZonePolicy
   def initialize(context, agent)
-    @context = context
+    @current_agent = context.agent
+    @current_territory = context.territory
     @agent = agent
   end
 
   def territorial_admin?
-    @context.agent.territorial_admin_in?(@context.territory)
+    @current_agent.territorial_admin_in?(@current_territory)
   end
 
   alias new? territorial_admin?

--- a/app/policies/configuration/zone_policy.rb
+++ b/app/policies/configuration/zone_policy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Configuration::ZonePolicy
+  def initialize(context, agent)
+    @context = context
+    @agent = agent
+  end
+
+  def territorial_admin?
+    @context.agent.territorial_admin_in?(@context.territory)
+  end
+
+  alias new? territorial_admin?
+  alias create? territorial_admin?
+  alias destroy? territorial_admin?
+end

--- a/app/views/admin/territories/agent_territorial_roles/index.html.slim
+++ b/app/views/admin/territories/agent_territorial_roles/index.html.slim
@@ -11,7 +11,7 @@
             th Agent
             th Actions
         tbody
-          - policy_scope_admin(AgentTerritorialRole).where(territory: current_territory).each do |role|
+          - @roles.each do |role|
             tr
               td
                 div

--- a/app/views/admin/territories/zones/_form.html.slim
+++ b/app/views/admin/territories/zones/_form.html.slim
@@ -21,7 +21,7 @@
       | Seule la rue désignée dans la commune sera couverte par le secteur
 
   = f.input :sector_id, \
-    collection: policy_scope_admin(Sector).where(territory: current_territory), \
+    collection: @available_sectors, \
     disabled: true, \
     include_blank: false
 

--- a/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
+++ b/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
@@ -11,14 +11,14 @@ describe Admin::Territories::SectorisationTestsController, type: :controller do
 
   describe "#search" do
     context "without params" do
-      xit "returns success" do
+      it "returns success" do
         get :search, params: { territory_id: territory.id }
         expect(response).to be_successful
       end
     end
 
     context "with adresse parameters" do
-      xit "returns success" do
+      it "returns success" do
         get :search, params: {
           territory_id: territory.id,
           address: "21 Chemin de la Marion, Le Faouët, 5632, 56, Morbihan, Bretagne",

--- a/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
+++ b/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe Admin::Territories::SectorisationTestsController, type: :controller do
-  render_views
-
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
   let(:agent) { create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory]) }
@@ -13,15 +11,14 @@ describe Admin::Territories::SectorisationTestsController, type: :controller do
 
   describe "#search" do
     context "without params" do
-      it "returns success" do
+      xit "returns success" do
         get :search, params: { territory_id: territory.id }
         expect(response).to be_successful
       end
     end
 
     context "with adresse parameters" do
-      it "returns success" do
-        pending "error with not gening_errors en attente depuis un moment. Page à supprimer ?"
+      xit "returns success" do
         get :search, params: {
           territory_id: territory.id,
           address: "21 Chemin de la Marion, Le Faouët, 5632, 56, Morbihan, Bretagne",

--- a/spec/controllers/admin/territories/sms_configurations_controller_spec.rb
+++ b/spec/controllers/admin/territories/sms_configurations_controller_spec.rb
@@ -3,7 +3,7 @@
 describe Admin::Territories::SmsConfigurationsController, type: :controller do
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
-  let(:agent) { create(:agent, organisations: [organisation]) }
+  let(:agent) { create(:agent, role_in_territories: [territory], basic_role_in_organisations: [organisation]) }
 
   before do
     sign_in agent

--- a/spec/controllers/admin/territories/teams_controller_spec.rb
+++ b/spec/controllers/admin/territories/teams_controller_spec.rb
@@ -19,7 +19,7 @@ describe Admin::Territories::TeamsController, type: :controller do
       agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
       team = create(:team, territory: territory, name: "first team")
       create(:team, territory: territory, name: "second")
-      create(:team, territory: create(:territory))
+      create(:team, territory: create(:territory), name: "first group")
       sign_in agent
 
       get :index, params: { territory_id: territory.id, search: "first" }
@@ -116,7 +116,7 @@ describe Admin::Territories::TeamsController, type: :controller do
     it "assigns teams" do
       agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
       sign_in agent
-      team = create(:team, name: "bla", territory: organisation.territory)
+      team = create(:team, name: "bla", territory: territory)
       get :search, params: { territory_id: territory.id, term: "bla", format: "json" }
       expect(assigns(:teams)).to eq([team])
     end

--- a/spec/controllers/admin/territories_controller_spec.rb
+++ b/spec/controllers/admin/territories_controller_spec.rb
@@ -1,39 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe Admin::TerritoriesController, type: :controller do
-  render_views
-
-  let!(:territory) { create(:territory, departement_number: "62") }
-  # let!(:organisation) { create(:organisation, territory: territory) }
+  let(:territory) { create(:territory, departement_number: "62") }
+  let(:organisation) { create(:organisation, territory: territory) }
+  let(:agent) { create(:agent, role_in_territories: [territory], basic_role_in_organisations: [organisation]) }
 
   before { sign_in agent }
 
   describe "#update" do
     context "agent has role in territory" do
-      let!(:territory) do
-        create(
-          :territory,
-          name: "Yvelines",
-          phone_number: "0101010101",
-          departement_number: "78"
-        )
+      it "returns success" do
+        put :update, params: { id: territory.id, territory: { name: "La Clé St Pierre", phone_number: "0202020202" } }
+        expect(response).to redirect_to admin_territory_agent_territorial_roles_path(territory)
       end
-      let!(:agent) { create(:agent, role_in_territories: [territory]) }
 
-      it "updates territory" do
-        put(
-          :update,
-          params: {
-            id: territory.id,
-            territory: {
-              name: "La Clé St Pierre",
-              phone_number: "0202020202"
-            }
-          }
-        )
-        expect(response).to be_successful
-        expect(territory.reload.name).to eq("La Clé St Pierre")
-        expect(territory.reload.phone_number).to eq("0202020202")
+      it "update territory" do
+        expect do
+          put :update, params: { id: territory.id, territory: { name: "La Clé St Pierre", phone_number: "0202020202" } }
+        end.to change { territory.reload.name }.to("La Clé St Pierre")
       end
     end
   end

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -3,7 +3,7 @@
 describe Admin::EditRdvForm, type: :form do
   let(:organisation) { create(:organisation) }
   let(:agent) { create(:agent) }
-  let(:agent_context) { instance_double(AgentContext, agent: agent, organisation: organisation) }
+  let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
 
   describe "#update" do
     it "updates rdv's lieu" do

--- a/spec/form_models/admin/rdv_form_concern_spec.rb
+++ b/spec/form_models/admin/rdv_form_concern_spec.rb
@@ -21,7 +21,7 @@ describe Admin::RdvFormConcern, type: :form do
 
   let(:now) { Time.zone.parse("2021-11-23 11:00") }
   let!(:agent_author) { create(:agent, first_name: "Poney", last_name: "FOU") }
-  let(:agent_context) { instance_double(AgentContext, agent: agent_author, organisation: build(:organisation)) }
+  let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent_author, organisation: build(:organisation)) }
   let(:rdv_start_coherence) { instance_double(RdvStartCoherence) }
   let(:rdvs_overlapping) { instance_double(RdvsOverlapping) }
 

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -37,7 +37,7 @@ describe Agent::RdvPolicy, type: :policy do
     let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
     let(:motif) { create(:motif, organisation: organisation, service: service) }
     let(:rdv) { create(:rdv, organisation: organisation, agents: [agent], motif: motif) }
-    let(:pundit_context) { AgentContext.new(agent, organisation) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
     it_behaves_like "permit actions", :show?, :edit?, :update?, :destroy?
     it_behaves_like "included in scope"
@@ -50,7 +50,7 @@ describe Agent::RdvPolicy, type: :policy do
     let(:motif) { create(:motif, organisation: organisation, service: service_rdv) }
     let(:rdv) { create(:rdv, motif: motif, organisation: organisation) }
     let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service_agent) }
-    let(:pundit_context) { AgentContext.new(agent, organisation) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
     it_behaves_like "not permit actions", :show?, :edit?, :update?, :destroy?
     it_behaves_like "not included in scope"
@@ -76,7 +76,7 @@ describe Agent::RdvPolicy, type: :policy do
     let(:agents) { create_list(:agent, 2, organisations: [organisation], service: service) }
     let(:motif) { create(:motif, organisation: organisation, service: service) }
     let(:rdv) { create(:rdv, agents: [agents[0]], motif: motif, organisation: organisation) }
-    let(:pundit_context) { AgentContext.new(agents[1], organisation) }
+    let(:pundit_context) { AgentOrganisationContext.new(agents[1], organisation) }
 
     it_behaves_like "permit actions", :show?, :edit?, :update?, :destroy?
     it_behaves_like "included in scope"
@@ -90,7 +90,7 @@ describe Agent::RdvPolicy, type: :policy do
     let(:agent2) { create(:agent, basic_role_in_organisations: [organisation2], service: service) }
     let(:motif1) { create(:motif, organisation: organisation1, service: service) }
     let(:rdv) { create(:rdv, agents: [agent1], motif: motif1, organisation: organisation1) }
-    let(:pundit_context) { AgentContext.new(agent2, organisation2) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent2, organisation2) }
 
     it_behaves_like "not permit actions", :show?, :edit?, :update?, :destroy?
     it_behaves_like "not included in scope"

--- a/spec/policies/agent/user_policy_spec.rb
+++ b/spec/policies/agent/user_policy_spec.rb
@@ -3,96 +3,14 @@
 describe Agent::UserPolicy, type: :policy do
   subject { described_class }
 
-  let!(:organisation1) { create(:organisation) }
-  let!(:organisation2) { create(:organisation) }
-  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation1, organisation2]) }
+  describe "creating user is always allowed" do
+    let(:organisation) { create(:organisation) }
+    let(:user) { build(:user, organisations: [organisation]) }
+    let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
-  context "in orga context" do
-    let(:pundit_context) { AgentContext.new(agent, organisation1) }
-
-    context "creating user that belongs to one of agent's orga" do
-      let(:user) { build(:user, organisations: [organisation1]) }
-
-      permissions :create? do
-        it { is_expected.to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs to both agent's orgas" do
-      let(:user) { build(:user, organisations: [organisation1, organisation2]) }
-
-      permissions :create? do
-        # should not permit because in orga context
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs to no orga" do
-      let(:user) { build(:user, organisations: []) }
-
-      permissions :create? do
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs to orgas different from agents" do
-      let(:user) { build(:user, organisations: [create(:organisation), create(:organisation)]) }
-
-      permissions :create? do
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs both to agent's orga and different one" do
-      let(:user) { build(:user, organisations: [organisation1, create(:organisation)]) }
-
-      permissions :create? do
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
-    end
-  end
-
-  context "outside orga context, whole agent" do
-    let(:pundit_context) { AgentContext.new(agent) }
-
-    context "creating user that belongs to one of agent's orga" do
-      let(:user) { build(:user, organisations: [organisation1]) }
-
-      permissions :create? do
-        it { is_expected.to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs to both agent's orgas" do
-      let(:user) { build(:user, organisations: [organisation1, organisation2]) }
-
-      permissions :create? do
-        it { is_expected.to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs to no orga" do
-      let(:user) { build(:user, organisations: []) }
-
-      permissions :create? do
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs to orgas different from agents" do
-      let(:user) { build(:user, organisations: [create(:organisation), create(:organisation)]) }
-
-      permissions :create? do
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
-    end
-
-    context "creating user that belongs both to agent's orga and different one" do
-      let(:user) { build(:user, organisations: [organisation1, create(:organisation)]) }
-
-      permissions :create? do
-        it { is_expected.not_to permit(pundit_context, user) }
-      end
+    permissions :create? do
+      it { is_expected.to permit(pundit_context, user) }
     end
   end
 end

--- a/spec/policies/configuration/agent_policy_spec.rb
+++ b/spec/policies/configuration/agent_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::AgentPolicy, type: :policy do
+  %i[edit? update?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/configuration/agent_territorial_role_policy_spec.rb
+++ b/spec/policies/configuration/agent_territorial_role_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::AgentTerritorialRolePolicy, type: :policy do
+  %i[new? create? destroy?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/configuration/sector_attribution_policy_spec.rb
+++ b/spec/policies/configuration/sector_attribution_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::SectorAttributionPolicy, type: :policy do
+  %i[new? create? destroy?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/configuration/sector_policy_spec.rb
+++ b/spec/policies/configuration/sector_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::SectorPolicy, type: :policy do
+  %i[edit? show? update?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/configuration/team_policy_spec.rb
+++ b/spec/policies/configuration/team_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::TeamPolicy, type: :policy do
+  %i[new? create? destroy? edit? update?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/configuration/territory_policy_spec.rb
+++ b/spec/policies/configuration/territory_policy_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Configuration::TerritoryPolicy, type: :policy do
+  describe "show?" do
+    it "returns false with agent without admin access to this territory" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [])
+      agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+      expect(described_class.new(agent_territorial_context, territory).show?).to be false
+    end
+
+    it "returns true with agent with admin access to this territory" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [territory])
+      agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+      expect(described_class.new(agent_territorial_context, territory).show?).to be true
+    end
+  end
+end

--- a/spec/policies/configuration/webhook_endpoint_policy_spec.rb
+++ b/spec/policies/configuration/webhook_endpoint_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::WebhookEndpointPolicy, type: :policy do
+  %i[new? create? edit? update? destroy?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/policies/configuration/zone_policy_spec.rb
+++ b/spec/policies/configuration/zone_policy_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe Configuration::ZonePolicy, type: :policy do
+  %i[new? create? destroy?].each do |action|
+    describe "##{action}" do
+      it "returns false with agent without admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be false
+      end
+
+      it "returns true with agent with admin access to this territory" do
+        territory = create(:territory)
+        agent = create(:agent, role_in_territories: [territory])
+        agent_territorial_context = AgentTerritorialContext.new(agent, territory)
+        expect(described_class.new(agent_territorial_context, territory).send(action)).to be true
+      end
+    end
+  end
+end

--- a/spec/presenters/plage_ouverture_presenter_spec.rb
+++ b/spec/presenters/plage_ouverture_presenter_spec.rb
@@ -8,7 +8,7 @@ describe PlageOuverturePresenter, type: :presenter do
       let!(:organisation) { create(:organisation, name: "Ivry/Seine") }
       let!(:service) { create(:service) }
       let!(:agent1) { create(:agent, service: service, basic_role_in_organisations: [organisation]) }
-      let!(:agent1_context) { AgentContext.new(agent1, organisation) }
+      let!(:agent1_context) { AgentOrganisationContext.new(agent1, organisation) }
       let!(:agent2) { create(:agent, first_name: "Jeanne", last_name: "Longo", service: service, basic_role_in_organisations: [organisation]) }
       let!(:lieu) { create(:lieu, name: "MDS du coin", organisation: organisation) }
       let!(:plage_ouverture) do

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -14,7 +14,7 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "same agent (=> in scope)" do
       let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
-      let(:agent_context) { instance_double(AgentContext, agent: agent, organisation: organisation) }
+      let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
       let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
       let!(:rdv_context) { create(:rdv, organisation: organisation, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
@@ -26,7 +26,7 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "rdv from other agent but still in scope" do
       let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
-      let(:agent_context) { instance_double(AgentContext, agent: build(:agent), organisation: organisation) }
+      let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
       let!(:rdv_context) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
       let!(:agent) { create(:agent, first_name: "Maya", last_name: "JOAO", basic_role_in_organisations: [organisation]) }
@@ -38,7 +38,7 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "rdv from other agent and not in scope" do
       let(:in_scope_mock_value) { false }
       let!(:organisation) { create(:organisation) }
-      let(:agent_context) { instance_double(AgentContext, agent: build(:agent), organisation: organisation) }
+      let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
       let!(:rdv_context) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
       let!(:agent) { create(:agent, first_name: "Maya", last_name: "JOAO", basic_role_in_organisations: [organisation]) }

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -149,48 +149,6 @@ describe "api/v1/users requests", type: :request do
       end
     end
 
-    context "invalid: forbidden orga" do
-      let!(:other_orga) { create(:organisation) }
-
-      it "does not work" do
-        user_count_before = User.count
-        post(
-          api_v1_users_path,
-          params: {
-            organisation_ids: [other_orga.id],
-            first_name: "Jean",
-            last_name: "Jacques"
-          },
-          headers: api_auth_headers_for_agent(agent)
-        )
-        expect(response.status).to eq(403)
-        expect(User.count).to eq(user_count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
-      end
-    end
-
-    context "invalid: empty orgas" do
-      let!(:other_orga) { create(:organisation) }
-
-      it "does not work" do
-        user_count_before = User.count
-        post(
-          api_v1_users_path,
-          params: {
-            organisation_ids: [],
-            first_name: "Jean",
-            last_name: "Jacques"
-          },
-          headers: api_auth_headers_for_agent(agent)
-        )
-        expect(response.status).to eq(403)
-        expect(User.count).to eq(user_count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
-      end
-    end
-
     context "invalid: missing orgas" do
       let!(:other_orga) { create(:organisation) }
 


### PR DESCRIPTION
refs #2032

_À fusionner après #2151_

close ##2209

- Ajout des `policies` pour le module de configuration
- Création d'un `AgentContext` sans organisation. Nous envisageons de récupérer les organisations ou territoires depuis l'objet sur lequel nous demandons l'accès.

Cette PR est une étape pour considérer les droits d'accès à ces modules. Nous devons verrouiller l'accès aux divers menu actuel pour pouvoir ouvrir au fur et à mesure en fonction des droits d'accès. Le reste des étapes pourra se faire élément par élément.


AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
