### PR TITLE
précise la date et l'heure pour le test du RDV-Collectif

### DIFF
--- a/spec/features/agents/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_collectif_spec.rb
@@ -14,7 +14,10 @@ describe "Agent can create a Rdv collectif" do
 
   let!(:lieu) { create(:lieu, organisation: organisation) }
 
+  let(:now) { Time.zone.parse("20220123 13:00") }
+
   before do
+    travel_to(now)
     login_as(agent, scope: :agent)
     visit admin_organisation_agent_agenda_path(organisation, agent)
   end


### PR DESCRIPTION
J'avais un test rouge, peut-être à cause de l'heure ?... Je me prenais une erreur sur le fait de ne pas pouvoir créer un RDV dans le passé. Là, au moins, c'est figé :)

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
