### PR TITLE
Fixup CustomDeviseTokenGenerator initialization for zeitwerk autoloading

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -128,8 +128,12 @@ Devise.setup do |config|
   # When invite_for is 0 (the default), the invitation won't expire.
   config.invite_for = 4.weeks
 
-  # replace the token generator normally instantiated here : https://github.com/heartcombo/devise/blob/88724e10adaf9ffd1d8dbfbaadda2b9d40de756a/lib/devise/rails.rb#L41
-  Devise.token_generator = CustomDeviseTokenGenerator.new(ActiveSupport::CachingKeyGenerator.new(ActiveSupport::KeyGenerator.new(Devise.secret_key)))
+  Rails.application.reloader.to_prepare do
+    # Replace the token generator normally instantiated here : https://github.com/heartcombo/devise/blob/88724e10adaf9ffd1d8dbfbaadda2b9d40de756a/lib/devise/rails.rb#L41
+    # Do it in a to_prepare block so that Zeitwerk autoreloads the CustomDeviseTokenGenerator class correctly.
+    Devise.token_generator = CustomDeviseTokenGenerator.new(ActiveSupport::CachingKeyGenerator.new(ActiveSupport::KeyGenerator.new(Devise.secret_key)))
+  end
+
   # Number of invitations users can send.
   # - If invitation_limit is nil, there is no limit for invitations, users can
   # send unlimited invitations, invitation_limit column is not used.


### PR DESCRIPTION
This fixes this warning at launch:

```
DEPRECATION WARNING: Initialization autoloaded the constant CustomDeviseTokenGenerator.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload CustomDeviseTokenGenerator, for example,
the expected changes won't be reflected in that stale Class object.

This autoloaded constant has been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
 (called from <main> at /Users/nicolas/Documents/rdv-solidarites.fr/config/environment.rb:5)
```

followup #2150

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
