### PR TITLE
empêche la création de la première orga en autonome

### DIFF
--- a/app/views/welcome/welcome_agent.html.slim
+++ b/app/views/welcome/welcome_agent.html.slim
@@ -44,8 +44,6 @@ section.py-5.bg-lightturquoise.text-primary
             .col-md-3.p-2.px-3.p-md-0
               = link_to "Contactez-nous", contact_path(anchor: "tech-support"), class: "btn btn-tertiary"
             .col-md-3.p-2.px-3.p-md-0
-              = link_to "Créez votre service", new_organisation_path, class: "btn btn-tertiary"
-            .col-md-3.p-2.px-3.p-md-0
               = link_to "Testez l’outil", "https://demo.rdv-solidarites.fr#{new_organisation_path}", class: "btn btn-tertiary"
 
 section.bg-white.py-5

--- a/spec/features/accessibility/accueil_mds_spec.rb
+++ b/spec/features/accessibility/accueil_mds_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe "accueil_mds", js: true do
+  it "root path page is accessible" do
+    expect_page_to_be_axe_clean(accueil_mds_path)
+  end
+end

--- a/spec/features/accessibility/user_pages_spec.rb
+++ b/spec/features/accessibility/user_pages_spec.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-def expect_page_to_be_axe_clean(path)
-  visit path
-  expect(page).to have_current_path(path)
-  expect(page).to be_axe_clean
-end
-
 describe "welcome", js: true do
   it "root path page is accessible" do
     expect_page_to_be_axe_clean(root_path)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,3 +167,9 @@ RSpec.configure do |config|
     end
   end
 end
+
+def expect_page_to_be_axe_clean(path)
+  visit path
+  expect(page).to have_current_path(path)
+  expect(page).to be_axe_clean
+end


### PR DESCRIPTION
Je crois que ce bouton ne sert à rien en production, à part nous envoyer quelques emails à traiter, en plus des autres...

Avant

![Screenshot 2022-02-28 at 23-03-02 RDV Solidarités](https://user-images.githubusercontent.com/42057/156065995-d88ea2c7-3660-457d-903a-3711829a7507.png)

après

![Screenshot 2022-02-28 at 23-03-11 RDV Solidarités](https://user-images.githubusercontent.com/42057/156066009-d92a9ce2-c94e-4ec6-9ee8-abd793d146a9.png)

J'en ai profité pour ajouter un test sur l'accessibilité de cette page.

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
