### PR TITLE
Rendre une spec plus fiable

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@
 
 require "axe-rspec"
 require "webdrivers/chromedriver"
-Webdrivers::Chromedriver.required_version = "97.0.4692.71"
 require "capybara/rspec"
 require "capybara/email/rspec"
 require "webdrivers"

--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -10,8 +10,9 @@ module Select2SpecHelper
 
   def add_user(user)
     find("span", text: "Ajouter un usager", match: :first).click
-    sleep 0.5
     find("li", text: user.last_name).click
-    sleep 0.5
+
+    # This is to make sure we wait for the user to be added before doing the next action
+    expect(page).to have_content("#{user.first_name} #{user.last_name}")
   end
 end


### PR DESCRIPTION
Cette spec échouait aléatoirement sur la CI. Le fix utilise le fait que si on fait un expect sur un élément, capybara attendra et réessayera si l'élément n'est pas trouvé tout de suite, ce qui est plus fiable que d'ajouter des sleep et de croiser les doigts pour qu'ils durent assez longtemps.

La suppression de la ligne sur chromedriver n'est pas directement liée à cette spec, mais elle empêche de faire tourner les specs en local si on n'a pas chrome 97. J'espère que ça va passer sur la CI, si ce n'est pas le cas il faudra peut-être faire une manip.


REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
