### PR TITLE
Supprimer une gem inutilisée

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ gem "typhoeus"
 
 # Form
 gem "simple_form", "~> 5.0"
-gem "image_processing", "~> 1.12"
 gem "phonelib"
 gem "auto_strip_attributes"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,9 +252,6 @@ GEM
       ice_cube (~> 0.16)
     ice_cube (0.16.4)
     ice_nine (0.11.2)
-    image_processing (1.12.2)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -303,7 +300,6 @@ GEM
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 7)
     method_source (1.0.0)
-    mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
@@ -488,8 +484,6 @@ GEM
       rexml
     ruby-ole (1.2.12.2)
     ruby-progressbar (1.11.0)
-    ruby-vips (2.1.4)
-      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -640,7 +634,6 @@ DEPENDENCIES
   groupdate (~> 4.2)
   hiredis
   icalendar (~> 2.5)
-  image_processing (~> 1.12)
   jbuilder
   kaminari
   letter_opener_web


### PR DESCRIPTION
En creusant un peu après avoir fait passer la pr pour la faille de sécurité de cette gem, je me suis rendu compte qu'elle est inutilisée. Moins de code, c'est moins de problèmes.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
