### PR TITLE
Fix pour la fusion d'usagers

### DIFF
--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -9,7 +9,7 @@ class MergeUsersForm
     address
   ].freeze
 
-  attr_accessor :user1, :user2, :change_user1_id, :change_user2_id, *ATTRIBUTES
+  attr_accessor :user1, :user2, :change_user1_id, :change_user2_id, *ATTRIBUTES, *Territory::OPTIONAL_FIELD_TOGGLES.values
 
   validates_presence_of :user1, :user2
   validate :different_users?

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 describe "Agent can delete user" do
-  let!(:organisation) { create(:organisation) }
+  let!(:organisation) { create(:organisation, territory: territory) }
+  let!(:territory) { create(:territory, enable_logement_field: true) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user1) do
     create(
@@ -10,9 +11,11 @@ describe "Agent can delete user" do
       first_name: "Aalyah",
       last_name: "SWAN",
       birth_date: nil,
-      phone_number: "01 02 03 04 05",
-      organisations: [organisation]
+      phone_number: "01 02 03 04 05"
     )
+  end
+  let!(:user_profile1) do
+    create(:user_profile, user: user1, organisation: organisation, logement: :locataire)
   end
   let!(:user2) do
     create(
@@ -41,6 +44,9 @@ describe "Agent can delete user" do
     find(".select2-results__option") { _1.text == "SWAN Anna" }.click
     choose "aalyah@damn.com"
     choose "Anna"
+
+    find("label", text: "Locataire").click
+
     # forget to check phone number
     find("input[type=submit]").click
     page.driver.browser.switch_to.alert.accept


### PR DESCRIPTION
Fix pour https://sentry.io/organizations/rdv-solidarites/issues/3069215539/?environment=production&project=1811205&query=is%3Aunresolved

Pour les attr_accessors qui sont définis de manière statique, il vaut mieux rendre tous les champs accessibles. Les champs qui ne sont pas activés seront ensuite filtrés par `#available_attributes`, et n'apparaitront pas dans le formulaire.

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
