### PR TITLE
Limite les agents référentes à ceux de l'organisation

### DIFF
--- a/app/controllers/admin/referents_controller.rb
+++ b/app/controllers/admin/referents_controller.rb
@@ -5,7 +5,7 @@ class Admin::ReferentsController < AgentAuthController
     @user = policy_scope(User).find(index_params[:user_id])
     authorize(@user, :update?)
     @referents = policy_scope(@user.agents).distinct.order(:last_name)
-    @agents = policy_scope(Agent)
+    @agents = policy_scope(Agent).joins(:organisations).where("organisations.id": current_organisation.id)
     @agents = @agents.search_by_text(index_params[:search]) if index_params[:search].present?
     @agents = @agents.page(params[:page])
   end


### PR DESCRIPTION
Je crois que nous avions fait ça en modifiant le scope de `agent_policy`. Et plutôt que de réduire les agents auxquels un agent connecté peut accéder, je crois que c'est mieux de placer la limite contextuelle dans le contrôleur.

Est-ce que l'organisation restera un élément de cloisonnement pour les usagers et donc les agents référents ? À voir avec les changements sur les droits d'accès.

Avant
![Screenshot 2022-03-04 at 22-37-13 Modifier les référents de Élodie PELCAT - RDV Solidarités](https://user-images.githubusercontent.com/42057/156845132-7c231675-f285-4da3-bcf8-6a0ec4b1e6bd.png)

Après
![Screenshot 2022-03-04 at 22-37-34 Modifier les référents de Élodie PELCAT - RDV Solidarités](https://user-images.githubusercontent.com/42057/156845146-54f777bf-49aa-4fb3-aca3-38c44f07be4e.png)


Close #2214

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
