### PR TITLE
Supprime le lien de téléchargement de statistique personnel

### DIFF
--- a/app/views/admin/stats/index.html.slim
+++ b/app/views/admin/stats/index.html.slim
@@ -6,9 +6,6 @@
 .card.mb-5
   .card-body
     = render "stats/rdv_counters_with_links", rdvs: @stats.rdvs, breadcrumb_page: "agent_stats", agent_id: current_agent.id
-    = link_to admin_organisation_rdvs_path(current_organisation, format: "xls", agent_id: current_agent.id), class: "btn btn-link" do
-      i.fa.fa-download>
-      | Télécharger un export de vos RDVs
 
 .card.mb-5
   .card-body


### PR DESCRIPTION
Close #2218 

Suppression du lien de téléchargement du fichier de stats individuel. Nous avons vocation à réduire la possibilité de sortie des données. Dans quelque temps cet export ne sera possible pour certains profiles. Autant le supprimer (surtout s'il n'était plus à jour et ne fonctionnait pas :))

avant
![Screenshot 2022-03-07 at 23-50-16 Statistiques Martine VALIDAY - RDV Solidarités](https://user-images.githubusercontent.com/42057/157131481-73112cfd-c127-41ac-bfa3-ed3427aad1c6.png)

après
![Screenshot 2022-03-07 at 23-49-30 Statistiques Martine VALIDAY - RDV Solidarités](https://user-images.githubusercontent.com/42057/157131492-c13355d2-5474-4e03-8337-207a4b843bd6.png)


AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
