### PR TITLE
Cacher la réservation en ligne pour les CNFS

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -164,4 +164,11 @@ class Agent < ApplicationRecord
   def to_s
     "#{first_name} #{last_name}"
   end
+
+  # This is the main toggle to enable or disable features for Conseillers Numériques (cnfs)
+  # TODO: As the usage of this toggle grows, we might need to rethink it, and see if these changes
+  # should be done via configuration, or something else
+  def conseiller_numerique?
+    service.name == "Conseiller Numérique"
+  end
 end

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -48,47 +48,48 @@
         span.ml-1=  Motif.human_attribute_value(:collectif, true)
         p.text-muted.font-14= Motif.human_attribute_value(:collectif, true, context: :hint)
 
-  .card
-    .card-body
-      h5.card-title= Motif.human_attribute_name("reservable_online_title")
-      p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
-      = f.input :reservable_online
-      .form-row
-        .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
-        .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
+  - unless current_agent.conseiller_numerique?
+    .card
+      .card-body
+        h5.card-title= Motif.human_attribute_name("reservable_online_title")
+        p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
+        = f.input :reservable_online
+        .form-row
+          .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
+          .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
 
-  .card.js-sectorisation-card
-    .card-body
-      h5.mb-2= Motif.human_attribute_name("sectorisation_level_title")
-      .text-muted.mb-3
-        span>= Motif.human_attribute_name("sectorisation_level_hint")
-        = link_to "https://doc.rdv-solidarites.fr/sectorisation-geographique" do
-          span> Documentation sur la sectorisation
-          i.fa.fa-external-link-alt>
-      .mb-2= label_tag do
-        = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
-        span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT, context: :hint)
-      = label_tag do
-        = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION)
-        span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION, context: :hint)
-        .text-muted.font-14.my-1.ml-3
-          - sectors_attributed_to_orga = Sector.attributed_to_organisation(current_organisation)
-          = t("motifs.form.sectorisation_level.sectors_attributed_to_orga", count: sectors_attributed_to_orga.count, sectors: sectors_attributed_to_orga.map(&:name).to_sentence.truncate(100), organisation: current_organisation.name)
-      = label_tag do
-        = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT)
-        span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT, context: :hint)
-        - if motif.service.present?
-          - attributions_group = SectorAttribution.level_agent_grouped_by_service(current_organisation).fetch(motif.service_id, {agents_count: 0, attributions: []})
+    .card.js-sectorisation-card
+      .card-body
+        h5.mb-2= Motif.human_attribute_name("sectorisation_level_title")
+        .text-muted.mb-3
+          span>= Motif.human_attribute_name("sectorisation_level_hint")
+          = link_to "https://doc.rdv-solidarites.fr/sectorisation-geographique" do
+            span> Documentation sur la sectorisation
+            i.fa.fa-external-link-alt>
+        .mb-2= label_tag do
+          = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
+          span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT, context: :hint)
+        = label_tag do
+          = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION)
+          span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION, context: :hint)
           .text-muted.font-14.my-1.ml-3
-            = t( \
-              "motifs.form.sectorisation_level.sectors_attributed_to_agents", \
-              count: attributions_group[:agents_count], \
-              service: motif.service.name, \
-              sectors_count_human: t("motifs.index.sectorisation_level_organisation", count: attributions_group[:sectors_count]), \
-              sectors: attributions_group[:attributions].map { "#{_1.agent.full_name} -> #{_1.sector.name}" }.to_sentence.truncate(100) \
-            )
-      - if current_agent.territorial_admin_in?(current_organisation.territory)
-        = link_to "Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
+            - sectors_attributed_to_orga = Sector.attributed_to_organisation(current_organisation)
+            = t("motifs.form.sectorisation_level.sectors_attributed_to_orga", count: sectors_attributed_to_orga.count, sectors: sectors_attributed_to_orga.map(&:name).to_sentence.truncate(100), organisation: current_organisation.name)
+        = label_tag do
+          = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT)
+          span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT, context: :hint)
+          - if motif.service.present?
+            - attributions_group = SectorAttribution.level_agent_grouped_by_service(current_organisation).fetch(motif.service_id, {agents_count: 0, attributions: []})
+            .text-muted.font-14.my-1.ml-3
+              = t( \
+                "motifs.form.sectorisation_level.sectors_attributed_to_agents", \
+                count: attributions_group[:agents_count], \
+                service: motif.service.name, \
+                sectors_count_human: t("motifs.index.sectorisation_level_organisation", count: attributions_group[:sectors_count]), \
+                sectors: attributions_group[:attributions].map { "#{_1.agent.full_name} -> #{_1.sector.name}" }.to_sentence.truncate(100) \
+              )
+        - if current_agent.territorial_admin_in?(current_organisation.territory)
+          = link_to "Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
 
   .card
     .card-body

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -32,9 +32,10 @@
           motif_option_value(@motif, :for_secretariat)
         hr
 
-        = motif_attribute_row \
-          Motif.human_attribute_name(:reservable_online), \
-          motif_option_value(@motif, :reservable_online)
+        - unless current_agent.conseiller_numerique?
+          = motif_attribute_row \
+            Motif.human_attribute_name(:reservable_online), \
+            motif_option_value(@motif, :reservable_online)
         = motif_attribute_row \
           Motif.human_attribute_name(:min_booking_delay_short), \
           @motif.reservable_online? && \
@@ -45,12 +46,13 @@
           @motif.reservable_online? && \
             min_max_delay_int_to_human(@motif.max_booking_delay), \
           hint: Motif.human_attribute_name(:max_booking_delay_hint)
-        = motif_attribute_row("Sectorisation") do
-          - if @motif.reservable_online?
-            div= @motif.human_attribute_value(:sectorisation_level)
-            div.text-muted= @motif.human_attribute_value(:sectorisation_level, context: :hint)
-          - else
-            span.text-muted N/A
+        - unless current_agent.conseiller_numerique?
+          = motif_attribute_row("Sectorisation") do
+            - if @motif.reservable_online?
+              div= @motif.human_attribute_value(:sectorisation_level)
+              div.text-muted= @motif.human_attribute_value(:sectorisation_level, context: :hint)
+            - else
+              span.text-muted N/A
         hr
 
         = motif_attribute_row(Motif.human_attribute_name(:visibility_type)) do

--- a/app/views/admin/organisations/setup_checklists/show.slim
+++ b/app/views/admin/organisations/setup_checklists/show.slim
@@ -8,7 +8,7 @@
     .card
       .card-body
         h4.card-title.mb-3 Installation pas à pas
-        - if current_agent.service.name == "Conseiller Numérique"
+        - if current_agent.conseiller_numerique?
           p Pour démarrer du bon pied avec RDV Solidarités, nous vous recommandons de faire les actions suivantes :
         - else
           p L'objectif de cette page est de regrouper les actions nécessaires pour permettre la prise de RDV (en ligne ou en interne) au sein de votre organisation puis de permettre cette prise de RDV en ligne.
@@ -65,7 +65,7 @@
               span>= setup_checklist_item(agent.absences.any?)
               span>= link_to t(".add_busy_time_in_agenda_of", full_name: agent.full_name), admin_organisation_agent_absences_path(@organisation, agent.id)
 
-        - if current_agent.service.name != "Conseiller Numérique"
+        - unless current_agent.conseiller_numerique?
           h5 Motifs ouverts à la réservation en ligne
           ul.mb-1.list-unstyled
             li.mb-2
@@ -86,7 +86,7 @@
                 - else
                   i>= "fermé à la réservation en ligne"
 
-        - if current_agent.service.name != "Conseiller Numérique"
+        - unless current_agent.conseiller_numerique?
           h5 Tester la vue usager
           ul.mb-4.list-unstyled
             li.mb-2

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,6 +23,13 @@ territory62 = Territory.create!(
   sms_configuration: { api_url: "an_url", user_pwd: "pwd" }
 )
 
+territory_cnfs = Territory.create!(
+  departement_number: "CN",
+  name: "Conseillers Numériques",
+  sms_provider: "netsize",
+  sms_configuration: { api_url: "an_url", user_pwd: "pwd" }
+)
+
 # ORGANISATIONS & SECTORS
 
 Organisation.skip_callback(:create, :after, :notify_admin_organisation_created)
@@ -31,6 +38,12 @@ org_paris_nord = Organisation.create!(
   phone_number: "0123456789",
   human_id: "paris-nord",
   territory: territory75
+)
+org_cnfs = Organisation.create!(
+  name: "Mediathèque Paris Nord",
+  phone_number: "0123456789",
+  human_id: "mediatheque-paris-nord",
+  territory: territory_cnfs
 )
 human_id_map = [
   { human_id: "1030", name: "MDS Arques" },
@@ -83,6 +96,7 @@ service_pmi = Service.create!(name: "PMI (Protection Maternelle Infantile)", sho
 service_social = Service.create!(name: "Service social", short_name: "Service Social")
 _service_secretariat = Service.create!(name: "Secrétariat", short_name: "Secrétariat")
 _service_nouveau = Service.create!(name: "Médico-social", short_name: "Médico-social")
+service_cnfs = Service.create!(name: "Conseiller Numérique", short_name: "Conseiller Numérique")
 
 # MOTIFS org_paris_nord
 
@@ -405,6 +419,19 @@ agent_org_bapaume_pmi_gina = Agent.new(
 )
 agent_org_bapaume_pmi_gina.skip_confirmation!
 agent_org_bapaume_pmi_gina.save!
+
+agent_cnfs = Agent.new(
+  email: "camille-clavier@demo.rdv-solidarites.fr",
+  uid: "camille-clavier@demo.rdv-solidarites.fr",
+  first_name: "Camille",
+  last_name: "Clavier",
+  password: "123456",
+  service_id: service_cnfs.id,
+  invitation_accepted_at: 1.day.ago,
+  roles_attributes: [{ organisation: org_cnfs, level: AgentRole::LEVEL_ADMIN }]
+)
+agent_cnfs.skip_confirmation!
+agent_cnfs.save!
 
 # Insert a lot of agents and add them to the paris_nord organisation
 # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
Voir #2243 

- le premier commit ajoute des CNFS au seed pour faciliter les tests
- le deuxième commit est un nettoyage de #2206 pour continuer dans cette direction, et indiquer que ce genre de toggles devra être modifié à long terme. Il est probable qu'ils soient supprimés lorsqu'on ouvre le deuxième palier cnfs (voir l'issue). J'espère que d'ici là on aura un assez bon onboarding pour les cnfs pour que la complexité supplémentaire ne soit pas un problème.
- le troisième commit fait les modifications de l'interface