### PR TITLE
Empeche acces file attente pour motif non reservable en ligne

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -143,7 +143,7 @@ class Rdv < ApplicationRecord
   end
 
   def available_to_file_attente?
-    !cancelled? && starts_at > 7.days.from_now && !home?
+    motif.reservable_online? && !cancelled? && starts_at > 7.days.from_now && !home?
   end
 
   def creneaux_available(date_range)

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -15,6 +15,9 @@ FactoryBot.define do
 
     status { "unknown" }
 
+    trait :at_public_office do
+      motif { build(:motif, :at_public_office, organisation: organisation) }
+    end
     trait :by_phone do
       motif { build(:motif, :by_phone, organisation: organisation) }
       lieu { nil }

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -463,4 +463,42 @@ describe Rdv, type: :model do
       expect(rdv.overlapping_plages_ouvertures?).to eq(false)
     end
   end
+
+  describe "#available_to_file_attente?" do
+    it "returns true with a 9 days later public office RDV" do
+      now = Time.zone.parse("20220221 10:34")
+      travel_to(now)
+      rdv = build(:rdv, :at_public_office, starts_at: now + 9.days)
+      expect(rdv.available_to_file_attente?).to eq(true)
+    end
+
+    it "returns false with a tomorrow RDV" do
+      now = Time.zone.parse("20220221 10:34")
+      travel_to(now)
+      rdv = build(:rdv, :at_public_office, starts_at: now + 1.day)
+      expect(rdv.available_to_file_attente?).to eq(false)
+    end
+
+    it "returns false with a home RDV" do
+      now = Time.zone.parse("20220221 10:34")
+      travel_to(now)
+      rdv = build(:rdv, :at_home, starts_at: now + 9.days)
+      expect(rdv.available_to_file_attente?).to eq(false)
+    end
+
+    it "returns false with a cancelled RDV" do
+      now = Time.zone.parse("20220221 10:34")
+      travel_to(now)
+      rdv = build(:rdv, :at_home, starts_at: now + 9.days, cancelled_at: now - 1.day)
+      expect(rdv.available_to_file_attente?).to eq(false)
+    end
+
+    it "returns false with a not allowed online reservation motif" do
+      now = Time.zone.parse("20220221 10:34")
+      travel_to(now)
+      motif = build(:motif, reservable_online: false)
+      rdv = build(:rdv, :at_home, starts_at: now + 9.days, motif: motif)
+      expect(rdv.available_to_file_attente?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Le Var nous a signalé qu'un usager a pu prendre un RDV sur un motif non ouvert à la réservation en ligne.
Après enquête, il se trouve que c'est l'agent qui a créé le RDV, mais que l'usager l'a « modifié ».

C'est en fait le mécanisme de file d'attente qui a proposé à l'usager un créneau plus tôt (mais avec une autre agent).

Cette PR propose de restreindre le mécanisme de file d'attente au RDV dont le motif est ouvert à la réservation en ligne.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
