### PR TITLE
Corrige l’erreur 500 à la première utilisation des review apps 

### DIFF
--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -11,7 +11,9 @@ module Admin::RdvWizardFormConcern
     attr_reader :agent_author
 
     # delegates all getters and setters to rdv
-    delegate(*::Rdv.attribute_names, to: :rdv)
+    delegate(*%i[id starts_at organisation_id created_at updated_at cancelled_at motif_id sequence
+                 uuid old_location created_by context lieu_id status ends_at max_participants_count
+                 rdv_collectif_users_count], to: :rdv)
     delegate :duration_in_min, to: :rdv
     delegate :motif, :organisation, :agents, :users, to: :rdv
 

--- a/spec/form_models/admin/rdv_wizard_form_concern_spec.rb
+++ b/spec/form_models/admin/rdv_wizard_form_concern_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class DummyWizardForm
+  include ActiveModel::Model
+  include Admin::RdvWizardFormConcern
+end
+
+describe Admin::RdvWizardFormConcern, type: :form do
+  subject(:form) { DummyWizardForm.new(agent, organisation, {}) }
+
+  let(:agent) { build(:agent) }
+  let(:organisation) { build(:organisation) }
+
+  Rdv.attribute_names.each do |attr_name|
+    it "delegates the gettersfor the rdv attribute #{attr_name}" do
+      value = double
+      expect(form.rdv).to receive(attr_name).and_return(value)
+
+      expect(form.public_send(attr_name)).to eq value
+    end
+  end
+end


### PR DESCRIPTION
Close #2139

En changeant la définition, on évite d'avoir du code dépendant de l'état du la db au moment du chargement de l'appli.

Par contre, on devra effecitvement maintenir manuellement ces définitions en cas de changements de colonnes de rdvs.

La spec qui est ajoutée permet d'être averti de la nécessité de changer les définitions. J'ai l'impression qu'on utilise des review apps plus souvent qu'on ne change des colonnes de rdvs, donc ça semble avoir du sens.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
