### PR TITLE
paramètre l'affichage du motif dans la notif mail

### DIFF
--- a/app/controllers/admin/territories/notification_settings_controller.rb
+++ b/app/controllers/admin/territories/notification_settings_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Admin::Territories::NotificationSettingsController < Admin::Territories::BaseController
+  def edit; end
+
+  def update
+    current_territory.update(notification_settings_params)
+    redirect_to edit_admin_territory_notification_settings_path(current_territory)
+  end
+
+  private
+
+  def notification_settings_params
+    params.require(:territory).permit(:show_rdv_motif)
+  end
+end

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -2,13 +2,13 @@
 
 module Payloads
   module Rdv
-    def payload(action = nil, recipient = users.first) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def payload(action = nil, recipient = users.first) # rubocop:disable Metrics/CyclomaticComplexity
       payload = {
         name: "rdv-#{uuid}-#{starts_at.to_s.parameterize}.ics",
         starts_at: starts_at,
         ends_at: ends_at,
         ical_uid: uuid,
-        summary: "RDV #{motif&.name}",
+        summary: summary,
         address: motif.phone? ? nil : address,
         sequence: sequence
       }
@@ -38,7 +38,7 @@ module Payloads
           reservable_online?: reservable_online?,
           users_full_names: users.map(&:full_name).sort.to_sentence,
           agents_short_names: agents.map(&:short_name).sort.to_sentence,
-          motif_name: motif.name,
+          motif_name: motif_name,
           motif_instruction: motif.instruction_for_rdv,
           motif_service_name: motif.service.name,
           duration_in_min: duration_in_min,
@@ -56,6 +56,14 @@ module Payloads
       payload[:action] = action if action.present?
 
       payload
+    end
+
+    def summary
+      motif && organisation.territory.show_rdv_motif? ? "RDV #{motif&.name}" : "RDV"
+    end
+
+    def motif_name
+      motif && organisation.territory.show_rdv_motif? ? motif.name : nil
     end
   end
 end

--- a/app/views/admin/territories/notification_settings/edit.html.slim
+++ b/app/views/admin/territories/notification_settings/edit.html.slim
@@ -1,0 +1,16 @@
+= territory_navigation(t(".title"))
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = simple_form_for current_territory, url: admin_territory_notification_settings_path(current_territory) do |f|
+          = render "model_errors", model: current_territory
+
+          h5.card-title= t(".card_title")
+
+          p.text-muted.font-14= t(".hint_1")
+          = f.input :show_rdv_motif, as: :boolean
+
+          .text-right
+            = f.button :submit

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -72,6 +72,13 @@
         | Fiches usagers
       p Gérer les informations enregistrées sur les usagers
 
+  .col.col-md-4.p-2.rounded.settings-box
+    = link_to edit_admin_territory_notification_settings_path(current_territory) do
+      h3.fw-bold.mb-0
+        i.fa.fa-envelope-open-text>
+        | Notifications
+      p Paramétrer le contenu des notifications
+
   / Ce lien est la manière principale de sortir de la configuration pour retourner à l'écran métier, donc on le garde à la fin de la liste
   .col.col-md-4.p-2.rounded.settings-box
     = link_to admin_organisations_path do

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -13,10 +13,11 @@
       span.title Usager(s) :
       span.float-right= rdv.users_full_names
     .clear
-  div.row-result
-    span.title Motif :
-    span.float-right= rdv.motif_name
-    .clear
+  - if rdv.motif_name.present?
+    div.row-result
+      span.title Motif :
+      span.float-right= rdv.motif_name
+      .clear
   div.row-result
     span.title Service :
     span.float-right= rdv.motif_service_name

--- a/config/locales/models/territory.fr.yml
+++ b/config/locales/models/territory.fr.yml
@@ -8,6 +8,7 @@ fr:
         departement_number: Département
         sms_configuration: "Clef d’API / Mot de passe"
         sms_provider: "Fournisseur pour l’envoi de SMS"
+        show_rdv_motif: Afficher le motif de RDV
     errors:
       models:
         territory:

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -105,3 +105,8 @@ fr:
           card_title: Champs optionnels pour les fiches usagers
           hint_1: Vous pouvez activer ou désactiver les champs suivants sur les fiches usagers.
           hint_2: "Les champs seront simplement masqués dans l’interface : les données préexistantes ne seront pas supprimées."
+      notification_settings:
+        edit:
+          title: Configuration du contenu des notificaitons
+          card_title: Information optionnelle
+          hint_1: Dans certains cas, le motif est considéré comme une donnée de santé, ou une donnée très caractérisé et trop personnel. Dans ce genre de situation, il est préférable de ne pas l'envoyer dans les notifications.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,7 @@ Rails.application.routes.draw do
             end
           end
           resource :user_fields, only: %i[edit update]
+          resource :notification_settings, only: %i[edit update]
           resource :sms_configuration, only: %i[show edit update]
           resources :zone_imports, only: %i[new create]
           resources :zones, only: [:index] # exports only

--- a/db/migrate/20220311194904_add_show_rdv_motif_to_territory.rb
+++ b/db/migrate/20220311194904_add_show_rdv_motif_to_territory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddShowRdvMotifToTerritory < ActiveRecord::Migration[6.1]
+  def change
+    add_column :territories, :show_rdv_motif, :boolean, default: false
+
+    Territory.update_all(show_rdv_motif: true) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_05_160339) do
+ActiveRecord::Schema.define(version: 2022_03_11_194904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -445,6 +445,7 @@ ActiveRecord::Schema.define(version: 2022_03_05_160339) do
     t.boolean "enable_family_situation_field", default: false
     t.boolean "enable_number_of_children_field", default: false
     t.boolean "enable_logement_field", default: false
+    t.boolean "show_rdv_motif", default: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", unique: true, where: "((departement_number)::text <> ''::text)"
   end
 

--- a/spec/controllers/admin/territories/notification_settings_controller_spec.rb
+++ b/spec/controllers/admin/territories/notification_settings_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe Admin::Territories::NotificationSettingsController, type: :controller do
+  describe "#edit" do
+    it "respond success" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [territory], organisations: [create(:organisation, territory: territory)])
+      sign_in agent
+      get :edit, params: { territory_id: territory.id }
+      expect(response).to be_successful
+    end
+  end
+
+  describe "#update" do
+    it "respond redirect to edit" do
+      territory = create(:territory, show_rdv_motif: 1)
+      agent = create(:agent, role_in_territories: [territory], organisations: [create(:organisation, territory: territory)])
+      sign_in agent
+      post :update, params: { territory_id: territory.id, territory: { show_rdv_motif: 0 } }
+      expect(response).to redirect_to(edit_admin_territory_notification_settings_path(territory))
+    end
+
+    it "update territory" do
+      territory = create(:territory, show_rdv_motif: 1)
+      agent = create(:agent, role_in_territories: [territory], organisations: [create(:organisation, territory: territory)])
+      sign_in agent
+      expect do
+        post :update, params: { territory_id: territory.id, territory: { show_rdv_motif: 0 } }
+      end.to change { territory.reload.show_rdv_motif }.from(true).to(false)
+    end
+  end
+end

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -74,7 +74,7 @@ describe Payloads::Rdv, type: :service do
       let(:user) { build(:user, first_name: "Ethan", last_name: "DUVAL") }
       let(:rdv) { build(:rdv, users: [user], motif: build(:motif, name: "Consultation")) }
 
-      it { expect(rdv.payload[:summary]).to eq("RDV Consultation") }
+      it { expect(rdv.payload[:summary]).to eq("RDV") }
     end
 
     describe ":users_full_names" do


### PR DESCRIPTION
Close #2221 

Pour ne pas envoyer trop de donnée à caractère médical / personnel, sans pénaliser les usages généraliste du RDV-Solidarités, cette PR propose un nouvel écran pour afficher ou pas le motif dans la notification email.

![Screenshot 2022-03-11 at 22-36-32 RDV Solidarités](https://user-images.githubusercontent.com/42057/157973846-a0bbe475-d13f-4c17-a105-17a06f993216.png)

![Screenshot 2022-03-11 at 22-37-55 LetterOpenerWeb](https://user-images.githubusercontent.com/42057/157974055-7ddad9fd-85ae-4e9b-bd8d-ac609f509bce.png)

![Screenshot 2022-03-11 at 22-38-46 LetterOpenerWeb](https://user-images.githubusercontent.com/42057/157974065-e42fe9c5-4d3d-4f13-a3be-4ba4ccc0c5a3.png)

Plus tard, cet écran pourrait servir à paramétrer un peu plus que ça au niveau des notifications.

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
