### PR TITLE
Renseigne le tel avant le mail dans la fiche usager

### DIFF
--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -15,6 +15,8 @@
   .col-md-6= f.input :birth_name, **input_opts.deep_merge(frozen_fields_opts)
   .col-md-6= date_input(f, :birth_date, **input_opts.deep_merge(frozen_fields_opts))
 
+= f.input :phone_number, as: :tel, **input_opts
+
 = f.input(:email, as: :email, **input_opts)
 - if user.new_record?
   label
@@ -23,8 +25,6 @@
       false, \
       class:"align-items-baseline ml-0"
     |&nbsp; Inviter l'utilisateur à se créer un compte sur RDV-solidarites.
-
-= f.input :phone_number, as: :tel, **input_opts
 
 label Préférences de notifications
 .mb-2


### PR DESCRIPTION
Le tel est souvent l'élément de communication le plus utilisé et
renseigné.

avant
![Screenshot 2022-03-15 at 22-45-32 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/158478013-0f8d55ba-4170-4c6b-b7a2-cca7e1ffa331.png)

après
![Screenshot 2022-03-15 at 22-43-44 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/158477956-b46168f2-cf9a-42af-a90a-6f7451607979.png)


AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
