### PR TITLE
Paramètre l'affichage du contexte d'un RDV

### DIFF
--- a/app/controllers/admin/territories/rdv_fields_controller.rb
+++ b/app/controllers/admin/territories/rdv_fields_controller.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class Admin::Territories::RdvFieldsController < Admin::Territories::BaseController
-
   def edit
     authorize current_territory
-  end 
+  end
 
   def update
     authorize current_territory
     current_territory.update(rdv_fields_params)
-    redirect_to edit_admin_territory_rdv_fields_path(current_territory)
+    flash[:alert] = "Configuration enregistrée"
+    redirect_to action: :edit
   end
 
   private

--- a/app/controllers/admin/territories/rdv_fields_controller.rb
+++ b/app/controllers/admin/territories/rdv_fields_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Admin::Territories::RdvFieldsController < Admin::Territories::BaseController
+
+  def edit
+    authorize current_territory
+  end 
+
+  def update
+    authorize current_territory
+    current_territory.update(rdv_fields_params)
+    redirect_to edit_admin_territory_rdv_fields_path(current_territory)
+  end
+
+  private
+
+  def rdv_fields_params
+    params.require(:territory).permit(Territory::OPTIONAL_RDV_FIELD_TOGGLES.keys)
+  end
+end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -40,6 +40,11 @@ class Territory < ApplicationRecord
 
   ## -
 
+  OPTIONAL_RDV_FIELD_TOGGLES = {
+    enable_context_field: :context,
+  }.freeze
+
+
   SOCIAL_FIELD_TOGGLES = {
     enable_caisse_affiliation_field: :caisse_affiliation,
     enable_affiliation_number_field: :affiliation_number,

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -41,9 +41,8 @@ class Territory < ApplicationRecord
   ## -
 
   OPTIONAL_RDV_FIELD_TOGGLES = {
-    enable_context_field: :context,
+    enable_context_field: :context
   }.freeze
-
 
   SOCIAL_FIELD_TOGGLES = {
     enable_caisse_affiliation_field: :caisse_affiliation,

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -14,4 +14,5 @@ class Configuration::TerritoryPolicy
   alias show? territorial_admin?
   alias update? territorial_admin?
   alias edit? territorial_admin?
+  alias display_rdv_fields_configuration? territorial_admin?
 end

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -60,7 +60,8 @@ ruby:
               ), \
           data: { modal: true }
 
-    .mt-3= f.input :context, as: :text, label: Rdv.human_attribute_name(:context), input_html: { rows: 4 }
+    - if current_organisation.territory.enable_context_field
+      .mt-3= f.input :context, as: :text, label: Rdv.human_attribute_name(:context), input_html: { rows: 4 }
 
     = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f
 

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -28,7 +28,8 @@
                     li= object_attribute_tag(user, :phone_number, clickable_user_phone_number(user))
                     li= object_attribute_tag(user, :address)
                     li= object_attribute_tag(user, :email, clickable_user_email(user))
-                    li= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
+                    - if current_territory.enable_notes_field
+                      li= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
                     - if current_territory.enable_logement_field
                       li= object_attribute_tag(user_profile, :logement)
                     - Territory::SOCIAL_FIELD_TOGGLES.each do |toggle, field_name|

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -11,7 +11,7 @@
     - if current_organisation.territory.enable_context_field
       div
         - if rdv.context.blank?
-          .text-muted Pas de contexte renseigné
+          .text-muted = t(".empty_context")
         - else
           .text-muted Contexte :
           .border-left.pl-2= simple_format(rdv.context)

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -8,12 +8,13 @@
     i.fa.fa-fw.fa-info-circle>
   div
     = rdv.motif.name
-    div
-      - if rdv.context.blank?
-        .text-muted Pas de contexte renseigné
-      - else
-        .text-muted Contexte :
-        .border-left.pl-2= simple_format(rdv.context)
+    - if current_organisation.territory.enable_context_field
+      div
+        - if rdv.context.blank?
+          .text-muted Pas de contexte renseigné
+        - else
+          .text-muted Contexte :
+          .border-left.pl-2= simple_format(rdv.context)
 
 - if rdv.phone?
   p.card-text

--- a/app/views/admin/rdvs/_short_rdv.html.slim
+++ b/app/views/admin/rdvs/_short_rdv.html.slim
@@ -3,9 +3,10 @@ li.card-body.py-2
   = rdv_status_tag(short_rdv)
   div
     = short_rdv.motif.name
-    div
-      - if short_rdv.context.blank?
-        .text-muted Pas de contexte renseigné
-      - else
-        .text-muted Contexte :
-        .border-left.pl-2= simple_format(short_rdv.context)
+    - if current_organisation.territory.enable_context_field
+      div
+        - if short_rdv.context.blank?
+          .text-muted Pas de contexte renseigné
+        - else
+          .text-muted Contexte :
+          .border-left.pl-2= simple_format(short_rdv.context)

--- a/app/views/admin/territories/rdv_fields/edit.html.slim
+++ b/app/views/admin/territories/rdv_fields/edit.html.slim
@@ -12,7 +12,7 @@
           p.text-muted.font-14= t(".hint_1")
           p.text-muted.font-14= t(".hint_2")
           - Territory::OPTIONAL_RDV_FIELD_TOGGLES.each do |toggle, field_name|
-            = f.input toggle, label: User.human_attribute_name(field_name)
+            = f.input toggle, label: Rdv.human_attribute_name(field_name)
 
           .text-right
             = f.button :submit

--- a/app/views/admin/territories/rdv_fields/edit.html.slim
+++ b/app/views/admin/territories/rdv_fields/edit.html.slim
@@ -1,0 +1,18 @@
+= territory_navigation(t(".title"))
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = simple_form_for current_territory, url: admin_territory_rdv_fields_path(current_territory) do |f|
+          = render "model_errors", model: current_territory
+
+          h5.card-title= t(".card_title")
+
+          p.text-muted.font-14= t(".hint_1")
+          p.text-muted.font-14= t(".hint_2")
+          - Territory::OPTIONAL_RDV_FIELD_TOGGLES.each do |toggle, field_name|
+            = f.input toggle, label: User.human_attribute_name(field_name)
+
+          .text-right
+            = f.button :submit

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -72,6 +72,15 @@
         | Fiches usagers
       p Gérer les informations enregistrées sur les usagers
 
+  - if policy([:configuration, current_territory]).display_rdv_fields_configuration?
+    .col.col-md-4.p-2.rounded.settings-box
+      = link_to edit_admin_territory_rdv_fields_path(current_territory) do
+        h3.fw-bold.mb-0
+          i.fa.fa-calendar>
+          | Fiches RDV
+        p Gérer les informations enregistrées sur les rendez-vous
+
+
   / Ce lien est la manière principale de sortir de la configuration pour retourner à l'écran métier, donc on le garde à la fin de la liste
   .col.col-md-4.p-2.rounded.settings-box
     = link_to admin_organisations_path do

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -80,7 +80,6 @@
           | Fiches RDV
         p Gérer les informations enregistrées sur les rendez-vous
 
-
   / Ce lien est la manière principale de sortir de la configuration pour retourner à l'écran métier, donc on le garde à la fin de la liste
   .col.col-md-4.p-2.rounded.settings-box
     = link_to admin_organisations_path do

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -99,6 +99,12 @@ fr:
           teams: Équipes
           actions: Actions
           edit_agents: Modification des équipes de l'agent
+      rdv_fields:
+        edit:
+          title: Champs de la fiche RDV
+          card_title: Champs optionnels pour la fiche RDV
+          hint_1: Vous pouvez activer ou désactiver les champs suivants sur la fiche RDV.
+          hint_2: "Les champs seront simplement masqués dans l’interface : les données préexistantes ne seront pas supprimées."
       user_fields:
         edit:
           title: Champs de la fiche usager

--- a/config/locales/views/rdv.fr.yml
+++ b/config/locales/views/rdv.fr.yml
@@ -1,0 +1,6 @@
+fr:
+  admin:
+    rdvs:
+      rdv_details:
+        empty_context: Pas de contexte renseigné 
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,7 @@ Rails.application.routes.draw do
             end
           end
           resource :user_fields, only: %i[edit update]
+          resource :rdv_fields, only: %i[edit update]
           resource :sms_configuration, only: %i[show edit update]
           resources :zone_imports, only: %i[new create]
           resources :zones, only: [:index] # exports only

--- a/db/migrate/20220317141436_add_enable_context_field_to_territory.rb
+++ b/db/migrate/20220317141436_add_enable_context_field_to_territory.rb
@@ -1,0 +1,7 @@
+class AddEnableContextFieldToTerritory < ActiveRecord::Migration[6.1]
+  def change
+    add_column :territories, :enable_context_field, :boolean, default: false
+    
+    Territory.all.update_all(enable_context_field: true)
+  end
+end

--- a/db/migrate/20220317141436_add_enable_context_field_to_territory.rb
+++ b/db/migrate/20220317141436_add_enable_context_field_to_territory.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class AddEnableContextFieldToTerritory < ActiveRecord::Migration[6.1]
   def change
     add_column :territories, :enable_context_field, :boolean, default: false
-    
+
     Territory.all.update_all(enable_context_field: true)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_134640) do
+ActiveRecord::Schema.define(version: 2022_03_17_141436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -448,6 +448,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_134640) do
     t.boolean "enable_logement_field", default: false
     t.boolean "enable_case_number", default: false
     t.boolean "enable_address_details", default: false
+    t.boolean "enable_context_field", default: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", unique: true, where: "((departement_number)::text <> ''::text)"
   end
 

--- a/spec/controllers/admin/territories/rdv_fields_controller_spec.rb
+++ b/spec/controllers/admin/territories/rdv_fields_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe Admin::Territories::RdvFieldsController, type: :controller do
+  describe "#edit" do
+    it "responds success" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [territory])
+      create(:agent_territorial_access_right, agent: agent, territory: territory)
+      sign_in agent
+      get :edit, params: {territory_id: territory.id}
+      expect(response).to be_successful
+    end
+  end
+
+  describe "#update" do
+    it "responds redirect" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [territory])
+      create(:agent_territorial_access_right, agent: agent, territory: territory)
+      sign_in agent
+      post :update, params: {territory_id: territory.id, territory: { enable_context_field: false }}
+      expect(response).to redirect_to(edit_admin_territory_rdv_fields_path(territory))
+    end
+
+    it "update territory" do
+      territory = create(:territory, enable_context_field: true)
+      agent = create(:agent, role_in_territories: [territory])
+      create(:agent_territorial_access_right, agent: agent, territory: territory)
+      sign_in agent
+
+      expect {
+        post :update, params: {territory_id: territory.id, territory: { enable_context_field: false }}
+      }.to change{ territory.reload.enable_context_field }.to(false)
+    end
+
+  end
+
+end
+

--- a/spec/controllers/admin/territories/rdv_fields_controller_spec.rb
+++ b/spec/controllers/admin/territories/rdv_fields_controller_spec.rb
@@ -5,9 +5,8 @@ describe Admin::Territories::RdvFieldsController, type: :controller do
     it "responds success" do
       territory = create(:territory)
       agent = create(:agent, role_in_territories: [territory])
-      create(:agent_territorial_access_right, agent: agent, territory: territory)
       sign_in agent
-      get :edit, params: {territory_id: territory.id}
+      get :edit, params: { territory_id: territory.id }
       expect(response).to be_successful
     end
   end
@@ -16,24 +15,19 @@ describe Admin::Territories::RdvFieldsController, type: :controller do
     it "responds redirect" do
       territory = create(:territory)
       agent = create(:agent, role_in_territories: [territory])
-      create(:agent_territorial_access_right, agent: agent, territory: territory)
       sign_in agent
-      post :update, params: {territory_id: territory.id, territory: { enable_context_field: false }}
+      post :update, params: { territory_id: territory.id, territory: { enable_context_field: false } }
       expect(response).to redirect_to(edit_admin_territory_rdv_fields_path(territory))
     end
 
     it "update territory" do
       territory = create(:territory, enable_context_field: true)
       agent = create(:agent, role_in_territories: [territory])
-      create(:agent_territorial_access_right, agent: agent, territory: territory)
       sign_in agent
 
-      expect {
-        post :update, params: {territory_id: territory.id, territory: { enable_context_field: false }}
-      }.to change{ territory.reload.enable_context_field }.to(false)
+      expect do
+        post :update, params: { territory_id: territory.id, territory: { enable_context_field: false } }
+      end.to change { territory.reload.enable_context_field }.to(false)
     end
-
   end
-
 end
-

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -3,7 +3,8 @@
 describe "Agent can create a Rdv with wizard" do
   include UsersHelper
 
-  let(:organisation) { create(:organisation) }
+  let(:territory) { create(:territory, enable_context_field: true) }
+  let(:organisation) { create(:organisation, territory: territory) }
   let(:service) { create(:service) }
   let!(:agent) { create(:agent, first_name: "Alain", last_name: "DIALO", service: service, basic_role_in_organisations: [organisation]) }
   let!(:agent2) { create(:agent, first_name: "Robert", last_name: "Martin", service: service, basic_role_in_organisations: [organisation]) }


### PR DESCRIPTION
Je suis parti sur une nouvelle interface pour la gestion de l'interface RDV. J'aurais peut-être pu l'ajouter à l'interface de configuration de la fiche usager :thinking:. J'ai hésité, et ça me parait plus simple comme ça. Si nous voulons les fusionner, ça sera toujours faisable plus tard.

![Screenshot 2022-03-17 at 16-14-37 RDV Solidarités](https://user-images.githubusercontent.com/42057/158833590-ad7939b1-690a-45ab-a17c-be58f371d8d5.png)

![Screenshot 2022-03-17 at 16-14-26 RDV Solidarités](https://user-images.githubusercontent.com/42057/158833630-31e8f83a-6dc1-483b-a062-8bc2a58c3e05.png)

Le contexte est affiché à 4 endroits : 
- le formulaire de création d'un RDV ;
- la fiche RDV (le show) ;
- la liste des RDV (avec détails) ;
- l'historique des RDV d'un usager.


Close #2233 

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local

