### PR TITLE
Selectionne les plages d'ouvertures et non des occurrences

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -39,6 +39,16 @@ class PlageOuverture < ApplicationRecord
 
     not_recurring_start_in_range.or(recurring_in_range)
   }
+  scope :overlapping_range, lambda { |range|
+    in_range(range).select do |plage_ouverture|
+      plage_ouverture.occurrences_for(range).select do |o|
+        range.cover?(o.starts_at) ||
+          range.cover?(o.ends_at) ||
+          (o.starts_at..o.ends_at).cover?(range) ||
+          range.cover?(o.starts_at..o.ends_at)
+      end.any?
+    end
+  }
 
   ## -
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -464,6 +464,19 @@ describe Rdv, type: :model do
     end
   end
 
+  describe "#overlapping_plages_ouvertures" do
+    let(:now) { Time.zone.parse("2022-12-27 11:00") }
+
+    before { travel_to(now) }
+
+    it "return plage_ouvertures" do
+      agent = create(:agent)
+      rdv = build(:rdv, agents: [agent], starts_at: now + 1.week, ends_at: now + 1.week + 30.minutes)
+      create(:plage_ouverture, agent: agent, first_day: (now + 1.week).to_date, start_time: Tod::TimeOfDay.new(8), end_time: Tod::TimeOfDay.new(14))
+      expect(rdv.overlapping_plages_ouvertures.first).to be_a_kind_of(PlageOuverture)
+    end
+  end
+
   describe "#available_to_file_attente?" do
     it "returns true with a 9 days later public office RDV" do
       now = Time.zone.parse("20220221 10:34")


### PR DESCRIPTION
Nous avions mis en place un système où nous regardions le recouvrement
d'occurrence et non uniquement les plages d'ouvertures (voir
https://github.com/betagouv/rdv-solidarites.fr/commit/9411317abf4f86ed0e58278a15b8c10bbd512dcd).
L'idée, c'était de ramener la vérification qui se faisait au niveau de
l'affichage dans le RDV, au moment de la validation.

Mais nous n'avions pas vérifié l'usage qui était fait des plages
d'ouvertures qui recouvre. Or, elles sont utilisées pour construire le
message d'erreur et vérifier si c'est dans le scope (pourquoi ?)...

Nous reprenons ici pour utiliser les occurrences pour filtrer les plages
d'ouvertures et continuons à envoyer des plages d'ouvertures.

Close https://sentry.io/organizations/rdv-solidarites/issues/3098486121/?project=1811205&query=is%3Aunresolved

Il y a d'autres mécanismes de vérification de recouvrement dans la plage
d'ouverture et l'appel à un objet service. Je me retiens de faire le
nettoyage, mais il faudra sans doute y passer un jour.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
