### PR TITLE
Ajout le dossier et détail adresse a DisplayableUser

### DIFF
--- a/app/presenters/displayable_user_presenter.rb
+++ b/app/presenters/displayable_user_presenter.rb
@@ -27,6 +27,14 @@ class DisplayableUserPresenter
     @user.human_attribute_value(:family_situation)
   end
 
+  def address_details
+    @user.human_attribute_value(:address_details)
+  end
+
+  def case_number
+    @user.human_attribute_value(:case_number)
+  end
+
   def phone_number
     @user.responsible_phone_number
   end

--- a/spec/presenters/displayable_user_presenter_spec.rb
+++ b/spec/presenters/displayable_user_presenter_spec.rb
@@ -104,6 +104,24 @@ describe DisplayableUserPresenter, type: :presenter do
     end
   end
 
+  describe "#address_details" do
+    it "return user's address details" do
+      organisation = create(:organisation)
+      user = create(:user, organisations: [organisation], address_details: "Appartement 2334")
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.address_details).to eq("Appartement 2334")
+    end
+  end
+
+  describe "#case_number" do
+    it "return user's case number" do
+      organisation = create(:organisation)
+      user = create(:user, organisations: [organisation], case_number: "1234567")
+      displayable_user = described_class.new(user, organisation)
+      expect(displayable_user.case_number).to eq("1234567")
+    end
+  end
+
   describe "#notify_by_sms" do
     it "returns no phone number when user dont have phone number" do
       organisation = build(:organisation)


### PR DESCRIPTION
En ajoutant le `case_number` et `address_details` nous avons oublié de
les ajouter au `DisplayableUserPresenter`. Cette classe est
principalement (uniquement ?) utilisé dans l'outil de fusion d'usager.

Close https://sentry.io/organizations/rdv-solidarites/issues/3107074499/?project=1811205&query=is%3Aunresolved

Close #issue_number

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
