### PR TITLE
Arrête d'afficher l'historique des RDV d'un usager

### DIFF
--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -46,18 +46,5 @@
           .btn-group
             = link_to t(".update"), edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
             = link_to t(".duplicate"), admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, motif_id: @rdv.motif_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context, lieu_ids: [@rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary"
-.row.justify-content-md-center
-  .col-md-8
-    - @rdv.rdvs_users.each do |rdv_user|
-      - user = rdv_user.user
-      .card
-        - rdv_user_presenter = Admin::RdvUserPresenter.new(@rdv, user)
-        .card-header.h5= "Rendez-vous précédents pour #{user.full_name}"
-        = render "admin/rdvs/short_rdvs_list", user: user, rdvs: rdv_user_presenter.previous_rdvs_truncated
-        - if rdv_user_presenter.previous_rdvs_more?
-          .card-footer
-            = link_to \
-              "Voir les #{rdv_user_presenter.previous_rdvs_count} RDVs précédents…", \
-              admin_organisation_rdvs_path(current_organisation, user_id: rdv_user.user.id, end: @rdv.starts_at)
 
 = render "admin/versions/resource_versions_row", resource: @rdv


### PR DESCRIPTION
Dans la fiche d'un RDV, nous affichions pour chaque usager du RDV une
liste des 5 derniers RDV en mode raccourcis.

Nous n'avons pas vraiment besoin de cette liste, et elle va nous gêner
pour les RDV collectif.

C'est aussi une source de problème de performance.

![Screenshot 2022-03-23 at 21-50-31 RDV Léa DUPONT ☎️ - RDV Solidarités](https://user-images.githubusercontent.com/42057/159793399-841f96fd-294c-4bbd-a817-d5c55c50bbb0.png)
![Screenshot 2022-03-23 at 21-50-11 RDV Léa DUPONT ☎️ - RDV Solidarités](https://user-images.githubusercontent.com/42057/159793405-09ffc1ac-507f-4504-8abd-05d5893d72bf.png)


close #2234

AVANT LA REVUE
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
