### PR TITLE
Pose un scope pour l'accès aux secteurs / zones

### DIFF
--- a/app/controllers/admin/territories/zones_controller.rb
+++ b/app/controllers/admin/territories/zones_controller.rb
@@ -5,7 +5,6 @@ class Admin::Territories::ZonesController < Admin::Territories::BaseController
 
   def index
     zones = policy_scope(Zone)
-      .in_territory(current_territory)
       .where(params[:sector_id].present? ? { sector: params[:sector_id] } : {})
     respond_to do |format|
       format.xls do

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -19,11 +19,13 @@ class Territory < ApplicationRecord
   # Relations
   has_many :teams, dependent: :destroy
   has_many :organisations, dependent: :destroy
+  has_many :sectors, dependent: :destroy
   has_many :roles, class_name: "AgentTerritorialRole", dependent: :delete_all
 
   # Through relations
   has_many :organisations_agents, through: :organisations, source: :agents
   has_many :agents, through: :roles
+  has_many :zones, through: :sectors
 
   # Validations
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -28,7 +28,6 @@ class Zone < ApplicationRecord
   # Scopes
   scope :cities, -> { where(level: LEVEL_CITY) }
   scope :streets, -> { where(level: LEVEL_STREET) }
-  scope :in_territory, -> { joins(:sector).where(sectors: { territory_id: _1.id }) }
 
   ## -
 

--- a/app/policies/configuration/zone_policy.rb
+++ b/app/policies/configuration/zone_policy.rb
@@ -21,8 +21,7 @@ class Configuration::ZonePolicy
     end
 
     def resolve
-      Zone.in_territory(@current_territory)
+      @current_territory.zones
     end
   end
-
 end

--- a/app/policies/configuration/zone_policy.rb
+++ b/app/policies/configuration/zone_policy.rb
@@ -14,4 +14,15 @@ class Configuration::ZonePolicy
   alias new? territorial_admin?
   alias create? territorial_admin?
   alias destroy? territorial_admin?
+
+  class Scope
+    def initialize(context, _scope)
+      @current_territory = context.territory
+    end
+
+    def resolve
+      Zone.in_territory(@current_territory)
+    end
+  end
+
 end

--- a/spec/services/export_zones_service_spec.rb
+++ b/spec/services/export_zones_service_spec.rb
@@ -2,7 +2,7 @@
 
 describe ExportZonesService, type: :service do
   describe "#perform" do
-    subject { described_class.new(Zone.in_territory(territory)).perform }
+    subject { described_class.new(territory.zones).perform }
 
     let!(:territory) { create(:territory, name: "Yvelines", departement_number: "78") }
     let!(:sector1) { create(:sector, name: "Yvelines Sud", human_id: "78-sud", territory: territory) }


### PR DESCRIPTION
Signalé par Claire de Data.insertion, il y a une erreur sur l'export des secteurs dans la configuration de la sectorisation.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
