### PR TITLE
Ne pas afficher les warnings d’overlap avec les plages d’ouverture dans l’agenda

### DIFF
--- a/app/views/admin/agents/rdvs/index.json.jbuilder
+++ b/app/views/admin/agents/rdvs/index.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.array! @rdvs do |rdv|
-  json.title rdv_title_for_agent(rdv) + (rdv.overlapping_plages_ouvertures? ? " ⚠️" : "")
+  json.title rdv_title_for_agent(rdv) + (rdv.overlapping_plages_ouvertures? ? " ⚠️" : "") # we compute overlapping_plages_ouvertures? twice, once here
   json.id rdv.id
   json.extendedProps do
     json.organisationName rdv.organisation&.name
@@ -11,7 +11,7 @@ json.array! @rdvs do |rdv|
     json.lieu rdv.public_office? && rdv.lieu&.name
     json.past rdv.past?
     json.duration rdv.duration_in_min
-    json.overlappingPlagesOuvertures rdv.overlapping_plages_ouvertures?
+    json.overlappingPlagesOuvertures rdv.overlapping_plages_ouvertures? # and once here again
   end
   json.start rdv.starts_at.as_json
   json.end rdv.ends_at.as_json

--- a/app/views/admin/agents/rdvs/index.json.jbuilder
+++ b/app/views/admin/agents/rdvs/index.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.array! @rdvs do |rdv|
-  json.title rdv_title_for_agent(rdv) + (rdv.overlapping_plages_ouvertures? ? " ⚠️" : "") # we compute overlapping_plages_ouvertures? twice, once here
+  json.title rdv_title_for_agent(rdv)
   json.id rdv.id
   json.extendedProps do
     json.organisationName rdv.organisation&.name
@@ -11,7 +11,6 @@ json.array! @rdvs do |rdv|
     json.lieu rdv.public_office? && rdv.lieu&.name
     json.past rdv.past?
     json.duration rdv.duration_in_min
-    json.overlappingPlagesOuvertures rdv.overlapping_plages_ouvertures? # and once here again
   end
   json.start rdv.starts_at.as_json
   json.end rdv.ends_at.as_json

--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -194,11 +194,6 @@ class CalendarRdvSolidarites {
       }
       if (extendedProps.lieu) {
         title += `<br><strong>Lieu:</strong> ${extendedProps.lieu}`;
-        // In the details, why only indicate an overlap warning if lieu is present?
-        // In the event title, we add the warning even if lieu is nil.
-        if (extendedProps.overlappingPlagesOuvertures) {
-          title += " ⚠️";
-        }
       }
       if (extendedProps.readableStatus) {
         title += `<br><strong>Statut:</strong> ${extendedProps.readableStatus}`;

--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -194,6 +194,8 @@ class CalendarRdvSolidarites {
       }
       if (extendedProps.lieu) {
         title += `<br><strong>Lieu:</strong> ${extendedProps.lieu}`;
+        // In the details, why only indicate an overlap warning if lieu is present?
+        // In the event title, we add the warning even if lieu is nil.
         if (extendedProps.overlappingPlagesOuvertures) {
           title += " ⚠️";
         }


### PR DESCRIPTION
~~Pour discussion: les problèmes de performance dans l’agenda sont dûs à l’affichage des warning d’overlap avec une plage d’ouverture.~~

---

On n’affiche plus ces warnings dans l’agenda; ils restent visible dans la vue de détail de chaque rdv.

![Sans titre](https://user-images.githubusercontent.com/139391/160373262-4bb06ebe-4cd1-4555-9607-9ec7a2380fc3.gif)

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
