### PR TITLE
Ajoute une option de délai de motif pour 3 semaines

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -26,7 +26,7 @@ module MotifsHelper
   def min_max_delay_options
     [["1/2 heure", 30.minutes], ["1 heure", 1.hour], ["2 heures", 2.hours],
      ["3 heures", 3.hours], ["6 heures", 6.hours], ["12 heures", 12.hours],
-     ["1 jour", 1.day], ["2 jours", 2.days], ["3 jours", 3.days], ["1 semaine", 1.week], ["2 semaines", 2.weeks],
+     ["1 jour", 1.day], ["2 jours", 2.days], ["3 jours", 3.days], ["1 semaine", 1.week], ["2 semaines", 2.weeks], ["3 semaines", 3.weeks],
      ["1 mois", 1.month], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year]]
   end
 


### PR DESCRIPTION
Les agents traitant du RSA souhaitent pouvoir configurer les motifs avec
un délai max de 3 semaines.

Les options de délais passaient de 2 semaines à 1 mois. Cette PR ajoute
l'option à 3 semaines.

![Screenshot 2022-03-24 at 21-40-40 Nouveau motif - RDV Solidarités](https://user-images.githubusercontent.com/42057/160006582-a6897d85-6c08-4d20-8719-6147aeb2c3d5.png)

close #2302

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
