### PR TITLE
Affiche le bon prochain créneau

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -85,9 +85,10 @@ class SearchContext
 
   def next_availability_by_lieux
     @next_availability_by_lieux ||= lieux.to_h do |lieu|
+      motif = matching_motifs.where(organisation: lieu.organisation).first
       [
         lieu.id,
-        creneaux_search_for(lieu, (Time.zone.today..(Time.zone.today + 7.days))).next_availability
+        NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
       ]
     end
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe SearchController, type: :controller do
         get :search_rdv, params: {
           address: address, departement: departement_number, city_code: city_code
         }
-        expect(subject).to match(/Prochaine disponibilité le(.)*lundi 05 août 2019 à 08h00/)
+        expect(subject).to match(/Aucune disponibilité/)
       end
     end
 


### PR DESCRIPTION
Une correction avait été apportée sur le parcours principal, mais pas reporté sur celui-ci.

Avant 

![Screenshot 2022-03-24 at 22-04-04 RDV Solidarités](https://user-images.githubusercontent.com/42057/160010462-0d6815f9-4863-455c-9787-b6e3c5383d33.png)

![Screenshot 2022-03-24 at 22-04-12 RDV Solidarités](https://user-images.githubusercontent.com/42057/160010472-aa7f8388-df83-4fe2-9f5e-29c979d17bda.png)


après

![Screenshot 2022-03-24 at 22-08-34 RDV Solidarités](https://user-images.githubusercontent.com/42057/160010557-4cae36d2-8af7-4807-aa4c-ad494a985573.png)

![Screenshot 2022-03-24 at 22-08-42 RDV Solidarités](https://user-images.githubusercontent.com/42057/160010561-52fdd3ef-95eb-42f0-8395-f17019fb9738.png)


@aminedhobb j'aimerais bien ton œil avisé sur ce changement. Il y a peut-être des trucs qui pourraient être nettoyé en plus. Est-ce que j'ai cassé un truc en faisant ça ? Merci d'avance ! :bow: 

Close #2298 


AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
