### PR TITLE
Bloque la navigation s'il n'y a plus de créneau

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -85,9 +85,10 @@ class SearchContext
 
   def next_availability_by_lieux
     @next_availability_by_lieux ||= lieux.to_h do |lieu|
+      motif = matching_motifs.where(organisation: lieu.organisation).first
       [
         lieu.id,
-        creneaux_search_for(lieu, (Time.zone.today..(Time.zone.today + 7.days))).next_availability
+        NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
       ]
     end
   end

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -13,7 +13,7 @@ section.bg-light.p-4
               h6.card-subtitle= context.selected_motif.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
               - if next_availability
-                = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id, date: next_availability&.starts_at)), class: "d-block stretched-link" do
+                = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
                   .row
                     .col
                       = t(".next_availability")

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -13,7 +13,7 @@ section.bg-light.p-4
               h6.card-subtitle= context.selected_motif.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
               - if next_availability
-                = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id)), class: "d-block stretched-link" do
+                = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id, date: next_availability&.starts_at)), class: "d-block stretched-link" do
                   .row
                     .col
                       = t(".next_availability")

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe SearchController, type: :controller do
         get :search_rdv, params: {
           address: address, departement: departement_number, city_code: city_code
         }
-        expect(subject).to match(/Prochaine disponibilité le(.)*lundi 05 août 2019 à 08h00/)
+        expect(subject).to match(/Aucune disponibilité/)
       end
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe SearchController, type: :controller do
           lieu_id: plage_ouverture.lieu_id,
           agent: plage_ouverture.agent
         )
-        expect(NextAvailabilityService).to receive(:find).and_return(slot)
+        allow(NextAvailabilityService).to receive(:find).and_return(slot)
         get :search_rdv, params: {
           address: address, departement: departement_number, city_code: city_code
         }

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -168,10 +168,17 @@ RSpec.describe SearchController, type: :controller do
       end
 
       it "shows the next availability" do
+        slot = Creneau.new(
+          starts_at: Time.zone.parse("20190805 8:00"),
+          motif: motif,
+          lieu_id: plage_ouverture.lieu_id,
+          agent: plage_ouverture.agent
+        )
+        expect(NextAvailabilityService).to receive(:find).and_return(slot)
         get :search_rdv, params: {
           address: address, departement: departement_number, city_code: city_code
         }
-        expect(subject).to match(/Aucune disponibilité/)
+        expect(subject).to match(/Prochaine disponibilité le(.)*lundi 05 août 2019 à 08h00/)
       end
     end
 


### PR DESCRIPTION
Comme pour #2298, il manquait un report de correction. Ici, c'est sur la navigation vers les créneaux suivants quand il n'y en a plus.

avant :

![Screenshot 2022-03-24 at 22-26-56 RDV Solidarités](https://user-images.githubusercontent.com/42057/160013524-bb2a4697-0cd1-43ce-b2e2-5ed05bc3cb75.png)

![Screenshot 2022-03-24 at 22-27-06 NoMethodError at prendre_rdv](https://user-images.githubusercontent.com/42057/160013538-bb4c7376-e4d1-4503-b540-98d9068b9af9.png)

après :

![Screenshot 2022-03-24 at 22-42-46 RDV Solidarités](https://user-images.githubusercontent.com/42057/160015311-7083fc68-2b64-444b-b18a-c66286e229ae.png)

![Screenshot 2022-03-24 at 22-42-53 RDV Solidarités](https://user-images.githubusercontent.com/42057/160015322-2b6e21d1-b982-4d80-b8c0-a0e0876ec358.png)

Close #2297 

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
