### PR TITLE
Précise qu'aucun résultat n'a été trouvé pour les critères dans la recherche de créneau

### DIFF
--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -74,37 +74,36 @@
       = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
 
 #creneaux
-  - if @search_results.present?
-    .text-center
-      - if @search_results.empty?
-        | Il n'y a pour l'instant aucune disponibilité pour le motif #{@form.motif.name}
-      - else
-        .container
-            h3.font-weight-bold Résultats de votre recherche
-            p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
-            - @search_results.each do |search_result|
-              / On veut connaître le premier créneau, cette semaine ou plus tard.
-              / `search_results.next_availability` contient le premier créneau à partir de la semaine suivante
-              / `search_results.creneaux` contient les créneaux de la semaine courante
-              - first_availability_this_week = search_result.creneaux.min_by(&:starts_at)
-              - first_availability = first_availability_this_week || search_result.next_availability
-              .card.mb-3 class=("card-hoverable" if first_availability)
-                .card-body
-                  .row
-                    .col-md
-                      h4.card-title.mb-3.mt-0.text-success.font-weight-bold= search_result.lieu.name
-                      h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
-                      h6.card-subtitle.text-black-50= search_result.lieu.address
-                    .col-md.align-self-center.pt-3.pt-md-0.position-static
-                      - if first_availability
-                        = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [search_result.lieu.id])),
-                                class: "d-block stretched-link" do
-                          .row
-                            .col
-                              | Prochaine disponibilité le
-                              br
-                              strong= l(first_availability.starts_at, format: :human)
-                            .col-auto.align-self-center
-                              i.fa.fa-chevron-right
-                      - else
-                        em Aucune disponibilité
+  .text-center
+    - if @search_results&.any?
+      .container
+        h3.font-weight-bold Résultats de votre recherche
+        p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
+        - @search_results.each do |search_result|
+          / On veut connaître le premier créneau, cette semaine ou plus tard.
+          / `search_results.next_availability` contient le premier créneau à partir de la semaine suivante
+          / `search_results.creneaux` contient les créneaux de la semaine courante
+          - first_availability_this_week = search_result.creneaux.min_by(&:starts_at)
+          - first_availability = first_availability_this_week || search_result.next_availability
+          .card.mb-3 class=("card-hoverable" if first_availability)
+            .card-body
+              .row
+                .col-md
+                  h4.card-title.mb-3.mt-0.text-success.font-weight-bold= search_result.lieu.name
+                  h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
+                  h6.card-subtitle.text-black-50= search_result.lieu.address
+                .col-md.align-self-center.pt-3.pt-md-0.position-static
+                  - if first_availability
+                    = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [search_result.lieu.id])),
+                            class: "d-block stretched-link" do
+                      .row
+                        .col
+                          | Prochaine disponibilité le
+                          br
+                          strong= l(first_availability.starts_at, format: :human)
+                        .col-auto.align-self-center
+                          i.fa.fa-chevron-right
+                  - else
+                    em Aucune disponibilité
+    - elsif @form.motif.present?
+      = t(".no_slot_available", motif_name: @form.motif.name)

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -3,4 +3,4 @@ fr:
     creneaux:
       agent_searches:
         index:
-          no_slot_available: Aucun créneaux n'est disoponible pour le motif %{motif_name} et les critères sélectionnés
+          no_slot_available: Aucun créneau n’est disponible pour le motif « %{motif_name} » selon les critères sélectionnés.

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -1,0 +1,6 @@
+fr:
+  admin:
+    creneaux:
+      agent_searches:
+        index:
+          no_slot_available: Aucun créneaux n'est disoponible pour le motif %{motif_name} et les critères sélectionnés


### PR DESCRIPTION
La structure de la page ne permettait pas de voir le message comme quoi
aucuns créneaux ne sont disponibles pour les critères sélectionnés.

Nous affichons maintenant un message.

Avant 

![Screenshot 2022-03-25 at 15-53-16 RDV Solidarités](https://user-images.githubusercontent.com/42057/160144988-8075ad41-0966-4dce-bd2c-b4ae1fc0f5f8.png)

Après

![Screenshot 2022-03-25 at 15-53-01 RDV Solidarités](https://user-images.githubusercontent.com/42057/160145020-106fbd0b-fa67-4f47-acc4-af9699fe0eae.png)

close #2119

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
