### PR TITLE
Valide une absence sans chevauchement

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -23,7 +23,7 @@ class Absence < ApplicationRecord
   # Validation
   validates :first_day, :title, presence: true
   validate :ends_at_should_be_after_starts_at
-  validate :no_recurrence_for_absnece_for_several_days
+  validate :no_recurrence_for_absence_for_several_days
 
   # Hooks
   before_validation :set_end_day

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -23,6 +23,7 @@ class Absence < ApplicationRecord
   # Validation
   validates :first_day, :title, presence: true
   validate :ends_at_should_be_after_starts_at
+  validate :no_recurrence_for_absnece_for_several_days
 
   # Hooks
   before_validation :set_end_day
@@ -57,5 +58,11 @@ class Absence < ApplicationRecord
     return if starts_at.blank? || ends_at.blank?
 
     errors.add(:ends_time, "doit être après le début.") if starts_at >= ends_at
+  end
+
+  def no_recurrence_for_absnece_for_several_days
+    return if recurrence.blank? || end_day.blank? || first_day == end_day
+
+    errors.add(:recurrence, "pas possible avec une absence de plusieurs jours")
   end
 end

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -60,7 +60,7 @@ class Absence < ApplicationRecord
     errors.add(:ends_time, "doit être après le début.") if starts_at >= ends_at
   end
 
-  def no_recurrence_for_absnece_for_several_days
+  def no_recurrence_for_absence_for_several_days
     return if recurrence.blank? || end_day.blank? || first_day == end_day
 
     errors.add(:recurrence, "pas possible avec une absence de plusieurs jours")

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -13,6 +13,16 @@ describe Absence, type: :model do
     end
   end
 
+  describe "no reccurence for absence for several days" do
+    it "invalid with recurrence and absence on more than one day" do
+      expect(build(:absence, :weekly, first_day: Date.new(2019, 7, 20), end_day: Date.new(2019, 7, 23))).to be_invalid
+    end
+
+    it "valid without recurrence and absence on more than one day" do
+      expect(build(:absence, first_day: Date.new(2019, 7, 20), end_day: Date.new(2019, 7, 23))).to be_valid
+    end
+  end
+
   describe "#occurrences_for" do
     subject { absence.occurrences_for(date_range) }
 


### PR DESCRIPTION
Il y a une situtation un peu étrange où l'on peut définir une absence
sur plusieurs jours et qui se répète, ce qui cause le chevauchement de
l'absence sur elle même.

D'une manire un peu direct / radical, suggéré par Clarisse (92) lors de
la dernière réunion référente, cette PR ajoute une validation pour
empêcher la création d'une indisponibilité récurrente si elle est sur
plusieurs jours.

Close #2165

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
