### PR TITLE
Script d'import des cnfs pour la phase 4

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -13,7 +13,11 @@ class CustomDeviseMailer < Devise::Mailer
   def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}
-    opts[:reply_to] = record.invited_by.email if record.is_a? Agent
-    devise_mail(record, :invitation_instructions, opts)
+    opts[:reply_to] = record.invited_by&.email if record.is_a? Agent
+    if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
+      devise_mail(record, :invitation_instructions_cnfs, opts)
+    else
+      devise_mail(record, :invitation_instructions, opts)
+    end
   end
 end

--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -1,0 +1,44 @@
+<p><%= t("devise.mailer.invitation_instructions_cnfs.hello") %></p>
+
+<p>
+  <%= t("devise.mailer.invitation_instructions_cnfs.create_account",
+         link: link_to("créer votre compte", accept_invitation_url(@resource, invitation_token: @token, user: @user_params))).html_safe %>
+</p>
+
+
+<p><%= t("devise.mailer.invitation_instructions_cnfs.intro1") %></p>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.intro2") %></p>
+<br/>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.intro3") %></p>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.intro4") %></p>
+
+<br>
+<h1><%= t("devise.mailer.invitation_instructions_cnfs.title1") %></h1>
+
+<p><%= t("devise.mailer.invitation_instructions_cnfs.recap") %></p>
+<ul>
+  <li><%= t("devise.mailer.invitation_instructions_cnfs.recap_item1") %></li>
+  <li><%= t("devise.mailer.invitation_instructions_cnfs.recap_item2") %></li>
+  <li><%= t("devise.mailer.invitation_instructions_cnfs.recap_item3") %></li>
+</ul>
+
+<br>
+
+<h1><%= t("devise.mailer.invitation_instructions_cnfs.title2") %></h1>
+
+<p><%= t("devise.mailer.invitation_instructions_cnfs.video_text", link: link_to("vidéo de présentation de l’outil", "https://peertube.ethibox.fr/w/sLqvuTvx4vgsjmKXpz9awH"), target: "_blank").html_safe %></p>
+
+<p><%= t("devise.mailer.invitation_instructions_cnfs.first_steps_info") %></p>
+
+<br>
+<h1><%= t("devise.mailer.invitation_instructions_cnfs.title3") %></h1>
+
+<p>
+  <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
+        mattermost: link_to("Aide RDV Solidarités", "https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites"),
+        support_email: link_to("contact@rdv-solidarités.fr", "mailto:contact@rdv-solidarités.fr")
+       ).html_safe %>
+</p>
+
+<p><%= t("devise.mailer.invitation_instructions_cnfs.sign_off") %></p>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.signature") %></p>

--- a/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
@@ -1,0 +1,39 @@
+<%= t("devise.mailer.invitation_instructions_cnfs.hello") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.create_account", link: "créer votre compte", ) %>
+
+<%= accept_invitation_url(@resource, invitation_token: @token, user: @user_params) %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.intro1") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.intro2") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.intro3") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.intro4") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.title1") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.recap") %>
+- <%= t("devise.mailer.invitation_instructions_cnfs.recap_item1") %>
+- <%= t("devise.mailer.invitation_instructions_cnfs.recap_item2") %>
+- <%= t("devise.mailer.invitation_instructions_cnfs.recap_item3") %>
+
+
+<%= t("devise.mailer.invitation_instructions_cnfs.title2") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.video_text", link: "vidéo de présentation de l’outil") %>
+
+https://peertube.ethibox.fr/w/sLqvuTvx4vgsjmKXpz9awH
+
+<%= t("devise.mailer.invitation_instructions_cnfs.first_steps_info") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.title3") %>
+
+
+<%= t("devise.mailer.invitation_instructions_cnfs.help_info",
+      mattermost: "Aide RDV Solidarités",
+      support_email: "contact@rdv-solidarités.fr") %>
+
+https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites
+
+<%= t("devise.mailer.invitation_instructions_cnfs.sign_off") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.signature") %>

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -41,6 +41,25 @@ fr:
         submit_button: "Créer son compte"
         click_on_link_sent: "Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé"
     mailer:
+      invitation_instructions_cnfs:
+        hello: "Hello 👋"
+        create_account: "Nous vous contactons pour %{link} RDV-Solidarités. "
+        intro1: "✅ RDV-Solidarités est un outil de gestion des rendez-vous."
+        intro2: "✅ RDV-Solidarités est en phase de généralisation à tous les Conseillers Numérique France Services."
+        intro3: Chaque semaine, nous lançons l’embarquement d’un nouveau groupe de Conseillers Numérique.
+        intro4: Vous faites partie  d’un embarquement et vous disposez  alors d’un droit d’accès à RDV-Solidarités.
+        title1: RDV-Solidarités c’est ?
+        recap: "Un outil,  qui vous permet de :"
+        recap_item1: planifier des rendez-vous individuels et collectifs,
+        recap_item2: envoyer des rappels (sms & mail) automatiques aux  usagers
+        recap_item3: permettre à vos collègues de planifier des rendez-vous selon vos disponibilités.
+        title2: Comment ça marche  ?
+        video_text: "Pour mieux comprendre, nous vous proposons de regarder la %{link}"
+        first_steps_info: Vous trouverez  également un guide “premiers pas” dans l’interface de l’outil.
+        title3: Besoin d’aide ?
+        help_info: "Vous pouvez  nous contacter sur le Mattermost dans le canal : %{mattermost}  ou bien par mail à %{support_email}"
+        sign_off: En vous souhaitant un bon embarquement !
+        signature: L'équipe RDV-Solidarités
       invitation_instructions_for_agents:
         subject: "Vous avez été invité sur RDV-Solidarités."
         hello: "Bonjour %{email}"

--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "csv"
+
+def geocode(street_address, zipcode)
+  response = Faraday.get(
+    "https://api-adresse.data.gouv.fr/search/",
+    q: street_address,
+    postcode: zipcode
+  )
+  response_hash = JSON.parse(response.body)
+  response_hash.dig("features", 0, "geometry", "coordinates")
+end
+
+conseillers_numeriques = CSV.read("/tmp/uploads/export-cnfs.csv", headers: true, col_sep: ";")
+
+conseiller_numerique_service = Service.find_by(name: "Conseiller Numérique")
+cnfs_territory = Territory.find_by(name: "Conseillers Numériques")
+
+conseillers_numeriques.each do |conseiller_numerique|
+  ActiveRecord::Base.transaction do
+    organisation = Organisation.find_or_create_by(
+      name: conseiller_numerique["Nom de la structure"],
+      territory: cnfs_territory
+    )
+
+    if organisation.motifs.none?
+      Motif.create!(
+        name: "Accompagnement individuel",
+        color: "#99CC99",
+        default_duration_in_min: 60,
+        location_type: :public_office,
+        organisation: organisation,
+        service: conseiller_numerique_service
+      )
+
+      Motif.create!(
+        name: "Atelier collectif",
+        color: "#4A86E8",
+        default_duration_in_min: 120,
+        location_type: :public_office,
+        collectif: true,
+        organisation: organisation,
+        service: conseiller_numerique_service
+      )
+    end
+
+    if organisation.lieux.none?
+      zipcode_regex = /\d{5}/
+      zipcode = conseiller_numerique["Adresse de la structure"][zipcode_regex]
+      longitude, latitude = geocode(conseiller_numerique["Adresse de la structure"], zipcode)
+
+      Lieu.create!(
+        name: conseiller_numerique["Nom de la structure"],
+        organisation: organisation,
+        latitude: latitude,
+        longitude: longitude,
+        address: conseiller_numerique["Adresse de la structure"],
+        availability: :enabled
+      )
+    end
+
+    Agent.invite!(
+      email: conseiller_numerique["Email @conseiller-numerique.fr"],
+      first_name: conseiller_numerique["Prénom"].capitalize,
+      last_name: conseiller_numerique["Nom"],
+      service: conseiller_numerique_service,
+      password: SecureRandom.hex,
+      roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }]
+    )
+  end
+  puts "Import réussi pour #{conseiller_numerique['Email @conseiller-numerique.fr']}"
+end


### PR DESCRIPTION
Close #2311

Oooh, le joli mail d'invitation (d'après une [création originale de Matis Alves](https://docs.google.com/presentation/d/120rOre1wm_4wqHvlP61e4QnhT6snwQUilUPL-V9Lxys/edit?pli=1#slide=id.g1208040ce53_1_0) )

<img width="631" alt="Capture d’écran 2022-03-30 à 19 04 33" src="https://user-images.githubusercontent.com/1840367/160891700-93f71608-78cf-4910-9819-c5ed56827c85.png">
<img width="625" alt="Capture d’écran 2022-03-30 à 19 04 37" src="https://user-images.githubusercontent.com/1840367/160891707-913be2b3-4b45-45c1-8d73-56e528d7674c.png">

### Mode d'emploi

Mettre les 200 cnfs concernés dans le fichier `tmp/export-cnfs.csv` puis lancer :
```
scalingo run "rails runner scripts/import_conseillers_numeriques.rb" --app demo-rdv-solidarites --region osc-secnum-fr1 --file tmp/export-cnfs.csv
```

Il faudra que je mette à jour le lien pour la vidéo quand on sortira la v3.

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
