### PR TITLE
RDV Collectifs : limite du nombre de participants

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -7,7 +7,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
     @rdvs = policy_scope(Rdv).where(organisation: current_organisation).collectif
     @rdvs = @rdvs.order(starts_at: :asc).page(params[:page])
 
-    @form = Admin::RdvCollectifSearchForm.new(params.permit(:motif_id, :organisation_id, :from_date))
+    @form = Admin::RdvCollectifSearchForm.new(params.permit(:motif_id, :organisation_id, :from_date, :with_remaining_seats))
 
     @rdvs = @form.filter(@rdvs)
   end
@@ -19,7 +19,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
   end
 
   def create
-    @rdv = Rdv.new(organisation: current_organisation)
+    @rdv = Rdv.new(organisation: current_organisation, users_count: 0)
     authorize(@rdv, :new?)
 
     if @rdv.update(create_params)
@@ -30,9 +30,38 @@ class Admin::RdvsCollectifsController < AgentAuthController
     end
   end
 
+  def edit
+    @rdv = Rdv.find(params[:id])
+
+    authorize(@rdv)
+
+    @add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
+    users_to_add = User.where(id: @add_user_ids)
+    @rdv_users_to_add = users_to_add.ids.map { @rdv.rdvs_users.build(user_id: _1) }
+  end
+
+  def update
+    @rdv = Rdv.find(params[:id])
+    authorize(@rdv, :update?)
+
+    if @rdv.update(update_users_params)
+      flash[:notice] = "Participants mis à jour"
+      redirect_to admin_organisation_rdvs_collectifs_path(current_organisation)
+    else
+      render :edit
+    end
+  end
+
   private
 
   def create_params
-    params.require(:rdv).permit(:starts_at, :duration_in_min, :lieu_id, :name, :context, :motif_id, agent_ids: [])
+    params.require(:rdv).permit(:starts_at, :duration_in_min, :lieu_id, :name, :max_participants_count, :context, :motif_id, agent_ids: [])
+  end
+
+  def update_users_params
+    params.require(:rdv).permit(
+      user_ids: [],
+      rdvs_users_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy]
+    )
   end
 end

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -89,7 +89,7 @@ class Admin::RdvsController < AgentAuthController
   def rdv_params
     params
       .require(:rdv)
-      .permit(:motif_id, :status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors,
+      .permit(:motif_id, :status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors, :max_participants_count,
               agent_ids: [],
               user_ids: [],
               rdvs_users_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy])

--- a/app/form_models/admin/rdv_collectif_search_form.rb
+++ b/app/form_models/admin/rdv_collectif_search_form.rb
@@ -3,11 +3,15 @@
 class Admin::RdvCollectifSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :motif_id
+  attr_accessor :organisation_id, :motif_id, :with_remaining_seats
 
   def filter(rdvs)
     if motif_id.present?
       rdvs = rdvs.where(motif_id: motif_id)
+    end
+
+    if with_remaining_seats.to_bool
+      rdvs = rdvs.with_remaining_seats
     end
 
     rdvs.where("starts_at >= ?", from_date)

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -2,7 +2,7 @@
 
 class RdvsUser < ApplicationRecord
   # Relations
-  belongs_to :rdv, touch: true, inverse_of: :rdvs_users
+  belongs_to :rdv, touch: true, inverse_of: :rdvs_users, counter_cache: :users_count
   belongs_to :user
 
   # Validations

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -49,6 +49,11 @@
                 data: { "select-options": { ajax: { url: search_admin_organisation_agents_path(current_organisation),
                                                           dataType: "json", delay: 250 } } } }
 
+            - if @rdv_form.motif.collectif?
+              = f.input :name, wrapper_html: { class: "mb-1" }
+              p.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
+
+              = f.input :max_participants_count, input_html: { min: 1 }
             .form-group
               = "#{User.model_name.human.pluralize} :"
               = f.fields_for :rdvs_users, @rdv.rdvs_users do |rdv_user_form|

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -6,10 +6,34 @@
   .card-body
     .row
       .col-md-6
+        - if rdv.remaining_seats?
+          = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "d-flex card-text mb-2" do
+            div.mr-1
+              i.fa.fa-fw.fa-user-plus>
+            div
+              = "Ajouter un participant"
+
+        .d-flex.card-text.mb-2
+          - if rdv.remaining_seats?
+              div.mr-3
+              div
+                - if rdv.max_participants_count
+                  = I18n.t("rdvs.available_seats", count: rdv.max_participants_count - rdv.users_count)
+                - else
+                  = "Pas de limite de places"
+          - elsif rdv.fully_booked?
+              div.mr-1
+                i.fa.fa-fw.fa-user-check>
+                = "Complet"
+          - elsif rdv.overbooked?
+            div.mr-1
+              i.fa.fa-fw.fa-user-times>
+              = "Trop de participants (#{rdv.users_count} personnes pour #{I18n.t('rdvs.seats', count: rdv.max_participants_count)})"
+
         .d-flex.card-text.mb-3
           div.mr-1
             i.fa.fa-fw.fa-users>
-            = "#{rdv.rdvs_users.count} participants"
+            = I18n.t("rdvs.participants", count: rdv.users_count)
 
       .col-md-6
         .d-flex.card-text.mb-2

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -1,0 +1,87 @@
+- content_for(:title) { "Ajouter un participant" }
+
+.row.justify-content-md-center
+  .col-md-8
+    = simple_form_for(@rdv, url: admin_organisation_rdvs_collectif_path(current_organisation), method: :put) do |f|
+      .card
+        .card-header
+          h3.text-center #{@rdv.motif.name} (#{@rdv.motif.service.short_name})
+        .card-body.px-3
+          .row.mt-3
+            .col-md-6
+              .d-flex.card-text.mb-2
+                div.mr-1
+                  i.fa.fa-fw.fa-users>
+                div
+                  - if @rdv.max_participants_count
+                    = I18n.t("rdvs.seats", count: @rdv.max_participants_count)
+                  - else
+                    = "Pas de limite de places"
+
+              .d-flex.card-text.mb-3
+                div.mr-1
+                  i.fa.fa-fw.fa-users>
+                div
+                  = I18n.t("rdvs.participants", count: @rdv.users_count)
+                  ul
+                    - @rdv.users.each do |user|
+                      li= user.full_name
+
+            .col-md-6
+              .d-flex.card-text.mb-2
+                - if @rdv.phone?
+                    i.fa.fa-fw.fa-phone>
+                    | RDV téléphonique
+                - else
+                  div.mr-1
+                    i.fa.fa-fw.fa-map-marker-alt>
+                    - if @rdv.home?
+                      | RDV à domicile
+                      = human_location(@rdv)
+                    - elsif @rdv.public_office?
+                      = @rdv.lieu.name
+
+              .d-flex.card-text.mb-2
+                div.mr-1
+                  i.fa.fa-fw.fa-user>
+                div
+                  strong> Animé par
+                  = agents_to_sentence(@rdv.agents)
+
+              .d-flex.card-text
+                div.mr-1
+                  i.fa.fa-fw.fa-clock>
+                div
+                  = "#{@rdv.duration_in_min} minutes"
+
+        .card-footer.px-3
+          = render "model_errors", model: @rdv
+
+          .form-group
+            = "Usager à inscrire :"
+            = f.fields_for :rdvs_users, @rdv_users_to_add do |rdv_user_form|
+              = render "admin/rdvs_users/form", form: rdv_user_form
+
+          .form-group
+            = select_tag :status,
+                    options_for_select([]),
+                    include_blank: "Ajouter un usager",
+                    required: false,
+                    class: "select2-input js-rdv-user-select",
+                    data: { \
+              width: "auto", \
+              "scroll-to-bottom": @add_user_ids.present?, \
+              "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.rdvs_users.map(&:user_id)), dataType: "json", delay: 250 } } \
+             }
+            span.small.text-muted
+              | L'usager n'existe pas ?&nbsp;
+              = link_to \
+                "Créer un usager", \
+                new_admin_organisation_user_path( \
+                  current_organisation, modal: true, return_location: edit_admin_organisation_rdvs_collectif_path(current_organisation, @rdv, add_user: @add_user_ids), role: default_service_selection_from(@rdv.motif.service) \
+                    ), \
+                data: { modal: true }
+
+          .text-right
+            = link_to t("helpers.back"), admin_organisation_rdvs_collectifs_path(current_organisation), class: "btn btn-link"
+            = f.button :submit, t("helpers.submit.submit")

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -23,7 +23,8 @@
               data: { placeholder: "Sélectionnez un motif", "allow-clear": true }, \
               class: "select2-input" \
             }
-        .col-md-3
+        .col-md-3.mt-4
+          = f.input :with_remaining_seats, as: :boolean, label: "Avec des places disponibles"
         .col-md-1.d-flex-justify-content-end.mt-3
           = f.submit "Filtrer", class: "btn btn-outline-primary"
 

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -17,12 +17,12 @@
 
           .form-row
             .col-md-6= datetime_input(f, :starts_at)
-            .col-md-6= f.input :duration_in_min, as: :integer, label: "Durée en minutes"
+            .col-md-6= f.input :duration_in_min, as: :integer
           = f.association :agents, collection: @rdv.motif.authorized_agents.includes(:service), label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input" }
-          = f.input :name, label: "Intitulé", wrapper_html: { class: "mb-1" }
-          p.text-muted.font-14= "Cet intitulé apparaitra dans les notifications envoyées aux usagers."
+          = f.input :name, wrapper_html: { class: "mb-1" }
+          p.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")
 
-          = f.input :context, label: "Contexte"
+          = f.input :context
           = f.hidden_field :motif_id, value: @rdv.motif_id
           = f.association :lieu, \
             collection: policy_scope(Lieu).enabled.ordered_by_name, \
@@ -31,6 +31,8 @@
             required: true,
             input_html: { class: "select2-input" }
 
+          = f.input :max_participants_count, input_html: { min: 1 }
+
           .d-flex.justify-content-end
             .btn-group
-              = f.button :submit, "Enregistrer"
+              = f.button :submit, t("helpers.submit.submit")

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -27,9 +27,11 @@ fr:
         location: Lieu
         starts_at: Commence à
         duration_in_min: Durée en minutes
+        max_participants_count: Nombre de places
         ends_at: Termine à
         status: Statut
         context: Contexte
+        name: Intitulé
       rdv/created_by:
         agent: "Créé par un agent"
         user: "RDV Pris sur internet"
@@ -58,6 +60,9 @@ fr:
         excused: L’usager a pu prévenir de son absence. Une notification de confirmation lui sera envoyée.
         revoked: Le rendez-vous a du être annulé par le service, par exemple pour une raison administrative. Une notification sera envoyée à l’usager.
         noshow: L’usager ne s’est pas présenté a son rendez-vous.
+      rdv/name:
+        hint: "Cet intitulé apparaitra dans les notifications envoyées aux usagers."
+
   activemodel:
     warnings:
       models:

--- a/config/locales/rdvs.fr.yml
+++ b/config/locales/rdvs.fr.yml
@@ -2,3 +2,13 @@ fr:
   rdvs:
     title: "Le %{starts_at} (durée : %{duration} minutes)"
     title_time_only: "Aujourd’hui à %{starts_at} (durée : %{duration} minutes)"
+    available_seats:
+      one: 1 place disponible
+      other: "%{count} places disponibles"
+    seats:
+      one: 1 place
+      other: "%{count} places"
+    participants:
+      one: 1 participant
+      other: "%{count} participants"
+      zero: aucun participant

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,7 @@ Rails.application.routes.draw do
         resources :slots, only: :index
         resources :lieux, except: :show
         resources :motifs
-        resources :rdvs_collectifs, only: %i[index new create] do
+        resources :rdvs_collectifs, only: %i[index new create edit update] do
           collection do
             resources :motifs, only: [:index], as: :rdvs_collectif_motifs, controller: "rdvs_collectifs/motifs"
           end

--- a/db/migrate/20220321103957_add_rdvs_max_participants_count_and_users_count.rb
+++ b/db/migrate/20220321103957_add_rdvs_max_participants_count_and_users_count.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddRdvsMaxParticipantsCountAndUsersCount < ActiveRecord::Migration[6.1]
+  def change
+    add_column :rdvs, :max_participants_count, :integer
+
+    add_column :rdvs, :users_count, :integer
+
+    add_index :rdvs, :max_participants_count
+    add_index :rdvs, :users_count
+
+    up_only do
+      execute(<<-SQL.squish
+        UPDATE rdvs SET users_count = (SELECT count(1) FROM rdvs_users WHERE rdvs_users.rdv_id = rdvs.id)
+      SQL
+             )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -377,15 +377,19 @@ ActiveRecord::Schema.define(version: 2022_03_21_181557) do
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
     t.datetime "ends_at", null: false
     t.string "name"
+    t.integer "max_participants_count"
+    t.integer "users_count"
     t.index "tsrange(starts_at, ends_at, '[)'::text)", name: "index_rdvs_on_tsrange_starts_at_ends_at", using: :gist
     t.index ["created_by"], name: "index_rdvs_on_created_by"
     t.index ["ends_at"], name: "index_rdvs_on_ends_at"
     t.index ["lieu_id"], name: "index_rdvs_on_lieu_id"
+    t.index ["max_participants_count"], name: "index_rdvs_on_max_participants_count"
     t.index ["motif_id"], name: "index_rdvs_on_motif_id"
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"
     t.index ["starts_at"], name: "index_rdvs_on_starts_at"
     t.index ["status"], name: "index_rdvs_on_status"
     t.index ["updated_at"], name: "index_rdvs_on_updated_at"
+    t.index ["users_count"], name: "index_rdvs_on_users_count"
   end
 
   create_table "rdvs_users", force: :cascade do |t|

--- a/spec/features/agents/agent_can_organize_rdv_collectif_spec.rb
+++ b/spec/features/agents/agent_can_organize_rdv_collectif_spec.rb
@@ -10,7 +10,6 @@ describe "Agent can organize a rdv collectif", js: true do
 
   let!(:user1) { create(:user, organisations: [organisation]) }
   let!(:user2) { create(:user, organisations: [organisation]) }
-  let!(:user3) { create(:user, organisations: [organisation]) }
 
   specify do
     travel_to(Time.zone.local(2022, 3, 14))
@@ -29,7 +28,8 @@ describe "Agent can organize a rdv collectif", js: true do
 
     fill_in "Commence à", with: "17/3/2022 14:00"
     fill_in "Durée en minutes", with: "30"
-    fill_in "Contexte", with: "Traitement de texte"
+    fill_in "Nombre de places", with: 3
+    fill_in "Intitulé", with: "Traitement de texte"
 
     select("DIALO Alain", from: "rdv_agent_ids")
     select(lieu.name, from: "Lieu")
@@ -38,5 +38,20 @@ describe "Agent can organize a rdv collectif", js: true do
     expect(page).to have_content("Atelier participatif créé")
 
     expect(page).to have_content("Jeudi 17 mars à 14:00")
+    expect(page).to have_content("3 places disponibles")
+
+    click_link("Ajouter un participant")
+    add_user(user1)
+
+    add_new_user
+    click_button "Enregistrer"
+
+    expect(page).to have_content("1 place disponible")
+
+    click_link("Ajouter un participant")
+    add_user(user2)
+    click_button "Enregistrer"
+
+    expect(page).to have_content("Complet")
   end
 end

--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -15,4 +15,17 @@ module Select2SpecHelper
     # This is to make sure we wait for the user to be added before doing the next action
     expect(page).to have_content("#{user.first_name} #{user.last_name}")
   end
+
+  def add_new_user
+    click_link("Créer un usager")
+    first_name = Faker::Name.first_name
+    last_name = Faker::Name.last_name.upcase
+
+    fill_in("Prénom", with: first_name)
+    fill_in("Nom d’usage", with: last_name)
+    click_button("Créer usager")
+
+    # Wait for the user to be added before doing the next action
+    expect(page).to have_content("#{first_name} #{last_name}")
+  end
 end


### PR DESCRIPTION
Close #2188

Cette PR ajoute la possibilité de gérer les participants à un rdv collectif.

<img width="1405" alt="Capture d’écran 2022-03-29 à 17 46 08" src="https://user-images.githubusercontent.com/1840367/160655064-2c46d7cc-f936-49fb-9bc1-01b77526bf33.png">

Dans l'index des rdv collectifs, on a un aperçu du nombre de participants
<img width="1131" alt="Capture d’écran 2022-03-29 à 17 45 31" src="https://user-images.githubusercontent.com/1840367/160655083-92fe16c4-c209-4886-82b8-92c25ec38699.png">

<img width="1123" alt="Capture d’écran 2022-03-29 à 17 46 14" src="https://user-images.githubusercontent.com/1840367/160655059-e2090e7b-800a-40a6-88d0-e5ba265a5b6f.png">

<img width="1124" alt="Capture d’écran 2022-03-29 à 18 00 13" src="https://user-images.githubusercontent.com/1840367/160655049-6d34463c-3639-42c4-949d-89d7702c1aed.png">

<img width="1146" alt="Capture d’écran 2022-03-29 à 17 59 52" src="https://user-images.githubusercontent.com/1840367/160655056-731e8454-54f9-417d-9bb5-815073ee71a8.png">

Comme montré lors de la réunion référente il y a quelques semaines, il est possible de faire de la sur-réservation.

### Implémentation

Pour éviter de surcharger la base, cette PR ajoute un counter cache sur le nombre de participants. Pour éviter de faire trop d'écritures, ce counter cache n'est activé que pour les rdv collectifs (il n'est pas mis à jour pour les autres rdvs). Cette option n'étant pas disponible avec les counter-cache classiques de rails, ça a motivé l'ajout de la gem counter-culture.
Pour clarifier que ce counter cache n'est que pour les rdv collectifs, j'ai préfixé son nom, mais je ne suis pas sûr que ça soit l'option la plus élégante.

Pour le moment, cette fonctionnalité est encore cachée. Une fois qu'elle sera mergée, je vais voir comment je peux l'intégrer à la recherche par créneaux.



REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
