### PR TITLE
Améliore accessibilité new_organisation_path

### DIFF
--- a/app/views/organisations/new.html.slim
+++ b/app/views/organisations/new.html.slim
@@ -3,35 +3,33 @@
     .container
       .row
         .col-md-9.m-auto
-          h1.mb-3.text-white
-            span.text-secondary> Gérez les rendez-vous
-            | de votre département
+          h1.mb-3.text-white = t(".manage_rdvs_in_your_region")
 
 section.py-5.bg-lightturquoise.text-primary
   .container
     .row
       .col-md-12.m-auto
-        h2 Créez et paramétrez votre service en moins de 5 minutes pour accepter des RDVs en ligne dès aujourd'hui&nbsp;!
+        h2 = t(".create_service_now")
         = render "model_errors", model: @organisation
         = simple_form_for @organisation do |f|
           .form-row.mb-2.d-flex
-            .col-lg-10= f.input :name, label: "Nom de votre organisation", placeholder: "Maison départementale des solidarités de Beaupréau-en-Mauges", input_html: { class: "form-control-lg" }, wrapper_html: { class: "mb-1 mb-lg-0" }
+            .col-lg-10= f.input :name, label: t(".organisation_name"), placeholder: t(".example_address_organisation"), input_html: { class: "form-control-lg" }, wrapper_html: { class: "mb-1 mb-lg-0" }
             .col-lg-2
               = f.simple_fields_for :territory do |ff|
                 = ff.input :departement_number, \
-                  label: "Département", \
-                  placeholder: "49", \
+                  label: t(".departement"), \
+                  placeholder: t(".example_departement_organisation"), \
                   input_html: { class: "form-control-lg" }, \
                   wrapper_html: { class: "mb-1 mb-lg-0" }
           = f.simple_fields_for :agent_roles do |ff|
             = ff.input :level, as: :hidden
             = ff.simple_fields_for :agent do |fff|
               .form-row.mb-2
-                .col-lg-12= fff.input :email, label: "Votre email", placeholder: "benoit.goulli@departement.fr", input_html: { class: "form-control-lg" }, wrapper_html: { class: "mb-1 mb-lg-0" }
+                .col-lg-12= fff.input :email, label: t(".your_email"), placeholder: t(".example_email_organisation"), input_html: { class: "form-control-lg" }, wrapper_html: { class: "mb-1 mb-lg-0" }
               .form-row.mb-2
-                .col-lg-12= fff.association :service, label: "Votre service"
+                .col-lg-12= fff.association :service, label: t("common.search_form.service")
           .form-row.d-flex.mb-2
             .col-lg-3.align-self-end
-              = f.button :button, id: "search_submit", class: "btn-secondary btn-lg w-100 text-center" do
-                | Créer
+              = f.button :button, id: "search_submit", class: "btn-primary btn-lg w-100 text-center" do
+                = t("admin.organisations.index.create")
                 i.fa.fa-angle-right<

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,6 +4,7 @@ fr:
     organisations:
       index:
         configuration: Configuration
+        create: Créer
     rdvs:
       message:
         confirm:

--- a/config/locales/models/organisation.fr.yml
+++ b/config/locales/models/organisation.fr.yml
@@ -1,4 +1,14 @@
 fr:
+  organisations:
+    new:
+      create_service_now: Créez et paramétrez votre service en moins de 5 minutes pour accepter des RDVs en ligne dès aujourd'hui !
+      organisation_name: Nom de votre organisation
+      departement: Département
+      manage_rdvs_in_your_region: Gérez les rendez-vous de votre département
+      example_address_organisation: Maison départementale des solidarités de Beaupréau-en-Mauges
+      example_departement_organisation: "49"
+      your_email: Votre email 
+      example_email_organisation: benoit.goulli@departement.fr
   activerecord:
     models:
       organisation: Organisation

--- a/spec/features/accessibility/welcome_pages_spec.rb
+++ b/spec/features/accessibility/welcome_pages_spec.rb
@@ -17,4 +17,8 @@ describe "accueil_mds", js: true do
                             address: "152 Avenue Jean Jaurès Paris 75019 Paris")
     expect_page_to_be_axe_clean(path)
   end
+
+  it "new_organisation is accessible" do
+    expect_page_to_be_axe_clean(new_organisation_path)
+  end
 end


### PR DESCRIPTION
Close #2075 

Ajoute test d'accessibilité sur la route `new_organisation_path`.
Corrige les erreurs renvoyées.

Bouton 
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/44778533/160663170-98ddf9df-55eb-417e-bdae-5e0902cff6b8.gif)

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
