### PR TITLE
Restriction des services pour les CNFS

### DIFF
--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -11,6 +11,7 @@ class Agent::ServicePolicy < Agent::AdminPolicy
 
   class AdminScope < Scope
     def resolve
+      return [scope.secretariat] if current_agent.conseiller_numerique?
       return scope.all if current_agent_role.admin?
 
       scope.where(id: current_agent.service_id)

--- a/app/views/admin/invitations_devise/new.html.slim
+++ b/app/views/admin/invitations_devise/new.html.slim
@@ -10,10 +10,10 @@
         = simple_form_for [:admin, resource], as: resource_name, url: admin_agent_organisation_invitation_path(current_organisation, resource), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: resource
           = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}
-          = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
+          = f.association :service, collection: @services, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
           = f.simple_fields_for :roles do |ff|
             = ff.input :level, \
-              collection: current_agent.conseiller_numerique? ? [AgentRole::LEVEL_BASIC] : AgentRole::LEVELS, \
+              collection: @roles, \
               label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
               hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
               as: :radio_buttons

--- a/app/views/admin/invitations_devise/new.html.slim
+++ b/app/views/admin/invitations_devise/new.html.slim
@@ -13,7 +13,7 @@
           = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
           = f.simple_fields_for :roles do |ff|
             = ff.input :level, \
-              collection: AgentRole::LEVELS, \
+              collection: current_agent.conseiller_numerique? ? [AgentRole::LEVEL_BASIC] : AgentRole::LEVELS, \
               label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
               hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
               as: :radio_buttons

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
     Devise.mailer.deliveries.clear
   end
 
+  describe "GET #new" do
+    context "for a cnfs" do
+      let!(:agent) do
+        create(:agent, admin_role_in_organisations: [organisation],
+                       invitation_accepted_at: nil, service: create(:service, name: "Conseiller Numérique"))
+      end
+
+      it "only allows inviting agents for the secretariat" do
+        get :new
+        expect(response).not_to have_content("Admin")
+      end
+    end
+  end
+
   describe "POST #create" do
     subject { post :create, params: params }
 


### PR DESCRIPTION
Cette PR cache les services du médico-social aux cnfs au moment de l'invitation d'un nouvel agent.

Avant :
<img width="889" alt="Capture d’écran 2022-03-31 à 14 22 11" src="https://user-images.githubusercontent.com/1840367/161054085-9b39d802-4fbe-4183-85f2-a665e76ab7f9.png">

Après :
<img width="928" alt="Capture d’écran 2022-03-31 à 14 22 01" src="https://user-images.githubusercontent.com/1840367/161054073-e7dcde48-8298-41c4-9f26-ae5e1b26b23a.png">

Cette première implémentation est un peu simpliste : on commence à distinguer les services propres au médico-social de ceux propre aux cnfs. Au fur et à mesure qu'on ouvre à plus d'usages différents, peut-être qu'on voudra stocker en base plutôt que dans le code les données qui permettent de distinguer les différentes catégories de services.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
