### PR TITLE
Restriction des invitations pour les cnfs

### DIFF
--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -11,6 +11,7 @@ class Agent::ServicePolicy < Agent::AdminPolicy
 
   class AdminScope < Scope
     def resolve
+      return [scope.secretariat] if current_agent.conseiller_numerique?
       return scope.all if current_agent_role.admin?
 
       scope.where(id: current_agent.service_id)

--- a/app/views/admin/invitations_devise/new.html.slim
+++ b/app/views/admin/invitations_devise/new.html.slim
@@ -10,10 +10,10 @@
         = simple_form_for [:admin, resource], as: resource_name, url: admin_agent_organisation_invitation_path(current_organisation, resource), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: resource
           = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}
-          = f.association :service, collection: Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
+          = f.association :service, collection: @services, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
           = f.simple_fields_for :roles do |ff|
             = ff.input :level, \
-              collection: AgentRole::LEVELS, \
+              collection: @roles, \
               label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
               hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
               as: :radio_buttons


### PR DESCRIPTION
close #2312

Cette PR cache les services du médico-social aux cnfs au moment de l'invitation d'un nouvel agent, et évite que les cnfs puissent inviter des nouveaux agents qui pourraient avoir des rdvs.

Avant :
<img width="889" alt="Capture d’écran 2022-03-31 à 14 22 11" src="https://user-images.githubusercontent.com/1840367/161054085-9b39d802-4fbe-4183-85f2-a665e76ab7f9.png">

Après :
<img width="881" alt="Capture d’écran 2022-03-31 à 17 29 31" src="https://user-images.githubusercontent.com/1840367/161092826-ff0f0acf-fd78-448b-be90-4e90b0072156.png">

Pour le moment, c'est une implémentation très simpliste. On en a discuté avec Yannick, et ce fonctionnement va sans doute avoir vocation à évoluer au fur et à mesure du redécoupage des droits d'accès.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
