### PR TITLE
Vérifie la période de recherche de créneau l'ensemble de la période de réservation

### DIFF
--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -4,7 +4,7 @@ module Lapin
   module Range
     class << self
       def reduce_range_to_delay(motif, date_range)
-        return nil if !motif.booking_delay_range.cover?(date_range.end) && !motif.booking_delay_range.cover?(date_range.begin)
+        return nil unless motif.booking_delay_range.overlaps?(date_range)
 
         start_range = [motif.start_booking_delay, date_range.begin].max
         end_range = [motif.end_booking_delay, date_range.end].min

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -4,10 +4,10 @@ module Lapin
   module Range
     class << self
       def reduce_range_to_delay(motif, date_range)
-        return nil if date_range.end < (Time.zone.now + motif.min_booking_delay.seconds)
+        return nil if !motif.booking_delay_range.cover?(date_range.end) && !motif.booking_delay_range.cover?(date_range.begin)
 
-        start_range = [(Time.zone.now + motif.min_booking_delay.seconds), date_range.begin].max
-        end_range = [(Time.zone.now + motif.max_booking_delay.seconds), date_range.end].min
+        start_range = [motif.start_booking_delay, date_range.begin].max
+        end_range = [motif.end_booking_delay, date_range.end].min
         start_range..end_range
       end
 

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -148,6 +148,18 @@ class Motif < ApplicationRecord
     custom_cancel_warning_message || Motif.human_attribute_name("default_cancel_warning_message")
   end
 
+  def start_booking_delay
+    Time.zone.now + min_booking_delay.seconds
+  end
+
+  def end_booking_delay
+    Time.zone.now + max_booking_delay.seconds
+  end
+
+  def booking_delay_range
+    start_booking_delay..end_booking_delay
+  end
+
   private
 
   def booking_delay_validation

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -67,5 +67,14 @@ describe Lapin::Range do
       motif = build(:motif, min_booking_delay: (8 * 24 * 60 * 60), max_booking_delay: (9 * 24 * 60 * 60))
       expect(described_class.reduce_range_to_delay(motif, date_range)).to be_nil
     end
+
+    it "return empty range when ..." do
+      now = Time.zone.parse("20220331 10:30")
+      travel_to(now)
+      friday = Date.new(2022, 4, 8)
+      date_range = friday..(friday + 6.days)
+      motif = build(:motif, min_booking_delay: (1 * 24 * 60 * 60), max_booking_delay: (7 * 24 * 60 * 60))
+      expect(described_class.reduce_range_to_delay(motif, date_range)).to be_nil
+    end
   end
 end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -187,8 +187,8 @@ describe Motif, type: :model do
     it "return now + 7 days (in minutes) when min_booking_delay is set to one week" do
       now = Time.zone.parse("20220123 14:54")
       travel_to(now)
-      motif = build(:motif, min_booking_delay: 604_800)
-      expect(motif.start_booking_delay).to eq(now + 604_800.seconds)
+      motif = build(:motif, min_booking_delay: 1.week)
+      expect(motif.start_booking_delay).to eq(now + 1.week)
     end
   end
 

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -175,4 +175,38 @@ describe Motif, type: :model do
       ]
     end
   end
+
+  describe "#start_booking_delay" do
+    it "return now + 30 minutes when min_booking_delay is at default value" do
+      now = Time.zone.parse("20220123 14:54")
+      travel_to(now)
+      motif = build(:motif, min_booking_delay: 1800)
+      expect(motif.start_booking_delay).to eq(now + 1800.seconds)
+    end
+
+    it "return now + 7 days (in minutes) when min_booking_delay is set to one week" do
+      now = Time.zone.parse("20220123 14:54")
+      travel_to(now)
+      motif = build(:motif, min_booking_delay: 604_800)
+      expect(motif.start_booking_delay).to eq(now + 604_800.seconds)
+    end
+  end
+
+  describe "#end_booking_delay" do
+    it "return now + 3 months when max_booking_delay default value" do
+      now = Time.zone.parse("20220123 14:54")
+      travel_to(now)
+      motif = build(:motif, min_booking_delay: 3.months.in_seconds)
+      expect(motif.start_booking_delay).to eq(now + 3.months.in_seconds.seconds)
+    end
+  end
+
+  describe "#booking_delay_range" do
+    it "returns (now + min_booking_delay)..(now + max_booking_delay)" do
+      now = Time.zone.parse("20220123 14:54")
+      travel_to(now)
+      motif = build(:motif, min_booking_delay: 30.minutes.in_seconds, max_booking_delay: 3.months.in_seconds)
+      expect(motif.booking_delay_range).to eq((now + 30.minutes.in_seconds.seconds)..(now + 3.months.in_seconds.seconds))
+    end
+  end
 end


### PR DESCRIPTION
Un bug remonté par Data.insertion depuis la manche. La recherche de
créneau coté usager propose une date, mais en cliquant dessus, on obtient
une erreur 500. C'est au moment de retailler la période de recherche
pour la faire correspondre avec la période de réservation autorisée dans
le motif, que nous nous retrouvons à faire une période où le début et
après la fin :-/

En contrôlant sur les deux bornes, nous évitons cette situation.

Il reste que nous proposons une date alors qu'il n'y a pas de dispo car
nous passons toujours par un autre chemin pour calculer « la prochaine
disponibilité ». Une PR suivante pourrait rassembler le code de ces
services pour uniformiser le mode de calcul.

Ferme le ticket [#3036616730](https://sentry.io/organizations/rdv-solidarites/issues/3036616730/?project=1811205&query=is%3Aunresolved) sur Sentry

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
