### PR TITLE
Écarte certaines erreurs d'envoie de webhook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,4 +113,5 @@ group :test do
   gem "capybara-screenshot"
   gem "webdrivers", "~> 4.6.0"
   gem "database_cleaner"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,8 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     css_parser (1.11.0)
       addressable
@@ -242,6 +244,7 @@ GEM
       activesupport (>= 5.0)
     groupdate (4.3.0)
       activesupport (>= 5)
+    hashdiff (1.0.1)
     hashie (5.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
@@ -585,6 +588,10 @@ GEM
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -680,6 +687,7 @@ DEPENDENCIES
   typhoeus
   wannabe_bool
   webdrivers (~> 4.6.0)
+  webmock
   webpacker
 
 RUBY VERSION

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -22,14 +22,32 @@ class WebhookJob < ApplicationJob
     )
 
     request.on_complete do |response|
-      message = "Webhook Failure:\n"
-      message += "url: #{webhook_endpoint.target_url}\n"
-      message += "org: #{webhook_endpoint.organisation.name}\n"
-      message += "response: #{response.code}\n"
-      message += "body: #{response.body.force_encoding('UTF-8')[0...1000]}\n"
-      raise OutgoingWebhookError, message unless response.success?
+      message = "Webhook-Failure:\n"
+      message += "  url: #{webhook_endpoint.target_url}\n"
+      message += "  org: #{webhook_endpoint.organisation.name}\n"
+      message += "  response: #{response.code}\n"
+      message += "  body: #{response.body.force_encoding('UTF-8')[0...1000]}\n"
+      raise OutgoingWebhookError, message if !response.success? && !false_negative_from_drome?(response.body)
     end
 
     request.run
+  end
+
+  private
+
+  # La réponse de la Drôme est en JSON
+  # mais leur serveur nous renvoie des erreurs
+  # quand il n'arrive pas à faire son boulot.
+  # Nous ne pouvons pas y faire grand chose,
+  # c'est en général lié à une mise à jour
+  # ou une suppression qui ne fonctionne pas
+  #
+  # Ce petit paliatif est là en attendant qu'ils
+  # fassent évoluer leur système.
+  def false_negative_from_drome?(body)
+    body = JSON.parse(body)
+    body["message"] && (body["message"] == "Can't update appointment." || body["message"] == "Appointment already deleted." || body["message"] == "Appointment id doesn't exist.")
+  rescue StandardError
+    false
   end
 end

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: false
+
+describe WebhookJob, type: :job do
+  describe "#perform" do
+    it "raise OutgoingWebhookError" do
+      payload = "{}"
+      webhook_endpoint = create(:webhook_endpoint, secret: "bla", target_url: "https://example.com/rdv-s-endpoint")
+
+      stub_request(:post, "https://example.com/rdv-s-endpoint").and_return({ status: 500, body: "ERROR" })
+
+      expect do
+        described_class.perform_now(payload, webhook_endpoint.id)
+      end.to raise_error(OutgoingWebhookError)
+    end
+
+    it "raise error with error message in body" do
+      payload = "{}"
+      webhook_endpoint = create(:webhook_endpoint, secret: "bla", target_url: "https://example.com/rdv-s-endpoint")
+
+      stub_request(:post, "https://example.com/rdv-s-endpoint").and_return({ status: 500, body: "ERROR" })
+
+      begin
+        described_class.perform_now(payload, webhook_endpoint.id)
+        raise
+      rescue OutgoingWebhookError => e
+        expect(YAML.safe_load(e.message)["Webhook-Failure"]["body"]).to eq("ERROR")
+      end
+    end
+
+    it "doesnt throw exception when drome serveur can't update appointment" do
+      payload = "{}"
+      webhook_endpoint = create(:webhook_endpoint, secret: "bla", target_url: "https://example.com/rdv-s-endpoint")
+
+      stub_request(:post, "https://example.com/rdv-s-endpoint").and_return({ status: 500, body: "{\"message\": \"Can't update appointment.\"}" })
+
+      expect do
+        described_class.perform_now(payload, webhook_endpoint.id)
+      end.not_to raise_error
+    end
+
+    it "doesnt throw exception when appointment id doesn't exist" do
+      payload = "{}"
+      webhook_endpoint = create(:webhook_endpoint, secret: "bla", target_url: "https://example.com/rdv-s-endpoint")
+
+      stub_request(:post, "https://example.com/rdv-s-endpoint").and_return({ status: 500, body: "{\"message\": \"Appointment id doesn't exist.\"}" })
+
+      expect do
+        described_class.perform_now(payload, webhook_endpoint.id)
+      end.not_to raise_error
+    end
+
+    it "doesnt throw exception when appointment already deleted" do
+      payload = "{}"
+      webhook_endpoint = create(:webhook_endpoint, secret: "bla", target_url: "https://example.com/rdv-s-endpoint")
+
+      stub_request(:post, "https://example.com/rdv-s-endpoint").and_return({ status: 500, body: "{\"message\": \"Appointment already deleted.\"}" })
+
+      expect do
+        described_class.perform_now(payload, webhook_endpoint.id)
+      end.not_to raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,9 +26,11 @@ require "pundit/rspec"
 require "webmock/rspec"
 require "simplecov"
 
-# TODO: SimpleCov.minimum_coverage 80
 SimpleCov.minimum_coverage 80
 SimpleCov.start
+
+# Autorise Chromedrive storage pour l'execution de la CI
+WebMock.disable_net_connect!(allow: ["127.0.0.1", "localhost", "chromedriver.storage.googleapis.com"])
 
 Capybara.register_driver :chrome_headless do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ require "capybara/email/rspec"
 require "webdrivers"
 require "capybara-screenshot/rspec"
 require "pundit/rspec"
+require "webmock/rspec"
 require "simplecov"
 
 # TODO: SimpleCov.minimum_coverage 80


### PR DESCRIPTION
Dans la liste des erreurs qui nous sont remonté lors de des envoies de
données via les webhooks, ils y en a certaines qui sont liées à une
implémentation particulière du serveur (voir [delayed_job/failed](https://www.rdv-solidarites.fr/super_admins/delayed_job/failed))

C'est le cas dans la Drôme.

En attendant une correction de leur part, nous devons faire en sorte de
réduire le bruit.

Cette PR écarte certaines erreurs. Elle devrait permettre de réduire le
nombre de ticket sentry
[#2447517267](https://sentry.io/organizations/rdv-solidarites/issues/2447517267/?project=1811205&query=is%3Aunresolved)

J'en profite pour introduire une gem pour stubber les appels externes.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
