### PR TITLE
Fix pour les invitations d'agents existants par des cnfs

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -117,7 +117,7 @@ class Motif < ApplicationRecord
   end
 
   def authorized_services
-    for_secretariat ? [service, Service.secretariat] : [service]
+    for_secretariat ? [service, Service.secretariat.first] : [service]
   end
 
   def secretariat?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -17,7 +17,7 @@ class Service < ApplicationRecord
 
   # Scopes
   scope :with_motifs, -> { where.not(name: SECRETARIAT) }
-  scope :secretariat, -> { find_by(name: SECRETARIAT) }
+  scope :secretariat, -> { where(name: SECRETARIAT) }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
 
   ## -

--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -11,7 +11,7 @@ class Agent::ServicePolicy < Agent::AdminPolicy
 
   class AdminScope < Scope
     def resolve
-      return [scope.secretariat] if current_agent.conseiller_numerique?
+      return scope.secretariat if current_agent.conseiller_numerique?
       return scope.all if current_agent_role.admin?
 
       scope.where(id: current_agent.service_id)

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -143,6 +143,29 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
         expect { subject }.to change(Agent, :count).by(1)
         expect(AgentRole.last).to have_attributes(level: AgentRole::LEVEL_BASIC)
       end
+
+      context "when the agent already exists" do
+        let!(:agent2) do
+          create(:agent, basic_role_in_organisations: [organisation2], service: secretariat)
+        end
+        let(:secretariat) { create(:service, name: Service::SECRETARIAT) }
+
+        let(:params) do
+          {
+            organisation_id: organisation.id,
+            agent: {
+              email: agent2.email,
+              service_id: agent2.service_id,
+              roles_attributes: { "0" => { level: "basic" } }
+            }
+          }
+        end
+
+        it "invites the agent" do
+          expect { subject }.to change { organisation.agents.count }.by(1)
+          expect(AgentRole.last).to have_attributes(level: AgentRole::LEVEL_BASIC)
+        end
+      end
     end
 
     context "when email is correct and no invitation has been sent" do


### PR DESCRIPTION
Fix pour https://sentry.io/organizations/rdv-solidarites/issues/3162256671
Cette erreur a été introduite dans https://github.com/betagouv/rdv-solidarites.fr/pull/2321

Le fix est de faire que le scope renvoie une relation activerecord plutôt qu'un tableau, pour qu'on puisse chaîner des appels AR normalement.
D'après mes recherches, il n'était utilisé que dans `Motifs#authorized_services`

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
