### PR TITLE
Ajout des infos de rdv collectifs à l'api

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -3,7 +3,8 @@
 class RdvBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :uuid, :status, :starts_at, :ends_at, :duration_in_min, :address, :context, :cancelled_at, :created_by
+  fields :uuid, :status, :starts_at, :ends_at, :duration_in_min, :address, :context, :cancelled_at,
+         :max_participants_count, :users_count, :name, :collectif, :created_by
 
   association :organisation, blueprint: OrganisationBlueprint
   association :motif, blueprint: MotifBlueprint

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -42,7 +42,7 @@ class Rdv < ApplicationRecord
   has_many :webhook_endpoints, through: :organisation
 
   # Delegates
-  delegate :home?, :phone?, :public_office?, :reservable_online?, :service_social?, :follow_up?, :service, :collectif?, to: :motif
+  delegate :home?, :phone?, :public_office?, :reservable_online?, :service_social?, :follow_up?, :service, :collectif?, :collectif, to: :motif
 
   # Validations
   validates :starts_at, :ends_at, :agents, presence: true

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -4,6 +4,7 @@ describe RdvBlueprint do
   subject(:json) { JSON.parse(rendered) }
 
   let(:rendered) { described_class.render(rdv, { root: :rdv }) }
+  let(:rdv) { build(:rdv) }
 
   describe "status" do
     let(:rdv) { build(:rdv, status: "revoked") }
@@ -11,5 +12,16 @@ describe RdvBlueprint do
     it do
       expect(json.dig("rdv", "status")).to eq "revoked"
     end
+  end
+
+  it "shows rdv collectif fields" do
+    expect(json["rdv"]).to include({
+                                     "collectif" => false,
+                                     "context" => nil,
+                                     "created_by" => "agent",
+                                     "duration_in_min" => 45,
+                                     "max_participants_count" => nil,
+                                     "name" => nil
+                                   })
   end
 end


### PR DESCRIPTION
Close #2331

Suite à la demande des reférentes ce matin (et même avant ça), on ajoute les infos relatives aux rdvs dans l'api.
Je n'ai pas trouvé dans la doc de page sur l'api des rdvs en eux mêmes. Est-ce que j'ai loupé quelque chose ?

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
