### PR TITLE
Ajout du nombre de participants dans l'agenda

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -10,14 +10,24 @@ module RdvsHelper
   end
 
   def rdv_title_for_agent(rdv)
-    if rdv.collectif?
-      if rdv.name.present?
-        "#{rdv.motif.name} : #{rdv.name}"
-      else
-        rdv.motif.name
-      end
+    return rdv_individuel_title_for_agent(rdv) if rdv.individuel?
+
+    if rdv.name.present?
+      "#{rdv.motif.name} : #{rdv.name}"
     else
-      rdv_individuel_title_for_agent(rdv)
+      rdv.motif.name
+    end
+  end
+
+  def rdv_title_in_agenda(rdv)
+    title = rdv_title_for_agent(rdv)
+
+    return title if rdv.individuel?
+
+    if rdv.max_participants_count
+      "#{title} (#{rdv.users_count}/#{rdv.max_participants_count})"
+    else
+      "#{title} (#{rdv.users_count})"
     end
   end
 
@@ -61,20 +71,6 @@ module RdvsHelper
     tag.div(data: { toggle: "dropdown" },
             class: "dropdown-toggle btn rdv-status-#{rdv.temporal_status}") do
       Rdv.human_attribute_value(:status, rdv.temporal_status, disable_cast: true)
-    end
-  end
-
-  def rdv_status_dropdown_item(rdv, agent, status, remote)
-    link_to admin_organisation_rdv_path(rdv.organisation, rdv, rdv: { status: status, ignore_benign_errors: true }, agent_id: agent&.id),
-            method: :put,
-            class: "dropdown-item",
-            data: { confirm: change_status_confirmation_message(rdv, status) },
-            remote: remote do
-      tag.span do
-        tag.i(class: "fa fa-circle mr-1 rdv-status-#{status}") +
-          Rdv.human_attribute_value(:status, status, context: :action) +
-          tag.div(Rdv.human_attribute_value(:status, status, context: :explanation), class: "text-wrap text-muted")
-      end
     end
   end
 

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -160,6 +160,10 @@ class Motif < ApplicationRecord
     start_booking_delay..end_booking_delay
   end
 
+  def individuel?
+    !collectif?
+  end
+
   private
 
   def booking_delay_validation

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -42,7 +42,7 @@ class Rdv < ApplicationRecord
   has_many :webhook_endpoints, through: :organisation
 
   # Delegates
-  delegate :home?, :phone?, :public_office?, :reservable_online?, :service_social?, :follow_up?, :service, :collectif?, :collectif, to: :motif
+  delegate :home?, :phone?, :public_office?, :reservable_online?, :service_social?, :follow_up?, :service, :collectif?, :collectif, :individuel?, to: :motif
 
   # Validations
   validates :starts_at, :ends_at, :agents, presence: true

--- a/app/views/admin/agents/rdvs/index.json.jbuilder
+++ b/app/views/admin/agents/rdvs/index.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.array! @rdvs do |rdv|
-  json.title rdv_title_for_agent(rdv)
+  json.title rdv_title_in_agenda(rdv)
   json.id rdv.id
   json.extendedProps do
     json.organisationName rdv.organisation&.name

--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -4,32 +4,33 @@
   .dropdown-menu
     - case rdv.temporal_status
       - when "unknown_future"
-        = rdv_status_dropdown_item(rdv, agent, "excused", remote)
-        = rdv_status_dropdown_item(rdv, agent, "revoked", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "excused", remote: remote
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "revoked", remote: remote
 
       - when "unknown_today"
-        = rdv_status_dropdown_item(rdv, agent, "waiting", remote)
-        = rdv_status_dropdown_item(rdv, agent, "seen", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "waiting", remote: remote
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "seen", remote: remote
         - if rdv.in_the_past? # See issue #1642, I’d rather get rid of `temporal_status` than adding more variants.
-          = rdv_status_dropdown_item(rdv, agent, "noshow", remote)
+          = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "noshow", remote: remote
         .dropdown-divider
-        = rdv_status_dropdown_item(rdv, agent, "excused", remote)
-        = rdv_status_dropdown_item(rdv, agent, "revoked", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "excused", remote: remote
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "revoked", remote: remote
 
       - when "unknown_past"
-        = rdv_status_dropdown_item(rdv, agent, "seen", remote)
-        = rdv_status_dropdown_item(rdv, agent, "noshow", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "seen", remote: remote
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "noshow", remote: remote
         .dropdown-divider
-        = rdv_status_dropdown_item(rdv, agent, "excused", remote)
-        = rdv_status_dropdown_item(rdv, agent, "revoked", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "excused", remote: remote
+        .dropdown-divider
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "revoked", remote: remote
 
       - when "waiting"
-        = rdv_status_dropdown_item(rdv, agent, "seen", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "seen", remote: remote
         .dropdown-divider
-        = rdv_status_dropdown_item(rdv, agent, "unknown", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "unknown", remote: remote
 
       - else
-        = rdv_status_dropdown_item(rdv, agent, "unknown", remote)
+        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "unknown", remote: remote
 
     - if current_agent.role_in_organisation(current_organisation).admin?
       .dropdown-divider

--- a/app/views/admin/rdvs/_rdv_status_dropdown_item.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown_item.html.slim
@@ -1,0 +1,7 @@
+= link_to admin_organisation_rdv_path(rdv.organisation, rdv, rdv: { status: status, ignore_benign_errors: true }, agent_id: agent&.id),
+  method: :put, class: "dropdown-item", data: { confirm: change_status_confirmation_message(rdv, status) }, remote: remote do
+  span
+    i class=("fa fa-circle mr-1 rdv-status-#{status}")
+    = Rdv.human_attribute_value(:status, status, context: :action)
+    .text-wrap.text-muted
+      = Rdv.human_attribute_value(:status, status, context: :explanation)

--- a/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
+++ b/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe "Agent can see rdvs in their calendar", js: true do
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let(:organisation) { create(:organisation) }
+
+  before { login_as(agent, scope: :agent) }
+
+  context "for a rdv collectif" do
+    let(:motif) { create(:motif, :collectif, organisation: organisation, service: agent.service, name: "Atelier collectif") }
+    let!(:rdv) do
+      create(:rdv, agents: [agent], motif: motif, organisation: organisation, name: "Traitement de texte",
+                   users: create_list(:user, 2), max_participants_count: 3, starts_at: starts_at)
+    end
+
+    let(:starts_at) do
+      Time.zone.today + 12.hours # This date is always visible on the calendar, so the spec is green no matter when it runs (we can't easily stub the time for the browser)
+    end
+
+    it "shows the number of participants and the max number of participants" do
+      visit admin_organisation_agent_agenda_path(organisation, agent)
+      expect(page).to have_content("Atelier collectif : Traitement de texte (2/3)")
+    end
+  end
+end


### PR DESCRIPTION
Close #2333

Avant :
<img width="258" alt="Capture d’écran 2022-04-05 à 18 30 22" src="https://user-images.githubusercontent.com/1840367/161802121-a8987b11-4cda-48fe-b985-51d7e6f371b0.png">

Après : 
<img width="264" alt="Capture d’écran 2022-04-05 à 18 30 12" src="https://user-images.githubusercontent.com/1840367/161802145-e9c30d93-6cc5-44ac-ba62-8e609c51f533.png">



En plus de l'intitulé, et en préparation de la sortie des rdv collectifs, on affiche le nombre de participants dans l'agenda

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
