### PR TITLE
Clarifie l'erreur sur la validation d'un lieu

### DIFF
--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -20,7 +20,8 @@ class Lieu < ApplicationRecord
   has_many :agents, through: :plage_ouvertures
 
   # Validations
-  validates :name, :address, :availability, :latitude, :longitude, presence: true
+  validates :name, :address, :availability, presence: true
+  validate :longitude_and_latitude_must_be_present
   validate :cant_change_availibility_single_use
 
   # Scopes
@@ -80,6 +81,12 @@ class Lieu < ApplicationRecord
   end
 
   private
+
+  def longitude_and_latitude_must_be_present
+    return if latitude.present? && longitude.present?
+
+    errors.add(:address, :must_be_valid)
+  end
 
   def cant_change_availibility_single_use
     return if new_record?

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -19,6 +19,8 @@ fr:
             availability:
               cant_change_from_or_to_single_use: Les lieux ponctuels ne peuvent pas être transformés en lieux permanents, et réciproquement.
               format: "%{message}"
+            address:
+              must_be_valid: doit être valide
   simple_form:
     hints:
       lieu:

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -8,6 +8,22 @@ describe Lieu, type: :model do
   describe "validation" do
     subject { lieu.errors }
 
+    it "invalid without latitude" do
+      lieu = build(:lieu, latitude: nil)
+      expect(lieu).to be_invalid
+    end
+
+    it "invalid without longitude" do
+      lieu = build(:lieu, longitude: nil)
+      expect(lieu).to be_invalid
+    end
+
+    it "return errror message about address" do
+      lieu = build(:lieu, longitude: nil, latitude: nil)
+      lieu.valid?
+      expect(lieu.errors.full_messages).to eq(["Adresse doit être valide"])
+    end
+
     describe "availability changes" do
       let(:lieu) { create :lieu, availability: initial_value }
 


### PR DESCRIPTION
C'est sans doute pas le mieux. Je crois que nous pourrions questionner,
dans le cadre de la sectorisation, l'intérêt de récupérer la latitude et
la longitude, et donc l'intérêt de dépendre de la base adresse
nationale.

Cette PR propose simplement d'avoir un message d'erreur qui parle d'un
champ visible à l'écran plutôt que de champs cachés.

![Screenshot 2022-04-06 at 14-46-25 Nouveau lieu - RDV Solidarités](https://user-images.githubusercontent.com/42057/161977686-0683fab2-c162-4b9d-845c-7495b1561f85.png)

![Screenshot 2022-04-06 at 14-46-05 Nouveau lieu - RDV Solidarités](https://user-images.githubusercontent.com/42057/161977690-d8d7338f-5f85-4f59-86d1-2973c1405824.png)


Close #2277

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
