### PR TITLE
réduit le bruit sur le hover du module de config

### DIFF
--- a/app/webpacker/stylesheets/components/_settings.scss
+++ b/app/webpacker/stylesheets/components/_settings.scss
@@ -1,5 +1,4 @@
 
 .settings-box:hover, .settings-box:hover p, .settings-box:hover h3, .settings-box:hover a {
-  background-color: $primary;
-  color: white;
+  text-decoration: underline;
 }


### PR DESCRIPTION
Mon œil a un peu saigné à votre de me balader sur le module de configuration.
Le `hover` est vraiment violent (inverse des couleurs) car sur un trop gros morceau, je pense et sur presque toute la zone de l'écran.

Cette PR propose de passer à un simple souligné. Je pense que c'est plus simple et tout aussi efficace.

![Screenshot 2022-04-06 at 22-56-52 RDV Solidarités](https://user-images.githubusercontent.com/42057/162069744-52f52268-d8da-4c03-967d-3df63b489046.png)

![Screenshot 2022-04-06 at 22-57-15 RDV Solidarités](https://user-images.githubusercontent.com/42057/162069740-7b92521f-d40a-4783-8155-78589f60f263.png)


AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
