### PR TITLE
feat(sector): Remove existing city restriction when adding a street zone

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -23,7 +23,6 @@ class Zone < ApplicationRecord
   validates :street_ban_id, :street_name, presence: true, if: :level_street?
   validates :street_ban_id, uniqueness: { scope: :sector }, if: :level_street?
   validate :coherent_street_ban_id, if: :level_street?
-  validate :no_existing_city_zone?, if: :level_street?
 
   # Scopes
   scope :cities, -> { where(level: LEVEL_CITY) }
@@ -54,11 +53,5 @@ class Zone < ApplicationRecord
     return true if street_ban_id.blank? || city_code.blank? || street_ban_id.start_with?(expected_prefix)
 
     errors.add(:base, "La rue #{street_name} n'appartient pas à la ville #{city_name}")
-  end
-
-  def no_existing_city_zone?
-    return true if city_code.blank? || sector.blank? || sector.zones.cities.where(city_code: city_code).empty?
-
-    errors.add(:base, "La commune #{city_name} est déjà couverte intégralement par le secteur")
   end
 end


### PR DESCRIPTION
Aujourd'hui, si on ajoute une commune à un secteur, on ne peut pas ajouter une rue de cette commune à ce même secteur.
Je pense que  la logique derrière ça est de dire que si je sectorise un quartier en mettant les rues de ce quartier, il est normal que je ne mette pas la ville entière.

Seulement ça peut poser problème dans les cas où chaque quartier d'une ville a son secteur et la ville entière a son secteur aussi (cas du 64 avec la ville de Pau).
En effet aujourd'hui que si une personne de Pau rentre son adresse, on veut que le secteur "Pau entier" soit retrouvé dans tous les cas. 
Pour cela, il faut que ce secteur contienne: 
* Toutes les rues de Pau, parce que si la rue de l'utilisateur est retrouvée dans un des autres secteurs/quartiers de Pau, [cette condition](https://github.com/betagouv/rdv-solidarites.fr/blob/f18d9116c38134170f8f3a588db2faee5cd5b98b/app/services/users/geo_search.rb#L34) fait qu'on va lui attribuer les secteurs où il y a cette rue et pas les secteurs  où il y a juste la commune de Pau
* La commune de Pau, comme ça si la rue de l'utilisateur n'est pas listée dans le secteur on fallback sur la commune et retrouve quand même notre secteur

Voilà pourquoi on voudrait avoir les 2.