### PR TITLE
Ajout des rdvs collectifs à la recherche de créneaux

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -35,7 +35,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     if @form.motif.individuel?
       SearchCreneauxForAgentsService.perform_with(@form)
     else
-      SearchRdvCollectifForAgentsService.perform_with(@form)
+      SearchRdvCollectifForAgentsService.search_with(@form)
     end
   end
 end

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -7,7 +7,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     @form = helpers.build_agent_creneaux_search_form(current_organisation, params)
     @search_results = search_results
 
-    if @search_results&.count == 1 && @form.motif.individuel?
+    if @search_results&.count == 1
       skip_policy_scope # TODO: improve pundit checks for creneaux
 
       redirect_to admin_organisation_slots_path(current_organisation,
@@ -35,7 +35,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     if @form.motif.individuel?
       SearchCreneauxForAgentsService.perform_with(@form)
     else
-      SearchRdvCollectifForAgentsService.search_with(@form)
+      SearchRdvCollectifForAgentsService.new(@form).search
     end
   end
 end

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -35,7 +35,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     if @form.motif.individuel?
       SearchCreneauxForAgentsService.perform_with(@form)
     else
-      SearchRdvCollectifForAgentsService.new(@form).search
+      SearchRdvCollectifForAgentsService.new(@form).lieu_search
     end
   end
 end

--- a/app/controllers/admin/slots_controller.rb
+++ b/app/controllers/admin/slots_controller.rb
@@ -9,7 +9,7 @@ class Admin::SlotsController < AgentAuthController
     # - une pour construire la liste des lieux
     # - une pour le cas où nous avons déjà un lieu
     # À terme, ça pourrait également être un calcul plus réduit. Dans le cas de la recherche sur plusieurs lieux, nous avons besoin de connaitre la prochaine dispo, pas TOUTES les dispo
-    @search_result = SearchCreneauxForAgentsService.perform_with(@form).first
+    @search_result = search_result
 
     @motifs = policy_scope(Motif).active.ordered_by_name
     @services = policy_scope(Service)
@@ -20,5 +20,15 @@ class Admin::SlotsController < AgentAuthController
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .complete.active.order_by_last_name
     @lieux = policy_scope(Lieu).enabled.ordered_by_name
+  end
+
+  private
+
+  def search_result
+    if @form.motif.individuel?
+      SearchCreneauxForAgentsService.perform_with(@form).first
+    else
+      SearchRdvCollectifForAgentsService.new(@form).slot_search
+    end
   end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -95,6 +95,7 @@ class Motif < ApplicationRecord
   }
   scope :visible, -> { where(visibility_type: [Motif::VISIBLE_AND_NOTIFIED, Motif::VISIBLE_AND_NOT_NOTIFIED]) }
   scope :collectif, -> { where(collectif: true) }
+  scope :individuel, -> { where(collectif: false) }
 
   ## -
 

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -53,7 +53,7 @@ class PlageOuverture < ApplicationRecord
   end
 
   def available_motifs
-    Motif.available_motifs_for_organisation_and_agent(organisation, agent)
+    Motif.available_motifs_for_organisation_and_agent(organisation, agent).individuel
   end
 
   def overlaps?(other)

--- a/app/services/search_rdv_collectif_for_agents_service.rb
+++ b/app/services/search_rdv_collectif_for_agents_service.rb
@@ -1,21 +1,19 @@
 # frozen_string_literal: true
 
-class SearchRdvCollectifForAgentsService < BaseService
-  def initialize(agent_creneaux_search_form)
-    @form = agent_creneaux_search_form
-  end
+class SearchRdvCollectifForAgentsService
+  def self.search_with(agent_creneaux_search_form)
+    form = agent_creneaux_search_form
 
-  def perform
-    rdvs = Rdv.where(organisation: @form.organisation).collectif
-      .where(motif: @form.motif).with_remaining_seats
-      .where("starts_at > ?", @form.from_date)
+    rdvs = Rdv.where(organisation: form.organisation).collectif
+      .where(motif: form.motif).with_remaining_seats
+      .where("starts_at > ?", form.from_date)
 
-    if @form.lieu_ids.present?
-      rdvs = rdvs.where(lieu_id: @form.lieu_ids)
+    if form.lieu_ids.present?
+      rdvs = rdvs.where(lieu_id: form.lieu_ids)
     end
 
-    if @form.agent_ids.present?
-      rdvs = rdvs.joins(:agents_rdvs).where(agents_rdvs: { agent_id: @form.agent_ids })
+    if form.agent_ids.present?
+      rdvs = rdvs.joins(:agents_rdvs).where(agents_rdvs: { agent_id: form.agent_ids })
     end
 
     rdvs.distinct.order("starts_at asc")

--- a/app/services/search_rdv_collectif_for_agents_service.rb
+++ b/app/services/search_rdv_collectif_for_agents_service.rb
@@ -5,7 +5,7 @@ class SearchRdvCollectifForAgentsService
     @form = agent_creneaux_search_form
   end
 
-  def search
+  def lieu_search
     lieux.map do |lieu|
       OpenStruct.new(lieu: lieu, next_availability: rdvs.where(lieu: lieu).first.starts_at, creneaux: rdvs.where(lieu: lieu))
     end
@@ -21,9 +21,7 @@ class SearchRdvCollectifForAgentsService
   private
 
   def lieux
-    lieux = @form.organisation.lieux
-
-    lieux.joins(:rdvs).merge(rdvs_scope).distinct("lieux.id")
+    @form.organisation.lieux.joins(:rdvs).merge(rdvs_scope).distinct
   end
 
   def rdvs_scope

--- a/app/services/search_rdv_collectif_for_agents_service.rb
+++ b/app/services/search_rdv_collectif_for_agents_service.rb
@@ -1,21 +1,48 @@
 # frozen_string_literal: true
 
 class SearchRdvCollectifForAgentsService
-  def self.search_with(agent_creneaux_search_form)
-    form = agent_creneaux_search_form
+  def initialize(agent_creneaux_search_form)
+    @form = agent_creneaux_search_form
+  end
 
-    rdvs = Rdv.where(organisation: form.organisation).collectif
-      .where(motif: form.motif).with_remaining_seats
-      .where("starts_at > ?", form.from_date)
+  def search
+    lieux.map do |lieu|
+      OpenStruct.new(lieu: lieu, next_availability: rdvs.where(lieu: lieu).first.starts_at, creneaux: rdvs.where(lieu: lieu))
+    end
+  end
 
-    if form.lieu_ids.present?
-      rdvs = rdvs.where(lieu_id: form.lieu_ids)
+  def slot_search
+    OpenStruct.new(
+      lieu: @form.organisation.lieux.find(@form.lieu_ids.first),
+      creneaux: rdvs
+    )
+  end
+
+  private
+
+  def lieux
+    lieux = @form.organisation.lieux
+
+    lieux.joins(:rdvs).merge(rdvs_scope).distinct("lieux.id")
+  end
+
+  def rdvs_scope
+    rdvs = Rdv.where(organisation: @form.organisation).collectif
+      .where(motif: @form.motif).with_remaining_seats
+      .where("starts_at > ?", @form.from_date)
+
+    if @form.lieu_ids.present?
+      rdvs = rdvs.where(lieu_id: @form.lieu_ids)
     end
 
-    if form.agent_ids.present?
-      rdvs = rdvs.joins(:agents_rdvs).where(agents_rdvs: { agent_id: form.agent_ids })
+    if @form.agent_ids.present?
+      rdvs = rdvs.joins(:agents_rdvs).where(agents_rdvs: { agent_id: @form.agent_ids })
     end
 
-    rdvs.distinct.order("starts_at asc")
+    rdvs
+  end
+
+  def rdvs
+    rdvs_scope.distinct.order("starts_at asc")
   end
 end

--- a/app/services/search_rdv_collectif_for_agents_service.rb
+++ b/app/services/search_rdv_collectif_for_agents_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SearchRdvCollectifForAgentsService < BaseService
+  def initialize(agent_creneaux_search_form)
+    @form = agent_creneaux_search_form
+  end
+
+  def perform
+    rdvs = Rdv.where(organisation: @form.organisation).collectif
+      .where(motif: @form.motif).with_remaining_seats
+      .where("starts_at > ?", @form.from_date)
+
+    if @form.lieu_ids.present?
+      rdvs = rdvs.where(lieu_id: @form.lieu_ids)
+    end
+
+    if @form.agent_ids.present?
+      rdvs = rdvs.joins(:agents_rdvs).where(agents_rdvs: { agent_id: @form.agent_ids })
+    end
+
+    rdvs.distinct.order("starts_at asc")
+  end
+end

--- a/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
@@ -1,0 +1,25 @@
+/ On veut connaître le premier créneau, cette semaine ou plus tard.
+/ `search_results.next_availability` contient le premier créneau à partir de la semaine suivante
+/ `search_results.creneaux` contient les créneaux de la semaine courante
+- first_availability_this_week = search_result.creneaux.min_by(&:starts_at)
+- first_availability = first_availability_this_week || search_result.next_availability
+.card.mb-3 class=("card-hoverable" if first_availability)
+  .card-body
+    .row
+      .col-md
+        h4.card-title.mb-3.mt-0.text-success.font-weight-bold= search_result.lieu.name
+        h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
+        h6.card-subtitle.text-black-50= search_result.lieu.address
+      .col-md.align-self-center.pt-3.pt-md-0.position-static
+        - if first_availability
+          = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [search_result.lieu.id])),
+                  class: "d-block stretched-link" do
+            .row
+              .col
+                | Prochaine disponibilité le
+                br
+                strong= l(first_availability.starts_at, format: :human)
+              .col-auto.align-self-center
+                i.fa.fa-chevron-right
+        - else
+          em Aucune disponibilité

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -78,12 +78,8 @@
     - if @search_results&.any?
       .container
         h3.font-weight-bold Résultats de votre recherche
-        - if @form.motif.individuel?
-          p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
-          - @search_results.each do |search_result|
-            = render "lieu_search_results", search_result: search_result
-        - else
-          - @search_results.each do |search_result|
-            = render "admin/rdvs_collectifs/rdv", rdv: search_result
+        p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
+        - @search_results.each do |search_result|
+          = render "lieu_search_results", search_result: search_result
     - elsif @form.motif.present?
       = t(".no_slot_available", motif_name: @form.motif.name)

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -78,32 +78,12 @@
     - if @search_results&.any?
       .container
         h3.font-weight-bold Résultats de votre recherche
-        p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
-        - @search_results.each do |search_result|
-          / On veut connaître le premier créneau, cette semaine ou plus tard.
-          / `search_results.next_availability` contient le premier créneau à partir de la semaine suivante
-          / `search_results.creneaux` contient les créneaux de la semaine courante
-          - first_availability_this_week = search_result.creneaux.min_by(&:starts_at)
-          - first_availability = first_availability_this_week || search_result.next_availability
-          .card.mb-3 class=("card-hoverable" if first_availability)
-            .card-body
-              .row
-                .col-md
-                  h4.card-title.mb-3.mt-0.text-success.font-weight-bold= search_result.lieu.name
-                  h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
-                  h6.card-subtitle.text-black-50= search_result.lieu.address
-                .col-md.align-self-center.pt-3.pt-md-0.position-static
-                  - if first_availability
-                    = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [search_result.lieu.id])),
-                            class: "d-block stretched-link" do
-                      .row
-                        .col
-                          | Prochaine disponibilité le
-                          br
-                          strong= l(first_availability.starts_at, format: :human)
-                        .col-auto.align-self-center
-                          i.fa.fa-chevron-right
-                  - else
-                    em Aucune disponibilité
+        - if @form.motif.individuel?
+          p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
+          - @search_results.each do |search_result|
+            = render "lieu_search_results", search_result: search_result
+        - else
+          - @search_results.each do |search_result|
+            = render "admin/rdvs_collectifs/rdv", rdv: search_result
     - elsif @form.motif.present?
       = t(".no_slot_available", motif_name: @form.motif.name)

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -29,6 +29,8 @@
           |&nbsp;
           = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, @rdv.agents.first, selected_event_id: @rdv.id, date: @rdv.starts_at.to_date)
         = render "rdv_details", rdv: @rdv, show_users: false
+        - if @rdv.collectif?
+          = render "admin/rdvs_collectifs/participants_info", rdv: @rdv
         p.card-text
           strong> Usager(s) :
           - @rdv.rdvs_users.each do |rdvs_user|

--- a/app/views/admin/rdvs_collectifs/_participants_info.html.slim
+++ b/app/views/admin/rdvs_collectifs/_participants_info.html.slim
@@ -1,0 +1,21 @@
+.d-flex.card-text.mb-2
+    div.mr-1
+      i.fa.fa-fw.fa-users>
+    = I18n.t("rdvs.participants", count: rdv.users_count)
+
+.d-flex.card-text.mb-3
+  - if rdv.remaining_seats?
+      div.mr-3
+      div
+        - if rdv.max_participants_count
+          = I18n.t("rdvs.available_seats", count: rdv.max_participants_count - rdv.users_count)
+        - else
+          = "Pas de limite de places"
+  - elsif rdv.fully_booked?
+      div.mr-1
+        i.fa.fa-fw.fa-user-check>
+        = "Complet"
+  - elsif rdv.overbooked?
+    div.mr-1
+      i.fa.fa-fw.fa-user-times>
+      = "Trop de participants (#{rdv.users_count} personnes pour #{I18n.t('rdvs.seats', count: rdv.max_participants_count)})"

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -6,36 +6,6 @@
   .card-body
     .row
       .col-md-6
-        - if rdv.remaining_seats?
-          = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "d-flex card-text mb-2" do
-            div.mr-1
-              i.fa.fa-fw.fa-user-plus>
-            div
-              = "Ajouter un participant"
-
-        .d-flex.card-text.mb-2
-          - if rdv.remaining_seats?
-              div.mr-3
-              div
-                - if rdv.max_participants_count
-                  = I18n.t("rdvs.available_seats", count: rdv.max_participants_count - rdv.users_count)
-                - else
-                  = "Pas de limite de places"
-          - elsif rdv.fully_booked?
-              div.mr-1
-                i.fa.fa-fw.fa-user-check>
-                = "Complet"
-          - elsif rdv.overbooked?
-            div.mr-1
-              i.fa.fa-fw.fa-user-times>
-              = "Trop de participants (#{rdv.users_count} personnes pour #{I18n.t('rdvs.seats', count: rdv.max_participants_count)})"
-
-        .d-flex.card-text.mb-3
-          div.mr-1
-            i.fa.fa-fw.fa-users>
-            = I18n.t("rdvs.participants", count: rdv.users_count)
-
-      .col-md-6
         .d-flex.card-text.mb-2
           div.mr-1
             i.fa.fa-fw.fa-map-marker-alt>
@@ -51,3 +21,12 @@
           div.mr-1
             i.fa.fa-fw.fa-clock>
             = "#{rdv.duration_in_min} minutes"
+
+      .col-md-6
+        = render "admin/rdvs_collectifs/participants_info", rdv: rdv
+        - if rdv.remaining_seats?
+          = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "d-flex card-text mb-2" do
+            div.mr-1
+              i.fa.fa-fw.fa-user-plus>
+            div
+              = "Ajouter un participant"

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -8,10 +8,15 @@
         = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,
                 creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"
 
-  .card-body
-
-    = render "/admin/slots/slots", \
-      lieu: @search_result.lieu, \
-      creneaux: @search_result.creneaux, \
-      form: @form, \
-      next_availability: @search_result.next_availability
+  - if @form.motif.individuel?
+    .card-body
+      = render "/admin/slots/slots", \
+        lieu: @search_result.lieu, \
+        creneaux: @search_result.creneaux, \
+        form: @form, \
+        next_availability: @search_result.next_availability
+- if @form.motif.collectif?
+  .row.justify-content-center.pb-3
+    .col-md-8
+      - @search_result.creneaux.each do |search_result|
+        = render "admin/rdvs_collectifs/rdv", rdv: search_result

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -74,6 +74,8 @@ nav
               = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu)
             li.my-2
               = active_link_to t(".busy_times"), admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu)
+            li.my-2
+              = active_link_to "RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation)
 
         li.side-nav-item.mb-4.pl-3.pr-2
           = active_link_to admin_organisation_users_path(current_organisation)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -641,6 +641,17 @@ Rdv.create(
     users_count: 1,
     user_ids: []
   )
+
+  Rdv.create(
+    starts_at: Time.zone.today + 2.days + 16.hours + i.weeks,
+    duration_in_min: 60,
+    motif_id: motif_org_paris_nord_pmi_collectif.id,
+    lieu: lieu_org_paris_nord_bolivar,
+    organisation_id: org_paris_nord.id,
+    agent_ids: [agent_org_paris_nord_social_polo.id],
+    users_count: 1,
+    user_ids: []
+  )
 end
 
 # Insert a lot of rdvs in the past 2 years

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -149,7 +149,7 @@ motif_org_paris_nord_pmi_securite = Motif.create!(
   reservable_online: true,
   location_type: :home
 )
-_motif_org_paris_nord_pmi_collectif = Motif.create!(
+motif_org_paris_nord_pmi_collectif = Motif.create!(
   name: "Atelier Collectif",
   color: "#1049F3",
   organisation_id: org_paris_nord.id,
@@ -215,6 +215,26 @@ motifs = {}
     location_type: :public_office
   )
 end
+
+# MOTIFS Conseiller Numérique
+Motif.create!(
+  name: "Accompagnement individuel",
+  color: "#99CC99",
+  default_duration_in_min: 60,
+  location_type: :public_office,
+  organisation: org_cnfs,
+  service: service_cnfs
+)
+
+Motif.create!(
+  name: "Atelier collectif",
+  color: "#4A86E8",
+  default_duration_in_min: 120,
+  location_type: :public_office,
+  collectif: true,
+  organisation: org_cnfs,
+  service: service_cnfs
+)
 
 # LIEUX
 
@@ -598,6 +618,30 @@ Rdv.create(
   user_ids: [user_org_paris_nord_josephine.id],
   context: "Visite à domicile"
 )
+
+Rdv.create(
+  starts_at: Time.zone.today + 5.days + 11.hours,
+  duration_in_min: 30,
+  motif_id: motif_org_paris_nord_pmi_securite.id,
+  lieu: lieu_org_paris_nord_bd_aubervilliers,
+  organisation_id: org_paris_nord.id,
+  agent_ids: [agent_org_paris_nord_pmi_martine.id],
+  user_ids: [user_org_paris_nord_josephine.id],
+  context: "Visite à domicile"
+)
+
+10.times do |i|
+  Rdv.create(
+    starts_at: Time.zone.today + 17.hours + i.weeks,
+    duration_in_min: 60,
+    motif_id: motif_org_paris_nord_pmi_collectif.id,
+    lieu: lieu_org_paris_nord_bd_aubervilliers,
+    organisation_id: org_paris_nord.id,
+    agent_ids: [agent_org_paris_nord_pmi_marco.id],
+    users_count: 1,
+    user_ids: []
+  )
+end
 
 # Insert a lot of rdvs in the past 2 years
 # rubocop:disable Rails/SkipsModelValidations

--- a/spec/features/agents/finding_creneau_for_rdv_collectif_spec.rb
+++ b/spec/features/agents/finding_creneau_for_rdv_collectif_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe "Agent can find a creneau for a rdv collectif", js: true do
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let!(:motif) do
+    create(:motif, :collectif, name: "Atelier participatif", organisation: organisation, service: service)
+  end
+  let(:organisation) { create(:organisation) }
+  let!(:service) { create(:service) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+  let!(:rdv) do
+    create(:rdv, motif: motif, organisation: organisation, agents: [agent], max_participants_count: 5)
+  end
+
+  specify do
+    login_as(agent, scope: :agent)
+
+    # Creating a new RDV Collectif
+    visit admin_organisation_agent_agenda_path(organisation, agent)
+    click_link "Trouver un RDV"
+
+    select "Atelier participatif", from: "Motif"
+    click_button "Afficher les créneaux"
+
+    # The rdv collectif appears in the search results
+    expect(page).to have_content("Résultats de votre recherche")
+    expect(page).to have_content("1 participant")
+    expect(page).to have_content("4 places disponibles")
+
+    click_link "Ajouter un participant"
+
+    expect(page).to have_current_path(edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv))
+  end
+end

--- a/spec/features/agents/finding_creneau_for_rdv_collectif_spec.rb
+++ b/spec/features/agents/finding_creneau_for_rdv_collectif_spec.rb
@@ -9,13 +9,12 @@ describe "Agent can find a creneau for a rdv collectif", js: true do
   let!(:service) { create(:service) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:rdv) do
-    create(:rdv, motif: motif, organisation: organisation, agents: [agent], max_participants_count: 5)
+    create(:rdv, motif: motif, organisation: organisation, agents: [agent], max_participants_count: 5, lieu: lieu)
   end
 
-  specify do
-    login_as(agent, scope: :agent)
+  before { login_as(agent, scope: :agent) }
 
-    # Creating a new RDV Collectif
+  specify do
     visit admin_organisation_agent_agenda_path(organisation, agent)
     click_link "Trouver un RDV"
 
@@ -23,12 +22,31 @@ describe "Agent can find a creneau for a rdv collectif", js: true do
     click_button "Afficher les créneaux"
 
     # The rdv collectif appears in the search results
-    expect(page).to have_content("Résultats de votre recherche")
+    expect(page).to have_content("Créneaux disponibles pour atelier participatif")
     expect(page).to have_content("1 participant")
     expect(page).to have_content("4 places disponibles")
 
     click_link "Ajouter un participant"
 
     expect(page).to have_current_path(edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv))
+  end
+
+  context "when there are rdvs available in two different lieux" do
+    let!(:lieu2) { create(:lieu, organisation: organisation) }
+    let!(:rdv2) do
+      create(:rdv, motif: motif, organisation: organisation, agents: [agent], max_participants_count: 5, lieu: lieu2)
+    end
+
+    it "shows the list of lieux before the list of rdvs" do
+      visit admin_organisation_agent_searches_path(organisation)
+
+      select "Atelier participatif", from: "Motif"
+      click_button "Afficher les créneaux"
+
+      expect(page).to have_content("2 lieux proposent des disponibilités")
+      click_link("Prochaine disponibilité", match: :first)
+
+      expect(page).to have_content("Créneaux disponibles pour atelier participatif")
+    end
   end
 end


### PR DESCRIPTION
Close #2246

Cette PR ajoute les rdv collectifs à la recherche de créneau. Cela permet d'avoir un moyen unifié d'ajouter des participants à un rdv, qu'il soit collectif ou individuel.
C'est le fonctionnement qui a été montré aux référentes à la réunion de mardi.

<img width="1167" alt="Capture d’écran 2022-04-07 à 15 05 25" src="https://user-images.githubusercontent.com/1840367/162218020-2a9aee92-799b-411a-a467-b5c415701179.png">

Pour une expérience de review optimale, je vous recommande de lire la PR commit par commit (le gros des changements a lieu dans le deuxième commit)

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
