### PR TITLE
Optimize User duplicate search on creation

### DIFF
--- a/app/services/duplicate_users_finder_service.rb
+++ b/app/services/duplicate_users_finder_service.rb
@@ -2,6 +2,8 @@
 
 class DuplicateUsersFinderService < BaseService
   def initialize(user, organisation = nil)
+    # TODO: Remove organisation from the parameters
+    #   It is never used in the app. It’s only used when find_duplicate_based_on_phone_number is called directly.
     @user = user
     @organisation = organisation
   end
@@ -18,41 +20,48 @@ class DuplicateUsersFinderService < BaseService
     def find_duplicate_based_on_email(user, organisation)
       return if user.email.blank?
 
-      similar_user = users_in_scope(user, organisation)
-        .where(email: user.email).first
-      return nil if similar_user.blank?
+      duplicates = users_in_scope(user, organisation)
+        .where(email: user.email)
+      return unless duplicates.exists?
 
-      OpenStruct.new(severity: :error, attributes: [:email], user: similar_user)
+      OpenStruct.new(severity: :error, attributes: [:email], user: most_relevant_user(duplicates))
     end
 
     def find_duplicate_based_on_identity(user, organisation)
-      return nil unless user.birth_date.present? && user.first_name.present? && user.last_name.present?
+      return unless user.birth_date.present? && user.first_name.present? && user.last_name.present?
 
-      similar_user = users_in_scope(user, organisation)
-        .where(birth_date: user.birth_date)
+      duplicates = users_in_scope(user, organisation)
+        .where(birth_date: user.birth_date) # index this
         .where(User.arel_table[:first_name].matches(user.first_name))
-        .where(User.arel_table[:last_name].matches(user.last_name)).first
-      return nil if similar_user.blank?
+        .where(User.arel_table[:last_name].matches(user.last_name))
+      return unless duplicates.exists?
 
-      OpenStruct.new(severity: :warning, attributes: %i[first_name last_name birth_date], user: similar_user)
+      OpenStruct.new(severity: :warning, attributes: %i[first_name last_name birth_date], user: most_relevant_user(duplicates))
     end
 
     def find_duplicate_based_on_phone_number(user, organisation)
       return nil if user.phone_number_formatted.blank?
 
-      similar_user = users_in_scope(user, organisation)
+      duplicates = users_in_scope(user, organisation)
         .where(phone_number_formatted: user.phone_number_formatted)
-        .first
-      return if similar_user.nil?
+      return unless duplicates.exists?
 
-      OpenStruct.new(severity: :warning, attributes: [:phone_number], user: similar_user)
+      OpenStruct.new(severity: :warning, attributes: [:phone_number], user: most_relevant_user(duplicates))
     end
 
+    private
+
     def users_in_scope(user, organisation)
-      u = User.active.left_joins(:rdvs).group(:id).order("COUNT(rdvs.id) DESC")
+      u = User.active
       u = u.where.not(id: user.id) if user.persisted?
       u = u.merge(organisation.users) if organisation.present?
       u
+    end
+
+    def most_relevant_user(scope)
+      # return the user with the most Rdvs.
+      # Avoid doing it in users_in_scope because the join may be expensive.
+      scope.left_joins(:rdvs).group(:id).order("COUNT(rdvs.id) DESC").first
     end
   end
 end

--- a/db/migrate/20220411085428_index_users_birth_date_and_first_name.rb
+++ b/db/migrate/20220411085428_index_users_birth_date_and_first_name.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class IndexUsersBirthDateAndFirstName < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :birth_date
+    add_index :users, :first_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_06_140258) do
+ActiveRecord::Schema.define(version: 2022_04_11_085428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -536,9 +536,11 @@ ActiveRecord::Schema.define(version: 2022_04_06_140258) do
     t.string "case_number"
     t.string "address_details"
     t.index "to_tsvector('simple'::regconfig, COALESCE(search_terms, ''::text))", name: "index_users_search_terms", using: :gin
+    t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_through"], name: "index_users_on_created_through"
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
+    t.index ["first_name"], name: "index_users_on_first_name"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"


### PR DESCRIPTION
`find_duplicate_based_on_identity` is quite slow because `User#birth_date` (and `User#first_name`) are not indexed

Dans les logs de performance, c’est `Admin::UsersController#create` qui est particulièrement lent, mais ça pointe directement sur `duplicate_users_finder_service.rb` avec une grosse requête SQL sur birth_date, donc on sait où agir.

SQL EXPLAIN, avant/après:

```
=> EXPLAIN for: SELECT "users".* FROM "users" LEFT OUTER JOIN "rdvs_users" ON "rdvs_users"."user_id" = "users"."id" LEFT OUTER JOIN "rdvs" ON "rdvs"."id" = "rdvs_users"."rdv_id" WHERE "users"."deleted_at" IS NULL AND "users"."birth_date" = $1 AND "users"."first_name" ILIKE 'toto' AND "users"."last_name" ILIKE 'toto' GROUP BY "users"."id" ORDER BY COUNT(rdvs.id) DESC [["birth_date", "2022-04-01"]]
                                                                                          QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=606.50..606.50 rows=1 width=765)
   Sort Key: (count(rdvs.id)) DESC
   ->  GroupAggregate  (cost=606.47..606.49 rows=1 width=765)
         Group Key: users.id
         ->  Sort  (cost=606.47..606.47 rows=1 width=765)
               Sort Key: users.id
               ->  Nested Loop Left Join  (cost=446.37..606.46 rows=1 width=765)
                     ->  Hash Right Join  (cost=446.08..606.13 rows=1 width=765)
                           Hash Cond: (rdvs_users.user_id = users.id)
                           ->  Seq Scan on rdvs_users  (cost=0.00..139.03 rows=8003 width=16)
                           ->  Hash  (cost=446.07..446.07 rows=1 width=757)
                                 ->  Seq Scan on users  (cost=0.00..446.07 rows=1 width=757)
                                       Filter: ((deleted_at IS NULL) AND ((first_name)::text ~~* 'toto'::text) AND ((last_name)::text ~~* 'toto'::text) AND (birth_date = '2022-04-01'::date))
                     ->  Index Only Scan using rdvs_pkey on rdvs  (cost=0.28..0.32 rows=1 width=8)
                           Index Cond: (id = rdvs_users.rdv_id)
(15 rows)
```

```
=> EXPLAIN for: SELECT "users".* FROM "users" WHERE "users"."deleted_at" IS NULL AND "users"."birth_date" = $1 AND "users"."first_name" ILIKE 'toto' AND "users"."last_name" ILIKE 'toto' LIMIT $2 [["birth_date", "2022-04-01"], ["LIMIT", 1]]
                                                        QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..8.31 rows=1 width=757)
   ->  Index Scan using index_users_on_birth_date on users  (cost=0.29..8.31 rows=1 width=757)
         Index Cond: (birth_date = '2022-04-01'::date)
         Filter: ((deleted_at IS NULL) AND ((first_name)::text ~~* 'toto'::text) AND ((last_name)::text ~~* 'toto'::text))
(4 rows)
```

J’en ai aussi profité pour retirer le tri et le join, qui n’ont pas d’intérêt s’il ne s’agit que de vérifier la présence d’un duplicate. Un explain de la requête avec un index sur birth_date mais en continuant de faire le tri et le join systématiquement donne un cout de `168.73..168.74`.


AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
