### PR TITLE
Retire la gem Webmock qui ne sert à rien

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,5 +113,4 @@ group :test do
   gem "capybara-screenshot"
   gem "webdrivers", "~> 4.6.0"
   gem "database_cleaner"
-  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,8 +156,6 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.9)
-    crack (0.4.5)
-      rexml
     crass (1.0.6)
     css_parser (1.11.0)
       addressable
@@ -244,7 +242,6 @@ GEM
       activesupport (>= 5.0)
     groupdate (4.3.0)
       activesupport (>= 5)
-    hashdiff (1.0.1)
     hashie (5.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
@@ -588,10 +585,6 @@ GEM
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
-    webmock (3.14.0)
-      addressable (>= 2.8.0)
-      crack (>= 0.3.2)
-      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -687,7 +680,6 @@ DEPENDENCIES
   typhoeus
   wannabe_bool
   webdrivers (~> 4.6.0)
-  webmock
   webpacker
 
 RUBY VERSION

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,14 +23,10 @@ require "capybara/email/rspec"
 require "webdrivers"
 require "capybara-screenshot/rspec"
 require "pundit/rspec"
-require "webmock/rspec"
 require "simplecov"
 
 SimpleCov.minimum_coverage 80
 SimpleCov.start
-
-# Autorise Chromedrive storage pour l'execution de la CI
-WebMock.disable_net_connect!(allow: ["127.0.0.1", "localhost", "chromedriver.storage.googleapis.com"])
 
 Capybara.register_driver :chrome_headless do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new


### PR DESCRIPTION
Suite à #2348 et une oublie de plus... 

Suppression de la Gem inutile `webmock`

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
