### PR TITLE
Améliore les performances de l’affichage des plages d’ouverture

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -82,10 +82,15 @@ class PlageOuverture < ApplicationRecord
   def overlapping_plages_ouvertures_candidates
     return [] unless valid_date_and_times?
 
-    candidate_pos = PlageOuverture.where(agent: agent).where.not(id: id)
-      .where("recurrence IS NOT NULL or first_day >= ?", first_day)
+    candidate_pos = agent.plage_ouvertures
+      .not_expired
+      .where.not(id: id)
+
+    # The next two lines mean:
+    # if self is exceptionnelle, we want to inspect recurring POs that start before self and exceptionnelle POs on the same day
+    # if self is recurring, we want to inspect all recurring POs and exceptionnelle that start after self
+    candidate_pos = candidate_pos.where("recurrence IS NOT NULL or first_day >= ?", first_day)
     candidate_pos = candidate_pos.where("first_day <= ?", first_day) if exceptionnelle?
-    # we could further restrict this query if perfs are an issue
     candidate_pos
   end
 

--- a/app/services/plage_ouverture_overlap.rb
+++ b/app/services/plage_ouverture_overlap.rb
@@ -8,7 +8,7 @@ class PlageOuvertureOverlap
     @po2 = po2
   end
 
-  def exists?
+  def exists? # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     return false if po1.agent != po2.agent
 
     if po1.exceptionnelle? && po2.exceptionnelle?
@@ -17,6 +17,8 @@ class PlageOuvertureOverlap
       !po1_ends_before_po2? &&
         !po2_ends_before_po1? &&
         times_of_day_overlap? &&
+        !both_weekly_but_different_days? &&
+        !both_monthly_but_different_days? &&
         po1_occurrences_dates.any? { po2_occurrences_dates.include?(_1) }
     end
   end
@@ -33,6 +35,39 @@ class PlageOuvertureOverlap
 
   def po2_ends_before_po1?
     po2.ends_at && po2.ends_at < po1.starts_at
+  end
+
+  def both_weekly_but_different_days?
+    return false unless po1.recurring? && po2.recurring?
+
+    # both PO are weekly
+    options1 = po1.recurrence.default_options
+    options2 = po2.recurrence.default_options
+    return false unless options1.every == :week && options2.every == :week
+
+    # but are on different days
+    # for monthly recurrences, day is [3] for the third day of the week
+    options1.day.intersection(options2.day).empty?
+  end
+
+  def both_monthly_but_different_days? # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    return false unless po1.recurring? && po2.recurring?
+
+    # both PO are monthly
+    options1 = po1.recurrence.default_options
+    options2 = po2.recurrence.default_options
+    return false unless options1.every == :month && options2.every == :month
+
+    # … but but are on different weeks
+    # for monthly recurrences, day is {2=>[3]} for the third day of the second week of the month
+    return true if options1.day.keys.intersection(options2.day.keys).empty?
+
+    # … but are on the same week of the month but on different days
+    # day is a hash, the key is the week number in the month, the value is the days in this week.
+    # In RDVS, monthly PO are only on a single day per month
+    return true if options1.day.keys == options2.day.keys && options1.day.keys.size == 1 && options1.day.values.first.intersection(options2.day.values.first).empty?
+
+    false
   end
 
   def times_of_day_overlap?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -574,17 +574,20 @@ _plage_ouverture_org_bapaume_bruno_classique = PlageOuverture.create!(
   end_time: Tod::TimeOfDay.new(15),
   recurrence: Montrose.every(:week, interval: 1, starts: Date.tomorrow)
 )
-_plage_ouverture_org_bapaume_gina_classique = PlageOuverture.create!(
-  title: "Perm. prenatale",
-  organisation_id: org_bapaume.id,
-  agent_id: agent_org_bapaume_pmi_gina.id,
-  lieu_id: lieu_bapaume_est.id,
-  motif_ids: [motifs[:bapaume][:pmi_prenatale].id],
-  first_day: Date.tomorrow,
-  start_time: Tod::TimeOfDay.new(11),
-  end_time: Tod::TimeOfDay.new(18),
-  recurrence: Montrose.every(:week, interval: 1, starts: Date.tomorrow)
-)
+
+[1, 2, 4, 5].each do |weekday|
+  PlageOuverture.create(
+    title: "Permamence jour #{weekday}",
+    organisation_id: org_bapaume.id,
+    agent_id: agent_org_bapaume_pmi_gina.id,
+    lieu_id: lieu_bapaume_est.id,
+    motif_ids: [motifs[:bapaume][:pmi_prenatale].id],
+    first_day: Date.tomorrow,
+    start_time: Tod::TimeOfDay.new(11),
+    end_time: Tod::TimeOfDay.new(18),
+    recurrence: Montrose.every(:week, interval: 1, starts: Date.tomorrow, day: [weekday])
+  )
+end
 
 # RDVs
 

--- a/spec/services/plage_ouverture_overlap_spec.rb
+++ b/spec/services/plage_ouverture_overlap_spec.rb
@@ -257,4 +257,18 @@ describe PlageOuvertureOverlap do
 
     it_behaves_like "plage ouvertures do not overlap"
   end
+
+  context "po1 and po2 recurring monthly, same time and day but different week" do
+    let(:po1) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 1 })) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 2 })) }
+
+    it_behaves_like "plage ouvertures do not overlap"
+  end
+
+  context "po1 and po2 recurring monthly, same time and week but different days" do
+    let(:po1) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 1 })) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:month, day: { 2 => 2 })) }
+
+    it_behaves_like "plage ouvertures do not overlap"
+  end
 end


### PR DESCRIPTION
Sur skylight c’est ici: https://www.skylight.io/app/applications/RgR7i58P67xN/recent/6h/endpoints/Admin::PlageOuverturesController%23index?responseType=html

En local avec un agent qui a 4 PO hebdomadaires sur 4 jours de la semaines, je passe de ~500 ms à ~100 ms pour plages_ouvertures#index.

Je vais peut-être ajouter un ou deux tests spécifiques, si les cas que je mets de côté ne sont pas déjà couverts par les tests.

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
