### PR TITLE
Ajout du sujet des mails d'invitation cnfs

### DIFF
--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -42,6 +42,7 @@ fr:
         click_on_link_sent: "Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé"
     mailer:
       invitation_instructions_cnfs:
+        subject: "Vous avez été invité sur RDV-Solidarités"
         hello: "Hello 👋"
         create_account: "Nous vous contactons pour %{link} RDV-Solidarités. "
         intro1: "✅ RDV-Solidarités est un outil de gestion des rendez-vous."


### PR DESCRIPTION
 Je me suis rendu compte qu'il manquait ce sujet, et que du coup les mails arrivaient avec le sujet "Invitation instructions cnfs", ce qui est pas top. C'est bien si on peut réparer ça avant de lancer les invitations d'aujourd'hui.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
