### PR TITLE
Clarifie PlageOuverture#overlapping_plages_ouvertures_candidates

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -86,12 +86,13 @@ class PlageOuverture < ApplicationRecord
       .not_expired
       .where.not(id: id)
 
-    # The next two lines mean:
-    # if self is exceptionnelle, we want to inspect recurring POs that start before self and exceptionnelle POs on the same day
-    # if self is recurring, we want to inspect all recurring POs and exceptionnelle that start after self
-    candidate_pos = candidate_pos.where("recurrence IS NOT NULL or first_day >= ?", first_day)
-    candidate_pos = candidate_pos.where("first_day <= ?", first_day) if exceptionnelle?
-    candidate_pos
+    if exceptionnelle?
+      candidate_pos.regulieres.where(first_day: ..first_day)
+        .or(candidate_pos.exceptionnelles.where(first_day: first_day))
+    else
+      candidate_pos.regulieres
+        .or(candidate_pos.exceptionnelles.where(first_day: first_day..))
+    end
   end
 
   def valid_date_and_times?

--- a/app/services/plage_ouverture_overlap.rb
+++ b/app/services/plage_ouverture_overlap.rb
@@ -44,6 +44,7 @@ class PlageOuvertureOverlap
     options1 = po1.recurrence.default_options
     options2 = po2.recurrence.default_options
     return false unless options1.every == :week && options2.every == :week
+    return false if options1.day.nil? || options2.day.nil?
 
     # but are on different days
     # for monthly recurrences, day is [3] for the third day of the week
@@ -57,9 +58,10 @@ class PlageOuvertureOverlap
     options1 = po1.recurrence.default_options
     options2 = po2.recurrence.default_options
     return false unless options1.every == :month && options2.every == :month
+    return false if options1.day.nil? || options2.day.nil?
 
     # … but but are on different weeks
-    # for monthly recurrences, day is {2=>[3]} for the third day of the second week of the month
+    # for monthly recurrences, day is {2=>[3]} for the second day of the third week of the month
     return true if options1.day.keys.intersection(options2.day.keys).empty?
 
     # … but are on the same week of the month but on different days

--- a/spec/services/plage_ouverture_overlap_spec.rb
+++ b/spec/services/plage_ouverture_overlap_spec.rb
@@ -271,4 +271,11 @@ describe PlageOuvertureOverlap do
 
     it_behaves_like "plage ouvertures do not overlap"
   end
+
+  context "po1 is set to recurring but days are not set" do
+    let(:po1) { build_po(monday, 10, 12, Montrose.every(:week, day: nil)) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, day: { 2 => 2 })) }
+
+    it_behaves_like "plage ouvertures do not overlap"
+  end
 end


### PR DESCRIPTION
followup #2355. Je ne sais pas si c’est vraiment plus facile à comprendre; je crois que c’est équivalent :p

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
