### PR TITLE
Fix pour les notifications qui ne partent pas à la création de rdv collectif

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -23,6 +23,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
     authorize(@rdv, :new?)
 
     if @rdv.update(create_params)
+      Notifiers::RdvCreated.perform_with(@rdv, current_agent)
       flash[:notice] = "#{@rdv.motif.name} créé"
       redirect_to admin_organisation_rdvs_collectifs_path(current_organisation)
     else


### PR DESCRIPTION
Suite à la discussion avec Christelle, cette PR corrige le bug sur l'envoi de notification à l'agent avec un ics.

Les notifications pour les ajouts de participants sont un peu plus compliquées à gérer, donc je préfère les faire dans une PR à part, et déjà corriger ça.

Par ailleurs, j'ai aussi remarqué que les intitulés ne s'affichent pas correctement dans les mails. Je vais essayer de corriger ça aussi dans une pr suivante.

J'ai testé en local, et j'ajouterai plus de tests la semaine prochaine
REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
