### PR TITLE
Corrige l'intitulé des rdv collectifs dans les mailers

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -12,8 +12,8 @@ module RdvsHelper
   def rdv_title_for_agent(rdv)
     return rdv_individuel_title_for_agent(rdv) if rdv.individuel?
 
-    if rdv.name.present?
-      "#{rdv.motif.name} : #{rdv.name}"
+    if rdv.title.present?
+      "#{rdv.motif.name} : #{rdv.title}"
     else
       rdv.motif.name
     end

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -49,7 +49,8 @@ module Payloads
           organisation_name: organisation.name,
           organisation_departement_number: organisation.departement_number,
           motif_name_with_location_type: motif.name_with_location_type,
-          collectif?: collectif?
+          collectif?: collectif?,
+          title: title
         }
       )
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -234,6 +234,11 @@ class Rdv < ApplicationRecord
     users_count > max_participants_count
   end
 
+  # FIXME: we should either rename the column, or avoid the ambiguity in rdv_payload
+  def title
+    name
+  end
+
   private
 
   def starts_at_is_plausible

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -15,8 +15,8 @@
   div.row-result
     span.title Motif :
     span.float-right
-      - if rdv.collectif? && rdv.name.present?
-        = "#{rdv.motif_name} : #{rdv.name}"
+      - if rdv.collectif? && rdv.title.present?
+        = "#{rdv.motif_name} : #{rdv.title}"
       - else
         = rdv.motif_name
     .clear


### PR DESCRIPTION
Avant : 
<img width="379" alt="Capture d’écran 2022-04-15 à 14 58 11" src="https://user-images.githubusercontent.com/1840367/163573620-e62b148d-66a5-4f06-b986-2910eb2b77e8.png">

Après : 
<img width="426" alt="Capture d’écran 2022-04-15 à 14 58 15" src="https://user-images.githubusercontent.com/1840367/163573627-3cabb8d2-2989-453a-a1e2-80e928877541.png">

Il y avait un comportement différent pour la méthode `#name` entre les rdv activerecord et les payload de rdv. :-/
Ce fix un peu rapide ajoute un alias de méthode, mais la semaine prochaine ça mériterait de prendre un peu plus de temps pour réfléchir à renommer la colonne, ou la méthode name des payloads.
On discutait avec nicolas d'arrêter d'utiliser les payloads, et c'est un argument de plus dans cette direction.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
