### PR TITLE
Garder en cache les occurrences des plages d’ouverture et des absences

### DIFF
--- a/app/controllers/admin/agents/absences_controller.rb
+++ b/app/controllers/admin/agents/absences_controller.rb
@@ -7,10 +7,12 @@ class Admin::Agents::AbsencesController < ApplicationController
   def index
     agent = Agent.find(params[:agent_id])
     @organisation = Organisation.find(params[:organisation_id])
-    @absence_occurrences = policy_scope_admin(Absence)
-      .includes(:organisation)
-      .where(agent: agent)
-      .all_occurrences_for(date_range_params)
+
+    absences = policy_scope_admin(Absence).includes(:organisation).where(agent: agent)
+    # Cache occurrences for this relation
+    @absence_occurrences = cache([absences, :all_occurrences_for, date_range_params]) do
+      absences.all_occurrences_for(date_range_params)
+    end
   end
 
   private

--- a/app/controllers/admin/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/agents/plage_ouvertures_controller.rb
@@ -7,10 +7,12 @@ class Admin::Agents::PlageOuverturesController < ApplicationController
   def index
     agent = Agent.find(params[:agent_id])
     @organisation = Organisation.find(params[:organisation_id])
-    @plage_ouverture_occurrences = custom_policy
-      .includes(:lieu, :organisation)
-      .where(agent: agent)
-      .all_occurrences_for(date_range_params)
+
+    plage_ouvertures = custom_policy.includes(:lieu, :organisation).where(agent: agent)
+    # Cache occurrences for this relation
+    @plage_ouverture_occurrences = cache([plage_ouvertures, :all_occurrences_for, date_range_params]) do
+      plage_ouvertures.all_occurrences_for(date_range_params)
+    end
   end
 
   private

--- a/db/migrate/20220419093944_add_plage_ouverture_absence_index_updated_at.rb
+++ b/db/migrate/20220419093944_add_plage_ouverture_absence_index_updated_at.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPlageOuvertureAbsenceIndexUpdatedAt < ActiveRecord::Migration[6.1]
+  def change
+    add_index :absences, :updated_at
+    add_index :plage_ouvertures, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_145216) do
+ActiveRecord::Schema.define(version: 2022_04_19_093944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_145216) do
     t.index ["first_day"], name: "index_absences_on_first_day"
     t.index ["organisation_id"], name: "index_absences_on_organisation_id"
     t.index ["recurrence"], name: "index_absences_on_recurrence", where: "(recurrence IS NOT NULL)"
+    t.index ["updated_at"], name: "index_absences_on_updated_at"
   end
 
   create_table "action_text_rich_texts", force: :cascade do |t|
@@ -374,6 +375,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_145216) do
     t.index ["lieu_id"], name: "index_plage_ouvertures_on_lieu_id"
     t.index ["organisation_id"], name: "index_plage_ouvertures_on_organisation_id"
     t.index ["recurrence"], name: "index_plage_ouvertures_on_recurrence", where: "(recurrence IS NOT NULL)"
+    t.index ["updated_at"], name: "index_plage_ouvertures_on_updated_at"
   end
 
   create_table "rdv_events", force: :cascade do |t|


### PR DESCRIPTION
Pour les agents qui configurent beaucoup de plages d’ouvertures, je crois qu’on y gagne pas mal. À surveiller: https://www.skylight.io/app/applications/RgR7i58P67xN/recent/6h/endpoints/Admin::Agents::PlageOuverturesController%23index?responseType=json

Utiliser une relation AR comme clé de cache utilise en fait son `COUNT` et `MAX(updated_at)`; c’est ce qu’on veut pour invalider le cache quand une plage d’ouverture (ou une absence) est ajoutée, modifiée ou supprimée.

Autre suggestion: j’utiliserais bien `fresh_when` dans ces méthodes; peut-être que ça rendrait même le cache redondant.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
