### PR TITLE
Ne pas charger tous les Motifs quand on modifie un Rdv

### DIFF
--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -26,7 +26,7 @@
           = render "model_errors", model: @rdv_form, f: f
           = collapsible_form_fields_for_warnings(@rdv_form) do
             = hidden_field_tag :agent_id, @agent&.id
-            = f.association :motif, disabled: true
+            = f.association :motif, collection: [@rdv_form.motif], disabled: true
             = f.input :context, input_html: { rows: 3 }
             .form-row
               .col-md-6= datetime_input(f, :starts_at)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,7 +94,7 @@ Organisation.set_callback(:create, :after, :notify_admin_organisation_created)
 
 service_pmi = Service.create!(name: "PMI (Protection Maternelle Infantile)", short_name: "PMI")
 service_social = Service.create!(name: "Service social", short_name: "Service Social")
-_service_secretariat = Service.create!(name: "Secrétariat", short_name: "Secrétariat")
+service_secretariat = Service.create!(name: "Secrétariat", short_name: "Secrétariat")
 _service_nouveau = Service.create!(name: "Médico-social", short_name: "Médico-social")
 service_cnfs = Service.create!(name: "Conseiller Numérique", short_name: "Conseiller Numérique")
 
@@ -236,6 +236,21 @@ Motif.create!(
   service: service_cnfs
 )
 
+now = Time.zone.now
+motifs_attributes = 1000.times.map do |i|
+  {
+    created_at: now,
+    updated_at: now,
+    name: "motif_#{i}",
+    color: "#000000",
+    organisation_id: org_arques.id,
+    service_id: service_secretariat.id,
+    reservable_online: true,
+    location_type: :public_office
+  }
+end
+Motif.insert_all!(motifs_attributes) # rubocop:disable Rails/SkipsModelValidations
+
 # LIEUX
 
 lieu_org_paris_nord_bolivar = Lieu.create!(
@@ -270,6 +285,21 @@ lieu_bapaume_est = Lieu.create!(
   latitude: 50.1026,
   longitude: 2.8486
 )
+
+now = Time.zone.now
+lieux_attributes = 100.times.map do |i|
+  {
+    created_at: now,
+    updated_at: now,
+    name: "lieu_#{i}",
+    organisation_id: org_bapaume.id,
+    availability: :enabled,
+    address: "Adresse #{i}",
+    latitude: 45 + (i.to_f / 100.0),
+    longitude: 2 + (i.to_f / 100.0)
+  }
+end
+Lieu.insert_all!(lieux_attributes) # rubocop:disable Rails/SkipsModelValidations
 
 ## ZONES
 zones_csv_path = Rails.root.join("db/seeds/zones_62.csv")


### PR DESCRIPTION
Il y a plus de 900 motifs en production. Une fois qu’on sait ce qu’on cherche, [le diagramme de performances est évident](https://www.skylight.io/app/applications/RgR7i58P67xN/recent/6h/endpoints/Admin::RdvsController%23edit?mode=memory&responseType=html).

En local avec 1000 motifs, je diminue le temps de chargement de la page par deux.

(Et en plus, le formulaire interdit la modification de motif.)


AVANT LA REVUE
- [x] ~Préparer des captures de l’interface avant et après~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
