### PR TITLE
correction du gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep 
+
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep


### PR DESCRIPTION
Il manque le répertoire pids après le clone.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] ~~Test sur la review app / en local~~
