### PR TITLE
Afficher l'adresse de support plutôt que celle de contact

### DIFF
--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -26,7 +26,7 @@
           span> Contacter l'équipe technique
           i.fa.fa-question-circle
       .card-body
-        = mail_to "contact@rdv-solidarites.fr",
+        = mail_to "support@rdv-solidarites.fr",
           subject: "[Problème Agent]",
           body: t(".contact-email-body"), class: "btn btn-primary" do
           span>

--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -36,7 +36,7 @@
 <p>
   <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
         mattermost: link_to("Aide RDV Solidarités", "https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites"),
-        support_email: link_to("contact@rdv-solidarités.fr", "mailto:contact@rdv-solidarités.fr")
+        support_email: link_to("support@rdv-solidarités.fr", "mailto:support@rdv-solidarités.fr")
        ).html_safe %>
 </p>
 

--- a/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
@@ -31,7 +31,7 @@ https://peertube.ethibox.fr/w/sLqvuTvx4vgsjmKXpz9awH
 
 <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
       mattermost: "Aide RDV Solidarités",
-      support_email: "contact@rdv-solidarités.fr") %>
+      support_email: "support@rdv-solidarités.fr") %>
 
 https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites
 

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -5,7 +5,7 @@ section.bg-light.p-4
         .card-body
           - if context.invitation?
             h4.font-weight-bold Nous sommes désolés, un problème semble s'être produit pour votre invitation.
-            = mail_to "contact@rdv-solidarites.fr",
+            = mail_to "support@rdv-solidarites.fr",
               subject: "[Problème Invitation]",
               class: "btn btn-primary" do
               span>

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -15,7 +15,7 @@
   .row#tech-support
     .col-md-6
       h3.mt-4
-        = mail_to "contact@rdv-solidarites.fr",
+        = mail_to "support@rdv-solidarites.fr",
           subject: "[Problème Usager]",
           body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "btn btn-primary" do
           span>

--- a/app/webpacker/components/calendar.js
+++ b/app/webpacker/components/calendar.js
@@ -59,7 +59,7 @@ class CalendarRdvSolidarites {
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: function (errorObj) {
         Sentry.captureException(errorObj)
-        alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à contact@rdv-solidarites.fr.");
+        alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
       },
       defaultDate: this.getDefaultDate(),
       defaultView: this.getDefaultView(),

--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -2,7 +2,7 @@
 
 ## Signaler un problème
 
-Si vous rencontrez un problème, [contactez-nous par email](mailto:contact@rdv-solidarites.fr).
+Si vous rencontrez un problème, [contactez-nous par email](mailto:support@rdv-solidarites.fr).
 
 ## Soumettre une modification
 
@@ -10,7 +10,7 @@ Les pull requests sont bienvenues ! N’hésitez pas à [nous en parler à l’
 
 ## Style de code
 
-Au delà du style de syntaxe, nous essayons de suivre quelques principes. RDVS-S a déjà plusieurs années, et a été développé par plusieurs équipes successives. C’est pour cette raison qu’on peut trouver plusieurs façons de faire au sein du projet. Aujourd’hui, nous essayons d’aller dans cette direction:  
+Au delà du style de syntaxe, nous essayons de suivre quelques principes. RDVS-S a déjà plusieurs années, et a été développé par plusieurs équipes successives. C’est pour cette raison qu’on peut trouver plusieurs façons de faire au sein du projet. Aujourd’hui, nous essayons d’aller dans cette direction:
 
 1. Écrire moins de code, et du code plus simple
   - Éviter de créer trop de classes auxiliaires, comme les presenters, form objects, services, etc.
@@ -31,7 +31,7 @@ Au delà du style de syntaxe, nous essayons de suivre quelques principes. RDVS-S
   - utiliser les relation through autant que possible pour construire les queries
 6. Pour les tests, utiliser les helpers et rspec avec parcimonie
   - Par exemple, les `let`, `subject`, etc, doivent rester proches de leur lieu d’utilisation, quitte à être répétés dans un autre `context`.
-        
+
 ## Linters
 
 Dans l’ensemble, nous suivons les conventions de Ruby on Rails [Rails best practice](https://rails-bestpractices.com/) et [The rails Style Guide](https://github.com/rubocop-hq/rails-style-guide). Nous utilisons aussi largement rubocop; dans tous les cas, le linter alertera en cas de problèmes.

--- a/public/404.html
+++ b/public/404.html
@@ -43,7 +43,7 @@
           </p>
           <div class="error-actions pb-5">
             <a href="/" class="btn btn-orange">Retour à l'accueil </a>
-            <a href="mailto:contact@rdv-solidarites.fr" class="btn btn-default">Contacter le support </a>
+            <a href="mailto:support@rdv-solidarites.fr" class="btn btn-default">Contacter le support </a>
           </div>
         </div>
       </div>

--- a/public/500.html
+++ b/public/500.html
@@ -48,7 +48,7 @@
           </p>
           <div class="error-actions pb-5">
             <a href="/" class="btn btn-orange">Retour à l'accueil </a>
-            <a href="mailto:contact@rdv-solidarites.fr" class="btn btn-default">Contacter le support </a>
+            <a href="mailto:support@rdv-solidarites.fr" class="btn btn-default">Contacter le support </a>
           </div>
         </div>
       </div>

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe SearchController, type: :controller do
               invitation_token: invitation_token, motif_search_terms: "something random"
             }
             expect(subject).to include("Nous sommes désolés, un problème semble s'être produit pour votre invitation.")
-            expect(subject).to include("contact@rdv-solidarites.fr")
+            expect(subject).to include("support@rdv-solidarites.fr")
           end
         end
       end


### PR DESCRIPTION
Comme discuté suite à la mise en place de Zammad, cette PR affiche l'adresse support@rdv-solidarites.fr plutôt que contact@rdv-solidarites.fr à la plupart des endroits où on propose de nous contacter.

L'adresse contact reste celle qui envoie les mails.

J'ai aussi gardé l'adresse de contact dans la documentation pour nous signaler des vulnérabilités sur l'appli ou pour discuter de pull request, vu que ça me semblait être un autre niveau de discussion que le support utilisateur habituel.

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
