### PR TITLE
Corrige un lien mort

### DIFF
--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -6,7 +6,7 @@
         ul.list-unstyled.text-small
           li.mb-2
             span> Un service fourni par
-            = link_to "l'ANCT et un consortium de départements", "https://doc.rdv-solidarites.fr/gouvernance"
+            = link_to "l'ANCT et un consortium de départements", "https://doc.rdv-solidarites.fr/organisation-dequipe/gouvernance"
           li.mb-2
             = link_to image_pack_tag("logos/logo-incub-territoire.svg", size: "80x70", alt:"incubateur.anct.gouv.fr"), "https://incubateur.anct.gouv.fr/", title: "Aller sur le site de l'incubateur des territoires"
           li.mb-2


### PR DESCRIPTION
Un cnfs nous a fait remarquer que ce lien sur la page d'accueil était mort.
Il faudrait aussi qu'on mette à jour cette page de doc dans un second temps pour intégrer les nouvelles infos.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
