### PR TITLE
Perf: Avoid sorting all users by name

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,7 +28,7 @@ class Admin::UsersController < AgentAuthController
 
   def search
     @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.limit(10)
-    @users = search_params[:term].present? ? @users.search_by_text(search_params[:term]) : @users.order_by_last_name
+    @users = search_params[:term].present? ? @users.search_by_text(search_params[:term]) : @users.none
     skip_authorization
   end
 

--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -10,6 +10,9 @@ module Select2SpecHelper
 
   def add_user(user)
     find("span", text: "Ajouter un usager", match: :first).click
+    within(".select2-search--dropdown") do
+      fill_in(class: "select2-search__field", with: user.first_name)
+    end
     find("li", text: user.last_name).click
 
     # This is to make sure we wait for the user to be added before doing the next action


### PR DESCRIPTION
`Admin::UsersController#search` est utilisé par les select de users, pour le rdv wizard, pour rdv#index, etc. Quand il n’y pas de nom saisi, on retourne “les dix premiers utilisateurs”, pour avoir quelque chose dans le select. C’est une mauvaise idée:

* déjà parce qu’on ne devrait pas faire fuire d’informations usagers, c’est pour ça que users#index est vide par défaut
* mais aussi parce qu’on trie par `LOWER(last_name)` pour prendre les dix premiers (dans `User#order_by_last_name`) que ce n’est pas indexé, et que ça veut dire qu’on trie tous les usagers de l’organisation.


AVANT LA REVUE
- [ ] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
