### PR TITLE
refactor(creneaux): Always use min booking delay for next availability

### DIFF
--- a/app/controllers/lieux_controller.rb
+++ b/app/controllers/lieux_controller.rb
@@ -15,9 +15,7 @@ class LieuxController < ApplicationController
       .includes(:organisation)
       .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
     @next_availability_by_lieux = @lieux.to_h do |lieu|
-      motif = @matching_motifs.where(organisation: lieu.organisation).first
-      next_availability = NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
-      [lieu.id, next_availability]
+      [lieu.id, creneaux_search_for(lieu).next_availability]
     end
   end
 
@@ -69,7 +67,7 @@ class LieuxController < ApplicationController
     @matching_motifs.first&.follow_up?
   end
 
-  def creneaux_search_for(lieu, date_range)
+  def creneaux_search_for(lieu, date_range = nil)
     Users::CreneauxSearch.new(
       user: current_user,
       motif: @matching_motifs.where(organisation: lieu.organisation).first, # there can be only one

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -4,10 +4,7 @@ module Users::CreneauxSearchConcern
   extend ActiveSupport::Concern
 
   def next_availability
-    reduced_date_range = Lapin::Range.reduce_range_to_delay(motif, date_range)
-    return if reduced_date_range.blank?
-
-    NextAvailabilityService.find(motif, @lieu, reduced_date_range.end, agents)
+    NextAvailabilityService.find(motif, @lieu, motif.start_booking_delay, agents)
   end
 
   def creneaux

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -86,10 +86,9 @@ class SearchContext
 
   def next_availability_by_lieux
     @next_availability_by_lieux ||= lieux.to_h do |lieu|
-      motif = matching_motifs.where(organisation: lieu.organisation).first
       [
         lieu.id,
-        NextAvailabilityService.find(motif, lieu, (Time.zone.today + motif.min_booking_delay.seconds).to_date, [])
+        creneaux_search_for(lieu, date_range).next_availability
       ]
     end
   end

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -12,7 +12,7 @@ section.bg-light.p-4
               h5.card-subtitle.mb-2= lieu.address
               h6.card-subtitle= context.selected_motif.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
-              - if next_availability && next_availability.starts_at < context.selected_motif.end_booking_delay
+              - if next_availability
                 = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
                   .row
                     .col


### PR DESCRIPTION
Nous rencontrons des soucis lors de l'affichage des prochaines disponibilités: 

* Nous voyons des lieux avec des prochaines disponibilités affichées, sauf que lorsque l'on clique sur le lieu il n'y a pas de créneaux disponibles. C'est dû au fait nous passons plus par la classe `Users::CreneauxSearch` pour appeler le `NextAvailabilityService` depuis #2305 , et donc on ne prenait plus en compte les agents attribués au secteur [ici](https://github.com/betagouv/rdv-solidarites.fr/blob/3b84924d2a05eea8d6aef6d110345f6f4802f19d/app/services/concerns/users/creneaux_search_concern.rb#L25). Cette PR corrige ça en repassant par le `Users::CreneauxSearch`.

Avant
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/7602809/164485567-506b8f8d-292c-4c64-99eb-fa3837042b9a.png">

Après
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/7602809/164485650-5262c976-d019-497b-8ce7-9b5103c9e389.png">


* Certaines pages affichaient des calendriers vides sans créneaux et sans afficher la prochaine disponibilité. C'est parce qu'on ne calculait pas la prochaine disponibilité dans ces cas-là, puisque l'intersection entre la semaine du calendrier et de la période de réservation disponible était vide. Je corrige ça en appelant `NextAvailabilityService` avec la date du délai minimum de réservation du motif et sans prendre le "range" de la semaine, qui il me semble n'est pas utile pour calculer la prochaine dispo.

Avant
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/7602809/164485770-11f511a6-01b2-48f2-9ff1-b6925d3956f6.png">

Après
<img width="1275" alt="image" src="https://user-images.githubusercontent.com/7602809/164485892-366c638a-03dc-4a12-9d10-82a36ed5d777.png">
