### PR TITLE
Supprime les équipes de la vue listant les agents

### DIFF
--- a/app/views/admin/territories/agents/index.html.slim
+++ b/app/views/admin/territories/agents/index.html.slim
@@ -15,7 +15,6 @@
           th = t(".last_name")
           th = t(".first_name")
           th = t(".email")
-          th = t(".teams")
           th = t(".actions")
       tbody
         - @agents.each do |agent|
@@ -23,7 +22,6 @@
             td = agent.last_name
             td = agent.first_name
             td = agent.email
-            td = agent.teams.count
 
             td
               .d-flex


### PR DESCRIPTION
Cette information n'apporte pas grand-chose à cet endroit. Il y aura
sans doute d'autres choses à ajouter à la place des équipes ici.

C'est des trucs que j'avais faits sans trop m'en rendre compte dans la PR sur les droits d'accès. Je les extrais pour alléger la PR #2283
