### PR TITLE
Preloads User#responsible and #organisation in Rdv#show

### DIFF
--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -48,7 +48,7 @@
     - if @rdvs.any?
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
       = render(partial: "admin/rdvs/rdv",
-              collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service),
+              collection: @rdvs.includes(:organisation, :lieu, :motif, agents: :service, users: %i[responsible organisations]),
               locals: {show_user_details: @form.show_user_details},
               cached: ->(rdv) { [rdv, @form.show_user_details, locale_cache_key] })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -31,7 +31,7 @@
           = render "admin/rdvs_collectifs/participants_info", rdv: @rdv
         p.card-text
           strong> Usager(s) :
-          - @rdv.rdvs_users.each do |rdvs_user|
+          - @rdv.rdvs_users.includes(user: %i[responsible organisations]).each do |rdvs_user|
             .ml-2
               .rdv_user
                 = render rdvs_user


### PR DESCRIPTION
This is only following bullet hints. User’s responsible and Organisation are used when displaying the user name.

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
