### PR TITLE
Utiliser l'adresse de support en reply-to pour les mails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,7 +5,7 @@ class ApplicationMailer < ActionMailer::Base
 
   prepend IcsMultipartAttached
 
-  default from: "contact@rdv-solidarites.fr"
+  default from: "contact@rdv-solidarites.fr", reply_to: "support@rdv-solidarites.fr"
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,18 +6,26 @@ class CustomDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application
-  default template_path: "devise/mailer"
+  default template_path: "devise/mailer", reply_to: "support@rdv-solidarites.fr"
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper
 
   def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}
-    opts[:reply_to] = record.invited_by&.email if record.is_a? Agent
+    opts[:reply_to] = reply_to(record)
     if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
       devise_mail(record, :invitation_instructions_cnfs, opts)
     else
       devise_mail(record, :invitation_instructions, opts)
     end
+  end
+
+  private
+
+  def reply_to(record)
+    return unless record.is_a? Agent
+
+    record.invited_by&.email || "support@rdv-solidarites.fr"
   end
 end


### PR DESCRIPTION
L'ajout du reply-to fera que les mails arriveront dans Zammad, qui est plus pratique pour les trier que la boîte mail partagée de contact.

Testé en local et en review app :) (voir ce ticket : https://zammad10.ethibox.fr/#ticket/zoom/22)

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
