### PR TITLE
Autorise la suppression de TOUT les agents d'une orga

### DIFF
--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -18,7 +18,6 @@ class AgentRole < ApplicationRecord
   # Validation
   validates :level, inclusion: { in: LEVELS }
   validate :organisation_cannot_change
-  validate :organisation_have_at_least_one_admin
   # Customize the uniqueness error message. This class needs to be declared before the validates :agent, uniqueness: line.
   class UniquenessValidator < ActiveRecord::Validations::UniquenessValidator
     def validate_each(record, attribute, value)
@@ -34,7 +33,6 @@ class AgentRole < ApplicationRecord
   validates :agent, uniqueness: { scope: :organisation }
 
   # Hooks
-  before_destroy :organisation_have_at_least_one_admin_before_destroy
 
   # Scopes
   scope :level_basic, -> { where(level: LEVEL_BASIC) }
@@ -60,18 +58,5 @@ class AgentRole < ApplicationRecord
     return if !organisation_id_changed? || new_record?
 
     errors.add(:organisation_id, "Vous ne pouvez pas changer ce rôle d'organisation")
-  end
-
-  def organisation_have_at_least_one_admin
-    return if new_record? || level == LEVEL_ADMIN || organisation.agent_roles.where.not(id: id).any?(&:admin?)
-
-    errors.add(:base, "Il doit toujours y avoir au moins un agent Admin par organisation")
-  end
-
-  def organisation_have_at_least_one_admin_before_destroy
-    return if organisation.agent_roles.where.not(id: id).any?(&:admin?)
-
-    errors.add(:base, "Il doit toujours y avoir au moins un agent Admin par organisation")
-    throw :abort
   end
 end

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -55,44 +55,6 @@ describe AgentRole, type: :model do
         expect(agent_role1.reload.level).to eq(AgentRole::LEVEL_BASIC)
       end
     end
-
-    context "there are no other admins" do
-      let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_BASIC, organisation: organisation) }
-
-      it "forbids downgrading admin" do
-        result = agent_role1.update(level: AgentRole::LEVEL_BASIC)
-        expect(result).to be_falsey
-        expect(agent_role1.errors).not_to be_empty
-        expect(agent_role1.reload.level).to eq(AgentRole::LEVEL_ADMIN)
-      end
-    end
-  end
-
-  describe "#organisation_have_at_least_one_admin_before_destroy" do
-    context "there is another admin" do
-      let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-
-      it "allows destroying one agent" do
-        agent_role1.destroy
-        expect(organisation.agent_roles.count).to eq 1
-      end
-    end
-
-    context "there are no other admins" do
-      let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_BASIC, organisation: organisation) }
-
-      it "forbids destroying admin" do
-        agent_role1.destroy
-        expect(agent_role1.errors).not_to be_empty
-        expect(organisation.agent_roles.count).to eq 2
-      end
-    end
   end
 
   describe "uniqueness error differ if the agent has not accepted the invitation yet" do


### PR DESCRIPTION
Les organisations sont associées à un territoire, nous n'avons plus besoin de maintenir un agent dedans.

C'est des trucs que j'avais faits sans trop m'en rendre compte dans la PR sur les droits d'accès. Je les extrais pour alléger la PR #2283

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
