### PR TITLE
Écarter les fausse erreur de la Drôme sur les RDV non trouvé suite à l'appel API

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -46,7 +46,12 @@ class WebhookJob < ApplicationJob
   # fassent évoluer leur système.
   def self.false_negative_from_drome?(body)
     body = JSON.parse(body)
-    body["message"] && (body["message"] == "Can't update appointment." || body["message"] == "Appointment already deleted." || body["message"] == "Appointment id doesn't exist.")
+    error_messages_from_drome = [
+      "Can't update appointment",
+      "Appointment already deleted",
+      "Appointment id doesn't exist"
+    ]
+    body["message"]&.in?(error_messages_from_drome)
   rescue StandardError
     false
   end

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -35,9 +35,9 @@ describe WebhookJob, type: :job do
     end
 
     [
-      "{\"message\": \"Can't update appointment.\"}",
-      "{\"message\": \"Appointment id doesn't exist.\"}",
-      "{\"message\": \"Appointment already deleted.\"}"
+      "{\"message\": \"Can't update appointment\"}",
+      "{\"message\": \"Appointment id doesn't exist\"}",
+      "{\"message\": \"Appointment already deleted\"}"
     ].each do |returned_message|
       it "return true when message is `#{returned_message}`" do
         expect(described_class.false_negative_from_drome?(returned_message)).to eq(true)


### PR DESCRIPTION
Close #2404

Les messages d'erreur de la Drôme ne contiennent pas de point ([voir Sentry](https://sentry.io/organizations/rdv-solidarites/issues/3183773178)).

Ceci est mon premier ticket, pour découvrir le workflow.

## REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
