### PR TITLE
Utiliser l'adresse de support en reply-to pour les mails

### DIFF
--- a/app/mailers/admins/grc_92_mailer.rb
+++ b/app/mailers/admins/grc_92_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admins::Grc92Mailer < ApplicationMailer
-  default from: "ne-pas-repondre-grc@hauts-de-seine.fr"
+  default from: "ne-pas-repondre-grc@hauts-de-seine.fr", reply_to: nil
 
   def send_sms(recipient, phone_number, message)
     headers["Content-Type"] = "text/plain"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,7 +5,7 @@ class ApplicationMailer < ActionMailer::Base
 
   prepend IcsMultipartAttached
 
-  default from: "contact@rdv-solidarites.fr"
+  default from: "contact@rdv-solidarites.fr", reply_to: "support@rdv-solidarites.fr"
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,18 +6,26 @@ class CustomDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application
-  default template_path: "devise/mailer"
+  default template_path: "devise/mailer", reply_to: "support@rdv-solidarites.fr"
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper
 
   def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}
-    opts[:reply_to] = record.invited_by&.email if record.is_a? Agent
+    opts[:reply_to] = reply_to(record)
     if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
       devise_mail(record, :invitation_instructions_cnfs, opts)
     else
       devise_mail(record, :invitation_instructions, opts)
     end
+  end
+
+  private
+
+  def reply_to(record)
+    return unless record.is_a? Agent
+
+    record.invited_by&.email || "support@rdv-solidarites.fr"
   end
 end

--- a/spec/mailers/admins/grc92_mailer_spec.rb
+++ b/spec/mailers/admins/grc92_mailer_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Admins::Grc92Mailer do
+  let(:mail) { described_class.send_sms("test@example.com", "0611223344", "test sms") }
+
+  describe "#send_sms" do
+    it "sends the email correctly" do
+      expect(mail).to have_attributes(
+        from: ["ne-pas-repondre-grc@hauts-de-seine.fr"],
+        reply_to: []
+      )
+    end
+  end
+end


### PR DESCRIPTION
En évitant de spammer Zammad avec les mails qui servent à envoyer des sms !

Le premier commit est un cherry-pick de la pr précédente (https://github.com/betagouv/rdv-solidarites.fr/pull/2399) et le deuxième corrige le mailer qui sert à envoyer des sms pour le 92.

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
