### PR TITLE
Ne pas utiliser de payload pour les emails de Rdv

### DIFF
--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -4,32 +4,32 @@ class Agents::RdvMailer < ApplicationMailer
   include DateHelper
   helper DateHelper
 
-  def rdv_created(rdv_payload, agent)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_created(rdv, agent)
+    @rdv = rdv
     @agent = agent
 
-    self.ics_payload = @rdv
+    self.ics_payload = @rdv.payload(:create, agent)
 
     mail(to: agent.email, subject: "Nouveau RDV ajouté sur votre agenda rdv-solidarités pour #{relative_date @rdv.starts_at}")
   end
 
-  def rdv_cancelled(rdv_payload, agent, author)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_cancelled(rdv, agent, author)
+    @rdv = rdv
     @agent = agent
     @author = author
 
-    self.ics_payload = @rdv
+    self.ics_payload = @rdv.payload(:destroy, agent)
 
     mail(to: agent.email, subject: "RDV annulé #{relative_date @rdv.starts_at}")
   end
 
-  def rdv_date_updated(rdv_payload, agent, author, old_starts_at)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_date_updated(rdv, agent, author, old_starts_at)
+    @rdv = rdv
     @agent = agent
     @author = author
     @old_starts_at = old_starts_at
 
-    self.ics_payload = @rdv
+    self.ics_payload = @rdv.payload(:update, agent)
 
     mail(to: agent.email, subject: "RDV #{relative_date old_starts_at} reporté à plus tard")
   end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -6,52 +6,52 @@ class Users::RdvMailer < ApplicationMailer
   helper RdvsHelper
   helper DateHelper
 
-  def rdv_created(rdv_payload, user, token)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_created(rdv, user, token)
+    @rdv = rdv
     @user = user
     @token = token
 
-    self.ics_payload = rdv_payload
+    self.ics_payload = @rdv.payload(:create, user)
     mail(
       to: user.email,
       subject: "RDV confirmé le #{l(@rdv.starts_at, format: :human)}"
     )
   end
 
-  def rdv_date_updated(rdv_payload, user, token, old_starts_at)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_date_updated(rdv, user, token, old_starts_at)
+    @rdv = rdv
     @user = user
     @token = token
     @old_starts_at = old_starts_at
 
-    self.ics_payload = rdv_payload
+    self.ics_payload = @rdv.payload(:update, user)
     mail(
       to: user.email,
       subject: "RDV #{relative_date old_starts_at} déplacé"
     )
   end
 
-  def rdv_upcoming_reminder(rdv_payload, user, token)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_upcoming_reminder(rdv, user, token)
+    @rdv = rdv
     @user = user
     @token = token
 
-    self.ics_payload = rdv_payload
+    self.ics_payload = @rdv.payload(nil, user)
     mail(
       to: user.email,
       subject: "[Rappel] RDV le #{l(@rdv.starts_at, format: :human)}"
     )
   end
 
-  def rdv_cancelled(rdv_payload, user, token)
-    @rdv = OpenStruct.new(rdv_payload)
+  def rdv_cancelled(rdv, user, token)
+    @rdv = rdv
     @user = user
     @token = token
 
-    self.ics_payload = rdv_payload
+    self.ics_payload = @rdv.payload(:destroy, user)
     mail(
       to: user.email,
-      subject: "RDV annulé le #{l(@rdv.starts_at, format: :human)} avec #{@rdv.organisation_name}"
+      subject: "RDV annulé le #{l(@rdv.starts_at, format: :human)} avec #{@rdv.organisation.name}"
     )
   end
 end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -16,6 +16,7 @@ class Users::RdvMailer < ApplicationMailer
       to: user.email,
       subject: "RDV confirmé le #{l(@rdv.starts_at, format: :human)}"
     )
+    save_receipt(:rdv_created)
   end
 
   def rdv_date_updated(rdv, user, token, old_starts_at)
@@ -29,6 +30,7 @@ class Users::RdvMailer < ApplicationMailer
       to: user.email,
       subject: "RDV #{relative_date old_starts_at} déplacé"
     )
+    save_receipt(:rdv_date_updated)
   end
 
   def rdv_upcoming_reminder(rdv, user, token)
@@ -41,6 +43,7 @@ class Users::RdvMailer < ApplicationMailer
       to: user.email,
       subject: "[Rappel] RDV le #{l(@rdv.starts_at, format: :human)}"
     )
+    save_receipt(:rdv_upcoming_reminder)
   end
 
   def rdv_cancelled(rdv, user, token)
@@ -53,5 +56,18 @@ class Users::RdvMailer < ApplicationMailer
       to: user.email,
       subject: "RDV annulé le #{l(@rdv.starts_at, format: :human)} avec #{@rdv.organisation.name}"
     )
+    save_receipt(:rdv_cancelled)
+  end
+
+  def save_receipt(event)
+    params = {
+      rdv: @rdv,
+      user: @user,
+      event: event,
+      channel: :mail,
+      result: :processed,
+      email_address: @user.email
+    }
+    Receipt.create!(params)
   end
 end

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -2,7 +2,7 @@
 
 module Payloads
   module Rdv
-    def payload(action = nil, recipient = users.first) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def payload(action = nil, recipient = users.first) # rubocop:disable Metrics/CyclomaticComplexity
       payload = {
         name: "rdv-#{uuid}-#{starts_at.to_s.parameterize}.ics",
         starts_at: starts_at,
@@ -27,32 +27,6 @@ module Payloads
       if recipient.is_a? Agent
         payload[:attendees] = agents.pluck(:email)
       end
-
-      payload.merge!(
-        {
-          id: id,
-          status: status,
-          home?: home?,
-          phone?: phone?,
-          follow_up?: follow_up?,
-          reservable_online?: reservable_online?,
-          users_full_names: users.map(&:full_name).sort.to_sentence,
-          agents_short_names: agents.map(&:short_name).sort.to_sentence,
-          motif_name: motif.name,
-          motif_instruction: motif.instruction_for_rdv,
-          motif_service_name: motif.service.name,
-          duration_in_min: duration_in_min,
-          address_complete: address_complete_without_personal_details,
-          phone_number: phone_number,
-          organisation_id: organisation.id,
-          motif_service_id: motif.service.id,
-          organisation_name: organisation.name,
-          organisation_departement_number: organisation.departement_number,
-          motif_name_with_location_type: motif.name_with_location_type,
-          collectif?: collectif?,
-          title: title
-        }
-      )
 
       payload[:name] = name if name.present?
       payload[:action] = action if action.present?

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -38,22 +38,7 @@ class Notifiers::RdvBase < ::BaseService
 
     users_to_notify
       .select(&:notifiable_by_email?)
-      .each do |user|
-        notify_user_by_mail(user)
-        create_mail_receipt(user)
-      end
-  end
-
-  def create_mail_receipt(user)
-    params = {
-      rdv: @rdv,
-      user: user,
-      event: self.class.name.demodulize.underscore,
-      channel: :mail,
-      result: :processed,
-      email_address: user.email
-    }
-    Receipt.create!(params)
+      .each { notify_user_by_mail(_1) }
   end
 
   def notify_users_by_sms

--- a/app/services/notifiers/rdv_cancelled.rb
+++ b/app/services/notifiers/rdv_cancelled.rb
@@ -5,7 +5,7 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
     # Only send sms for excused cancellations (not for no-show)
     return unless @rdv.status.in?(%w[excused revoked]) || @rdv.collectif?
 
-    Users::RdvMailer.rdv_cancelled(@rdv.payload(:destroy, user), user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
+    Users::RdvMailer.rdv_cancelled(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
 
     status_to_event_name = {
       "excused" => :cancelled_by_user,
@@ -31,6 +31,6 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
   end
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_cancelled(@rdv.payload(:destroy, agent), agent, @author).deliver_later
+    Agents::RdvMailer.rdv_cancelled(@rdv, agent, @author).deliver_later
   end
 end

--- a/app/services/notifiers/rdv_created.rb
+++ b/app/services/notifiers/rdv_created.rb
@@ -2,7 +2,7 @@
 
 class Notifiers::RdvCreated < Notifiers::RdvBase
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_created(@rdv.payload(:create, user), user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
+    Users::RdvMailer.rdv_created(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :created)
   end
 
@@ -18,6 +18,6 @@ class Notifiers::RdvCreated < Notifiers::RdvBase
   end
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_created(@rdv.payload(:create, agent), agent).deliver_later
+    Agents::RdvMailer.rdv_created(@rdv, agent).deliver_later
   end
 end

--- a/app/services/notifiers/rdv_date_updated.rb
+++ b/app/services/notifiers/rdv_date_updated.rb
@@ -8,7 +8,7 @@ class Notifiers::RdvDateUpdated < Notifiers::RdvBase
   end
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_date_updated(@rdv.payload(:update, user), user, @rdv_users_tokens_by_user_id[user.id], @rdv.attribute_before_last_save(:starts_at)).deliver_later
+    Users::RdvMailer.rdv_date_updated(@rdv, user, @rdv_users_tokens_by_user_id[user.id], @rdv.attribute_before_last_save(:starts_at)).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :updated)
   end
 
@@ -19,7 +19,7 @@ class Notifiers::RdvDateUpdated < Notifiers::RdvBase
 
   def notify_agent(agent)
     Agents::RdvMailer.rdv_date_updated(
-      @rdv.payload(:update, agent),
+      @rdv,
       agent,
       @author,
       @rdv.attribute_before_last_save(:starts_at)

--- a/app/services/notifiers/rdv_upcoming_reminder.rb
+++ b/app/services/notifiers/rdv_upcoming_reminder.rb
@@ -8,7 +8,7 @@ class Notifiers::RdvUpcomingReminder < Notifiers::RdvBase
   end
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_upcoming_reminder(@rdv.payload(nil, user), user, @rdv_users_tokens_by_user_id[user.id]).deliver_later(queue: :mailers_low)
+    Users::RdvMailer.rdv_upcoming_reminder(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later(queue: :mailers_low)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :upcoming_reminder)
   end
 

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -10,24 +10,24 @@
       span.float-right= @user.full_name
     - else
       span.title Usager(s) :
-      span.float-right= rdv.users_full_names
+      span.float-right= rdv.users.map(&:full_name).sort.to_sentence
     .clear
   div.row-result
     span.title Motif :
     span.float-right
-      - if rdv.collectif? && rdv.title.present?
-        = "#{rdv.motif_name} : #{rdv.title}"
+      - if rdv.collectif? && rdv.name.present?
+        = "#{rdv.motif.name} : #{rdv.name}"
       - else
-        = rdv.motif_name
+        = rdv.motif.name
     .clear
   div.row-result
     span.title Service :
-    span.float-right= rdv.motif_service_name
+    span.float-right= rdv.motif.service.name
     .clear
   - if rdv.follow_up?
     div.row-result
       span.title Travailleur médico-social :
-      span.float-right= rdv.agents_short_names
+      span.float-right= rdv.agents.map(&:short_name).sort.to_sentence
       .clear
   div.row-result
     span.title Durée :
@@ -47,7 +47,7 @@
       span.float-right
         = rdv.address_complete
       .clear
-  - if rdv.motif_instruction.present? && for_role == :user
+  - if rdv.motif.instruction_for_rdv.present? && for_role == :user
     .div.row-result.no-border
       span.title Informations supplémentaires :
-      = auto_link(simple_format(rdv.motif_instruction), html: { target: "_blank" })
+      = auto_link(simple_format(rdv.motif.instruction_for_rdv), html: { target: "_blank" })

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -1,6 +1,6 @@
 div
   p= t("mailers.common.hello")
-  - motif = @rdv.motif_service_name
+  - motif = @rdv.motif.service.name
   - date = l(@rdv.starts_at, format: :human)
   - if @rdv.status == "revoked"
     p= t(".revoked_for_motif_at_date", motif: motif, date: date)
@@ -15,8 +15,8 @@ div
     p= t(".reschedule_online")
     .btn-wrapper
       = link_to t(".reschedule_button"), prendre_rdv_url(\
-        departement: @rdv.organisation_departement_number, \
-        motif_name_with_location_type: @rdv.motif_name_with_location_type, \
+        departement: @rdv.organisation.departement_number, \
+        motif_name_with_location_type: @rdv.motif.name_with_location_type, \
         organisation_ids: [@rdv.organisation_id], \
         address: @rdv.address, \
         invitation_token: @token \

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_created" do
     let(:agent) { build(:agent) }
     let(:t) { DateTime.parse("2020-03-01 10:20") }
-    let(:mail) { described_class.rdv_created(rdv.payload(:create), agent) }
+    let(:mail) { described_class.rdv_created(rdv, agent) }
     let(:rdv) { create(:rdv, starts_at: t + 2.hours, agents: [agent]) }
 
     before { travel_to(t) }

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -2,37 +2,37 @@
 
 class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_created
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = 2.hours.from_now
-    Agents::RdvMailer.rdv_created(rdv.payload(:create), rdv.agents.first)
+    Agents::RdvMailer.rdv_created(rdv, rdv.agents.first)
   end
 
   def rdv_revoked
-    rdv = Rdv.last
+    rdv = Rdv.joins(:users).last
     rdv.status = :revoked
     Agents::RdvMailer
-      .rdv_cancelled(rdv.payload(:destroy), rdv.agents.first, rdv.agents.first)
+      .rdv_cancelled(rdv, rdv.agents.first, rdv.agents.first)
   end
 
   def rdv_cancelled_by_agent
-    rdv = Rdv.last
+    rdv = Rdv.joins(:users).last
     rdv.status = :excused
     Agents::RdvMailer
-      .rdv_cancelled(rdv.payload(:destroy), rdv.agents.first, rdv.agents.first)
+      .rdv_cancelled(rdv, rdv.agents.first, rdv.agents.first)
   end
 
   def rdv_cancelled_by_user
-    rdv = Rdv.last
+    rdv = Rdv.joins(:users).last
     rdv.status = :excused
     Agents::RdvMailer
-      .rdv_cancelled(rdv.payload(:destroy), rdv.agents.first, rdv.users.first)
+      .rdv_cancelled(rdv, rdv.agents.first, rdv.users.first)
   end
 
   def rdv_date_updated
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
     Agents::RdvMailer.rdv_date_updated(
-      rdv.payload(:update),
+      rdv,
       rdv.agents.first,
       rdv.agents.first,
       2.hours.from_now

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -6,58 +6,58 @@ class Users::RdvMailerPreview < ActionMailer::Preview
   # it's pretty hacky but avoids overriding rails email templates
 
   def rdv_created
-    rdv = Rdv.not_cancelled.last
-    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
+    rdv = Rdv.joins(:users).not_cancelled.last
+    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_visite_a_domicile
-    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
+    rdv = Rdv.joins(:users).not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_phone
-    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
+    rdv = Rdv.joins(:users).not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_created_CONTEXT_public_office
-    rdv = Rdv.not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
+    rdv = Rdv.joins(:users).not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv.payload(:create), rdv.users.first)
+    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
   end
 
   def rdv_date_updated
-    rdv = Rdv.not_cancelled.last
+    rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
     Users::RdvMailer.rdv_date_updated(
-      rdv.payload(:update),
+      rdv,
       rdv.agents.first,
       2.hours.from_now
     )
   end
 
   def rdv_cancelled
-    rdv = Rdv.last
+    rdv = Rdv.joins(:users).last
     rdv.status = "excused"
 
-    Users::RdvMailer.rdv_cancelled(rdv.payload(:destroy), rdv.users.first)
+    Users::RdvMailer.rdv_cancelled(rdv, rdv.users.first)
   end
 
   def rdv_revoked
-    rdv = Rdv.last
+    rdv = Rdv.joins(:users).last
     rdv.status = "revoked"
 
-    Users::RdvMailer.rdv_cancelled(rdv.payload(:destroy), rdv.users.first)
+    Users::RdvMailer.rdv_cancelled(rdv, rdv.users.first)
   end
 
   def rdv_upcoming_reminder
-    rdv = Rdv.not_cancelled.last
-    Users::RdvMailer.rdv_upcoming_reminder(rdv.payload, rdv.users.first)
+    rdv = Rdv.joins(:users).not_cancelled.last
+    Users::RdvMailer.rdv_upcoming_reminder(rdv, rdv.users.first)
   end
 
   # rubocop:enable Naming/MethodName

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let(:rdv) { create(:rdv) }
     let(:user) { rdv.users.first }
     let(:token) { "12345" }
-    let(:mail) { described_class.rdv_created(rdv.payload(:create), user, token) }
+    let(:mail) { described_class.rdv_created(rdv, user, token) }
 
     it "renders the headers" do
       expect(mail.to).to eq([user.email])
@@ -38,7 +38,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "send mail to user" do
       rdv = create(:rdv)
       user = rdv.users.first
-      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, token)
+      mail = described_class.rdv_cancelled(rdv, user, token)
 
       expect(mail.to).to eq([user.email])
     end
@@ -47,7 +47,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, token)
+      mail = described_class.rdv_cancelled(rdv, user, token)
 
       expect(mail.subject).to eq("RDV annulé le lundi 15 juin 2020 à 12h30 avec Orga du coin")
     end
@@ -56,7 +56,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, token)
+      mail = described_class.rdv_cancelled(rdv, user, token)
 
       expect(mail.html_part.body).to match("lundi 15 juin 2020 à 12h30")
     end
@@ -65,7 +65,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, token)
+      mail = described_class.rdv_cancelled(rdv, user, token)
 
       expect(mail.html_part.body).to match(rdv.motif.service_name)
     end
@@ -74,14 +74,13 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv.payload(:destroy), user, token)
-      rdv_payload = OpenStruct.new(rdv.payload(:destroy))
+      mail = described_class.rdv_cancelled(rdv, user, token)
 
       expected_url = prendre_rdv_url(\
-        departement: rdv_payload.organisation_departement_number, \
-        motif_name_with_location_type: rdv_payload.motif_name_with_location_type, \
-        organisation_ids: [rdv_payload.organisation_id], \
-        address: rdv_payload.address, \
+        departement: rdv.organisation.departement_number, \
+        motif_name_with_location_type: rdv.motif.name_with_location_type, \
+        organisation_ids: [rdv.organisation_id], \
+        address: rdv.address, \
         invitation_token: token \
       )
 
@@ -95,7 +94,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let!(:user) { create(:user) }
 
     it "send mail to user" do
-      mail = described_class.rdv_upcoming_reminder(rdv.payload, user, token)
+      mail = described_class.rdv_upcoming_reminder(rdv, user, token)
       expect(mail.to).to eq([user.email])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
       expect(mail.html_part.body.raw_source).to include("/users/rdvs/#{rdv.id}?invitation_token=12345")

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -76,28 +76,5 @@ describe Payloads::Rdv, type: :service do
 
       it { expect(rdv.payload[:summary]).to eq("RDV Consultation") }
     end
-
-    describe ":users_full_names" do
-      let(:user) { build(:user, first_name: "Henri", last_name: "Frice") }
-      let(:other_user) { build(:user, first_name: "Claire", last_name: "Flou") }
-      let(:rdv) { build(:rdv, users: [user, other_user]) }
-
-      it { expect(rdv.payload[:users_full_names]).to eq("Claire FLOU et Henri FRICE") }
-    end
-
-    describe ":agents_short_names" do
-      let(:agent) { build(:agent, first_name: "Alphone", last_name: "Némone") }
-      let(:other_agent) { build(:agent, first_name: "Béatrice", last_name: "Gonia") }
-      let(:rdv) { build(:rdv, agents: [agent, other_agent]) }
-
-      it { expect(rdv.payload[:agents_short_names]).to eq("A. NÉMONE et B. GONIA") }
-    end
-
-    describe ":follow_up?" do
-      let(:motif) { build(:motif, follow_up: true) }
-      let(:rdv) { build(:rdv, motif: motif) }
-
-      it { expect(rdv.payload[:follow_up?]).to be(true) }
-    end
   end
 end

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -7,8 +7,6 @@ describe Notifiers::RdvCancelled, type: :service do
   let(:agent2) { build(:agent) }
   let(:user) { build(:user) }
   let(:rdv) { build(:rdv, starts_at: starts_at, agents: [agent1, agent2]) }
-  let(:rdv_payload_for_users) { rdv.payload(:destroy, user) }
-  let(:rdv_payload_for_agents) { rdv.payload(:destroy, agent1) }
   let(:rdv_user) { create(:rdvs_user, user: user, rdv: rdv) }
   let(:rdvs_users) { RdvsUser.where(id: rdv_user.id) }
   let(:token) { "123456" }
@@ -31,9 +29,9 @@ describe Notifiers::RdvCancelled, type: :service do
       let(:starts_at) { 3.days.from_now }
 
       it "only notifies the user" do
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv_payload_for_agents, agent1, agent1)
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv_payload_for_agents, agent2, agent1)
-        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload_for_users, user, token)
+        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent1, agent1)
+        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent2, agent1)
+        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, token)
 
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
@@ -49,9 +47,9 @@ describe Notifiers::RdvCancelled, type: :service do
       let(:starts_at) { 1.day.from_now }
 
       it "notifies the users and the other agents (not the author)" do
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv_payload_for_agents, agent1, agent1)
-        expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload_for_agents, agent2, agent1)
-        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload_for_users, user, token)
+        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent1, agent1)
+        expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent2, agent1)
+        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, token)
 
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
@@ -66,9 +64,9 @@ describe Notifiers::RdvCancelled, type: :service do
     let(:starts_at) { 1.day.from_now }
 
     it "notifies the user and the agents" do
-      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload_for_agents, agent1, user)
-      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload_for_agents, agent2, user)
-      expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv_payload_for_users, user, token)
+      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent1, user)
+      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent2, user)
+      expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, token)
 
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_user").count).to eq 1

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -8,8 +8,6 @@ describe Notifiers::RdvCreated, type: :service do
   let(:agent1) { build(:agent) }
   let(:agent2) { build(:agent) }
   let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, agents: [agent1, agent2]) }
-  let(:rdv_payload_for_users) { rdv.payload(:create, user1) }
-  let(:rdv_payload_for_agents) { rdv.payload(:create, agent1) }
   let(:rdv_user1) { create(:rdvs_user, user: user1, rdv: rdv) }
   let(:rdv_user2) { create(:rdvs_user, user: user2, rdv: rdv) }
   let(:rdvs_users_relation) { RdvsUser.where(id: [rdv_user1.id, rdv_user2.id]) }
@@ -32,8 +30,8 @@ describe Notifiers::RdvCreated, type: :service do
     let(:motif) { build(:motif) }
 
     it "triggers sending mail to users but not to agents" do
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload_for_users, user1, token1)
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload_for_users, user2, token2)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1, token1)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2, token2)
       expect(Agents::RdvMailer).not_to receive(:rdv_created)
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "created").count).to eq 2
@@ -49,10 +47,10 @@ describe Notifiers::RdvCreated, type: :service do
     let(:motif) { build(:motif) }
 
     it "triggers sending mails to both user and agents" do
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload_for_users, user1, token1)
-      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv_payload_for_users, user2, token2)
-      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv_payload_for_agents, agent1)
-      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv_payload_for_agents, agent2)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user1, token1)
+      expect(Users::RdvMailer).to receive(:rdv_created).with(rdv, user2, token2)
+      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv, agent1)
+      expect(Agents::RdvMailer).to receive(:rdv_created).with(rdv, agent2)
       subject
     end
   end

--- a/spec/services/notifiers/rdv_date_updated_spec.rb
+++ b/spec/services/notifiers/rdv_date_updated_spec.rb
@@ -8,8 +8,6 @@ describe Notifiers::RdvDateUpdated, type: :service do
   let(:agent1) { build(:agent, first_name: "Sean", last_name: "PAUL") }
   let(:agent2) { build(:agent) }
   let(:rdv) { create(:rdv, starts_at: starts_at_initial, agents: [agent1, agent2]) }
-  let(:rdv_payload_for_users) { rdv.payload(:update, user1) }
-  let(:rdv_payload_for_agents) { rdv.payload(:update, agent1) }
   let(:rdv_user1) { create(:rdvs_user, user: user1, rdv: rdv) }
   let(:rdv_user2) { create(:rdvs_user, user: user2, rdv: rdv) }
   let(:rdvs_users_relation) { RdvsUser.where(id: [rdv_user1.id, rdv_user2.id]) }
@@ -33,8 +31,8 @@ describe Notifiers::RdvDateUpdated, type: :service do
     let(:starts_at_initial) { 3.days.from_now }
 
     it "triggers sending mail to users but not to agents" do
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload_for_users, user1, token1, starts_at_initial)
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload_for_users, user2, token2, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user1, token1, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user2, token2, starts_at_initial)
       expect(Agents::RdvMailer).not_to receive(:rdv_date_updated)
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "updated").count).to eq 2
@@ -49,10 +47,10 @@ describe Notifiers::RdvDateUpdated, type: :service do
     let(:starts_at_initial) { 2.hours.from_now }
 
     it "triggers sending mails to both user and agents (except the one who initiated the change)" do
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload_for_users, user1, token1, starts_at_initial)
-      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload_for_users, user2, token2, starts_at_initial)
-      expect(Agents::RdvMailer).not_to receive(:rdv_date_updated).with(rdv_payload_for_agents, agent1, agent1, starts_at_initial)
-      expect(Agents::RdvMailer).to receive(:rdv_date_updated).with(rdv_payload_for_agents, agent2, agent1, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user1, token1, starts_at_initial)
+      expect(Users::RdvMailer).to receive(:rdv_date_updated).with(rdv, user2, token2, starts_at_initial)
+      expect(Agents::RdvMailer).not_to receive(:rdv_date_updated).with(rdv, agent1, agent1, starts_at_initial)
+      expect(Agents::RdvMailer).to receive(:rdv_date_updated).with(rdv, agent2, agent1, starts_at_initial)
       subject
     end
   end

--- a/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
+++ b/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
@@ -5,7 +5,6 @@ describe Notifiers::RdvUpcomingReminder, type: :service do
 
   let(:user1) { build(:user) }
   let(:rdv) { create(:rdv, starts_at: 2.days.from_now) }
-  let(:rdv_payload) { rdv.payload }
   let(:rdv_user) { create(:rdvs_user, user: user1, rdv: rdv) }
   let(:rdvs_users) { RdvsUser.where(id: rdv_user.id) }
   let(:token) { "123456" }
@@ -19,7 +18,7 @@ describe Notifiers::RdvUpcomingReminder, type: :service do
   end
 
   it "sends an sms and an email" do
-    expect(Users::RdvMailer).to receive(:rdv_upcoming_reminder).with(rdv_payload, user1, token)
+    expect(Users::RdvMailer).to receive(:rdv_upcoming_reminder).with(rdv, user1, token)
     expect(Users::RdvSms).to receive(:rdv_upcoming_reminder).with(rdv, user1, token)
     subject
     expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "upcoming_reminder").count).to eq 1

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -136,7 +136,6 @@ describe RdvUpdater, type: :service do
     let(:user_staying) { create(:user, first_name: "Stay") }
     let(:user_added) { create(:user, first_name: "Add") }
     let(:user_removed) { create(:user, first_name: "Remove") }
-    let(:rdv_payload_for_users) { rdv.payload(:create, user1) }
 
     let(:token) { "some-token" }
 
@@ -147,8 +146,8 @@ describe RdvUpdater, type: :service do
     end
 
     it "notifies the new participant, and the one that is removed" do
-      expect(Users::RdvMailer).to receive(:rdv_created).once.with(rdv.payload(:create, user_added), user_added, token)
-      expect(Users::RdvMailer).to receive(:rdv_cancelled).once.with(rdv.payload(:destroy, user_removed), user_removed, nil)
+      expect(Users::RdvMailer).to receive(:rdv_created).once.with(rdv, user_added, token)
+      expect(Users::RdvMailer).to receive(:rdv_cancelled).once.with(rdv, user_removed, nil)
 
       described_class.update(agent, rdv, rdv_params)
     end


### PR DESCRIPTION
Pour #1431; pour l’instant, c’est seulement du refactor, mais ça permet de mettre le contenu de l’email dans le Receipt.

En ce qui concerne les jobs d’emails d’annulation, en fait pour les rdv je pense qu’on peut _ne rien faire_. J’ai le même refactor sous le couds pour les absence et plages d’ouvertures, et là, il faut faire un `deliver_now`. Pour les rdv, la suppression ne déclenche jamais elle-même d’envoi d’email.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
