### PR TITLE
Crash de l'appel à `cp` dans bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -26,7 +26,7 @@ FileUtils.chdir APP_ROOT do
     FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   end
   unless File.exist?('.env')
-    cp '.env.sample', '.env'
+    FileUtils.cp '.env.sample', '.env'
   end
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
(PR sans ticket car tout petit fix)

Lors de mon installation, l'appel à `cp` a déclenché

    undefined method `cp' for main:Object (NoMethodError)

donc je suppose qu'il faut plutôt appeler `FileUtils.cp` (comme juste au dessus dans le fichier).