### PR TITLE
Écarter les fausses erreurs de la Drôme (bis)

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -47,11 +47,11 @@ class WebhookJob < ApplicationJob
   def self.false_negative_from_drome?(body)
     body = JSON.parse(body)
     error_messages_from_drome = [
-      "Can't update appointment",
-      "Appointment already deleted",
-      "Appointment id doesn't exist"
+      /^Can't update appointment/,
+      /^Appointment already deleted/,
+      /^Appointment id doesn't exist/
     ]
-    body["message"]&.in?(error_messages_from_drome)
+    body["message"]&.match?(Regexp.union(error_messages_from_drome))
   rescue StandardError
     false
   end

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -29,13 +29,18 @@ describe WebhookJob, type: :job do
   end
 
   describe ".false_negative_from_drome?" do
-    it "return false when..." do
+    it "return false when the body is 'ERROR'" do
       body = "ERROR"
       expect(described_class.false_negative_from_drome?(body)).to eq(false)
     end
 
+    it "return false when the message is 'Another error message'" do
+      body = "{\"message\": \"Another error message\"}"
+      expect(described_class.false_negative_from_drome?(body)).to eq(false)
+    end
+
     [
-      "{\"message\": \"Can't update appointment\"}",
+      "{\"message\": \"Can't update appointment.\"}",
       "{\"message\": \"Appointment id doesn't exist\"}",
       "{\"message\": \"Appointment already deleted\"}"
     ].each do |returned_message|


### PR DESCRIPTION
Close #2404 

Je n'avais pas compris que certaines erreurs avaient un point et d'autres non. Je propose de matcher le début de l'erreur pour ne pas avoir à savoir si il y a un point ou pas. :wink: 