### PR TITLE
Refactor des RdvMailer pour intégrer le sujet dans le receipt

### DIFF
--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -4,33 +4,31 @@ class Agents::RdvMailer < ApplicationMailer
   include DateHelper
   helper DateHelper
 
-  def rdv_created(rdv, agent)
-    @rdv = rdv
-    @agent = agent
-
-    self.ics_payload = @rdv.payload(:create, agent)
-
-    mail(to: agent.email, subject: "Nouveau RDV ajouté sur votre agenda rdv-solidarités pour #{relative_date @rdv.starts_at}")
+  before_action do
+    @rdv = params[:rdv]
+    @agent = params[:agent]
+    @author = params[:author]
   end
 
-  def rdv_cancelled(rdv, agent, author)
-    @rdv = rdv
-    @agent = agent
-    @author = author
+  default to: -> { @agent.email }
 
-    self.ics_payload = @rdv.payload(:destroy, agent)
-
-    mail(to: agent.email, subject: "RDV annulé #{relative_date @rdv.starts_at}")
+  def rdv_created
+    self.ics_payload = @rdv.payload(:create, @agent)
+    subject = t("agents.rdv_mailer.rdv_created.title", date: relative_date(@rdv.starts_at))
+    mail(subject: subject)
   end
 
-  def rdv_date_updated(rdv, agent, author, old_starts_at)
-    @rdv = rdv
-    @agent = agent
-    @author = author
+  def rdv_cancelled
+    self.ics_payload = @rdv.payload(:destroy, @agent)
+    subject = t("agents.rdv_mailer.rdv_cancelled.title", date: relative_date(@rdv.starts_at))
+    mail(subject: subject)
+  end
+
+  def rdv_date_updated(old_starts_at)
     @old_starts_at = old_starts_at
 
-    self.ics_payload = @rdv.payload(:update, agent)
-
-    mail(to: agent.email, subject: "RDV #{relative_date old_starts_at} reporté à plus tard")
+    self.ics_payload = @rdv.payload(:update, @agent)
+    subject = t("agents.rdv_mailer.rdv_date_updated.title", date: relative_date(@old_starts_at))
+    mail(subject: subject)
   end
 end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -18,7 +18,7 @@ class Users::RdvMailer < ApplicationMailer
     self.ics_payload = @rdv.payload(:create, @user)
     subject = t("users.rdv_mailer.rdv_created.title", date: l(@rdv.starts_at, format: :human))
     mail(subject: subject)
-    save_receipt
+    save_receipt(subject)
   end
 
   def rdv_date_updated(old_starts_at)
@@ -27,26 +27,26 @@ class Users::RdvMailer < ApplicationMailer
     self.ics_payload = @rdv.payload(:update, @user)
     subject = t("users.rdv_mailer.rdv_date_updated.title", date: relative_date(@old_starts_at))
     mail(subject: subject)
-    save_receipt
+    save_receipt(subject)
   end
 
   def rdv_upcoming_reminder
     self.ics_payload = @rdv.payload(nil, @user)
     subject = t("users.rdv_mailer.rdv_upcoming_reminder.title", date: l(@rdv.starts_at, format: :human))
     mail(subject: subject)
-    save_receipt
+    save_receipt(subject)
   end
 
   def rdv_cancelled
     self.ics_payload = @rdv.payload(:destroy, @user)
     subject = t("users.rdv_mailer.rdv_cancelled.title", date: l(@rdv.starts_at, format: :human), organisation: @rdv.organisation.name)
     mail(subject: subject)
-    save_receipt
+    save_receipt(subject)
   end
 
   private
 
-  def save_receipt
-    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.email)
+  def save_receipt(subject)
+    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.email, content: subject)
   end
 end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -6,68 +6,47 @@ class Users::RdvMailer < ApplicationMailer
   helper RdvsHelper
   helper DateHelper
 
-  def rdv_created(rdv, user, token)
-    @rdv = rdv
-    @user = user
-    @token = token
-
-    self.ics_payload = @rdv.payload(:create, user)
-    mail(
-      to: user.email,
-      subject: "RDV confirmé le #{l(@rdv.starts_at, format: :human)}"
-    )
-    save_receipt(:rdv_created)
+  before_action do
+    @rdv = params[:rdv]
+    @user = params[:user]
+    @token = params[:token]
   end
 
-  def rdv_date_updated(rdv, user, token, old_starts_at)
-    @rdv = rdv
-    @user = user
-    @token = token
+  default to: -> { @user.email }
+
+  def rdv_created
+    self.ics_payload = @rdv.payload(:create, @user)
+    subject = t("users.rdv_mailer.rdv_created.title", date: l(@rdv.starts_at, format: :human))
+    mail(subject: subject)
+    save_receipt
+  end
+
+  def rdv_date_updated(old_starts_at)
     @old_starts_at = old_starts_at
 
-    self.ics_payload = @rdv.payload(:update, user)
-    mail(
-      to: user.email,
-      subject: "RDV #{relative_date old_starts_at} déplacé"
-    )
-    save_receipt(:rdv_date_updated)
+    self.ics_payload = @rdv.payload(:update, @user)
+    subject = t("users.rdv_mailer.rdv_date_updated.title", date: relative_date(@old_starts_at))
+    mail(subject: subject)
+    save_receipt
   end
 
-  def rdv_upcoming_reminder(rdv, user, token)
-    @rdv = rdv
-    @user = user
-    @token = token
-
-    self.ics_payload = @rdv.payload(nil, user)
-    mail(
-      to: user.email,
-      subject: "[Rappel] RDV le #{l(@rdv.starts_at, format: :human)}"
-    )
-    save_receipt(:rdv_upcoming_reminder)
+  def rdv_upcoming_reminder
+    self.ics_payload = @rdv.payload(nil, @user)
+    subject = t("users.rdv_mailer.rdv_upcoming_reminder.title", date: l(@rdv.starts_at, format: :human))
+    mail(subject: subject)
+    save_receipt
   end
 
-  def rdv_cancelled(rdv, user, token)
-    @rdv = rdv
-    @user = user
-    @token = token
-
-    self.ics_payload = @rdv.payload(:destroy, user)
-    mail(
-      to: user.email,
-      subject: "RDV annulé le #{l(@rdv.starts_at, format: :human)} avec #{@rdv.organisation.name}"
-    )
-    save_receipt(:rdv_cancelled)
+  def rdv_cancelled
+    self.ics_payload = @rdv.payload(:destroy, @user)
+    subject = t("users.rdv_mailer.rdv_cancelled.title", date: l(@rdv.starts_at, format: :human), organisation: @rdv.organisation.name)
+    mail(subject: subject)
+    save_receipt
   end
 
-  def save_receipt(event)
-    params = {
-      rdv: @rdv,
-      user: @user,
-      event: event,
-      channel: :mail,
-      result: :processed,
-      email_address: @user.email
-    }
-    Receipt.create!(params)
+  private
+
+  def save_receipt
+    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.email)
   end
 end

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -55,6 +55,16 @@ class Notifiers::RdvBase < ::BaseService
     end
   end
 
+  ## Configured Mailers
+  #
+  def user_mailer(user)
+    Users::RdvMailer.with(rdv: @rdv, user: user, token: @rdv_users_tokens_by_user_id[user.id])
+  end
+
+  def agent_mailer(agent)
+    Agents::RdvMailer.with(rdv: @rdv, agent: agent, author: @author)
+  end
+
   private
 
   def users_to_notify

--- a/app/services/notifiers/rdv_cancelled.rb
+++ b/app/services/notifiers/rdv_cancelled.rb
@@ -5,7 +5,7 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
     # Only send sms for excused cancellations (not for no-show)
     return unless @rdv.status.in?(%w[excused revoked]) || @rdv.collectif?
 
-    Users::RdvMailer.rdv_cancelled(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
+    user_mailer(user).rdv_cancelled.deliver_later
 
     status_to_event_name = {
       "excused" => :cancelled_by_user,
@@ -31,6 +31,6 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
   end
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_cancelled(@rdv, agent, @author).deliver_later
+    agent_mailer(agent).rdv_cancelled.deliver_later
   end
 end

--- a/app/services/notifiers/rdv_created.rb
+++ b/app/services/notifiers/rdv_created.rb
@@ -2,7 +2,7 @@
 
 class Notifiers::RdvCreated < Notifiers::RdvBase
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_created(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
+    user_mailer(user).rdv_created.deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :created)
   end
 
@@ -18,6 +18,6 @@ class Notifiers::RdvCreated < Notifiers::RdvBase
   end
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_created(@rdv, agent).deliver_later
+    agent_mailer(agent).rdv_created.deliver_later
   end
 end

--- a/app/services/notifiers/rdv_date_updated.rb
+++ b/app/services/notifiers/rdv_date_updated.rb
@@ -8,7 +8,7 @@ class Notifiers::RdvDateUpdated < Notifiers::RdvBase
   end
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_date_updated(@rdv, user, @rdv_users_tokens_by_user_id[user.id], @rdv.attribute_before_last_save(:starts_at)).deliver_later
+    user_mailer(user).rdv_date_updated(@rdv.attribute_before_last_save(:starts_at)).deliver_later
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :updated)
   end
 
@@ -18,11 +18,6 @@ class Notifiers::RdvDateUpdated < Notifiers::RdvBase
   end
 
   def notify_agent(agent)
-    Agents::RdvMailer.rdv_date_updated(
-      @rdv,
-      agent,
-      @author,
-      @rdv.attribute_before_last_save(:starts_at)
-    ).deliver_later
+    agent_mailer(agent).rdv_date_updated(@rdv.attribute_before_last_save(:starts_at)).deliver_later
   end
 end

--- a/app/services/notifiers/rdv_upcoming_reminder.rb
+++ b/app/services/notifiers/rdv_upcoming_reminder.rb
@@ -8,7 +8,7 @@ class Notifiers::RdvUpcomingReminder < Notifiers::RdvBase
   end
 
   def notify_user_by_mail(user)
-    Users::RdvMailer.rdv_upcoming_reminder(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later(queue: :mailers_low)
+    user_mailer(user).rdv_upcoming_reminder.deliver_later(queue: :mailers_low)
     @rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :upcoming_reminder)
   end
 

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -18,13 +18,25 @@ fr:
       absence_updated:
         description_html: <p>Une de vos indisponibilités a été modifiée.</p><p>Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce-jointe de cet email.</p>
     rdv_mailer:
+      rdv_created:
+        title: Nouveau RDV ajouté sur votre agenda rdv-solidarités pour %{date}
+      rdv_date_updated:
+        title: RDV %{date} reporté à plus tard
       rdv_cancelled:
+        title: RDV annulé %{date}
         revoked_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} pour raison administrative.
         cancelled_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} à la demande de l’usager.
         cancelled_at_date_by_user: Un RDV qui devait avoir lieu %{date} vient d’être annulé par l’usager %{author}.
   users:
     rdv_mailer:
+      rdv_created:
+        title: RDV confirmé le %{date}
+      rdv_date_updated:
+        title: RDV %{date} reporté à plus tard
+      rdv_upcoming_reminder:
+        title: "[Rappel] RDV le %{date}"
       rdv_cancelled:
+        title: RDV annulé le %{date} avec %{organisation}
         revoked_for_motif_at_date: Votre RDV %{motif} du %{date} a été annulé pour raison administrative.
         cancelled_for_motif_at_date: Votre RDV %{motif} du %{date} a bien été annulé à votre demande.
         reschedule_by_phone: Vous pouvez reprendre un rendez-vous en appelant au %{telephone_link}.

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_created" do
     let(:agent) { build(:agent) }
     let(:t) { DateTime.parse("2020-03-01 10:20") }
-    let(:mail) { described_class.rdv_created(rdv, agent) }
+    let(:mail) { described_class.with(rdv: rdv, agent: agent).rdv_created }
     let(:rdv) { create(:rdv, starts_at: t + 2.hours, agents: [agent]) }
 
     before { travel_to(t) }

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -4,38 +4,40 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
   def rdv_created
     rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = 2.hours.from_now
-    Agents::RdvMailer.rdv_created(rdv, rdv.agents.first)
+
+    rdv_mailer(rdv).rdv_created
   end
 
   def rdv_revoked
     rdv = Rdv.joins(:users).last
     rdv.status = :revoked
-    Agents::RdvMailer
-      .rdv_cancelled(rdv, rdv.agents.first, rdv.agents.first)
+
+    rdv_mailer(rdv).rdv_cancelled
   end
 
   def rdv_cancelled_by_agent
     rdv = Rdv.joins(:users).last
     rdv.status = :excused
-    Agents::RdvMailer
-      .rdv_cancelled(rdv, rdv.agents.first, rdv.agents.first)
+    rdv_mailer(rdv).rdv_cancelled
   end
 
   def rdv_cancelled_by_user
     rdv = Rdv.joins(:users).last
     rdv.status = :excused
-    Agents::RdvMailer
-      .rdv_cancelled(rdv, rdv.agents.first, rdv.users.first)
+
+    rdv_mailer(rdv, rdv.users.first).rdv_cancelled
   end
 
   def rdv_date_updated
     rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
-    Agents::RdvMailer.rdv_date_updated(
-      rdv,
-      rdv.agents.first,
-      rdv.agents.first,
-      2.hours.from_now
-    )
+
+    rdv_mailer(rdv).rdv_date_updated(2.hours.from_now)
+  end
+
+  private
+
+  def rdv_mailer(rdv, author = rdv.agents.first)
+    Agents::RdvMailer.with(rdv: rdv, agent: rdv.agents.first, author: author)
   end
 end

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -7,58 +7,60 @@ class Users::RdvMailerPreview < ActionMailer::Preview
 
   def rdv_created
     rdv = Rdv.joins(:users).not_cancelled.last
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_created
   end
 
   def rdv_created_CONTEXT_visite_a_domicile
     rdv = Rdv.joins(:users).not_cancelled.joins(:motif).where(motifs: { location_type: :home }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_created
   end
 
   def rdv_created_CONTEXT_phone
     rdv = Rdv.joins(:users).not_cancelled.joins(:motif).where(motifs: { location_type: :phone }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_created
   end
 
   def rdv_created_CONTEXT_public_office
     rdv = Rdv.joins(:users).not_cancelled.joins(:motif).where(motifs: { location_type: :public_office }).last
     raise ActiveRecord::RecordNotFound unless rdv
 
-    Users::RdvMailer.rdv_created(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_created
   end
 
   def rdv_date_updated
     rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
-    Users::RdvMailer.rdv_date_updated(
-      rdv,
-      rdv.agents.first,
-      2.hours.from_now
-    )
+
+    rdv_mailer(rdv).rdv_date_updated(2.hours.from_now)
   end
 
   def rdv_cancelled
     rdv = Rdv.joins(:users).last
     rdv.status = "excused"
 
-    Users::RdvMailer.rdv_cancelled(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_cancelled
   end
 
   def rdv_revoked
     rdv = Rdv.joins(:users).last
     rdv.status = "revoked"
 
-    Users::RdvMailer.rdv_cancelled(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_cancelled
   end
 
   def rdv_upcoming_reminder
     rdv = Rdv.joins(:users).not_cancelled.last
-    Users::RdvMailer.rdv_upcoming_reminder(rdv, rdv.users.first)
+    rdv_mailer(rdv).rdv_upcoming_reminder
   end
 
+  private
+
+  def rdv_mailer(rdv)
+    Users::RdvMailer.with(rdv: rdv, user: rdv.users.first)
+  end
   # rubocop:enable Naming/MethodName
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let(:rdv) { create(:rdv) }
     let(:user) { rdv.users.first }
     let(:token) { "12345" }
-    let(:mail) { described_class.rdv_created(rdv, user, token) }
+    let(:mail) { described_class.with(rdv: rdv, user: user, token: token).rdv_created }
 
     it "renders the headers" do
       expect(mail.to).to eq([user.email])
@@ -38,7 +38,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "send mail to user" do
       rdv = create(:rdv)
       user = rdv.users.first
-      mail = described_class.rdv_cancelled(rdv, user, token)
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expect(mail.to).to eq([user.email])
     end
@@ -47,7 +47,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, token)
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expect(mail.subject).to eq("RDV annulé le lundi 15 juin 2020 à 12h30 avec Orga du coin")
     end
@@ -56,7 +56,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, token)
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expect(mail.html_part.body).to match("lundi 15 juin 2020 à 12h30")
     end
@@ -65,7 +65,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, token)
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expect(mail.html_part.body).to match(rdv.motif.service_name)
     end
@@ -74,7 +74,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       organisation = build(:organisation, name: "Orga du coin")
       user = build(:user)
       rdv = create(:rdv, starts_at: Time.zone.parse("2020-06-15 12:30"), organisation: organisation, users: [user])
-      mail = described_class.rdv_cancelled(rdv, user, token)
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expected_url = prendre_rdv_url(\
         departement: rdv.organisation.departement_number, \
@@ -94,7 +94,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let!(:user) { create(:user) }
 
     it "send mail to user" do
-      mail = described_class.rdv_upcoming_reminder(rdv, user, token)
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_upcoming_reminder
       expect(mail.to).to eq([user.email])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
       expect(mail.html_part.body.raw_source).to include("/users/rdvs/#{rdv.id}?invitation_token=12345")

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -14,8 +14,8 @@ describe Notifiers::RdvCancelled, type: :service do
   before do
     rdv.update!(status: new_status)
 
-    allow(Agents::RdvMailer).to receive(:rdv_cancelled).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
-    allow(Users::RdvMailer).to receive(:rdv_cancelled).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
+    allow(Agents::RdvMailer).to receive(:with).and_call_original
+    allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(rdv).to receive(:rdvs_users).and_return(rdvs_users)
     allow(rdvs_users).to receive(:where).and_return([rdv_user])
     allow(rdv_user).to receive(:new_raw_invitation_token).and_return(token)
@@ -29,9 +29,9 @@ describe Notifiers::RdvCancelled, type: :service do
       let(:starts_at) { 3.days.from_now }
 
       it "only notifies the user" do
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent1, agent1)
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent2, agent1)
-        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, token)
+        expect(Agents::RdvMailer).not_to receive(:with).with({ rdv: rdv, agent: agent1, author: agent1 })
+        expect(Agents::RdvMailer).not_to receive(:with).with({ rdv: rdv, agent: agent2, author: agent1 })
+        expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user, token: token })
 
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
@@ -47,9 +47,9 @@ describe Notifiers::RdvCancelled, type: :service do
       let(:starts_at) { 1.day.from_now }
 
       it "notifies the users and the other agents (not the author)" do
-        expect(Agents::RdvMailer).not_to receive(:rdv_cancelled).with(rdv, agent1, agent1)
-        expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent2, agent1)
-        expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, token)
+        expect(Agents::RdvMailer).not_to receive(:with).with({ rdv: rdv, agent: agent1, author: agent1 })
+        expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent2, author: agent1 })
+        expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user, token: token })
 
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_agent").count).to eq 1
@@ -64,9 +64,9 @@ describe Notifiers::RdvCancelled, type: :service do
     let(:starts_at) { 1.day.from_now }
 
     it "notifies the user and the agents" do
-      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent1, user)
-      expect(Agents::RdvMailer).to receive(:rdv_cancelled).with(rdv, agent2, user)
-      expect(Users::RdvMailer).to receive(:rdv_cancelled).with(rdv, user, token)
+      expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent1, author: user })
+      expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent2, author: user })
+      expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user, token: token })
 
       subject
       expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "cancelled_by_user").count).to eq 1

--- a/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
+++ b/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
@@ -10,7 +10,7 @@ describe Notifiers::RdvUpcomingReminder, type: :service do
   let(:token) { "123456" }
 
   before do
-    allow(Users::RdvMailer).to receive(:rdv_upcoming_reminder).and_call_original
+    allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(Users::RdvSms).to receive(:rdv_upcoming_reminder).and_call_original
     allow(rdv).to receive(:rdvs_users).and_return(rdvs_users)
     allow(rdvs_users).to receive(:where).and_return([rdv_user])
@@ -18,7 +18,7 @@ describe Notifiers::RdvUpcomingReminder, type: :service do
   end
 
   it "sends an sms and an email" do
-    expect(Users::RdvMailer).to receive(:rdv_upcoming_reminder).with(rdv, user1, token)
+    expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user1, token: token })
     expect(Users::RdvSms).to receive(:rdv_upcoming_reminder).with(rdv, user1, token)
     subject
     expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "upcoming_reminder").count).to eq 1

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -140,14 +140,14 @@ describe RdvUpdater, type: :service do
     let(:token) { "some-token" }
 
     before do
-      allow(Users::RdvMailer).to receive(:rdv_created).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
-      allow(Users::RdvMailer).to receive(:rdv_cancelled).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
+      allow(Users::RdvMailer).to receive(:with).and_call_original
+      allow(Users::RdvMailer).to receive(:with).and_call_original
       allow_any_instance_of(RdvsUser).to receive(:new_raw_invitation_token).and_return(token) # rubocop:disable RSpec/AnyInstance
     end
 
     it "notifies the new participant, and the one that is removed" do
-      expect(Users::RdvMailer).to receive(:rdv_created).once.with(rdv, user_added, token)
-      expect(Users::RdvMailer).to receive(:rdv_cancelled).once.with(rdv, user_removed, nil)
+      expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user_added, token: token })
+      expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user_removed, token: nil })
 
       described_class.update(agent, rdv, rdv_params)
     end


### PR DESCRIPTION
- [x] À merger après #2411

Le principal commit est le dernier, ou j’ajoute le sujet de l’email à `Receipt#content`. Le reste est un changement un peu discutable de style sur les mailers, où j’utilise la _parameterization_ de ActionMailer (cf https://api.rubyonrails.org/classes/ActionMailer/Parameterized.html) pour créer les Agents::RdvMailer et Users::RdvMailer. Je trouve ça mieux dans l’absolu, mais ça demande de toucher un peu tout, ce qui ne se justifie pas forcément. Je vous laisse juge :)

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
