### PR TITLE
Refactor des mailers PlageOuverture et Absence

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -45,7 +45,7 @@ class Admin::AbsencesController < AgentAuthController
     @absence.organisation = current_organisation
     authorize(@absence)
     if @absence.save
-      Agents::AbsenceMailer.absence_created(@absence.payload(:create)).deliver_later
+      Agents::AbsenceMailer.with(absence: @absence).absence_created.deliver_later
       flash[:notice] = t(".busy_time_created")
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
@@ -56,7 +56,7 @@ class Admin::AbsencesController < AgentAuthController
   def update
     authorize(@absence)
     if @absence.update(absence_params)
-      Agents::AbsenceMailer.absence_updated(@absence.payload(:update)).deliver_later
+      Agents::AbsenceMailer.with(absence: @absence).absence_updated.deliver_later
       flash[:notice] = t(".busy_time_updated")
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
@@ -67,7 +67,7 @@ class Admin::AbsencesController < AgentAuthController
   def destroy
     authorize(@absence)
     if @absence.destroy
-      Agents::AbsenceMailer.absence_destroyed(@absence.payload(:destroy)).deliver_later
+      Agents::AbsenceMailer.with(absence: @absence).absence_destroyed.deliver_later
       flash[:notice] = t(".busy_time_deleted")
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -52,7 +52,7 @@ class Admin::PlageOuverturesController < AgentAuthController
     authorize(@plage_ouverture)
     if @plage_ouverture.save
 
-      Agents::PlageOuvertureMailer.plage_ouverture_created(@plage_ouverture.payload(:create)).deliver_later
+      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_created.deliver_later
       flash[:notice] = "Plage d'ouverture créée"
       redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
     else
@@ -63,7 +63,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   def update
     authorize(@plage_ouverture)
     if @plage_ouverture.update(plage_ouverture_params)
-      Agents::PlageOuvertureMailer.plage_ouverture_updated(@plage_ouverture.payload(:update)).deliver_later
+      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_updated.deliver_later
       redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture), notice: "La plage d'ouverture a été modifiée."
     else
       render :edit
@@ -73,7 +73,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   def destroy
     authorize(@plage_ouverture)
     if @plage_ouverture.destroy
-      Agents::PlageOuvertureMailer.plage_ouverture_destroyed(@plage_ouverture.payload(:destroy)).deliver_later
+      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_destroyed.deliver_later
       redirect_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent), notice: "La plage d'ouverture a été supprimée."
     else
       render :edit

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -52,7 +52,7 @@ class Admin::PlageOuverturesController < AgentAuthController
     authorize(@plage_ouverture)
     if @plage_ouverture.save
 
-      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_created.deliver_later
+      plage_ouverture_mailer.plage_ouverture_created.deliver_later
       flash[:notice] = "Plage d'ouverture créée"
       redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
     else
@@ -63,7 +63,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   def update
     authorize(@plage_ouverture)
     if @plage_ouverture.update(plage_ouverture_params)
-      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_updated.deliver_later
+      plage_ouverture_mailer.plage_ouverture_updated.deliver_later
       redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture), notice: "La plage d'ouverture a été modifiée."
     else
       render :edit
@@ -72,8 +72,9 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def destroy
     authorize(@plage_ouverture)
-    if @plage_ouverture.destroy
-      Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_destroyed.deliver_later
+    # NOTE: the destruction email is sent synchronously (not in a job) to ensure @absence still exists.
+    if @plage_ouverture.delay.destroy
+      plage_ouverture_mailer.plage_ouverture_destroyed.deliver_now
       redirect_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent), notice: "La plage d'ouverture a été supprimée."
     else
       render :edit
@@ -100,5 +101,9 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def filter_params
     params.permit(:start, :end, :organisation_id, :agent_id, :page, :current_tab)
+  end
+
+  def plage_ouverture_mailer
+    Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture)
   end
 end

--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
 class Agents::AbsenceMailer < ApplicationMailer
-  def absence_created(absence_payload)
-    send_mail(absence_payload)
+  helper PlageOuverturesHelper
+
+  before_action do
+    @absence = params[:absence]
   end
 
-  def absence_updated(absence_payload)
-    send_mail(absence_payload)
+  default from: "secretariat-auto@rdv-solidarites.fr",
+          to: -> { @absence.agent.email }
+
+  def absence_created
+    self.ics_payload = @absence.payload(:created)
+    mail(subject: t("agents.absence_mailer.absence_created.title", title: @absence.title))
   end
 
-  def absence_destroyed(absence_payload)
-    send_mail(absence_payload)
+  def absence_updated
+    self.ics_payload = @absence.payload(:updated)
+    mail(subject: t("agents.absence_mailer.absence_updated.title", title: @absence.title))
   end
 
-  private
-
-  def send_mail(absence_payload)
-    self.ics_payload = absence_payload
-
-    mail(
-      from: "secretariat-auto@rdv-solidarites.fr",
-      to: absence_payload[:agent_email],
-      subject: "#{BRAND} - #{absence_payload[:title]}"
-    )
+  def absence_destroyed
+    self.ics_payload = @absence.payload(:destroyed)
+    mail(subject: t("agents.absence_mailer.absence_destroyed.title", title: @absence.title))
   end
 end

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -1,27 +1,28 @@
 # frozen_string_literal: true
 
 class Agents::PlageOuvertureMailer < ApplicationMailer
-  def plage_ouverture_created(plage_ouverture_payload)
-    send_mail(plage_ouverture_payload)
+  helper MotifsHelper
+  helper PlageOuverturesHelper
+
+  before_action do
+    @plage_ouverture = params[:plage_ouverture]
   end
 
-  def plage_ouverture_updated(plage_ouverture_payload)
-    send_mail(plage_ouverture_payload)
+  default from: "secretariat-auto@rdv-solidarites.fr",
+          to: -> { @plage_ouverture.agent.email }
+
+  def plage_ouverture_created
+    self.ics_payload = @plage_ouverture.payload(:create)
+    mail(subject: t("agents.plage_ouverture_mailer.plage_ouverture_created.title", title: @plage_ouverture.title))
   end
 
-  def plage_ouverture_destroyed(plage_ouverture_payload)
-    send_mail(plage_ouverture_payload)
+  def plage_ouverture_updated
+    self.ics_payload = @plage_ouverture.payload(:update)
+    mail(subject: t("agents.plage_ouverture_mailer.plage_ouverture_updated.title", title: @plage_ouverture.title))
   end
 
-  private
-
-  def send_mail(plage_ouverture_payload)
-    self.ics_payload = plage_ouverture_payload
-
-    mail(
-      from: "secretariat-auto@rdv-solidarites.fr",
-      to: plage_ouverture_payload[:agent_email],
-      subject: "#{BRAND} - #{plage_ouverture_payload[:title]}"
-    )
+  def plage_ouverture_destroyed
+    self.ics_payload = @plage_ouverture.payload(:destroy)
+    mail(subject: t("agents.plage_ouverture_mailer.plage_ouverture_destroyed.title", title: @plage_ouverture.title))
   end
 end

--- a/app/models/concerns/payloads/absence.rb
+++ b/app/models/concerns/payloads/absence.rb
@@ -5,12 +5,10 @@ module Payloads
     def payload(action = nil)
       payload = {
         name: "absence-#{title.parameterize}-#{starts_at.to_s.parameterize}.ics",
-        agent_email: agent.email,
         starts_at: starts_at,
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
         summary: "#{BRAND} #{title}",
-        title: title,
         recurrence: rrule
       }
 

--- a/app/models/concerns/payloads/plage_ouverture.rb
+++ b/app/models/concerns/payloads/plage_ouverture.rb
@@ -5,14 +5,11 @@ module Payloads
     def payload(action = nil)
       payload = {
         name: "plage-ouverture-#{title.parameterize}-#{starts_at.to_s.parameterize}.ics",
-        agent_email: agent.email,
         starts_at: starts_at,
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
         summary: "#{BRAND} #{title}",
-        title: title,
-        recurrence: rrule,
-        address: lieu.address
+        recurrence: rrule
       }
 
       payload[:action] = action if action.present?

--- a/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
+++ b/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
@@ -1,0 +1,22 @@
+.overview
+  h3.aligncenter Absence ##{@absence.id}
+  div.row-result
+    span.title Description :
+    span.float-right= @absence.title
+    .clear
+  div.row-result
+    span.title Professionnel :
+    span.float-right= @absence.agent.full_name
+    .clear
+  div.row-result
+    span.title Répétition :
+    span.float-right= @absence.recurring? ? "Récurrente" : po_exceptionnelle_tag(@absence)
+    .clear
+  div.row-result.no-border
+    span.title Dates :
+    span.float-right
+      - if @absence.recurring?
+        = sanitize(display_recurrence(@absence).join(" "))
+      - else
+        | Le #{l(@absence.first_day, format: :human)} #{display_time_range(@absence)}
+    .clear

--- a/app/views/mailers/agents/absence_mailer/absence_created.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_created.html.slim
@@ -3,6 +3,8 @@ p = t("mailers.common.hello")
 p= t(".description_1")
 p= t(".description_2")
 
+= render "absence_overview", absence: @absence
+
 .btn-wrapper= link_to t("mailers.common.see_on_rdvs"), edit_admin_organisation_absence_url(@absence.organisation, @absence), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_created.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_created.html.slim
@@ -1,5 +1,8 @@
 p = t("mailers.common.hello")
 
-= t(".description_html")
+p= t(".description_1")
+p= t(".description_2")
+
+.btn-wrapper= link_to t("mailers.common.see_on_rdvs"), edit_admin_organisation_absence_url(@absence.organisation, @absence), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
@@ -1,4 +1,6 @@
 p = t("mailers.common.hello")
-= t(".description_html")
+
+p= t(".description_1")
+p= t(".description_2")
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_destroyed.html.slim
@@ -3,4 +3,6 @@ p = t("mailers.common.hello")
 p= t(".description_1")
 p= t(".description_2")
 
+= render "absence_overview", absence: @absence
+
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
@@ -3,6 +3,8 @@ p = t("mailers.common.hello")
 p= t(".description_1")
 p= t(".description_2")
 
+= render "absence_overview", absence: @absence
+
 .btn-wrapper= link_to t("mailers.common.see_on_rdvs"), edit_admin_organisation_absence_url(@absence.organisation, @absence), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
+++ b/app/views/mailers/agents/absence_mailer/absence_updated.html.slim
@@ -1,4 +1,8 @@
 p = t("mailers.common.hello")
-= t(".description_html")
+
+p= t(".description_1")
+p= t(".description_2")
+
+.btn-wrapper= link_to t("mailers.common.see_on_rdvs"), edit_admin_organisation_absence_url(@absence.organisation, @absence), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -1,0 +1,36 @@
+.overview
+  h3.aligncenter Plage d’ouverture ##{plage_ouverture.id}
+  div.row-result
+    span.title Description :
+    span.float-right= plage_ouverture.title
+    .clear
+  div.row-result
+    span.title Professionnel :
+    span.float-right= plage_ouverture.agent.full_name
+    .clear
+  div.row-result
+    span.title Lieu :
+    span.float-right
+      = plage_ouverture.lieu.name
+      = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu.enabled?
+      = " (#{plage_ouverture.lieu.address})"
+    .clear
+  div.row-result
+    span.title Motifs :
+    span.float-right
+      ul
+        - plage_ouverture.motifs.each do |motif|
+          li= motif_name_with_location_type_and_badges(motif)
+    .clear
+  div.row-result
+    span.title Répétition :
+    span.float-right= plage_ouverture.recurring? ? "Récurrente" : po_exceptionnelle_tag(plage_ouverture)
+    .clear
+  div.row-result.no-border
+    span.title Dates :
+    span.float-right
+      - if plage_ouverture.recurring?
+        = sanitize(display_recurrence(plage_ouverture).join(" "))
+      - else
+        | Le #{l(plage_ouverture.first_day, format: :human)} #{display_time_range(plage_ouverture)}
+    .clear

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_created.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_created.html.slim
@@ -3,6 +3,8 @@ p = t("mailers.common.hello")
 p= t(".description_1")
 p= t(".description_2")
 
+= render "plage_ouverture_overview", plage_ouverture: @plage_ouverture
+
 .btn-wrapper= link_to t("mailers.common.see_on_rdvs"), admin_organisation_plage_ouverture_url(@plage_ouverture.organisation, @plage_ouverture), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_created.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_created.html.slim
@@ -1,6 +1,8 @@
-p Bonjour,
+p = t("mailers.common.hello")
 
-p Vous venez de créer une plage d'ouverture sur votre planning de RDV Solidarités.
-p Vous pouvez synchroniser cette plage sur votre calendrier en ouvrant la pièce-jointe de cet email.
+p= t(".description_1")
+p= t(".description_2")
+
+.btn-wrapper= link_to t("mailers.common.see_on_rdvs"), admin_organisation_plage_ouverture_url(@plage_ouverture.organisation, @plage_ouverture), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_destroyed.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_destroyed.html.slim
@@ -3,4 +3,6 @@ p = t("mailers.common.hello")
 p= t(".description_1")
 p= t(".description_2")
 
+= render "plage_ouverture_overview", plage_ouverture: @plage_ouverture
+
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_destroyed.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_destroyed.html.slim
@@ -1,6 +1,6 @@
-p Bonjour,
+p = t("mailers.common.hello")
 
-p Une de vos plages d'ouvertures a été supprimée.
-p Vous pouvez supprimer l'événement correspondant de votre logiciel de calendrier externe (Outlook, Zimbra, Thunderbird etc) en ouvrant la pièce jointe
+p= t(".description_1")
+p= t(".description_2")
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_updated.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_updated.html.slim
@@ -1,6 +1,8 @@
-p Bonjour,
+p = t("mailers.common.hello")
 
-p Une de vos plages d'ouvertures a été modifiée.
-p Vous pouvez synchroniser cette plage sur votre calendrier en ouvrant la pièce-jointe de cet email.
+p= t(".description_1")
+p= t(".description_2")
+
+.btn-wrapper= link_to t("mailers.common.see_on_rdvs"), admin_organisation_plage_ouverture_url(@plage_ouverture.organisation, @plage_ouverture), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_updated.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/plage_ouverture_updated.html.slim
@@ -3,6 +3,8 @@ p = t("mailers.common.hello")
 p= t(".description_1")
 p= t(".description_2")
 
+= render "plage_ouverture_overview", plage_ouverture: @plage_ouverture
+
 .btn-wrapper= link_to t("mailers.common.see_on_rdvs"), admin_organisation_plage_ouverture_url(@plage_ouverture.organisation, @plage_ouverture), class:"btn btn-primary"
 
 = t("mailers.common.farewell_html")

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -12,22 +12,28 @@ fr:
   agents:
     absence_mailer:
       absence_created:
+        title: RDV Solidarités - Indisponibilité créée - %{title}
         description_1: Vous venez de créer une indisponibilité sur votre planning de RDV Solidarités.
         description_2: Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce jointe de cet email.
       absence_updated:
+        title: RDV Solidarités - Indisponibilité modifiée - %{title}
         description_1: Une de vos indisponibilités a été modifiée.
         description_2: Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce jointe de cet email.
       absence_destroyed:
+        title: RDV Solidarités - Indisponibilité supprimée - %{title}
         description_1: Une de vos indisponibilités a été supprimée.
         description_2: Vous pouvez supprimer l’évènement correspondant de votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
     plage_ouverture_mailer:
       plage_ouverture_created:
+        title: RDV Solidarités - Plage d’ouverture créée - %{title}
         description_1: Vous venez de créer une plage d’ouverture sur votre planning de RDV Solidarités.
         description_2: Vous pouvez synchroniser l’évènement sur votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
       plage_ouverture_updated:
+        title: RDV Solidarités - Plage d’ouverture modifiée - %{title}
         description_1: Une de vos plages d’ouvertures a été modifiée.
         description_2: Vous pouvez synchroniser l’évènement sur votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
       plage_ouverture_destroyed:
+        title: RDV Solidarités - Plage d’ouverture supprimée - %{title}
         description_1: Une de vos plages d’ouvertures a été supprimée.
         description_2: Vous pouvez supprimer l’évènement de votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
     rdv_mailer:

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -8,15 +8,28 @@ fr:
     common:
       hello: Bonjour,
       farewell_html: "<p>À bientôt,<br>L’équipe RDV-Solidarités</p>"
-
+      see_on_rdvs: Voir sur RDV-Solidarités
   agents:
     absence_mailer:
       absence_created:
-        description_html: <p>Vous venez de créer une indisponibilité sur votre planning de RDV Solidarités.</p><p> Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce-jointe de cet email.</p>
-      absence_destroyed:
-        description_html: <p>Une de vos indisponibilités a été supprimée.</p><p>Vous pouvez supprimer l'événement correspondant de votre logiciel de calendrier externe (Outlook, Zimbra, Thunderbird etc) en ouvrant la pièce jointe</p>
+        description_1: Vous venez de créer une indisponibilité sur votre planning de RDV Solidarités.
+        description_2: Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce jointe de cet email.
       absence_updated:
-        description_html: <p>Une de vos indisponibilités a été modifiée.</p><p>Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce-jointe de cet email.</p>
+        description_1: Une de vos indisponibilités a été modifiée.
+        description_2: Vous pouvez synchroniser cette indisponibilité sur votre calendrier en ouvrant la pièce jointe de cet email.
+      absence_destroyed:
+        description_1: Une de vos indisponibilités a été supprimée.
+        description_2: Vous pouvez supprimer l’évènement correspondant de votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
+    plage_ouverture_mailer:
+      plage_ouverture_created:
+        description_1: Vous venez de créer une plage d’ouverture sur votre planning de RDV Solidarités.
+        description_2: Vous pouvez synchroniser l’évènement sur votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
+      plage_ouverture_updated:
+        description_1: Une de vos plages d’ouvertures a été modifiée.
+        description_2: Vous pouvez synchroniser l’évènement sur votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
+      plage_ouverture_destroyed:
+        description_1: Une de vos plages d’ouvertures a été supprimée.
+        description_2: Vous pouvez supprimer l’évènement de votre logiciel de calendrier en ouvrant la pièce jointe de cet email.
     rdv_mailer:
       rdv_created:
         title: Nouveau RDV ajouté sur votre agenda rdv-solidarités pour %{date}

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -3,52 +3,31 @@
 describe Agents::PlageOuvertureMailer, type: :mailer do
   { created: "créée", updated: "modifiée", destroyed: "supprimée" }.each do |action, verb|
     context "when #{action}" do
-      let(:ics_payload) do
-        {
-          name: "plage-ouverture--.ics",
-          object: "plage_ouverture",
-          action: action,
-          agent_email: "bob@demo.rdv-solidarites.fr",
-          starts_at: Time.zone.parse("20190423 13h00"),
-          ical_uid: "plage_ouverture_@RDV Solidarités",
-          title: "Plage d'ouverture #{verb}",
-          first_occurrence_ends_at: Time.zone.parse("20190423 18h00"),
-          address: "une adresse"
-        }
-      end
+      let(:plage_ouverture) { create :plage_ouverture, agent: create(:agent, email: "bob@demo.rdv-solidarites.fr") }
 
       it "mail to plage ouverture's agent" do
-        mail = described_class.send("plage_ouverture_#{action}", ics_payload)
+        mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
         expect(mail.to).to eq(["bob@demo.rdv-solidarites.fr"])
       end
 
       it "have a good subject" do
-        mail = described_class.send("plage_ouverture_#{action}", ics_payload)
-        expect(mail.subject).to eq("RDV Solidarités - Plage d'ouverture #{verb}")
+        mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
+        expect(mail.subject).to eq("RDV Solidarités - Plage d’ouverture #{verb} - #{plage_ouverture.title}")
       end
 
       it "has a ICS file join with UID" do
-        mail = described_class.send("plage_ouverture_#{action}", ics_payload)
+        mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
         cal = mail.find_first_mime_type("text/calendar")
-        expect(cal.decoded).to match("UID:plage_ouverture_@RDV Solidarités")
+        expect(cal.decoded).to match("UID:plage_ouverture_#{plage_ouverture.id}@RDV Solidarités")
       end
     end
   end
 
   describe "#plage_ouverture_destroyed" do
+    let(:plage_ouverture) { create :plage_ouverture }
+
     it "have a STATUS:CANCELLED in ICS file joined" do
-      ics_payload = {
-        name: "plage-ouverture--.ics",
-        object: "plage_ouverture",
-        action: :destroy,
-        agent_email: "bob@demo.rdv-solidarites.fr",
-        starts_at: Time.zone.parse("20190423 13h00"),
-        ical_uid: "plage_ouverture_@RDV Solidarités",
-        title: "Plage d'ouverture supprimée",
-        first_occurrence_ends_at: Time.zone.parse("20190423 18h00"),
-        address: "une adresse"
-      }
-      mail = described_class.send("plage_ouverture_destroyed", ics_payload)
+      mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_destroyed")
       cal = mail.find_first_mime_type("text/calendar")
       expect(cal.decoded).to match("STATUS:CANCELLED")
     end

--- a/spec/mailers/previews/agents/absence_mailer_preview.rb
+++ b/spec/mailers/previews/agents/absence_mailer_preview.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
 class Agents::AbsenceMailerPreview < ActionMailer::Preview
-  def absence_created
-    absence = Absence.last
-    Agents::AbsenceMailer.absence_created(absence.payload(:create))
-  end
+  delegate :absence_created, :absence_updated, :absence_destroyed, to: :absence_mailer
 
-  def absence_updated
-    absence = Absence.last
-    Agents::AbsenceMailer.absence_updated(absence.payload(:update))
-  end
+  private
 
-  def absence_destroyed
-    absence = Absence.last
-    Agents::AbsenceMailer.absence_destroyed(absence.payload(:destroy))
+  def absence_mailer
+    Agents::AbsenceMailer.with(absence: Absence.last)
   end
 end

--- a/spec/mailers/previews/agents/plage_ouverture_mailer_preview.rb
+++ b/spec/mailers/previews/agents/plage_ouverture_mailer_preview.rb
@@ -1,19 +1,11 @@
 # frozen_string_literal: true
 
 class Agents::PlageOuvertureMailerPreview < ActionMailer::Preview
-  def plage_ouverture_created
-    plage_ouverture = PlageOuverture.last
+  delegate :plage_ouverture_created, :plage_ouverture_updated, :plage_ouverture_destroyed, to: :plage_ouverture_mailer
 
-    Agents::PlageOuvertureMailer.plage_ouverture_created(plage_ouverture.payload(:create))
-  end
+  private
 
-  def plage_ouverture_updated
-    plage_ouverture = PlageOuverture.last
-    Agents::PlageOuvertureMailer.plage_ouverture_updated(plage_ouverture.payload(:update))
-  end
-
-  def plage_ouverture_destroyed
-    plage_ouverture = PlageOuverture.last
-    Agents::PlageOuvertureMailer.plage_ouverture_destroyed(plage_ouverture.payload(:destroy))
+  def plage_ouverture_mailer
+    Agents::PlageOuvertureMailer.with(plage_ouverture: PlageOuverture.last)
   end
 end

--- a/spec/models/concerns/payloads/absence_spec.rb
+++ b/spec/models/concerns/payloads/absence_spec.rb
@@ -2,7 +2,7 @@
 
 describe Payloads::Absence do
   describe "#payload" do
-    %i[name agent_email starts_at recurrence ical_uid title ends_at].each do |key|
+    %i[name starts_at recurrence ical_uid ends_at].each do |key|
       it "return an hash with key #{key}" do
         absence = build(:absence)
         expect(absence.payload).to have_key(key)
@@ -22,12 +22,6 @@ describe Payloads::Absence do
       it { expect(absence.payload[:name]).to eq("absence-something-2020-11-13-12-30-00-0100.ics") }
     end
 
-    describe ":agent_email" do
-      let(:absence) { build(:absence, agent: build(:agent, email: "polo@demo.rdv-solidarites.fr")) }
-
-      it { expect(absence.payload[:agent_email]).to eq("polo@demo.rdv-solidarites.fr") }
-    end
-
     describe ":starts_at" do
       let(:starts_at) { Time.zone.parse("20201009 11h45") }
       let(:absence) { build(:absence, start_time: starts_at, first_day: starts_at.to_date) }
@@ -45,12 +39,6 @@ describe Payloads::Absence do
       let(:absence) { create(:absence) }
 
       it { expect(absence.payload[:ical_uid]).to eq("absence_#{absence.id}@#{BRAND}") }
-    end
-
-    describe ":title" do
-      let(:absence) { build(:absence, title: "Permanence") }
-
-      it { expect(absence.payload[:title]).to eq("Permanence") }
     end
 
     describe ":ends_at" do

--- a/spec/models/concerns/payloads/plage_ouverture_spec.rb
+++ b/spec/models/concerns/payloads/plage_ouverture_spec.rb
@@ -2,7 +2,7 @@
 
 describe Payloads::PlageOuverture do
   describe "#payload" do
-    %i[name agent_email starts_at recurrence ical_uid title ends_at address].each do |key|
+    %i[name starts_at recurrence ical_uid ends_at].each do |key|
       it "return an hash with key #{key}" do
         plage_ouverture = build(:plage_ouverture)
         expect(plage_ouverture.payload).to have_key(key)
@@ -20,12 +20,6 @@ describe Payloads::PlageOuverture do
       let(:plage_ouverture) { build(:plage_ouverture, title: "something", start_time: Time.zone.parse("12h30"), first_day: Date.new(2020, 11, 13)) }
 
       it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-something-2020-11-13-12-30-00-0100.ics") }
-    end
-
-    describe ":agent_email" do
-      let(:plage_ouverture) { build(:plage_ouverture, agent: build(:agent, email: "polo@demo.rdv-solidarites.fr")) }
-
-      it { expect(plage_ouverture.payload[:agent_email]).to eq("polo@demo.rdv-solidarites.fr") }
     end
 
     describe ":starts_at" do
@@ -47,24 +41,11 @@ describe Payloads::PlageOuverture do
       it { expect(plage_ouverture.payload[:ical_uid]).to eq("plage_ouverture_#{plage_ouverture.id}@#{BRAND}") }
     end
 
-    describe ":title" do
-      let(:plage_ouverture) { build(:plage_ouverture, title: "Permanence") }
-
-      it { expect(plage_ouverture.payload[:title]).to eq("Permanence") }
-    end
-
     describe ":ends_at" do
       let(:starts_at) { Time.zone.parse("20201009 11h45") }
       let(:plage_ouverture) { build(:plage_ouverture, end_time: starts_at + 5.hours, first_day: starts_at.to_date) }
 
       it { expect(plage_ouverture.payload[:ends_at]).to eq(starts_at + 5.hours) }
-    end
-
-    describe ":address" do
-      let(:lieu) { build(:lieu, address: "10 rue de là-bas") }
-      let(:plage_ouverture) { build(:plage_ouverture, lieu: lieu) }
-
-      it { expect(plage_ouverture.payload[:address]).to eq("10 rue de là-bas") }
     end
   end
 end


### PR DESCRIPTION
Dans l’esprit de #2411 et #2412 (et en réalité, j’avais déjà commencé cette branche il y a longtemps)

* arrêt de l’utilisation des payloads pour créer les jobs de mailers
* utilisation des paramètres pour les mailers (avec `.with`), ça clarifie plutôt bien le code
* nettoyage i18n
* ajout de l’aperçu de la PO ou de l’absence dans le corps du mail
* ajout d’un lien vers la PO ou l’absence dans le corps du mail
* ⚠️ envoi des mails de suppression de façon synchrone

Ça ressemble à ça:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/139391/165340367-a6ffd551-6dd2-4770-bb7f-6b226788fef2.png">


AVANT LA REVUE
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
