### PR TITLE
Réduire la confusion des messages d'information sur l'invitation et la connexion Franceconnect de la ficher usager

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,7 +106,11 @@ class User < ApplicationRecord
   end
 
   def invitable?
-    invitation_accepted_at.nil? && encrypted_password.blank? && email.present? && !relative? && invited_through != "external"
+    invitation_accepted_at.nil? &&
+      encrypted_password.blank? &&
+      email.present? && !relative? &&
+      invited_through != "external" &&
+      !logged_once_with_franceconnect?
   end
 
   def active_for_authentication?

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -21,7 +21,7 @@
         - if @user.invitable?
           .row.bg-info.text-white.p-2.mb-3
             .col-md-8
-              | Cet usager ne s'est pas encore créé de compte RDV-Solidarités
+              | Cet usager ne s'est pas encore créé de compte RDV-Solidarités.
               - if @user.invitation_sent_at
                 p.small.m-0 Invitation envoyée il y a #{distance_of_time_in_words_to_now(@user.invitation_sent_at)}
             .col-md-4.text-right
@@ -33,7 +33,7 @@
               | Cet usager a reçu une invitation via un partenaire de RDV-Solidarités, mais il ne l’a pas encore acceptée.
 
         - if @user.logged_once_with_franceconnect?
-          .row.bg-info.text-white.p-2.mb-3 Cet usager s'est déjà connecté via FranceConnect
+          .row.bg-info.text-white.p-2.mb-3 Cet usager s'est déjà connecté via FranceConnect.
 
         - if @user.responsible?
           h2.card-title.mb-3 Informations générales

--- a/spec/features/agents/users/agent_can_display_user_spec.rb
+++ b/spec/features/agents/users/agent_can_display_user_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe "Agent can display user" do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+  before do
+    login_as(agent, scope: :agent)
+    visit admin_organisation_user_path(organisation, user)
+  end
+
+  context "when user is unregistered and never logged through FranceConnect" do
+    let!(:user) { create(:user, :unconfirmed, :unregistered, organisations: [organisation]) }
+
+    it "prompts the agent to invite the user" do
+      expect(page).to have_content("Cet usager ne s'est pas encore créé de compte RDV-Solidarités.")
+      expect(page).to have_link("Inviter", href: invite_admin_organisation_user_path(id: user.id, organisation_id: organisation.id))
+    end
+  end
+
+  context "when user is unregistered but has logged through FranceConnect" do
+    let!(:user) { create(:user, :unconfirmed, :unregistered, logged_once_with_franceconnect: true, organisations: [organisation]) }
+
+    it "displays a message to inform of FranceConnect binding, and hides the invitation prompt" do
+      expect(page).to have_content("Cet usager s'est déjà connecté via FranceConnect.")
+      # There is no need to invite the user since FranceConnect binding is in place
+      expect(page).not_to have_content("Cet usager ne s'est pas encore créé de compte RDV-Solidarités")
+    end
+  end
+end


### PR DESCRIPTION
Close #2249

AVANT LA REVUE
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local

------------

# Avant

![image](https://user-images.githubusercontent.com/6357692/165485757-82e72f23-56b8-407c-9d92-b2b4a0d189ea.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/165485818-c1eae788-3b8d-46ca-808f-0b4f433751de.png)
