### PR TITLE
Correction d'une spec JS flaky

### DIFF
--- a/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
+++ b/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Agent can find a creneau for a rdv collectif", js: true do
+describe "Agent can find a creneau for a rdv collectif" do
   let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
   let!(:motif) do
     create(:motif, :collectif, name: "Atelier participatif", organisation: organisation, service: service)


### PR DESCRIPTION
Visiblement le `js: true` rend ce test flaky, ce qui explique les échecs de CI depuis 15 jours. :wink: 

Cette spec a été introduite dans #2343. J'ai l'impression que le `js: true` n'est pas nécessaire, j'ai désactivé le JS dans mon navigateur et testé les fonctionnalités : elles fonctionnent ! :tada: 

Qu'en pensez-vous ?

Note : une solution alternative est d'installer la gem `rspec-retry`, avec laquelle j'ai eu de bonnes expériences : 
https://github.com/betagouv/rdv-solidarites.fr/compare/rspec-retry-frf?expand=1