### PR TITLE
Exporte tous les motifs dans un csv

### DIFF
--- a/scripts/export_motifs_to_csv.rb
+++ b/scripts/export_motifs_to_csv.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+puts "Nom;Type;Reservable en ligne ?;Ouvert au secrétariat ?;Suivi ?;RDV Collectif ?;Durée par défaut (en min);Category;Nom du service;Nom du territoire;Code du territoire"
+
+Motif.joins(:organisation).all.each do |m|
+  line = [m.name]
+  line << m.location_type
+  line << m.reservable_online
+  line << m.secretariat?
+  line << m.follow_up?
+  line << m.collectif
+  line << m.default_duration_in_min
+  line << m.category
+  line << m.service.name
+  line << m.organisation.territory
+  line << m.organisation.territory.departement_number
+  puts line.join(";")
+end


### PR DESCRIPTION
Suite à la demande de Christelle Cufay (64), j'ai fait un petit bout
d'export que j'ai exécuté sur un backup de prod depuis ma machine.

Ça serait intéressant de faire une page publique pour diffuser la liste
des motifs (OpenData). Il y a quelques freins de la part des référentes,
mais peut-être que nous pouvons passer outre ?

Je le commit un peu pour l'historique.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
