### PR TITLE
Enregistre le Receipt dans FileAttenteMailer

### DIFF
--- a/app/mailers/users/file_attente_mailer.rb
+++ b/app/mailers/users/file_attente_mailer.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 class Users::FileAttenteMailer < ApplicationMailer
-  def new_creneau_available(rdv, user, token)
-    @rdv = rdv
-    @token = token
-    mail(to: user.email, subject: "Un créneau vient de se liberer !")
+  before_action do
+    @rdv = params[:rdv]
+    @user = params[:user]
+    @token = params[:token]
+  end
+
+  default to: -> { @user.email }
+
+  def new_creneau_available
+    subject = t("users.file_attente_mailer.new_creneau_available.title")
+    mail(subject: subject)
+    save_receipt(subject)
+  end
+
+  private
+
+  def save_receipt(subject)
+    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.email, content: subject)
   end
 end

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -45,19 +45,9 @@ class FileAttente < ApplicationRecord
 
       next unless user.notifiable_by_email?
 
-      Users::FileAttenteMailer.new_creneau_available(rdv, user, invitation_token).deliver_later
+      Users::FileAttenteMailer.with(rdv: rdv, user: user, token: invitation_token).new_creneau_available.deliver_later
       update!(notifications_sent: notifications_sent + 1, last_creneau_sent_at: Time.zone.now)
       rdv.events.create!(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: :file_attente_creneaux_available)
-
-      params = {
-        rdv: rdv,
-        user: user,
-        event: :new_creneau_available,
-        channel: :mail,
-        result: :processed,
-        email_address: user.email
-      }
-      Receipt.create!(params)
     end
   end
 

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -47,6 +47,9 @@ fr:
         cancelled_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} à la demande de l’usager.
         cancelled_at_date_by_user: Un RDV qui devait avoir lieu %{date} vient d’être annulé par l’usager %{author}.
   users:
+    file_attente_mailer:
+      new_creneau_available:
+        title: Un créneau vient de se liberer !
     rdv_mailer:
       rdv_created:
         title: RDV confirmé le %{date}

--- a/spec/mailers/previews/users/file_attente_mailer_preview.rb
+++ b/spec/mailers/previews/users/file_attente_mailer_preview.rb
@@ -2,6 +2,6 @@
 
 class Users::FileAttenteMailerPreview < ActionMailer::Preview
   def new_creneau_available
-    Users::FileAttenteMailer.new_creneau_available(Rdv.last, User.last)
+    Users::FileAttenteMailer.with(rdv: Rdv.last, user: User.last).new_creneau_available
   end
 end

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -48,8 +48,8 @@ describe FileAttente, type: :model do
       end
 
       it "sends an email" do
-        allow(Users::FileAttenteMailer).to receive(:new_creneau_available).with(rdv, user, token).and_call_original
-        expect(Users::FileAttenteMailer).to receive(:new_creneau_available).with(rdv, user, token)
+        allow(Users::FileAttenteMailer).to receive(:with).and_call_original
+        expect(Users::FileAttenteMailer).to receive(:with).with({ rdv: rdv, user: user, token: token })
         subject
         expect(rdv.events.where(event_type: RdvEvent::TYPE_NOTIFICATION_MAIL, event_name: "file_attente_creneaux_available").count).to eq 1
       end
@@ -61,7 +61,7 @@ describe FileAttente, type: :model do
       it "does not send notification" do
         subject
         expect(Users::FileAttenteSms).not_to receive(:new_creneau_available)
-        expect(Users::FileAttenteMailer).not_to receive(:new_creneau_available)
+        expect(Users::FileAttenteMailer).not_to receive(:with)
         expect(rdv_user).not_to receive(:new_raw_invitation_token)
       end
     end
@@ -74,7 +74,7 @@ describe FileAttente, type: :model do
         file_attente.reload
         subject
         expect(Users::FileAttenteSms).not_to receive(:new_creneau_available)
-        expect(Users::FileAttenteMailer).not_to receive(:new_creneau_available)
+        expect(Users::FileAttenteMailer).not_to receive(:with)
         expect(rdv_user).not_to receive(:new_raw_invitation_token)
       end
     end


### PR DESCRIPTION
Petit oubli de #2411, pour utiliser les mailers paramétrés et enregistrer les receipts en fin de job plutôt qu’à la création du job.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
