### PR TITLE
suppression des plages d'ouvertures de plus d'un an

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -86,9 +86,12 @@ class CronJob < ApplicationJob
     self.cron_expression = "0 1 * * *"
 
     def perform
-      po_exceptionnelle_closed_since_1_month = PlageOuverture.where(recurrence: nil).where(first_day: ..1.month.ago)
-      po_reccurent_closed_since_1_month = PlageOuverture.where(recurrence_ends_at: ..1.month.ago)
-      po_exceptionnelle_closed_since_1_month.or(po_reccurent_closed_since_1_month).destroy_all
+      po_exceptionnelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)
+      po_reccurent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
+      po_exceptionnelle_closed_since_1_year.or(po_reccurent_closed_since_1_year).each do |po|
+        po.skip_webhooks = true
+        po.destroy
+      end
     end
   end
 

--- a/spec/jobs/cron_job/destroy_old_plage_ouverture_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_plage_ouverture_job_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 describe CronJob::DestroyOldPlageOuvertureJob do
-  it "Destroy exceptional po closed since 2 months" do
+  it "Destroy exceptional po closed since 2 years" do
     now = Time.zone.parse("20220405 10:00")
     travel_to(now)
-    po_exceptionelle_closed_since_2_months = create(:plage_ouverture, first_day: now - 2.months, recurrence: nil)
+    po_exceptionelle_closed_since_2_years = create(:plage_ouverture, first_day: now - 2.years, recurrence: nil)
 
     described_class.new.perform
 
-    expect(PlageOuverture.all).not_to include(po_exceptionelle_closed_since_2_months)
+    expect(PlageOuverture.all).not_to include(po_exceptionelle_closed_since_2_years)
   end
 
   it "keep exceptional po closed since 10 days" do
@@ -21,20 +21,20 @@ describe CronJob::DestroyOldPlageOuvertureJob do
     expect(PlageOuverture.all).to include(po_exceptionelle_closed_since_10_days)
   end
 
-  it "destroy recurrence po closed since 2 months" do
+  it "destroy recurrence po closed since 2 years" do
     now = Time.zone.parse("20220405 10:00")
     travel_to(now)
-    po_recurrence_closed_since_2_months = create(:plage_ouverture, first_day: now - 5.months, recurrence: Montrose.every(:week, starts: now - 5.months, until: now - 2.months))
+    po_recurrence_closed_since_2_years = create(:plage_ouverture, first_day: now - 3.years, recurrence: Montrose.every(:week, starts: now - 3.years, until: now - 2.years))
 
     described_class.new.perform
 
-    expect(PlageOuverture.all).not_to include(po_recurrence_closed_since_2_months)
+    expect(PlageOuverture.all).not_to include(po_recurrence_closed_since_2_years)
   end
 
   it "keep recurrence po closed since 10 days" do
     now = Time.zone.parse("20220405 10:00")
     travel_to(now)
-    po_recurrence_closed_since_10_days = create(:plage_ouverture, first_day: now - 5.months, recurrence: Montrose.every(:week, starts: now - 5.months, until: now - 10.days))
+    po_recurrence_closed_since_10_days = create(:plage_ouverture, first_day: now - 3.years, recurrence: Montrose.every(:week, starts: now - 3.years, until: now - 10.days))
 
     described_class.new.perform
 
@@ -44,7 +44,7 @@ describe CronJob::DestroyOldPlageOuvertureJob do
   it "keep recurrence po still open" do
     now = Time.zone.parse("20220405 10:00")
     travel_to(now)
-    po_recurrence_not_closed = create(:plage_ouverture, first_day: now - 5.months, recurrence: Montrose.every(:week, starts: now - 5.months, until: nil))
+    po_recurrence_not_closed = create(:plage_ouverture, first_day: now - 3.years, recurrence: Montrose.every(:week, starts: now - 3.years, until: nil))
 
     described_class.new.perform
 


### PR DESCRIPTION
Close #2428

Nouvelle PR suite à une mauvaise manip au cour de la précédente.

Les plages d'ouvertures de plus d'un an seront supprimées.

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
