### PR TITLE
précise "source-map" pour les devtool

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require("webpack")
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
+  devtool: "source-map",
   entry: {
     administrate: "./app/javascript/administrate",
     application: "./app/javascript/application",


### PR DESCRIPTION
Remise en place d'une option `devtool` pour webpack. 

Cette PR est aussi là pour vérifier que ça ne posera pas de problème en prod.

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
