### PR TITLE
Correctif pour la recherche de créneaux lorsque la prochaine plage d'ouverture est après le délai max de réservation

### DIFF
--- a/app/services/next_availability_service.rb
+++ b/app/services/next_availability_service.rb
@@ -5,12 +5,15 @@ class NextAvailabilityService
     available_creneau = nil
     from = from.to_datetime
 
-    from.step(from + 6.months, 7).find do |date|
+    max_search_date = [motif.end_booking_delay.to_datetime, from + 6.months].min
+
+    from.step(max_search_date, 7).find do |date|
       # NOTE: LOOP 2 loop here for ~ 27 weeks
       # We break out of the loop once we find a creneau.
-      #
 
-      creneaux = SlotBuilder.available_slots(motif, lieu, date..(date + 7.days), OffDays.all_in_date_range(date..(date + 7.days)), agents)
+      max_creneau_date = [motif.end_booking_delay.to_datetime, date + 7.days].min
+
+      creneaux = SlotBuilder.available_slots(motif, lieu, date..max_creneau_date, OffDays.all_in_date_range(date..max_creneau_date), agents)
       # NOTE: We build the whole list of creneaux of the week just to return the first one.
       available_creneau = creneaux.min_by(&:starts_at) if creneaux.any?
     end

--- a/spec/features/users/user_can_search_for_creneaux_spec.rb
+++ b/spec/features/users/user_can_search_for_creneaux_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe "User can search for creneaux" do
+  let(:now) { Time.zone.parse("2021-12-13 8:00") }
+
+  let!(:territory92) { create(:territory, departement_number: "92") }
+  let!(:organisation) { create(:organisation, territory: territory92) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+
+  before { travel_to(now) }
+
+  context "when the next creneau is after the max booking delay" do
+    let!(:motif) { create(:motif, name: "Vaccination", reservable_online: true, organisation: organisation, max_booking_delay: 7.days) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation) }
+
+    it "doesn't show a next availability date", js: true do
+      visit root_path
+      fill_in("search_where", with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
+
+      # Fake autocomplete
+      page.execute_script("document.querySelector('#search_departement').value = '92'")
+      page.execute_script("document.querySelector('#search_submit').disabled = false")
+
+      click_button("Rechercher")
+
+      select(motif.service.name, from: "search_service")
+      click_button("Choisir ce service")
+
+      select(motif.name, from: "search_motif_name_with_location_type")
+      click_button("Choisir ce motif")
+
+      expect(page).to have_content("Aucune disponibilité")
+    end
+  end
+end


### PR DESCRIPTION
Fix pour https://zammad10.ethibox.fr/#ticket/zoom/148

Le bug est que la recherche du prochain créneau ne prenait pas en compte le délai maximum de réservation.

Avant : 
<img width="934" alt="Capture d’écran 2022-05-09 à 11 18 00" src="https://user-images.githubusercontent.com/1840367/167379877-b676a9fa-dd89-4220-bd68-1839a5dea8f7.png">
On indique qu'un créneau est disponible, mais à l'étape suivante il est impossible d'en réserver.

Après : 

<img width="915" alt="Capture d’écran 2022-05-09 à 11 18 05" src="https://user-images.githubusercontent.com/1840367/167379871-f7e16240-29d2-4b2e-89a1-cc06b7046b4b.png">
On indique correctement qu'aucun créneau n'est disponible


REVUE
- [x] Relecture du code
- [x] Test sur la review app / en local
