### PR TITLE
Cleanup stats views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,4 +97,8 @@ module ApplicationHelper
       name
     end
   end
+
+  def self_anchor(identifier, &block)
+    tag.a(id: identifier, href: "##{identifier}", data: { turbolinks: false }, &block)
+  end
 end

--- a/app/javascript/stylesheets/components/_cards.scss
+++ b/app/javascript/stylesheets/components/_cards.scss
@@ -14,6 +14,11 @@
   font-size: 1.5rem;
 }
 
+.card-subtitle{
+  color: $blue;
+  font-size: 1.25rem;
+}
+
 .card-hoverable {
   border: 1px solid transparent;
   &:hover {

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -11,25 +11,30 @@
 .card.mb-5
   .card-body
     = link_to "stats", rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
-    h4.card-title#rdvs RDV créés (#{@stats.rdvs.count})
+    = self_anchor "rdvs"
+      h4.card-title RDV créés (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
-    h4.card-title#rdvs-service RDV créés par service (#{@stats.rdvs.count})
+    = self_anchor "rdvs-service"
+      h4.card-title RDV créés par service (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, by_service: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
-    h4.card-title#rdvs-type RDV par type (#{@stats.rdvs.count})
+    = self_anchor "rdvs-type"
+      h4.card-title RDV par type (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, by_location_type: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
-    h4.card-title#usagers Usagers créés (#{@stats.users_active.count})
+    = self_anchor "usagers"
+      h4.card-title Usagers créés (#{@stats.users_active.count})
     = column_chart users_admin_organisation_stats_path(@organisation, departement: @departement)
 
 .card.mb-5
   .card-body
-    h4.card-title#agents Agents créés (#{@stats.agents_for_default_range.count})
+    = self_anchor "agents"
+      h4.card-title Agents créés (#{@stats.agents_for_default_range.count})
     = column_chart agents_stats_path(departement: @departement)

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -12,24 +12,24 @@
   .card-body
     = link_to "stats", rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
     h4.card-title.mb-3 RDV créés (#{@stats.rdvs.count})
-    = column_chart rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json), stacked: true
+    = column_chart rdvs_admin_organisation_stats_path(@organisation, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés par service (#{@stats.rdvs.count})
-    = column_chart rdvs_admin_organisation_stats_path(@organisation, by_service: true, departement: @departement, format: :json), stacked: true
+    = column_chart rdvs_admin_organisation_stats_path(@organisation, by_service: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV par type (#{@stats.rdvs.count})
-    = column_chart rdvs_admin_organisation_stats_path(@organisation, by_location_type: true, departement: @departement, format: :json), stacked: true
+    = column_chart rdvs_admin_organisation_stats_path(@organisation, by_location_type: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 Usagers créés (#{@stats.users_active.count})
-    = column_chart users_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
+    = column_chart users_admin_organisation_stats_path(@organisation, departement: @departement)
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 Agents créés (#{@stats.agents_for_default_range.count})
-    = column_chart agents_stats_path(departement: @departement, format: :json)
+    = column_chart agents_stats_path(departement: @departement)

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -11,25 +11,25 @@
 .card.mb-5
   .card-body
     = link_to "stats", rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
-    h4.card-title.mb-3 RDV créés (#{@stats.rdvs.count})
+    h4.card-title#rdvs RDV créés (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
-    h4.card-title.mb-3 RDV créés par service (#{@stats.rdvs.count})
+    h4.card-title#rdvs-service RDV créés par service (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, by_service: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
-    h4.card-title.mb-3 RDV par type (#{@stats.rdvs.count})
+    h4.card-title#rdvs-type RDV par type (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, by_location_type: true, departement: @departement), stacked: true
 
 .card.mb-5
   .card-body
-    h4.card-title.mb-3 Usagers créés (#{@stats.users_active.count})
+    h4.card-title#usagers Usagers créés (#{@stats.users_active.count})
     = column_chart users_admin_organisation_stats_path(@organisation, departement: @departement)
 
 .card.mb-5
   .card-body
-    h4.card-title.mb-3 Agents créés (#{@stats.agents_for_default_range.count})
+    h4.card-title#agents Agents créés (#{@stats.agents_for_default_range.count})
     = column_chart agents_stats_path(departement: @departement)

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -10,26 +10,26 @@
 
 .card.mb-5
   .card-body
-    = link_to "stats", add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), departement: @departement)
+    = link_to "stats", rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
     h4.card-title.mb-3 RDV créés (#{@stats.rdvs.count})
-    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), departement: @departement), stacked: true
+    = column_chart rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV créés par service (#{@stats.rdvs.count})
-    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), by_service: true, departement: @departement), stacked: true
+    = column_chart rdvs_admin_organisation_stats_path(@organisation, by_service: true, departement: @departement, format: :json), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 RDV par type (#{@stats.rdvs.count})
-    = column_chart add_query_string_params_to_url(rdvs_admin_organisation_stats_path(@organisation, format: :json), by_location_type: true, departement: @departement), stacked: true
+    = column_chart rdvs_admin_organisation_stats_path(@organisation, by_location_type: true, departement: @departement, format: :json), stacked: true
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 Usagers créés (#{@stats.users_active.count})
-    = column_chart add_query_string_params_to_url(users_admin_organisation_stats_path(@organisation, format: :json), departement: @departement)
+    = column_chart users_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
 
 .card.mb-5
   .card-body
     h4.card-title.mb-3 Agents créés (#{@stats.agents_for_default_range.count})
-    = column_chart add_query_string_params_to_url(agents_stats_path(format: :json), departement: @departement)
+    = column_chart agents_stats_path(departement: @departement, format: :json)

--- a/app/views/admin/stats/index.html.slim
+++ b/app/views/admin/stats/index.html.slim
@@ -9,5 +9,6 @@
 
 .card.mb-5
   .card-body
-    h4.card-title#rdvs RDV créés (#{@stats.rdvs.count})
+    = self_anchor "rdvs"
+      h4.card-title RDV créés (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_agent_stats_path(current_organisation, current_agent), stacked: true

--- a/app/views/admin/stats/index.html.slim
+++ b/app/views/admin/stats/index.html.slim
@@ -9,5 +9,5 @@
 
 .card.mb-5
   .card-body
-    h4.card-title.mb-3 RDV créés (#{@stats.rdvs.count})
+    h4.card-title#rdvs RDV créés (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_agent_stats_path(current_organisation, current_agent), stacked: true

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -59,7 +59,7 @@
           .card-header
             h2 RDV créés par département(#{@stats.rdvs.count})
           .card-body
-            = column_chart rdvs_stats_path(by_departement: true, departement: @departement), stacked: true
+            = column_chart rdvs_stats_path(by_departement: true), stacked: true
 
       .card.mb-5
         .card-header

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -20,9 +20,8 @@
     h3 Ce departement n'utilise pas RDV-Solidarités.
   - else
       .card.mb-5
-        .card-header
-          h2 Nombre de RDV par statut
         .card-body
+          h2.card-title Nombre de RDV par statut
           .row
             .col-lg-4
               .px-1
@@ -49,34 +48,29 @@
                   count: @stats.rdvs.count
 
       .card.mb-5
-        .card-header
-          h2 RDV créés (#{@stats.rdvs.count})
         .card-body
+          h2.card-title#rdvs RDV créés (#{@stats.rdvs.count})
           = column_chart rdvs_stats_path(departement: @departement), stacked: true
 
       - unless @departement.present?
         .card.mb-5
-          .card-header
-            h2 RDV créés par département(#{@stats.rdvs.count})
           .card-body
+            h2.card-title#rdvs-departement RDV créés par département(#{@stats.rdvs.count})
             = column_chart rdvs_stats_path(by_departement: true), stacked: true
 
       .card.mb-5
-        .card-header
-          h2 RDV créés par service (#{@stats.rdvs.count})
         .card-body
+          h2.card-title#rdvs-service RDV créés par service (#{@stats.rdvs.count})
           = column_chart rdvs_stats_path(by_service: true, departement: @departement), stacked: true
 
       .card.mb-5
-        .card-header
-          h2 RDV par type (#{@stats.rdvs.count})
         .card-body
+          h2.card-title#rdvs-type RDV par type (#{@stats.rdvs.count})
           = column_chart rdvs_stats_path(by_location_type: true, departement: @departement), stacked: true
 
       .card.mb-5
-        .card-header
-          h2 RDV par statut
         .card-body
+          h2.card-title#rdvs-status RDV par statut
           /
             Note: colors are synced manually with the status css and the order of the stats.
             From stat.rb, Stat#rdvs_group_by_status:
@@ -91,27 +85,23 @@
           = column_chart rdvs_stats_path(by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%", colors: colors
 
       .card.mb-5
-        .card-header
-          h2= "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
         .card-body
+          h2.card-title#notifications = "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
           - %i[event channel result].each do |attribute|
-            h3 Par #{Receipt.human_attribute_name(attribute).downcase}
+            h3.card-subtitle{id= "notifications-#{attribute}"} Par #{Receipt.human_attribute_name(attribute).downcase}
             = column_chart receipts_stats_path(group_by: attribute, departement: @departement), stacked: true
 
       .card.mb-5
-        .card-header
-          h2 Usagers créés (#{@stats.users_active.count})
         .card-body
+          h2.card-title#usagers Usagers créés (#{@stats.users_active.count})
           = column_chart users_stats_path(departement: @departement)
 
       .card.mb-5
-        .card-header
-          h2 Agents créés (#{@stats.agents_for_default_range.count})
         .card-body
+          h2.card-title#agents Agents créés (#{@stats.agents_for_default_range.count})
           = column_chart agents_stats_path(departement: @departement)
 
   .card.mb-5
-    .card-header
-      h2 Organisations créées (#{@stats.organisations.count})
     .card-body
+      h2.card-title#organisations Organisations créées (#{@stats.organisations.count})
       = column_chart organisations_stats_path(departement: @departement)

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -52,26 +52,26 @@
         .card-header
           h2 RDV créés (#{@stats.rdvs.count})
         .card-body
-          = column_chart add_query_string_params_to_url(rdvs_stats_path, departement: @departement), stacked: true
+          = column_chart rdvs_stats_path(departement: @departement), stacked: true
 
       - unless @departement.present?
         .card.mb-5
           .card-header
             h2 RDV créés par département(#{@stats.rdvs.count})
           .card-body
-            = column_chart add_query_string_params_to_url(rdvs_stats_path, by_departement: true, departement: @departement), stacked: true
+            = column_chart rdvs_stats_path(by_departement: true, departement: @departement), stacked: true
 
       .card.mb-5
         .card-header
           h2 RDV créés par service (#{@stats.rdvs.count})
         .card-body
-          = column_chart add_query_string_params_to_url(rdvs_stats_path, by_service: true, departement: @departement), stacked: true
+          = column_chart rdvs_stats_path(by_service: true, departement: @departement), stacked: true
 
       .card.mb-5
         .card-header
           h2 RDV par type (#{@stats.rdvs.count})
         .card-body
-          = column_chart add_query_string_params_to_url(rdvs_stats_path, by_location_type: true, departement: @departement), stacked: true
+          = column_chart rdvs_stats_path(by_location_type: true, departement: @departement), stacked: true
 
       .card.mb-5
         .card-header
@@ -88,7 +88,7 @@
               "revoked": $teal, #02a8b5
               "noshow": $danger, #fa5c7c
           - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
-          = column_chart add_query_string_params_to_url(rdvs_stats_path, by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%", colors: colors
+          = column_chart rdvs_stats_path(by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%", colors: colors
 
       .card.mb-5
         .card-header
@@ -102,16 +102,16 @@
         .card-header
           h2 Usagers créés (#{@stats.users_active.count})
         .card-body
-          = column_chart add_query_string_params_to_url(users_stats_path, departement: @departement)
+          = column_chart users_stats_path(departement: @departement)
 
       .card.mb-5
         .card-header
           h2 Agents créés (#{@stats.agents_for_default_range.count})
         .card-body
-          = column_chart add_query_string_params_to_url(agents_stats_path, departement: @departement)
+          = column_chart agents_stats_path(departement: @departement)
 
   .card.mb-5
     .card-header
       h2 Organisations créées (#{@stats.organisations.count})
     .card-body
-      = column_chart add_query_string_params_to_url(organisations_stats_path, departement: @departement)
+      = column_chart organisations_stats_path(departement: @departement)

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -49,28 +49,33 @@
 
       .card.mb-5
         .card-body
-          h2.card-title#rdvs RDV créés (#{@stats.rdvs.count})
+          = self_anchor "rdvs"
+           h2.card-title RDV créés (#{@stats.rdvs.count})
           = column_chart rdvs_stats_path(departement: @departement), stacked: true
 
       - unless @departement.present?
         .card.mb-5
           .card-body
-            h2.card-title#rdvs-departement RDV créés par département(#{@stats.rdvs.count})
+            = self_anchor "rdvs-departement"
+              h2.card-title RDV créés par département(#{@stats.rdvs.count})
             = column_chart rdvs_stats_path(by_departement: true), stacked: true
 
       .card.mb-5
         .card-body
-          h2.card-title#rdvs-service RDV créés par service (#{@stats.rdvs.count})
+          = self_anchor "rdvs-service"
+            h2.card-title RDV créés par service (#{@stats.rdvs.count})
           = column_chart rdvs_stats_path(by_service: true, departement: @departement), stacked: true
 
       .card.mb-5
         .card-body
-          h2.card-title#rdvs-type RDV par type (#{@stats.rdvs.count})
+          = self_anchor "rdvs-type"
+            h2.card-title RDV par type (#{@stats.rdvs.count})
           = column_chart rdvs_stats_path(by_location_type: true, departement: @departement), stacked: true
 
       .card.mb-5
         .card-body
-          h2.card-title#rdvs-status RDV par statut
+          = self_anchor "rdvs-status"
+            h2.card-title RDV par statut
           /
             Note: colors are synced manually with the status css and the order of the stats.
             From stat.rb, Stat#rdvs_group_by_status:
@@ -86,22 +91,26 @@
 
       .card.mb-5
         .card-body
-          h2.card-title#notifications = "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
+          = self_anchor "notifications"
+            h2.card-title "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
           - %i[event channel result].each do |attribute|
-            h3.card-subtitle{id= "notifications-#{attribute}"} Par #{Receipt.human_attribute_name(attribute).downcase}
+            h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
             = column_chart receipts_stats_path(group_by: attribute, departement: @departement), stacked: true
 
       .card.mb-5
         .card-body
-          h2.card-title#usagers Usagers créés (#{@stats.users_active.count})
+          = self_anchor "usagers"
+            h2.card-title Usagers créés (#{@stats.users_active.count})
           = column_chart users_stats_path(departement: @departement)
 
       .card.mb-5
         .card-body
-          h2.card-title#agents Agents créés (#{@stats.agents_for_default_range.count})
+          = self_anchor "agents"
+            h2.card-title Agents créés (#{@stats.agents_for_default_range.count})
           = column_chart agents_stats_path(departement: @departement)
 
   .card.mb-5
     .card-body
-      h2.card-title#organisations Organisations créées (#{@stats.organisations.count})
+      = self_anchor "organisations"
+        h2.card-title Organisations créées (#{@stats.organisations.count})
       = column_chart organisations_stats_path(departement: @departement)


### PR DESCRIPTION
Miettes de #2438

Ça se lit probablement plus simplement commit par commit, même si ce n’est globalement pas très complexe:

* Do not use add_query_string_params_to_url when unnecessary
* Do not explicitly specify the format in stats path sources
* Remove a nil param
* Add identifiers to stats cards and make them consistent
* Make headers self-referencing anchors

AVANT LA REVUE
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

REVUE
- [x] Relecture du code
- [ ] Test sur la review app / en local
