### PR TITLE
Ne pas utiliser le max_booking_delay pour les réservations faites par les agents

### DIFF
--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -4,7 +4,7 @@ module Users::CreneauxSearchConcern
   extend ActiveSupport::Concern
 
   def next_availability
-    NextAvailabilityService.find(motif, @lieu, motif.start_booking_delay, agents)
+    NextAvailabilityService.find(motif, @lieu, agents, from: motif.start_booking_delay, to: motif.end_booking_delay)
   end
 
   def creneaux

--- a/app/services/next_availability_service.rb
+++ b/app/services/next_availability_service.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 class NextAvailabilityService
-  def self.find(motif, lieu, from, agents)
+  def self.find(motif, lieu, agents, from:, to: nil)
     available_creneau = nil
     from = from.to_datetime
+    to = to&.to_datetime || (from + 6.months)
 
-    max_search_date = [motif.end_booking_delay.to_datetime, from + 6.months].min
-
-    from.step(max_search_date, 7).find do |date|
+    from.step(to, 7).find do |date|
       # NOTE: LOOP 2 loop here for ~ 27 weeks
       # We break out of the loop once we find a creneau.
 
-      max_creneau_date = [motif.end_booking_delay.to_datetime, date + 7.days].min
+      max_creneau_date = [to, date + 7.days].min
 
       creneaux = SlotBuilder.available_slots(motif, lieu, date..max_creneau_date, OffDays.all_in_date_range(date..max_creneau_date), agents)
       # NOTE: We build the whole list of creneaux of the week just to return the first one.

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -12,7 +12,7 @@ class SearchCreneauxForAgentsService < BaseService
   def build_result(lieu)
     # utiliser les ids des agents pour ne pas faire de requêtes supplémentaire
     # Utilise le date_range.end + 1 pour chercher la date suivante du créneau affiché
-    next_availability = NextAvailabilityService.find(@form.motif, lieu, @form.date_range.end + 1.day, all_agents)
+    next_availability = NextAvailabilityService.find(@form.motif, lieu, all_agents, from: @form.date_range.end + 1.day)
     creneaux = SlotBuilder.available_slots(@form.motif, lieu, @form.date_range, OffDays.all_in_date_range(@form.date_range), all_agents)
     return nil if creneaux.empty? && next_availability.nil?
 

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -3,40 +3,65 @@
 describe "Agent can create a Rdv with creneau search" do
   include UsersHelper
 
-  let!(:organisation) { create(:organisation) }
-  let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
-  let!(:agent2) { create(:agent, first_name: "Robert", last_name: "Voila", service: service, basic_role_in_organisations: [organisation]) }
-  let!(:agent3) { create(:agent, first_name: "Michel", last_name: "Lapin", service: service, basic_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, reservable_online: true, service: service, organisation: organisation) }
-  let!(:user) { create(:user, organisations: [organisation]) }
-  let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, agent: agent, organisation: organisation) }
-  let!(:lieu2) { create(:lieu, organisation: organisation) }
-  let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu2, agent: agent2, organisation: organisation) }
-  let!(:plage_ouverture3) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, agent: agent3, organisation: organisation) }
-
   before do
-    travel_to(Time.zone.local(2019, 7, 22))
+    travel_to(now)
     login_as(agent, scope: :agent)
-    visit admin_organisation_agent_searches_path(organisation)
   end
 
-  it "default", js: true do
-    expect(page).to have_content("Trouver un RDV")
-    select(motif.name, from: "motif_id")
-    click_button("Afficher les créneaux")
+  let!(:organisation) { create(:organisation) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
 
-    # Display results for both lieux
-    expect(page).to have_content(plage_ouverture.lieu.address)
-    expect(page).to have_content(plage_ouverture2.lieu.address)
+  context "default" do
+    let!(:organisation) { create(:organisation) }
+    let!(:service) { create(:service) }
+    let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
+    let!(:agent2) { create(:agent, first_name: "Robert", last_name: "Voila", service: service, basic_role_in_organisations: [organisation]) }
+    let!(:agent3) { create(:agent, first_name: "Michel", last_name: "Lapin", service: service, basic_role_in_organisations: [organisation]) }
+    let!(:motif) { create(:motif, reservable_online: true, service: service, organisation: organisation) }
+    let!(:user) { create(:user, organisations: [organisation]) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, agent: agent, organisation: organisation) }
+    let!(:lieu2) { create(:lieu, organisation: organisation) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu2, agent: agent2, organisation: organisation) }
+    let!(:plage_ouverture3) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, agent: agent3, organisation: organisation) }
+    let(:now) { Time.zone.local(2019, 7, 22) }
 
-    # Add a filter on lieu
-    select(lieu.name, from: "lieu_ids")
-    click_button("Afficher les créneaux")
-    expect(page).to have_content(plage_ouverture.lieu.address)
-    expect(page).not_to have_content(plage_ouverture2.lieu.address)
+    it "default", js: true do
+      visit admin_organisation_agent_searches_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      select(motif.name, from: "motif_id")
+      click_button("Afficher les créneaux")
 
-    # TODO : refaire un parcours jusqu'à l'enregistrement du RDV
+      # Display results for both lieux
+      expect(page).to have_content(plage_ouverture.lieu.address)
+      expect(page).to have_content(plage_ouverture2.lieu.address)
+
+      # Add a filter on lieu
+      select(lieu.name, from: "lieu_ids")
+      click_button("Afficher les créneaux")
+      expect(page).to have_content(plage_ouverture.lieu.address)
+      expect(page).not_to have_content(plage_ouverture2.lieu.address)
+
+      # TODO : refaire un parcours jusqu'à l'enregistrement du RDV
+    end
+  end
+
+  context "when the motif is bookable online and the next creneau is after the max booking delay" do
+    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+    let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, max_booking_delay: 7.days, service: agent.service) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation) }
+
+    let(:now) { Time.zone.parse("2021-12-13 8:00") }
+
+    it "still allows the agent to book a rdv, because the booking delays should only apply to agents", js: true do
+      visit admin_organisation_agent_searches_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      select(motif.name, from: "motif_id")
+      click_button("Afficher les créneaux")
+
+      # Display results
+      expect(page).to have_content(plage_ouverture.lieu.address)
+      expect(page).to have_content("Créneaux disponibles")
+    end
   end
 end

--- a/spec/services/next_availability_service_spec.rb
+++ b/spec/services/next_availability_service_spec.rb
@@ -17,7 +17,7 @@ describe NextAvailabilityService, type: :service do
         create(:plage_ouverture,
                motifs: [motif], lieu: lieu, agent: agent, organisation: organisation,
                first_day: today + 8.days, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
-        next_available = described_class.find(motif, lieu, today, [])
+        next_available = described_class.find(motif, lieu, [], from: today)
         expect(next_available.starts_at).to eq((today + 8.days).in_time_zone + 9.hours)
       end
     end
@@ -31,7 +31,7 @@ describe NextAvailabilityService, type: :service do
                agent: agent, organisation: organisation,
                first_day: today, start_time: Tod::TimeOfDay.new(9), end_day: today, end_time: Tod::TimeOfDay.new(12, 0))
 
-        next_available = described_class.find(motif, lieu, today, [])
+        next_available = described_class.find(motif, lieu, [], from: today)
         expect(next_available).to be_nil
       end
 
@@ -45,7 +45,7 @@ describe NextAvailabilityService, type: :service do
                agent: agent, organisation: organisation,
                first_day: today, start_time: Tod::TimeOfDay.new(9), end_day: today, end_time: Tod::TimeOfDay.new(12, 0))
 
-        next_available = described_class.find(motif, lieu, today, [])
+        next_available = described_class.find(motif, lieu, [], from: today)
         expect(next_available.starts_at).to eq(today.in_time_zone + 1.month + 9.hours)
       end
     end
@@ -62,7 +62,7 @@ describe NextAvailabilityService, type: :service do
                motif: motif,
                starts_at: today.in_time_zone + 9.hours, duration_in_min: 120,
                status: "unknown")
-        next_creneau = described_class.find(motif, lieu, today, [])
+        next_creneau = described_class.find(motif, lieu, [], from: today)
         expect(next_creneau).to be_nil
       end
 
@@ -78,7 +78,7 @@ describe NextAvailabilityService, type: :service do
                starts_at: (today + 8.days).in_time_zone + 9.hours, duration_in_min: 120,
                status: "revoked")
 
-        next_creneau = described_class.find(motif, lieu, today, [])
+        next_creneau = described_class.find(motif, lieu, [], from: today)
         expect(next_creneau.starts_at).to eq((today + 8.days).in_time_zone + 9.hours)
       end
 
@@ -96,7 +96,7 @@ describe NextAvailabilityService, type: :service do
                first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
                recurrence: Montrose.every(:month, starts: today))
 
-        next_creneau = described_class.find(motif, lieu, today, [])
+        next_creneau = described_class.find(motif, lieu, [], from: today)
         expect(next_creneau.starts_at).to eq(today.in_time_zone + 1.month + 9.hours)
       end
     end
@@ -111,7 +111,7 @@ describe NextAvailabilityService, type: :service do
                first_day: other_agent_start_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
                agent: other_agent, organisation: organisation)
         wanted_agents = [agent.id, other_agent.id]
-        next_creneau = described_class.find(motif, lieu, today, wanted_agents)
+        next_creneau = described_class.find(motif, lieu, wanted_agents, from: today)
         expect(next_creneau.starts_at).to eq(today + 7.days + 9.hours)
       end
 
@@ -121,7 +121,7 @@ describe NextAvailabilityService, type: :service do
                first_day: other_agent_start_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
                agent: other_agent, organisation: organisation)
         wanted_agents = [other_agent.id]
-        next_creneau = described_class.find(motif, lieu, today, wanted_agents)
+        next_creneau = described_class.find(motif, lieu, wanted_agents, from: today)
         expect(next_creneau.starts_at).to eq(other_agent_start_day + 9.hours)
       end
     end


### PR DESCRIPTION
Bug introduit dans https://github.com/betagouv/rdv-solidarites.fr/pull/2450/files : On s'est mis à appliquer le délai max de réservation aux agents, et non pas uniquement aux usagers.

Plutôt que systématiquement utiliser le `Motif#end_booking_delay` dans le NextAvailabilityService, on bouge cette logique métier un étage plus haut (et c'est plus cohérent), et on ajoute un paramètre optionnel de date max au NextAvailabilityService.

Comme pour tous les bugfix, il y a un test de non-régression.

Cette PR a malheureusement un air de déjà vu, puisqu'elle fait écho à ce fix d'il y a quelques mois pour les délais min : https://github.com/betagouv/rdv-solidarites.fr/pull/2170. Je me demande presque s'il nous faut quelque chose dans le nommage pour se souvenir que des délais ne s'appliquent qu'aux usagers ? (genre `start_user_booking_delay` ?)

REVUE
- [ ] Relecture du code
- [ ] Test sur la review app / en local
