### PR TITLE
Mini améliorations du template de PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,12 @@
-Close #issue_number
+Closes #issue_number
 
-AVANT LA REVUE
+# Checklist
+
+Avant la revue :
 - [ ] Préparer des captures de l’interface avant et après
 - [ ] Nettoyer les commits pour faciliter la relecture
 - [ ] Supprimer les éventuels logs de test et le code mort
 
-REVUE
+Revue :
 - [ ] Relecture du code
 - [ ] Test sur la review app / en local


### PR DESCRIPTION
Je trouve l'usage de "Closes" plus parlant que "Close" : 

> This PR close**s** that issue.

------------

Et pour l'usage des headings en markdown, je me suis dit que ça nous permettrait de faire des descriptions de PR dans ce style : 

> Closes #issue_number
> 
> # Ce que j'ai fait
> 
> J'ai fait des trucs
> 
> ## Premier truc
> 
> C'était simple
> 
> ## Second truc
> 
> C'était moins simple
> 
> # Une note sur les specs
> 
> Ah vraiment les tests c'est rigolo.
> 
> # Checklist
> 
> Avant la revue :
> - [ ] Préparer des captures de l’interface avant et après
> - [ ] Nettoyer les commits pour faciliter la relecture
> - [ ] Supprimer les éventuels logs de test et le code mort
> 
> Revue :
> - [ ] Relecture du code
> - [ ] Test sur la review app / en local