### PR TITLE
Rubocop : forcer les virgules en dernière ligne des Array / Hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,4 +182,8 @@ Style/StringLiterals:
   Exclude:
     - "config/**/*"
 
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
 
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma

--- a/Guardfile
+++ b/Guardfile
@@ -51,7 +51,7 @@ guard :rspec, cmd: "bin/rspec" do
     [
       rspec.spec.call("routing/#{m[1]}_routing"),
       rspec.spec.call("controllers/#{m[1]}_controller"),
-      rspec.spec.call("acceptance/#{m[1]}")
+      rspec.spec.call("acceptance/#{m[1]}"),
     ]
   end
 

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -28,7 +28,7 @@ class Admin::AbsencesController < AgentAuthController
       defaults = {
         first_day: Time.zone.tomorrow,
         start_time: Tod::TimeOfDay.new(9),
-        end_time: Tod::TimeOfDay.new(18)
+        end_time: Tod::TimeOfDay.new(18),
       }
     end
 

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -32,7 +32,7 @@ class Admin::PlageOuverturesController < AgentAuthController
       defaults = {
         first_day: Time.zone.now,
         start_time: Tod::TimeOfDay.new(9),
-        end_time: Tod::TimeOfDay.new(12)
+        end_time: Tod::TimeOfDay.new(12),
       }
     end
     @plage_ouverture = PlageOuverture.new(

--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -6,7 +6,7 @@ class Admin::RdvWizardStepsController < AgentAuthController
   PERMITTED_PARAMS = [
     :motif_id, :duration_in_min, :starts_at, :lieu_id, :context, :service_id,
     :organisation_id, :ignore_benign_errors,
-    { agent_ids: [], user_ids: [], rdvs_users_attributes: {}, lieu_attributes: Rdv::ACCEPTED_NESTED_LIEU_ATTRIBUTES }
+    { agent_ids: [], user_ids: [], rdvs_users_attributes: {}, lieu_attributes: Rdv::ACCEPTED_NESTED_LIEU_ATTRIBUTES },
   ].freeze
 
   def new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,7 +18,7 @@ class Admin::UsersController < AgentAuthController
 
   PERMITTED_NESTED_ATTRIBUTES = {
     agent_ids: [],
-    user_profiles_attributes: %i[notes logement id organisation_id]
+    user_profiles_attributes: %i[notes logement id organisation_id],
   }.freeze
 
   def index
@@ -162,7 +162,7 @@ class Admin::UsersController < AgentAuthController
       view_locals: {
         current_organisation: current_organisation,
         from_modal: from_modal?,
-        return_location: params[:return_location]
+        return_location: params[:return_location],
       }
     )
   end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::BaseController < ActionController::Base
       next_page: objects.next_page,
       prev_page: objects.prev_page,
       total_pages: objects.total_pages,
-      total_count: objects.total_count
+      total_count: objects.total_count,
     }
 
     objects_klass = objects.klass
@@ -73,7 +73,7 @@ class Api::V1::BaseController < ActionController::Base
       status: :forbidden,
       json: {
         errors: [{ base: :forbidden }],
-        error_messages: [t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default)]
+        error_messages: [t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default)],
       }
     )
   end
@@ -95,7 +95,7 @@ class Api::V1::BaseController < ActionController::Base
       json: {
         success: false,
         errors: exception.record.errors.details,
-        error_messages: exception.record.errors.map { "#{_1.attribute} #{_1.message}" }
+        error_messages: exception.record.errors.map { "#{_1.attribute} #{_1.message}" },
       }
     )
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,7 +39,7 @@ class ApplicationController < ActionController::Base
     {
       id: user&.id,
       role: user&.class&.name || "Guest",
-      email: user&.email
+      email: user&.email,
     }.compact
   end
 

--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -24,7 +24,7 @@ module SuperAdmins
 
       if agent.errors.any?
         render :new, locals: {
-          page: Administrate::Page::Form.new(dashboard, resource)
+          page: Administrate::Page::Form.new(dashboard, resource),
         }
       else
         redirect_to(

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -49,7 +49,7 @@ class UserAuthController < ApplicationController
 
   def set_user_name_initials_verified
     cookies.encrypted[user_name_initials_cookie_name] = {
-      value: true, expires: 10.minutes.from_now
+      value: true, expires: 10.minutes.from_now,
     }
   end
 

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -4,7 +4,7 @@ class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
     :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code,
-    :street_ban_id, :invitation_token, :address, :motif_search_terms, { organisation_ids: [] }
+    :street_ban_id, :invitation_token, :address, :motif_search_terms, { organisation_ids: [] },
   ].freeze
   after_action :allow_iframe
   before_action :set_step_titles
@@ -89,7 +89,7 @@ class Users::RdvWizardStepsController < UserAuthController
                     :number_of_children,
                     :notify_by_email,
                     :notify_by_sms,
-                    { user_profiles_attributes: %i[logement id organisation_id] }
+                    { user_profiles_attributes: %i[logement id organisation_id] },
                   ])
   end
 end

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -43,7 +43,7 @@ class Users::RdvsController < UserAuthController
         address: (new_rdv_extra_params[:address] || new_rdv_extra_params[:where]),
         city_code: new_rdv_extra_params[:city_code], street_ban_id: new_rdv_extra_params[:street_ban_id],
         service: motif.service.id, motif_name_with_location_type: motif.name_with_location_type,
-        departement: new_rdv_extra_params[:departement], organisation_ids:  new_rdv_extra_params[:organisation_ids], invitation_token: invitation_token
+        departement: new_rdv_extra_params[:departement], organisation_ids:  new_rdv_extra_params[:organisation_ids], invitation_token: invitation_token,
       }
       redirect_to prendre_rdv_path(query), flash: { error: t(".creneau_unavailable") }
     end

--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -19,7 +19,7 @@ class AgentDashboard < Administrate::BaseDashboard
     invitation_sent_at: Field::DateTime,
     deleted_at: Field::DateTime,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/motif_dashboard.rb
+++ b/app/dashboards/motif_dashboard.rb
@@ -27,7 +27,7 @@ class MotifDashboard < Administrate::BaseDashboard
     max_booking_delay: Field::Number,
     deleted_at: Field::DateTime,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -19,7 +19,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     human_id: Field::String,
     territory: Field::BelongsTo,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/service_dashboard.rb
+++ b/app/dashboards/service_dashboard.rb
@@ -16,7 +16,7 @@ class ServiceDashboard < Administrate::BaseDashboard
     agents: Field::HasMany,
     motifs: Field::HasMany,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/super_admin_dashboard.rb
+++ b/app/dashboards/super_admin_dashboard.rb
@@ -13,7 +13,7 @@ class SuperAdminDashboard < Administrate::BaseDashboard
     id: Field::Number,
     email: Field::String,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -41,7 +41,7 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :email
+    :email,
   ].freeze
 
   # Overwrite this method to customize how super admins are displayed

--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -14,7 +14,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     departement_number: Field::String,
     name: Field::String,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -27,7 +27,7 @@ class UserDashboard < Administrate::BaseDashboard
     birth_date: Field::DateTime,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    deleted_at: Field::DateTime
+    deleted_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -54,7 +54,7 @@ class Admin::UserForm
       locals: {
         user: duplicate_result.user,
         attributes: duplicate_result.attributes,
-        **@view_locals
+        **@view_locals,
       }
     )
   end

--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -23,7 +23,7 @@ module Admin::RdvWizardFormConcern
       rdv_defaults = {
         agent_ids: [agent_author.id],
         organisation_id: organisation.id,
-        starts_at: Time.zone.now
+        starts_at: Time.zone.now,
       }
       @organisation = organisation
       @agent_author = agent_author
@@ -42,7 +42,7 @@ module Admin::RdvWizardFormConcern
       user_ids: rdv.rdvs_users&.map(&:user_id),
       agent_ids: rdv.agents&.map(&:id),
       context: rdv.context,
-      service_id: service_id
+      service_id: service_id,
     }
 
     if rdv.lieu.present?

--- a/app/helpers/agent_user_form_helper.rb
+++ b/app/helpers/agent_user_form_helper.rb
@@ -24,13 +24,13 @@ module AgentUserFormHelper
       relative: {
         "data-togglable": true,
         "data-responsability-type": "relative",
-        class: ("d-none" if user.responsability_type != :relative)
+        class: ("d-none" if user.responsability_type != :relative),
       },
       responsible: {
         "data-togglable": true,
         "data-responsability-type": "responsible",
-        class: ("d-none" if user.responsability_type != :responsible)
-      }
+        class: ("d-none" if user.responsability_type != :responsible),
+      },
     }
   end
 
@@ -48,9 +48,9 @@ module AgentUserFormHelper
     {
       input_html: {
         "data-togglable": true,
-        "data-responsability-type": "responsible"
+        "data-responsability-type": "responsible",
       },
-      disabled: user.responsability_type != :responsible
+      disabled: user.responsability_type != :responsible,
     }
   end
 
@@ -58,9 +58,9 @@ module AgentUserFormHelper
     {
       input_html: {
         "data-togglable": true,
-        "data-responsability-type": "relative"
+        "data-responsability-type": "relative",
       },
-      disabled: user.responsability_type != :relative
+      disabled: user.responsability_type != :relative,
     }
   end
 
@@ -69,9 +69,9 @@ module AgentUserFormHelper
       input_html: {
         "data-togglable": true,
         "data-responsability-type": "relative",
-        "data-relative-type": "new"
+        "data-relative-type": "new",
       },
-      disabled: !(user.responsability_type == :relative && user.responsible.new_and_blank?)
+      disabled: !(user.responsability_type == :relative && user.responsible.new_and_blank?),
     }
   end
 
@@ -80,9 +80,9 @@ module AgentUserFormHelper
       input_html: {
         "data-togglable": true,
         "data-responsability-type": "relative",
-        "data-relative-type": "existing"
+        "data-relative-type": "existing",
       },
-      disabled: !(user.responsability_type == :relative && !user.responsible.new_and_blank?)
+      disabled: !(user.responsability_type == :relative && !user.responsible.new_and_blank?),
     }
   end
 end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -43,7 +43,7 @@ module AgentsHelper
       "men-department-sectors" => "",
       "men-department-zones" => "",
       "men-department-setup-checklist" => "",
-      "men-department-zone-imports" => ""
+      "men-department-zone-imports" => "",
     }[content_for(:menu_item)]
   end
 
@@ -55,8 +55,8 @@ module AgentsHelper
       agent.reverse_full_name,
       agent.id,
       {
-        "data-url": send(path_helper_name, current_organisation, agent)
-      }
+        "data-url": send(path_helper_name, current_organisation, agent),
+      },
     ]
     select_tag(
       :planning_agent_select,
@@ -68,10 +68,10 @@ module AgentsHelper
           ajax: {
             url: admin_organisation_agents_path(current_organisation),
             dataType: "json",
-            delay: 250
-          }
+            delay: 250,
+          },
         },
-        "url-template": url_template
+        "url-template": url_template,
       }
     )
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,7 +29,7 @@ module ApplicationHelper
         value: form.object&.send(field)&.strftime("%d/%m/%Y"),
         data: { behaviour: "datepicker" },
         autocomplete: "off",
-        placeholder: "__/__/___"
+        placeholder: "__/__/___",
       }.deep_merge(input_html),
       **kwargs
     )

--- a/app/helpers/creneaux_helper.rb
+++ b/app/helpers/creneaux_helper.rb
@@ -27,7 +27,7 @@ module CreneauxHelper
       team_ids: form.team_ids,
       user_ids: form.user_ids,
       lieu_ids: form.lieu_ids,
-      context: form.context
+      context: form.context,
     }
   end
 

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -31,7 +31,7 @@ module MotifsHelper
     [["1/2 heure", 30.minutes], ["1 heure", 1.hour], ["2 heures", 2.hours],
      ["3 heures", 3.hours], ["6 heures", 6.hours], ["12 heures", 12.hours],
      ["1 jour", 1.day], ["2 jours", 2.days], ["3 jours", 3.days], ["1 semaine", 1.week], ["2 semaines", 2.weeks], ["3 semaines", 3.weeks],
-     ["1 mois", 1.month], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year]]
+     ["1 mois", 1.month], ["2 mois", 2.months], ["3 mois", 3.months], ["6 mois", 6.months], ["1 an", 1.year],]
   end
 
   def min_max_delay_int_to_human(int_value)

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -83,7 +83,7 @@ module PlageOuverturesHelper
       "thursday" => "jeudi",
       "friday" => "vendredi",
       "saturday" => "samedi",
-      "sunday" => "dimanche"
+      "sunday" => "dimanche",
     }
     weekdays[weekday]
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -96,7 +96,7 @@ module UsersHelper # rubocop:disable Metrics/ModuleLength
     relatives = user.relatives.merge(current_organisation.users).active
     [
       "Confirmez-vous la suppression de cet usager ?",
-      (I18n.t("users.soft_delete_confirm_message.relatives", count: relatives.size) if relatives.any?)
+      (I18n.t("users.soft_delete_confirm_message.relatives", count: relatives.size) if relatives.any?),
     ].select(&:present?).join("\n\n")
   end
 
@@ -145,7 +145,7 @@ module UsersHelper # rubocop:disable Metrics/ModuleLength
       "yahoo.fr" => { url: "https://fr.mail.yahoo.com", name: "Yahoo Mail" },
       "yahoo.com" => { url: "https://mail.yahoo.com", name: "Yahoo Mail" },
       "sfr.fr" => { url: "https://webmail.sfr.fr", name: "SFR Mail" },
-      "free.fr" => { url: "https://webmail.free.fr/", name: "Free Webmail" }
+      "free.fr" => { url: "https://webmail.free.fr/", name: "Free Webmail" },
     }[email_tld]
   end
 

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -15,7 +15,7 @@ class WebhookJob < ApplicationJob
       method: :post,
       headers: {
         "Content-Type" => "application/json; charset=utf-8",
-        "X-Lapin-Signature" => OpenSSL::HMAC.hexdigest("SHA256", webhook_endpoint.secret, payload)
+        "X-Lapin-Signature" => OpenSSL::HMAC.hexdigest("SHA256", webhook_endpoint.secret, payload),
       },
       body: payload,
       timeout: TIMEOUT
@@ -49,7 +49,7 @@ class WebhookJob < ApplicationJob
     error_messages_from_drome = [
       /^Can't update appointment/,
       /^Appointment already deleted/,
-      /^Appointment id doesn't exist/
+      /^Appointment id doesn't exist/,
     ]
     body["message"]&.match?(Regexp.union(error_messages_from_drome))
   rescue StandardError

--- a/app/mailers/admins/grc_92_mailer.rb
+++ b/app/mailers/admins/grc_92_mailer.rb
@@ -11,7 +11,7 @@ class Admins::Grc92Mailer < ApplicationMailer
       password: ENV["ALTERNATE_SMTP_PASSWORD"],
       address: ENV["ALTERNATE_SMTP_ADDRESS"],
       port: ENV["ALTERNATE_SMTP_PORT"],
-      authentication: ENV["ALTERNATE_SMTP_AUTHENTIFICATION"]
+      authentication: ENV["ALTERNATE_SMTP_AUTHENTIFICATION"],
     }
 
     mail(to: recipient, subject: phone_number, delivery_method_options: delivery_options) do |format|

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -7,7 +7,7 @@ class Agents::ExportMailer < ApplicationMailer
 
     mail.attachments["export-rdv-#{now.strftime('%Y-%m-%d')}.xls"] = {
       mime_type: "application/vnd.ms-excel",
-      content: RdvExporter.export(rdvs.order(starts_at: :desc))
+      content: RdvExporter.export(rdvs.order(starts_at: :desc)),
     }
 
     mail(

--- a/app/mailers/concerns/ics_multipart_attached.rb
+++ b/app/mailers/concerns/ics_multipart_attached.rb
@@ -54,7 +54,7 @@ module IcsMultipartAttached
       message.attachments[ics_payload[:name]] = {
         mime_type: "application/ics",
         content: Base64.encode64(cal.to_ical),
-        encoding: "base64"
+        encoding: "base64",
       }
     end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -27,17 +27,17 @@ class Agent < ApplicationRecord
     all: "all",       # notify of all rdv changes
     others: "others", # notify of changes made by other agents or users
     soon: "soon",     # notify of change (made by others) less than a day before the rdv
-    none: "none"      # never send rdv notifications
+    none: "none", # never send rdv notifications
   }, _prefix: true
 
   enum plage_ouverture_notification_level: {
     all: "all", # notify of all changes
-    none: "none" # never send plage_ouverture notifications
+    none: "none", # never send plage_ouverture notifications
   }, _prefix: true
 
   enum absence_notification_level: {
     all: "all", # notify of all changes
-    none: "none" # never send absence notifications
+    none: "none", # never send absence notifications
   }, _prefix: true
 
   # Relations

--- a/app/models/concerns/full_name_concern.rb
+++ b/app/models/concerns/full_name_concern.rb
@@ -9,7 +9,7 @@ module FullNameConcern
   def full_name
     names = [first_name,
              last_name&.upcase,
-             ("(#{birth_name})" if defined?(birth_name) && birth_name.present?)]
+             ("(#{birth_name})" if defined?(birth_name) && birth_name.present?),]
 
     names.compact.join(" ")
   end
@@ -18,7 +18,7 @@ module FullNameConcern
   def reverse_full_name
     names = [last_name&.upcase,
              ("(#{birth_name})" if defined?(birth_name) && birth_name.present?),
-             first_name]
+             first_name,]
 
     names.compact.join(" ")
   end

--- a/app/models/concerns/payloads/absence.rb
+++ b/app/models/concerns/payloads/absence.rb
@@ -9,7 +9,7 @@ module Payloads
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
         summary: "#{BRAND} #{title}",
-        recurrence: rrule
+        recurrence: rrule,
       }
 
       payload[:action] = action if action.present?

--- a/app/models/concerns/payloads/plage_ouverture.rb
+++ b/app/models/concerns/payloads/plage_ouverture.rb
@@ -9,7 +9,7 @@ module Payloads
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
         summary: "#{BRAND} #{title}",
-        recurrence: rrule
+        recurrence: rrule,
       }
 
       payload[:action] = action if action.present?

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -10,7 +10,7 @@ module Payloads
         ical_uid: uuid,
         summary: "RDV #{motif&.name}",
         address: motif.phone? ? nil : address,
-        sequence: sequence
+        sequence: sequence,
       }
 
       description = ""

--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -10,7 +10,7 @@ module WebhookDeliverable
     meta = {
       model: self.class.name,
       event: action,
-      timestamp: Time.zone.now
+      timestamp: Time.zone.now,
     }
     blueprint_class = "#{self.class.name}Blueprint".constantize
     blueprint_class.render(self, root: :data, meta: meta, api_options: api_options)

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -53,7 +53,7 @@ class FileAttente < ApplicationRecord
         event: :new_creneau_available,
         channel: :mail,
         result: :processed,
-        email_address: user.email
+        email_address: user.email,
       }
       Receipt.create!(params)
     end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -29,7 +29,7 @@ class Motif < ApplicationRecord
   enum location_type: { public_office: "public_office", phone: "phone", home: "home" }
   enum category: { rsa_orientation: "rsa_orientation",
                    rsa_accompagnement: "rsa_accompagnement",
-                   rsa_orientation_on_phone_platform: "rsa_orientation_on_phone_platform" }
+                   rsa_orientation_on_phone_platform: "rsa_orientation_on_phone_platform", }
 
   # Relations
   belongs_to :organisation
@@ -51,7 +51,7 @@ class Motif < ApplicationRecord
   validates :visibility_type, inclusion: { in: VISIBILITY_TYPES }
   validates :sectorisation_level, inclusion: { in: SECTORISATION_TYPES }
   validates :name, presence: true, uniqueness: { scope: %i[organisation location_type service],
-                                                 conditions: -> { where(deleted_at: nil) } }
+                                                 conditions: -> { where(deleted_at: nil) }, }
 
   validates :color, :default_duration_in_min, :min_booking_delay, :max_booking_delay, presence: true
   validates :min_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -41,7 +41,7 @@ class Organisation < ApplicationRecord
     format: {
       with: /\A[a-z0-9_\-]{3,99}\z/,
       message: :human_id_error,
-      if: -> { human_id.present? }
+      if: -> { human_id.present? },
     }
   )
   validates :human_id, uniqueness: { scope: :territory }, if: -> { human_id.present? }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -281,7 +281,7 @@ class Rdv < ApplicationRecord
       agent_ids: agents.ids,
       rdvs_users: rdvs_users.map do |rdvs_user|
         rdvs_user.slice(:user_id, :send_lifecycle_notifications, :send_reminder_notification)
-      end
+      end,
     }
   end
 

--- a/app/models/sector_attribution.rb
+++ b/app/models/sector_attribution.rb
@@ -42,7 +42,7 @@ class SectorAttribution < ApplicationRecord
         {
           sectors_count: attributions.pluck(:sector_id).uniq.count,
           agents_count: attributions.pluck(:agent_id).uniq.count,
-          attributions: attributions
+          attributions: attributions,
         }
       end
   end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -44,7 +44,7 @@ class Stat
     new_keys = {
       agent: "Agent (#{rdvs.created_by_agent.count})",
       user: "Usager (#{rdvs.created_by_user.count})",
-      file_attente: "File d'attente (#{rdvs.created_by_file_attente.count})"
+      file_attente: "File d'attente (#{rdvs.created_by_file_attente.count})",
     }
     rdvs_group_by_week.transform_keys { |key| [new_keys[key[0].to_sym], key[1]] }
   end
@@ -68,7 +68,7 @@ class Stat
       date_rdvs_count = rdvs_count_per_date[key[1]]
       [
         [::Rdv.human_attribute_value(:status, key[0]), key[1]],
-        date_rdvs_count.zero? ? 0 : (rdvs_count.to_f * 100 / date_rdvs_count).round
+        date_rdvs_count.zero? ? 0 : (rdvs_count.to_f * 100 / date_rdvs_count).round,
       ]
     end
   end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -13,7 +13,7 @@ class Territory < ApplicationRecord
     contact_experience: "contact_experience",
     sfr_mail2sms: "sfr_mail2sms",
     clever_technologies: "clever_technologies",
-    orange_contact_everyone: "orange_contact_everyone"
+    orange_contact_everyone: "orange_contact_everyone",
   }, _prefix: true
 
   # Relations
@@ -45,11 +45,11 @@ class Territory < ApplicationRecord
   ## -
 
   OPTIONAL_RDV_FIELD_TOGGLES = {
-    enable_context_field: :context
+    enable_context_field: :context,
   }.freeze
 
   OPTIONAL_MOTIF_FIELD_TOGGLES = {
-    enable_motif_categories_field: :category
+    enable_motif_categories_field: :category,
   }.freeze
 
   SOCIAL_FIELD_TOGGLES = {
@@ -58,12 +58,12 @@ class Territory < ApplicationRecord
     enable_family_situation_field: :family_situation,
     enable_number_of_children_field: :number_of_children,
     enable_case_number: :case_number,
-    enable_address_details: :address_details
+    enable_address_details: :address_details,
   }.freeze
 
   OPTIONAL_FIELD_TOGGLES = {
     enable_notes_field: :notes,
-    enable_logement_field: :logement
+    enable_logement_field: :logement,
   }.merge(SOCIAL_FIELD_TOGGLES).freeze
 
   def any_social_field_enabled?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   enum family_situation: { single: 0, in_a_relationship: 1, divorced: 2 }
   enum created_through: { agent_creation: "agent_creation", user_sign_up: "user_sign_up",
                           franceconnect_sign_up: "franceconnect_sign_up", user_relative_creation: "user_relative_creation",
-                          unknown: "unknown", agent_creation_api: "agent_creation_api" }
+                          unknown: "unknown", agent_creation_api: "agent_creation_api", }
   enum invited_through: { devise_email: "devise_email", external: "external" }
 
   # HACK : add *_sign_in_ip to accessor to bypass recording IPs from Trackable Devise's module

--- a/app/policies/agent/user_policy.rb
+++ b/app/policies/agent/user_policy.rb
@@ -34,7 +34,7 @@ class Agent::UserPolicy < DefaultAgentPolicy
         .joins(:organisations)
         .where(
           organisations: {
-            id: current_organisation&.id || current_agent.organisation_ids
+            id: current_organisation&.id || current_agent.organisation_ids,
           }
         )
     end

--- a/app/presenters/paper_trail_augmented_version.rb
+++ b/app/presenters/paper_trail_augmented_version.rb
@@ -44,7 +44,7 @@ class PaperTrailAugmentedVersion
     virtual_changes_array.to_h do |property_name, new_value|
       [
         property_name,
-        [previous_version_virtual_attributes[property_name], new_value]
+        [previous_version_virtual_attributes[property_name], new_value],
       ]
     end
   end

--- a/app/presenters/plage_ouverture_presenter.rb
+++ b/app/presenters/plage_ouverture_presenter.rb
@@ -15,7 +15,7 @@ class PlageOuverturePresenter
     i18n_key = [
       "overlapping_plage_ouverture",
       (in_scope? ? "in_scope" : "out_of_scope"),
-      (same_organisation? ? "in_current_organisation" : "in_other_organisation")
+      (same_organisation? ? "in_current_organisation" : "in_other_organisation"),
     ].join(".")
     attrs = { agent_name: plage_ouverture.agent.full_name }
     if in_scope?

--- a/app/presenters/rdv_ending_shortly_before_presenter.rb
+++ b/app/presenters/rdv_ending_shortly_before_presenter.rb
@@ -40,7 +40,7 @@ class RdvEndingShortlyBeforePresenter
     {
       agent_name: agent.full_name,
       ends_at_time: I18n.l(rdv.ends_at, format: :time_only),
-      gap_duration_in_min: ((rdv_context.starts_at - rdv.ends_at) / 1.minute).round
+      gap_duration_in_min: ((rdv_context.starts_at - rdv.ends_at) / 1.minute).round,
     }
   end
 
@@ -49,7 +49,7 @@ class RdvEndingShortlyBeforePresenter
 
     {
       user_names: rdv.users.map(&:full_name).to_sentence,
-      path: admin_organisation_rdv_path(rdv.organisation, rdv)
+      path: admin_organisation_rdv_path(rdv.organisation, rdv),
     }
   end
 end

--- a/app/presenters/rdvs_overlapping_rdv_presenter.rb
+++ b/app/presenters/rdvs_overlapping_rdv_presenter.rb
@@ -39,7 +39,7 @@ class RdvsOverlappingRdvPresenter
   def i18n_attrs_base
     {
       agent_name: agent.full_name,
-      ends_at_time: I18n.l(rdv.ends_at, format: :time_only)
+      ends_at_time: I18n.l(rdv.ends_at, format: :time_only),
     }
   end
 

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -19,7 +19,7 @@ module Users::CreneauxSearchConcern
   def agents
     @agents ||= [
       follow_up_rdv_and_online_user? ? @user.agents : nil,
-      geo_attributed_agents || nil
+      geo_attributed_agents || nil,
     ].compact.flatten
   end
 

--- a/app/services/duplicate_users_finder_service.rb
+++ b/app/services/duplicate_users_finder_service.rb
@@ -12,7 +12,7 @@ class DuplicateUsersFinderService < BaseService
     [
       self.class.find_duplicate_based_on_email(@user, @organisation),
       self.class.find_duplicate_based_on_identity(@user, @organisation),
-      self.class.find_duplicate_based_on_phone_number(@user, @organisation)
+      self.class.find_duplicate_based_on_phone_number(@user, @organisation),
     ].compact
   end
 

--- a/app/services/export_zones_service.rb
+++ b/app/services/export_zones_service.rb
@@ -34,7 +34,7 @@ class ExportZonesService
         zone.city_code,
         zone.city_name,
         zone.street_name,
-        zone.street_ban_id
+        zone.street_ban_id,
       ]
     )
   end

--- a/app/services/import_zone_rows_service.rb
+++ b/app/services/import_zone_rows_service.rb
@@ -5,7 +5,7 @@ class ImportZoneRowsService < BaseService
 
   REQUIRED_FIELDS = {
     Zone::LEVEL_CITY => %w[sector_id city_name city_code],
-    Zone::LEVEL_STREET => %w[sector_id city_name city_code street_name street_code]
+    Zone::LEVEL_STREET => %w[sector_id city_name city_code street_name street_code],
   }.freeze
 
   def initialize(rows, territory, agent, **options)
@@ -24,8 +24,8 @@ class ImportZoneRowsService < BaseService
         imported: Hash.new(0),
         imported_new: Hash.new(0),
         imported_override: Hash.new(0),
-        errors: Hash.new(0)
-      }
+        errors: Hash.new(0),
+      },
     }
     @result[:valid] = valid?
     @rows.each { import_row(_1) } if valid?

--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -13,7 +13,7 @@ class OffDays
     Date.new(2020, 8, 15),
     Date.new(2020, 11, 1),
     Date.new(2020, 11, 11),
-    Date.new(2020, 12, 25)
+    Date.new(2020, 12, 25),
   ].freeze
 
   JOURS_FERIES_2021 = [
@@ -27,7 +27,7 @@ class OffDays
     Date.new(2021, 8, 15),
     Date.new(2021, 11, 1),
     Date.new(2021, 11, 11),
-    Date.new(2021, 12, 25)
+    Date.new(2021, 12, 25),
   ].freeze
 
   # https://www.service-public.fr/particuliers/vosdroits/F2405
@@ -42,7 +42,7 @@ class OffDays
     Date.new(2022, 8, 15),
     Date.new(2022, 11, 1),
     Date.new(2022, 11, 11),
-    Date.new(2022, 12, 25)
+    Date.new(2022, 12, 25),
   ].freeze
 
   def self.all_in_date_range(date_range)

--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -18,7 +18,7 @@ module RdvExporter
     "professionnel.le(s)",
     "usager(s)",
     "commune du premier responsable",
-    "au moins un usager mineur ?"
+    "au moins un usager mineur ?",
   ].freeze
 
   def self.export(rdvs)
@@ -67,7 +67,7 @@ module RdvExporter
       rdv.agents.map(&:full_name).join(", "),
       rdv.users.map(&:full_name).join(", "),
       commune_premier_responsable(rdv),
-      rdv.users.any?(&:minor?) ? "oui" : "non"
+      rdv.users.any?(&:minor?) ? "oui" : "non",
     ]
   end
 

--- a/app/services/scalingo_app_restarter.rb
+++ b/app/services/scalingo_app_restarter.rb
@@ -17,7 +17,7 @@ class ScalingoAppRestarter < BaseService
       "https://auth.scalingo.com/v1/tokens/exchange",
       userpwd: ":#{@api_token}",
       headers: { "Content-Type": "application/json",
-                 Accept: "application/json" }
+                 Accept: "application/json", }
     )
 
     raise ApiError, "Token request failed: #{token_response.code}" unless token_response.success?
@@ -31,7 +31,7 @@ class ScalingoAppRestarter < BaseService
       "https://#{api_host}/v1/apps/#{@app_id}/restart",
       headers: { "Content-Type": "application/json",
                  Accept: "application/json",
-                 Authorization: "Bearer #{bearer_token}" }
+                 Authorization: "Bearer #{bearer_token}", }
     )
 
     raise ApiError, "Restart request failed: #{restart_response.code}" unless restart_response.success?

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -83,7 +83,7 @@ class SearchContext
     @next_availability_by_lieux ||= lieux.to_h do |lieu|
       [
         lieu.id,
-        creneaux_search_for(lieu, date_range).next_availability
+        creneaux_search_for(lieu, date_range).next_availability,
       ]
     end
   end

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -30,7 +30,7 @@ class SmsSender < BaseService
   def formatted_content(content)
     [
       ApplicationController.helpers.rdv_solidarites_instance_name,
-      content
+      content,
     ].compact
       .join("\n")
       .tr("áâãëẽêíïîĩóôõúûũçÀÁÂÃÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ", "aaaeeeiiiiooouuucAAAAEEEEIIIIIOOOOUUUU")
@@ -99,7 +99,7 @@ class SmsSender < BaseService
         originatingAddress: SENDER_NAME,
         originatorTON: 1,
         campaignName: @tags.join(" ").truncate(49),
-        maxConcatenatedMessages: 10
+        maxConcatenatedMessages: 10,
       }
     ).run
 
@@ -135,7 +135,7 @@ class SmsSender < BaseService
         number: @phone_number,
         msg: @content,
         devCode: @key,
-        emetteur: replies_email # The parameter is called “emetteur” but it is actually an email where we can receive replies to the sms.
+        emetteur: replies_email, # The parameter is called “emetteur” but it is actually an email where we can receive replies to the sms.
       }
     ).run
 
@@ -184,8 +184,8 @@ class SmsSender < BaseService
         datas: {
           text: @content,
           number_list: @phone_number,
-          encodage: 3
-        }
+          encodage: 3,
+        },
       }.to_json
     ).run
 
@@ -220,7 +220,7 @@ class SmsSender < BaseService
       body: {
         token: @key,
         to: @phone_number,
-        msg: @content
+        msg: @content,
       }
     ).run
 

--- a/app/services/upsert_user_for_franceconnect_service.rb
+++ b/app/services/upsert_user_for_franceconnect_service.rb
@@ -46,7 +46,7 @@ class UpsertUserForFranceconnectService < BaseService
       birth_date: omniauth_info.birthdate,
       franceconnect_openid_sub: omniauth_info.sub,
       last_name: omniauth_info.preferred_username.presence || omniauth_info.family_name, # nom d'usage (optionnel),
-      logged_once_with_franceconnect: true
+      logged_once_with_franceconnect: true,
     }.compact # do not fill with missing values
   end
 end

--- a/app/services/zone_import_row.rb
+++ b/app/services/zone_import_row.rb
@@ -5,7 +5,7 @@ class ZoneImportRow
 
   REQUIRED_FIELDS = {
     Zone::LEVEL_CITY => %w[sector_id city_name city_code],
-    Zone::LEVEL_STREET => %w[sector_id city_name city_code street_name street_code]
+    Zone::LEVEL_STREET => %w[sector_id city_name city_code street_name street_code],
   }.freeze
 
   def initialize(row, agent:, dry_run:, sectors_by_human_id:)
@@ -62,7 +62,7 @@ class ZoneImportRow
 
     @errors << {
       key: "invalid_zone_#{zone.errors.attribute_names.first}".to_sym,
-      message: zone.errors.full_messages.join(", ")
+      message: zone.errors.full_messages.join(", "),
     }
     false
   end
@@ -75,7 +75,7 @@ class ZoneImportRow
 
     @errors << {
       key: :unauthorized_zone,
-      message: "Pas les droits nécessaires pour ajouter une commune ou une rue au secteur #{zone.sector_id}"
+      message: "Pas les droits nécessaires pour ajouter une commune ou une rue au secteur #{zone.sector_id}",
     }
     false
   end
@@ -92,7 +92,7 @@ class ZoneImportRow
     unique_attributes = {
       level: zone_level,
       city_code: @row["city_code"],
-      sector: @sectors_by_human_id[@row["sector_id"]]
+      sector: @sectors_by_human_id[@row["sector_id"]],
     }
     unique_attributes[:street_ban_id] = @row["street_code"] if zone_level == Zone::LEVEL_STREET
     extra_attributes = { city_name: @row["city_name"], street_name: @row["street_name"] }

--- a/app/sms/users/base_sms.rb
+++ b/app/sms/users/base_sms.rb
@@ -14,7 +14,7 @@ class Users::BaseSms < ApplicationSms
       ENV["APP"]&.gsub("-rdv-solidarites", ""), # shorter names
       "dpt-#{rdv.organisation&.departement_number}",
       "org-#{rdv.organisation&.id}",
-      self.class.name.demodulize.underscore
+      self.class.name.demodulize.underscore,
     ].compact
 
     @receipt_params[:rdv] = rdv

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -20,8 +20,8 @@
               class: "select2-input js-service-filter", \
               data: { \
                 placeholder: "Sélectionnez un service pour filtrer les motifs", \
-                "select-options": { disableSearch: true } \
-              } \
+                "select-options": { disableSearch: true }, \
+              }, \
             }
         .col-md-4
           = f.input :motif_id, \
@@ -33,7 +33,7 @@
             label_method: -> { motif_name_with_location_type(_1) }, \
             input_html: { \
               data: { placeholder: "Sélectionnez un motif" }, \
-              class: "js-filtered-motifs" \
+              class: "js-filtered-motifs", \
             }
         .col-md-4
           = date_input(f, :from_date, label = "À partir du", required: true)
@@ -42,31 +42,31 @@
           .col-md-4
             = f.input :team_ids, collection: @teams, label: t(".teams"), label_method: :name, input_html: { \
                 multiple: true, \
-                class: "select2-input",\
-                data: {\
-                  "select-options": {\
+                class: "select2-input", \
+                data: { \
+                  "select-options": { \
                     ajax: {\
                       url: search_admin_territory_teams_path(current_organisation.territory),
                       dataType: "json",
-                      delay: 250\
-                    }\
-                  }\
-                }\
+                      delay: 250, \
+                    }, \
+                  }, \
+                }, \
               }
 
         .col-md-4
           = f.input :agent_ids, collection: @agents, label: t(".agents"), label_method: :reverse_full_name, input_html: { \
               multiple: true, \
               class: "select2-input",\
-              data: {\
-                "select-options": {\
-                  ajax: {\
+              data: { \
+                "select-options": { \
+                  ajax: { \
                     url: admin_organisation_agents_path(current_organisation),
                     dataType: "json",
-                    delay: 250\
-                  }\
-                }\
-              }\
+                    delay: 250, \
+                  }, \
+                }, \
+              }, \
             }
 
         .col-md-4

--- a/app/views/admin/merge_users/_user_selection.html.slim
+++ b/app/views/admin/merge_users/_user_selection.html.slim
@@ -27,9 +27,9 @@
             ajax: { \
               url: search_admin_organisation_users_path(current_organisation, **url_opts), \
               dataType: "json", \
-              delay: 250 \
-            } \
+              delay: 250, \
+            }, \
           }, \
-          "field-name": attribute \
-        } \
+          "field-name": attribute, \
+        }, \
       }

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -15,8 +15,8 @@
         class: "select2-input js-service-filter", \
         data: { \
           placeholder: "Sélectionnez un service pour filtrer les motifs", \
-          "select-options": { disableSearch: true } \
-        } \
+          "select-options": { disableSearch: true }, \
+        }, \
       }
     = f.input :motif_id, \
       required: true, \
@@ -27,7 +27,7 @@
       label_method: -> { motif_name_with_location_type(_1) }, \
       input_html: { \
         data: { placeholder: "Sélectionnez un motif" },
-        class: "js-filtered-motifs" \
+        class: "js-filtered-motifs", \
       }
 
     = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -49,7 +49,7 @@ ruby:
       class: "select2-input js-new-rdv-users-select",
       data: { \
         width: "auto", \
-        "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.users.map(&:id)), dataType: "json", delay: 250 }} \
+        "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.users.map(&:id)), dataType: "json", delay: 250 }}, \
       }
 
       span.small.text-muted

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -15,7 +15,7 @@ ruby:
         - controller_data = { "controller": "rdv-lieu",
                 "initial-state": (new_lieu_record ? "single_use" : "existing"),
                 "select-placeholder-single-use-lieu": t(".select_placeholder_single_use_lieu"),
-                "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu") }
+                "select-placeholder-existing-lieu": t(".select_placeholder_existing_lieu"), }
         .form-group data=controller_data
           = f.label :lieu, required: true
           fieldset

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -6,15 +6,15 @@
               label_method: :reverse_full_name, \
               input_html: { \
                 class: "select2-input", \
-                data: {\
-                  "select-options": {\
-                    ajax: {\
+                data: { \
+                  "select-options": { \
+                    ajax: { \
                       url: admin_organisation_agents_path(current_organisation),
                       dataType: "json",
-                      delay: 250\
-                    }\
-                  }\
-                }\
+                      delay: 250, \
+                    }, \
+                  }, \
+                }, \
               }, \
               wrapper: "horizontal_form"
 
@@ -23,15 +23,15 @@
               label_method: :reverse_full_name,
               input_html: { \
                 class: "select2-input", \
-                data: {\
-                  "select-options": {\
-                    ajax: {\
+                data: { \
+                  "select-options": { \
+                    ajax: { \
                       url: search_admin_organisation_users_path(current_organisation),
                       dataType: "json",
-                      delay: 250\
-                    }\
-                  }\
-                }\
+                      delay: 250, \
+                    }, \
+                  }, \
+                }, \
               },
               wrapper: "horizontal_form"
 

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -43,9 +43,18 @@
             = f.association :agents,
               collection: @rdv_form.agents,
               label_method: :full_name_and_service,
-              input_html: { multiple: true, class: "select2-input",
-                data: { "select-options": { ajax: { url: admin_organisation_agents_path(current_organisation),
-                                                          dataType: "json", delay: 250 } } } }
+                    input_html: { \
+                      multiple: true,
+                      class: "select2-input",
+                      data: { \
+                        "select-options": { \
+                          ajax: { \
+                            url: admin_organisation_agents_path(current_organisation),
+                            dataType: "json", delay: 250, \
+                          }, \
+                        }, \
+                      }, \
+                    }
 
             - if @rdv_form.motif.collectif?
               = f.input :name, wrapper_html: { class: "mb-1" }
@@ -66,7 +75,7 @@
                       data: { \
                 width: "auto", \
                 "scroll-to-bottom": params[:add_user].present?, \
-                "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.rdvs_users.map(&:user_id)), dataType: "json", delay: 250 } } \
+                "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.rdvs_users.map(&:user_id)), dataType: "json", delay: 250 } }, \
                }
 
             .text-right

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -71,7 +71,7 @@
                     data: { \
               width: "auto", \
               "scroll-to-bottom": @add_user_ids.present?, \
-              "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.rdvs_users.map(&:user_id)), dataType: "json", delay: 250 } } \
+              "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.rdvs_users.map(&:user_id)), dataType: "json", delay: 250 } }, \
              }
             span.small.text-muted
               | L'usager n'existe pas ?&nbsp;

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -21,7 +21,7 @@
             label_method: -> { motif_name_with_location_type(_1) }, \
             input_html: { \
               data: { placeholder: "Sélectionnez un motif", "allow-clear": true }, \
-              class: "select2-input" \
+              class: "select2-input", \
             }
         .col-md-3.mt-4
           = f.input :with_remaining_seats, as: :boolean, label: "Avec des places disponibles"

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -8,16 +8,16 @@
           label_method: :name,
           input_html: { \
             multiple: true, \
-            class: "select2-input",\
-            data: {\
-              "select-options": {\
-                ajax: {\
+            class: "select2-input", \
+            data: { \
+              "select-options": { \
+                ajax: { \
                   url: search_admin_territory_teams_path(current_territory),
                   dataType: "json",
-                  delay: 250\
-                }\
-              }\
-            }\
+                  delay: 250, \
+                }, \
+              }, \
+            }, \
           }
     = form.submit class: "btn btn-primary"
 

--- a/app/views/admin/territories/teams/_form.html.slim
+++ b/app/views/admin/territories/teams/_form.html.slim
@@ -5,15 +5,15 @@
           label_method: :reverse_full_name,
           input_html: { \
             multiple: true, \
-            class: "select2-input",\
-            data: {\
-              "select-options": {\
-                ajax: {\
+            class: "select2-input", \
+            data: { \
+              "select-options": { \
+                ajax: { \
                   url: admin_territory_agents_path(current_territory),
                   dataType: "json",
-                  delay: 250\
-                }\
-              }\
-            }\
+                  delay: 250, \
+                }, \
+              }, \
+            }, \
           }
   = form.submit class: "btn btn-primary"

--- a/app/views/admin/territories/teams/_form.html.slim
+++ b/app/views/admin/territories/teams/_form.html.slim
@@ -1,4 +1,4 @@
- = simple_form_for team, url: url do |form|
+= simple_form_for team, url: url do |form|
   = form.input :name
   = form.input :agent_ids, collection: team.agents,
           label: "Agents",

--- a/app/views/admin/territories/zones/_form.html.slim
+++ b/app/views/admin/territories/zones/_form.html.slim
@@ -3,7 +3,7 @@
   url: zone.new_record? ? admin_territory_sector_zones_path(current_territory, sector) : admin_territory_sector_zone_path(current_territory, sector, zone), \
   html: { \
     class: "js-zone-form", \
-    data: { "canonical-path": new_admin_territory_sector_zone_path(current_territory, sector)} \
+    data: { "canonical-path": new_admin_territory_sector_zone_path(current_territory, sector)}, \
   } \
 ) do |f|
   = f.input_field :level, \
@@ -30,14 +30,14 @@
       label: "Rechercher une commune", \
       input_html: { \
         class: "places-js-container", \
-        data: { "address-type": "municipality" } \
+        data: { "address-type": "municipality" }, \
       }
   - elsif zone.level_street?
     = f.input :street_label, \
       label: "Rechercher une rue", \
       input_html: { \
         class: "places-js-container", \
-        data: { "address-type": "street" } \
+        data: { "address-type": "street" }, \
       }
   .row
     .col-6

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -26,7 +26,7 @@
         wrapper: :vertical_collection_inline, \
         input_html: { \
           autocomplete: "off", \
-          class: "js-responsability-type" \
+          class: "js-responsability-type", \
         }, \
         label_html: { class: "mb-0" } \
       )
@@ -81,7 +81,7 @@
                   label: false, \
                   **{input_html: { \
                     class: "select2-input",\
-                    data: { "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation), dataType: "json", delay: 250 }} } \
+                    data: { "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation), dataType: "json", delay: 250 }} }, \
                    }}.deep_merge(input_opts[:relative_existing]), \
                   required: true\
                 )

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -21,16 +21,16 @@
                   label: "Agent référent",
                   label_method: :reverse_full_name,
                   input_html: { \
-                    class: "select2-input",\
-                    data: {\
-                      "select-options": {\
-                        ajax: {\
+                    class: "select2-input", \
+                    data: { \
+                      "select-options": { \
+                        ajax: { \
                           url: admin_organisation_agents_path(current_organisation),
                           dataType: "json",
-                          delay: 250\
-                        }\
-                      }\
-                    }\
+                          delay: 250, \
+                        }, \
+                      }, \
+                    }, \
                   }
 
       input.btn.btn-primary.d-print-none type="submit" value="Rechercher"

--- a/app/views/common/_search_form.html.slim
+++ b/app/views/common/_search_form.html.slim
@@ -31,7 +31,7 @@
               include_blank: t(".choose_motif"), \
               input_html: { \
                 class: "select2-input", \
-                data: { "select-options": { "disableSearch": true } } \
+                data: { "select-options": { "disableSearch": true } }, \
               }, \
               wrapper_html: { class: "mb-1 mb-lg-0" }
           .col-lg-3.align-self-end= f.button :submit, t(".choose_this_motif"), class: "btn btn-white btn-lg w-100 text-center"
@@ -50,7 +50,7 @@
                 include_blank: t(".choose_service"), \
                 input_html: { \
                   class: "form-control-lg w-100 select2-input", \
-                  data: { "select-options": { "disableSearch": true } } \
+                  data: { "select-options": { "disableSearch": true } }, \
                 }, \
                 wrapper_html: { class: "mb-1 mb-lg-0" }
             .col-lg-3.align-self-end= f.button :submit, t(".choose_this_service"), class: "btn btn-white btn-lg w-100 text-center"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
@@ -44,7 +44,7 @@ Rails.application.configure do
       address: ENV["DEVELOPMENT_SMTP_HOST"],
       domain: ENV["DEVELOPMENT_SMTP_DOMAIN"],
       port: ENV["DEVELOPMENT_SMTP_PORT"],
-      authentication: :cram_md5
+      authentication: :cram_md5,
     }
   else
     config.action_mailer.delivery_method = :letter_opener_web

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
     authentication: :plain,
     user_name: ENV["SENDINBLUE_USERNAME"],
     password: ENV["SENDINBLUE_PASSWORD"],
-    domain: "rdv-solidarites.fr"
+    domain: "rdv-solidarites.fr",
   }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.asset_host = ENV["HOST"]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/css_color_names.rb
+++ b/config/initializers/css_color_names.rb
@@ -148,5 +148,5 @@ CSS_COLOR_NAMES = {
   "white" => "#ffffff",
   "whitesmoke" => "#f5f5f5",
   "yellow" => "#ffff00",
-  "yellowgreen" => "#9acd32"
+  "yellowgreen" => "#9acd32",
 }.freeze

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -12,5 +12,5 @@
 # :sms_low
 Delayed::Worker.queue_attributes = {
   mailers_low: { priority: 10 }, # Higher numbers have lower priority.
-  sms_low: { priority: 10 }
+  sms_low: { priority: 10 },
 }

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -14,7 +14,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       identifier: ENV["FRANCECONNECT_APP_ID"],
       secret: ENV["FRANCECONNECT_APP_SECRET"],
       redirect_uri: "#{ENV['HOST']}/omniauth/franceconnect/callback",
-      host: ENV["FRANCECONNECT_HOST"]
+      host: ENV["FRANCECONNECT_HOST"],
     }
   )
 

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -418,7 +418,7 @@ SimpleForm.setup do |config|
     file: :vertical_file,
     radio_buttons: :vertical_collection,
     range: :vertical_range,
-    time: :vertical_multi_select
+    time: :vertical_multi_select,
   }
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,7 @@ Rails.application.routes.draw do
   devise_for :agents, controllers: {
     invitations: "admin/invitations_devise", # only using the accept route here
     sessions: "agents/sessions",
-    passwords: "agents/passwords"
+    passwords: "agents/passwords",
   }
 
   devise_scope :agent do

--- a/db/migrate/20210301135256_create_territories.rb
+++ b/db/migrate/20210301135256_create_territories.rb
@@ -11,7 +11,7 @@ class CreateTerritories < ActiveRecord::Migration[6.0]
     "77" => "0164147777",
     "80" => "0322718080",
     "92" => "0806000092",
-    "95" => "0134253030"
+    "95" => "0134253030",
   }.freeze
 
   def up

--- a/db/migrate/20210506164841_add_sms_configuration_to_territory.rb
+++ b/db/migrate/20210506164841_add_sms_configuration_to_territory.rb
@@ -12,7 +12,7 @@ class AddSmsConfigurationToTerritory < ActiveRecord::Migration[6.0]
         territory.sms_provider = "netsize"
         territory.sms_configuration = {
           api_url: "https://europe.ipx.com/restapi/v1/sms/send",
-          user_pwd: ENV["NETSIZE_API_USERPWD"]
+          user_pwd: ENV["NETSIZE_API_USERPWD"],
         }
         territory.save
       end

--- a/db/migrate/20220310223304_create_agent_territorial_access_right.rb
+++ b/db/migrate/20220310223304_create_agent_territorial_access_right.rb
@@ -19,7 +19,7 @@ class CreateAgentTerritorialAccessRight < ActiveRecord::Migration[6.1]
             territory_id: territory.id,
             allow_to_manage_teams: AgentTerritorialRole.exists?(territory: territory, agent: agent),
             created_at: Time.zone.now,
-            updated_at: Time.zone.now
+            updated_at: Time.zone.now,
           }
         end
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -102,7 +102,7 @@ human_id_map = [
   { human_id: "1051", name: "MDS Noeux les Mines" },
   { human_id: "1053", name: "MDS St Martin les Boulogne" },
   { human_id: "1054", name: "MDS St Omer" },
-  { human_id: "1055", name: "MDS St Pol sur Ternoise" }
+  { human_id: "1055", name: "MDS St Pol sur Ternoise" },
 ].to_h do |attributes|
   organisation = Organisation.create!(phone_number: "0123456789", territory: territory62, human_id: attributes[:human_id], name: attributes[:name])
   sector = Sector.create!(name: "Secteur de #{attributes[:name][4..]}", human_id: attributes[:human_id], territory: territory62)
@@ -341,7 +341,7 @@ motifs_attributes = 1000.times.map do |i|
     organisation_id: org_arques.id,
     service_id: service_secretariat.id,
     reservable_online: true,
-    location_type: :public_office
+    location_type: :public_office,
   }
 end
 Motif.insert_all!(motifs_attributes) # rubocop:disable Rails/SkipsModelValidations
@@ -420,7 +420,7 @@ lieux_attributes = 100.times.map do |i|
     availability: :enabled,
     address: "Adresse #{i}",
     latitude: 45 + (i.to_f / 100.0),
-    longitude: 2 + (i.to_f / 100.0)
+    longitude: 2 + (i.to_f / 100.0),
   }
 end
 Lieu.insert_all!(lieux_attributes) # rubocop:disable Rails/SkipsModelValidations
@@ -507,7 +507,7 @@ users_attributes = 10_000.times.map do |i|
     email: "email_#{i}@test.com",
     phone_number: (format "+336%08d", i),
     phone_number_formatted: (format "+336%08d", i),
-    created_through: "user_sign_up"
+    created_through: "user_sign_up",
   }
   search_terms = attrs.slice(*User.search_keys).values.compact.join(" ")
   attrs.merge(search_terms: search_terms)
@@ -631,7 +631,7 @@ agent_orgs_rdv_insertion = Agent.new(
   roles_attributes: [
     { organisation: org_drome1, level: AgentRole::LEVEL_ADMIN },
     { organisation: org_drome2, level: AgentRole::LEVEL_ADMIN },
-    { organisation: org_yonne, level: AgentRole::LEVEL_ADMIN }
+    { organisation: org_yonne, level: AgentRole::LEVEL_ADMIN },
   ],
   agent_territorial_access_rights_attributes: [{ territory: territory_drome, allow_to_manage_teams: true }, { territory: territory_yonne, allow_to_manage_teams: true }]
 )
@@ -650,7 +650,7 @@ agents_attributes = 1_000.times.map do |i|
     last_name: "last_name_#{i}",
     email: "email_#{i}@test.com",
     uid: "email_#{i}@test.com",
-    service_id: service_social.id
+    service_id: service_social.id,
   }
   search_terms = attrs.slice(*Agent.search_keys).values.compact.join(" ")
   attrs.merge(search_terms: search_terms)
@@ -720,7 +720,7 @@ _plage_ouverture_org_paris_nord_marco_perm = PlageOuverture.create!(
   agent_id: agent_org_paris_nord_pmi_marco.id,
   lieu_id: lieu_org_paris_nord_bd_aubervilliers.id,
   motif_ids: [motif_org_paris_nord_pmi_rappel.id, motif_org_paris_nord_pmi_gyneco.id, motif_org_paris_nord_pmi_prenatale.id, motif_org_paris_nord_pmi_suivi.id, motif_org_paris_nord_pmi_securite.id,
-              motif_org_paris_nord_pmi_prenatale_phone.id],
+              motif_org_paris_nord_pmi_prenatale_phone.id,],
   first_day: Date.tomorrow,
   start_time: Tod::TimeOfDay.new(14),
   end_time: Tod::TimeOfDay.new(16),
@@ -877,7 +877,7 @@ rdv_attributes = 1000.times.flat_map do |i|
       motif_id: motif_org_paris_nord_pmi_securite.id,
       lieu_id: lieu_org_paris_nord_bd_aubervilliers.id,
       organisation_id: org_paris_nord.id,
-      context: "Context #{day} #{hour}"
+      context: "Context #{day} #{hour}",
     }
   end
 end

--- a/lib/omniauth/strategies/franceconnect.rb
+++ b/lib/omniauth/strategies/franceconnect.rb
@@ -13,7 +13,7 @@ module OmniAuth
         scheme: "https",
         authorization_endpoint: "/api/v1/authorize?acr_values=eidas1",
         token_endpoint: "/api/v1/token",
-        userinfo_endpoint: "/api/v1/userinfo"
+        userinfo_endpoint: "/api/v1/userinfo",
       }
       info do
         {
@@ -21,7 +21,7 @@ module OmniAuth
           given_name: user_info.given_name,
           family_name: user_info.family_name,
           birthdate: user_info.birthdate.presence && Date.parse(user_info.birthdate),
-          email: user_info.email
+          email: user_info.email,
         }
       end
     end

--- a/lib/tasks/matomo.rake
+++ b/lib/tasks/matomo.rake
@@ -20,7 +20,7 @@ namespace :matomo do
       payload = {
         idSite: id_site,
         token_auth: token_auth,
-        excludedQueryParameters: params_to_filter.join(",")
+        excludedQueryParameters: params_to_filter.join(","),
       }
       response = Typhoeus.post(url, body: payload)
       result = JSON.parse(response.body)

--- a/scripts/copy_users_between_orgas.rb
+++ b/scripts/copy_users_between_orgas.rb
@@ -7,7 +7,7 @@ origin_organisation_ids = [
   147, # MDSI Eppeville
   146, # MDSI Roye
   145, # MDSI Montdidier
-  144 # MDSI Chaulnes
+  144, # MDSI Chaulnes
 ]
 
 target_organisation = Organisation.find(149) # TERRITOIRE SOMME-SANTERRE

--- a/scripts/load_absences_csv.rb
+++ b/scripts/load_absences_csv.rb
@@ -33,7 +33,7 @@ csv.each do |row|
       first_day: Date.parse(row[0]),
       start_time: Time.zone.parse(row[1]).to_time,
       end_day: Date.parse(row[2]),
-      end_time: Time.zone.parse(row[3]).to_time
+      end_time: Time.zone.parse(row[3]).to_time,
     }
   rescue StandardError
     puts "#{ligne} - erreur d'analyse de la ligne"

--- a/scripts/migrate_cnfs_to_different_organisations.rb
+++ b/scripts/migrate_cnfs_to_different_organisations.rb
@@ -11,7 +11,7 @@ agent_ids_by_organisation_id = {
   349 => [5976, 5977, 5978], # Grand Cognac
   350 => [5982], # Espace de la porte St Jacques, Troyes
   351 => [5974], # France Services Thenon
-  352 => [5981] # Tremblay-en-France
+  352 => [5981], # Tremblay-en-France
 }
 
 class MotifsPlageOuverture < ApplicationRecord

--- a/scripts/recycle_old_rdv_events_to_receipts.rb
+++ b/scripts/recycle_old_rdv_events_to_receipts.rb
@@ -16,7 +16,7 @@ event_name_to_event = {
   file_attente_creneaux_available: :new_creneau_available,
   created: :rdv_created,
   updated: :rdv_date_updated,
-  upcoming_reminder: :rdv_upcoming_reminder
+  upcoming_reminder: :rdv_upcoming_reminder,
 }
 
 # Do everything in a large transaction; errors raised will cancel it all.
@@ -32,7 +32,7 @@ Receipt.transaction do
         channel: type_to_channel[event.event_type.to_sym],
         result: :processed,
         created_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       }
       # We don’t have a user_id; RdvEvent used to be sent to all users;
       # We also don’t have content, sms_phone_number or email_address,

--- a/scripts/scalingo_scale.rb
+++ b/scripts/scalingo_scale.rb
@@ -9,7 +9,7 @@ require "dotenv/load"
 
 HEADERS = {
   "Accept" => "application/json",
-  "Content-Type" => "application/json"
+  "Content-Type" => "application/json",
 }.freeze
 
 options = {}
@@ -53,8 +53,8 @@ res = JSON.parse(
       containers: [
         {
           name: options[:containers_name],
-          amount: options[:containers_amount]
-        }
+          amount: options[:containers_amount],
+        },
       ]
     )
   ).body

--- a/scripts/update_city_name_postal_code_and_city_code_from_address.rb
+++ b/scripts/update_city_name_postal_code_and_city_code_from_address.rb
@@ -22,7 +22,7 @@ def geocode(file)
     method: :post,
     body: {
       data: File.new(file),
-      result_columns: "id,result_city,result_postcode,result_citycode"
+      result_columns: "id,result_city,result_postcode,result_citycode",
     }
   )
   CSV.parse(response.body, headers: true).map(&:to_h)

--- a/spec/blueprint/absence_blueprint_spec.rb
+++ b/spec/blueprint/absence_blueprint_spec.rb
@@ -9,7 +9,7 @@ describe AbsenceBlueprint do
                                                          "email" => "bob@example.com",
                                                          "first_name" => "Bob",
                                                          "last_name" => "Henri",
-                                                         "id" => nil
+                                                         "id" => nil,
                                                        })
     end
 

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -22,7 +22,7 @@ describe RdvBlueprint do
                                      "created_by" => "agent",
                                      "duration_in_min" => 45,
                                      "max_participants_count" => nil,
-                                     "name" => nil
+                                     "name" => nil,
                                    })
   end
 end

--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -90,7 +90,7 @@ describe Admin::AbsencesController, type: :controller do
             agent_id: agent.id,
             first_day: "12/09/2019",
             start_time: "09:00",
-            end_time: "07:00"
+            end_time: "07:00",
           }
         end
 
@@ -113,7 +113,7 @@ describe Admin::AbsencesController, type: :controller do
       context "with valid params" do
         let(:new_attributes) do
           {
-            title: "Le nouveau nom"
+            title: "Le nouveau nom",
           }
         end
 
@@ -148,7 +148,7 @@ describe Admin::AbsencesController, type: :controller do
         let(:new_attributes) do
           {
             start_time: "09:00",
-            end_time: "07:00"
+            end_time: "07:00",
           }
         end
 

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic"
-              }
-            }
-          }
+                level: "basic",
+              },
+            },
+          },
         }
       end
 
@@ -83,10 +83,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic"
-              }
-            }
-          }
+                level: "basic",
+              },
+            },
+          },
         }
       end
 
@@ -106,10 +106,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             roles_attributes: {
               "0" => {
                 level: "basic",
-                organisation_id: organisation2.id
-              }
-            }
-          }
+                organisation_id: organisation2.id,
+              },
+            },
+          },
         }
       end
 
@@ -128,10 +128,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "admin"
-              }
-            }
-          }
+                level: "admin",
+              },
+            },
+          },
         }
       end
 
@@ -156,8 +156,8 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             agent: {
               email: agent2.email,
               service_id: agent2.service_id,
-              roles_attributes: { "0" => { level: "basic" } }
-            }
+              roles_attributes: { "0" => { level: "basic" } },
+            },
           }
         end
 
@@ -177,10 +177,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic"
-              }
-            }
-          }
+                level: "basic",
+              },
+            },
+          },
         }
       end
 
@@ -208,10 +208,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic"
-              }
-            }
-          }
+                level: "basic",
+              },
+            },
+          },
         }
       end
 
@@ -239,10 +239,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic"
-              }
-            }
-          }
+                level: "basic",
+              },
+            },
+          },
         }
       end
 
@@ -303,10 +303,10 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic"
-              }
-            }
-          }
+                level: "basic",
+              },
+            },
+          },
         }
       end
       let!(:existing_agent) do

--- a/spec/controllers/admin/lieux_controller_spec.rb
+++ b/spec/controllers/admin/lieux_controller_spec.rb
@@ -53,7 +53,7 @@ describe Admin::LieuxController, type: :controller do
     context "with invalid params" do
       let(:invalid_attributes) do
         {
-          name: "test"
+          name: "test",
         }
       end
 
@@ -78,7 +78,7 @@ describe Admin::LieuxController, type: :controller do
     context "with valid params" do
       let(:new_attributes) do
         {
-          name: "Le nouveau nom"
+          name: "Le nouveau nom",
         }
       end
 
@@ -95,7 +95,7 @@ describe Admin::LieuxController, type: :controller do
     context "with invalid params" do
       let(:new_attributes) do
         {
-          name: ""
+          name: "",
         }
       end
 

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
     context "with invalid params" do
       let(:invalid_attributes) do
         {
-          name: "test motif"
+          name: "test motif",
         }
       end
 
@@ -109,7 +109,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
     context "with valid params" do
       let(:new_attributes) do
         {
-          name: "Le nouveau nom"
+          name: "Le nouveau nom",
         }
       end
 
@@ -126,7 +126,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
     context "with invalid params" do
       let(:new_attributes) do
         {
-          name: ""
+          name: "",
         }
       end
 

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -115,8 +115,8 @@ describe Admin::PlageOuverturesController, type: :controller do
               agent_id: agent.id,
               first_day: "17/11/2020",
               start_time: "09:00",
-              end_time: "12:00"
-            }
+              end_time: "12:00",
+            },
           }
         end
 
@@ -147,9 +147,9 @@ describe Admin::PlageOuverturesController, type: :controller do
                 motif_ids: [motif.id],
                 lieu_id: lieu1.id,
                 organisation_id: organisation.id,
-                agent_id: agent.id
+                agent_id: agent.id,
                 # missing fields
-              }
+              },
             }
           )
           expect(response).to be_successful

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -11,7 +11,7 @@ describe Admin::RdvWizardStepsController, type: :controller do
         duration_in_min: 30,
         motif_id: 1,
         lieu_id: 1,
-        starts_at: DateTime.new(2020, 4, 20, 8, 0, 0)
+        starts_at: DateTime.new(2020, 4, 20, 8, 0, 0),
       }
     end
     let!(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -134,7 +134,7 @@ describe Admin::RdvsController, type: :controller do
         agent_id: "",
         user_id: "",
         lieu_id: "",
-        status: ""
+        status: "",
       }
 
       # rubocop:disable RSpec/StubbedMock

--- a/spec/controllers/admin/slots_controller_spec.rb
+++ b/spec/controllers/admin/slots_controller_spec.rb
@@ -23,7 +23,7 @@ describe Admin::SlotsController, type: :controller do
         motif_id: motif.id,
         from_date: from_date,
         agent_ids: agent_ids,
-        lieu_id: lieu
+        lieu_id: lieu,
       }
 
       expect(assigns(:search_result)).not_to be_nil

--- a/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
+++ b/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::Territories::SectorisationTestsController, type: :controller do
           street_ban_id: 560_570_882,
           latitude: 48.039837,
           longitude: -3.498531,
-          commit: "Tester la sectorisation de cette adresse"
+          commit: "Tester la sectorisation de cette adresse",
         }
         expect(response).to be_successful
       end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Admin::UsersController, type: :controller do
         {
           first_name: "Michel",
           last_name: "Lapin",
-          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
+          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } },
         }
       end
 
@@ -59,7 +59,7 @@ RSpec.describe Admin::UsersController, type: :controller do
           first_name: "Michel",
           last_name: "Lapin",
           email: user.email,
-          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
+          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } },
         }
       end
 
@@ -71,7 +71,7 @@ RSpec.describe Admin::UsersController, type: :controller do
       let(:attributes) do
         {
           first_name: "Michel",
-          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
+          user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } },
         }
       end
       let(:format) { :html }
@@ -95,7 +95,7 @@ RSpec.describe Admin::UsersController, type: :controller do
             first_name: "Michel",
             last_name: "Lapin",
             email: "michel@lapin.com",
-            user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } }
+            user_profiles_attributes: { "0" => { "organisation_id" => organisation.id.to_s } },
           }
         end
         let(:format) { format }

--- a/spec/controllers/lieux_controller_spec.rb
+++ b/spec/controllers/lieux_controller_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe LieuxController, type: :controller do
             city_code: "62100",
             where: "useless 12345",
             service: motif.service_id,
-            motif_name_with_location_type: motif.name_with_location_type
-          }
+            motif_name_with_location_type: motif.name_with_location_type,
+          },
         }
       end
 
@@ -123,7 +123,7 @@ RSpec.describe LieuxController, type: :controller do
               Users::CreneauxSearch,
               creneaux: [
                 build(:creneau, starts_at: DateTime.parse("2019-07-22 08h00"), agent: create(:agent)),
-                build(:creneau, starts_at: DateTime.parse("2019-07-22 09h00"), agent: create(:agent))
+                build(:creneau, starts_at: DateTime.parse("2019-07-22 09h00"), agent: create(:agent)),
               ]
             )
           end
@@ -179,7 +179,7 @@ RSpec.describe LieuxController, type: :controller do
           departement: "62", city_code: "62100", where: "useless 12345",
           service: motif.service_id,
           motif_name_with_location_type: motif.name_with_location_type,
-          latitude: lieu.latitude, longitude: lieu.longitude
+          latitude: lieu.latitude, longitude: lieu.longitude,
         } }
         expect(response).to be_successful
       end
@@ -191,7 +191,7 @@ RSpec.describe LieuxController, type: :controller do
           departement: "62", city_code: "62100", where: "useless 12345",
           service: motif.service_id,
           motif_name_with_location_type: motif.name_with_location_type,
-          latitude: lieu.latitude, longitude: lieu.longitude
+          latitude: lieu.latitude, longitude: lieu.longitude,
         } }
         expect(assigns(:next_availability_by_lieux).count).to eq(2)
       end
@@ -203,7 +203,7 @@ RSpec.describe LieuxController, type: :controller do
           departement: "62", city_code: "62100", where: "useless 12345",
           service: motif.service_id,
           motif_name_with_location_type: motif.name_with_location_type,
-          latitude: lieu.latitude, longitude: lieu.longitude
+          latitude: lieu.latitude, longitude: lieu.longitude,
         } }
         expect(assigns(:lieux).first).to eq(lieu)
       end
@@ -215,7 +215,7 @@ RSpec.describe LieuxController, type: :controller do
           departement: "62", city_code: "62100", where: "useless 12345",
           service: motif.service_id,
           motif_name_with_location_type: motif.name_with_location_type,
-          latitude: lieu.latitude, longitude: lieu.longitude
+          latitude: lieu.latitude, longitude: lieu.longitude,
         } }
         expect(assigns(:next_availability_by_lieux).first.last.starts_at).to eq(Time.zone.parse("20190726 8"))
       end
@@ -228,7 +228,7 @@ RSpec.describe LieuxController, type: :controller do
         get :index, params: { search: { departement: "62", city_code: "62100", where: "useless 12345",
                                         service: motif.service_id,
                                         motif_name_with_location_type: motif.name_with_location_type,
-                                        latitude: lieu2.latitude, longitude: lieu2.longitude } }
+                                        latitude: lieu2.latitude, longitude: lieu2.longitude, } }
         expect(assigns(:lieux).first).to eq(lieu2)
       end
     end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -8,16 +8,16 @@ describe OrganisationsController, type: :controller do
         organisation: {
           name: "Ma nouvelle orga",
           territory_attributes: {
-            departement_number: "56"
+            departement_number: "56",
           },
           agent_roles_attributes: [{
             level: "admin",
             agent_attributes: {
               email: "me@myself.hi",
-              service_id: service.id
-            }
-          }]
-        }
+              service_id: service.id,
+            },
+          }],
+        },
       }
 
       expect(Territory.count).to eq 0
@@ -38,16 +38,16 @@ describe OrganisationsController, type: :controller do
         organisation: {
           name: "Ma nouvelle orga",
           territory_attributes: {
-            departement_number: "56"
+            departement_number: "56",
           },
           agent_roles_attributes: [{
             level: "admin",
             agent_attributes: {
               email: "me@myself.hi",
-              service_id: "unknow" # this is the error
-            }
-          }]
-        }
+              service_id: "unknow", # this is the error
+            },
+          }],
+        },
       }
 
       post :create, params: params

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe SearchController, type: :controller do
         it "redirects with an error message" do
           get :search_rdv, params: {
             organisation_ids: [organisation.id], address: address, departement: departement_number, city_code: city_code,
-            invitation_token: invitation_token
+            invitation_token: invitation_token,
           }
           expect(response).to redirect_to(root_path)
           expect(flash[:error]).to include("Votre invitation n'est pas valide.")
@@ -73,7 +73,7 @@ RSpec.describe SearchController, type: :controller do
         it "redirects with an error message" do
           get :search_rdv, params: {
             organisation_ids: [organisation.id], address: address, departement: departement_number, city_code: city_code,
-            invitation_token: invitation_token
+            invitation_token: invitation_token,
           }
           expect(response).to redirect_to(root_path)
           expect(flash[:error]).to include("L’utilisateur connecté ne correspond pas à l’utilisateur invité. Déconnectez-vous et réessayez.")
@@ -86,7 +86,7 @@ RSpec.describe SearchController, type: :controller do
 
       it "lists the motifs retrieved by the geo search" do
         get :search_rdv, params: {
-          address: address, departement: departement_number, city_code: city_code
+          address: address, departement: departement_number, city_code: city_code,
         }
         expect(subject).to include("RSA orientation 1")
         expect(subject).to include("RSA orientation 2")
@@ -96,7 +96,7 @@ RSpec.describe SearchController, type: :controller do
       context "when a motif category is passed" do
         it "retrieves motifs from the selected category" do
           get :search_rdv, params: {
-            address: address, departement: departement_number, city_code: city_code, motif_category: "rsa_orientation"
+            address: address, departement: departement_number, city_code: city_code, motif_category: "rsa_orientation",
           }
           expect(subject).to include("RSA orientation 1")
           expect(subject).not_to include("RSA orientation 2")
@@ -111,7 +111,7 @@ RSpec.describe SearchController, type: :controller do
         it "lists the available motifs that match the search terms" do
           get :search_rdv, params: {
             address: address, departement: departement_number, city_code: city_code,
-            invitation_token: invitation_token, motif_search_terms: "RSA orientation"
+            invitation_token: invitation_token, motif_search_terms: "RSA orientation",
           }
           expect(subject).to include("RSA orientation 1")
           expect(subject).to include("RSA orientation 2")
@@ -129,7 +129,7 @@ RSpec.describe SearchController, type: :controller do
           it "lists the available motifs" do
             get :search_rdv, params: {
               address: address, departement: departement_number, city_code: city_code,
-              invitation_token: invitation_token
+              invitation_token: invitation_token,
             }
             expect(subject).to include("RSA orientation 2")
             expect(subject).not_to include("RSA orientation 1")
@@ -142,7 +142,7 @@ RSpec.describe SearchController, type: :controller do
           it "lists the matching motifs linked to the orgas passed in the url" do
             get :search_rdv, params: {
               organisation_ids: [organisation.id], address: address, departement: departement_number, city_code: city_code,
-              invitation_token: invitation_token, motif_category: "rsa_orientation"
+              invitation_token: invitation_token, motif_category: "rsa_orientation",
             }
             expect(subject).to include("RSA orientation 1")
             expect(subject).not_to include("RSA orientation 2")
@@ -153,7 +153,7 @@ RSpec.describe SearchController, type: :controller do
           it "reveals a problem when no motifs are available" do
             get :search_rdv, params: {
               organisation_ids: [other_org.id], address: address, departement: departement_number, city_code: city_code,
-              invitation_token: invitation_token, motif_search_terms: "something random"
+              invitation_token: invitation_token, motif_search_terms: "something random",
             }
             expect(subject).to include("Nous sommes désolés, un problème semble s'être produit pour votre invitation.")
             expect(subject).to include("support@rdv-solidarites.fr")
@@ -175,7 +175,7 @@ RSpec.describe SearchController, type: :controller do
 
       it "lists the the available lieux linked to the motifs" do
         get :search_rdv, params: {
-          address: address, departement: departement_number, city_code: city_code
+          address: address, departement: departement_number, city_code: city_code,
         }
         expect(subject).to include("Lieu numéro 1")
         expect(subject).not_to include("Lieu numéro 2")
@@ -190,7 +190,7 @@ RSpec.describe SearchController, type: :controller do
         )
         allow(NextAvailabilityService).to receive(:find).and_return(slot)
         get :search_rdv, params: {
-          address: address, departement: departement_number, city_code: city_code
+          address: address, departement: departement_number, city_code: city_code,
         }
         expect(subject).to match(/Prochaine disponibilité le(.)*lundi 05 août 2019 à 08h00/)
       end
@@ -217,7 +217,7 @@ RSpec.describe SearchController, type: :controller do
 
         it "returns a creneau" do
           get :search_rdv, params: {
-            lieu_id: lieu.id, address: address, departement: departement_number, city_code: city_code
+            lieu_id: lieu.id, address: address, departement: departement_number, city_code: city_code,
           }
           expect(subject).to include("08:00")
         end
@@ -234,7 +234,7 @@ RSpec.describe SearchController, type: :controller do
 
         it "returns next availability" do
           get :search_rdv, params: {
-            lieu_id: lieu.id, address: address, departement: departement_number, city_code: city_code
+            lieu_id: lieu.id, address: address, departement: departement_number, city_code: city_code,
           }
           expect(subject).to match(/Prochaine disponibilité le(.)*lundi 05 août 2019 à 08h00/)
         end

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     subject do
       post :create, params: {
         organisation_id: organisation.id, lieu_id: lieu.id, departement: "12", city_code: "12100", where: "1 rue de la, ville 12345",
-        motif_id: motif.id, starts_at: starts_at, organisation_ids: [organisation.id], invitation_token: "44444"
+        motif_id: motif.id, starts_at: starts_at, organisation_ids: [organisation.id], invitation_token: "44444",
       }
     end
 

--- a/spec/features/accessibility/welcome_pages_spec.rb
+++ b/spec/features/accessibility/welcome_pages_spec.rb
@@ -54,7 +54,7 @@ describe "welcome pages", js: true do
                         motif_name_with_location_type: motif.name_with_location_type,
                         service: service.id,
                         street_ban_id: "75119_4903",
-                        where: "152 Avenue Jean Jaurès Paris 75019 Paris 19e Arrondissement 75 Paris Île-de-France"
+                        where: "152 Avenue Jean Jaurès Paris 75019 Paris 19e Arrondissement 75 Paris Île-de-France",
                       })
     expect_page_to_be_axe_clean(path)
   end

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -23,7 +23,7 @@ describe Admin::RdvSearchForm do
         lieu_id: lieu.id,
         show_user_details: nil,
         status: nil,
-        user_id: nil
+        user_id: nil,
       }
       expect(agent_rdv_search_form.to_query).to eq(expected_query)
     end

--- a/spec/form_models/admin/rdv_wizard_form/step2_spec.rb
+++ b/spec/form_models/admin/rdv_wizard_form/step2_spec.rb
@@ -11,7 +11,7 @@ describe Admin::RdvWizardForm::Step2 do
       attributes = {
         starts_at: Time.zone.now,
         motif_id: motif.id,
-        user_ids: [user.id]
+        user_ids: [user.id],
       }
       rdv_wizard = described_class.new(agent, organisation, attributes)
       expect(rdv_wizard.save).to be true
@@ -21,7 +21,7 @@ describe Admin::RdvWizardForm::Step2 do
       motif = create(:motif, :at_public_office, organisation: organisation)
       attributes = {
         starts_at: Time.zone.now,
-        motif_id: motif.id
+        motif_id: motif.id,
       }
       rdv_wizard = described_class.new(agent, organisation, attributes)
       expect(rdv_wizard.save).to be false
@@ -32,7 +32,7 @@ describe Admin::RdvWizardForm::Step2 do
       attributes = {
         starts_at: Time.zone.now,
         motif_id: motif.id,
-        user_ids: []
+        user_ids: [],
       }
       rdv_wizard = described_class.new(agent, organisation, attributes)
       expect(rdv_wizard.save).to be false
@@ -44,7 +44,7 @@ describe Admin::RdvWizardForm::Step2 do
       attributes = {
         starts_at: Time.zone.now,
         motif_id: motif.id,
-        user_ids: [user.id]
+        user_ids: [user.id],
       }
       rdv_wizard = described_class.new(agent, organisation, attributes)
       expect(rdv_wizard.save).to be false
@@ -57,7 +57,7 @@ describe Admin::RdvWizardForm::Step2 do
       attributes = {
         starts_at: Time.zone.now,
         motif_id: motif.id,
-        user_ids: [user1.id, user2.id]
+        user_ids: [user1.id, user2.id],
       }
       rdv_wizard = described_class.new(agent, organisation, attributes)
       expect(rdv_wizard.save).to be true
@@ -70,7 +70,7 @@ describe Admin::RdvWizardForm::Step2 do
       attributes = {
         starts_at: Time.zone.now,
         motif_id: motif.id,
-        user_ids: [user2.id]
+        user_ids: [user2.id],
       }
       rdv_wizard = described_class.new(agent, organisation, attributes)
       expect(rdv_wizard.save).to be true

--- a/spec/form_models/admin/user_search_form_spec.rb
+++ b/spec/form_models/admin/user_search_form_spec.rb
@@ -9,7 +9,7 @@ describe Admin::UserSearchForm do
       expected_query = {
         agent_id: nil,
         organisation_id: organisation.id,
-        search: nil
+        search: nil,
       }
       expect(user_search_form.to_query).to eq(expected_query)
     end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -17,7 +17,7 @@ describe UserRdvWizard do
       lieu_id: lieu.id,
       user_ids: [user_for_rdv.id],
       departement: "62",
-      city_code: "62100"
+      city_code: "62100",
     }
   end
 
@@ -52,10 +52,10 @@ describe UserRdvWizard do
         user: {
           first_name: "Léa",
           last_name: "Boubakar",
-          phone_number: nil
+          phone_number: nil,
         },
         departement: "62",
-        city_code: "62100"
+        city_code: "62100",
       }
       rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
       expect(rdv_wizard.save).to be true
@@ -71,10 +71,10 @@ describe UserRdvWizard do
         user: {
           first_name: "Léa",
           last_name: "Boubakar",
-          phone_number: nil
+          phone_number: nil,
         },
         departement: "62",
-        city_code: "62100"
+        city_code: "62100",
       }
       rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
       expect(rdv_wizard.save).to be false

--- a/spec/form_models/users/registration_form_spec.rb
+++ b/spec/form_models/users/registration_form_spec.rb
@@ -5,7 +5,7 @@ describe Users::RegistrationForm, type: :form_model do
     {
       first_name: "jean",
       last_name: "durand",
-      email: "jean@durand.fr"
+      email: "jean@durand.fr",
     }
   end
 

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -42,7 +42,7 @@ describe WebhookJob, type: :job do
     [
       "{\"message\": \"Can't update appointment.\"}",
       "{\"message\": \"Appointment id doesn't exist\"}",
-      "{\"message\": \"Appointment already deleted\"}"
+      "{\"message\": \"Appointment already deleted\"}",
     ].each do |returned_message|
       it "return true when message is `#{returned_message}`" do
         expect(described_class.false_negative_from_drome?(returned_message)).to eq(true)

--- a/spec/lib/csv_or_xls_reader/importer_spec.rb
+++ b/spec/lib/csv_or_xls_reader/importer_spec.rb
@@ -19,7 +19,7 @@ describe CsvOrXlsReader::Importer do
         [
           { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "organisation_id" => "arques" },
           { "city_code" => "62110", "city_name" => "ARQUES", "organisation_id" => "arques" },
-          { "city_code" => "62007", "city_name" => "ACQ", "organisation_id" => "arras-sud" }
+          { "city_code" => "62007", "city_name" => "ACQ", "organisation_id" => "arras-sud" },
         ]
       )
     end
@@ -33,7 +33,7 @@ describe CsvOrXlsReader::Importer do
         [
           { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "organisation_id" => "arques" },
           { "city_code" => "62110", "city_name" => "ARQUES", "organisation_id" => "arques" },
-          { "city_code" => "62007", "city_name" => "ACQ", "organisation_id" => "arras-sud" }
+          { "city_code" => "62007", "city_name" => "ACQ", "organisation_id" => "arras-sud" },
         ]
       )
     end

--- a/spec/mailers/previews/agents/export_mailer_preview.rb
+++ b/spec/mailers/previews/agents/export_mailer_preview.rb
@@ -5,7 +5,7 @@ class Agents::ExportMailerPreview < ActionMailer::Preview
     agent = Agent.first
     options = {
       start: Time.zone.today - 4.years - 7.days,
-      end: Time.zone.today - 4.years
+      end: Time.zone.today - 4.years,
     }
     Agents::ExportMailer.rdv_export(agent, agent.organisations.first, options)
   end

--- a/spec/models/concerns/human_attribute_value_spec.rb
+++ b/spec/models/concerns/human_attribute_value_spec.rb
@@ -7,7 +7,7 @@ class DemoThing
   def self.attribute_types
     {
       "some_str" => ActiveModel::Type::String.new,
-      "some_bool" => ActiveModel::Type::Boolean.new
+      "some_bool" => ActiveModel::Type::Boolean.new,
     }
   end
 
@@ -16,7 +16,7 @@ class DemoThing
       "some_strs.value_one" => "My string value",
       "some_strs/specific_context.value_one" => "My string value in context",
       "some_bools.true" => "My bool is true",
-      "some_bools.false" => "My bool is false"
+      "some_bools.false" => "My bool is false",
     }
     i18n[key]
   end

--- a/spec/models/concerns/ical_helpers/ics_spec.rb
+++ b/spec/models/concerns/ical_helpers/ics_spec.rb
@@ -14,7 +14,7 @@ describe IcalHelpers::Ics do
         description: "Infos et annulation:",
         address: "10 rue de la Ferronerie 44100 Nantes",
         ical_uid: "rdv_15@RDV Solidarités",
-        recurrence: "FREQ=WEEKLY;"
+        recurrence: "FREQ=WEEKLY;",
       }
     end
 

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -171,7 +171,7 @@ describe Motif, type: :model do
       expect(motif).not_to be_valid
       expect(subject.errors.full_messages).to eq [
         "La réservation en ligne n'est pas possible pour les RDV collectifs.",
-        "Les RDV collectifs doivent avoir lieu sur place."
+        "Les RDV collectifs doivent avoir lieu sur place.",
       ]
     end
   end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -273,7 +273,7 @@ describe Rdv, type: :model do
         expected_rdvs = [
           rdv_finished_shortly_before,
           rdv_starting_shortly_after,
-          rdv_that_ongoing
+          rdv_that_ongoing,
         ]
 
         expect(described_class.ongoing(time_margin: 1.hour).sort).to eq(expected_rdvs.sort)

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Zone, type: :model do
           sector: sector,
           level: "city",
           city_name: "Paris XXe",
-          city_code: "75120"
+          city_code: "75120",
         }
       end
 

--- a/spec/presenters/paper_trail_augmented_version_spec.rb
+++ b/spec/presenters/paper_trail_augmented_version_spec.rb
@@ -17,7 +17,7 @@ describe PaperTrailAugmentedVersion do
         expect(described_class.new(version, nil).changes).to eq(
           {
             "title" => %w[foo bar],
-            "user_ids" => [nil, [1, 2]]
+            "user_ids" => [nil, [1, 2]],
           }
         )
       end
@@ -46,7 +46,7 @@ describe PaperTrailAugmentedVersion do
         ).to eq(
           {
             "title" => %w[foo bar],
-            "user_ids" => [[1], [1, 2]]
+            "user_ids" => [[1], [1, 2]],
             # agent_ids has not changed so it does not appear here
           }
         )

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -60,7 +60,7 @@ describe "api/v1/absences requests", type: :request do
         first_day: "2020-11-20",
         start_time: "08:00",
         end_day: "2020-11-20",
-        end_time: "18:30"
+        end_time: "18:30",
       }
     end
 

--- a/spec/requests/api/v1/user_profiles_request_spec.rb
+++ b/spec/requests/api/v1/user_profiles_request_spec.rb
@@ -13,7 +13,7 @@ describe "api/v1/user_profiles requests", type: :request do
           api_v1_user_profiles_path,
           params: {
             organisation_id: organisation.id,
-            user_id: user.id
+            user_id: user.id,
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -36,7 +36,7 @@ describe "api/v1/user_profiles requests", type: :request do
             organisation_id: organisation.id,
             user_id: user.id,
             logement: "heberge",
-            notes: "Très pressé, vite vite"
+            notes: "Très pressé, vite vite",
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -91,7 +91,7 @@ describe "api/v1/user_profiles requests", type: :request do
           api_v1_user_profiles_path,
           params: {
             user_id: user.id,
-            organisation_id: unauthorized_orga.id
+            organisation_id: unauthorized_orga.id,
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -111,7 +111,7 @@ describe "api/v1/user_profiles requests", type: :request do
           api_v1_user_profiles_path,
           params: {
             user_id: user.id,
-            organisation_id: organisation.id
+            organisation_id: organisation.id,
           },
           headers: api_auth_headers_for_agent(agent)
         )

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -61,7 +61,7 @@ describe "api/v1/users requests", type: :request do
           params: {
             organisation_ids: [organisation.id],
             first_name: "Jean",
-            last_name: "Jacques"
+            last_name: "Jacques",
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -95,7 +95,7 @@ describe "api/v1/users requests", type: :request do
             family_situation: "single",
             number_of_children: 3,
             notify_by_sms: false,
-            notify_by_email: false
+            notify_by_email: false,
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -132,7 +132,7 @@ describe "api/v1/users requests", type: :request do
             organisation_ids: [organisation.id],
             first_name: "Jean",
             last_name: "Jacques",
-            responsible_id: user_responsible.id
+            responsible_id: user_responsible.id,
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -175,7 +175,7 @@ describe "api/v1/users requests", type: :request do
           api_v1_users_path,
           params: {
             organisation_ids: [organisation.id],
-            first_name: "Jean" # missing last_name
+            first_name: "Jean", # missing last_name
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -197,7 +197,7 @@ describe "api/v1/users requests", type: :request do
             organisation_ids: [organisation.id],
             first_name: "Jean",
             last_name: "Jacques",
-            phone_number: "blah blah"
+            phone_number: "blah blah",
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -220,7 +220,7 @@ describe "api/v1/users requests", type: :request do
             organisation_ids: [organisation.id],
             first_name: "Jean",
             last_name: "Jacques",
-            email: "jean@jacques.fr"
+            email: "jean@jacques.fr",
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -376,7 +376,7 @@ describe "api/v1/users requests", type: :request do
           invite_api_v1_user_path(user),
           headers: api_auth_headers_for_agent(agent),
           params: {
-            invite_for: 86_400 # invite_for en secondes (86400 = 1 jour),
+            invite_for: 86_400, # invite_for en secondes (86400 = 1 jour),
           },
           as: :json
         )
@@ -445,7 +445,7 @@ describe "api/v1/users requests", type: :request do
           api_v1_user_path(user),
           params: {
             first_name: "Alain",
-            last_name: "Deloin"
+            last_name: "Deloin",
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -475,7 +475,7 @@ describe "api/v1/users requests", type: :request do
             family_situation: "single",
             number_of_children: 3,
             notify_by_sms: false,
-            notify_by_email: false
+            notify_by_email: false,
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -509,7 +509,7 @@ describe "api/v1/users requests", type: :request do
           params: {
             first_name: "Alain",
             last_name: "Deloin",
-            responsible_id: user_responsible.id
+            responsible_id: user_responsible.id,
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -530,7 +530,7 @@ describe "api/v1/users requests", type: :request do
           params: {
             first_name: "Jean",
             last_name: "Jacques",
-            phone_number: "blah blah"
+            phone_number: "blah blah",
           },
           headers: api_auth_headers_for_agent(agent)
         )
@@ -549,7 +549,7 @@ describe "api/v1/users requests", type: :request do
           params: {
             first_name: "Jean",
             last_name: "Jacques",
-            email: "jean@jacques.fr"
+            email: "jean@jacques.fr",
           },
           headers: api_auth_headers_for_agent(agent)
         )

--- a/spec/requests/api_authentication_spec.rb
+++ b/spec/requests/api_authentication_spec.rb
@@ -45,7 +45,7 @@ describe "API auth", type: :request do
         headers: {
           "access-token": "blah",
           client: "blah",
-          uid: "jean@fun.fr"
+          uid: "jean@fun.fr",
         }
       )
       expect(response.status).to eq(401)
@@ -66,7 +66,7 @@ describe "API auth", type: :request do
         headers: {
           "access-token": response.headers["access-token"],
           client: response.headers["client"],
-          uid: response.headers["uid"]
+          uid: response.headers["uid"],
         }
       )
       expect(response.status).to eq(200)

--- a/spec/services/import_zone_rows_service_spec.rb
+++ b/spec/services/import_zone_rows_service_spec.rb
@@ -14,7 +14,7 @@ describe ImportZoneRowsService, type: :service do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
         { "city_code" => "62110", "city_name" => "ARQUES", "sector_id" => "arques" },
-        { "city_code" => "62007", "city_name" => "ACQ", "sector_id" => "arras-sud" }
+        { "city_code" => "62007", "city_name" => "ACQ", "sector_id" => "arras-sud" },
       ]
     end
 
@@ -46,7 +46,7 @@ describe ImportZoneRowsService, type: :service do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
         { "city_code" => "62080", "city_name" => "BAPAUME", "sector_id" => "arras-sud", "street_name" => "rue de la gare", "street_code" => "62080_0580" },
-        { "city_code" => "62080", "city_name" => "BAPAUME", "sector_id" => "arras-sud", "street_name" => "rue des casernes", "street_code" => "62080_0180" }
+        { "city_code" => "62080", "city_name" => "BAPAUME", "sector_id" => "arras-sud", "street_name" => "rue des casernes", "street_code" => "62080_0180" },
       ]
     end
 
@@ -90,7 +90,7 @@ describe ImportZoneRowsService, type: :service do
       [
         { "codeInsee" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
         { "codeInsee" => "62010", "city_name" => "ARQUES", "sector_id" => "arques" },
-        { "codeInsee" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arras-nord" }
+        { "codeInsee" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arras-nord" },
       ]
     end
 
@@ -106,7 +106,7 @@ describe ImportZoneRowsService, type: :service do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
         { "city_code" => "", "city_name" => "ARQUES", "sector_id" => "arques" },
-        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arras-nord" }
+        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arras-nord" },
       ]
     end
 
@@ -121,7 +121,7 @@ describe ImportZoneRowsService, type: :service do
     let(:rows) do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
-        { "city_code" => "62110", "city_name" => "ARQUES", "sector_id" => "" }
+        { "city_code" => "62110", "city_name" => "ARQUES", "sector_id" => "" },
       ]
     end
 
@@ -136,7 +136,7 @@ describe ImportZoneRowsService, type: :service do
     let(:rows) do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arras-nord" },
-        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arras-nord" }
+        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arras-nord" },
       ]
     end
 
@@ -151,7 +151,7 @@ describe ImportZoneRowsService, type: :service do
   context "mismatching departement code" do
     let(:rows) do
       [
-        { "city_code" => "75040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" }
+        { "city_code" => "75040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
       ]
     end
 
@@ -167,7 +167,7 @@ describe ImportZoneRowsService, type: :service do
     let(:rows) do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arques" },
-        { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arras-sud" }
+        { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-LYS", "sector_id" => "arras-sud" },
       ]
     end
 
@@ -184,7 +184,7 @@ describe ImportZoneRowsService, type: :service do
     let(:rows) do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-lièsse", "sector_id" => "arques" },
-        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arques" }
+        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arques" },
       ]
     end
 
@@ -207,7 +207,7 @@ describe ImportZoneRowsService, type: :service do
     let(:rows) do
       [
         { "city_code" => "62040", "city_name" => "AIRE-SUR-LA-lièsse", "sector_id" => "arques" },
-        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arques" }
+        { "city_code" => "62004", "city_name" => "ACHICOURT", "sector_id" => "arques" },
       ]
     end
 

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -24,7 +24,7 @@ describe RdvExporter, type: :service do
       it "return an header" do
         sheet = described_class.build_excel_workbook_from(Rdv.none).worksheet(0)
         expect(sheet.row(0)).to eq(["année", "date prise rdv", "heure prise rdv", "origine", "date rdv", "heure rdv", "service", "motif", "contexte", "statut", "lieu", "professionnel.le(s)",
-                                    "usager(s)", "commune du premier responsable", "au moins un usager mineur ?"])
+                                    "usager(s)", "commune du premier responsable", "au moins un usager mineur ?",])
       end
     end
   end

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -125,8 +125,8 @@ describe RdvUpdater, type: :service do
         rdvs_users_attributes: {
           0 => { user_id: user_staying.id, send_lifecycle_notifications: 1, id: rdv.rdvs_users.find_by(user_id: user_staying.id).id, _destroy: false },
           1 => { user_id: user_removed.id, send_lifecycle_notifications: 1, id: rdv.rdvs_users.find_by(user_id: user_removed.id).id, _destroy: true  },
-          2 => { user_id: user_added.id, send_lifecycle_notifications: 1 }
-        }
+          2 => { user_id: user_added.id, send_lifecycle_notifications: 1 },
+        },
       }
     end
     let(:rdv) { create(:rdv, agents: [agent], motif: motif, users: [user_staying, user_removed]) }

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -20,7 +20,7 @@ describe SearchContext, type: :service do
   let!(:search_query) do
     {
       organisation_ids: [organisation.id], departement: departement_number, city_code: city_code,
-      latitude: latitude, longitude: longitude
+      latitude: latitude, longitude: longitude,
     }
   end
 

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -50,7 +50,7 @@ describe SlotBuilder, type: :service do
         expect(slots.map(&:starts_at)).to match_array([
                                                         Time.zone.local(2021, 5, 3, 15, 5, 0),
                                                         Time.zone.local(2021, 5, 3, 18, 0, 0),
-                                                        Time.zone.local(2021, 5, 3, 19, 0, 0)
+                                                        Time.zone.local(2021, 5, 3, 19, 0, 0),
                                                       ])
       end
     end
@@ -239,7 +239,7 @@ describe SlotBuilder, type: :service do
       expected_ranges = [
         (Time.zone.parse("2021-10-26 9:00")..Time.zone.parse("2021-10-26 11:00")),
         (Time.zone.parse("2021-10-28 9:00")..Time.zone.parse("2021-10-28 11:00")),
-        (Time.zone.parse("2021-10-29 9:00")..Time.zone.parse("2021-10-29 11:00"))
+        (Time.zone.parse("2021-10-29 9:00")..Time.zone.parse("2021-10-29 11:00")),
       ]
       expect(described_class.calculate_free_times(plage_ouverture, range, [])).to eq(expected_ranges)
     end

--- a/spec/services/users/creneau_search_spec.rb
+++ b/spec/services/users/creneau_search_spec.rb
@@ -28,7 +28,7 @@ describe Users::CreneauSearch do
         [
           build(:creneau, starts_at: DateTime.parse("2020-10-20 09h30")),
           build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30"))
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
         ]
       end
 
@@ -40,7 +40,7 @@ describe Users::CreneauSearch do
         [
           build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
           build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 11h30"))
+          build(:creneau, starts_at: DateTime.parse("2020-10-20 11h30")),
         ]
       end
 


### PR DESCRIPTION
**L'essentiel de la PR consiste à ajouter les deux cops `TrailingCommaInArrayLiteral` et  `TrailingCommaInHashLiteral` dans `rubocop.yml` puis de lancer l'auto-correction.**

Note : J'ai dû corriger les templates slim à la main, j'en ai profité pour clarifier un petit tas d'accolades dans `app/views/admin/rdvs/edit.html.slim` : 

![image](https://user-images.githubusercontent.com/6357692/168096434-4b4d64b5-99e2-43cb-9408-2c0b0d49ad29.png)

# Checklist

Avant la revue :
- [ ] ~~Préparer des captures de l’interface avant et après~~
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
