### PR TITLE
Permettre aux usagers de répondre directement aux agents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,9 @@ Rails/LexicallyScopedActionFilter:
     - 'app/controllers/agents/sessions_controller.rb'
     - 'app/controllers/agent_auth_controller.rb'
 
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: false
+
 # This allows the standard syntax for the `change` matcher, see:
 # https://relishapp.com/rspec/rspec-expectations/docs/built-in-matchers/change-matcher
 Lint/AmbiguousBlockAssociation:
@@ -149,6 +152,7 @@ RSpec/NestedGroups:
 RSpec/DescribeClass:
   Exclude:
     - "spec/features/**/*"
+    - "spec/requests/**/*"
 
 Style/AsciiComments:
   Enabled: false

--- a/app/controllers/inbound_emails_controller.rb
+++ b/app/controllers/inbound_emails_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/ApplicationController
+class InboundEmailsController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+
+  before_action :authenticate_sendinblue
+
+  def sendinblue
+    payload = request.params["items"].first
+    TransferEmailReplyJob.perform_later(payload)
+  end
+
+  private
+
+  def authenticate_sendinblue
+    return if ActiveSupport::SecurityUtils.secure_compare(ENV["SENDINBLUE_INBOUND_PASSWORD"], params[:password])
+
+    Sentry.capture_message("Sendinblue inbound controller was called without valid password")
+    head :unauthorized
+  end
+end
+# rubocop:enable Rails/ApplicationController

--- a/app/javascript/stylesheets/mail.scss
+++ b/app/javascript/stylesheets/mail.scss
@@ -251,3 +251,9 @@ html,
     margin: 0 !important;
   }
 }
+
+blockquote {
+  background-color: $light;
+  padding: $padding;
+  margin: 15px;
+}

--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+class TransferEmailReplyJob < ApplicationJob
+  queue_as :mailers
+
+  def self.reply_address_for_rdv(rdv)
+    "rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"
+  end
+
+  UUID_EXTRACTOR = /rdv\+([a-f0-9\-]*)@reply\.rdv-solidarites\.fr/
+
+  def perform(sendinblue_hash)
+    @sendinblue_hash = sendinblue_hash.with_indifferent_access
+
+    if rdv
+      notify_agents
+    else
+      Sentry.capture_message("Reply email could not be forwarded to agent, it was sent to default mailbox")
+      forward_to_default_mailbox
+    end
+  end
+
+  private
+
+  def notify_agents
+    Agents::ReplyTransferMailer.notify_agent_of_user_reply(
+      rdv: rdv,
+      author: user || source_mail.header[:from],
+      agents: rdv.agents,
+      reply_body: extracted_response,
+      source_mail: source_mail
+    ).deliver_now
+  end
+
+  def forward_to_default_mailbox
+    Agents::ReplyTransferMailer.forward_to_default_mailbox(
+      reply_body: extracted_response,
+      source_mail: source_mail
+    ).deliver_now
+  end
+
+  def rdv
+    Rdv.find_by(uuid: uuid) if uuid
+  end
+
+  def user
+    rdv&.users&.find_by(email: source_mail.from.first)
+  end
+
+  def uuid
+    source_mail.to.first.match(UUID_EXTRACTOR)&.captures&.first
+  end
+
+  def extracted_response
+    # Sendinblue provides us with both
+    #   - the RAW email body (text + HTML)
+    #   - a smart extraction of the content in markdown format
+    # We chose to use the smart extract because it already does all
+    # the hard work of excluding the quoted reply part.
+    [@sendinblue_hash[:ExtractedMarkdownMessage], @sendinblue_hash[:ExtractedMarkdownSignature]].compact.join("\n\n")
+  end
+
+  # @return [Mail::Message]
+  def source_mail
+    payload = @sendinblue_hash
+
+    @source_mail ||= Mail.new do
+      headers payload[:Headers]
+      subject payload[:Subject]
+
+      if payload[:RawTextBody].present?
+        text_part do
+          body payload[:RawTextBody]
+        end
+      end
+
+      if payload[:RawHtmlBody].present?
+        html_part do
+          content_type "text/html; charset=UTF-8"
+          body payload[:RawHtmlBody]
+        end
+      end
+
+      payload.fetch(:Attachments, []).each do |attachment_payload|
+        attachments[attachment_payload[:Name]] = {
+          mime_type: attachment_payload[:ContentType],
+          content: "", # Sendinblue webhook does not provide the content of attachments
+        }
+      end
+    end
+  end
+end

--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Agents::ReplyTransferMailer < ApplicationMailer
+  include DateHelper
+  include ActionView::Helpers::TextHelper
+
+  # @param [Rdv] rdv
+  # @param [User, String] author
+  # @param [Array<Agent>] agents
+  # @param [Mail::Message] source_mail
+  def notify_agent_of_user_reply(rdv:, author:, agents:, reply_body:, source_mail:)
+    @rdv = rdv
+    @author = author
+    @reply_subject = source_mail.subject
+    @reply_body = reply_body
+    @attachment_names = source_mail.attachments.map(&:filename).join(", ")
+    @date = relative_date(@rdv.starts_at)
+
+    mail(to: agents.map(&:email), subject: t(".title", date: @date))
+  end
+
+  # @param [String] reply_body
+  # @param [Mail::Message] source_mail
+  def forward_to_default_mailbox(reply_body:, source_mail:)
+    @author = source_mail.header[:from]
+    @reply_subject = source_mail.subject
+    @reply_body = reply_body
+    @attachment_names = source_mail.attachments.map(&:filename).join(", ")
+
+    mail(to: "support@rdv-solidarites.fr", subject: t(".title"))
+  end
+end

--- a/app/mailers/users/file_attente_mailer.rb
+++ b/app/mailers/users/file_attente_mailer.rb
@@ -7,7 +7,7 @@ class Users::FileAttenteMailer < ApplicationMailer
     @token = params[:token]
   end
 
-  default to: -> { @user.email }
+  default to: -> { @user.email }, reply_to: -> { TransferEmailReplyJob.reply_address_for_rdv(@rdv) }
 
   def new_creneau_available
     subject = t("users.file_attente_mailer.new_creneau_available.title")

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -12,7 +12,7 @@ class Users::RdvMailer < ApplicationMailer
     @token = params[:token]
   end
 
-  default to: -> { @user.email }
+  default to: -> { @user.email }, reply_to: -> { TransferEmailReplyJob.reply_address_for_rdv(@rdv) }
 
   def rdv_created
     self.ics_payload = @rdv.payload(:create, @user)

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -57,7 +57,7 @@ class Rdv < ApplicationRecord
   # Hooks
   after_save :associate_users_with_organisation
   after_commit :update_agents_unknown_past_rdv_count, if: -> { past? }
-  after_commit :reload_uuid, on: :create
+  before_validation { self.uuid ||= SecureRandom.uuid }
 
   # Scopes
   scope :not_cancelled, -> { where(status: NOT_CANCELLED_STATUSES) }
@@ -299,11 +299,6 @@ class Rdv < ApplicationRecord
 
   def update_agents_unknown_past_rdv_count
     agents.each(&:update_unknown_past_rdv_count!)
-  end
-
-  def reload_uuid
-    # https://github.com/rails/rails/issues/17605
-    self[:uuid] = self.class.where(id: id).pick(:uuid) if attributes.key? "uuid"
   end
 
   def cant_destroy_if_receipts_exist

--- a/app/views/mailers/agents/reply_transfer_mailer/forward_to_default_mailbox.html.slim
+++ b/app/views/mailers/agents/reply_transfer_mailer/forward_to_default_mailbox.html.slim
@@ -1,0 +1,10 @@
+div
+  p = t("mailers.common.hello")
+  p = t(".intro", author: @author)
+  blockquote
+    h4 = @reply_subject
+    div = simple_format(@reply_body)
+
+  p = t("agents.reply_transfer_mailer.shared.attachments", attachment_names: @attachment_names) if @attachment_names.present?
+
+  p = t(".instructions")

--- a/app/views/mailers/agents/reply_transfer_mailer/notify_agent_of_user_reply.html.slim
+++ b/app/views/mailers/agents/reply_transfer_mailer/notify_agent_of_user_reply.html.slim
@@ -1,0 +1,13 @@
+div
+  p = t("mailers.common.hello")
+  p = t(".intro", date: @date, author: @author)
+  blockquote
+    h4 = @reply_subject
+    div = simple_format(@reply_body)
+
+  p = auto_link t("agents.reply_transfer_mailer.shared.attachments", attachment_names: @attachment_names) if @attachment_names.present?
+
+  p = t(".instructions")
+
+  .btn-wrapper
+    = link_to "Voir le RDV", admin_organisation_rdv_url(@rdv.organisation_id, @rdv.id),  class: "btn btn-primary"

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -41,6 +41,17 @@ fr:
         revoked_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} pour raison administrative.
         cancelled_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} à la demande de l’usager.
         cancelled_at_date_by_user: Un RDV qui devait avoir lieu %{date} vient d’être annulé par l’usager %{author}.
+    reply_transfer_mailer:
+      notify_agent_of_user_reply:
+        title: Message d'usager⋅e au sujet de votre RDV %{date}
+        intro: "Dans le cadre du RDV du %{date}, l'usager⋅e %{author} a envoyé la réponse suivante par e-mail :"
+        instructions: Merci de ne pas répondre à cet e-mail. Vous pouvez contacter l'usager⋅e à l'aide des informations inclues dans le RDV. Vous trouverez en pièce jointe l'email original.
+      forward_to_default_mailbox:
+        title: Message d'usager⋅e en réponse à un e-mail de notification
+        intro: "L'usager⋅e %{author} a répondu à un e-mail de notification :"
+        instructions: Merci de ne pas répondre à cet e-mail. Vous trouverez en pièce jointe l'email original.
+      shared:
+        attachments: Le mail de l'usager⋅e avait en pièce jointe "%{attachment_names}". Il nous est impossible de vous transmettre ce fichier. Vous pouvez contacter l'usager⋅e pour qu'iel l'envoie à votre adresse.
   users:
     file_attente_mailer:
       new_creneau_available:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,6 +267,8 @@ Rails.application.routes.draw do
   get "admin/organisations/:organisation_id/agents/:agent_id", to: redirect("/admin/organisations/%{organisation_id}/agent_agendas/%{agent_id}")
   # rubocop:enable Style/FormatStringToken
 
+  post "/inbound_emails/sendinblue", controller: :inbound_emails, action: :sendinblue
+
   if Rails.env.development?
     namespace :lapin do
       resources :sms_preview, only: %i[index] do

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+RSpec.describe TransferEmailReplyJob do
+  subject(:perform_job) { described_class.perform_now(sendinblue_payload) }
+
+  before do
+    # Set a fixed date so we can assert on dates within email body
+    travel_to(Time.zone.parse("2022-05-17 16:00:00"))
+  end
+
+  let!(:user) { create(:user, email: "bene_ficiaire@lapin.fr", first_name: "Bénédicte", last_name: "Ficiaire") }
+  let!(:agent) { create(:agent, email: "je_suis_un_agent@departement.fr") }
+  let(:rdv_uuid) { "8fae4d5f-4d63-4f60-b343-854d939881a3" }
+  let!(:rdv) { create(:rdv, users: [user], agents: [agent], uuid: rdv_uuid) }
+
+  let(:sendinblue_valid_payload) do
+    # The usual payload has more info, but I removed non-essential fields for readability.
+    # See: https://developers.sendinblue.com/docs/inbound-parsing-api-1#sample-payload
+    {
+      Cc: [],
+      ReplyTo: nil,
+      Subject: "coucou",
+      Attachments: [],
+      Headers: {
+        "Message-ID": "<d6c8663e3763aa750345a76c17f435a2bd14eded.camel@lapin.fr>",
+        Subject: "coucou",
+        From: "Bénédicte Ficiaire <bene_ficiaire@lapin.fr>",
+        To: "rdv+8fae4d5f-4d63-4f60-b343-854d939881a3@reply.rdv-solidarites.fr",
+        Date: "Thu, 12 May 2022 12:22:15 +0200",
+      },
+      ExtractedMarkdownMessage: "Je souhaite annuler mon RDV",
+      ExtractedMarkdownSignature: nil,
+      RawHtmlBody: %(<html dir="ltr"><head></head><body style="text-align:left; direction:ltr;"><div>Je souhaite annuler mon RDV</div>\n</body></html>\n),
+      RawTextBody: "Je souhaite annuler mon RDV\n",
+    }
+  end
+  let(:sendinblue_payload) { sendinblue_valid_payload } # use valid payload by default
+
+  context "when all goes well" do
+    it "sends a notification email to the agent, containing the user reply" do
+      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      transferred_email = ActionMailer::Base.deliveries.last
+      expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
+      expect(transferred_email.from).to eq(["contact@rdv-solidarites.fr"])
+      expect(transferred_email.reply_to).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
+      expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
+      expect(transferred_email.html_part.body.to_s).to include(%(href="http://#{ApplicationMailer.default_url_options[:host]}/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))
+    end
+  end
+
+  context "when reply token does not match any in DB" do
+    let(:rdv_uuid) { "6df62597-632e-4be1-a273-708ab58e4765" }
+
+    it "sends a notification email to the default mailbox, containing the user reply" do
+      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      transferred_email = ActionMailer::Base.deliveries.last
+      expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email.from).to eq(["contact@rdv-solidarites.fr"])
+      expect(transferred_email.reply_to).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+      expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
+    end
+
+    it "warns Sentry" do
+      expect(Sentry).to receive(:capture_message).with("Reply email could not be forwarded to agent, it was sent to default mailbox")
+      perform_job
+    end
+  end
+
+  context "when an e-mail address does not match our pattern" do
+    let(:sendinblue_payload) do
+      sendinblue_valid_payload.tap { |hash| hash[:Headers][:To] = "nimportequoi@reply.rdv-solidarites.fr" }
+    end
+
+    it "is forwarded to default mailbox" do
+      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      transferred_email = ActionMailer::Base.deliveries.last
+      expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+    end
+  end
+
+  context "when several agents are linked to the RDV" do
+    let!(:other_agent) { create(:agent, email: "autre@departement.fr").tap { |a| rdv.agents << a } }
+
+    it "sends one email with all agents in the TO: field" do
+      perform_job
+      expect(ActionMailer::Base.deliveries.last.to).to match_array(["je_suis_un_agent@departement.fr", "autre@departement.fr"])
+    end
+  end
+
+  context "when attachments are present" do
+    let(:sendinblue_payload) do
+      sendinblue_valid_payload.tap do |hash|
+        hash[:Attachments] = [{ Name: "mon_scan.pdf", ContentType: "application/pdf" }]
+      end
+    end
+
+    it "mentions the attachments in the notification e-mail" do
+      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      transferred_email = ActionMailer::Base.deliveries.last
+      expect(transferred_email.html_part.body.to_s).to include(%(Le mail de l'usager⋅e avait en pièce jointe "mon_scan.pdf".))
+    end
+  end
+end

--- a/spec/mailers/previews/agents/reply_transfer_mailer_preview.rb
+++ b/spec/mailers/previews/agents/reply_transfer_mailer_preview.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Agents::ReplyTransferMailerPreview < ActionMailer::Preview
+  def notify_agent_of_user_reply
+    rdv = Rdv.last
+
+    # rubocop:disable RSpec/VariableName
+    # rubocop:disable RSpec/VariableDefinition
+    source_mail = Mail.new do
+      subject "Une nouvelle importante"
+
+      text_part do
+        body "Bonjour,\nVoici une phrase après un saut de ligne."
+      end
+
+      attachments["signature.svg"] = { mime_type: "image/svg+xml", content: "" }
+    end
+    # rubocop:enable RSpec/VariableDefinition
+    # rubocop:enable RSpec/VariableName
+
+    body = <<~MARKDOWN
+      Bonjour,
+      Voici une phrase après un saut de ligne.
+
+      Voici une autre phrase après deux sauts de ligne (saut de paragraphe
+    MARKDOWN
+
+    Agents::ReplyTransferMailer.notify_agent_of_user_reply(
+      rdv: rdv,
+      author: rdv.users.first,
+      agents: rdv.agents,
+      reply_body: body,
+      source_mail: source_mail
+    )
+  end
+end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     it "renders the headers" do
       expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
 
     it "renders the subject" do
@@ -41,6 +42,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
       expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
 
     it "subject contains date of cancelled rdv" do
@@ -96,6 +98,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "send mail to user" do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_upcoming_reminder
       expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
       expect(mail.html_part.body.raw_source).to include("/users/rdvs/#{rdv.id}?invitation_token=12345")
     end

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe "Handling an email reply from a user" do
+  subject(:receive_sendinblue_callback) do
+    post "/inbound_emails/sendinblue?password=#{password_param}",
+         params: { items: [{ Subject: "Dummy email" }] }.to_json,
+         headers: { "Content-Type" => "application/json" }
+  end
+
+  before do
+    ENV["SENDINBLUE_INBOUND_PASSWORD"] = "S3cr3T"
+  end
+
+  context "when using a valid password" do
+    let(:password_param) { "S3cr3T" }
+
+    it "enqueues the job that handles transferring the email" do
+      expect do
+        receive_sendinblue_callback
+      end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:mailers)
+    end
+  end
+
+  context "when using an invalid password" do
+    let(:password_param) { "inv4l1d" }
+
+    it "does not enqueue any job" do
+      expect { receive_sendinblue_callback }.not_to have_enqueued_job
+    end
+
+    it "warns Sentry" do
+      expect(Sentry).to receive(:capture_message).with("Sendinblue inbound controller was called without valid password")
+      receive_sendinblue_callback
+    end
+  end
+end


### PR DESCRIPTION
Closes #1649

**Le fonctionnement en gros : lorsqu'un⋅e usagèr⋅e reçoit un mail de notif, iel peut y répondre par mail et sa réponse est transmise à / aux agent(s) liés au RDV.** 

# Fonctionnalités

- [x] Sécuriser l'adresse de callback appelée par Sendinblue (utiliser un password)
- [x] Retrouver un RDV à partir du token présent dans l'adresse
- [x] Envoyer un mail de notif aux agents du RDV avec 
  - [x] le contenu de la réponse
  - [x] un lien vers le RDV
  - [x] la liste des pièces jointes présentes
  - [x] l'e-mail original en pièce jointe
- [x] Faire en sorte que les e-mails de notification envoyés aux usagers aient bien un champ "reply to" qui contient le token*
- [x] Envoyer le mail de façon asynchrone
- [x] S'assurer que la citation du mail de notif original est ignorée lorsque l'on transmet le mail de réponse (utiliser le champ `ExtractedMarkdownMessage` de Sendinblue)
- [x] Envoyer un seul mail de notif à tous les agents, plutôt que des mails séparés

# Aperçu du mail transmis aux agents

![image](https://user-images.githubusercontent.com/6357692/170198371-8d0ef05a-6f79-4681-8881-be9fb8b5b38a.png)


# Choix techniques

## Où stocker le token ?

Afin de pouvoir retrouver un RDV à partir de l'e-mail de réponse, il fallait stocker un identifiant dans la base et faire en sorte de le joindre au mail de réponse, en utilisant une adresse du type rdv+UUID@reply.rdv-solidarites.fr.

Il était possible de stocker le token dans :
- un `Rdv`
- un `RdvsUser`
- un `Receipt`

J'ai fait le choix de stocker le token dans Rdv pour le moment, principalement car les mailers n'ont pas accès aux RdvsUsers et au Receipts, et qu'il était donc difficile de générer l'adresse de ReplyTo depuis les mailers.

Je me suis aussi dit que si une personne était ajoutée par erreur à un RDV puis supprimée juste ensuite, elle allait recevoir un mail de notification pour la création, et il était alors préférable qu'elle puisse répondre, ce qui aurait été impossible si le token était stocké dans un RdvsUser.

Je me dis aussi que si on change d'avis (par exemple stocker le token dans les Receipts), la migration sera simple.

## Comment router les mails reçus à rdv+***@reply.rdv-solidarites.fr ?

Deux options s'offrent à nous :
1. créer une boite mail chez Gandi, et faire du polling dessus pour récupérer les nouveaux mails, puis les traiter.
2. utiliser un service externe qui permet que tous les e-mails envoyés à un sous-domaine soient détectés et transmis en HTTP à notre appli

La solution retenue pour le moment est la seconde, à travers le [système proposé par Sendinblue](https://developers.sendinblue.com/docs/inbound-parsing-api-1) (qui est le seul non américain à proposer ce service, et qui se trouve être déjà notre outil d'envoi de mails transactionnels). Ce choix nous a paru le plus simple, mais rien ne nous empêchera de changer à l'avenir.

J'ai testé l'envoi de mails depuis mes adresses perso vers le domaine @reply.rdv-solidarites.fr avec un webhook en place qui transmet à une [URL de test proposée par webhook.site](https://webhook.site/#!/229cb0c5-d727-4aab-8d55-d4021bd1e3ae/).

Note : les webhooks Sendinblue de type "inbound" n’apparaissent pas dans [leur interface web](https://app-smtp.sendinblue.com/webhook), mais sont bien listés [via leur API](https://developers.sendinblue.com/reference/getwebhooks-1) (il faut bien demander les webhooks de type `inbound` et non `transactional`).

## Sous quel format transmettre le contenu de la réponse ?

Lorsque l'usagè⋅re répond au mail de notification, son client mail va faire en sorte de citer le mail original et de permettre de répondre au dessus de cette citation. Cette citation ne nous intéresse pas, ou du moins nous ne souhaitons pas la faire apparaître lorsque nous notifions l'agent de la réponse. 

La bonne nouvelle, c'est que Sendinblue nous fournit dans son payload une version Markdown du mail, dans laquelle ils ont déjà exclu la citation. C'est donc ce champ (`ExtractedMarkdownMessage`) que nous allons utiliser pour transmettre la réponse.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
