### PR TITLE
Réparer la config de select2

### DIFF
--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -34,9 +34,16 @@ class Select2Inputs {
     if (modal !== undefined)
       options.dropdownParent = modal
 
-    // Custom message for empty selects
-    options.minimumInputLength = 1
-    options.language = { inputTooShort: () => "Commencez à taper pour rechercher" } // Overrides select2/i18n/fr.js
+    // Lorsque le select est configuré en AJAX **et** qu'aucune option n'est pré-injectée dans le HTML,
+    // l'utilisateur⋅ice voit seulement un champ de recherche et une mention "Aucun résultat trouvé".
+    // Afin d'indiquer clairement qu'il est attendu de commencer à saisir quelque-chose, ce code fait en
+    // sorte que la mention soit plutot "Commencez à taper pour rechercher".
+    const isAjax = elt.dataset.selectOptions?.includes("ajax");
+    const hasAnyOption = Array.from(elt.options).some(opt => opt.value); // we rule out options without value, they are usually placeholders
+    if (isAjax && !hasAnyOption) {
+      options.minimumInputLength = 1
+      options.language = { inputTooShort: () => "Commencez à taper pour rechercher" } // Overrides select2/i18n/fr.js
+    }
 
     return options
   }


### PR DESCRIPTION
Closes #2484

# Description du problème

Nous avons 3 typologies d'usage de select2 avec le champ de recherche : 
1. Lorsque les balises <option> sont présentes dans le HTML, et que la saisie de recherche filtre ces options sans appel au serveur
2. Lorsque aucune <option> n'est présente dans le HTML et que la saisie déclenche un appel AJAX
3. Lorsque des balises <option> sont présentes dans le HTML **et** que la recherche est configurée pour utiliser AJAX lorsqu'une recherche est saisie

Le code ajouté dans #2479 avait pour but de cibler les selects qui sont dans le cas 2, mais il a aussi impacté les cas 1 et 3.

Le code que je propose permet de cibler uniquement le cas 2.

## Exemple de cas 1 avant et après cette PR

http://localhost:3000/departement/26?city_code=26362&latitude=44.921313&longitude=4.923011&street_ban_id=&where=Valence%2C+26000

![image](https://user-images.githubusercontent.com/6357692/169113300-950f1bd6-f677-4994-ad54-1568a7f8a575.png)
![image](https://user-images.githubusercontent.com/6357692/169113330-12c2e2c4-9325-4709-9f8b-cd3c4d4d62d0.png)


## Exemple de cas 2 avant et après cette PR (identiques)

http://localhost:3000/admin/organisations/1/rdvs/5929/edit

![image](https://user-images.githubusercontent.com/6357692/169113524-1151ad6b-6833-43a0-8511-2ad21ac4b438.png)
![image](https://user-images.githubusercontent.com/6357692/169113524-1151ad6b-6833-43a0-8511-2ad21ac4b438.png)

## Exemple de cas 3 avant et après cette PR

http://localhost:3000/admin/organisations/1/agent_searches

![image](https://user-images.githubusercontent.com/6357692/169113989-55273b9c-ffe3-446a-840c-fb908be96c25.png)
![image](https://user-images.githubusercontent.com/6357692/169114494-5e852c07-ff6a-40ae-8926-d4b067df51de.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
