### PR TITLE
Rappatrie les pages statiques qui était dans la doc

### DIFF
--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -33,9 +33,9 @@
     .col-6.col-md
       h2 Informations légales
       ul.list-unstyled.text-small
-        li.mb-1 = link_to "https://doc.rdv-solidarites.fr/informations-legales/mentions-legales" do
+        li.mb-1 = link_to mentions_legales_path do
           span> Mentions Légales
-        li.mb-1 = link_to "https://doc.rdv-solidarites.fr/informations-legales/conditions-dutilisation-de-la-plateforme-rdv-solidarites" do
+        li.mb-1 = link_to cgu_path do
           span> C.G.U.
-        li.mb-1 = link_to "https://doc.rdv-solidarites.fr/informations-legales/politique-de-confidentialite" do
+        li.mb-1 = link_to politique_de_confidentialite_path do
           span> Politique de confidentialité

--- a/app/views/static_pages/cgu.html.slim
+++ b/app/views/static_pages/cgu.html.slim
@@ -1,0 +1,123 @@
+- content_for :title do
+  h1 Conditions d’utilisation de la plateforme RDV-Solidarités
+
+.container.mt-3
+  .row.align-items-center.mb-4.content
+    .col-lg-8
+
+      p Les présentes conditions générales d’utilisation (dites « CGU ») encadrent les différents usages de la Plateforme "RDV-Solidarités" et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
+
+      h2 Article 1 - Champ d'application
+
+      p La plateforme "RDV-Solidarités " est à l'initiative de l’ Agence Nationale de la Cohésion des Territoires (ANCT).
+
+      h2 Article 2 - Objet
+
+      p RDV-Solidarités est un outil permettant d'organiser et de fluidifier la prise de rendez-vous médico-sociaux pour les services publics.
+
+      h2 Article 3 - Définitions
+
+      ul
+        li « L'Utilisateur » est toute personne utilisant la plateforme "RDV-Solidarités".
+        li « L'Usager » est tout administré utilisant la plateforme "RDV-Solidarités".
+        li « L'Agent » est tout agent public utilisant la plateforme "RDV-Solidarités".
+        li Les « Services » sont les fonctionnalités offertes par la plateforme.
+
+      h2 Article 4 - Fonctionnalités
+
+      h3 4.1 Fonctionnalités ouvertes aux Usagers
+
+      p RDV-Solidarités permet à tout Usager qui le souhaite de :
+      ul
+        li
+          p se créer un compte lui permettant de prendre un rendez-vous avec un service public.
+          p A cet effet, il lui suffira de se créer un compte sur le site de la plateforme en fournissant les informations suivantes : nom, prénom, adresse e-mail et numéro de téléphone. Il devra également remplir une fiche d'information dans laquelle il devra renseigner des informations relatives à sa situation sociale et familiale : adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants.
+
+        li
+          p vérifier s'il est possible de prendre rendez-vous via la plateforme en fonction de son adresse.
+          p En effet, en entrant l'adresse dans la barre de recherche, l'usager reçoit un message lui indiquant les services publics utilisant le dispositif à proximité de chez lui. Si de tels services n'existent pas, il recevra un message lui indiquant que la prise en charge n'est pas encore établie.
+
+        li
+          p renseigner des informations relatives à un "Proche".
+          p A cet effet, il pourra remplir une "fiche" pour simplifier les démarches futures d'un proche. Il lui revient d'informer le proche par tous moyens et dans un délai d'1 mois, de la transmission de ces informations à la Plateforme RDV-Solidarités.
+
+      h3 4.2 Fonctionnalités ouvertes aux Agents
+
+      p RDV-Solidarités permet à tout agent réalisant une mission de service public de :
+      ul
+        li Regrouper les actions relatives à la prise de rendez-vous en ligne ;
+        li Organiser directement la configuration générale de la prise de rendez-vous ;
+        li Etablir des plages d'ouverture relatives au rendez-vous ;
+        li Créer une fiche "Nouvel usager" ;
+        li Gérer les statistiques relatives à la prise de rendez-vous.
+
+      h4 A) Regrouper les actions relatives à la prise de rendez-vous
+
+      p Cette fonctionnalité permet de faciliter la prise de rendez-vous en ligne des usagers, en choisissant certaines modalités relatives à l'interface. Ainsi, la structure pourra :
+      ul
+        li Déterminer le service avec lequel l'usager prendra rendez-vous ;
+        li Préciser le lieu du rendez-vous ;
+        li Ajouter les Agents susceptibles de procéder aux rendez-vous et consultations ;
+        li Établir un délai minimum et maximum de réservation.
+
+      p Ces fonctionnalités permettent aux agents et structures de simplifier le processus de choix des usagers et l'organisation interne de la structure liée à la prise de rendez-vous.
+
+      h4 B) Organiser directement la configuration générale de la prise de rendez-vous
+
+      p Cette fonctionnalité permet aux structures de déterminer et préciser les modalités des rendez-vous. Ces modalités sont déterminantes pour l'organisation générale des structures et des prises de rendez-vous. En effet, chaque structure pourra :
+      ul
+        li Choisir la durée moyenne de rendez-vous ;
+        li Choisir le type de rendez-vous (sur place, téléphone, à domicile) ;
+        li Établir ou organiser un rendez-vous de suivi ;
+        li Permettre la notification par SMS aux usagers.
+
+      h4 C) Établir des plages d'ouvertures
+
+      p Cette fonctionnalité permet aux structures de mieux intégrer les rendez-vous pris ou à prendre dans les plages d'ouverture de la structure. En effet, chaque structure pourra :
+      ul
+        li Déterminer un "nom" pour la plage d'ouverture uniquement visible en interne ;
+        li Déterminer un lieu d'ouverture ;
+        li Déterminer la plage horaire.
+
+      p Après avoir déterminé ces éléments, la structure devra "créer sa plage". Cette plage préviendra toute prise de rendez-vous en dehors d'horaires ou de moments prévus par la structure. Elle pourra les modifier à tout moment.
+
+      p A ces possibilités, s'ajoutent celles permettant d'intégrer les RDV prévus dans le futur, en :
+      ul
+        li ajoutant directement un rendez-vous dans l'agenda de la structure ou d'un Agent de manière spécifique ;
+        li en précisant les créneaux pour lesquels un Agent n'est pas présent et ne peut donc prendre de rendez-vous.
+
+      h4 D) Créer une fiche "Nouvel Usager"
+
+      p Cette fonctionnalité est ouverte aux Agents, qui peuvent créer une fiche pour un usager ou pour un proche de l'usager. Cette fonctionnalité permet une meilleure visibilité et organisation aux structures. Ainsi, il est possible de remplir une fiche d'Usager et de proposer à l'usager de se créer un compte RDV-Solidarités. Lorsque l'usager est un "proche", alors l'Agent devra remplir la fiche du Nouvel usager "Responsable", c'est-à-dire celui avec lequel il est en relation directe. Il reviendra à l'Usager d'informer le proche par tous moyens et dans un délai d'1 mois, de la transmission de ces informations à la Plateforme RDV-Solidarités.
+
+      h4 E) Gérer les statistiques de la structure.
+
+      p Chaque Agent peut télécharger un export de ses Rendez-vous, et ainsi voir la progression relative aux Rendez-vous manqués (excusés ou non). Les informations suivantes sont disponibles :
+
+      ul
+        li Nombre de Rendez-vous ;
+        li Nombre de personnes vues ;
+        li Nombre d'absences excusées à des rendez-vous ;
+        li Nombre d'absences non excusées à des rendez-vous.
+
+      h2 Article 5 – Responsabilités
+
+      h3 5.1 L’éditeur de la « Plateforme RDV-Solidarités »
+
+      p Les sources des informations diffusées sur la Plateforme sont réputées fiables mais le site ne garantit pas qu’il soit exempt de défauts, d’erreurs ou d’omissions.
+
+      p L’éditeur s’autorise à suspendre ou révoquer n'importe quel compte et toutes les actions réalisées par ce biais, s’il estime que l’usage réalisé du service porte préjudice à son image ou ne correspond pas aux exigences de sécurité.
+
+      p L’éditeur s’engage à la sécurisation de la Plateforme, notamment en prenant toutes les mesures nécessaires permettant de garantir la sécurité et la confidentialité des informations fournies.
+
+      p L’éditeur fournit les moyens nécessaires et raisonnables pour assurer un accès continu, sans contrepartie financière, à la Plateforme. Il se réserve la liberté de faire évoluer, de modifier ou de suspendre, sans préavis, la plateforme pour des raisons de maintenance ou pour tout autre motif jugé nécessaire.
+
+      h3 5.2 L’Utilisateur
+
+      p L'Utilisateur s'assure de garder son mot de passe secret. Toute divulgation du mot de passe, quelle que soit sa forme, est interdite. Il assume les risques liés à l'utilisation de son identifiant et mot de passe.
+
+      p Toute information transmise par l'Utilisateur est de sa seule responsabilité. Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour autrui s’expose, notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des peines pouvant aller jusqu’à trois ans d’emprisonnement et 45 000 euros d’amende.
+
+      h2 Article 6 - Mise à jour des conditions d’utilisation
+
+      p Les termes des présentes conditions d’utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.

--- a/app/views/static_pages/mentions_legales.html.slim
+++ b/app/views/static_pages/mentions_legales.html.slim
@@ -1,0 +1,48 @@
+- content_for :title do
+  h1 Mentions légales
+
+.container.mt-3
+  .row.align-items-center.mb-4.content
+    .col-lg-8
+      h2 Éditeur de la plateforme
+
+      p
+        | La plateforme est éditée par :
+        br
+        b> Agence nationale de la cohésion des territoires
+        br
+        | 20, avenue de Ségur
+        br
+        | TSA 10717
+        br
+        | 75 334 Paris Cedex 07
+        br
+        | Téléphone : +33 1 85 58 60 00
+        br
+        | Mail :
+        = mail_to "info@anct.gouv.fr"
+
+      h2 Directeur de la publication
+
+      p Monsieur Yves Le Breton, Directeur général de l’Agence Nationale de la Cohésion des Territoires
+
+      h2 Hébergement de la plateforme
+
+      p
+        | Ce site est hébergé par
+        br
+        | Outscale SASU
+        br
+        |1 rue Royale - 319 Bureaux de la Colline
+        br
+        | 92210 Saint-Cloud
+
+      h2 Accessibilité
+
+      p La conformité aux normes d’accessibilité numérique est un objectif ultérieur mais nous tâchons de rendre ce site accessible à toutes et à tous.
+
+      p Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part. Si vous n'obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Pour en savoir plus sur la politique d'accessibilité numérique de l'État : ​
+
+      h2 Sécurité
+
+      p Le site est protégé par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges, mais permet aussi aux usagers de s’assurer de l’authenticité du site. En aucun cas les services associés à la plateforme ne seront à l’origine d’envoi de courriels pour demander la saisie d’informations personnelles, en particulier, le mot de passe qui reste sous le contrôle exclusif des usagers.

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -1,0 +1,214 @@
+- content_for :title do
+  h1 Politique de confidentialité
+
+.container.mt-3
+  .row.align-items-center.mb-4.content
+    .col-lg-8
+      h2 Traitement des données à caractère personnel
+
+      p La plateforme "RDV-Solidarités" est à l'initiative de l'Agence Nationale de la Cohésion des Territoires (ANCT), placé sous la tutelle des ministres chargés de l'aménagement du territoire, des collectivités territoriales et de la politique de la ville.
+
+      h3 Finalité
+
+      p La plateforme sert à collecter des données à caractère personnel pour organiser et fluidifier la prise de rendez-vous médico-sociaux pour les services publics.
+
+      h3 Données à caractère personnel traitées
+
+      p La plateforme peut traiter les données à caractère personnel suivantes :
+
+      ul
+        li
+          strong Données relatives au compte Agent :
+          span> Nom, prénom, adresse mail professionnelle de manière obligatoire, et le rôle de manière facultative ;
+        li
+          strong Données relatives au compte Usager :
+          span> Nom, prénom, adresse e-mail, numéro de téléphone, adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants ;
+        li
+          strong Données relatives à la fiche "Nouvel Usager" - Responsable :
+          span> Nom, prénom, nom de naissance, date de naissance, adresse e-mail, numéro de téléphone, adresse, champ "remarques", caisse d'affiliation, numéro d'allocataire, situation familiale, nombre d'enfants, modalités de logement (SDS, propriétaire, hébergé, locataire, en accession à la propriété) ;
+        li
+          strong Données relatives à la fiche "Nouvel Usager" - Proche :
+          span> Nom, prénom, date de naissance, champ "remarques", informations relatives à l'Usager "Type Responsable" ;
+        li
+          strong Données de localisation :
+          span> Adresse ;
+        li
+          strong Données d'hébergeur :
+          span> Identifiant de connexion ; Nature des opérations ;
+        li
+          strong Cookies.
+
+        p La création du compte professionnel n'est ouverte qu'aux seuls agents et professionnels exerçant une mission de service public à vocation médico-sociale.
+
+        h3 Base juridique des traitements de données
+
+        p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques :
+
+        ul
+          li l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD ;
+          li la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD.
+
+        p Ces fondements sont précisés ci-dessous :
+
+        h4 a) Les données relatives au compte professionnel
+        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+        h4 b) Les données relatives au compte usager
+        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+        h4 c) Les données relatives à la fiche "Nouvel Usager" - Responsable
+        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+        h4 d) Les données relatives à la fiche "Nouvel Usager" - Proche
+        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+        h4 e) Les données de localisation
+        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+        h4 f) Données d'hébergeur
+        p Ce traitement de données est nécessaire au respect d’une obligation légale à laquelle le responsable du traitement est soumis au sens de l’article 6-c du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+        p L’obligation légale est posée par :
+        ul
+          li = link_to "la loi LCEN n°2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique ;", "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000801164/2020-10-26/"
+          li = link_to "les articles 1 et 3 du décret n°2021-1362 du 20 octobre 2021.", "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044228912"
+
+        h4 g) Cookies
+
+        p Voir la partie sur les cookies ci-après.
+
+        h2 Durée de conservation
+
+        p Les données à caractère personnel sont conservées :
+
+        table.table
+          thead
+            tr
+              th Types de données
+              th Durées de conservation
+          tbody
+            tr
+              td Données relatives au compte Agent
+              td Les données sont conservées jusqu'à la suppression du compte professionnel, ou 2 ans après l’inactivité du compte.
+            tr
+              td Données relatives au compte Usager
+              td Les données sont conservées jusqu'à la suppression du compte usager, ou 2 ans après l’inactivité du compte.
+            tr
+              td Données relatives à la fiche "Nouvel Usager" - Responsable
+              td Les données sont conservées jusqu'à la création d'un compte usager, dans un délai maximum de 2 ans à compter de la création de la fiche.
+            tr
+              td Données relatives à la fiche "Nouvel Usager" - Proche
+              td Les données sont conservées jusqu'à la création d'un compte usager, dans un délai de 2 ans à compter de la création de la fiche.
+            tr
+              td Données de localisation
+              td Les données sont supprimées à compter de la prise de rendez-vous.
+            tr
+              td Données d'hébergeur
+              td 1 an.
+            tr
+              td Cookies
+              td 13 mois.
+
+        p L'inactivité d'un usager se mesure sur la date du dernier RDV pris.
+
+        h3 Droit des personnes concernées
+
+        p Vous disposez des droits suivants concernant vos données à caractère personnel :
+
+        ul
+          li Droit d’information ;
+          li Droit d’accès aux données ;
+          li Droit de rectification ;
+          li Droit de suppression des données.
+
+        p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
+
+        strong = mail_to "contact@rdv-solidarités.fr"
+
+        p ou par voie postale :
+
+        p Agence nationale de la cohésion des territoires
+        br
+        | 20, avenue de Ségur
+        br
+        | TSA 10717
+        br
+        | 75 334 Paris Cedex 07
+
+        p En raison de l’obligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici
+        = link_to "https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces"
+        span> , un modèle de courrier élaboré par la Cnil.
+
+        p Nous nous engageons à ne jamais céder ces informations à des tiers.
+
+        h3 Délais de réponse
+
+        p Le responsable de traitement s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
+
+        h3 Destinataires des données
+
+        p Le responsable de traitement s'engage à ce que les données à caractères personnels soient traitées par les seules personnes autorisées.
+
+        h3 Sous-traitants
+
+        p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
+
+        table.table
+          thead
+            tr
+              th Partenaire
+              th Traitement réalisé
+              th Pays destinataire
+              th Garanties
+          tbody
+            tr
+              td Outscale SASU
+              td Hébergement
+              td France
+              td = link_to "​​​​https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf"
+            tr
+              td Sendinblue
+              td Envoi de mails
+              td France
+              td = link_to "https://fr.sendinblue.com/rgpd/"
+            tr
+              td LinkMobility
+              td Envoi de SMS
+              td France
+              td = link_to "https://linkmobility.fr/wp-content/uploads/sites/12/2021/05/Notice-dinformation-sur-la-protection-des-donnees-FR-31032021-1.pdf"
+
+        h3 Sécurité et confidentialité des données
+
+        p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment :
+        ul
+          li Pare feu système.
+          li Pare feu applicatif (WAF).
+          li Chiffrement des flux réseaux via certificat SSL.
+          li Disque dur chiffré.
+          li Services isolés dans des containers.
+          li Gestion des journaux.
+          li Administration et monitoring centralisés des accès.
+          li Accès aux ressources via clés SSH (pas de mot de passe post installation).
+          li Accès aux données réservé aux membres de l'entité (hors restitution applicative publique des données).
+          li Accès aux données uniquement via un outil d'édition sécurisé (SSL + mot de passe) avec utilisation de comptes nominatifs.
+          li Hébergeur de données de santé.
+
+        h2 Utilisation de témoins de connexion (« cookies »)
+
+        p Les cookies utilisés sur RDV-Solidarités ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet.
+        p RDV-Solidarités utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
+
+        p RDV-Solidarités n'utilise aucun cookies dits "tiers".
+
+        p Il convient d'indiquer que :
+        ul
+          li Les données collectées ne sont pas recoupées avec d’autres traitements.
+          li Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
+
+        p À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+
+        p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
+
+        ul
+          li = link_to "Cookies & traceurs : que dit la loi ?", "https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
+          li = link_to "Cookies : les outils pour les maîtriser", "https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,8 +214,8 @@ Rails.application.routes.draw do
     root to: "admin/organisations#index", as: :authenticated_agent_root, defaults: { follow_unique: "1" }
   end
 
-  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite].each do |v|
-    get v => "static_pages##{v}"
+  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite].each do |page_name|
+    get page_name => "static_pages##{page_name}"
   end
 
   ## Shorten urls for SMS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,8 +214,8 @@ Rails.application.routes.draw do
     root to: "admin/organisations#index", as: :authenticated_agent_root, defaults: { follow_unique: "1" }
   end
 
-  { contact: "contact", mds: "mds", accessibility: "accessibility" }.each do |k, v|
-    get v => "static_pages##{k}"
+  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite].each do |v|
+    get v => "static_pages##{v}"
   end
 
   ## Shorten urls for SMS


### PR DESCRIPTION
Rapatriement des pages CGU, Mentions légales, Politique de confidentialité depuis la doc vers l'application.

Initialement dans la doc parce que c'était plus simple pour Thomas H de les écrire là-bas. Elles sont peu retouchées maintenant. De plus, c'est un peu bizarre d'avoir ces pages dans la doc.

J'ajouterais que le mail de Sophie N. (26) de ce jour nous rappel que la doc n'étant plus en ligne, ces pages ne le sont plus non plus :-/

Le HTML écrit est sans doute améliorable, mais je crois qu'en première approche, ce n'est pas si mal ?

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
