### PR TITLE
Remonter davantage d'infos sur Sentry en cas d'erreur XHR d'appels FullCalendar

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -58,7 +58,11 @@ class CalendarRdvSolidarites {
       locale: frLocale,
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: function (errorObj) {
-        Sentry.captureException(new Error(`XHR request failed with error code ${errorObj.xhr.status}`), { extra: errorObj.xhr })
+        const requestPath = new URL(errorObj.xhr.responseURL).pathname;
+        Sentry.captureException(
+          new Error(`XHR request to ${requestPath } failed with error code ${errorObj.xhr.status}`),
+          { extra: errorObj.xhr }
+        )
         alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
       },
       defaultDate: this.getDefaultDate(),

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -58,7 +58,7 @@ class CalendarRdvSolidarites {
       locale: frLocale,
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: function (errorObj) {
-        Sentry.captureException(errorObj)
+        Sentry.captureException(new Error(`XHR request failed with error code ${errorObj.xhr.status}`), { extra: errorObj.xhr })
         alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
       },
       defaultDate: this.getDefaultDate(),

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -60,8 +60,8 @@ class CalendarRdvSolidarites {
       eventSourceFailure: function (errorObj) {
         const requestPath = new URL(errorObj.xhr.responseURL).pathname;
         Sentry.captureException(
-          new Error(`XHR request to ${requestPath } failed with error code ${errorObj.xhr.status}`),
-          { extra: errorObj.xhr }
+          new Error(`XHR request to ${ requestPath } failed with error code ${errorObj.xhr.status}`),
+          { extra: { xhr: errorObj.xhr, responseBody: errorObj.xhr.response } }
         )
         alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
       },

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -61,7 +61,10 @@ class CalendarRdvSolidarites {
         const requestPath = new URL(errorObj.xhr.responseURL).pathname;
         Sentry.captureException(
           new Error(`XHR request to ${ requestPath } failed with error code ${errorObj.xhr.status}`),
-          { extra: { xhr: errorObj.xhr, responseBody: errorObj.xhr.response } }
+          {
+            extra: { xhr: errorObj.xhr, responseBody: errorObj.xhr.response },
+            fingerprint: ["fullcalendar_xhr_error", requestPath] // group occurrences by path
+          }
         )
         alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fullcalendar/list": "^4.4.2",
     "@fullcalendar/timegrid": "^4.4.2",
     "@rails/ujs": "^6.0.0",
-    "@sentry/browser": "^5.10.2",
+    "@sentry/browser": "^6.19.7",
     "autocomplete.js": "^0.37.1",
     "bootstrap": "^4.3.1",
     "bowser": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,56 +44,56 @@
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.4.tgz#093d5341595a02089ed309dec40f3c37da7b1b10"
   integrity sha512-O3lEzL5DYbxppMdsFSw36e4BHIlfz/xusynwXGv3l2lhSlvah41qviRpsoAlKXxl37nZAqK+UUF5cnGGK45Mfw==
 
-"@sentry/browser@^5.10.2":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.30.0.tgz#c28f49d551db3172080caef9f18791a7fd39e3b3"
-  integrity sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==
+"@sentry/browser@^6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.19.7.tgz#a40b6b72d911b5f1ed70ed3b4e7d4d4e625c0b5f"
+  integrity sha512-oDbklp4O3MtAM4mtuwyZLrgO1qDVYIujzNJQzXmi9YzymJCuzMLSRDvhY83NNDCRxf0pds4DShgYeZdbSyKraA==
   dependencies:
-    "@sentry/core" "5.30.0"
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
+    "@sentry/core" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/core@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.30.0.tgz#6b203664f69e75106ee8b5a2fe1d717379b331f3"
-  integrity sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==
+"@sentry/core@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.19.7.tgz#156aaa56dd7fad8c89c145be6ad7a4f7209f9785"
+  integrity sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==
   dependencies:
-    "@sentry/hub" "5.30.0"
-    "@sentry/minimal" "5.30.0"
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
+    "@sentry/hub" "6.19.7"
+    "@sentry/minimal" "6.19.7"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/hub@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.30.0.tgz#2453be9b9cb903404366e198bd30c7ca74cdc100"
-  integrity sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==
+"@sentry/hub@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.19.7.tgz#58ad7776bbd31e9596a8ec46365b45cd8b9cfd11"
+  integrity sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==
   dependencies:
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
+    "@sentry/types" "6.19.7"
+    "@sentry/utils" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.30.0.tgz#ce3d3a6a273428e0084adcb800bc12e72d34637b"
-  integrity sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==
+"@sentry/minimal@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.19.7.tgz#b3ee46d6abef9ef3dd4837ebcb6bdfd01b9aa7b4"
+  integrity sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==
   dependencies:
-    "@sentry/hub" "5.30.0"
-    "@sentry/types" "5.30.0"
+    "@sentry/hub" "6.19.7"
+    "@sentry/types" "6.19.7"
     tslib "^1.9.3"
 
-"@sentry/types@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.30.0.tgz#19709bbe12a1a0115bc790b8942917da5636f402"
-  integrity sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==
+"@sentry/types@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.19.7.tgz#c6b337912e588083fc2896eb012526cf7cfec7c7"
+  integrity sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==
 
-"@sentry/utils@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.30.0.tgz#9a5bd7ccff85ccfe7856d493bffa64cabc41e980"
-  integrity sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==
+"@sentry/utils@6.19.7":
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.19.7.tgz#6edd739f8185fd71afe49cbe351c1bbf5e7b7c79"
+  integrity sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==
   dependencies:
-    "@sentry/types" "5.30.0"
+    "@sentry/types" "6.19.7"
     tslib "^1.9.3"
 
 "@types/eslint-scope@^3.7.3":


### PR DESCRIPTION
Actuellement, lorsque FullCalendar rencontre une erreur HTTP lors d'un fetch, on a une remontée dans Sentry qui prend cette forme : 

> Non-Error exception captured with keys: message, xhr

Exemple : https://sentry.io/organizations/rdv-solidarites/issues/3251002405

**C'est gênant car on a des erreurs remontées côté JS qui nous disent seulement "une erreur XHR s'est produite" alors qu'elles pourraient nous donner l'URL de la requêtes HTTP ainsi que le contenu de la réponse !**

La raison est qu'on passe à `Sentry.captureException` un objet qui n'est pas une `Error`, et donc Sentry ne sait qu'en faire !
https://github.com/betagouv/rdv-solidarites.fr/blob/ba4933ab80d632a3997fdeb6f855a179ba30982c/app/javascript/components/calendar.js#L61

J'ai donc fait en sorte qu'on passe une vraie `Error` et qu'on fournisse en `extra` l'objet `XMLHttpRequest` (xhr pour les intimes). Le résultat est visible dans les captures d'écran ci dessous.

Pour tester, j'ai [simulé une réponse en erreur](https://github.com/betagouv/rdv-solidarites.fr/pull/2489/commits/0ea5b920120603cda9546882d139ad0cc2c6f1ed), et ça remonte comme ça : 
https://sentry.io/organizations/rdv-solidarites/issues/3288731043

# Avant

![image](https://user-images.githubusercontent.com/6357692/169511302-d0b120bb-01f3-47d3-91cd-b93f89fdf105.png)
![image](https://user-images.githubusercontent.com/6357692/169511310-edf8b13e-780c-4dd0-a632-e249b6a5debc.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/169517087-5453bd03-d79e-4c50-a55f-7fd263843e80.png)
![image](https://user-images.githubusercontent.com/6357692/169511360-3b7b866e-a7af-4e5c-9f02-1e608ded5d90.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
