### PR TITLE
Grouper toutes les erreurs FullCalendar dans la même issue Sentry

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -57,17 +57,7 @@ class CalendarRdvSolidarites {
       plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
       locale: frLocale,
       eventSources: JSON.parse(this.data.eventSourcesJson),
-      eventSourceFailure: function (errorObj) {
-        const requestPath = new URL(errorObj.xhr.responseURL).pathname;
-        Sentry.captureException(
-          new Error(`XHR request to ${ requestPath } failed with error code ${errorObj.xhr.status}`),
-          {
-            extra: { xhr: errorObj.xhr, responseBody: errorObj.xhr.response },
-            fingerprint: ["fullcalendar_xhr_error", requestPath] // group occurrences by path
-          }
-        )
-        alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
-      },
+      eventSourceFailure: this.handleAjaxError,
       defaultDate: this.getDefaultDate(),
       defaultView: this.getDefaultView(),
       viewSkeletonRender: function (info) {
@@ -216,6 +206,22 @@ class CalendarRdvSolidarites {
   isTodayVisible = ({ activeStart, activeEnd }) => {
     const now = new Date()
     return now >= activeStart && now <= activeEnd;
+  }
+
+  handleAjaxError = (errorObj) => {
+    Sentry.captureMessage(
+      'FullCalendar AJAX call failed',
+      {
+        extra: {
+          xhr: errorObj.xhr,
+          responseHeaders: errorObj.xhr.getAllResponseHeaders(),
+          responseBody: errorObj.xhr.response,
+        },
+        fingerprint: ["fullcalendar_xhr_error"], // group all FullCalendar errors under the same Sentry issue
+        level: Sentry.Severity.Error,
+      }
+    )
+    alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
   }
 }
 

--- a/app/views/admin/jours_feries/index.json.jbuilder
+++ b/app/views/admin/jours_feries/index.json.jbuilder
@@ -4,7 +4,7 @@ json.array! @jours_feries do |jour_ferie|
   json.title "Jour férié 🎉"
   json.start jour_ferie.beginning_of_day.as_json
   json.end jour_ferie.end_of_day.as_json
-  json.backgroundColor "#cecece"
+  json.backgroundColor "#6F6F71"
   json.allDay true
   json.extendedProps do
     json.jour_feries true


### PR DESCRIPTION
Dans #2489 j'avais fait en sorte que les remontées soient groupées par path, mais en fait on a plein de paths différents, ce qui crée de nombreuses entrées Sentry :

![image](https://user-images.githubusercontent.com/6357692/169758179-abfbb058-8fe1-48cc-9289-7a6ab03d4eaa.png)

Avec cette PR je groupe toutes les erreurs FullCalendar en utilisant le même fingerprint pour toutes les erreurs.

Une autre façon de faire aurait été de [modifier notre config Sentry](https://docs.sentry.io/product/data-management-settings/event-grouping/fingerprint-rules/) mais ça aurait créé une forme de nouvelle dépendance externe. Si on laisse ça dans le code, c'est sou nos yeux.

J'en ai profité pour :
- déplacer le code de gestion d'erreur dans une méthode séparée
- joindre à la remontée Sentry tous les headers de la réponse HTTP (en utilisant `XMLHttpRequest.getAllResponseHeaders`)

Bonus : [cette erreur](https://sentry.io/organizations/rdv-solidarites/issues/3288970732) sera réglé aussi !