### PR TITLE
Afficher l’historique paper_trail pour les Équipes

### DIFF
--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -2,7 +2,7 @@
 
 class PlageOuverture < ApplicationRecord
   # Mixins
-  has_paper_trail
+  has_paper_trail(ignore: :search_terms)
   include RecurrenceConcern
   include WebhookDeliverable
   include IcalHelpers::Ics

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,7 +2,11 @@
 
 class Team < ApplicationRecord
   # Mixins
-  has_paper_trail
+  has_paper_trail(
+    only: %i[name agent_ids],
+    meta: { virtual_attributes: :virtual_attributes_for_paper_trail }
+  )
+
   include TextSearch
   def self.search_keys = %i[name]
 
@@ -24,6 +28,12 @@ class Team < ApplicationRecord
 
   def to_s
     name
+  end
+
+  def virtual_attributes_for_paper_trail
+    {
+      agent_ids: agents.ids,
+    }
   end
 
   private

--- a/app/policies/configuration/team_policy.rb
+++ b/app/policies/configuration/team_policy.rb
@@ -19,6 +19,7 @@ class Configuration::TeamPolicy
   alias destroy? team_of_territory_and_allowed_to_manage_teams?
   alias edit? team_of_territory_and_allowed_to_manage_teams?
   alias update? team_of_territory_and_allowed_to_manage_teams?
+  alias versions? team_of_territory_and_allowed_to_manage_teams?
 
   alias create? allowed_to_manage_teams?
   alias display? allowed_to_manage_teams?

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -23,4 +23,4 @@
       .card-body
         = render "form", absence: @absence, agent: @agent
 
-= render "admin/versions/resource_versions_row", resource: @absence
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @absence

--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -37,4 +37,4 @@
             .col.text-right
               = f.button :submit
 
-= render "admin/versions/resource_versions_row", resource: @agent_role.agent
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @agent_role.agent

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -16,4 +16,4 @@
         = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
           = render "lieu_fields", f: f
 
-= render "admin/versions/resource_versions_row", resource: @lieu
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @lieu

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -84,4 +84,4 @@
             - if motif_policy.edit?
               div= link_to "Éditer", edit_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"
 
-= render "admin/versions/resource_versions_row", resource: @motif
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @motif

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -26,4 +26,4 @@
             | #{display_value_or_na_placeholder(@organisation.horaires)}
         .text-right= link_to "Modifier", edit_admin_organisation_path(@organisation), class: "btn btn-primary"
 
-= render "admin/versions/resource_versions_row", resource: @organisation
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @organisation

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -81,4 +81,4 @@
             class: "btn btn-primary" \
           )
 
-= render "admin/versions/resource_versions_row", resource: @plage_ouverture
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @plage_ouverture

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -52,4 +52,4 @@
 
 = render "admin/receipts/resource_receipts_row", resource: @rdv
 
-= render "admin/versions/resource_versions_row", resource: @rdv
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @rdv

--- a/app/views/admin/territories/teams/_form.html.slim
+++ b/app/views/admin/territories/teams/_form.html.slim
@@ -1,7 +1,6 @@
 = simple_form_for team, url: url do |form|
   = form.input :name
   = form.input :agent_ids, collection: team.agents,
-          label: "Agents",
           label_method: :reverse_full_name,
           input_html: { \
             multiple: true, \

--- a/app/views/admin/territories/teams/edit.html.slim
+++ b/app/views/admin/territories/teams/edit.html.slim
@@ -2,3 +2,5 @@
 
 .container-fluid.bg-white.rounded.m-2.p-2
   = render "form", team: @team, url: admin_territory_team_path(current_territory, @team)
+
+= render "admin/versions/resource_versions_row", policy_scope: :configuration, resource: @team

--- a/app/views/admin/territories/webhook_endpoints/edit.html.slim
+++ b/app/views/admin/territories/webhook_endpoints/edit.html.slim
@@ -6,4 +6,4 @@
       .card-body
         = render "form", webhook: @webhook, url: admin_territory_webhook_endpoint_path(current_territory, @webhook)
 
-= render "admin/versions/resource_versions_row", resource: @webhook
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @webhook

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -140,4 +140,4 @@
                 count: @rdvs.status(temporal_status).count,
                 path: admin_organisation_rdvs_path(current_organisation, status: temporal_status, user_id: @user.id, breadcrumb_page: "user")
 
-= render "admin/versions/resource_versions_row", resource: @user
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @user

--- a/app/views/admin/versions/_resource_versions_row.html.slim
+++ b/app/views/admin/versions/_resource_versions_row.html.slim
@@ -1,4 +1,4 @@
-- if policy([:agent, resource]).versions?
+- if policy([policy_scope, resource]).versions?
   .row.justify-content-center
     .col-md-8
       .card

--- a/config/locales/models/team.fr.yml
+++ b/config/locales/models/team.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  activerecord:
+    models:
+      team: Équipe
+    attributes:
+      team:
+        agent_ids: Agents


### PR DESCRIPTION
fixes #2146

Ce n’est pas un bug nouveau à cette PR, mais il y a un certain nombre de choses un peu bizarres avec les “virtual_attributes”, c’est à dire le truc qu’on utilise pour stocker les changements aux relations (et pas juste aux attributs).

En particulier, si le seul changement est dans `virtual_attributes`, aucune nouvelle version n’est enregistrée par `paper_trail` tout simplement parce que l’objet n’est pas `dirty`. En fait, notre façon de faire ne peut pas vraiment marcher; [il faudrait implémenter un `adapter`](https://github.com/paper-trail-gem/paper_trail#6c-custom-object-changes), c’est peut-être assez simple en fait.

<img width="703" alt="image" src="https://user-images.githubusercontent.com/139391/169819988-8dba8386-b713-40db-8008-72040ff1b050.png">

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
