### PR TITLE
Permet d’envoyer manuellement une notification de rappel

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -58,6 +58,14 @@ class Admin::RdvsController < AgentAuthController
     end
   end
 
+  def send_reminder_manually
+    authorize(@rdv, :update?)
+
+    Notifiers::RdvUpcomingReminder.perform_with(@rdv, nil)
+
+    redirect_to admin_organisation_rdv_path, flash: { notice: I18n.t("admin.receipts.reminder_manually_sent") }
+  end
+
   def destroy
     authorize(@rdv)
     if @rdv.destroy

--- a/app/views/admin/receipts/_resource_receipts_row.html.slim
+++ b/app/views/admin/receipts/_resource_receipts_row.html.slim
@@ -9,3 +9,5 @@
       .collapse.hide#receipts-collapse
         .card-body
           = render "admin/receipts/receipts", receipts: resource.receipts.most_recent_first
+        .card-footer
+          = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "btn btn-link"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,9 +51,9 @@ Rails.application.configure do
   end
   config.action_mailer.asset_host = ENV["HOST"]
 
-  config.active_job.queue_adapter = :delayed_job
-  # config.active_job.queue_adapter = :inline # perform all jobs inline
-  # Delayed::Worker.delay_jobs = false        # perform all jobs inline
+  # config.active_job.queue_adapter = :delayed_job
+  config.active_job.queue_adapter = :inline # perform all jobs inline
+  Delayed::Worker.delay_jobs = false        # perform all jobs inline
 
   config.action_mailer.perform_caching = false
 

--- a/config/locales/views/rdv.fr.yml
+++ b/config/locales/views/rdv.fr.yml
@@ -3,3 +3,6 @@ fr:
     rdvs:
       rdv_details:
         empty_context: Pas de contexte renseigné
+    receipts:
+      send_reminder_manually: Envoyer maintenant une nouvelle notification
+      reminder_manually_sent: Notification envoyée.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,9 @@ Rails.application.routes.draw do
           end
         end
         resources :rdvs, except: [:new] do
+          member do
+            post :send_reminder_manually
+          end
           collection do
             post :export
           end


### PR DESCRIPTION
Closes #1431

J’ai fait au plus simple: on n’envoie ainsi que des notifications de rappel, et le bouton est relativement discret.

<img width="923" alt="Capture d’écran 2022-05-23 à 15 51 16" src="https://user-images.githubusercontent.com/139391/169836390-84e46366-7e80-4db2-a566-cc51fdf77c30.png">

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
