### PR TITLE
refactor(app): Remove show token in sms flag

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -45,7 +45,6 @@ class Rdv < ApplicationRecord
 
   # Delegates
   delegate :home?, :phone?, :public_office?, :reservable_online?, :service_social?, :follow_up?, :service, :collectif?, :collectif, :individuel?, to: :motif
-  delegate :show_token_in_sms?, to: :organisation
 
   # Validations
   validates :starts_at, :ends_at, :agents, presence: true

--- a/app/sms/users/file_attente_sms.rb
+++ b/app/sms/users/file_attente_sms.rb
@@ -4,6 +4,6 @@ class Users::FileAttenteSms < Users::BaseSms
   include Rails.application.routes.url_helpers
 
   def new_creneau_available(rdv, _user, token)
-    @content = "Des créneaux se sont libérés plus tot.\nCliquez pour voir les disponibilités : #{creneaux_users_rdv_short_url(rdv, tkn: rdv.show_token_in_sms? ? token : nil, host: ENV['HOST'])}"
+    @content = "Des créneaux se sont libérés plus tot.\nCliquez pour voir les disponibilités : #{creneaux_users_rdv_short_url(rdv, tkn: token, host: ENV['HOST'])}"
   end
 end

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -17,7 +17,7 @@ class Users::RdvSms < Users::BaseSms
 
   def rdv_cancelled(rdv, _user, token)
     base_message = "RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short)} a été annulé"
-    url = prendre_rdv_short_url(host: ENV["HOST"], tkn: rdv.show_token_in_sms? ? token : nil)
+    url = prendre_rdv_short_url(host: ENV["HOST"], tkn: token)
 
     footer = if rdv.phone_number.present?
                "Appelez le #{rdv.phone_number} ou allez sur #{url} pour reprendre RDV."
@@ -44,7 +44,7 @@ class Users::RdvSms < Users::BaseSms
     agents_short_names = rdv.agents.map(&:short_name).sort.to_sentence
     message += " avec #{agents_short_names} " if rdv.follow_up?
 
-    url = rdv_short_url(rdv, host: ENV["HOST"], tkn: rdv.show_token_in_sms? ? token : nil)
+    url = rdv_short_url(rdv, host: ENV["HOST"], tkn: token)
     message += "Infos et annulation: #{url}"
 
     message += " / #{rdv.phone_number}" if rdv.phone_number.present?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_16_160337) do
+ActiveRecord::Schema.define(version: 2022_05_23_140836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -359,7 +359,6 @@ ActiveRecord::Schema.define(version: 2022_05_16_160337) do
     t.string "website"
     t.string "email"
     t.bigint "territory_id", null: false
-    t.boolean "show_token_in_sms", default: false
     t.index ["human_id", "territory_id"], name: "index_organisations_on_human_id_and_territory_id", unique: true, where: "((human_id)::text <> ''::text)"
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
     t.index ["name"], name: "index_organisations_on_name"

--- a/spec/sms/users/file_attente_sms_spec.rb
+++ b/spec/sms/users/file_attente_sms_spec.rb
@@ -4,7 +4,7 @@ describe Users::FileAttenteSms, type: :service do
   describe "#new_creneau_available" do
     subject { described_class.new_creneau_available(rdv, user, token).content }
 
-    let(:organisation) { build(:organisation, show_token_in_sms: true) }
+    let(:organisation) { build(:organisation) }
     let(:rdv) { build(:rdv, id: 82, organisation: organisation) }
     let(:user) { build(:user) }
     let(:token) { "12324" }
@@ -13,15 +13,6 @@ describe Users::FileAttenteSms, type: :service do
       expect(subject).to include("Des créneaux se sont libérés plus tot")
       expect(subject).to include("Cliquez pour voir les disponibilités")
       expect(subject).to include("#{ENV['HOST']}/r/82/cr?tkn=12324")
-    end
-
-    context "when the organisation does not show the token in sms" do
-      let!(:organisation) { build(:organisation, show_token_in_sms: false) }
-
-      it do
-        expect(subject).to include("#{ENV['HOST']}/r/82/cr")
-        expect(subject).not_to include("tkn")
-      end
     end
   end
 end

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -5,7 +5,7 @@ describe Users::RdvSms, type: :service do
     context "with a basic rdv" do
       subject { described_class.rdv_created(rdv, user, token).content }
 
-      let(:organisation) { build(:organisation, show_token_in_sms: true) }
+      let(:organisation) { build(:organisation) }
       let(:pmi) { build(:service, short_name: "PMI") }
       let(:motif) { build(:motif, service: pmi) }
       let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
@@ -18,15 +18,6 @@ describe Users::RdvSms, type: :service do
         expect(subject).to include("MDS Centre (10 rue d'ici)")
         expect(subject).to include("Infos et annulation")
         expect(subject).to include("#{ENV['HOST']}/r/123?tkn=12345")
-      end
-
-      context "when the organisation does not show the token in sms" do
-        let!(:organisation) { build(:organisation, show_token_in_sms: false) }
-
-        it "does not include the token in the sms" do
-          expect(subject).to include("#{ENV['HOST']}/r/123")
-          expect(subject).not_to include("tkn")
-        end
       end
     end
 
@@ -50,7 +41,7 @@ describe Users::RdvSms, type: :service do
 
     let(:pmi) { build(:service, short_name: "PMI") }
     let(:motif) { build(:motif, service: pmi) }
-    let(:organisation) { build(:organisation, show_token_in_sms: true) }
+    let(:organisation) { build(:organisation) }
     let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
     let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 124) }
     let(:token) { "2345" }
@@ -61,15 +52,6 @@ describe Users::RdvSms, type: :service do
       expect(subject).to include("MDS Centre (10 rue d'ici)")
       expect(subject).to include("Infos et annulation")
       expect(subject).to include("#{ENV['HOST']}/r/124?tkn=2345")
-    end
-
-    context "when the organisation does not show the token in sms" do
-      let!(:organisation) { build(:organisation, show_token_in_sms: false) }
-
-      it "does not include the token in the sms" do
-        expect(subject).to include("#{ENV['HOST']}/r/124")
-        expect(subject).not_to include("tkn")
-      end
     end
   end
 
@@ -85,7 +67,7 @@ describe Users::RdvSms, type: :service do
 
     context "with lieu phone number" do
       let(:lieu) { build(:lieu, phone_number: "0123456789") }
-      let(:organisation) { create(:organisation, phone_number: "0100000000", show_token_in_sms: true) }
+      let(:organisation) { create(:organisation, phone_number: "0100000000") }
 
       it "contains cancelled RDV's infos and lieu's phone number" do
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
@@ -97,7 +79,7 @@ describe Users::RdvSms, type: :service do
 
     context "with only organisation number" do
       let(:lieu) { build(:lieu, phone_number: nil) }
-      let(:organisation) { create(:organisation, phone_number: "0100000000", show_token_in_sms: true) }
+      let(:organisation) { create(:organisation, phone_number: "0100000000") }
 
       it "contains cancelled RDV's infos" do
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
@@ -109,7 +91,7 @@ describe Users::RdvSms, type: :service do
 
     context "with no phone number" do
       let(:lieu) { build(:lieu, phone_number: nil) }
-      let(:organisation) { create(:organisation, phone_number: nil, show_token_in_sms: true) }
+      let(:organisation) { create(:organisation, phone_number: nil) }
 
       it "contains cancelled RDV's infos" do
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
@@ -120,21 +102,12 @@ describe Users::RdvSms, type: :service do
 
     context "without lieu and no organisation number" do
       let(:lieu) { nil }
-      let(:organisation) { create(:organisation, phone_number: nil, show_token_in_sms: true) }
+      let(:organisation) { create(:organisation, phone_number: nil) }
 
       it "contains cancelled RDV's infos" do
         expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
         expected_content += "Allez sur #{ENV['HOST']}/prdv?tkn=393939 pour reprendre RDV."
         expect(subject).to eq(expected_content)
-      end
-    end
-
-    context "when the organisation does not show the token in sms" do
-      let(:organisation) { build(:organisation, show_token_in_sms: false) }
-
-      it "does not include the token in the sms" do
-        expect(subject).to include("#{ENV['HOST']}/prdv")
-        expect(subject).not_to include("tkn")
       end
     end
   end
@@ -145,7 +118,7 @@ describe Users::RdvSms, type: :service do
     let(:pmi) { build(:service, short_name: "PMI") }
     let(:motif) { build(:motif, service: pmi) }
     let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
-    let(:organisation) { build(:organisation, show_token_in_sms: true) }
+    let(:organisation) { build(:organisation) }
     let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 140) }
     let(:user) { build(:user) }
     let(:token) { "7777" }
@@ -155,15 +128,6 @@ describe Users::RdvSms, type: :service do
       expect(subject).to include("MDS Centre (10 rue d'ici)")
       expect(subject).to include("Infos et annulation")
       expect(subject).to include("#{ENV['HOST']}/r/140?tkn=7777")
-    end
-
-    context "when the organisation does not show the token in sms" do
-      let!(:organisation) { build(:organisation, show_token_in_sms: false) }
-
-      it "does not include the token in the sms" do
-        expect(subject).to include("#{ENV['HOST']}/r/140")
-        expect(subject).not_to include("tkn")
-      end
     end
   end
 


### PR DESCRIPTION
@yaf nous avait fait part de sa volonté de ne plus rendre facultatif l'ajout des tokens dans les sms de notifications: https://mattermost.incubateur.net/betagouv/pl/uh8is119r7b5xgz6b4c5kfdpga.
Cette PR répond à cela en enlevant le flag en DB `show_token_in_sms` sur la table `organisations`.
