### PR TITLE
Aperçu de développement des sms

### DIFF
--- a/app/controllers/lapin/sms_preview_controller.rb
+++ b/app/controllers/lapin/sms_preview_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Lapin
+  class SmsPreviewController < ApplicationController
+    KNOWN_SMS_ACTIONS = {
+      Users::FileAttenteSms => [:new_creneau_available],
+      Users::RdvSms => %i[rdv_created rdv_upcoming_reminder rdv_cancelled],
+    }.freeze
+
+    def index
+      @actions = KNOWN_SMS_ACTIONS
+    end
+
+    def preview
+      klass = KNOWN_SMS_ACTIONS.keys.find { |k| k.to_s.parameterize == params[:sms_preview_id] }
+      return head :forbidden if klass.nil?
+
+      action_name = KNOWN_SMS_ACTIONS[klass].find { |action| action.to_s == params[:action_name] }
+      return head :forbidden if action_name.nil?
+
+      user = User.joins(:rdvs).where.not(phone_number: nil).sample
+      rdv = user.rdvs.sample
+      token = "ABCTOKEN"
+
+      @title = "#{klass}/#{action_name}"
+      @sms = klass.send(action_name, rdv, user, token)
+    end
+  end
+end

--- a/app/sms/users/file_attente_sms.rb
+++ b/app/sms/users/file_attente_sms.rb
@@ -4,6 +4,6 @@ class Users::FileAttenteSms < Users::BaseSms
   include Rails.application.routes.url_helpers
 
   def new_creneau_available(rdv, _user, token)
-    @content = "Des créneaux se sont libérés plus tot.\nCliquez pour voir les disponibilités : #{creneaux_users_rdv_short_url(rdv, tkn: token, host: ENV['HOST'])}"
+    @content = "RDV #{rdv.motif&.service&.short_name}: des créneaux se sont libérés.\nPour voir les disponibilités: #{creneaux_users_rdv_short_url(rdv, tkn: token, host: ENV['HOST'])}"
   end
 end

--- a/app/views/lapin/sms_preview/index.html.slim
+++ b/app/views/lapin/sms_preview/index.html.slim
@@ -1,0 +1,10 @@
+.container.mt-3
+  .row.justify-content-center
+    .col-md-8
+      - @actions.each do |group, action_names|
+        .card
+          .card-body
+            h5.card-title= group
+            ul
+              - action_names.each do |name|
+                li= link_to name, lapin_sms_preview_preview_path(group.to_s.parameterize, name)

--- a/app/views/lapin/sms_preview/preview.html.slim
+++ b/app/views/lapin/sms_preview/preview.html.slim
@@ -1,0 +1,13 @@
+.container.mt-3
+  .row.justify-content-center
+    .col-md-8
+      .card
+        .card-header
+          = link_to t("helpers.back"), lapin_sms_preview_index_path
+        .card-body
+          h5.card-title= @title
+          p= @sms.phone_number
+          .bg-light.p-1
+            code= @sms.content
+        .card-footer
+          p="#{@sms.content.length} caractères"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,6 +267,14 @@ Rails.application.routes.draw do
   get "admin/organisations/:organisation_id/agents/:agent_id", to: redirect("/admin/organisations/%{organisation_id}/agent_agendas/%{agent_id}")
   # rubocop:enable Style/FormatStringToken
 
-  # LetterOpener
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  if Rails.env.development?
+    namespace :lapin do
+      resources :sms_preview, only: %i[index] do
+        get ":action_name", to: "sms_preview#preview", as: "preview"
+      end
+    end
+
+    # LetterOpener
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/spec/sms/users/file_attente_sms_spec.rb
+++ b/spec/sms/users/file_attente_sms_spec.rb
@@ -10,8 +10,8 @@ describe Users::FileAttenteSms, type: :service do
     let(:token) { "12324" }
 
     it do
-      expect(subject).to include("Des créneaux se sont libérés plus tot")
-      expect(subject).to include("Cliquez pour voir les disponibilités")
+      expect(subject).to include("RDV Service 1: des créneaux se sont libérés")
+      expect(subject).to include("Pour voir les disponibilités")
       expect(subject).to include("#{ENV['HOST']}/r/82/cr?tkn=12324")
     end
   end

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -70,7 +70,7 @@ describe Users::RdvSms, type: :service do
       let(:organisation) { create(:organisation, phone_number: "0100000000") }
 
       it "contains cancelled RDV's infos and lieu's phone number" do
-        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
+        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé.\n"
         expected_content += "Appelez le 0123456789 "
         expected_content += "ou allez sur #{ENV['HOST']}/prdv?tkn=393939 pour reprendre RDV."
         expect(subject).to eq(expected_content)
@@ -82,7 +82,7 @@ describe Users::RdvSms, type: :service do
       let(:organisation) { create(:organisation, phone_number: "0100000000") }
 
       it "contains cancelled RDV's infos" do
-        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
+        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé.\n"
         expected_content += "Appelez le 0100000000 "
         expected_content += "ou allez sur #{ENV['HOST']}/prdv?tkn=393939 pour reprendre RDV."
         expect(subject).to eq(expected_content)
@@ -94,7 +94,7 @@ describe Users::RdvSms, type: :service do
       let(:organisation) { create(:organisation, phone_number: nil) }
 
       it "contains cancelled RDV's infos" do
-        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
+        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé.\n"
         expected_content += "Allez sur #{ENV['HOST']}/prdv?tkn=393939 pour reprendre RDV."
         expect(subject).to eq(expected_content)
       end
@@ -105,7 +105,7 @@ describe Users::RdvSms, type: :service do
       let(:organisation) { create(:organisation, phone_number: nil) }
 
       it "contains cancelled RDV's infos" do
-        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé\n"
+        expected_content = "RDV PMI vendredi 10/12 à 13h10 a été annulé.\n"
         expected_content += "Allez sur #{ENV['HOST']}/prdv?tkn=393939 pour reprendre RDV."
         expect(subject).to eq(expected_content)
       end
@@ -158,7 +158,7 @@ describe Users::RdvSms, type: :service do
         let(:motif) { build(:motif, :by_phone) }
 
         it do
-          expect(subject).to include("RDV Téléphonique")
+          expect(subject).to include("RDV téléphonique")
           expect(subject).to include(rdv.address)
         end
       end


### PR DESCRIPTION
refs #2050

<img width="887" alt="image" src="https://user-images.githubusercontent.com/139391/170009990-ff1af031-9231-4910-afea-7ec56616c543.png">

Pour l’instant, ça choisit au hasard un rdv en base pour lequel l’utilisateur a un numéro de téléphone; il faudrait avoir plusieurs scénarios avec différents lieux, des rdv de suivi, des rdv collectifs, mais j’hésite sur la façon de faire. C’est déjà reviewable en l’état :)

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
