### PR TITLE
Permettre des plages d'ouverture qui permettent de faire un rdv à 19h

### DIFF
--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -2,7 +2,7 @@
 
 module PlageOuverturesHelper
   def time_collections_for_plage_ouverture
-    time_collections_for_hours(7..19)
+    time_collections_for_hours(7..19) + ["20:00"]
   end
 
   def time_collections_for_absence

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -8,9 +8,10 @@ describe PlageOuverturesHelper do
   end
 
   describe "#time_collections_for_plage_ouverture" do
-    it "return 156 entries" do
-      expect(time_collections_for_plage_ouverture.count).to eq(156)
+    it "goes from 7:00 to 20:00, so that it's possible to create a plage_ouverture that allows booking a rdv at 19:00" do
+      expect(time_collections_for_plage_ouverture.count).to eq(157)
       expect(time_collections_for_plage_ouverture.first).to eq("07:00")
+      expect(time_collections_for_plage_ouverture.last).to eq("20:00")
     end
   end
 
@@ -18,6 +19,7 @@ describe PlageOuverturesHelper do
     it "return 288 entries" do
       expect(time_collections_for_absence.count).to eq(288)
       expect(time_collections_for_absence.first).to eq("00:00")
+      expect(time_collections_for_absence.last).to eq("23:55")
     end
   end
 


### PR DESCRIPTION
Actuellement, l'heure de fin max qu'on propose pour les plages d'ouverture est 19h55. Si on crée une plage d'ouverture qui se finit à ce moment là, il est donc impossible de faire un rdv de 1h qui commence à 19h, or certains cnfs travaillent jusqu'à 20h.
Pour les absences, on va jusq'à 23h55, parce que aller jusqu'à minuit amènerait à la journée suivante.
Cette PR ajout les 5mn qui manquent. :)

voir https://zammad10.ethibox.fr/#ticket/zoom/291

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
