### PR TITLE
Faire remonter le user dans Sentry côté JS

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,11 +35,11 @@ class ApplicationController < ActionController::Base
   end
 
   def sentry_user
-    user = current_agent || current_user
-    {
-      id: user&.id,
-      role: user&.class&.name || "Guest",
-      email: user&.email,
+    user_or_agent = current_agent || current_user
+    @sentry_user = {
+      id: user_or_agent&.id,
+      role: user_or_agent&.class&.name || "Guest",
+      email: user_or_agent&.email,
     }.compact
   end
 

--- a/app/javascript/components/sentry.js
+++ b/app/javascript/components/sentry.js
@@ -6,6 +6,7 @@ function initSentry() {
       dsn: ENV.SENTRY_DSN_RAILS,
       environment: ENV.SENTRY_CURRENT_ENV,
     });
+    Sentry.setUser(ENV.SENTRY_USER_CONTEXT);
   }
 }
 

--- a/app/views/common/_env.html.erb
+++ b/app/views/common/_env.html.erb
@@ -1,0 +1,9 @@
+<script>
+  const ENV = {
+    MATOMO_APP_ID: "<%= ENV["MATOMO_APP_ID"] %>",
+    SENTRY_DSN_RAILS: "<%= ENV["SENTRY_DSN_RAILS"] %>",
+    ENV: "<%= Rails.env %>",
+    SENTRY_CURRENT_ENV: "<%= ENV["SENTRY_CURRENT_ENV"] %>",
+    SENTRY_USER_CONTEXT: <%= raw @sentry_user.to_json %>,
+  };
+</script>

--- a/app/views/common/_env.html.slim
+++ b/app/views/common/_env.html.slim
@@ -1,7 +1,0 @@
-javascript:
-  var ENV = {
-    MATOMO_APP_ID: "#{ ENV["MATOMO_APP_ID"] }",
-    SENTRY_DSN_RAILS: "#{ ENV["SENTRY_DSN_RAILS"] }",
-    ENV: "#{ Rails.env }",
-    SENTRY_CURRENT_ENV: "#{ ENV["SENTRY_CURRENT_ENV"] }",
-  };


### PR DESCRIPTION
Actuellement, les remontées Sentry côté JS ne portent aucune info sur le user / agent connecté. 

Le but est donc de remonter ces infos afin de faciliter le débuggage de certaines erreurs ([celle-ci par exemple](https://sentry.io/organizations/rdv-solidarites/issues/3294462748/?environment=production)).

J'ai fait un test en remontant une erreur bidon : https://sentry.io/organizations/rdv-solidarites/issues/3300260790

![image](https://user-images.githubusercontent.com/6357692/170235213-4a6657fd-2f4b-4554-b823-3412b04534c7.png)
