### PR TITLE
Permettre aux super admins de créer et modifier des lieux

### DIFF
--- a/app/controllers/super_admins/lieux_controller.rb
+++ b/app/controllers/super_admins/lieux_controller.rb
@@ -2,22 +2,26 @@
 
 module SuperAdmins
   class LieuxController < SuperAdmins::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Agent.
-    #     page(params[:page]).
-    #     per(10)
-    # end
+    # On modifie cette action pour pouvoir mettre une valeur par défaut en availability
+    def create
+      resource = resource_class.new(resource_params)
+      authorize_resource(resource)
 
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Agent.find_by!(slug: param)
-    # end
+      lieu = Lieu.new(resource_params)
+      lieu.availability = :enabled
 
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+      lieu.save
+
+      if lieu.errors.any?
+        render :new, locals: {
+          page: Administrate::Page::Form.new(dashboard, resource),
+        }
+      else
+        redirect_to(
+          [namespace, resource],
+          notice: translate_with_resource("create.success")
+        )
+      end
+    end
   end
 end

--- a/app/dashboards/lieu_dashboard.rb
+++ b/app/dashboards/lieu_dashboard.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "administrate/base_dashboard"
+
+class LieuDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+    versions: Field::HasMany,
+    organisation: Field::BelongsTo,
+    plage_ouvertures: Field::HasMany,
+    rdvs: Field::HasMany,
+    motifs: Field::HasMany,
+    agents: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    old_address: Field::String,
+    latitude: Field::Number.with_options(decimals: 6),
+    longitude: Field::Number.with_options(decimals: 6),
+    phone_number: Field::String,
+    phone_number_formatted: Field::String,
+    old_enabled: Field::Boolean,
+    availability: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    address: Field::String,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+    address
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    address
+    organisation
+    created_at
+    updated_at
+    latitude
+    longitude
+    phone_number_formatted
+    availability
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    name
+    latitude
+    longitude
+    address
+    organisation
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how lieux are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(lieu)
+  #   "Lieu ##{lieu.id}"
+  # end
+end

--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -14,6 +14,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     name: Field::String,
     agents: Field::HasMany,
     motifs: Field::HasMany,
+    lieux: Field::HasMany,
     horaires: Field::String,
     phone_number: Field::String,
     human_id: Field::String,
@@ -41,6 +42,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     phone_number
     agents
     motifs
+    lieux
     human_id
     created_at
     updated_at

--- a/app/views/super_admins/lieux/_form.html.slim
+++ b/app/views/super_admins/lieux/_form.html.slim
@@ -1,0 +1,18 @@
+= form_for([namespace, page.resource], html: { class: "form" }) do |f|
+  - if page.resource.errors.any?
+    #error_explanation
+      h2
+        = t("administrate.form.errors", pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+            resource_name: display_resource_name(page.resource_name, singular: true))
+      ul
+        - page.resource.errors.full_messages.each do |message|
+          li.flash-error= message
+  - page.attributes.each do |attribute|
+    div class=("field-unit field-unit--#{attribute.html_class} field-unit--#{requireness(attribute)}")
+      = render_field attribute, f: f
+  .form-actions
+    p
+      | La latitude et la longitude sont requises. Vous pouvez les retrouver en cherchant l'adresse du lieu dans #{link_to("Open Street Map", "https://www.openstreetmap.org/")}
+    p
+      | La latitude est le nombre plus élevé, proche de 48, et la longitude est le nombre plus faible, proche de 2.
+    = f.submit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     resources :organisations
     resources :services
     resources :motifs
+    resources :lieux
     resources :territories
     resources :users do
       get "sign_in_as", on: :member


### PR DESCRIPTION
<img width="1404" alt="Capture d’écran 2022-05-25 à 12 36 37" src="https://user-images.githubusercontent.com/1840367/170243423-b7fb365e-3d96-4eb2-bc15-8b18c9ee176f.png">

On a parfois des cas où les agents ne peuvent pas mettre l'adresse correcte d'un lieu parce qu'elle n'est pas dans la BAN. A court terme, on veut donc permettre à l'équipe support de créer ces lieux ou de les modifier pour mettre la bonne adresse. Ça leur permettra de répondre à ce genre de ticket en autonomie.

Exemple de ticket zammad : https://zammad10.ethibox.fr/#ticket/zoom/145

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
