### PR TITLE
feat(motifs): disallow rdv modifications by user

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -101,7 +101,9 @@ class Admin::MotifsController < AgentAuthController
               :for_secretariat,
               :follow_up,
               :collectif,
-              :sectorisation_level)
+              :sectorisation_level,
+              :rdvs_cancellable_by_user,
+              :rdvs_editable_by_user)
   end
 
   def set_available_services

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -102,7 +102,6 @@ class Admin::MotifsController < AgentAuthController
               :follow_up,
               :collectif,
               :sectorisation_level,
-              :rdvs_cancellable_by_user,
               :rdvs_editable_by_user)
   end
 

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -34,9 +34,9 @@ class MotifForm {
     this.sectorisationEnabled = enabled
   }
 
-  toggleRdvsEditableAndCancellable() {
+  toggleRdvsEditable() {
     const enabled = !!document.querySelector("#motif_reservable_online:checked")
-    document.querySelector(".js-rdvs-editable-and-cancellable").classList.toggle('translucent', !enabled)
+    document.querySelector(".js-rdvs-editable").classList.toggle('translucent', !enabled)
   }
 
   constructor() {
@@ -55,7 +55,7 @@ class MotifForm {
 
     this.toggleSecretariat()
     this.toggleSectorisation()
-    this.toggleRdvsEditableAndCancellable()
+    this.toggleRdvsEditable()
   }
 
 }

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -50,7 +50,7 @@ class MotifForm {
     )
     this.reservableOnlineCheckbox.addEventListener('change', e => {
       this.toggleSectorisation()
-      this.toggleRdvsEditableAndCancellable()
+      this.toggleRdvsEditable()
     })
 
     this.toggleSecretariat()

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -34,6 +34,11 @@ class MotifForm {
     this.sectorisationEnabled = enabled
   }
 
+  toggleRdvsEditableAndCancellable() {
+    const enabled = !!document.querySelector("#motif_reservable_online:checked")
+    document.querySelector(".js-rdvs-editable-and-cancellable").classList.toggle('translucent', !enabled)
+  }
+
   constructor() {
     this.secretariatCheckbox = document.querySelector('#motif_for_secretariat')
     this.reservableOnlineCheckbox = document.querySelector('#motif_reservable_online')
@@ -43,10 +48,14 @@ class MotifForm {
     document.querySelectorAll(noSecretariatInputs).forEach(input =>
       input.addEventListener('change', e => this.toggleSecretariat())
     )
-    this.reservableOnlineCheckbox.addEventListener('change', e => this.toggleSectorisation())
+    this.reservableOnlineCheckbox.addEventListener('change', e => {
+      this.toggleSectorisation()
+      this.toggleRdvsEditableAndCancellable()
+    })
 
     this.toggleSecretariat()
     this.toggleSectorisation()
+    this.toggleRdvsEditableAndCancellable()
   }
 
 }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -149,11 +149,12 @@ class Rdv < ApplicationRecord
   end
 
   def cancellable_by_user?
-    !cancelled? && starts_at > 4.hours.from_now && !collectif?
+    !cancelled? && !collectif? && motif.rdvs_cancellable_by_user? && starts_at > 4.hours.from_now
   end
 
   def editable_by_user?
-    cancellable_by_user? && starts_at > 2.days.from_now && motif.reservable_online && !created_by_agent?
+    !cancelled? && !collectif? && motif.rdvs_editable_by_user? && starts_at > 2.days.from_now &&
+      motif.reservable_online && !created_by_agent?
   end
 
   def available_to_file_attente?

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -68,9 +68,7 @@
           .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
           .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
 
-        .js-rdvs-editable-and-cancellable
-          = f.input(:rdvs_cancellable_by_user)
-          p.text-muted.font-14= Motif.human_attribute_name("rdvs_cancellable_by_user_hint")
+        .js-rdvs-editable
           = f.input(:rdvs_editable_by_user)
           p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
 

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -63,9 +63,16 @@
         h5.card-title= Motif.human_attribute_name("reservable_online_title")
         p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
         = f.input :reservable_online
+
         .form-row
           .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
           .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
+
+        .js-rdvs-editable-and-cancellable
+          = f.input(:rdvs_cancellable_by_user)
+          p.text-muted.font-14= Motif.human_attribute_name("rdvs_cancellable_by_user_hint")
+          = f.input(:rdvs_editable_by_user)
+          p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
 
     .card.js-sectorisation-card
       .card-body
@@ -109,12 +116,12 @@
           span.ml-1= Motif.human_attribute_value(:visibility_type, value)
           p.text-muted.font-14= Motif.human_attribute_value(:visibility_type, value, context: :hint)
 
-  .card
-    .card-body
-      h5 Instructions
-      p.text-muted.font-14 Ces instructions sont affichées à l'usager avant et après sa prise de RDV. Laissez ces champs vides si vous ne souhaitez pas donner d'instructions.
-      = f.input :restriction_for_rdv, input_html: {rows: 6}
-      = f.input :instruction_for_rdv, input_html: {rows: 6}
+    .card
+      .card-body
+        h5 Instructions
+        p.text-muted.font-14 Ces instructions sont affichées à l'usager avant et après sa prise de RDV. Laissez ces champs vides si vous ne souhaitez pas donner d'instructions.
+        = f.input :restriction_for_rdv, input_html: {rows: 6}
+        = f.input :instruction_for_rdv, input_html: {rows: 6}
 
   .card
     .card-body

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -49,9 +49,6 @@
             min_max_delay_int_to_human(@motif.max_booking_delay), \
           hint: Motif.human_attribute_name(:max_booking_delay_hint)
         = motif_attribute_row \
-          Motif.human_attribute_name(:rdvs_cancellable_by_user), \
-          motif_option_value(@motif, :rdvs_cancellable_by_user)
-        = motif_attribute_row \
           Motif.human_attribute_name(:rdvs_editable_by_user), \
            motif_option_value(@motif, :rdvs_editable_by_user)
 

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -48,6 +48,13 @@
           @motif.reservable_online? && \
             min_max_delay_int_to_human(@motif.max_booking_delay), \
           hint: Motif.human_attribute_name(:max_booking_delay_hint)
+        = motif_attribute_row \
+          Motif.human_attribute_name(:rdvs_cancellable_by_user), \
+          motif_option_value(@motif, :rdvs_cancellable_by_user)
+        = motif_attribute_row \
+          Motif.human_attribute_name(:rdvs_editable_by_user), \
+           motif_option_value(@motif, :rdvs_editable_by_user)
+
         - unless current_agent.conseiller_numerique?
           = motif_attribute_row("Sectorisation") do
             - if @motif.reservable_online?

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -38,16 +38,18 @@ ul.list-group.list-group-flush
   - unless defined?(hide_file_attente_infos) && hide_file_attente_infos
     = render "/users/rdvs/file_attente", rdv: rdv
 
-div.py-2.d-flex.justify-content-between.align-items-center
-  - if policy([:user, rdv]).edit?
-    .text-left.mt-2
+  - if !policy([:user, rdv]).cancel? && !rdv.cancelled? && !rdv.in_the_past?
+    li.list-group-item.font-italic
+      i.fa.fa-ban>
+      | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
+
+.py-2.d-flex.justify-content-between.align-items-center
+  .text-left.mt-2
+    - if policy([:user, rdv]).edit?
        = link_to "Déplacer le RDV", creneaux_users_rdv_path(rdv), class: "btn btn-outline-primary"
-  - if policy([:user, rdv]).cancel?
-    .text-right.mt-2
-      = link_to "Annuler le RDV", "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: "btn btn-outline-danger"
-  - elsif !rdv.past? && !rdv.cancelled? && !rdv.collectif?
-    p.font-italic
-      | Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne. Prenez contact avec le secrétariat.
+  .text-right.mt-2
+    - if policy([:user, rdv]).cancel?
+        = link_to "Annuler le RDV", "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: "btn btn-outline-danger"
 
 = render( \
   "common/modal_confirmation", \

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -43,8 +43,6 @@ fr:
         instruction_for_rdv: Indications affichées après la confirmation du rendez-vous
         instruction_for_rdv_hint: Indications affichées après la confirmation du rendez-vous
         instruction_for_rdv_short: Indications après
-        rdvs_cancellable_by_user: RDVs annulables
-        rdvs_cancellable_by_user_hint: Les RDVs peuvent être annulés par l'usager au plus tard 4 heures avant le début du RDV
         rdvs_editable_by_user: RDVs modifiables
         rdvs_editable_by_user_hint: L'horaire du RDV peut être changé par l'usager au plus tard 2 jours avant le début du RDV
       motif/categories:

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -43,6 +43,10 @@ fr:
         instruction_for_rdv: Indications affichées après la confirmation du rendez-vous
         instruction_for_rdv_hint: Indications affichées après la confirmation du rendez-vous
         instruction_for_rdv_short: Indications après
+        rdvs_cancellable_by_user: RDVs annulables
+        rdvs_cancellable_by_user_hint: Les RDVs peuvent être annulés par l'usager au plus tard 4 heures avant le début du RDV
+        rdvs_editable_by_user: RDVs modifiables
+        rdvs_editable_by_user_hint: L'horaire du RDV peut être changé par l'usager au plus tard 2 jours avant le début du RDV
       motif/categories:
         rsa_orientation: RSA - Orientation
         rsa_accompagnement: RSA - Accompagnement

--- a/db/migrate/20220524141757_add_rdv_editable_by_user_and_rdv_cancellable_by_user_to_motifs.rb
+++ b/db/migrate/20220524141757_add_rdv_editable_by_user_and_rdv_cancellable_by_user_to_motifs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRdvEditableByUserAndRdvCancellableByUserToMotifs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :motifs, :rdvs_editable_by_user, :boolean, default: true
+    add_column :motifs, :rdvs_cancellable_by_user, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_140836) do
+ActiveRecord::Schema.define(version: 2022_05_24_141757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -330,6 +330,8 @@ ActiveRecord::Schema.define(version: 2022_05_23_140836) do
     t.boolean "collectif", default: false
     t.enum "location_type", default: "public_office", null: false, enum_type: "location_type"
     t.enum "category", enum_type: "motif_category"
+    t.boolean "rdvs_editable_by_user", default: true
+    t.boolean "rdvs_cancellable_by_user", default: true
     t.index "to_tsvector('simple'::regconfig, (COALESCE(name, (''::text)::character varying))::text)", name: "index_motifs_name_vector", using: :gin
     t.index ["category"], name: "index_motifs_on_category"
     t.index ["collectif"], name: "index_motifs_on_collectif"

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -27,7 +27,7 @@ describe "User can manage their rdvs" do
     it "default", js: true do
       expect(page).to have_content(rdv.motif.name)
       expect(page).not_to have_selector("li", text: "Annuler le RDV")
-      expect(page).to have_selector("p.font-italic", text: "Ce rendez-vous commence dans moins de 4 heures, il n'est plus annulable en ligne.")
+      expect(page).to have_content("Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.")
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-insertion/issues/398

## Contexte

Nous avons eu plusieurs remontées de CD pour qui la possibilité de déplacer et/ou annuler RDV pose problème.
En effet, certains départements (le 64 notamment) ont des motifs de "convocation" aux RDV d'orientation pour les cas où les allocataires ne répondent pas à l'invitation de RDVI. Ils leur semblent alors incongru de laisser la possibilité aux usagers d'annuler ces RDVs.
J'ai donc ajouté deux attributs au niveau des motifs, qui rendent les RDVs sur ce motif non modifiable ou non annulable par les utiilisateurs

## Previews 📸 

* `admin/motifs#edit` : 

<img width="920" alt="image" src="https://user-images.githubusercontent.com/7602809/170314438-446cbd10-4f50-4618-93c8-496352c6a539.png">

* `admin/motifs#show`: 

<img width="908" alt="image" src="https://user-images.githubusercontent.com/7602809/170314566-974f8c69-d132-4459-861c-0d5db0ee491e.png">

-  `users/rdvs#show`: 

Quand le rdv est annulable et déplaçable: 

<img width="532" alt="image" src="https://user-images.githubusercontent.com/7602809/170315348-772533c8-2da9-4f5d-90d9-2534383948c9.png">

Quand le rdv est annulable seulement: 
 
<img width="543" alt="image" src="https://user-images.githubusercontent.com/7602809/170315628-f24b0a5d-d062-4ff8-ba77-4d712eb59b47.png">

Quand le rdv est ni annulable ni déplaçable: 
 
<img width="598" alt="image" src="https://user-images.githubusercontent.com/7602809/170315940-0a84de4d-e28c-48b4-87ae-292bc78c6350.png">



Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
