### PR TITLE
Exclu `/docs` du déclenchement de la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
-on: push
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
 jobs:
   rubocop:
     name: Ruby linter


### PR DESCRIPTION
Sur une suggestion de @francois-ferrandis, voici une petite modification qui devrait réduire les déclenchements de CI. Si seul le répertoire `docs` est modifié, alors il n'y aura pas de déclenchement de la CI (il parait :)).