### PR TITLE
Permettre des redirections externes vers l'url /prendre_rdv

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -20,4 +20,9 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins "*"
     resource "/api/v1/*", headers: :any, methods: %i[get post patch put], expose: %w[client uid access-token]
   end
+
+  allow do
+    origins "*"
+    resource "/prendre_rdv", headers: :any, methods: %i[get]
+  end
 end


### PR DESCRIPTION
RDV-Insertion effectue des redirections depuis la page `rdv-insertion.fr/invitation` vers la page `rdv-solidarites.fr/prendre_rdv` qui sont bloquées à cause d'un blocage par défaut des requêtes multiorigines. Je les autorise donc pour cette page en limitant cette autorisation aux requêtes `GET`