### PR TITLE
Permettre à turbolinks de recharger ENV côte JS

### DIFF
--- a/app/views/common/_env.html.erb
+++ b/app/views/common/_env.html.erb
@@ -1,5 +1,5 @@
 <script>
-  const ENV = {
+  var ENV = {
     MATOMO_APP_ID: "<%= ENV["MATOMO_APP_ID"] %>",
     SENTRY_DSN_RAILS: "<%= ENV["SENTRY_DSN_RAILS"] %>",
     ENV: "<%= Rails.env %>",


### PR DESCRIPTION
Depuis #2508, nous avons des remontées Sentry  `SyntaxError: Identifier 'ENV' has already been declared` : 

https://sentry.io/organizations/rdv-solidarites/issues/3300878842/?environment=production

La cause : j'ai modifié le `var` en `const` en pensant bien faire, mais au moment où turbolinks ré-injecte le JS issu du `<head>`, il tente de redéfinir la constante `ENV` et ça ne plaît pas aux navigateurs.

Cette PR est donc juste un revert à l'usage de `var`, qui permet le rechargement.