### PR TITLE
Ré-invitation des CNFS

### DIFF
--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -1,33 +1,30 @@
 <p><%= t("devise.mailer.invitation_instructions_cnfs.hello") %></p>
 
 <p>
-  <%= t("devise.mailer.invitation_instructions_cnfs.create_account",
-         link: link_to("créer votre compte", accept_invitation_url(@resource, invitation_token: @token, user: @user_params))).html_safe %>
+  <%= t("devise.mailer.invitation_instructions_cnfs.create_account") %>
 </p>
 
+<div class="btn-wrapper">
+  <%= link_to("Activer mon compte", accept_invitation_url(@resource, invitation_token: @token, user: @user_params),  class: "btn btn-primary") %>
+</div>
 
-<p><%= t("devise.mailer.invitation_instructions_cnfs.intro1") %></p>
-<p><%= t("devise.mailer.invitation_instructions_cnfs.intro2") %></p>
-<br/>
-<p><%= t("devise.mailer.invitation_instructions_cnfs.intro3") %></p>
-<p><%= t("devise.mailer.invitation_instructions_cnfs.intro4") %></p>
-
-<br>
 <h1><%= t("devise.mailer.invitation_instructions_cnfs.title1") %></h1>
 
-<p><%= t("devise.mailer.invitation_instructions_cnfs.recap") %></p>
-<ul>
-  <li><%= t("devise.mailer.invitation_instructions_cnfs.recap_item1") %></li>
-  <li><%= t("devise.mailer.invitation_instructions_cnfs.recap_item2") %></li>
-  <li><%= t("devise.mailer.invitation_instructions_cnfs.recap_item3") %></li>
-</ul>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.paragraph1") %></p>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.use1") %>
+<br>
+<%= t("devise.mailer.invitation_instructions_cnfs.use2") %>
+<br>
+<%= t("devise.mailer.invitation_instructions_cnfs.use3") %>
+<br>
 
 <br>
 
 <h1><%= t("devise.mailer.invitation_instructions_cnfs.title2") %></h1>
 
-<p><%= t("devise.mailer.invitation_instructions_cnfs.video_text", link: link_to("vidéo de présentation de l’outil", "https://peertube.ethibox.fr/w/sLqvuTvx4vgsjmKXpz9awH"), target: "_blank").html_safe %></p>
 
+<p><%= t("devise.mailer.invitation_instructions_cnfs.paragraph2", video_link: link_to("ici", "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV")).html_safe %></p>
 <p><%= t("devise.mailer.invitation_instructions_cnfs.first_steps_info") %></p>
 
 <br>

--- a/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
@@ -1,39 +1,36 @@
 <%= t("devise.mailer.invitation_instructions_cnfs.hello") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.create_account", link: "créer votre compte", ) %>
 
-<%= accept_invitation_url(@resource, invitation_token: @token, user: @user_params) %>
+<%= t("devise.mailer.invitation_instructions_cnfs.create_account") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.intro1") %>
-<%= t("devise.mailer.invitation_instructions_cnfs.intro2") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.intro3") %>
-<%= t("devise.mailer.invitation_instructions_cnfs.intro4") %>
+Activer mon compte: <%= accept_invitation_url(@resource, invitation_token: @token, user: @user_params) %>
 
 <%= t("devise.mailer.invitation_instructions_cnfs.title1") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.recap") %>
-- <%= t("devise.mailer.invitation_instructions_cnfs.recap_item1") %>
-- <%= t("devise.mailer.invitation_instructions_cnfs.recap_item2") %>
-- <%= t("devise.mailer.invitation_instructions_cnfs.recap_item3") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.paragraph1") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.use1") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.use2") %>
+
+<%= t("devise.mailer.invitation_instructions_cnfs.use3") %>
 
 
 <%= t("devise.mailer.invitation_instructions_cnfs.title2") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.video_text", link: "vidéo de présentation de l’outil") %>
-
-https://peertube.ethibox.fr/w/sLqvuTvx4vgsjmKXpz9awH
-
+<%= t("devise.mailer.invitation_instructions_cnfs.paragraph2", video_link: "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV") %>
 <%= t("devise.mailer.invitation_instructions_cnfs.first_steps_info") %>
+
 
 <%= t("devise.mailer.invitation_instructions_cnfs.title3") %>
 
 
 <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
-      mattermost: "Aide RDV Solidarités",
-      support_email: "support@rdv-solidarités.fr") %>
+      mattermost: "Aide RDV Solidarités: https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites",
+      support_email: "support@rdv-solidarités.fr"
+     ).html_safe %>
 
-https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites
 
 <%= t("devise.mailer.invitation_instructions_cnfs.sign_off") %>
 <%= t("devise.mailer.invitation_instructions_cnfs.signature") %>

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -44,18 +44,14 @@ fr:
       invitation_instructions_cnfs:
         subject: "Vous avez été invité sur RDV-Solidarités"
         hello: "Hello 👋"
-        create_account: "Nous vous contactons pour %{link} RDV-Solidarités. "
-        intro1: "✅ RDV-Solidarités est un outil de gestion des rendez-vous."
-        intro2: "✅ RDV-Solidarités est en phase de généralisation à tous les Conseillers Numérique France Services."
-        intro3: Chaque semaine, nous lançons l’embarquement d’un nouveau groupe de Conseillers Numérique.
-        intro4: Vous faites partie  d’un embarquement et vous disposez  alors d’un droit d’accès à RDV-Solidarités.
-        title1: RDV-Solidarités c’est ?
-        recap: "Un outil,  qui vous permet de :"
-        recap_item1: planifier des rendez-vous individuels et collectifs,
-        recap_item2: envoyer des rappels (sms & mail) automatiques aux  usagers
-        recap_item3: permettre à vos collègues de planifier des rendez-vous selon vos disponibilités.
-        title2: Comment ça marche  ?
-        video_text: "Pour mieux comprendre, nous vous proposons de regarder la %{link}"
+        create_account: "Vos missions de Conseiller•ère Numérique vous donnent accès à RDV Solidarités, un outil fourni par l'ANCT."
+        title1: A quoi ça sert ?
+        paragraph1: "RDV Solidarités est un outil de gestion des RDV qui vous permet de :"
+        use1: "✅ gérer vos RDV individuels et collectifs"
+        use2: "✅ envoyer des rappels SMS et mail aux usagers."
+        use3: "✅ partager vos créneaux disponibles à une personne tiers."
+        title2: Comment ça marche ?
+        paragraph2: Pour mieux comprendre, nous vous proposons de regarder la vidéo de présentation de l’outil %{video_link}.
         first_steps_info: Vous trouverez  également un guide “premiers pas” dans l’interface de l’outil.
         title3: Besoin d’aide ?
         help_info: "Vous pouvez  nous contacter sur le Mattermost dans le canal : %{mattermost}  ou bien par mail à %{support_email}"

--- a/scripts/reinvite_cnfs_batch1.rb
+++ b/scripts/reinvite_cnfs_batch1.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Renvoie les invitations pour 300 cnfs
+
+agents = Agent.joins(:organisations)
+  .where(organisations: { territory_id: 31 })
+  .where(invitation_accepted_at: nil)
+  .distinct
+  .order("agents.id asc")
+  .limit(300)
+
+agents.find_each do |agent|
+  agent.invite!(nil, validate: false)
+  puts "Invitation envoyée pour #{agent.email}"
+end

--- a/scripts/reinvite_cnfs_batch2.rb
+++ b/scripts/reinvite_cnfs_batch2.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Renvoie les invitations pour les cnfs restant
+
+agents = Agent.joins(:organisations)
+  .where(organisations: { territory_id: 31 })
+  .where(invitation_accepted_at: nil)
+  .distinct
+  .order("agents.id asc")
+  .offset(300) # Les 300 premiers sont invités dans le batch 1
+
+agents.find_each do |agent|
+  agent.invite!(nil, validate: false)
+  puts "Invitation envoyée pour #{agent.email}"
+end

--- a/spec/mailers/previews/custom_devise_mailer_preview.rb
+++ b/spec/mailers/previews/custom_devise_mailer_preview.rb
@@ -13,6 +13,10 @@ class CustomDeviseMailerPreview < ActionMailer::Preview
     CustomDeviseMailer.invitation_instructions(Agent.last, "faketoken")
   end
 
+  def invitation_instructions_cnfs
+    CustomDeviseMailer.invitation_instructions(Agent.joins(:service).where(service: { name: "Conseiller Numérique" }, invited_by: nil).last, "faketoken")
+  end
+
   def invitation_instructions
     CustomDeviseMailer.invitation_instructions(User.last, "faketoken")
   end


### PR DESCRIPTION
<img width="661" alt="Capture d’écran 2022-05-30 à 17 15 23" src="https://user-images.githubusercontent.com/1840367/171021468-1e4f4a8e-01da-4b9d-9d9c-c3e085b15dca.png">


Les invitations envoyées en avril dernier sont arrivées à expiration, donc on veut ré-inviter les CNFS qui n'ont pas encore activé leur compte.
Le texte du mail est celui mis à jour par Matis ici : https://pad.incubateur.net/0qQsnV7qR_mTYnJ2yxc7jA

Pour tester les choses tranquillement, on pourra faire un premier envoi à 300 CNFS en faisant `rails runner scripts/reinvite_cnfs_batch1.rb`, et ensuite faire le reste de l'envoi avec `rails runner scripts/reinvite_cnfs_batch2.rb`

J'ai testé en local, et les mails partent bien avec le bon lien.

Le lien vers la vidéo est à jour.

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
