### PR TITLE
Envoyer les mails de demande de nouvelle orga directement au support

### DIFF
--- a/app/mailers/admins/organisation_mailer.rb
+++ b/app/mailers/admins/organisation_mailer.rb
@@ -4,6 +4,6 @@ class Admins::OrganisationMailer < ApplicationMailer
   def organisation_created(agent, organisation)
     @agent = agent
     @organisation = organisation
-    mail(to: "contact@rdv-solidarites.fr", subject: "Nouvelle organisation créée - #{@organisation.departement_number} - #{@organisation.name}")
+    mail(to: "support@rdv-solidarites.fr", subject: "Nouvelle organisation créée - #{@organisation.departement_number} - #{@organisation.name}")
   end
 end


### PR DESCRIPTION
En ce moment ces mails sont forwardés manuellement depuis l'adresse contact vers l'adresse support (voir https://zammad10.ethibox.fr/#ticket/zoom/384 par exemple). Autant le faire directement :)