### PR TITLE
fix(api): Rename single use attribute for lieu blueprint

### DIFF
--- a/app/blueprints/lieu_blueprint.rb
+++ b/app/blueprints/lieu_blueprint.rb
@@ -3,5 +3,6 @@
 class LieuBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :address, :single_use?
+  fields :name, :address
+  field :single_use?, name: :single_use
 end


### PR DESCRIPTION
Nous avons eu un retour des Bouches-du-Rhône nous disant qu'ils avaient des problèmes à parser le JSON du webhook du fait du `?` de l'attribut `single_use?`. 
Je renomme ici l'attribut en `single_use`. Est-ce que vous savez si des organisations traitent déjà cet attribut en prod ? 

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
