### PR TITLE
Amélioration des aperçus de SMS

### DIFF
--- a/app/controllers/lapin/sms_preview_controller.rb
+++ b/app/controllers/lapin/sms_preview_controller.rb
@@ -19,48 +19,55 @@ module Lapin
       return head :forbidden if action_name.nil?
 
       @title = "#{klass}/#{action_name}"
-      data = test_data
+      data = mock_data
       @sms = klass.send(action_name, data[:rdv], data[:user], data[:token])
     end
 
     private
 
-    def test_data
+    def mock_params
+      @mock_params ||= begin
+        params.permit(:show_relatives, :show_agent, :location_type, :phone_number)
+
+        params[:show_relatives] = params[:show_relatives].to_b
+        params[:show_agent] = params[:show_agent].to_b
+        params[:location_type] = "public_office" unless params[:location_type].in? Motif.location_types.keys
+        params[:phone_number] ||= "+33 1 99 00 12 34"
+
+        params
+      end
+    end
+
+    def mock_data
       user = OpenStruct.new(phone_number: "+33 6 39 98 12 34")
       rdv = OpenStruct.new(starts_at: 10.days.from_now.at_noon)
       rdv.motif = OpenStruct.new(service: OpenStruct.new(short_name: "Aide au logement"))
       rdv.to_param = 999
 
-      show_relatives = [true, false].sample
-      if show_relatives
-        user1 = OpenStruct.new(full_name: "Irène Curie")
-        user2 = OpenStruct.new(full_name: "Ève Curie")
-
-        user.relatives = [user1, user2]
+      if mock_params[:show_relatives]
+        user.relatives = [OpenStruct.new(full_name: "Anaïs Chaumont")]
         rdv.users = user.relatives
       end
 
-      show_agent = [true, false].sample
-      if show_agent
+      if mock_params[:show_agent]
         rdv[:follow_up?] = true
-        rdv.agents = [OpenStruct.new(short_name: "James Bond")]
+        rdv.agents = [OpenStruct.new(short_name: "Jean-François Lenormand")]
       else
         rdv.agents = []
       end
 
-      location_type = %i[public_office phone home].sample
-      rdv.location_type = location_type
-      case location_type
+      rdv.location_type = mock_params[:location_type].to_sym
+      case rdv.location_type
       when :home
         rdv[:home?] = true
       when :phone
         rdv[:phone?] = true
       when :public_office
         rdv[:public_office?] = true
-        rdv.address_complete = "57 rue de Varenne, 75007 Paris"
+        rdv.address_complete = "13 bis rue Marcel Pagnol, 53700 Villaines-la-Juhel"
       end
 
-      rdv.phone_number = ["+33 1 99 00 12 34", nil].sample
+      rdv.phone_number = mock_params[:phone_number]
 
       { user: user, rdv: rdv, token: "ABCTOKEN" }
     end

--- a/app/controllers/lapin/sms_preview_controller.rb
+++ b/app/controllers/lapin/sms_preview_controller.rb
@@ -18,12 +18,51 @@ module Lapin
       action_name = KNOWN_SMS_ACTIONS[klass].find { |action| action.to_s == params[:action_name] }
       return head :forbidden if action_name.nil?
 
-      user = User.joins(:rdvs).where.not(phone_number: nil).sample
-      rdv = user.rdvs.sample
-      token = "ABCTOKEN"
-
       @title = "#{klass}/#{action_name}"
-      @sms = klass.send(action_name, rdv, user, token)
+      data = test_data
+      @sms = klass.send(action_name, data[:rdv], data[:user], data[:token])
+    end
+
+    private
+
+    def test_data
+      user = OpenStruct.new(phone_number: "+33 6 39 98 12 34")
+      rdv = OpenStruct.new(starts_at: 10.days.from_now.at_noon)
+      rdv.motif = OpenStruct.new(service: OpenStruct.new(short_name: "Aide au logement"))
+      rdv.to_param = 999
+
+      show_relatives = [true, false].sample
+      if show_relatives
+        user1 = OpenStruct.new(full_name: "Irène Curie")
+        user2 = OpenStruct.new(full_name: "Ève Curie")
+
+        user.relatives = [user1, user2]
+        rdv.users = user.relatives
+      end
+
+      show_agent = [true, false].sample
+      if show_agent
+        rdv[:follow_up?] = true
+        rdv.agents = [OpenStruct.new(short_name: "James Bond")]
+      else
+        rdv.agents = []
+      end
+
+      location_type = %i[public_office phone home].sample
+      rdv.location_type = location_type
+      case location_type
+      when :home
+        rdv[:home?] = true
+      when :phone
+        rdv[:phone?] = true
+      when :public_office
+        rdv[:public_office?] = true
+        rdv.address_complete = "57 rue de Varenne, 75007 Paris"
+      end
+
+      rdv.phone_number = ["+33 1 99 00 12 34", nil].sample
+
+      { user: user, rdv: rdv, token: "ABCTOKEN" }
     end
   end
 end

--- a/app/views/lapin/sms_preview/preview.html.slim
+++ b/app/views/lapin/sms_preview/preview.html.slim
@@ -4,6 +4,25 @@
       .card
         .card-header
           = link_to t("helpers.back"), lapin_sms_preview_index_path
+          hr
+          = form_with url: lapin_sms_preview_preview_path, method: :get do |f|
+            .form-row
+              .col.form-group
+                = f.label :location_type, Motif.human_attribute_name(:location_type)
+                = f.select :location_type, Motif.human_attribute_values(:location_type), { selected: @mock_params[:location_type] }, { class: "form-control", onchange: "this.form.submit()" }
+              .col.form-group
+                = f.label :phone_number, "Numéro du lieu"
+                = f.text_field :phone_number, value: @mock_params[:phone_number], class: "form-control"
+            .form-row
+              .col
+                .form-check.form-check-inline
+                  = f.check_box :show_relatives, checked: @mock_params[:show_relatives], class: "form-check-input", onchange: "this.form.submit()"
+                  = f.label :show_relatives, "Pour un(e) proche", class: "form-check-label"
+            .form-row
+              .col
+                .form-check.form-check-inline
+                  = f.check_box :show_agent, checked: @mock_params[:show_agent], class: "form-check-input", onchange: "this.form.submit()"
+                  = f.label :show_agent, "Suivi", class: "form-check-label"
         .card-body
           h5.card-title= @title
           p= @sms.phone_number

--- a/app/views/welcome/super_admin.html.slim
+++ b/app/views/welcome/super_admin.html.slim
@@ -10,6 +10,7 @@
         h5 Liens utiles
         ul
           li = link_to "Letter Opener", letter_opener_web_path
-          li = link_to "Mailers", "/rails/mailers"
+          li = link_to "Mailer Previews", "/rails/mailers"
+          li = link_to "SMS Previews", "/lapin/sms_preview"
           li = link_to "Routes", "/rails/info/routes"
           li = link_to "Rails properties", "/rails/info/properties"

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -45,6 +45,7 @@ rails runner scripts/export_sectors.rb 64
 
 - http://localhost:3000/letter_opener
 - http://localhost:3000/rails/mailers
+- http://localhost:3000/lapin/sms_preview
 - http://localhost:3000/rails/info/routes
 - http://localhost:3000/rails/info/properties
 


### PR DESCRIPTION
followup #2503, pour pouvoir changer les paramètres des données affichées.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/139391/171152254-5486a6ab-37cc-41e1-95ab-977af4b98ddb.png">


Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
