### PR TITLE
Remplacer "contact@rdv-solidarites.fr" par "support@rdv-solidarites.fr"

### DIFF
--- a/app/mailers/admins/organisation_mailer.rb
+++ b/app/mailers/admins/organisation_mailer.rb
@@ -4,6 +4,6 @@ class Admins::OrganisationMailer < ApplicationMailer
   def organisation_created(agent, organisation)
     @agent = agent
     @organisation = organisation
-    mail(to: "support@rdv-solidarites.fr", subject: "Nouvelle organisation créée - #{@organisation.departement_number} - #{@organisation.name}")
+    mail(to: SUPPORT_EMAIL, subject: "Nouvelle organisation créée - #{@organisation.departement_number} - #{@organisation.name}")
   end
 end

--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -27,6 +27,6 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     @reply_body = reply_body
     @attachment_names = source_mail.attachments.map(&:filename).join(", ")
 
-    mail(to: "support@rdv-solidarites.fr", subject: t(".title"))
+    mail(to: SUPPORT_EMAIL, subject: t(".title"))
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,7 +5,7 @@ class ApplicationMailer < ActionMailer::Base
 
   prepend IcsMultipartAttached
 
-  default from: "contact@rdv-solidarites.fr", reply_to: "support@rdv-solidarites.fr"
+  default from: SUPPORT_EMAIL
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,7 +6,7 @@ class CustomDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application
-  default template_path: "devise/mailer", reply_to: "support@rdv-solidarites.fr"
+  default template_path: "devise/mailer"
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper
 
@@ -26,6 +26,6 @@ class CustomDeviseMailer < Devise::Mailer
   def reply_to(record)
     return unless record.is_a? Agent
 
-    record.invited_by&.email || "support@rdv-solidarites.fr"
+    record.invited_by&.email || SUPPORT_EMAIL
   end
 end

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -127,7 +127,7 @@ class SmsSender < BaseService
   # /!\ does not report routing errors for wrong numbers
   #
   def send_with_contact_experience
-    replies_email = CONTACT_EMAIL
+    replies_email = SUPPORT_EMAIL
 
     response = Typhoeus::Request.new(
       "https://contact-experience.com/ccv/webServicesCCV/SMS/sendSms.php",

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -32,7 +32,7 @@
           span> Contacter l'équipe technique
           i.fa.fa-question-circle
       .card-body
-        = mail_to "support@rdv-solidarites.fr",
+        = mail_to SUPPORT_EMAIL,
           subject: "[Problème Agent]",
           body: t(".contact-email-body"), class: "btn btn-primary" do
           span>

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -5,7 +5,7 @@ section.bg-light.p-4
         .card-body
           - if context.invitation?
             h4.font-weight-bold Nous sommes désolés, un problème semble s'être produit pour votre invitation.
-            = mail_to "support@rdv-solidarites.fr",
+            = mail_to SUPPORT_EMAIL,
               subject: "[Problème Invitation]",
               class: "btn btn-primary" do
               span>

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -15,7 +15,7 @@
   .row#tech-support
     .col-md-6
       h3.mt-4
-        = mail_to "support@rdv-solidarites.fr",
+        = mail_to SUPPORT_EMAIL,
           subject: "[Problème Usager]",
           body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "btn btn-primary" do
           span>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 BRAND = "RDV Solidarités"
-CONTACT_EMAIL = "contact@rdv-solidarites.fr"
+SUPPORT_EMAIL = "support@rdv-solidarites.fr"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "contact@rdv-solidarites.fr"
+  config.mailer_sender = SUPPORT_EMAIL
 
   # Configure the class responsible to send e-mails.
   config.mailer = "CustomDeviseMailer"

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe TransferEmailReplyJob do
       expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
       transferred_email = ActionMailer::Base.deliveries.last
       expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
-      expect(transferred_email.from).to eq(["contact@rdv-solidarites.fr"])
-      expect(transferred_email.reply_to).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email.from).to eq(["support@rdv-solidarites.fr"])
       expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
       expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
       expect(transferred_email.html_part.body.to_s).to include(%(href="http://#{ApplicationMailer.default_url_options[:host]}/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))
@@ -56,8 +55,7 @@ RSpec.describe TransferEmailReplyJob do
       expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
       transferred_email = ActionMailer::Base.deliveries.last
       expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
-      expect(transferred_email.from).to eq(["contact@rdv-solidarites.fr"])
-      expect(transferred_email.reply_to).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email.from).to eq(["support@rdv-solidarites.fr"])
       expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
       expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
     end


### PR DESCRIPTION
Suite à la mise en place de l'adresse support@rdv-solidarites.fr, l'adresse de contact ne sert plus qu'aux communications avec les partenaires du projet. Toutes les questions de support doivent aller à support@rdv-solidarites.fr qui est branché sur un système de ticketing (Zammad).

J'ai profité de l'occasion pour utiliser une constante pour représenter l'adresse de support, ça paraît raisonnable.