### PR TITLE
Supprimer `rubocop_linter_action.yml` car il est inutilisé

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -1,2 +1,0 @@
-versions:
-  - rubocop


### PR DESCRIPTION
Visiblement ce fichier est requis par l'action GitHub suivante :

https://github.com/andrewmcodes-archive/rubocop-linter-action

Mais nous n'utilisons pas cette action, donc je suppose que ce fichier a simplement été ajouté par erreur dans #1232.