### PR TITLE
Revert "Fix rdv start time display in calendar for non-metropole agents"

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -87,18 +87,7 @@ class CalendarRdvSolidarites {
       maxTime: '20:00:00',
       datesRender: this.datesRender,
       eventRender: this.eventRender,
-      eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
-      timeZone: "Europe/Paris" // This is a hack to make sure that the events will be shown at the proper time in the calendar.
-      // If this is removed, there is a bug that causes the events in the calendar to be show at the wrong
-      // time for agents that are not in the Paris timezone.
-      // The proper fix for this would be to make sure we store all rdvs with the right timezone, but that's a much bigger project.
-      // The timezone is forced to paris on the server side, so if we make sure that we also force it to the same timezone here,
-      // we always have a consistent result.
-      // We're always assuming that people are interested in their local time.
-      //
-      // There is one case for which this fix would fail: if the local time of the user and the agent is not the same (for example the agent is
-      // in the métropole and the user is at la réunion), they will not see the same time
-      // see the same time for the rdv. This seems unlikely for now.
+      eventMouseLeave: (info) => $(info.el).tooltip('hide') // extra security
     });
   }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,8 +21,7 @@ module Lapin
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.time_zone = "Paris" # The timezone is also set on the client side for the FullCalendar plugin.
-    # You will need to change it there too if you change it here.
+    config.time_zone = "Paris"
 
     config.i18n.available_locales = %i[fr]
     config.i18n.default_locale = :fr


### PR DESCRIPTION
This reverts commit 2f6de6c016950b7fc97225caec9b544bc2bfb7b0.

Le lendemain du déploiement de cette PR, on nous a informé des incohérences dans l'affichage des heures :

![image](https://user-images.githubusercontent.com/6357692/171361158-ad6cc852-2319-4c32-b89b-30a96e9f5b1e.png)
