### PR TITLE
Fournir les params à Sentry pour certaines actions à débugger

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -3,6 +3,9 @@
 class Admin::Creneaux::AgentSearchesController < AgentAuthController
   respond_to :html, :js
 
+  # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3270502722
+  before_action :log_params_to_sentry, only: %i[index]
+
   def index
     @form = helpers.build_agent_creneaux_search_form(current_organisation, params)
     @search_results = search_results

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -5,6 +5,9 @@ class Admin::RdvsController < AgentAuthController
 
   before_action :set_rdv, :set_optional_agent, except: %i[index create export]
 
+  # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3268196907
+  before_action :log_params_to_sentry, only: %i[index export]
+
   def index
     @rdvs = policy_scope(Rdv).search_for(current_agent, current_organisation, parsed_params)
     @breadcrumb_page = params[:breadcrumb_page]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,19 @@ class ApplicationController < ActionController::Base
     }.compact
   end
 
+  # By default, Sentry does not log request URL and params because they could
+  # contain personal information. See documentation for `config.send_default_pii` :
+  # https://docs.sentry.io/platforms/ruby/guides/rack/migration/#removed-processors
+  # This method is meant to be used to debug specific actions for which we have
+  # Sentry entries, and thus need more context to debug.
+  def log_params_to_sentry
+    # The Sentry scope only lives for the current request (it uses threads)
+    Sentry.configure_scope do |scope|
+      scope.set_context("params", params.to_unsafe_h)
+      scope.set_context("url", { "request.original_url" => request.original_url })
+    end
+  end
+
   def authenticate_inviter!
     authenticate_agent!(force: true)
   end

--- a/app/controllers/concerns/admin/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/admin/authenticated_controller_concern.rb
@@ -8,7 +8,6 @@ module Admin::AuthenticatedControllerConcern
 
     before_action :authenticate_agent!
     before_action :set_paper_trail_whodunnit
-    before_action :log_params_to_sentry
     helper_method :authorize_admin
     helper_method :policy_scope_admin
   end
@@ -22,19 +21,6 @@ module Admin::AuthenticatedControllerConcern
   end
 
   protected
-
-  # By default, Sentry does not log request URL and params because the could
-  # contain personal information. See documentation for `config.send_default_pii` :
-  # https://docs.sentry.io/platforms/ruby/guides/rack/migration/#removed-processors
-  # For agents, however, it seems reasonable to log the URL and params,
-  # because they are much less likely to contain personal information.
-  def log_params_to_sentry
-    # The Sentry scope only lives for the current request (it uses threads)
-    Sentry.configure_scope do |scope|
-      scope.set_context("params", params.to_unsafe_h)
-      scope.set_context("url", { "request.original_url" => request.original_url })
-    end
-  end
 
   def user_for_paper_trail
     current_agent.name_for_paper_trail

--- a/app/controllers/concerns/admin/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/admin/authenticated_controller_concern.rb
@@ -8,6 +8,7 @@ module Admin::AuthenticatedControllerConcern
 
     before_action :authenticate_agent!
     before_action :set_paper_trail_whodunnit
+    before_action :log_params_to_sentry
     helper_method :authorize_admin
     helper_method :policy_scope_admin
   end
@@ -21,6 +22,19 @@ module Admin::AuthenticatedControllerConcern
   end
 
   protected
+
+  # By default, Sentry does not log request URL and params because the could
+  # contain personal information. See documentation for `config.send_default_pii` :
+  # https://docs.sentry.io/platforms/ruby/guides/rack/migration/#removed-processors
+  # For agents, however, it seems reasonable to log the URL and params,
+  # because they are much less likely to contain personal information.
+  def log_params_to_sentry
+    # The Sentry scope only lives for the current request (it uses threads)
+    Sentry.configure_scope do |scope|
+      scope.set_context("params", params.to_unsafe_h)
+      scope.set_context("url", { "request.original_url" => request.original_url })
+    end
+  end
 
   def user_for_paper_trail
     current_agent.name_for_paper_trail

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -8,6 +8,9 @@ class Users::RdvsController < UserAuthController
   before_action :build_creneau, :redirect_if_creneau_not_available, only: %i[edit update]
   after_action :allow_iframe
 
+  # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3268291575
+  before_action :log_params_to_sentry, only: %i[creneaux]
+
   include TokenInvitable
 
   def index

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -20,6 +20,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
   on_failure do |env|
     env["devise.mapping"] = Devise.mappings[:user]
-    SuperAdmins::OmniauthCallbacksController.action(:failure).call(env)
+    OmniauthCallbacksController.action(:failure).call(env)
   end
 end


### PR DESCRIPTION
# Edit du 9 juin 2022 (seconde version de la PR)

Suite aux retours de Yannick, cette PR ne loggue pas les params pour toutes les actions côté agent, mais seulement pour quelques actions spécifiques que l'on a besoin de débugger.

-----

# Description initiale de la PR

Dans le cadre de mon rôle de vigie, je vois des bugs qui remontent dans Sentry mais qui sont impossibles à investiguer car je n'ai pas les détails nécessaires pour les reproduire. En effet, Sentry désactive par défaut la remontée de l'URL, et les params pour mieux respecter le RGPD :

https://docs.sentry.io/platforms/ruby/guides/rack/migration/#removed-processors

Cette décision semble pertinent pour notre appli côté Users, mais je pense qu'il est raisonnable de remonter ces données pour les erreurs côté Agents, car les données ont moins de risques d'être personnelles.

## Rendu des remontées sur Sentry

![image](https://user-images.githubusercontent.com/6357692/171436877-acdacf2b-2f2b-441e-be36-782755bdf197.png)

![image](https://user-images.githubusercontent.com/6357692/171436919-2c530472-57d0-4276-afcf-28aee7daae75.png)


# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
