### PR TITLE
Bug > Crash sur la liste des RDVs si un⋅e user n'a pas de profil

### DIFF
--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -28,9 +28,9 @@
                     li= object_attribute_tag(user, :phone_number, clickable_user_phone_number(user))
                     li= object_attribute_tag(user, :address)
                     li= object_attribute_tag(user, :email, clickable_user_email(user))
-                    - if current_territory.enable_notes_field
+                    - if current_territory.enable_notes_field && user_profile
                       li= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
-                    - if current_territory.enable_logement_field
+                    - if current_territory.enable_logement_field && user_profile
                       li= object_attribute_tag(user_profile, :logement)
                     - Territory::SOCIAL_FIELD_TOGGLES.each do |toggle, field_name|
                       - if current_territory.attributes.with_indifferent_access[toggle]

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -19,7 +19,7 @@ ul.list-unstyled.mb-5
     .text-muted.mb-2
       | En attente de confirmation pour #{user.unconfirmed_email}
 
-  - if current_territory.enable_notes_field?
+  - if current_territory.enable_notes_field? && user_profile
     li.mb-2= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
 
 - if current_territory.any_social_field_enabled?

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -46,7 +46,8 @@
             li= object_attribute_tag(@user, :first_name)
             li= object_attribute_tag(@user, :last_name)
             li= object_attribute_tag(@user, :birth_date, birth_date_and_age(@user))
-            li= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
+            - if current_territory.enable_notes_field? && user_profile
+              li= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
 
         .row.mt-3
           .col.text-left


### PR DESCRIPTION
https://sentry.io/organizations/rdv-solidarites/issues/2999508699

On a `user_profile` à `nil` et donc ça crashe. Je ne suis pas certain que ce cas est censé se produire, mais il se produit depuis maintenant 4 mois ! Dîtes-moi si vous pensez qu'il vaut mieux investiguer comment on s'est retrouvés dans cette situation, plutôt que d'ajouter ces petits `if`.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
