### PR TITLE
Informe sur la suppression de plage d'ouverture

### DIFF
--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -7,8 +7,6 @@
   - else
     = t(".plage_ouverture_of", full_name: @agent.full_name_and_service)
 
-- content_for :breadcrumb do
-
 .text-right
   = link_to t(".create_plage_ouverture"), new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-outline-primary align-bottom"
   .m-3.d-flex.justify-content-end
@@ -60,3 +58,4 @@
         = t(".create_plage_ouverture")
       - else
         = t(".create_plage_ouverture_for", full_name: @agent.full_name)
+    .mt-2.text-muted = t(".hint_delete_old")

--- a/config/locales/views/plage_ouvertures.fr.yml
+++ b/config/locales/views/plage_ouvertures.fr.yml
@@ -17,3 +17,4 @@ fr:
         place: Lieu
         dates: Dates
         search_placeholder: "ex: permanence, consultation…"
+        hint_delete_old: "Les plages d'ouvertures fermées depuis plus d'un an sont automatiquement supprimées."


### PR DESCRIPTION
Simple petite phrase pour préciser dans l'écran l'information à propos
du délai de suppression automatique d'une plage d'ouverture fermée.

Cela fait partie d'un mouvement général pour ajouter de la documentation
dans les interfaces de l'application.

Avant

![Screenshot 2022-06-03 at 12-19-00 Vos plages d'ouvertures - RDV Solidarités](https://user-images.githubusercontent.com/42057/171836040-8f8cb242-1cd1-4aca-bdbc-8751f999e0fc.png)

Après 

![Screenshot 2022-06-03 at 12-19-12 Vos plages d'ouvertures - RDV Solidarités](https://user-images.githubusercontent.com/42057/171836060-46b3e1e8-17cb-45b1-b064-91cfe17833d8.png)


Closes #2434


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
