### PR TITLE
Supprimer une phrase fausse dans le ReplyTransferMailer

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,8 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# See https://github.com/rails/sprockets/issues/581
+Rails.application.config.assets.configure do |env|
+  env.export_concurrent = false
+end

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -45,11 +45,11 @@ fr:
       notify_agent_of_user_reply:
         title: Message d'usager⋅e au sujet de votre RDV %{date}
         intro: "Dans le cadre du RDV du %{date}, l'usager⋅e %{author} a envoyé la réponse suivante par e-mail :"
-        instructions: Merci de ne pas répondre à cet e-mail. Vous pouvez contacter l'usager⋅e à l'aide des informations inclues dans le RDV. Vous trouverez en pièce jointe l'email original.
+        instructions: Merci de ne pas répondre à cet e-mail. Vous pouvez contacter l'usager⋅e à l'aide des informations inclues dans le RDV.
       forward_to_default_mailbox:
         title: Message d'usager⋅e en réponse à un e-mail de notification
         intro: "L'usager⋅e %{author} a répondu à un e-mail de notification :"
-        instructions: Merci de ne pas répondre à cet e-mail. Vous trouverez en pièce jointe l'email original.
+        instructions: Merci de ne pas répondre à cet e-mail.
       shared:
         attachments: Le mail de l'usager⋅e avait en pièce jointe "%{attachment_names}". Il nous est impossible de vous transmettre ce fichier. Vous pouvez contacter l'usager⋅e pour qu'iel l'envoie à votre adresse.
   users:

--- a/spec/mailers/previews/agents/reply_transfer_mailer_preview.rb
+++ b/spec/mailers/previews/agents/reply_transfer_mailer_preview.rb
@@ -4,10 +4,8 @@ class Agents::ReplyTransferMailerPreview < ActionMailer::Preview
   def notify_agent_of_user_reply
     rdv = Rdv.last
 
-    # rubocop:disable RSpec/VariableName
-    # rubocop:disable RSpec/VariableDefinition
     source_mail = Mail.new do
-      subject "Une nouvelle importante"
+      subject "Re: RDV confirmé le #{I18n.l(rdv.starts_at, format: :human)}"
 
       text_part do
         body "Bonjour,\nVoici une phrase après un saut de ligne."
@@ -15,14 +13,12 @@ class Agents::ReplyTransferMailerPreview < ActionMailer::Preview
 
       attachments["signature.svg"] = { mime_type: "image/svg+xml", content: "" }
     end
-    # rubocop:enable RSpec/VariableDefinition
-    # rubocop:enable RSpec/VariableName
 
     body = <<~MARKDOWN
       Bonjour,
       Voici une phrase après un saut de ligne.
 
-      Voici une autre phrase après deux sauts de ligne (saut de paragraphe
+      Voici une autre phrase après deux sauts de ligne (saut de paragraphe)
     MARKDOWN
 
     Agents::ReplyTransferMailer.notify_agent_of_user_reply(


### PR DESCRIPTION
Cette PR retire la phrase 

> Vous trouverez en pièce jointe l'email original.

des mails que l'on transfert aux agents en cas de réponse.

Cette phrase avait été ajoutée pendant le développement initial dans #2473, quand j'avais l'intention de fournir en pièce jointe une copie de la réponse, mais au final j'ai renoncé à la fonctionnalité mais j'ai oublié de virer cette phrase du template.

J'ai glissé dans la PR un commit qui désactive la concurrence dans sprockets, ce qui permet d'éviter un crash. Plus d'infos ici :  https://github.com/rails/sprockets/issues/581