### PR TITLE
Corrige l'heure d'affichage des rdv pour les fuseaux horaires hors métropole (bis)

### DIFF
--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -3,8 +3,6 @@ require("turbolinks").start()
 require("chartkick")
 require("chart.js")
 import 'bootstrap';
-import 'moment/moment.js';
-import 'moment/locale/fr.js';
 import 'holderjs/holder.min';
 import 'select2/dist/js/select2.full.min.js';
 import 'select2/dist/js/i18n/fr.js';

--- a/app/javascript/components/recurrence-form.js
+++ b/app/javascript/components/recurrence-form.js
@@ -1,3 +1,5 @@
+import 'moment/locale/fr.js';
+
 class RecurrenceForm {
   constructor() {
     this.element = document.querySelector('.js-recurrence-container')

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,8 @@ module Lapin
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.time_zone = "Paris"
+    config.time_zone = "Paris" # The timezone is also set on the client side for the FullCalendar plugin.
+    # You will need to change it there too if you change it here.
 
     config.i18n.available_locales = %i[fr]
     config.i18n.default_locale = :fr

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mini-css-extract-plugin": "^2.6.0",
     "minimist": "^1.2.6",
     "moment": "^2.29.2",
+    "moment-timezone": "^0.5.34",
     "popper.js": "^1.15.0",
     "rails-erb-loader": ">=5.5.2",
     "sass": "^1.51.0",

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -110,6 +110,7 @@ describe "Agent can create a Rdv with wizard", js: true do
 
       expect(page).to have_current_path(admin_organisation_agent_agenda_path(organisation, agent, date: rdv.starts_at.to_date, selected_event_id: rdv.id))
       expect(page).to have_content("Le rendez-vous a été créé.")
+      expect(page).to have_css("*", text: "14:15", visible: :all)
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,6 +966,18 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   dependencies:
     minimist "^1.2.5"
 
+moment-timezone@^0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
+  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+
 moment@^2.10.2, moment@^2.29.2:
   version "2.29.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-solidarites.fr/issues/2393

Cette PR est une version corrigée de https://github.com/betagouv/rdv-solidarites.fr/pull/2518

Le premier commit est un cherry-pick du premier fix, qui a été reverté entre temps, parce qu'il cassait le tooltip du calendrier pour les autres timezones.

Le deuxième commit est un correctif pour le tooltip du calendrier.

<img width="377" alt="Capture d’écran 2022-06-08 à 10 18 19" src="https://user-images.githubusercontent.com/1840367/172572406-343e725c-915d-40a0-85d4-428006ff87f8.png">

Le troisième commit ajoute une spec de non régression pour l'horaire d'affichage (c'est bien pratique que le navigateur de la ci ne soit pas sur la timezone de paris)

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
