### PR TITLE
Réduit le scope des agents visible

### DIFF
--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -29,10 +29,18 @@ class Configuration::AgentPolicy
   class Scope
     def initialize(context, _scope)
       @current_territory = context.territory
+      @current_agent = context.agent
     end
 
     def resolve
-      Agent.includes(:agent_territorial_access_rights).where("agent_territorial_access_rights.territory": @current_territory)
+      scope = Agent.includes(:agent_territorial_access_rights).where("agent_territorial_access_rights.territory": @current_territory)
+      unless @current_agent.territorial_admin_in?(@current_territory)
+        scope = scope.includes(:organisations) \
+          .where(organisations: @current_agent.organisations)
+          .includes(:service) \
+          .where(service: @current_agent.service)
+      end
+      scope
     end
   end
 end

--- a/spec/policies/configuration/agent_policy/scope_spec.rb
+++ b/spec/policies/configuration/agent_policy/scope_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe Configuration::AgentPolicy::Scope, type: :policy do
+  it "returns agents of same territory and same organisation and same service" do
+    territory = create(:territory)
+    service = create(:service)
+    organisation = create(:organisation, territory: territory)
+    agent = create(:agent, organisations: [organisation], service: service)
+    create(:agent_territorial_access_right, agent: agent, territory: territory)
+    agent_from_same_terr = create(:agent, organisations: [organisation], service: service)
+    create(:agent_territorial_access_right, agent: agent_from_same_terr, territory: territory)
+
+    expect(described_class.new(AgentTerritorialContext.new(agent, territory), Agent).resolve).to match_array([agent, agent_from_same_terr])
+  end
+
+  it "returns only agents from my organisations" do
+    territory = create(:territory)
+    organisation = create(:organisation, territory: territory)
+    other_organisation = create(:organisation, territory: territory)
+    agent = create(:agent, organisations: [organisation])
+    create(:agent_territorial_access_right, agent: agent, territory: territory)
+
+    agent_from_other_orga = create(:agent, organisations: [other_organisation])
+    create(:agent_territorial_access_right, agent: agent_from_other_orga, territory: territory)
+
+    expect(described_class.new(AgentTerritorialContext.new(agent, territory), Agent).resolve).to eq([agent])
+  end
+
+  it "returns only agents from my service" do
+    territory = create(:territory)
+    service = create(:service)
+    other_service = create(:service)
+
+    organisation = create(:organisation, territory: territory)
+
+    agent = create(:agent, organisations: [organisation], service: service)
+    create(:agent_territorial_access_right, agent: agent, territory: territory)
+
+    agent_from_other_service = create(:agent, organisations: [organisation], service: other_service)
+    create(:agent_territorial_access_right, agent: agent_from_other_service, territory: territory)
+
+    expect(described_class.new(AgentTerritorialContext.new(agent, territory), Agent).resolve).to eq([agent])
+  end
+
+  it "returns all agents when territory admin" do
+    territory = create(:territory)
+    service = create(:service)
+    other_service = create(:service)
+
+    organisation = create(:organisation, territory: territory)
+    other_organisation = create(:organisation, territory: territory)
+
+    agent = create(:agent, role_in_territories: [territory], organisations: [organisation], service: service)
+    create(:agent_territorial_access_right, agent: agent, territory: territory)
+
+    agent_from_other_service = create(:agent, organisations: [organisation], service: other_service)
+    create(:agent_territorial_access_right, agent: agent_from_other_service, territory: territory)
+
+    agent_from_other_orga = create(:agent, organisations: [other_organisation])
+    create(:agent_territorial_access_right, agent: agent_from_other_orga, territory: territory)
+
+    expect(described_class.new(AgentTerritorialContext.new(agent, territory), Agent).resolve).to eq([agent, agent_from_other_service, agent_from_other_orga])
+  end
+end


### PR DESCRIPTION
Suite aux changements sur les droits d'accès et les invitations, tout
passe maintenant par le module de configuration.

Sur ce module, nous pouvons voir la liste de tous les agents du
territoire.

Cette PR vis à réduire la visibilité en fonction de certains critères.

- les organisations auxquelles j'accède
- le service dont je fais partie
- ma situation dans le territoire (si je suis admin du territoire, je peux tout voir)

Avant

![Screenshot 2022-06-09 at 13-03-13 RDV Solidarités](https://user-images.githubusercontent.com/42057/172832469-3c12a869-0c11-46e4-bd53-56fce66668d8.png)

Après

![Screenshot 2022-06-09 at 13-03-26 RDV Solidarités](https://user-images.githubusercontent.com/42057/172832488-9cc846e5-f94f-449d-9ec3-2981b888c252.png)


_Ici, Marco qui est connecté est du service social, alors que tout les agents `first_name...` sont de la PMI_


Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
