### PR TITLE
Fetch available services on demand from template

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -4,7 +4,6 @@ class Admin::MotifsController < AgentAuthController
   respond_to :html, :json
 
   before_action :set_organisation, only: %i[new create]
-  before_action :set_available_services, only: %i[new edit index]
   before_action :set_motif, only: %i[show edit update destroy]
 
   def index
@@ -49,7 +48,6 @@ class Admin::MotifsController < AgentAuthController
       flash[:notice] = "Le motif a été modifié."
       redirect_to admin_organisation_motif_path(@motif.organisation, @motif)
     else
-      set_available_services
       render :edit
     end
   end
@@ -102,9 +100,5 @@ class Admin::MotifsController < AgentAuthController
               :follow_up,
               :collectif,
               :sectorisation_level)
-  end
-
-  def set_available_services
-    @available_services = Service.where(agents: Agent.joins(:organisations).merge(current_organisation.territory.organisations))
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,6 +22,10 @@ class Service < ApplicationRecord
 
   ## -
 
+  def self.all_for_territory(territory)
+    where(agents: Agent.joins(:organisations).merge(territory.organisations))
+  end
+
   def secretariat?
     name == SECRETARIAT
   end

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -7,7 +7,7 @@
       h5.card-title Configuration générale
       .form-row
         .col-md-6
-          = f.association :service, collection: @available_services
+          = f.association :service, collection: Service.all_for_territory(current_territory)
         .col-md-6
           = f.input :name
       .form-row

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -33,7 +33,8 @@
             div
               = Motif.human_attribute_name("service")
             div
-              - options = options_from_collection_for_select(@available_services.sort, :id, :short_name, params[:service_filter])
+              - available_services = Service.all_for_territory(current_territory)
+              - options = options_from_collection_for_select(available_services.sort, :id, :short_name, params[:service_filter])
               = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           th
             div


### PR DESCRIPTION
Ticket Zammad : https://zammad10.ethibox.fr/#ticket/zoom/1880

Lorsque l'on tente de créer un motif mais que le formulaire contient une erreur, le select des services affiche "Oui - Non".

La cause : la méthode `set_available_services` n'est pas appelée pour l'action `#create` :

```ruby
before_action :set_available_services, only: %i[new edit index]
```

Plutôt que de rajouter `create` à la liste, j'ai préféré faire en sorte que le helper qui liste les services disponibles pour un territoire soit appelé de façon explicite et à la demande. De cette façon :
- on est sûrs que la liste des services est récupérée lorsque l'on en a besoin
- on est sûrs que cette liste n'est pas récupérée lorsqu’on en a pas besoin

J'ai placé la méthode de helper dans le modèle `Service` (pas trop gros pour le moment), je suis ouvert aux suggestions pour la mettre à d'autres endroits.

# Avant

![image](https://user-images.githubusercontent.com/6357692/173408958-43910086-25b6-4bbf-977a-41516ea443a7.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/173408976-be138f6e-e8a9-4a7b-8546-cb5a48625628.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
