### PR TITLE
fix(invitation): Invitation period validity

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,16 +207,12 @@ class User < ApplicationRecord
   protected
 
   def compute_invitation_due_at
-    time = invitation_created_at || invitation_sent_at
-    time + invite_for
+    (invitation_created_at || invitation_sent_at) + invite_for
   end
 
   # overriding Devise to allow custom invitation validity duration (PR #1484)
   def invitation_period_valid?
-    time = invitation_created_at || invitation_sent_at
-    return (time && (time.utc <= invitation_due_at)) unless invite_for.nil?
-
-    super
+    invite_for.present? ? (Time.zone.now <= invitation_due_at) : super
   end
 
   def password_required?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -258,6 +258,40 @@ describe User, type: :model do
     end
   end
 
+  describe "#invitation_period_valid?" do
+    subject { user.send(:invitation_period_valid?) }
+
+    let(:now) { Time.zone.parse("2022-04-05 13:45") }
+    let(:invitation_created_at) { Time.zone.parse("2022-04-05 13:00") }
+    let(:user) { create(:user, invitation_created_at: invitation_created_at, invite_for: invite_for) }
+
+    before { travel_to(now) }
+
+    context "when no invitation period is precised" do
+      let(:invite_for) { nil }
+
+      it "is valid" do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when invitation was created less than invitation period ago" do
+      let(:invite_for) { 1.hour.to_i }
+
+      it "is valid" do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when invitation was created more than invitation period ago" do
+      let(:invite_for) { 30.minutes.to_i }
+
+      it "is not valid" do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+
   describe "#minor?" do
     it "return true when user birth in 2016 and we are un 2020" do
       now = Time.zone.parse("2020-4-3 13:45")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -261,11 +261,10 @@ describe User, type: :model do
   describe "#invitation_period_valid?" do
     subject { user.send(:invitation_period_valid?) }
 
-    let(:now) { Time.zone.parse("2022-04-05 13:45") }
     let(:invitation_created_at) { Time.zone.parse("2022-04-05 13:00") }
     let(:user) { create(:user, invitation_created_at: invitation_created_at, invite_for: invite_for) }
 
-    before { travel_to(now) }
+    before { travel_to(Time.zone.parse("2022-04-05 13:45")) }
 
     context "when no invitation period is precised" do
       let(:invite_for) { nil }


### PR DESCRIPTION
Dans cette PR je fixe la méthode qui checke si un token est encore valide introduit dans #1484 .
J'en profite pour rajouter des tests sur la méthode concernée.

N.B: Les noms des méthodes/attributs liés à ce mécanisme ne sont pas toujours très intuitifs, mais reprennent ce qui est fait dans la gem `devise_invitable`.

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
