### PR TITLE
Limite la liste des organisations dans la page d'invitation

### DIFF
--- a/app/views/admin/territories/invitations_devise/new.html.slim
+++ b/app/views/admin/territories/invitations_devise/new.html.slim
@@ -9,7 +9,7 @@
     - else
       = f.association :service, collection: @services, include_blank: false, hint: t(".services_hint")
 
-    = f.association :organisations, as: :check_boxes, collection: current_agent.organisations, label: t(".organisations"), include_hidden: false
+    = f.association :organisations, as: :check_boxes, collection: current_agent.organisations.where(territory: current_territory), label: t(".organisations"), include_hidden: false
 
     .text-right
       = f.button :submit, t("devise.invitations.new.submit_button")


### PR DESCRIPTION
À lister l'ensemble des organisations d'un agents, nous avons oublié que
certains agents sont sur plusieurs territoire.

C'est peut-être un point à résoudre d'ailleurs, est-ce que nous
souhaitons continuer à avoir des agents multiterritoire ?

Toujours est-il que cette PR limite les organisations afficher aux
organisations de l'agent DANS le contexte de ce territoire.

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
