### PR TITLE
Rétablir l'interface de gestion des agents/invitation au sein d'une organisation

### DIFF
--- a/app/controllers/admin/agent_roles_controller.rb
+++ b/app/controllers/admin/agent_roles_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Admin::AgentRolesController < AgentAuthController
+  before_action :set_agent_role, :set_agent_removal_presenter
+
+  def edit
+    authorize(@agent_role)
+  end
+
+  def update
+    authorize(@agent_role)
+    if @agent_role.update(agent_role_params)
+      redirect_to admin_organisation_agents_path(current_organisation), success: "Les permissions de l'agent ont été mises à jour"
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def agent_role_params
+    params.require(:agent_role).permit(:level)
+  end
+
+  def set_agent_role
+    @agent_role = AgentRole.find(params[:id])
+  end
+
+  def set_agent_removal_presenter
+    @agent_removal_presenter = AgentRemovalPresenter.new(@agent_role.agent, current_organisation)
+  end
+end

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -1,14 +1,34 @@
 # frozen_string_literal: true
 
 class Admin::AgentsController < AgentAuthController
-  respond_to :json
+  respond_to :html, :json
 
   def index
     @agents = policy_scope(Agent)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .includes(:service, :roles, :organisations)
-      .active.complete
+      .active
+    @invited_agents_count = @agents.invitation_not_accepted.created_by_invite.count
     @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.order_by_last_name
+    @agents = @agents.complete.page(params[:page])
+  end
+
+  def destroy
+    @agent = policy_scope(Agent).find(params[:id])
+    authorize(@agent)
+    removal_service = AgentRemoval.new(@agent, current_organisation)
+    if removal_service.upcoming_rdvs?
+      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent.role_in_organisation(current_organisation)), flash: { error: t(".cannot_delete_because_of_rdvs") }
+    else
+      removal_service.remove!
+      if @agent.invitation_accepted_at.blank?
+        redirect_to admin_organisation_invitations_path(current_organisation), notice: t(".invitation_deleted")
+      elsif @agent.deleted_at?
+        redirect_to admin_organisation_agents_path(current_organisation), notice: t(".agent_deleted")
+      else
+        redirect_to admin_organisation_agents_path(current_organisation), notice: t(".agent_removed_from_org")
+      end
+    end
   end
 
   private

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Admin::InvitationsController < AgentAuthController
+  def index
+    @invited_agents = policy_scope(Agent)
+      .joins(:organisations).where(organisations: { id: current_organisation.id })
+      .invitation_not_accepted
+      .created_by_invite
+      .page(params[:page])
+    @invited_agents = index_params[:search].present? ? @invited_agents.search_by_text(index_params[:search]) : @invited_agents.order(invitation_sent_at: :desc)
+  end
+
+  def reinvite
+    @agent = policy_scope(Agent).find(params[:id])
+    authorize(@agent)
+    @agent.invite!(current_agent, validate: false)
+    redirect_to admin_organisation_invitations_path(current_organisation), notice: "Une nouvelle invitation a été envoyée à l'agent #{@agent.email}."
+  end
+
+  private
+
+  def index_params
+    @index_params ||= params.permit(:search)
+  end
+end

--- a/app/controllers/admin/invitations_devise_controller.rb
+++ b/app/controllers/admin/invitations_devise_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+class Admin::InvitationsDeviseController < Devise::InvitationsController
+  def new
+    self.resource = resource_class.new(organisations: [current_organisation])
+    authorize(resource)
+
+    @services = services
+    @roles = current_agent.conseiller_numerique? ? [AgentRole::LEVEL_BASIC] : AgentRole::LEVELS
+
+    render :new, layout: "application_agent"
+  end
+
+  def create
+    agent = Agent.find_by(email: invite_params[:email].downcase)
+    if agent.nil?
+      # Authorize against a dummy Agent
+      authorize(Agent.new(invite_params))
+      agent = invite_resource # invite_resource creates the new Agent in DB and sends the invitation.
+    else
+      # Authorize against a new AgentRole
+      new_role = agent.roles.new(invite_params[:roles_attributes].values.first)
+      authorize(new_role)
+      agent.save(context: :invite) # Specify a different validation context to bypass last_name/first_name presence
+      # Warn if the service isn’t the one that was requested
+      service = services.find(invite_params[:service_id])
+      flash[:error] = I18n.t "activerecord.warnings.models.agent_role.different_service", service: service.name, agent_service: agent.service.name if agent.service != service
+    end
+
+    if agent.errors.empty?
+      if agent.invitation_accepted?
+        flash[:notice] = I18n.t "activerecord.notice.models.agent_role.existing", email: agent.email
+        redirect_to admin_organisation_agents_path(current_organisation)
+      else
+        flash[:notice] = I18n.t "activerecord.notice.models.agent_role.invited", email: agent.email
+        redirect_to admin_organisation_invitations_path(current_organisation)
+      end
+    else
+      # Keep the error message, but redirect instead of just rendering the template:
+      # we want a new empty form.
+      flash[:error] = agent.errors.full_messages.to_sentence
+      redirect_to action: :new
+    end
+  end
+
+  protected
+
+  def services
+    Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve
+  end
+
+  def pundit_user
+    AgentOrganisationContext.new(current_agent, current_organisation)
+  end
+
+  def current_organisation
+    Organisation.find(params[:organisation_id])
+  end
+  helper_method :current_organisation
+
+  def policy_scope(*args, **kwargs)
+    super([:agent, *args], **kwargs)
+  end
+  helper_method :policy_scope
+
+  def authorize(*args, **kwargs)
+    super([:agent, *args], **kwargs)
+  end
+
+  # invite_params is called by Devise::InvitationsController#invite_resource
+  def invite_params
+    params = devise_parameter_sanitizer.sanitize(:invite)
+
+    # Make sure the agent is being invited for exactly one role
+    raise ActionController::BadRequest unless params[:roles_attributes].is_a?(Hash) && params[:roles_attributes].keys == ["0"]
+
+    # Only ever invite to the current organisation
+    params[:roles_attributes]["0"][:organisation] = current_organisation
+
+    if current_agent.conseiller_numerique?
+      params[:roles_attributes]["0"][:level] = AgentRole::LEVEL_BASIC
+    end
+
+    # The omniauth uid _is_ the email, always. Note: this may be better suited in a hook in Agent.rb
+    params[:uid] = params[:email]
+
+    params
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,8 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     if resource_class == Agent
-      devise_parameter_sanitizer.permit(:invite, keys: [:email, :service_id, { organisation_ids: [] }, { agent_territorial_access_rights_attributes: :territory_id }])
+      devise_parameter_sanitizer.permit(:invite, keys: [:email, :service_id, { organisation_ids: [] },
+                                                        { agent_territorial_access_rights_attributes: :territory_id }, { roles_attributes: %i[level organisation_id] },])
       devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name])
       devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name service_id])
     elsif resource_class == User

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -14,16 +14,16 @@ class Configuration::AgentPolicy
 
   def territorial_admin_or_allowed_to_manage_agent_part?
     territorial_admin? ||
-      @access_rights.allow_to_manage_access_rights? ||
-      @access_rights.allow_to_manage_teams? ||
-      @access_rights.allow_to_invite_agents?
+      @access_rights&.allow_to_manage_access_rights? ||
+      @access_rights&.allow_to_manage_teams? ||
+      @access_rights&.allow_to_invite_agents?
   end
 
   alias display? territorial_admin_or_allowed_to_manage_agent_part?
   alias edit? territorial_admin_or_allowed_to_manage_agent_part?
 
   def create?
-    territorial_admin? || @access_rights.allow_to_invite_agents?
+    territorial_admin? || @access_rights&.allow_to_invite_agents?
   end
 
   class Scope

--- a/app/policies/configuration/agent_role_policy.rb
+++ b/app/policies/configuration/agent_role_policy.rb
@@ -9,7 +9,7 @@ class Configuration::AgentRolePolicy
 
   def territorial_admin?
     @current_agent.territorial_admin_in?(@current_territory) ||
-      @access_rights.allow_to_invite_agents?
+      @access_rights&.allow_to_invite_agents?
   end
 
   alias update? territorial_admin?

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -12,10 +12,12 @@ class Configuration::TerritoryPolicy
   end
 
   def show?
+    # FIXME: le safe operator (&) est fait pour que les nouveaux agents invités via le revert de la liste
+    # des agents dans le menu de gauche qui n'ont pas d'access_rights n'aient pas une erreur à l'affichage de la liste des organisations
     territorial_admin? ||
-      @access_rights.allow_to_manage_teams? ||
-      @access_rights.allow_to_manage_access_rights? ||
-      @access_rights.allow_to_invite_agents?
+      @access_rights&.allow_to_manage_teams? ||
+      @access_rights&.allow_to_manage_access_rights? ||
+      @access_rights&.allow_to_invite_agents?
   end
 
   def display_sms_configuration?
@@ -23,15 +25,15 @@ class Configuration::TerritoryPolicy
   end
 
   def allow_to_manage_access_rights?
-    @access_rights.allow_to_manage_access_rights?
+    @access_rights&.allow_to_manage_access_rights?
   end
 
   def allow_to_invite_agents?
-    @access_rights.allow_to_invite_agents?
+    @access_rights&.allow_to_invite_agents?
   end
 
   def allow_to_manage_teams?
-    @access_rights.allow_to_manage_teams?
+    @access_rights&.allow_to_manage_teams?
   end
 
   alias display_user_fields_configuration? territorial_admin?

--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -1,0 +1,40 @@
+- content_for(:menu_item) { "menu-agents" }
+
+- content_for :title do
+  | Modifier le rôle de l'agent #{@agent_role.agent.full_name}
+
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to "Vos agents", admin_organisation_agents_path(current_organisation)
+    li.breadcrumb-item.active
+      = @agent_role.agent.full_name
+
+.row.justify-content-center
+  .col-md-8
+    .card
+      .card-body
+        = simple_form_for [:admin, current_organisation, @agent_role] do |f|
+          = render "model_errors", model: @agent_role
+          = f.simple_fields_for :agent do |ff|
+            = ff.input :service_id, collection: [@agent_role.agent.service], as: :select, label: "Service", hint: "Vous ne pouvez pas changer un agent de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer et recréer le compte de l'agent", disabled: true
+
+          = f.input :organisation, as: :hidden
+          = f.input :level, \
+            collection: AgentRole::LEVELS, \
+            label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
+            hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
+            as: :radio_buttons
+
+          .row
+            - if policy([:agent, @agent_role.agent]).destroy?
+              .col.text-left
+                = link_to @agent_removal_presenter.button_value, \
+                  admin_organisation_agent_path(current_organisation, @agent_role.agent), \
+                  data: { confirm: @agent_removal_presenter.confirm_message }, \
+                  method: :delete, \
+                  class: "btn btn-outline-danger"
+            .col.text-right
+              = f.button :submit
+
+= render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @agent_role.agent

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -1,0 +1,35 @@
+- agent_role = agent.role_in_organisation(current_organisation)
+
+tr id="agent_#{agent.id}"
+  td
+    - if agent.complete?
+      - if policy([:agent, agent_role]).edit?
+        = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
+      - else
+        span.mr-2= agent.reverse_full_name
+      = me_tag(agent)
+  td.word-break-all
+    = agent.email
+  td
+    = agent.service&.name
+  td.text-nowrap
+    span>= agent_role.human_attribute_value(:level)
+    - if agent_role.admin?
+      i.fa.fa-user-cog
+  td
+    .d-flex
+      - if policy([:agent, agent_role]).create? && !agent.invitation_accepted?
+        div.mr-3= link_to t("devise.invitations.reinvite"),
+                reinvite_admin_organisation_invitation_path(current_organisation, agent),
+                method: :post
+      - if policy([:agent, agent_role]).edit?
+        div.mr-3= link_to edit_admin_organisation_agent_role_path(current_organisation, agent_role), title: t("helpers.edit") do
+          i.fa.fa-edit
+      - if policy([:agent, agent]).destroy?
+        - agent_removal_presenter = AgentRemovalPresenter.new(agent, current_organisation)
+        - path = admin_organisation_agent_path(current_organisation, agent_role.agent)
+        = link_to path,
+                method: :delete,
+                title: agent_removal_presenter.button_value,
+                data: { confirm: agent_removal_presenter.confirm_message } do
+          i.fa.fa-trash-alt

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -1,0 +1,40 @@
+- content_for(:menu_item) { "menu-agents" }
+
+- content_for(:title, "Agents de #{current_organisation.name}")
+
+- if current_agent_can?(:create, Agent)
+  - content_for :breadcrumb do
+    = link_to "Inviter un agent", new_admin_agent_organisation_invitation_path(current_organisation), class:"btn btn-outline-primary"
+
+= simple_form_for "", url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
+  .container-fluid.bg-white.rounded
+    .m-3.d-flex.justify-content-end
+      - search = params[:term].blank? && "d-none"
+      div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
+      = f.input :term, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
+      = f.button :submit, t("helpers.search")
+    table.table
+      thead
+        tr
+          th= Agent.human_attribute_name(:name)
+          th= Agent.human_attribute_name(:email)
+          th= Agent.human_attribute_name(:service)
+          th= AgentRole.human_attribute_name(:level)
+          th Actions
+      tbody
+        = render partial: "agent", collection: @agents
+    - if @agents.empty?
+      .mb-4.p.text-center Aucun agent trouvé
+    - elsif @agents.total_pages > 1
+      .m-3
+        .d-flex.justify-content-center
+          = paginate @agents, theme: "twitter-bootstrap-4"
+        .text-center= page_entries_info @agents
+
+    - if current_agent_can?(:create, Agent)
+      .m-3.d-flex.justify-content-center
+        = link_to "Inviter un agent", new_admin_agent_organisation_invitation_path(current_organisation), class: "btn btn-primary"
+        - if @invited_agents_count > 0
+          = link_to "Voir les #{@invited_agents_count} invitations en attente", admin_organisation_invitations_path(current_organisation), class: "btn btn-link"
+        - else
+          .m-2 Aucune invitation en attente

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -1,0 +1,36 @@
+- content_for(:menu_item) { "menu-invitations" }
+
+- content_for(:title, "Invitations en cours pour #{current_organisation.name}")
+
+- if current_agent_can?(:create, Agent)
+  - content_for :breadcrumb do
+    = link_to "Inviter un agent", new_admin_agent_organisation_invitation_path(current_organisation), class:"btn btn-outline-primary"
+
+= simple_form_for "", url: admin_organisation_invitations_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
+  .container-fluid.bg-white.rounded
+    .m-3.d-flex.justify-content-end
+      - search = params[:search].blank? ? "d-none" : ""
+      div= link_to t("helpers.reset"), admin_organisation_invitations_path(current_organisation), class: "btn btn-link #{search}"
+      = f.input :search, placeholder: "Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+      = f.button :submit, t("helpers.search")
+    table.table
+      thead
+        tr
+          th= Agent.human_attribute_name(:name)
+          th= Agent.human_attribute_name(:email)
+          th= Agent.human_attribute_name(:service)
+          th= AgentRole.human_attribute_name(:level)
+          th Actions
+      tbody
+        = render partial: "admin/agents/agent", collection: @invited_agents
+    - if @invited_agents.empty?
+      .mb-4.p.text-center Aucune invitation en attente
+    - elsif @invited_agents.total_pages > 1
+      .m-3
+        .d-flex.justify-content-center
+          = paginate @invited_agents, theme: "twitter-bootstrap-4"
+        .text-center= page_entries_info @invited_agents
+
+    - if current_agent_can?(:create, Agent)
+      .m-3.d-flex.justify-content-center
+        = link_to "Inviter un agent", new_admin_agent_organisation_invitation_path(current_organisation), class: "btn btn-primary"

--- a/app/views/admin/invitations_devise/new.html.slim
+++ b/app/views/admin/invitations_devise/new.html.slim
@@ -1,0 +1,21 @@
+- content_for(:menu_item) { "menu-agents" }
+
+- content_for :title do
+  = t "devise.invitations.new.header"
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = simple_form_for [:admin, resource], as: resource_name, url: admin_agent_organisation_invitation_path(current_organisation, resource), html: { method: :post } do |f|
+          = render "devise/shared/error_messages", resource: resource
+          = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}
+          = f.association :service, collection: @services, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
+          = f.simple_fields_for :roles do |ff|
+            = ff.input :level, \
+              collection: @roles, \
+              label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
+              hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
+              as: :radio_buttons
+          .text-right
+            = f.button :submit, t("devise.invitations.new.submit_button")

--- a/app/views/devise/invitations/edit.html.slim
+++ b/app/views/devise/invitations/edit.html.slim
@@ -1,0 +1,14 @@
+= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f|
+  .text-center.w-75.m-auto
+    h4.text-dark-50.text-center.mt-0.font-weight-bold  Inscription
+    p.text-muted.mb-4 Complétez vos informations.
+  = render "devise/shared/error_messages", resource: resource
+  = f.hidden_field :invitation_token
+  .form-row
+    .col-md-6= f.input :first_name, placeholder: "Dominique"
+    .col-md-6= f.input :last_name, placeholder: "DUPONT"
+  .form-group
+    = f.label :password
+    = f.password_field :password, required: true, class: "form-control ", placeholder: "Choisissez votre mot de passe", id: "password"
+    span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
+  .text-center= f.button :submit, t("devise.invitations.edit.submit_button")

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -127,6 +127,10 @@ nav
               li.my-2
                 = active_link_to "Vos lieux", admin_organisation_lieux_path(current_organisation)
               li.my-2
+                = active_link_to "Vos agents", admin_organisation_agents_path(current_organisation)
+              li.my-2
+                = active_link_to "Vos invitations", admin_organisation_invitations_path(current_organisation)
+              li.my-2
                 = active_link_to "Vos motifs", admin_organisation_motifs_path(current_organisation)
               - if current_agent.territorial_admin_in?(current_organisation.territory)
                 = link_to admin_territory_path(current_organisation.territory) do

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -27,6 +27,9 @@ fr:
       invitation_removed: "Votre invitation a été annulée."
       current_user_mismatch: "L’utilisateur connecté ne correspond pas à l’utilisateur invité. Déconnectez-vous et réessayez."
       organisation_mismatch: "L’utilisateur concerné n’appartient pas à cette organisation."
+      new:
+        header: "Envoyer une invitation"
+        submit_button: "Envoyer une invitation"
       edit:
         header: "Choisir son mot de passe"
         submit_button: "Enregistrer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -192,7 +192,8 @@ Rails.application.routes.draw do
         resources :agent_agendas, only: %i[show] do
           put :toggle_displays, on: :member
         end
-        resources :agents, only: %i[index] do
+        resources :agent_roles, only: %i[edit update]
+        resources :agents, only: %i[index destroy] do
           resources :absences, only: %i[index new]
           resources :plage_ouvertures, only: %i[index new]
           resources :stats, only: :index do

--- a/spec/controllers/admin/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/agent_roles_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::AgentRolesController, type: :controller do
+  render_views
+
+  let!(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:agent_user) { create(:agent) }
+  let!(:agent_role) { create(:agent_role, agent: agent_user, organisation: organisation) }
+
+  before do
+    sign_in agent
+  end
+
+  describe "GET #edit" do
+    it "returns a success response" do
+      get :edit, params: { organisation_id: organisation.id, id: agent_role.id }
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST #update" do
+    subject do
+      post :update, params: { organisation_id: organisation.id, id: agent_role.id, agent_role: { level: "admin" } }
+      agent_role.reload
+    end
+
+    it "returns a success response" do
+      subject
+      expect(response).to redirect_to(admin_organisation_agents_path(organisation))
+    end
+
+    it "changes role" do
+      expect { subject }.to change(agent_role, :level).from(AgentRole::LEVEL_BASIC).to(AgentRole::LEVEL_ADMIN)
+    end
+  end
+end

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::AgentsController, type: :controller do
+  render_views
+
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:agent1) { create(:agent, admin_role_in_organisations: [organisation], invitation_accepted_at: nil) }
+
+  before { sign_in agent }
+
+  describe "GET #index" do
+    it "returns a success response" do
+      get :index, params: { organisation_id: organisation.id }
+      expect(response).to be_successful
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, params: { organisation_id: organisation.id, id: agent1.id } }
+
+    it "destroys the requested agent" do
+      subject
+      expect(agent1.reload.organisations).not_to include(organisation)
+    end
+
+    it "redirects to the invitations list" do
+      subject
+      expect(response).to redirect_to(admin_organisation_invitations_path(organisation))
+    end
+  end
+end

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::InvitationsController, type: :controller do
+  render_views
+
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+  before do
+    sign_in agent
+  end
+
+  describe "GET #index" do
+    context "blank state" do
+      it "contains some explanation text" do
+        get :index, params: { organisation_id: organisation.id }
+        expect(response).to be_successful
+        expect(response.body).to include "Aucune invitation en attente"
+      end
+    end
+
+    context "some invitations exist" do
+      let!(:agent1) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:agent_invitee) { create(:agent, :invitation_not_accepted, first_name: nil, last_name: nil, basic_role_in_organisations: [organisation]) }
+
+      it "returns a success response" do
+        get :index, params: { organisation_id: organisation.id }
+        expect(response).to be_successful
+        expect(response.body).not_to include agent1.email
+        expect(response.body).to include agent_invitee.email
+      end
+    end
+  end
+
+  describe "POST #reinvite" do
+    let(:agent_invitee) { create(:agent, invited_by: agent, confirmed_at: nil, first_name: nil, last_name: nil, basic_role_in_organisations: [organisation]) }
+
+    it "returns a success response" do
+      post :reinvite, params: { organisation_id: organisation.id, id: agent_invitee.to_param }
+      expect(response).to redirect_to(admin_organisation_invitations_path(organisation))
+    end
+  end
+end

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::InvitationsDeviseController, type: :controller do
+  render_views
+
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], invitation_accepted_at: nil) }
+  let!(:organisation2) { create(:organisation) }
+  let(:service_id) { agent.service.id }
+
+  before do
+    request.env["devise.mapping"] = Devise.mappings[:agent]
+    sign_in agent
+  end
+
+  after do
+    Devise.mailer.deliveries.clear
+  end
+
+  describe "GET #new" do
+    context "for a cnfs" do
+      let!(:agent) do
+        create(:agent, admin_role_in_organisations: [organisation],
+                       invitation_accepted_at: nil, service: create(:service, name: "Conseiller Numérique"))
+      end
+
+      it "only allows inviting agents for the secretariat" do
+        get :new, params: { organisation_id: organisation.id }
+        expect(response).not_to have_content("Admin")
+      end
+    end
+  end
+
+  describe "POST #create" do
+    subject { post :create, params: params }
+
+    shared_examples "existing agent is added to organization" do
+      it "does not create a new agent" do
+        expect { subject }.not_to change(Agent, :count)
+      end
+
+      it "redirects to the invitations list" do
+        subject
+        expect(response).to redirect_to(admin_organisation_invitations_path(organisation.id))
+      end
+
+      it "adds agent to organisation" do
+        subject
+        expect(existing_agent.organisation_ids).to include(organisation.id)
+      end
+    end
+
+    context "when trying to invite while not being an admin" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "hacker@renard.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+              },
+            },
+          },
+        }
+      end
+
+      it "rejects the change" do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(Agent.last.email).not_to eq "hacker@renard.com"
+      end
+    end
+
+    context "when trying to invite to another organisation" do
+      let(:params) do
+        {
+          organisation_id: organisation2.id,
+          agent: {
+            email: "hacker@renard.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+              },
+            },
+          },
+        }
+      end
+
+      it "rejects the change" do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(Agent.last.email).not_to eq "hacker@renard.com"
+      end
+    end
+
+    context "when trying to set the role to another organisation" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "hacker@renard.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+                organisation_id: organisation2.id,
+              },
+            },
+          },
+        }
+      end
+
+      it "ignores the organisation param" do
+        expect(Agent.last.organisations).to eq [organisation]
+      end
+    end
+
+    context "when trying to invite an admin as a conseiller numerique" do
+      let(:service_id) { create(:service, name: Service::SECRETARIAT).id }
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "michel@lapin.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "admin",
+              },
+            },
+          },
+        }
+      end
+
+      before do
+        agent.service.update!(name: "Conseiller Numérique")
+      end
+
+      it "creates a new basic agent instead of an admin" do
+        expect { subject }.to change(Agent, :count).by(1)
+        expect(AgentRole.last).to have_attributes(level: AgentRole::LEVEL_BASIC)
+      end
+
+      context "when the agent already exists" do
+        let!(:agent2) do
+          create(:agent, basic_role_in_organisations: [organisation2], service: secretariat)
+        end
+        let(:secretariat) { create(:service, name: Service::SECRETARIAT) }
+
+        let(:params) do
+          {
+            organisation_id: organisation.id,
+            agent: {
+              email: agent2.email,
+              service_id: agent2.service_id,
+              roles_attributes: { "0" => { level: "basic" } },
+            },
+          }
+        end
+
+        it "invites the agent" do
+          expect { subject }.to change { organisation.agents.count }.by(1)
+          expect(AgentRole.last).to have_attributes(level: AgentRole::LEVEL_BASIC)
+        end
+      end
+    end
+
+    context "when email is correct and no invitation has been sent" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "michel@lapin.com",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+              },
+            },
+          },
+        }
+      end
+
+      it "creates a new agent" do
+        expect { subject }.to change(Agent, :count).by(1)
+      end
+
+      it "redirects to invitations list" do
+        subject
+        expect(response).to redirect_to(admin_organisation_invitations_path(organisation.id))
+      end
+
+      it "sends an email" do
+        subject
+        expect(Devise.mailer.deliveries.count).to eq(1)
+      end
+    end
+
+    context "when email is incorrect" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "aa@hhh",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+              },
+            },
+          },
+        }
+      end
+
+      it "does not create a new agent" do
+        expect { subject }.not_to change(Agent, :count)
+      end
+
+      it "renders new page" do
+        subject
+        expect(response).to redirect_to new_admin_agent_organisation_invitation_path
+      end
+
+      it "renders errors" do
+        subject
+        expect(flash[:error]).to include "Email n'est pas valide"
+      end
+    end
+
+    context "when agent already exist" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: existing_agent.email,
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+              },
+            },
+          },
+        }
+      end
+
+      context "when agent is in another organisation" do
+        let!(:existing_agent) { create(:agent, basic_role_in_organisations: [organisation2], invitation_accepted_at: nil) }
+
+        it_behaves_like "existing agent is added to organization"
+
+        it "does not send an email" do
+          subject
+          expect(Devise.mailer.deliveries.count).to eq(0)
+        end
+      end
+
+      context "when agent already exists but has a different service" do
+        let(:other_service) { build(:service) }
+        let!(:existing_agent) { create(:agent, basic_role_in_organisations: [organisation2], service: other_service, invitation_accepted_at: nil) }
+
+        it_behaves_like "existing agent is added to organization"
+
+        it "displays an error about the mismatch" do
+          subject
+          expect(flash[:error]).to match(/Attention : le service demandé .* ne correspond pas/)
+        end
+      end
+
+      context "when agent has been invited by another organisation" do
+        let!(:existing_agent) do
+          create(:agent, :not_confirmed, basic_role_in_organisations: [organisation2], invitation_accepted_at: nil)
+        end
+
+        it_behaves_like "existing agent is added to organization"
+      end
+
+      context "when agent is already in this organisation" do
+        let!(:existing_agent) do
+          create(:agent, basic_role_in_organisations: [organisation], invitation_accepted_at: nil)
+        end
+
+        it { expect { subject }.not_to change(Agent, :count) }
+      end
+
+      context "when agent has been invited by this organisation" do
+        let!(:existing_agent) do
+          create(:agent, :not_confirmed, basic_role_in_organisations: [organisation], invitation_accepted_at: nil)
+        end
+
+        it { expect { subject }.not_to change(Agent, :count) }
+      end
+    end
+
+    context "when agent already exist but with different email capitalization" do
+      let(:params) do
+        {
+          organisation_id: organisation.id,
+          agent: {
+            email: "MARCO@demo.rdv-solidarites.fr",
+            service_id: service_id,
+            roles_attributes: {
+              "0" => {
+                level: "basic",
+              },
+            },
+          },
+        }
+      end
+      let!(:existing_agent) do
+        create(:agent, email: "marco@demo.rdv-solidarites.fr", basic_role_in_organisations: [organisation2], invitation_accepted_at: nil)
+      end
+
+      it_behaves_like "existing agent is added to organization"
+    end
+  end
+end

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -60,6 +60,35 @@ describe "Admin can configure the organisation" do
     end
   end
 
+  it "CRUD on agents" do
+    click_link "Vos agents"
+    expect_page_title("Agents de Organisation n°1")
+
+    click_link "PATRICK Tony"
+    expect_page_title("Modifier le rôle de l'agent Tony PATRICK")
+    choose :agent_role_level_admin
+    click_button("Enregistrer")
+
+    expect_page_title("Agents de Organisation n°1")
+    expect(page).to have_content("Admin", count: 2)
+
+    click_link "PATRICK Tony"
+    click_link("Supprimer le compte")
+
+    expect_page_title("Invitations en cours pour Organisation n°1")
+    expect(page).to have_no_content("Tony PATRICK")
+
+    click_link "Inviter un agent", match: :first
+    fill_in "Email", with: "jean@paul.com"
+    click_button "Envoyer une invitation"
+
+    expect_page_title("Invitations en cours pour Organisation n°1")
+    expect(page).to have_content("jean@paul.com")
+
+    open_email("jean@paul.com")
+    expect(current_email.subject).to eq I18n.t("devise.mailer.invitation_instructions.subject")
+  end
+
   it "Update organisation" do
     click_link "Votre organisation"
     click_link "Modifier"


### PR DESCRIPTION
Dans #2283, l'[interface de gestion des agents et des invitations en cours "côté organisation"](https://user-images.githubusercontent.com/6357692/174080493-d1cd09be-4a7f-4a6a-94b2-abc740b2e177.png) a été supprimée au profit d'une interface située dans la config du territoire (voir captures dans la PR sus-citée).

Nous avons depuis reçu de nombreuses demandes au support quant à la disparition de l'interface existante, avec comme problème principaux :
- difficile de retrouver l'interface permettant d'inviter, lister, modifier et supprimer les agents
- impossibilité de lister les invitations envoyées mais pas encore acceptée (cette fonctionnalité n'avait pas été conservée lors du "déplacement" de l'interface fait dans la PR)

Cette PR a donc pour but de restaurer l'interface qui avait été supprimée (côté organisation, "dans le menu de gauche"), tout en gardant la nouvelle (dans la config des territoires). Cela permet aux agents de continuer à travailler pendant que nous réfléchissons à comment faire les changements structurels nécessaires sans casser les usages du produit.