### PR TITLE
Suppression de stats peu intéressante

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -23,18 +23,6 @@ class StatsController < ApplicationController
     render json: stats.chart_json
   end
 
-  def agents
-    render json: Stat.new(agents: @agents).agents_group_by_week
-  end
-
-  def organisations
-    render json: Stat.new(organisations: @organisations).organisations_group_by_week
-  end
-
-  def users
-    render json: Stat.new(users: @users).users_group_by_week
-  end
-
   def receipts
     attribute = params[:group_by]&.to_sym
     attribute = :channel unless attribute.in?(%i[event channel result])

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -8,20 +8,8 @@ class Stat
 
   delegate :active, to: :users, prefix: true
 
-  def users_group_by_week
-    users.active.group_by_week("users.created_at", format: DEFAULT_FORMAT).count
-  end
-
-  def organisations_group_by_week
-    organisations.group_by_week("organisations.created_at", format: DEFAULT_FORMAT).count
-  end
-
   def agents_for_default_range
     agents.active
-  end
-
-  def agents_group_by_week
-    agents.active.group_by_week("agents.created_at", format: DEFAULT_FORMAT).count
   end
 
   def rdvs_group_by_week

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -26,15 +26,3 @@
     = self_anchor "rdvs-type"
       h4.card-title RDV par type (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, by_location_type: true, departement: @departement), stacked: true
-
-.card.mb-5
-  .card-body
-    = self_anchor "usagers"
-      h4.card-title Usagers créés (#{@stats.users_active.count})
-    = column_chart users_admin_organisation_stats_path(@organisation, departement: @departement)
-
-.card.mb-5
-  .card-body
-    = self_anchor "agents"
-      h4.card-title Agents créés (#{@stats.agents_for_default_range.count})
-    = column_chart agents_stats_path(departement: @departement)

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -19,98 +19,80 @@
   - if @departement.present? && Organisation.joins(:territory).where(territories: { departement_number: @departement }).empty?
     h3 Ce departement n'utilise pas RDV-Solidarités.
   - else
-      .card.mb-5
-        .card-body
-          h2.card-title Nombre de RDV par statut
-          .row
-            .col-lg-4
-              .px-1
-                - %i[seen excused revoked noshow].each do |temporal_status|
-                  = render "stats/rdv_counter_without_link", \
-                    temporal_status: temporal_status, \
-                    count: @stats.rdvs.status(temporal_status).count
-            .col-lg-4
-              .px-1
+    .card.mb-5
+      .card-body
+        h2.card-title Nombre de RDV par statut
+        .row
+          .col-lg-4
+            .px-1
+              - %i[seen excused revoked noshow].each do |temporal_status|
                 = render "stats/rdv_counter_without_link", \
-                  temporal_status: :unknown_past, \
-                  count: @stats.rdvs.status(:unknown_past).count
-            .col-lg-4
-              .px-1
-                = render "stats/rdv_counter_without_link", \
-                  temporal_status: :unknown_future, \
-                  count: @stats.rdvs.status(:unknown_future).count
-          hr
-          .row
-            .col-lg-4
-              .px-1
-                = render "stats/rdv_counter_without_link", \
-                  label: "Tous", \
-                  count: @stats.rdvs.count
+                  temporal_status: temporal_status, \
+                  count: @stats.rdvs.status(temporal_status).count
+          .col-lg-4
+            .px-1
+              = render "stats/rdv_counter_without_link", \
+                temporal_status: :unknown_past, \
+                count: @stats.rdvs.status(:unknown_past).count
+          .col-lg-4
+            .px-1
+              = render "stats/rdv_counter_without_link", \
+                temporal_status: :unknown_future, \
+                count: @stats.rdvs.status(:unknown_future).count
+        hr
+        .row
+          .col-lg-4
+            .px-1
+              = render "stats/rdv_counter_without_link", \
+                label: "Tous", \
+                count: @stats.rdvs.count
 
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs"
+         h2.card-title RDV créés (#{@stats.rdvs.count})
+        = column_chart rdvs_stats_path(departement: @departement), stacked: true
+
+    - unless @departement.present?
       .card.mb-5
         .card-body
-          = self_anchor "rdvs"
-           h2.card-title RDV créés (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(departement: @departement), stacked: true
+          = self_anchor "rdvs-departement"
+            h2.card-title RDV créés par département(#{@stats.rdvs.count})
+          = column_chart rdvs_stats_path(by_departement: true), stacked: true
 
-      - unless @departement.present?
-        .card.mb-5
-          .card-body
-            = self_anchor "rdvs-departement"
-              h2.card-title RDV créés par département(#{@stats.rdvs.count})
-            = column_chart rdvs_stats_path(by_departement: true), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-service"
+          h2.card-title RDV créés par service (#{@stats.rdvs.count})
+        = column_chart rdvs_stats_path(by_service: true, departement: @departement), stacked: true
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-service"
-            h2.card-title RDV créés par service (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(by_service: true, departement: @departement), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-type"
+          h2.card-title RDV par type (#{@stats.rdvs.count})
+        = column_chart rdvs_stats_path(by_location_type: true, departement: @departement), stacked: true
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-type"
-            h2.card-title RDV par type (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(by_location_type: true, departement: @departement), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-status"
+          h2.card-title RDV par statut
+        /
+          Note: colors are synced manually with the status css and the order of the stats.
+          From stat.rb, Stat#rdvs_group_by_status:
+            * stats are in this order: unknown seen excused revoked noshow
+          From _rdv_status.scss, the colors are:
+            "unknown": $info, #ffbc00
+            "seen": $success, #0acf97
+            "excused": $info, #39afd1
+            "revoked": $teal, #02a8b5
+            "noshow": $danger, #fa5c7c
+        - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
+        = column_chart rdvs_stats_path(by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%", colors: colors
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-status"
-            h2.card-title RDV par statut
-          /
-            Note: colors are synced manually with the status css and the order of the stats.
-            From stat.rb, Stat#rdvs_group_by_status:
-              * stats are in this order: unknown seen excused revoked noshow
-            From _rdv_status.scss, the colors are:
-              "unknown": $info, #ffbc00
-              "seen": $success, #0acf97
-              "excused": $info, #39afd1
-              "revoked": $teal, #02a8b5
-              "noshow": $danger, #fa5c7c
-          - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
-          = column_chart rdvs_stats_path(by_status: true, departement: @departement), stacked: :percent, max: 100, suffix: "%", colors: colors
-
-      .card.mb-5
-        .card-body
-          = self_anchor "notifications"
-            h2.card-title "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
-          - %i[event channel result].each do |attribute|
-            h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
-            = column_chart receipts_stats_path(group_by: attribute, departement: @departement), stacked: true
-
-      .card.mb-5
-        .card-body
-          = self_anchor "usagers"
-            h2.card-title Usagers créés (#{@stats.users_active.count})
-          = column_chart users_stats_path(departement: @departement)
-
-      .card.mb-5
-        .card-body
-          = self_anchor "agents"
-            h2.card-title Agents créés (#{@stats.agents_for_default_range.count})
-          = column_chart agents_stats_path(departement: @departement)
-
-  .card.mb-5
-    .card-body
-      = self_anchor "organisations"
-        h2.card-title Organisations créées (#{@stats.organisations.count})
-      = column_chart organisations_stats_path(departement: @departement)
+    .card.mb-5
+      .card-body
+        = self_anchor "notifications"
+          h2.card-title "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
+        - %i[event channel result].each do |attribute|
+          h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
+          = column_chart receipts_stats_path(group_by: attribute, departement: @departement), stacked: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,10 +58,7 @@ Rails.application.routes.draw do
     post "file_attente", to: "file_attentes#create_or_delete"
   end
   resources :stats, only: :index
-  get "stats/agents", to: "stats#agents", as: "agents_stats"
-  get "stats/organisations", to: "stats#organisations", as: "organisations_stats"
   get "stats/rdvs", to: "stats#rdvs", as: "rdvs_stats"
-  get "stats/users", to: "stats#users", as: "users_stats"
   get "stats/receipts", to: "stats#receipts", as: "receipts_stats"
   get "stats/:departement", to: "stats#index", as: "departement_stats"
 

--- a/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
+++ b/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
@@ -9,6 +9,5 @@ describe "Admin can configure the organisation" do
     click_link "Statistiques"
     expect(page).to have_content("Statistiques")
     expect(page).to have_content("RDV créés")
-    expect(page).to have_content("Usagers créés")
   end
 end

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -6,6 +6,5 @@ describe "Anybody can see stats" do
     click_link "Statistiques"
     expect(page).to have_content("Statistiques")
     expect(page).to have_content("RDV créés")
-    expect(page).to have_content("Usagers créés")
   end
 end

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -54,26 +54,6 @@ describe Stat, type: :model do
     end
   end
 
-  describe "#users_group_by_week" do
-    it "returns user count group by created at" do
-      now = Time.zone.parse("20220123 13:00")
-      travel_to(now)
-      create(:user)
-      stats = described_class.new(users: User.all)
-      expect(stats.users_group_by_week).to eq({ "23/01/2022" => 1 })
-    end
-  end
-
-  describe "#organisations_group_by_week" do
-    it "returns organisations count group by created at" do
-      now = Time.zone.parse("20220123 13:00")
-      travel_to(now)
-      create(:organisation)
-      stats = described_class.new(organisations: Organisation.all)
-      expect(stats.organisations_group_by_week).to eq({ "23/01/2022" => 1 })
-    end
-  end
-
   describe "#agents_for_default_range" do
     it "returns active agents only" do
       now = Time.zone.parse("20220123 13:00")
@@ -82,17 +62,6 @@ describe Stat, type: :model do
       create(:agent, deleted_at: now - 1.week)
       stats = described_class.new(agents: Agent.all)
       expect(stats.agents_for_default_range).to eq([active_agent])
-    end
-  end
-
-  describe "#agents_group_by_week" do
-    it "returns active agents count group by week" do
-      now = Time.zone.parse("20220123 13:00")
-      travel_to(now)
-      create(:agent)
-      create(:agent, deleted_at: now - 1.week)
-      stats = described_class.new(agents: Agent.all)
-      expect(stats.agents_group_by_week).to eq({ "23/01/2022" => 1 })
     end
   end
 


### PR DESCRIPTION
Suppression de stats peu intéressante.

Le nombre d'usagers ne représente pas vraiment l'utilisation de la plateforme par les usagers puisque ce sont les agents qui créent des fiches. Et ça a peut de rapport avec la participation à un RDV.

Le nombre d'organisations est plutôt lié à la façon dont souhaite s'organiser une structure.

Le nombre d'agents permet éventuellement de regarder le niveau de déploiement, mais un pourcentage en fonction du nombre d'agents de la structure serait plus intéressante.

# Checklist

Avant la revue :
- [x] ~~Préparer des captures de l’interface avant et après~~
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
