### PR TITLE
[Perf] Réduire le nombre d'occurrences à évaluer lors du calcul de créneaux

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -4,8 +4,6 @@ module RecurrenceConcern
   extend ActiveSupport::Concern
 
   included do
-    require "montrose"
-
     serialize :recurrence, Montrose::Recurrence
     serialize :start_time, Tod::TimeOfDay
     serialize :end_time, Tod::TimeOfDay
@@ -60,11 +58,22 @@ module RecurrenceConcern
     recurrence.present?
   end
 
-  def occurrences_for(inclusive_date_range)
+  def occurrences_for(inclusive_date_range, only_future: false)
     return [] if inclusive_date_range.nil?
 
-    occurrence_start_at_list_for(inclusive_date_range)
+    occurrence_start_at_list_for(inclusive_date_range, only_future: only_future)
       .map { |o| Recurrence::Occurrence.new(starts_at: o, ends_at: o + duration) }
+  end
+
+  # @return [ActiveSupport::TimeWithZone, nil] the earliest future occurrence at the time of computation
+  def earliest_future_occurrence_time(refresh: false)
+    return unless recurring?
+
+    cache_key = "earliest_future_occurrence_#{self.class.table_name}_#{id}_#{updated_at}"
+
+    Rails.cache.fetch(cache_key, force: refresh, expires_in: 1.week) do
+      recurrence.starting(starts_at).until(recurrence_ends_at).lazy.select(&:future?).first
+    end
   end
 
   def recurrence_interval
@@ -85,11 +94,19 @@ module RecurrenceConcern
 
   private
 
-  def occurrence_start_at_list_for(inclusive_date_range)
+  # The `only_future` param was introduced to circumvent performance
+  # issues with Montrose's occurrence generation.
+  # It uses a cached value of the next occurrence as a starting point
+  # when computing future occurrences, which is faster
+  # than starting form the very first occurrence.
+  # Warning: using `only_future: true` will only yield future occurrences, not past ones.
+  def occurrence_start_at_list_for(inclusive_date_range, only_future:)
     min_until = [inclusive_date_range.end, recurrence_ends_at].compact.min.end_of_day
     inclusive_datetime_range = (inclusive_date_range.begin)..(inclusive_date_range.end.end_of_day)
+
     if recurring?
-      recurrence.starting(starts_at).until(min_until).lazy.select do |occurrence_starts_at|
+      min_from = only_future ? (earliest_future_occurrence_time || starts_at) : starts_at
+      recurrence.starting(min_from).until(min_until).lazy.select do |occurrence_starts_at|
         event_in_range?(occurrence_starts_at, occurrence_starts_at + duration, inclusive_datetime_range)
       end.to_a
     else

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -38,7 +38,7 @@ module SlotBuilder
     end
 
     def ranges_for(plage_ouverture, datetime_range)
-      occurrences = plage_ouverture.occurrences_for(datetime_range)
+      occurrences = plage_ouverture.occurrences_for(datetime_range, only_future: true)
 
       occurrences.map do |occurrence|
         next if occurrence.ends_at < Time.zone.now
@@ -162,7 +162,7 @@ module SlotBuilder
         busy_times = []
         absences.each do |absence|
           if absence.recurrence
-            absence.occurrences_for(range).each do |absence_occurrence|
+            absence.occurrences_for(range, only_future: true).each do |absence_occurrence|
               next if absence_out_of_range?(absence_occurrence, range)
 
               busy_times << BusyTime.new(absence_occurrence)

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -133,5 +133,59 @@ shared_examples_for "recurrence" do
         expect(subject[0].ends_at).to eq(Time.zone.local(2019, 8, 5, 12))
       end
     end
+
+    describe "the future_only parameter" do
+      # In june of 2022, wednesdays land on 1, 8, 15, 22 and 29.
+      # Let's create a recurrent event that repeats on wednesdays beginning june 1st.
+      # Let's say we wish to search on the whole month (date range is june 1st to 30th).
+      # Let's say today is monday 13th of june.
+      # Using `future_only: false` should return all wednesdays (1, 8, 15, 22 and 29).
+      # Using `future_only: true` should return future wednesdays (15, 22 and 29).
+
+      before { travel_to(Time.zone.local(2022, 6, 13)) }
+
+      let(:first_day) { Date.new(2022, 6, 1) }
+      let(:model_instance) do
+        build(model_symbol,
+              first_day: first_day,
+              start_time: Tod::TimeOfDay.new(8),
+              end_time: Tod::TimeOfDay.new(12),
+              recurrence: Montrose.every(
+                :week,
+                on: [:wednesday],
+                interval: 1,
+                starts: first_day
+              ).to_json)
+      end
+      let(:date_range) { Date.new(2022, 6, 1)..Date.new(2022, 6, 30) }
+
+      context "when using the future_only: false switch" do
+        subject { model_instance.occurrences_for(date_range, only_future: false) }
+
+        it "returns all wednesdays of june" do
+          all_wednesdays_of_june = [
+            Time.zone.parse("2022-06-01 08:00:00"),
+            Time.zone.parse("2022-06-08 08:00:00"),
+            Time.zone.parse("2022-06-15 08:00:00"),
+            Time.zone.parse("2022-06-22 08:00:00"),
+            Time.zone.parse("2022-06-29 08:00:00"),
+          ]
+          expect(subject.map(&:starts_at)).to eq(all_wednesdays_of_june)
+        end
+      end
+
+      context "when using the future_only: true switch" do
+        subject { model_instance.occurrences_for(date_range, only_future: true) }
+
+        it "returns future wednesdays of june (after today which is june 13th)" do
+          future_wednesdays_of_june = [
+            Time.zone.parse("2022-06-15 08:00:00"),
+            Time.zone.parse("2022-06-22 08:00:00"),
+            Time.zone.parse("2022-06-29 08:00:00"),
+          ]
+          expect(subject.map(&:starts_at)).to eq(future_wednesdays_of_june)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #2542

Note : la méthode proposée dans le ticket ci-dessus (filtrer les plages d'ouvertures sur le jour de la semaine) s'est révélée inefficace car la recherche se fait sur une semaine complète. Cette PR est donc le résultat d'une investigation sans à priori sur les solutions technique, et dans ce sens elle s'inscrit dans la démarche plus généraliste de #2173.

# TLDR : ce que j'ai fait

Ayant déterminé que c'était le calcul des occurrences avec Montrose qui prenait le plus gros du temps, j'ai décidé d'éviter ce calcul en évitant de calculer toutes les occurrences à la demande en partant de la première. Pour ce faire, j'ai choisi de mettre en cache une occurrence récente, afin de partir de cette occurrence plutôt que de la première, en ainsi grandement diminuer le nombre d'itération nécessaire à générer une occurrence qui soit inclue dans la période recherchée (les semaines à venir au moment de la requête).

# En détails : l'investigation

Les deux exemples de lenteurs donnés dans l'issue sont assez différents :
- la recherche côté agent est lente car elle manipule **28 plages d'ouvertures récurrentes**
- la recherche côté user est lente car elle cherche des créneaux dans **64 lieux** de manière synchrone et sans pagination

Explorons plus en détail les deux cas. :mag:  

## Recherche de créneau côté agent

> En production, pour l'organisation avec l'ID 92, la recherche d'un créneau sur le motif « planification (sur place) » met en général 20 s :scream:

Pour ce cas, **un seul lieu** est trouvé, mais **30 plages d'ouvertures dont 28 récurrentes** correspondent à ce lieu. Nous itérons sur ces 30 plages 4 fois (c'est à dire 4 appels à `SlotBuilder.available_slots`) :
1. une fois pour trouver les créneaux de la semaine courante : il n'y en a pas :frowning_face: 
2. une fois pour trouver une date la semaine prochaine : il n'y en a pas :frowning_face: 
3. une fois pour trouver une date la semaine suivante : il n'y en a pas :frowning_face: 
4. une fois pour trouver une date la semaine suivante : on en trouve un ! :tada: 

Chacun de ces appels itère donc sur les 30 plages, et pour chacun des plages, détermine quels créneaux pourraient en être issus. 

Pour les plages récurrentes, il faut générer dynamiquement les récurrences à partir du premier jour d'occurrence. C'est à dire que si la plage d'ouverture existe depuis 18 mois, il faut calculer toutes occurrences depuis cette date. Or, l'opération de calcul d'occurrence est coûteuse, et on le fait pour les 28 plages x 4 = 112 fois !

On peut voir sur le flamegraph suivant que **Montrose prend 70-80 % du temps d'exécution** ! 

![image](https://user-images.githubusercontent.com/6357692/174783388-7bc83418-703e-4f45-aae4-0b3e5abe3c9b.png)

Il semble alors stratégique de faire en sorte de réduire le temps passé à calculer les occurrences. Pour ce faire, j'ai étudié 3 pistes : 
1. pré-calculer les occurrences et les stocker dans une table postgres
2. mettre en cache les occurrences pour une plage donné et un interval donné
3. continuer d'utiliser montrose pour calculer les occurrences, mais ne pas repartir de la première occurrence

Je suis arrivé à des résultats peu concluants avec la première méthode. Le préchargement des occurrences en base au moment de la requête prenait beaucoup de temps, presque autant que le calcul des récurrences via Montrose.

La seconde méthode apportait de très bons résultats en termes de perf (requête 4 fois plus rapide).

Les deux premières méthodes ont pour inconvénient qu'il faut décider de combien de temps en avance on doit calculer les occurrences dans les cas où la date de fin est absente (récurrence infinie).

La troisième méthode offre des performances comparable à la seconde (requête 4 fois plus rapide), tout en évitant de poser la question du paragraphe ci-dessus. Elle a aussi pour avantage de se "dégrader gracieusement" : si la valeur mise en cache est absente ou ancienne, il n'y aura pas d'impact fonctionnel mais seulement un impact de performance. J'ai choisi le cache (Redis) plutôt qu'une colonne Postgres pour éviter d'alourdir le schéma, et pour profiter des performances de Redis en écriture.

Je suis donc parti sur la troisième option.

Note : ces optimisations sont aussi valables pour les absences, qui peuvent aussi être récurrentes.

Note 2 : Côté agents, le calcul de créneaux se fait lors de l'affichage de la liste des lieux et leur prochaine dispo (1ère étape), puis une seconde fois lorsque l'on clique sur un lieu pour afficher tous les créneaux (seconde étape). Dans le cas particulier où un seul lieu est trouvé à la première étape, [une redirection est faite automatiquement](https://github.com/betagouv/rdv-solidarites.fr/blob/1299630eef24b0a6e30cffa5fcd3de6266c79469/app/controllers/admin/creneaux/agent_searches_controller.rb#L13). Cela signifie que dans le cas étudié ici (où un seul lieu est trouvé, et où la prochaine dispo est dans plusieurs semaines), les deux étapes s'exécutent à la suite, ce qui double le temps d'attente perçu ! (28 plages x 4 semaines x 2 étapes = 224 plages pour lesquelles calculer des occurrences)

## Recherche de créneau côté usager⋅e

> En production, coté usager, pour le 62, en cherchant un RDV sur Calais, en PMI, pour une consultation médicale (examen, vaccination), le temps d'affichage est de plus de 10 s. La recherche porte sur l'ensemble du département.

Dans cette recherche, la part de temps passé dans le calcul des occurrences est moindre, car il y a 2 ou 3 plages d'ouverture par lieu. C'est plutôt de fait d'itérer sur 64 lieux qui rend la requête lente. On a donc un gain de temps moins impressionnant que pour la requête côté agent (ci-dessus) : on passe de ~5000 ms à ~3200 ms.

Un axe pertinent d'amélioration de cette requête serait de paginer les lieux (si on en met 10 par page on passe à 700 ms par requête). Cette pagination peut prendre la forme traditionnelle ou bien consister à des appels asynchrones faits en AJAX pour chaque lieu (ce que fait Doctolib). Je vais créer une issue séparée pour explorer cette piste, qui pourrait être simple et diablement efficace.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
