### PR TITLE
Vérifie le contenu d'un tableau dans un test 

### DIFF
--- a/spec/policies/configuration/agent_policy/scope_spec.rb
+++ b/spec/policies/configuration/agent_policy/scope_spec.rb
@@ -59,6 +59,6 @@ describe Configuration::AgentPolicy::Scope, type: :policy do
     agent_from_other_orga = create(:agent, organisations: [other_organisation])
     create(:agent_territorial_access_right, agent: agent_from_other_orga, territory: territory)
 
-    expect(described_class.new(AgentTerritorialContext.new(agent, territory), Agent).resolve).to eq([agent, agent_from_other_service, agent_from_other_orga])
+    expect(described_class.new(AgentTerritorialContext.new(agent, territory), Agent).resolve).to match_array([agent, agent_from_other_service, agent_from_other_orga])
   end
 end


### PR DESCRIPTION
Plutôt que d'espérer que les agents soient toujours dans le bon ordre...

C'est suite à un test échoué (de manière aléatoire) j'ai jeté un œil à ce test et pensé qu'un `match_array` serait toujours mieux qu'un `eq`... Pas sur que ça résolve le coté flaky de ce test, mais c'est toujours un peu mieux comme ça.