### PR TITLE
Met à jour la version de paper_trail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.1)
     momentjs-rails (2.29.1.1)
       railties (>= 3.1)
     montrose (0.12.0)
@@ -373,7 +373,7 @@ GEM
       validate_url
       webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
-    paper_trail (12.1.0)
+    paper_trail (12.3.0)
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.21.0)
@@ -459,7 +459,7 @@ GEM
       ffi (~> 1.0)
     redis (4.5.1)
     regexp_parser (2.2.0)
-    request_store (1.5.0)
+    request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -614,7 +614,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby

--- a/spec/models/paper_trail_version_spec.rb
+++ b/spec/models/paper_trail_version_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe "PaperTrail::Version" do
+  describe "changes" do
+    it "can read changes" do
+      user = create(:user, first_name: "Frédérique")
+      user.update(first_name: "Frédéric")
+      expect(user.versions.last.changeset).to eq({ "first_name" => %w[Frédérique Frédéric] })
+    end
+
+    it "cant read changes" do
+      now = Time.zone.parse("2022-04-21 12h30")
+      travel_to(now - 1.day)
+      user = create(:user)
+      travel_to(now)
+      user.update(confirmed_at: now)
+      expect(user.versions.last.changeset).to eq({ "confirmed_at" => [now - 1.day, now] })
+    end
+  end
+end


### PR DESCRIPTION
Suite à la mise à jour de Ruby, `Psych`, l'outil pour parser le `YAML` intégré à Ruby, a changé de mode de fonctionnement sur le parsing de certaines classes comme `Time`, `Date` et autres.

Conséquence, la lecture des changements (sérialisé en `YAML`) sur les objets suivis avec PaperTrail renvoyait une structure vide `{}`.

Cette PR ajoute un test (peut-être pas rangé au bon endroit ?) qui m'a permis de vérifier le mauvais fonctionnement avec un test, puis de m'assurer qu'avec la mise à jour de PaperTrail que ça fonctionnait correctement. Nous pourrions supprimer ce test, mais je crois que son coût relativement faible nous permet de le laisser dans le coin :)

Closes #2600 

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
