### PR TITLE
Ajoute l'organisation dans l'export CSV

### DIFF
--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -20,6 +20,7 @@ module RdvExporter
     "usager(s)",
     "commune du premier responsable",
     "au moins un usager mineur ?",
+    "Organisation",
   ].freeze
 
   def self.export(rdvs)
@@ -70,6 +71,7 @@ module RdvExporter
       rdv.users.map(&:full_name).join(", "),
       commune_premier_responsable(rdv),
       rdv.users.any?(&:minor?) ? "oui" : "non",
+      rdv.organisation.name,
     ]
   end
 

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -25,7 +25,7 @@ describe RdvExporter, type: :service do
         sheet = described_class.build_excel_workbook_from(Rdv.none).worksheet(0)
         expect(sheet.row(0)).to eq(["année", "date prise rdv", "heure prise rdv", "origine", "date rdv", "heure rdv", "service", "motif", "contexte",
                                     "statut", "résultat des notifications", "lieu", "professionnel.le(s)",
-                                    "usager(s)", "commune du premier responsable", "au moins un usager mineur ?",])
+                                    "usager(s)", "commune du premier responsable", "au moins un usager mineur ?", "Organisation",])
       end
     end
   end
@@ -193,6 +193,14 @@ describe RdvExporter, type: :service do
         rdv = build(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
         expect(described_class.row_array_from(rdv)[15]).to eq("oui")
       end
+    end
+  end
+
+  describe "contient l'organisation courante" do
+    it "return organisation name" do
+      organisation = build(:organisation, name: "CMS du Brusc")
+      rdv = build(:rdv, organisation: organisation)
+      expect(described_class.row_array_from(rdv)[16]).to eq("CMS du Brusc")
     end
   end
 end


### PR DESCRIPTION
Pour préparer #1719 ?

Et surtout, pour faciliter la fusion des divers fichiers de statistique exporté organisation par organisation, cette PR ajoute une colonne à la fin avec le nom de l'organisation.

Pas très utile à priori, mais il faut voir que les statistiques sont en fait cumulées et chaque fichier est fusionné. Donc difficile, une fois fusionné, de repérer quel RDV est lié à quelle organisation.

Closes #2007

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
