### PR TITLE
Notifie l'usager de la création d'un RDV suite à un RDV annulé

### DIFF
--- a/app/services/rdv_updater.rb
+++ b/app/services/rdv_updater.rb
@@ -16,30 +16,47 @@ module RdvUpdater
 
       success = rdv.update(rdv_params)
 
-      rdv_users_tokens_by_user_id = {}
-
-      # Send relevant notifications (cancellation and date update)
-      if success
-        if rdv.previous_changes["status"]&.last.in? %w[excused revoked noshow]
-          # Also destroy the file_attentes
-          rdv.file_attentes.destroy_all
-
-          rdv_users_tokens_by_user_id = Notifiers::RdvCancelled.perform_with(rdv, author)
-        end
-
-        if rdv.previous_changes["starts_at"].present?
-          rdv_users_tokens_by_user_id = Notifiers::RdvDateUpdated.perform_with(rdv, author)
-        end
-
-        if rdv.collectif?
-          rdv_users_tokens_by_user_id = Notifiers::RdvCollectifParticipations.perform_with(rdv, author, previous_participant_ids)
-        end
-      end
-
       Result.new(
         success: success,
-        rdv_users_tokens_by_user_id: rdv_users_tokens_by_user_id
+        rdv_users_tokens_by_user_id: success ? notify!(author, rdv, previous_participant_ids) : {}
       )
+    end
+
+    def rdv_status_reloaded_from_cancelled?(rdv)
+      rdv.status_previously_was.in?(%w[revoked excused]) &&
+        rdv.status == "unknown"
+    end
+
+    private
+
+    def notify!(author, rdv, previous_participant_ids)
+      rdv_users_tokens_by_user_id = {}
+      if rdv_cancelled?(rdv)
+        rdv.file_attentes.destroy_all
+        rdv_users_tokens_by_user_id = Notifiers::RdvCancelled.perform_with(rdv, author)
+      end
+
+      if rdv_status_reloaded_from_cancelled?(rdv)
+        rdv_users_tokens_by_user_id = Notifiers::RdvCreated.perform_with(rdv, author)
+      end
+
+      if starts_at_change?(rdv)
+        rdv_users_tokens_by_user_id = Notifiers::RdvDateUpdated.perform_with(rdv, author)
+      end
+
+      if rdv.collectif?
+        rdv_users_tokens_by_user_id = Notifiers::RdvCollectifParticipations.perform_with(rdv, author, previous_participant_ids)
+      end
+
+      rdv_users_tokens_by_user_id
+    end
+
+    def rdv_cancelled?(rdv)
+      rdv.previous_changes["status"]&.last.in? %w[excused revoked noshow]
+    end
+
+    def starts_at_change?(rdv)
+      rdv.previous_changes["starts_at"].present?
     end
   end
 


### PR DESCRIPTION
Lorsque l'on souhaite remettre un RDV annulé en RDV à venir, nous n'envoyons pas de notification à l'usager qui n'a aucun moyen de le savoir.

Cette PR propose d'envoyer une notification pour les RDV qui passe d'un statut annulé (à l'initiative de l'usager ou de l'agent) pour un statut autre.

L'outil de notification n'enverra pas de notification sur le RDV est passé.
Il n'y a pas d'autre statut que `unknown` pour les RDV futurs (en dehors des statuts d'annulation).

La notification envoyée est celle de la création d'un RDV. Ce qui aurait été le cas de toute façon si nous avions forcé à recréer un RDV plutôt que de le l'ouvrir à nouveau.

Closes #2538

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
