### PR TITLE
Prévenir la création d’un rendez-vous en doublon

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Metrics/ClassLength:
   Max: 150
   CountAsOne: ['array', 'hash', 'heredoc']
   Exclude:
+    - 'app/models/rdv.rb'
     - 'app/models/user.rb'
 
 Metrics/MethodLength:

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -73,10 +73,11 @@ module Admin::RdvFormConcern
     return if ignore_benign_errors
 
     rdv.users.each do |user|
-      suspicious_rdvs = Rdv.joins(:users).on_day(rdv.starts_at).where(
-        motif: motif,
-        rdvs_users: { user_id: user.id }
-      ).to_a
+      suspicious_rdvs = Rdv
+        .on_day(rdv.starts_at)
+        .with_user(user)
+        .where(motif: motif)
+        .to_a
 
       if suspicious_rdvs.any?
         user_path = admin_organisation_user_path(rdv.organisation, user)

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -38,6 +38,7 @@ module Admin::RdvFormConcern
       ends_at: rdv.ends_at,
       motif: rdv.motif
     ).select do |existing_rdv|
+      # Use #sort to compare arrays ignoring order
       existing_rdv.users.sort == rdv.users.sort && existing_rdv.agents.sort == rdv.agents.sort
     end
 
@@ -92,7 +93,6 @@ module Admin::RdvFormConcern
         .on_day(rdv.starts_at)
         .with_user(user)
         .where(motif: motif)
-        .to_a
 
       if suspicious_rdvs.any?
         user_path = admin_organisation_user_path(rdv.organisation, user)

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -64,7 +64,7 @@ class Rdv < ApplicationRecord
   scope :past, -> { where("starts_at < ?", Time.zone.now) }
   scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :start_after, ->(time) { where("starts_at > ?", time) }
-  scope :on_day, ->(day) { where(starts_at: day.beginning_of_day...day.end_of_day) }
+  scope :on_day, ->(day) { where(starts_at: day.beginning_of_day..day.end_of_day) }
   scope :day_after_tomorrow, -> { on_day(Time.zone.tomorrow + 1.day) }
   scope :for_today, -> { on_day(Time.zone.today) }
   scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where(users: { id: [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten }) }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -68,6 +68,7 @@ class Rdv < ApplicationRecord
   scope :day_after_tomorrow, -> { on_day(Time.zone.tomorrow + 1.day) }
   scope :for_today, -> { on_day(Time.zone.today) }
   scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where(users: { id: [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten }) }
+  scope :with_user, ->(user) { joins(:users).where(rdvs_users: { user_id: user.id }) }
   scope :status, lambda { |status|
     case status.to_s
     when "unknown_past"

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -64,7 +64,7 @@ class Rdv < ApplicationRecord
   scope :past, -> { where("starts_at < ?", Time.zone.now) }
   scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :start_after, ->(time) { where("starts_at > ?", time) }
-  scope :on_day, ->(day) { where(starts_at: day.beginning_of_day..day.end_of_day) }
+  scope :on_day, ->(day) { where(starts_at: day.all_day) }
   scope :day_after_tomorrow, -> { on_day(Time.zone.tomorrow + 1.day) }
   scope :for_today, -> { on_day(Time.zone.today) }
   scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where(users: { id: [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten }) }

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -65,9 +65,10 @@ class Rdv < ApplicationRecord
   scope :past, -> { where("starts_at < ?", Time.zone.now) }
   scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :start_after, ->(time) { where("starts_at > ?", time) }
-  scope :tomorrow, -> { where(starts_at: DateTime.tomorrow...DateTime.tomorrow + 1.day) }
-  scope :day_after_tomorrow, -> { where(starts_at: DateTime.tomorrow + 1.day...DateTime.tomorrow + 2.days) }
-  scope :for_today, -> { where(starts_at: Time.zone.now.beginning_of_day...Time.zone.now.end_of_day) }
+  scope :on_day, ->(day) { where(starts_at: day.beginning_of_day...day.end_of_day) }
+  scope :tomorrow, -> { on_day(Time.zone.tomorrow) }
+  scope :day_after_tomorrow, -> { on_day(Time.zone.tomorrow + 1.day) }
+  scope :for_today, -> { on_day(Time.zone.today) }
   scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where(users: { id: [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten }) }
   scope :status, lambda { |status|
     case status.to_s

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -61,12 +61,10 @@ class Rdv < ApplicationRecord
 
   # Scopes
   scope :not_cancelled, -> { where(status: NOT_CANCELLED_STATUSES) }
-  scope :cancelled, -> { where(status: CANCELLED_STATUSES) }
   scope :past, -> { where("starts_at < ?", Time.zone.now) }
   scope :future, -> { where("starts_at > ?", Time.zone.now) }
   scope :start_after, ->(time) { where("starts_at > ?", time) }
   scope :on_day, ->(day) { where(starts_at: day.beginning_of_day...day.end_of_day) }
-  scope :tomorrow, -> { on_day(Time.zone.tomorrow) }
   scope :day_after_tomorrow, -> { on_day(Time.zone.tomorrow + 1.day) }
   scope :for_today, -> { on_day(Time.zone.today) }
   scope :user_with_relatives, ->(responsible_id) { joins(:users).includes(:rdvs_users, :users).where(users: { id: [responsible_id, User.find(responsible_id).relatives.pluck(:id)].flatten }) }
@@ -97,10 +95,6 @@ class Rdv < ApplicationRecord
 
   def in_the_past?
     starts_at <= Time.zone.now
-  end
-
-  def today?
-    Time.zone.today == starts_at.to_date
   end
 
   def temporal_status

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -86,4 +86,4 @@ fr:
                 current_agent: "Vous avez <a href='%{path}'>un autre RDV</a> qui chevauche celui-ci"
                 in_scope: "%{agent_name} a <a href='%{path}'>un autre RDV</a> qui chevauche celui-ci"
                 out_of_scope: "Ce rendez-vous en chevauche un autre. %{agent_name} a un RDV dans une autre organisation (ce RDV est dans un autre service ou une autre organisation à laquelle vous n'avez pas accès)"
-
+              rdv_duplicate_suspected: L'usager⋅e <a href="%{user_path}">%{user_name}</a> a un autre RDV pour le même motif le même jour

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -6,6 +6,7 @@ fr:
           attributes:
             base:
               cant_destroy_if_receipts_exist: Il n’est pas possible de supprimer un rendez-vous une fois que des notifications ont été envoyées à des usagers.
+              duplicate: Il existe déjà un RDV au même moment, au même lieu, pour le même motif, avec les mêmes participant⋅es
             starts_at:
               must_be_future: "doit être dans le futur."
               must_be_within_two_years: "doit être dans moins de deux ans."

--- a/spec/features/agents/agent_cant_create_duplicate_rdv_spec.rb
+++ b/spec/features/agents/agent_cant_create_duplicate_rdv_spec.rb
@@ -4,43 +4,65 @@ RSpec.describe "Agent can't create duplicate RDV" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, service: service, basic_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, organisation: organisation, service: service) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
 
   context "when the user already has a RDV for the same motif on that same day" do
-    let!(:motif) { create(:motif, organisation: organisation, service: service) }
-    let!(:lieu) { create(:lieu, organisation: organisation) }
-    let!(:user) { create(:user, first_name: "Marie", last_name: "Curie") }
+    let!(:marie) { create(:user, first_name: "Marie", last_name: "Curie") }
 
     # Setup the 3 existing RDVs: monday, tuesday and wednesday of next week at 09:00
     let!(:monday_of_next_week) { Time.zone.today.next_week.change(hour: 9) }
     let!(:tuesday_of_next_week) { monday_of_next_week + 1.day }
     let!(:wednesday_of_next_week) { tuesday_of_next_week + 1.day }
-    let!(:existing_rdv_the_day_before) { create(:rdv, users: [user], motif: motif, starts_at: monday_of_next_week) }
-    let!(:existing_rdv_same_day) { create(:rdv, users: [user], motif: motif, starts_at: tuesday_of_next_week) }
-    let!(:existing_rdv_the_day_after) { create(:rdv, users: [user], motif: motif, starts_at: wednesday_of_next_week) }
+    let!(:existing_rdv_the_day_before)  { create(:rdv, organisation: organisation, users: [marie], motif: motif, starts_at: monday_of_next_week) }
+    let!(:existing_rdv_same_day)        { create(:rdv, organisation: organisation, users: [marie], motif: motif, starts_at: tuesday_of_next_week) }
+    let!(:existing_rdv_the_day_after)   { create(:rdv, organisation: organisation, users: [marie], motif: motif, starts_at: wednesday_of_next_week) }
 
-    # Try to create a new RDV on tuesday at 14:00
-    let(:rdv) { build(:rdv, users: [user], motif: motif, starts_at: tuesday_of_next_week.change(hour: 14)) }
-
-    it "warns of existing RDV" do
+    it "warns of existing RDV with a benign error" do
       login_as(agent, scope: :agent)
 
+      # Try to create a new RDV on tuesday at 14:00
       route_params = {
         step: 3,
         rdv: {
-          starts_at: tuesday_of_next_week.beginning_of_day,
+          starts_at: tuesday_of_next_week.change(hour: 14),
           duration_in_min: 30,
-          service_id: motif.service_id,
           motif_id: motif.id,
           lieu_id: lieu.id,
           agent_ids: [agent.id],
-          user_ids: [user.id],
+          user_ids: [marie.id],
         },
       }
 
       visit admin_organisation_rdv_wizard_step_path(organisation, route_params)
 
-      user_path = "/admin/organisations/#{organisation.id}/users/#{user.id}"
+      user_path = "/admin/organisations/#{organisation.id}/users/#{marie.id}"
       expect(page.html).to include(%(L'usager⋅e <a href="#{user_path}">Marie CURIE</a> a un autre RDV pour le même motif le même jour))
+    end
+  end
+
+  context "when the RDV has the same motif, smae lieu, same agents and users and occurs at the same time" do
+    let!(:existing_rdv) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.next_week.change(hour: 9)) }
+
+    it "prevents creation with an error" do
+      login_as(agent, scope: :agent)
+
+      route_params = {
+        step: 3,
+        rdv: {
+          starts_at: existing_rdv.starts_at,
+          duration_in_min: existing_rdv.duration_in_min,
+          motif_id: existing_rdv.motif.id,
+          lieu_id: existing_rdv.lieu.id,
+          agent_ids: existing_rdv.agents.map(&:id),
+          user_ids: existing_rdv.users.map(&:id),
+          ignore_benign_errors: true,
+        },
+      }
+
+      visit admin_organisation_rdv_wizard_step_path(organisation, route_params)
+
+      expect(page).to have_content("Il existe déjà un RDV au même moment, au même lieu, pour le même motif, avec les mêmes participant⋅es")
     end
   end
 end

--- a/spec/features/agents/agent_cant_create_duplicate_rdv_spec.rb
+++ b/spec/features/agents/agent_cant_create_duplicate_rdv_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe "Agent can't create duplicate RDV" do
+  let!(:organisation) { create(:organisation) }
+  let!(:service) { create(:service) }
+  let!(:agent) { create(:agent, service: service, basic_role_in_organisations: [organisation]) }
+
+  context "when the user already has a RDV for the same motif on that same day" do
+    let!(:motif) { create(:motif, organisation: organisation, service: service) }
+    let!(:lieu) { create(:lieu, organisation: organisation) }
+    let!(:user) { create(:user, first_name: "Marie", last_name: "Curie") }
+
+    # Setup the 3 existing RDVs: monday, tuesday and wednesday of next week at 09:00
+    let!(:monday_of_next_week) { Time.zone.today.next_week.change(hour: 9) }
+    let!(:tuesday_of_next_week) { monday_of_next_week + 1.day }
+    let!(:wednesday_of_next_week) { tuesday_of_next_week + 1.day }
+    let!(:existing_rdv_the_day_before) { create(:rdv, users: [user], motif: motif, starts_at: monday_of_next_week) }
+    let!(:existing_rdv_same_day) { create(:rdv, users: [user], motif: motif, starts_at: tuesday_of_next_week) }
+    let!(:existing_rdv_the_day_after) { create(:rdv, users: [user], motif: motif, starts_at: wednesday_of_next_week) }
+
+    # Try to create a new RDV on tuesday at 14:00
+    let(:rdv) { build(:rdv, users: [user], motif: motif, starts_at: tuesday_of_next_week.change(hour: 14)) }
+
+    it "warns of existing RDV" do
+      login_as(agent, scope: :agent)
+
+      route_params = {
+        step: 3,
+        rdv: {
+          starts_at: tuesday_of_next_week.beginning_of_day,
+          duration_in_min: 30,
+          service_id: motif.service_id,
+          motif_id: motif.id,
+          lieu_id: lieu.id,
+          agent_ids: [agent.id],
+          user_ids: [user.id],
+        },
+      }
+
+      visit admin_organisation_rdv_wizard_step_path(organisation, route_params)
+
+      user_path = "/admin/organisations/#{organisation.id}/users/#{user.id}"
+      expect(page.html).to include(%(L'usager⋅e <a href="#{user_path}">Marie CURIE</a> a un autre RDV pour le même motif le même jour))
+    end
+  end
+end


### PR DESCRIPTION
Closes #1633 

Voici les deux validations ajoutées :
- un avertissement (que l'on peut ignorer) quand un RDV existe déjà pour l'usager⋅e le même jour pour le même motif
- un blocage (erreur de validation) si il existe en base un RDV strictement similaire

# L'avertissement

Voici se qui s'affiche si il existe déjà un RDV qui a :
- le/la **même usager⋅e**
- le **même motif**
- a lieu le **même jour** (pas forcément à la même heure)

![image](https://user-images.githubusercontent.com/6357692/176474301-cf44aa76-2a97-496e-b35f-46181c169bee.png)

Le comportement de cet avertissement est le même que les autres avertissements déjà en place.

# Le blocage

Voici se qui s'affiche si il existe déjà un RDV qui a :
- le/la **même usager⋅e**
- le/la **même agent⋅e**
- le **même motif**
- le **même lieu**
- le **même débute** et la **même fin**

![image](https://user-images.githubusercontent.com/6357692/176475131-efd710e2-c640-426d-a050-02ec799f7d89.png)

Il s'agit d'un erreur de validation qui est déclenchée sur les formulaires de "wizard" et d'édition, elle bloque l'enregistrement.

Je ne l'ai pas mise au niveau du modèle car je pense que ça pourrait nous gêner en s'appliquant à des contextes où on ne veut pas de cette validation.

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [x] Test sur la review app / en local
