### PR TITLE
Ajout de statistique d'activation des agents

### DIFF
--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module StatsHelper
+  def percent(number, total)
+    return "" if total.zero?
+
+    "#{(number * 100.0 / total).round}%"
+  end
+end

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -128,4 +128,3 @@
 
         - active_count = active_agents.joins(:rdvs).where(rdvs: {updated_at: 60.days.ago..30.days.ago}).distinct.count
         p #{percent(active_count, active_agents.count)} avaient été actifs les 30 derniers jours (#{active_count})
-

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -96,3 +96,36 @@
         - %i[event channel result].each do |attribute|
           h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
           = column_chart receipts_stats_path(group_by: attribute, departement: @departement), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "activations"
+          h2.card-title Activité des agents
+        - active_agents = @agents.active
+
+        h5 Aujourd'hui
+
+        p #{active_agents.count} agents ont été invités
+
+        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).count
+        p #{percent(accepted_count, active_agents.count)} ont accepté l'invitation (#{accepted_count})
+
+        - first_rdv_count = active_agents.joins(:rdvs).distinct.count
+        p #{percent(first_rdv_count, active_agents.count)} ont créé au moins un rdv (#{first_rdv_count})
+
+        - active_count = active_agents.joins(:rdvs).where("rdvs.updated_at > ?", 30.days.ago).distinct.count
+        p #{percent(active_count, active_agents.count)} ont été actifs les 30 derniers jours (ont créé ou modifié un rdv) (#{active_count})
+
+        h5 Il y a 30 jours
+
+        - active_agents = active_agents.where("invitation_sent_at < ?", 30.days.ago)
+        p #{active_agents.count} agents avaient été invités
+
+        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("invitation_accepted_at < ?", 30.days.ago).count
+        p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
+
+        - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
+        p #{percent(first_rdv_count, active_agents.count)} avaient créé au moins un rdv (#{first_rdv_count})
+
+        - active_count = active_agents.joins(:rdvs).where(rdvs: {updated_at: 60.days.ago..30.days.ago}).distinct.count
+        p #{percent(active_count, active_agents.count)} avaient été actifs les 30 derniers jours (#{active_count})
+


### PR DESCRIPTION
Cette PR ajoute de la visibilité sur les indicateurs utilisés par l'équipe CNFS pour mesurer l'adoption de RDV Solidarités par les agents

![Capture d’écran 2022-07-01 à 18 43 13](https://user-images.githubusercontent.com/1840367/176936457-4374e8c3-d095-4a58-ac2b-12f6890c83c6.png)

Pour faire un vrai graphe avec ces quatre pourcentages en stacked bar chart, ça commençait à faire du sql un peu compliqué, donc pour le moment on peut se contenter d'un indicateur qui nous donne les chiffres maintenant, et il y a 30 jours.

# Checklist

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
