### PR TITLE
Rend ce test correct le week-end aussi

### DIFF
--- a/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
+++ b/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
@@ -1,23 +1,32 @@
 # frozen_string_literal: true
 
 describe "Agent can see rdvs in their calendar", js: true do
-  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-  let(:organisation) { create(:organisation) }
-
-  before { login_as(agent, scope: :agent) }
-
   context "for a rdv collectif" do
-    let(:motif) { create(:motif, :collectif, organisation: organisation, service: agent.service, name: "Atelier collectif") }
-    let!(:rdv) do
-      create(:rdv, agents: [agent], motif: motif, organisation: organisation, name: "Traitement de texte",
-                   users: create_list(:user, 2), max_participants_count: 3, starts_at: starts_at)
-    end
-
-    let(:starts_at) do
-      Time.zone.today + 12.hours # This date is always visible on the calendar, so the spec is green no matter when it runs (we can't easily stub the time for the browser)
-    end
-
     it "shows the number of participants and the max number of participants" do
+      organisation = create(:organisation)
+      # display saturday to see 6 week days
+      agent = create(:agent, basic_role_in_organisations: [organisation], display_saturdays: true)
+      login_as(agent, scope: :agent)
+
+      # Use today because it not really easy to stub browser time
+      today = Time.zone.today
+      # force hour to be in visible agenda range
+      starts_at = Time.zone.parse("#{today.strftime('%F')} 14:00")
+      # move back one day ago one sunday
+      starts_at = 1.day.ago if today.strftime("%w").to_i > 6
+
+      motif = create(:motif, :collectif, organisation: organisation, service: agent.service, name: "Atelier collectif")
+      create(
+        :rdv,
+        agents: [agent],
+        motif: motif,
+        organisation: organisation,
+        name: "Traitement de texte",
+        users: create_list(:user, 2),
+        max_participants_count: 3,
+        starts_at: starts_at
+      )
+
       visit admin_organisation_agent_agenda_path(organisation, agent)
       expect(page).to have_content("Atelier collectif : Traitement de texte (2/3)")
     end


### PR DESCRIPTION
Il m'arrive de lancer des tests le week-end, et celui-ci tombe toujours en panne...

J'ai également remanié le test pour le rendre plus lisible (pour moi).
Ça mérite sans doute une bonne discussion tech.

Je pose ici des éléments en duplication du pad tech.

Un fil stackoverflow regroupe la plupart des points d'entrée que j'ai
rencontré à travers le temps

https://stackoverflow.com/questions/12869026/what-is-the-argument-against-using-before-let-and-subject-in-rspec-tests

On y retrouve
- [Let's not](https://thoughtbot.com/blog/lets-not)
- [ThougthBot StyleGuide](https://github.com/thoughtbot/guides/blob/40090e22f298c380a51b958cb9d6454e1cd4f700/README.md)
- [Commit's discussion @thoughbot](https://github.com/thoughtbot/guides/commit/04b6e2ea8597ae46b24247b96da9b04645478fa0#r1906596)
- [Mystery Guest](https://thoughtbot.com/blog/mystery-guest)

J'ajoute cet article de Lewis Jones [Is the RSpec DSL making your tests harder to read?](https://ljones140.hashnode.dev/is-the-rspec-dsl-making-your-tests-harder-to-read)

Même la [doc de RSpec évoque un point d'attention sur l'utilisation abusive de Let (plus de 3
décalaration)](https://www.rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FMemoizedHelpers%2FClassMethods%3Alet)

