### PR TITLE
Correctif pour les stats d'activation

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -112,8 +112,8 @@
         - first_rdv_count = active_agents.joins(:rdvs).distinct.count
         p #{percent(first_rdv_count, active_agents.count)} ont créé au moins un rdv (#{first_rdv_count})
 
-        - active_count = active_agents.joins(:rdvs).where("rdvs.updated_at > ?", 30.days.ago).distinct.count
-        p #{percent(active_count, active_agents.count)} ont été actifs les 30 derniers jours (ont créé ou modifié un rdv) (#{active_count})
+        - active_count = active_agents.joins(:rdvs).where("rdvs.created_at > ?", 30.days.ago).distinct.count
+        p #{percent(active_count, active_agents.count)} ont créé un rdv les 30 derniers jours (#{active_count})
 
         h5 Il y a 30 jours
 
@@ -126,5 +126,5 @@
         - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
         p #{percent(first_rdv_count, active_agents.count)} avaient créé au moins un rdv (#{first_rdv_count})
 
-        - active_count = active_agents.joins(:rdvs).where(rdvs: {updated_at: 60.days.ago..30.days.ago}).distinct.count
-        p #{percent(active_count, active_agents.count)} avaient été actifs les 30 derniers jours (#{active_count})
+        - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
+        p #{percent(active_count, active_agents.count)} avaient créé un rdv les 30 derniers jours précédents (#{active_count})


### PR DESCRIPTION
On utilisait les `updated_at`, qui peuvent être modifiés, ce qui donnait des stats faussées

## Avant

![Capture d’écran 2022-07-07 à 11 47 56](https://user-images.githubusercontent.com/1840367/177746038-d2ea9da9-4843-4e91-a3c1-98393e674869.png)

## Après

![Capture d’écran 2022-07-07 à 11 47 42](https://user-images.githubusercontent.com/1840367/177746042-04329102-08a2-46bf-b2ff-a38cfd749933.png)

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
