### PR TITLE
ajoute une première passe sur le budget

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -6,4 +6,6 @@ class StaticPagesController < ApplicationController
   def accessibility; end
 
   def contact; end
+
+  def budget; end
 end

--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -20,6 +20,7 @@
         li.mb-1 = link_to "Les solidarités dans votre département", mds_path
         li.mb-1 = link_to "Espace professionnel", accueil_mds_path
         li.mb-1 = link_to "Statistiques", stats_path
+        li.mb-1 = link_to "Budget", budget_path
     .col-6.col-md
       h2 Produit
       ul.list-unstyled.text-small

--- a/app/views/static_pages/budget.html.slim
+++ b/app/views/static_pages/budget.html.slim
@@ -1,0 +1,14 @@
+- content_for :title do
+  h1 Budget
+
+.container.mt-3
+  .row.align-items-center.mb-4.content
+    .col-lg-8
+      h2 Liste des bons de commande et des montants associé
+
+      ul
+        li 498 600 € TTC le 3 mai 2022
+        li 306 000 € TTC le 3 décembre 2021
+        li 180 000 € TTC le 22 juin 2021
+
+      | Soit 984 600 TTC depuis le 22 juin 2021

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,7 +218,7 @@ Rails.application.routes.draw do
     root to: "admin/organisations#index", as: :authenticated_agent_root, defaults: { follow_unique: "1" }
   end
 
-  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite].each do |page_name|
+  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite budget].each do |page_name|
     get page_name => "static_pages##{page_name}"
   end
 


### PR DESCRIPTION
Suite à une discussion au Forum Ouvert de BetaGouv, nous avons reparlé de la transparence et de la publication du budget. Je ne savais pas trop comment amorcer la chose.

Cette PR est une première étape où l'on affiche les montants des bons de commandes (depuis le passage à Scopyleft). 

Une prochaine étape intéressante serait de récupérer les anciens bon de commande Octo pour remonter au démarrage du projet (ils sont dans le nextcloud ?)