### PR TITLE
Afficher les instructions de RDV au moment du choix du motif

### DIFF
--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -21,21 +21,11 @@ div id="creneaux-lieu-#{lieu.id}"
             - if creneaux_for_date.any? && creneaux_for_date[date].first.respects_max_booking_delay?
               - creneaux_for_date.each do |date, creneaux|
                 - creneaux.sort_by(&:starts_at).each do |creneau|
-                  - if creneau.motif.restriction_for_rdv.blank?
-                    = link_to new_users_rdv_wizard_step_path(query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100", aria: { label: "Choisir le créneau de #{l(creneau.starts_at, format: '%H:%M')}"} do
-                      = l(creneau.starts_at, format: "%H:%M")
-                      - if creneau.motif.follow_up?
-                        br
-                        small= creneau.agent.short_name
-                  - else
-                    = link_to "#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{creneau.starts_at.to_i}" }, class: "btn btn-light mr-1 mb-1 w-100" do
-                      = l(creneau.starts_at, format: "%H:%M")
-                      - if creneau.motif.follow_up?
-                        br
-                        small= creneau.agent.short_name
-
-                    =  render "/common/modal", id: "js-rdv-restriction-motif#{creneau.starts_at.to_i}" , title: "À lire avant de prendre un rendez-vous", confirm_path: new_users_rdv_wizard_step_path(query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)) do
-                      = ActionController::Base.helpers.auto_link(simple_format(creneau.motif.restriction_for_rdv), html: { target: "_blank"})
+                  = link_to new_users_rdv_wizard_step_path(query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100", aria: { label: "Choisir le créneau de #{l(creneau.starts_at, format: '%H:%M')}"} do
+                    = l(creneau.starts_at, format: "%H:%M")
+                    - if creneau.motif.follow_up?
+                      br
+                      small= creneau.agent.short_name
             - elsif date >= (Time.now + max_booking_delay.seconds).to_date
               p.text-center.text-muted
                 | Date fermée à la reservation

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -17,10 +17,11 @@ section.bg-light.p-4
       h2.font-weight-bold Sélectionnez le motif de votre RDV :
       - context.unique_motifs_by_name_and_location_type.each do |motif|
         .card.mb-3
-          = link_to root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))
-            .card-body
-              .row
-                .col-md
-                  h3.card-title.mb-3.mt-0.text-success.font-weight-bold= motif.name
-                  .card-subtitle= motif.human_attribute_value(:location_type)
-                  .card-subtitle= motif.service.name
+          - if motif.restriction_for_rdv.blank?
+            = link_to(root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+              = render "motif_selection_card", motif: motif
+          - else
+            = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
+              = render "motif_selection_card", motif: motif
+            = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
+              = ActionController::Base.helpers.auto_link(simple_format(motif.restriction_for_rdv), html: { target: "_blank"})

--- a/app/views/search/_motif_selection_card.html.slim
+++ b/app/views/search/_motif_selection_card.html.slim
@@ -1,0 +1,6 @@
+.card-body
+  .row
+    .col-md
+      h3.card-title.mb-3.mt-0.text-success.font-weight-bold= motif.name
+      .card-subtitle= motif.human_attribute_value(:location_type)
+      .card-subtitle= motif.service.name

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -25,7 +25,9 @@ describe "User can be invited" do
   let!(:organisation) { create(:organisation, territory: territory26) }
   let!(:motif) { create(:motif, name: "RSA orientation sur site", reservable_online: true, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
+  let!(:autre_lieu) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
+  let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: autre_lieu, organisation: organisation) }
 
   let!(:organisation2) { create(:organisation) }
 
@@ -52,11 +54,6 @@ describe "User can be invited" do
       # Creneau selection
       expect(page).to have_content(lieu.name)
       first(:link, "11:00").click
-
-      # Restriction Page
-      expect(page).to have_content("À lire avant de prendre un rendez-vous")
-      expect(page).to have_content(motif.restriction_for_rdv)
-      click_link("Accepter")
 
       # RDV informations
       expect(page).to have_content("Vos informations")
@@ -126,6 +123,11 @@ describe "User can be invited" do
       expect(page).to have_content(motif2.name)
       find(".card-title", text: /#{motif.name}/).click
 
+      # Restriction Page
+      expect(page).to have_content("À lire avant de prendre un rendez-vous")
+      expect(page).to have_content(motif.restriction_for_rdv)
+      click_link("Accepter")
+
       # Lieu selection
       expect(page).to have_content(lieu.name)
       find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
@@ -133,11 +135,6 @@ describe "User can be invited" do
       # Creneau selection
       expect(page).to have_content(lieu.name)
       first(:link, "11:00").click
-
-      # Restriction Page
-      expect(page).to have_content("À lire avant de prendre un rendez-vous")
-      expect(page).to have_content(motif.restriction_for_rdv)
-      click_link("Accepter")
 
       # RDV informations
       expect(page).to have_content("Vos informations")
@@ -182,6 +179,11 @@ describe "User can be invited" do
       expect(page).to have_content(motif2.name)
       find(".card-title", text: /#{motif.name}/).click
 
+      # Restriction Page
+      expect(page).to have_content("À lire avant de prendre un rendez-vous")
+      expect(page).to have_content(motif.restriction_for_rdv)
+      click_link("Accepter")
+
       # Lieu selection
       expect(page).to have_content(lieu.name)
       find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
@@ -189,11 +191,6 @@ describe "User can be invited" do
       # Crenenau selection
       expect(page).to have_content(lieu.name)
       first(:link, "11:00").click
-
-      # Restriction Page
-      expect(page).to have_content("À lire avant de prendre un rendez-vous")
-      expect(page).to have_content(motif.restriction_for_rdv)
-      click_link("Accepter")
 
       # RDV informations
       expect(page).to have_content("Vos informations")

--- a/spec/features/users/user_can_search_for_creneaux_spec.rb
+++ b/spec/features/users/user_can_search_for_creneaux_spec.rb
@@ -10,7 +10,7 @@ describe "User can search for creneaux" do
   before { travel_to(now) }
 
   context "when the next creneau is after the max booking delay" do
-    let!(:motif) { create(:motif, name: "Vaccination", reservable_online: true, organisation: organisation, max_booking_delay: 7.days) }
+    let!(:motif) { create(:motif, name: "Vaccination", reservable_online: true, organisation: organisation, max_booking_delay: 7.days, restriction_for_rdv: nil) }
     # Avec un seul motif on passe par le choix d'un lieu.
     # Avec deux motifs, on affiche directement la disponibilité.
     let!(:autre_motif) { create(:motif, reservable_online: true, organisation: organisation, max_booking_delay: 7.days) }


### PR DESCRIPTION
Pour faire la recette : https://production-rdv-solidarites-pr2634.osc-secnum-fr1.scalingo.io/
Closes #1790

Avant, les instructions paramétrées sur le motif apparaissaient dans une pop-up au moment de la sélection du crénaux.

![image](https://user-images.githubusercontent.com/60173782/178271820-9b23574a-972c-4d08-bfa9-a1df9dd13543.png)


Maintenant, elle apparaissent juste après la sélection du motif.

![image](https://user-images.githubusercontent.com/60173782/178271885-b3c1ff3a-2598-4217-b85a-7c2eeca49bcc.png)


# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
