### PR TITLE
2458 reinitialisation filtres select

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -118,7 +118,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def parsed_params
-    params.permit(:organisation_id, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :start, :end,
+    params.permit(:organisation_id, :agent_id, :user_id, :lieu_id, :motif_id, :status, :show_user_details, :start, :end,
                   lieu_attributes: %i[name address latitude longitude]).to_hash.to_h do |param_name, param_value|
       case param_name
       when "start", "end"

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -3,7 +3,7 @@
 class Admin::RdvSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details
+  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :motif_id
 
   def organisation
     @organisation ||= Organisation.find(organisation_id) if organisation_id.present?
@@ -19,6 +19,10 @@ class Admin::RdvSearchForm
 
   def lieu
     @lieu ||= Lieu.find(lieu_id) if lieu_id.present?
+  end
+
+  def motif
+    @motif ||= Motif.find(motif_id) if motif_id.present
   end
 
   def to_query

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -3,7 +3,7 @@
 class Admin::RdvSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :motif_id
+  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :motif_id,
 
   def organisation
     @organisation ||= Organisation.find(organisation_id) if organisation_id.present?
@@ -21,12 +21,8 @@ class Admin::RdvSearchForm
     @lieu ||= Lieu.find(lieu_id) if lieu_id.present?
   end
 
-  def motif
-    @motif ||= Motif.find(motif_id) if motif_id.present
-  end
-
   def to_query
-    %i[organisation_id start end agent_id user_id status show_user_details lieu_id]
+    %i[organisation_id start end agent_id user_id status show_user_details lieu_id motif_id]
       .map { [_1, send(_1)] }.to_h
   end
 end

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -3,7 +3,7 @@
 class Admin::RdvSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :motif_id,
+  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :motif_id
 
   def organisation
     @organisation ||= Organisation.find(organisation_id) if organisation_id.present?

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -206,6 +206,7 @@ class Rdv < ApplicationRecord
       rdvs = rdvs.joins(:motif).where(motifs: { service: agent.service })
     end
     rdvs = rdvs.joins(:lieu).where(lieux: { id: options["lieu_id"] }) if options["lieu_id"].present?
+    rdvs = rdvs.joins(:motif).where(motifs: { id: options["motif_id"] }) if options["motif_id"].present?
     rdvs = rdvs.joins(:agents).where(agents: { id: options["agent_id"] }) if options["agent_id"].present?
     rdvs = rdvs.joins(:rdvs_users).where(rdvs_users: { user_id: options["user_id"] }) if options["user_id"].present?
     rdvs = rdvs.status(options["status"]) if options["status"].present?

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -44,6 +44,7 @@
               label: "Statut", wrapper: "horizontal_form", input_html: { class: "select2-input" }
       = date_input(f, :start, label = "Période - Début", wrapper: "horizontal_form")
       = date_input(f, :end, label = "Période - Fin", wrapper: "horizontal_form")
-  input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste" name="search"
-  - search = params[:search].blank? ? "d-none" : ""
-  = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "btn btn-link #{search}"
+  .d-flex.justify-content-end
+    - search = params[:search].blank? ? "d-none" : ""
+    = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "btn btn-link #{search}"
+    input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste" name="search"

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -44,4 +44,6 @@
               label: "Statut", wrapper: "horizontal_form", input_html: { class: "select2-input" }
       = date_input(f, :start, label = "Période - Début", wrapper: "horizontal_form")
       = date_input(f, :end, label = "Période - Fin", wrapper: "horizontal_form")
-  input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste"
+  input.btn.btn-primary.d-print-none type="submit" value="Rafraîchir la liste" name="search"
+  - search = params[:search].blank? ? "d-none" : ""
+  = link_to "Réinitialiser", admin_organisation_rdvs_path(current_organisation), class: "btn btn-link #{search}"

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -38,6 +38,7 @@
       = f.input :lieu_id, collection: policy_scope(Lieu).enabled.order(:name), label: "Lieu", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
       = f.input :show_user_details, as: :boolean, wrapper: "horizontal_form", label: "Détails usagers"
     .col-md-6
+      = f.input :motif_id, collection: policy_scope(Motif), label: "Motifs", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
       - temporal_statuses = Rdv.statuses.keys - ["unknown"] + ["unknown_past", "unknown_future"]
       = f.input :status, collection: temporal_statuses,
               label_method: -> { ::Rdv.human_attribute_value(:status, _1, disable_cast: true) },

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -13,14 +13,17 @@ describe Admin::RdvSearchForm do
     it "return query with lieu" do
       organisation = create(:organisation)
       lieu = create(:lieu, organisation: organisation)
+      motif = create(:motif, organisation: organisation)
 
-      agent_rdv_search_form = described_class.new(organisation_id: organisation.id, lieu_id: lieu.id)
+      agent_rdv_search_form = described_class.new(organisation_id: organisation.id, lieu_id: lieu.id, motif_id: motif.id)
+
       expected_query = {
         agent_id: nil,
         start: nil,
         end: nil,
         organisation_id: organisation.id,
         lieu_id: lieu.id,
+        motif_id: motif.id,
         show_user_details: nil,
         status: nil,
         user_id: nil,

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -425,6 +425,17 @@ describe Rdv, type: :model do
   end
 
   describe "#search_for" do
+    it "returns allowed rdvs even with blank option" do
+      organisation = create(:organisation)
+      other_organisation = create(:organisation)
+      admin = create(:agent, admin_role_in_organisations: [organisation, other_organisation])
+      rdv = create(:rdv, organisation: organisation)
+      create(:rdv, organisation: other_organisation)
+
+      options = { lieu_id: "" }
+      expect(described_class.search_for(admin, organisation, options)).to eq([rdv])
+    end
+
     it "returns allowed rdvs" do
       organisation = create(:organisation)
       other_organisation = create(:organisation)

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -447,6 +447,18 @@ describe Rdv, type: :model do
       expect(described_class.search_for(admin, organisation, options)).to eq([rdv])
     end
 
+    it "returns rdv for motif when given" do
+      organisation = create(:organisation)
+      admin = create(:agent, admin_role_in_organisations: [organisation])
+      motif = create(:motif, organisation: organisation, service: admin.service)
+      autre_motif = create(:motif, organisation: organisation, service: admin.service)
+      rdv = create(:rdv, motif: motif, organisation: organisation)
+      create(:rdv, motif: autre_motif, organisation: organisation)
+
+      options = { "motif_id" => motif.id }
+      expect(described_class.search_for(admin, organisation, options)).to eq([rdv])
+    end
+
     it "returns rdv for given agent" do
       organisation = create(:organisation)
       admin = create(:agent, admin_role_in_organisations: [organisation])


### PR DESCRIPTION
Pour faire la recette : https://production-rdv-solidarites-pr2635.osc-secnum-fr1.scalingo.io/
Closes #2458
Closes #2435 

Mise en place d'un lien de réinitialisation des champs de recherche d'un RDV.
Possibilité de rechercher par motifs

# Captures d'écran : 

avant 

![image](https://user-images.githubusercontent.com/60173782/178213885-1dc66b01-8bd6-4f4d-a437-92ba2b41b03a.png)


après

![image](https://user-images.githubusercontent.com/60173782/178213633-6456deef-a0f2-4527-9954-69df27002798.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
