### PR TITLE
Tri les territoires sur leur nom

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -72,7 +72,7 @@ class Territory < ApplicationRecord
   end
 
   def to_s
-    [departement_number.presence, name].compact.join(" - ")
+    [name, departement_number.presence].compact.join(" - ")
   end
 
   private

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -123,6 +123,6 @@
         = "#{@territories.count} structures utilisent RDV-Solidarités"
       .card-body
         ul
-          - @territories.each do |territory|
+          - @territories.order(:name).each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -85,7 +85,7 @@ describe Territory, type: :model do
   describe "#to_s" do
     it "returns name and departement number if exist" do
       territory = build(:territory, departement_number: "93", name: "Seine Saint-Denis")
-      expect(territory.to_s).to eq("93 - Seine Saint-Denis")
+      expect(territory.to_s).to eq("Seine Saint-Denis - 93")
     end
 
     it "returns name" do


### PR DESCRIPTION
Dans la PR #2593 nous avons changé l'affichage de la liste des territoires pour privilégier le nom.

Dans cette PR, nous trions les territoires sur leur nom et déplaçons le numéro de département en suffixe histoire de ne pas rendre le tri trop étrange.

ref #2593

Avant 

![Screenshot 2022-07-11 at 18-39-54 Statistiques - RDV Solidarités](https://user-images.githubusercontent.com/42057/178314635-b7d3016b-eacc-4729-8ca3-f16400309840.png)

Après

![Screenshot 2022-07-11 at 18-39-40 Statistiques - RDV Solidarités](https://user-images.githubusercontent.com/42057/178314678-58da0d9a-14cf-44c0-a488-b436b8ae4a90.png)




Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
