### PR TITLE
Petites améliorations à la synchronisation d'agenda

### DIFF
--- a/app/controllers/agents/calendar_sync_controller.rb
+++ b/app/controllers/agents/calendar_sync_controller.rb
@@ -24,6 +24,6 @@ class Agents::CalendarSyncController < AgentAuthController
   private
 
   def new_calendar_uid(agent)
-    "#{agent.full_name.parameterize}#{SecureRandom.uuid}"
+    "#{agent.full_name.parameterize}-#{SecureRandom.uuid}"
   end
 end

--- a/app/controllers/agents/calendar_sync_controller.rb
+++ b/app/controllers/agents/calendar_sync_controller.rb
@@ -7,17 +7,23 @@ class Agents::CalendarSyncController < AgentAuthController
 
   def show
     @agent = current_agent
-    @agent.update!(calendar_uid: SecureRandom.uuid) if @agent.calendar_uid.nil?
+    @agent.update!(calendar_uid: new_calendar_uid(current_agent)) if @agent.calendar_uid.nil?
     authorize @agent
   end
 
   def update
     authorize current_agent
-    current_agent.update!(calendar_uid: SecureRandom.uuid)
+    current_agent.update!(calendar_uid: new_calendar_uid(current_agent))
     redirect_to agents_calendar_sync_path, flash: { notice: "Votre url de calendrier a été mise à jour." }
   end
 
   def pundit_user
     AgentContext.new(current_agent)
+  end
+
+  private
+
+  def new_calendar_uid(agent)
+    "#{agent.full_name.parameterize}#{SecureRandom.uuid}"
   end
 end

--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -11,7 +11,7 @@ p
 p Tous vos rendez-vous de RDV Solidarités seront copiés automatiquement au fur et à mesure de leur création (ou modification).
 p.mb-4
   | Cette fonctionnalité est encore expérimentale. N'hésitez pas à nous faire part de vos retours à l'adresse
-  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchro d'agenga").html_safe}.
+  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchro d'agenda").html_safe}.
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 

--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -11,7 +11,7 @@ p
 p Tous vos rendez-vous de RDV Solidarités seront copiés automatiquement au fur et à mesure de leur création (ou modification).
 p.mb-4
   | Cette fonctionnalité est encore expérimentale. N'hésitez pas à nous faire part de vos retours à l'adresse
-  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchro de calendriers").html_safe}.
+  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchro d'agenga").html_safe}.
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -2,7 +2,7 @@ fr:
   agents:
     calendar_sync:
       show:
-        title: Synchronisation avec un calendrier externe
+        title: Synchronisation avec un agenda externe
     preferences:
       show:
         title: Préférences de notifications

--- a/spec/features/agents/calendar_export_spec.rb
+++ b/spec/features/agents/calendar_export_spec.rb
@@ -10,7 +10,7 @@ describe "Agents can export their calendar to other tools, such as Outlook or Go
 
     visit agents_calendar_sync_path
 
-    webcal_url = "webcal://#{Capybara.server_host}:#{Capybara.server_port}/calendrier/remi-nom-d-agent#{uid}.ics"
+    webcal_url = "webcal://#{Capybara.server_host}:#{Capybara.server_port}/calendrier/remi-nom-d-agent-#{uid}.ics"
 
     expect(page).to have_link(webcal_url)
 

--- a/spec/features/agents/calendar_export_spec.rb
+++ b/spec/features/agents/calendar_export_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 describe "Agents can export their calendar to other tools, such as Outlook or Google calendar" do
-  it "allows resetting the link" do
+  it "allows resetting the link and shows the agent's name in the link to make it clear that it's their info" do
     uid = "37b24280-7015-4a8a-b752-907e33171106"
     allow(SecureRandom).to receive(:uuid).and_return(uid)
     organisation = create(:organisation)
-    agent = create(:agent, basic_role_in_organisations: [organisation])
+    agent = create(:agent, basic_role_in_organisations: [organisation], first_name: "Rémi", last_name: "NOM D'AGENT")
     login_as(agent, scope: :agent)
 
     visit agents_calendar_sync_path
 
-    webcal_url = "webcal://#{Capybara.server_host}:#{Capybara.server_port}/calendrier/#{uid}.ics"
+    webcal_url = "webcal://#{Capybara.server_host}:#{Capybara.server_port}/calendrier/remi-nom-d-agent#{uid}.ics"
 
     expect(page).to have_link(webcal_url)
 


### PR DESCRIPTION
Après une première démo à Myriam, on a déjà deux petites améliorations à faire sur les synchronisatiosn d'agenda :
- Ajouter le nom de l'agent dans l'url pour clarifier que les données exportées sont celles de son agenda. Il y avait une confusion sur quel lien envoyer aux référentes, donc le fait d'ajouter explicitement un nom dans cette url rend les choses plus claires
- Utiliser tout le temps le terme "agenda externe", et non pas "calendrier externe".


## Avant :

<img width="503" alt="Capture d’écran 2022-07-12 à 15 59 18" src="https://user-images.githubusercontent.com/1840367/178507820-d2302c9d-fa83-4c4b-92e2-a6e5c889b645.png">

## Après

<img width="530" alt="Capture d’écran 2022-07-12 à 15 59 07" src="https://user-images.githubusercontent.com/1840367/178507778-174dee98-1df2-4262-8e63-a7af516a3970.png">


# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
