### PR TITLE
Correction des liens sur la page de support

### DIFF
--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -47,12 +47,9 @@
           i.fa.fa-file-alt
       .card-body
         ul
-          li= link_to "https://doc.rdv-solidarites.fr/mentions-legales" do
+          li= link_to mentions_legales_path do
             span> Mentions Légales
-            i.fa.fa-external-link-alt
-          li= link_to "https://doc.rdv-solidarites.fr/conditions-dutilisation-de-la-plateforme-rdv-solidarites" do
+          li= link_to cgu_path do
             span> C.G.U.
-            i.fa.fa-external-link-alt
-          li= link_to "https://doc.rdv-solidarites.fr/politique-de-confidentialite" do
+          li= link_to politique_de_confidentialite_path do
             span> Politique de confidentialité
-            i.fa.fa-external-link-alt

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -36,10 +36,7 @@ html lang="fr"
                 i.fa.fa-external-link-alt
               = link_to mentions_legales_path do
                 span> Mentions Légales
-                i.fa.fa-external-link-alt
               = link_to cgu_path do
                 span> C.G.U.
-                i.fa.fa-external-link-alt
               = link_to politique_de_confidentialite_path do
                 span> Politique de confidentialité
-                i.fa.fa-external-link-alt

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -22,6 +22,5 @@ html
               table width="100%"
                 tr
                   td.aligncenter.content-block
-                    = link_to "https://doc.rdv-solidarites.fr/mentions-legales" do
+                    = link_to mentions_legales_url do
                       span> Mentions Légales
-                      i.fa.fa-external-link-alt

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -18,7 +18,7 @@
       .form-group
         small
         span> En vous inscrivant, vous acceptez les
-        = link_to "conditions générales d'utilisation", "https://doc.rdv-solidarites.fr/conditions-dutilisation-de-la-plateforme-rdv-solidarites"
+        = link_to("conditions générales d'utilisation", cgu_path)
 
       .form-group.mb-0.text-center
         = f.button :submit, "Je m'inscris"


### PR DESCRIPTION
On avait oublié de corriger ces liens quand on a déplacé ces pages depuis la doc vers l'appli.
J'en ai profité pour chercher les autres liens vers la doc et les corriger.

Avant :
![Capture d’écran 2022-07-13 à 11 02 17](https://user-images.githubusercontent.com/1840367/178694944-2a31eb32-b840-41d0-b4fe-8101f743b211.png)

Après :
![Capture d’écran 2022-07-13 à 11 05 39](https://user-images.githubusercontent.com/1840367/178695583-60aac83c-c12e-4ff7-89ab-6350f3006cf9.png)


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
