### PR TITLE
#2547 Crash lors de la recherche de créneau : "PG::DataException: range lower bound must...

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -3,9 +3,6 @@
 class Admin::Creneaux::AgentSearchesController < AgentAuthController
   respond_to :html, :js
 
-  # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3270502722
-  before_action :log_params_to_sentry, only: %i[index]
-
   def index
     @form = helpers.build_agent_creneaux_search_form(current_organisation, params)
     @search_results = search_results

--- a/app/javascript/components/datetimepicker.js
+++ b/app/javascript/components/datetimepicker.js
@@ -5,29 +5,40 @@ $.datetimepicker.setLocale('fr');
 class Datetimepicker {
 
   constructor() {
-    $("[data-behaviour='datepicker']").datetimepicker({
-      format:'d/m/Y',
-      timepicker:false,
-      mask: true,
-      scrollMonth: false,
-      scrollInput: false,
-      dayOfWeekStart: 1,
-      onChangeDateTime: (_, $input) => { $input[0].dispatchEvent(new CustomEvent("change")); } // forces hooks to execute
+    document.querySelectorAll("[data-behaviour='datepicker']").forEach(input => {
+      $(input).datetimepicker({
+        format:'d/m/Y',
+        timepicker:false,
+        mask: true,
+        scrollMonth: false,
+        scrollInput: false,
+        dayOfWeekStart: 1,
+        onChangeDateTime: (_, $input) => { $input[0].dispatchEvent(new CustomEvent("change")); }, // forces hooks to execute
+        ...input.dataset,
+      });
     });
-    $("[data-behaviour='datetimepicker']").datetimepicker({
-      format:'d/m/Y H:i',
-      mask: false,
-      step: 5,
-      scrollMonth: false,
-      scrollInput: false,
-      dayOfWeekStart: 1,
+
+    document.querySelectorAll("[data-behaviour='datetimepicker']").forEach(input => {
+      $(input).datetimepicker({
+        format:'d/m/Y H:i',
+        mask: false,
+        step: 5,
+        scrollMonth: false,
+        scrollInput: false,
+        dayOfWeekStart: 1,
+        ...input.dataset,
+      });
     });
-    $("[data-behaviour='timepicker']").datetimepicker({
-      format:'H:i',
-      step: 5,
-      datepicker: false,
-      mask: true,
-      scrollInput: false,
+
+    document.querySelectorAll("[data-behaviour='timepicker']").forEach(input => {
+      $(input).datetimepicker({
+        format:'H:i',
+        step: 5,
+        datepicker: false,
+        mask: true,
+        scrollInput: false,
+        ...input.dataset,
+      });
     });
   }
 }

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -13,7 +13,6 @@ module Lapin
 
       def ensure_date_range_with_time(date_range)
         time_begin = date_range.begin.instance_of?(Date) ? date_range.begin.beginning_of_day : date_range.begin.to_time
-        time_begin = Time.zone.now if time_begin < Time.zone.now
         time_end = date_range.end.instance_of?(Date) ? date_range.end.end_of_day : date_range.end.to_time
 
         time_begin..time_end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -96,9 +96,10 @@ module RecurrenceConcern
 
   # The `only_future` param was introduced to circumvent performance
   # issues with Montrose's occurrence generation.
-  # It uses a cached value of the next occurrence as a starting point
+  # It uses a recent occurrence as a starting point
   # when computing future occurrences, which is faster
   # than starting form the very first occurrence.
+  # The value of a recent occurrence is computed and cached in #earliest_future_occurrence_time.
   # Warning: using `only_future: true` will only yield future occurrences, not past ones.
   def occurrence_start_at_list_for(inclusive_date_range, only_future:)
     min_until = [inclusive_date_range.end, recurrence_ends_at].compact.min.end_of_day

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -36,7 +36,8 @@
               class: "js-filtered-motifs", \
             }
         .col-md-4
-          = date_input(f, :from_date, label = "À partir du", required: true)
+          - input_html = { data: { "min-date": Time.zone.today.strftime("%d/%m/%Y") } } # prevent from selecting past dates
+          = date_input(f, :from_date, "À partir du", input_html: input_html, required: true)
       .row
         - if @teams.any?
           .col-md-4

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -36,16 +36,6 @@ describe Lapin::Range do
         expect(subject).to eq(expected_range)
       end
     end
-
-    context "when the lower bound is before now" do
-      let!(:lower_bound) { "2021-12-09 11:00".to_datetime }
-      let!(:higher_bound) { "2021-12-21 18:00".to_datetime }
-
-      it "takes now as a lower_bound" do
-        expected_range = now..higher_bound
-        expect(subject).to eq(expected_range)
-      end
-    end
   end
 
   describe "#reduce_range_to_delay" do


### PR DESCRIPTION
Closes #2547

Ce crash avait lieux lorsque l'on faisait une recherche de créneau avec un date "À partir du" il y a 7 jours ou plus. Nous avions dès lors un `Range` "inversé", c'est à dire avec un début ultérieur à la fin. Ceci était cause par [cette ligne](https://github.com/betagouv/rdv-solidarites.fr/blob/4bb223234acb4a688c4c214be378e59bbaaaa92a/app/lib/lapin/range.rb#L16).

La ligne en question a été ajoutée dans cd8ee2ff87fec99c181ce5bc131d3ce678ea87a0, sans trop d'explication sur le pourquoi, mais on pourrait supposer que c'est pour éviter d'avoir des résultats dans le passé lorsque l'on cherche des créneau. 

Mais, en creusant, on réalise qu'il y a aussi d'autres endroits où l'on s'assure (plus ou moins rigoureusement) de retirer les créneaux passés :
- [dans le `SlotBuilder` ici](https://github.com/betagouv/rdv-solidarites.fr/blob/d4a664e6efb0107eef4f76b3498e0c4c366fb022/app/services/slot_builder.rb#L44)
- dans un filtre que l'on fait en [excluant les plages d'ouvertures expirées](https://github.com/betagouv/rdv-solidarites.fr/blob/d4a664e6efb0107eef4f76b3498e0c4c366fb022/app/services/slot_builder.rb#L14)


# Côté front

J'ai fait en sorte de désactiver les dates passées via le paramètre `minDate` de [jQuery DateTimePicker](https://xdsoft.net/jqplugins/datetimepicker/#mindate).

## Avant

![image](https://user-images.githubusercontent.com/6357692/178750676-f29b9aa6-de74-4a09-bccb-e18c4f1e17f9.png)

## Après

![image](https://user-images.githubusercontent.com/6357692/178750697-babbd893-50b9-46c6-a6d3-6d694f271c29.png)

# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
