### PR TITLE
Affichage du motif dans l'export de calendrier

### DIFF
--- a/app/controllers/ics_calendar_controller.rb
+++ b/app/controllers/ics_calendar_controller.rb
@@ -41,7 +41,7 @@ class IcsCalendarController < ActionController::Base
         event.status = rdv.cancelled? ? "CANCELLED" : "CONFIRMED"
 
         event.uid = rdv.uuid
-        event.summary = "RDV via RDV Solidarités"
+        event.summary = rdv.collectif? ? rdv_title_in_agenda(rdv) : rdv.motif.name
         event.description = "plus d'infos dans RDV Solidarités: #{admin_organisation_rdv_url(rdv.organisation, rdv.id)}"
       end
     end

--- a/app/controllers/ics_calendar_controller.rb
+++ b/app/controllers/ics_calendar_controller.rb
@@ -2,6 +2,8 @@
 
 # rubocop:disable Rails/ApplicationController
 class IcsCalendarController < ActionController::Base
+  include RdvsHelper
+
   def show
     @agent = Agent.find_by(calendar_uid: params[:id])
 

--- a/spec/features/agents/calendar_export_spec.rb
+++ b/spec/features/agents/calendar_export_spec.rb
@@ -39,8 +39,12 @@ describe "Agents can export their calendar to other tools, such as Outlook or Go
     travel_to(Time.zone.local(2022, 7, 8))
     org = create(:organisation, id: 123_000)
     agent = create(:agent, calendar_uid: SecureRandom.uuid, first_name: "Marceau", last_name: "COLIN")
-    create(:rdv, agents: [agent], status: "unknown", starts_at: 1.day.from_now, uuid: "e0a8dbac-d06c-4d18-98c6-a48f47fddd4c", organisation: org, id: 456_000)
-    create(:rdv, agents: [agent], status: "revoked", starts_at: 2.days.from_now, uuid: "749336ce-eaca-40a3-8c28-246ed8d18849", organisation: org, id: 789_000)
+    motif = create(:motif, name: "Accompagnement individuel")
+    create(:rdv, motif: motif, agents: [agent], status: "unknown", starts_at: 1.day.from_now, uuid: "e0a8dbac-d06c-4d18-98c6-a48f47fddd4c", organisation: org, id: 456_000)
+    create(:rdv, motif: motif, agents: [agent], status: "revoked", starts_at: 2.days.from_now, uuid: "749336ce-eaca-40a3-8c28-246ed8d18849", organisation: org, id: 789_000)
+    motif_collectif = create(:motif, :collectif, name: "Atelier collectif", organisation: org)
+    create(:rdv, motif: motif_collectif, agents: [agent], status: "unknown", starts_at: 3.days.from_now, uuid: "abb701a5-381a-4fae-9157-129b5843834c", organisation: org, id: 123_123,
+                 max_participants_count: 5)
 
     visit ics_calendar_path(agent.calendar_uid, format: :ics)
 

--- a/spec/support/calendar.ics
+++ b/spec/support/calendar.ics
@@ -6,6 +6,17 @@ METHOD:PUBLISH
 X-WR-CALNAME:Marceau COLIN sur RDV Solidarités
 BEGIN:VEVENT
 DTSTAMP:20220707T220000Z
+UID:abb701a5-381a-4fae-9157-129b5843834c
+DTSTART;TZID=Europe/Paris:20220711T000000
+DTEND;TZID=Europe/Paris:20220711T004500
+DESCRIPTION:plus d'infos dans RDV Solidarités: http://localhost:9887/admin
+ /organisations/123000/rdvs/123123
+LOCATION:Lieu n°3 (3 rue de l'adresse 12345 Ville)
+STATUS:CONFIRMED
+SUMMARY:Atelier collectif (1/5)
+END:VEVENT
+BEGIN:VEVENT
+DTSTAMP:20220707T220000Z
 UID:749336ce-eaca-40a3-8c28-246ed8d18849
 DTSTART;TZID=Europe/Paris:20220710T000000
 DTEND;TZID=Europe/Paris:20220710T004500
@@ -13,7 +24,7 @@ DESCRIPTION:plus d'infos dans RDV Solidarités: http://localhost:9887/admin
  /organisations/123000/rdvs/789000
 LOCATION:Lieu n°2 (2 rue de l'adresse 12345 Ville)
 STATUS:CANCELLED
-SUMMARY:RDV via RDV Solidarités
+SUMMARY:Accompagnement individuel
 END:VEVENT
 BEGIN:VEVENT
 DTSTAMP:20220707T220000Z
@@ -24,6 +35,6 @@ DESCRIPTION:plus d'infos dans RDV Solidarités: http://localhost:9887/admin
  /organisations/123000/rdvs/456000
 LOCATION:Lieu n°1 (1 rue de l'adresse 12345 Ville)
 STATUS:CONFIRMED
-SUMMARY:RDV via RDV Solidarités
+SUMMARY:Accompagnement individuel
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
On a eu la demande de la part de plusieurs référentes et de plusieurs cnfs d'ajouter le motif aux informations qui sont synchronisées avec les calendriers extérieurs.

Après discussion en interne dans l'équipe, on a conclu qu'il n'y avait pas de risque siginificatif en terme de confidentialité des données à faire cette modification : les rdvs exportés ne comportent pas l'identité, ni l'adresse, ni l'email ni aucune autre information sur l'usager. Tout au plus on peut avoir le nom de la ville pour un rdv à domicile

Pour accéder aux informations sur l'usager, on garde le lien vers RDVS dans la description de l'évènement
Au passage pour les ateliers collectifs, j'en ai profité pour ajouter le nombre de participants (comme ce qui s'affiche sur l'agenda RDVS)

![Capture d’écran 2022-07-15 à 17 13 16](https://user-images.githubusercontent.com/1840367/179252907-4dd5174a-945c-4faa-a4a2-539be3736f6d.png)




Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
