### PR TITLE
Supprime le lien cassé depuis la checklist

### DIFF
--- a/app/views/admin/organisations/setup_checklists/show.slim
+++ b/app/views/admin/organisations/setup_checklists/show.slim
@@ -81,8 +81,3 @@
                 i>= "ouvert à la réservation en ligne"
               - else
                 i>= "fermé à la réservation en ligne"
-
-        h5 Tester la vue usager
-        ul.mb-4.list-unstyled
-          li.mb-2
-            = link_to "Accéder à la vue usager de prise de RDV en ligne", welcome_departement_path(departement: @organisation.departement_number)


### PR DESCRIPTION
Le lien vers « la vue usager » ne fonctionnait plus, suite à la fusion
des parcours usagers (#1901).

Étant, il me semble, peu utiliser, autant supprimer la ligne.

Permets de fermer le ticket sentry
https://sentry.io/organizations/rdv-solidarites/issues/3435012678/?alert_rule_id=899770&alert_timestamp=1658126342261&alert_type=email&environment=production&project=1811205&referrer=alert_email

![Screenshot 2022-07-18 at 09-32-00 Votre installation - RDV Solidarités](https://user-images.githubusercontent.com/42057/179463743-e4cb5032-5b55-45dd-924f-a589fa5aee5f.png)

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
