### PR TITLE
Use sassc 2.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,6 @@ gem "bootsnap", require: false # Reduces boot times through caching; required in
 gem "rack-cors" # CORS management
 
 # Temporarily fixed versions
-# sassc 2.4.0 requires g++ on recent ruby versions, so let's stick to 2.1.0 (https://github.com/docker-library/ruby/issues/331)
-gem "sassc", "2.1.0"
 # This RC version supports Ruby 3.1 ()https://github.com/mikel/mail/commit/d9d8dcc)
 gem "mail", "2.8.0.rc1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -507,7 +507,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sassc (2.1.0)
+    sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -683,7 +683,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
-  sassc (= 2.1.0)
   selenium-webdriver
   sentry-rails
   sentry-ruby


### PR DESCRIPTION
Cette PR réutilise la version plus récente de sassc (le changement de version précédent venait d'ici : https://github.com/betagouv/rdv-solidarites.fr/pull/2548)