### PR TITLE
Bug : champ `users` vide dans le payload du webhook à la création d'un Rdv

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,10 @@ Metrics/ClassLength:
     - 'app/models/rdv.rb'
     - 'app/models/user.rb'
 
+Metrics/ModuleLength:
+  Max: 150
+  CountAsOne: ['array', 'hash', 'heredoc']
+
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash', 'heredoc']
   Max: 20

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module UsersHelper # rubocop:disable Metrics/ModuleLength
+module UsersHelper
   def birth_date_and_age(user)
     return unless user.birth_date
 

--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -7,13 +7,17 @@ module WebhookDeliverable
   extend ActiveSupport::Concern
 
   def generate_webhook_payload(action, api_options)
+    # Reload attributes and associations from DB to ensure they are up to date.
+    # We dont use #reload on self because some other behaviour depends on the object's state.
+    model = self.class.find(id)
+
     meta = {
       model: self.class.name,
       event: action,
       timestamp: Time.zone.now,
     }
     blueprint_class = "#{self.class.name}Blueprint".constantize
-    blueprint_class.render(self, root: :data, meta: meta, api_options: api_options)
+    blueprint_class.render(model, root: :data, meta: meta, api_options: api_options)
   end
 
   def generate_payload_and_send_webhook(action)

--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -8,7 +8,8 @@ module WebhookDeliverable
 
   def generate_webhook_payload(action, api_options)
     # Reload attributes and associations from DB to ensure they are up to date.
-    # We dont use #reload on self because some other behaviour depends on the object's state.
+    # We dont use #reload on self because some other parts
+    # of the code rely on the state of the current object.
     model = self.class.find(id)
 
     meta = {

--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -10,7 +10,7 @@ module WebhookDeliverable
     # Reload attributes and associations from DB to ensure they are up to date.
     # We dont use #reload on self because some other parts
     # of the code rely on the state of the current object.
-    model = self.class.find(id)
+    record = self.class.find(id)
 
     meta = {
       model: self.class.name,
@@ -18,7 +18,7 @@ module WebhookDeliverable
       timestamp: Time.zone.now,
     }
     blueprint_class = "#{self.class.name}Blueprint".constantize
-    blueprint_class.render(model, root: :data, meta: meta, api_options: api_options)
+    blueprint_class.render(record, root: :data, meta: meta, api_options: api_options)
   end
 
   def generate_payload_and_send_webhook(action)

--- a/spec/features/agents/agent_cant_create_duplicate_rdv_spec.rb
+++ b/spec/features/agents/agent_cant_create_duplicate_rdv_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Agent can't create duplicate RDV" do
     end
   end
 
-  context "when the RDV has the same motif, smae lieu, same agents and users and occurs at the same time" do
+  context "when the RDV has the same motif, same lieu, same agents and users and occurs at the same time" do
     let!(:existing_rdv) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.next_week.change(hour: 9)) }
 
     it "prevents creation with an error" do


### PR DESCRIPTION
Cette PR corrige un bug qui fait que sous certaines conditions, à la création d'un Rdv, le payload du webhook envoyé contient un tableau de `users` vide.

La cause était la suivante : [cet accès à `rdv.users`](https://github.com/betagouv/rdv-solidarites.fr/blob/2ebaba8d1d2b1b68a3c18dd406aae2eb76d7427a/app/form_models/admin/rdv_form_concern.rb#L42) mémoïze la valeur à `[]` (ce code s'exécute avant l'enregistrement en base), et qu'ensuite, dans le callback `after_commit` qui génère le payload à envoyer en webhook, la valeur n'est pas rechargée depuis la base !

On peut donc conclure que le bug ne se produisait que lorsque l'on exécute le bloc passé au `select`, c'est à dire dans les cas où il existe en base un Rdv similaire : **même lieu, même motif, même heure, mais users et / ou agent différents**. En effet, si les users et agent étaient aussi les mêmes, il serait impossible de créer le Rdv car on aurait un véritable doublon !

Note : la relation `has_many :users, through: :rdvs_users` est à utiliser pour des Rdvs déjà en base, mais à éviter pour des Rdvs pas encore persistés, car elle retournera un tableau vide même si des `rdvs_users` existent en mémoire sur l'objet.

Plusieurs solutions pour régler ce bug : 
1. Ne pas appeler `rdv.users` dans la méthode de validation
2. Recharger le Rdv depuis la base de données avant de générer le payload
3. Faire en sorte de générer le payload de manière asynchrone, dans un job. On passerait alors simplement l'ID du Rdv en paramètre au job, plutôt que de passer tout un payload. Problème : difficile à gérer dans le cas d'une suppression (et aussi, le Rdv pourrait avoir changé entre la mise à la file et l'exécution du job).

La solution 3 est à envisager mais elle est complexe. La solution 1 suffit à régler le problème signalé, mais ne nous met pas à l'abri de soucis similaires dans le futur. La solution 2 semble judicieuse car elle s'assure de partir de données fraîches au moment de la génération du payload, peu importe l'état de l'objet en mémoire (elle a donc pour avantage sur la solution 1 de nous mettre à l'abri de bugs similaires à celui signalé).

C'est donc la solution 2 qui a été choisie. La solution 1 est aussi implémentée, non pas directement pour corriger le bug signalé, mais plutôt pour éviter l'usage de `rdv.users`, dont le comportement est surprenant !

-------

@aminedhobb a reporté le 18 juillet 2022 à 15:14 :

> Hello la team :wave: !
> 
> On nous remonte depuis une semaine environ des rdvs créés sur RDV-S et qui ne remontent pas sur RDV-I :warning: . 
> En fouillant les logs de notre appli pour voir si on recevait bien les webhooks pour ces rdvs, je me suis rendu compte que ces webhooks étaient bien envoyés **mais sans les données des utilisateurs associés** (je vous mets un exemple ci-dessous où on voit bien que `users` renvoie un tableau vide). 
> Or sans ça on peut pas faire le lien entre l'utilsateur et le rdv, c'est pour ça qu'ils ne remontent pas sur RDV-I. 
> 
> Est-ce que ça vous dit quelque chose ? Bizarrement le `users_count` est lui correct. 
> 
> En base sur RDV-S, le rdv est bien associé à l'utilisateur en question. D'ailleurs si on met à jour le rdv, le webhook est bien envoyé avec les infos de l'utilisateur. Ce problème ne se produit qu'à la création du rdv.
>
> ```ruby
> {"data"=>
>   {"id"=>869713,
>    "lieu"=>{...},
>    "motif"=>{...},
>    "users"=>[],
>    "users_count"=>1,
>    "uuid"=>"33b95f1a-ed62-4371-ac2e-331f874bb555"},
>  "meta"=>{"model"=>"Rdv", "event"=>"created", "timestamp"=>"2022-07-13 14:41:05 +0200"}}
> ```

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
