### PR TITLE
Ajout d'un graphe des agents actifs aux stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -30,6 +30,11 @@ class StatsController < ApplicationController
     render json: Stat.new(receipts: @receipts).receipts_group_by(attribute).chart_json
   end
 
+  def active_agents
+    stats = Stat.new(rdvs: @rdvs).active_agents_group_by_month
+    render json: stats.chart_json
+  end
+
   def scope_rdv_to_territory
     if params[:territory].present?
       @territory = Territory.find(params[:territory])

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -68,4 +68,8 @@ class Stat
       .count
       .transform_keys { |key| [Receipt.human_attribute_value(attribute, key[0]), key[1]] }
   end
+
+  def active_agents_group_by_month
+    rdvs.joins(:agents_rdvs).where("rdvs.starts_at < ?", Time.zone.now).group_by_month("rdvs.starts_at").count("distinct agents_rdvs.agent_id")
+  end
 end

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -120,6 +120,10 @@
         - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
         p #{percent(active_count, active_agents.count)} avaient participé à un rdv créé un rdv les 30 derniers jours précédents (#{active_count})
 
+        = self_anchor "active_agents"
+          h2.card-title Agents actifs par mois
+        p Nombre d'agents ayant participé à au moins un rdv chaque mois
+        = column_chart active_agents_stats_path(territory: @territory)
     .card.mb-5
       .card-header
         = "#{@territories.count} structures utilisent RDV-Solidarités"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   end
   resources :stats, only: :index
   get "stats/rdvs", to: "stats#rdvs", as: "rdvs_stats"
+  get "stats/active_agents", to: "stats#active_agents", as: "active_agents_stats"
   get "stats/receipts", to: "stats#receipts", as: "receipts_stats"
 
   authenticate :user do


### PR DESCRIPTION
Cette PR ajoute une version en graphe des stats ajoutées récemment

![Capture d’écran 2022-07-18 à 18 09 14](https://user-images.githubusercontent.com/1840367/179554924-11e1a242-e10c-4522-823f-de1989afc8aa.png)

Ce graphe permet de mieux suivre le progrès du déploiement des CNFS, mais peut aussi avoir le même usage dans les département, et peut aussi servir de base aux réflexions sur les tarifs à base du nombre d'agents actifs.

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
