### PR TITLE
Clarification des stats sur les agents actifs

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -99,10 +99,10 @@
         p #{percent(accepted_count, active_agents.count)} ont accepté l'invitation (#{accepted_count})
 
         - first_rdv_count = active_agents.joins(:rdvs).distinct.count
-        p #{percent(first_rdv_count, active_agents.count)} ont créé au moins un rdv (#{first_rdv_count})
+        p #{percent(first_rdv_count, active_agents.count)} ont participé à au moins un rdv (#{first_rdv_count})
 
         - active_count = active_agents.joins(:rdvs).where("rdvs.created_at > ?", 30.days.ago).distinct.count
-        p #{percent(active_count, active_agents.count)} ont créé un rdv les 30 derniers jours (#{active_count})
+        p #{percent(active_count, active_agents.count)} ont participé à un rdv créé dans les 30 derniers jours (#{active_count})
 
         h5 Il y a 30 jours
 
@@ -113,10 +113,10 @@
         p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
 
         - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
-        p #{percent(first_rdv_count, active_agents.count)} avaient créé au moins un rdv (#{first_rdv_count})
+        p #{percent(first_rdv_count, active_agents.count)} avaient participé à au moins un rdv (#{first_rdv_count})
 
         - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
-        p #{percent(active_count, active_agents.count)} avaient créé un rdv les 30 derniers jours précédents (#{active_count})
+        p #{percent(active_count, active_agents.count)} avaient participé à un rdv créé un rdv les 30 derniers jours précédents (#{active_count})
 
     .card.mb-5
       .card-header


### PR DESCRIPTION
Ce matin, Matis avait un doute sur l'interprétation de ces stats : 
> Hey ! Avez-vous des éléments d'explication concernant ces chiffres : 
"Seine-Et-Marne : 
1658 agents ont été invités
97% ont accepté l'invitation (1606)
42% ont créé au moins un rdv (694)" 
Je pense tout particulièrement à "42% ont créé au moins un rdv (694)" sur les 1606 agents actifs. Ce sont les agents qui distribuent des RDV sans forcément en planifier pour eux ? 

Ce correctif vise à éviter les confusions pour les autres gens qui consultent les stats

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
