### PR TITLE
Bugfix : envoi de 2 webhooks à la création d'un RDV

### DIFF
--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -50,6 +50,11 @@ class Notifiers::RdvBase < ::BaseService
   end
 
   def generate_invitation_tokens
+    # Prevent token generation to trigger a webhook notification,
+    # because generating the RdvsUser tokens does not change any of the
+    # attributes or associations of the Rdv.
+    @rdv.skip_webhooks = true
+
     rdv_users_with_token_needed.each do |rdv_user|
       @rdv_users_tokens_by_user_id[rdv_user.user_id] = rdv_user.new_raw_invitation_token
     end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -144,8 +144,7 @@ describe "Agent can create a Rdv with wizard" do
 
         stub_request(:post, "https://example.com/")
         click_button("Créer RDV")
-        # TODO: Investigate why 2 webhooks calls are sent
-        expect(WebMock).to(have_requested(:post, "https://example.com/").times(2).with do |req|
+        expect(WebMock).to(have_requested(:post, "https://example.com/").with do |req|
           JSON.parse(req.body)["data"]["users"].map { |user| user["id"] } == [user.id]
         end)
       end


### PR DESCRIPTION
Closes #2662

À es yeux, ce second appel est un comportement non attendu, que ce soit pour les consommateur de nos webhook autant que pour nous. Quand on a découvert le comportement (en rédigeant [ce test](https://github.com/betagouv/rdv-solidarites.fr/pull/2656/files#r924524864)), on a été surpris. C'est bien que le comportement n'est pas attendu.

De plus, le second webhook a strictement le même payload que le premier, on peut donc considérer qu'il est inutile pour les consommateurs de nos webhooks.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
