### PR TITLE
Regroupe les motifs par service pour l'usager

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -49,6 +49,10 @@ class SearchContext
     @invitation_token.present?
   end
 
+  def services
+    unique_motifs_by_name_and_location_type.map(&:service).uniq.sort_by(&:name)
+  end
+
   def unique_motifs_by_name_and_location_type
     @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq { [_1.name, _1.location_type] }
   end

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -15,13 +15,15 @@ section.bg-light.p-4
             .font-weight-bold La prise de rendez-vous n'est pas disponible pour ce département.
     - else
       h2.font-weight-bold Sélectionnez le motif de votre RDV :
-      - context.unique_motifs_by_name_and_location_type.each do |motif|
-        .card.mb-3
-          - if motif.restriction_for_rdv.blank?
-            = link_to(root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))) do
-              = render "motif_selection_card", motif: motif
-          - else
-            = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
-              = render "motif_selection_card", motif: motif
-            = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
-              = ActionController::Base.helpers.auto_link(simple_format(motif.restriction_for_rdv), html: { target: "_blank"})
+      - context.services.each do |service|
+        h3 = service.name
+        - context.unique_motifs_by_name_and_location_type.select{|m| m.service == service}.each do |motif|
+          .card.mb-3
+            - if motif.restriction_for_rdv.blank?
+              = link_to(root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+                = render "motif_selection_card", motif: motif
+            - else
+              = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
+                = render "motif_selection_card", motif: motif
+              = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
+                = ActionController::Base.helpers.auto_link(simple_format(motif.restriction_for_rdv), html: { target: "_blank"})

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -90,4 +90,16 @@ describe SearchContext, type: :service do
       end
     end
   end
+
+  describe "#services" do
+    it "returns services sort by name" do
+      service_a = create(:service, name: "A")
+      service_b = create(:service, name: "B")
+      motif_a = create(:motif, service: service_a)
+      motif_b = create(:motif, service: service_b)
+      search_context = described_class.new(nil, motif_name_with_location_type: [])
+      allow(search_context).to receive(:matching_motifs).and_return([motif_b, motif_a])
+      expect(search_context.services).to eq([service_a, service_b])
+    end
+  end
 end


### PR DESCRIPTION
Pour tester https://production-rdv-solidarites-pr2669.osc-secnum-fr1.scalingo.io/

Pour clarifier un peu la présentation des motifs ;
Pour aider l'usager à trouver le bon motif ;
Cette PR propose de les regrouper par service ;

C'est Sandra (80) qui a fait remonter par le biais de la mailling list que le filtre par service manque et que les motifs sont tous mélangés actuellement.

Avant :
![Screenshot 2022-07-19 at 21-00-20 RDV Solidarités](https://user-images.githubusercontent.com/42057/179829712-847d2196-6cad-4989-87a1-fc6956659922.png)

Après :

![Screenshot 2022-07-19 at 20-59-59 RDV Solidarités](https://user-images.githubusercontent.com/42057/179829716-f373ad1a-f29b-4f45-a0f7-5de236ac682e.png)


Closes #2666

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
