### PR TITLE
Fix: charts défectueux si on charge la page avec Turbolinks

### DIFF
--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -1,4 +1,5 @@
-= javascript_include_tag "charts", "data-turbolinks-track": "reload"
+/ Include the charts pack in the <head> section
+- content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for(:menu_item) { "menu-organisation-stats" }
 

--- a/app/views/admin/stats/index.html.slim
+++ b/app/views/admin/stats/index.html.slim
@@ -1,4 +1,5 @@
-= javascript_include_tag "charts", "data-turbolinks-track": "reload"
+/ Include the charts pack in the <head> section
+- content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for(:menu_item) { "menu-stats" }
 

--- a/app/views/common/_head.html.slim
+++ b/app/views/common/_head.html.slim
@@ -2,3 +2,5 @@
 = render "common/env"
 = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
 = javascript_include_tag "application", "data-turbolinks-track": "reload"
+
+= content_for(:charts_script)

--- a/app/views/common/_head_agent.html.slim
+++ b/app/views/common/_head_agent.html.slim
@@ -2,3 +2,5 @@
 = render "common/env"
 = stylesheet_link_tag "application_agent", media: "all", "data-turbolinks-track": "reload"
 = javascript_include_tag "application_agent", "data-turbolinks-track": "reload"
+
+= content_for(:charts_script)

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -1,4 +1,5 @@
-= javascript_include_tag "charts", "data-turbolinks-track": "reload"
+/ Include the charts pack in the <head> section
+- content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for :title do
   h1


### PR DESCRIPTION
Depuis #2672 nous avons [une erreur](https://sentry.io/organizations/rdv-solidarites/issues/3444163260) lorsque nous visitons une page de stats en arrivant depuis une autre page, c'est à dire que la page de stats est chargée avec Turbolinks.

Visiblement, il faut que la ressource JS soit déclarée dans la section `<head>` pour que Turbolinks puisse la charger correctement. Je ne n'ai pas pris le temps d'explorer le fonctionnement précis de Turbolinks, mais le bug semble bien corrigé maintenant que le pack `charts.js` est bien déclaré dans `<head>`.

Comment reproduire : visiter la page d'accueil usagers (http://localhost:3000/) puis cliquer sur "Statistiques". Les charts ne s'affichent pas et on a une erreur (`Chartkick is not defined`) dans la console du navigateur. Si on visite (http://localhost:3000/stats) directement, pas d'erreur et les charts s'affichent.