### PR TITLE
Ouverture de la synchronisation avec des agendas externes

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -31,4 +31,12 @@ module AdminHelper
     end
     policy([:agent, mock]).send("#{action}?")
   end
+
+  def faq_url
+    if current_agent.conseiller_numerique?
+      "https://rdv-solidarites.notion.site/F-A-Q-Conseillers-num-riques-d5ab1db8e311467eb2f3b317cb4c059f"
+    else
+      "https://rdv-solidarites.notion.site/F-A-Q-M-dico-social-aaf94709c0ea448b8eb9d93f548acdb9"
+    end
+  end
 end

--- a/app/views/admin/organisations/setup_checklists/show_conseiller_numerique.slim
+++ b/app/views/admin/organisations/setup_checklists/show_conseiller_numerique.slim
@@ -45,6 +45,16 @@
             span>= setup_checklist_item(current_agent.rdvs.any?)
             span>= link_to "Ajouter un RDV dans votre agenda", admin_organisation_agent_agenda_path(@organisation, current_agent.id)
 
+        h5.mb-2 Synchroniser votre agenda externe
+        p Si vous utilisez déjà un agenda comme Outlook ou Google Calendar, vous pouvez synchroniser votre agenda RDV Solidarité vers votre agenda externe, pour que vos rendez-vous y soient visibles aussi.
+        ul.mb-4.list-unstyled
+          li.mb-2
+            span>= setup_checklist_item(current_agent.calendar_uid.present?)
+            span>= link_to "Si vous utilisez Outlook, nous vous conseillons d'utiliser un lien de synchronisation", agents_calendar_sync_path
+          li.mb-2
+            span>= setup_checklist_item(current_agent.rdv_notifications_level_all?)
+            span>= link_to "Si vous utilisez Google Calendar, nous vous conseillons d'activer les notifications pour chaque modification de rdv", agents_preferences_path
+
         h5 Recherche de créneaux
         p Lorsque vous avez plusieurs rendez-vous de prévus, vous pouvez définir des plages d’ouverture pour trouver le prochain créneau disponible plus facilement.
         p Cela permettra aussi à vos collègues de savoir quand ils peuvent vous prévoir des rendez-vous.

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -17,11 +17,6 @@
         p
           span> Vous pouvez aussi consulter les
           ruby:
-            faq_url = if current_agent.conseiller_numerique?
-                        "https://rdv-solidarites-cnfs.notion.site/rdv-solidarites-cnfs/F-A-Q-Conseillers-num-riques-d9104d70ab9d4a6695ef96b1d9ea7f29"
-                      else
-                        "https://rdv-solidarites.notion.site/F-A-Q-M-dico-social-aaf94709c0ea448b8eb9d93f548acdb9"
-                      end
           = link_to faq_url do
             span> Questions fréquentes
             i.fa.fa-external-link-alt

--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -9,9 +9,7 @@ p
   =  link_to(calendar_url, calendar_url, class: "mb-1")
 
 p Tous vos rendez-vous de RDV Solidarités seront copiés automatiquement au fur et à mesure de leur création (ou modification).
-p.mb-4
-  | Cette fonctionnalité est encore expérimentale. N'hésitez pas à nous faire part de vos retours à l'adresse
-  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchronisation d'agenda").html_safe}.
+p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", faq_url)}.
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 

--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -11,9 +11,9 @@ p
 p Tous vos rendez-vous de RDV Solidarités seront copiés automatiquement au fur et à mesure de leur création (ou modification).
 p.mb-4
   | Cette fonctionnalité est encore expérimentale. N'hésitez pas à nous faire part de vos retours à l'adresse
-  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchro d'agenda").html_safe}.
+  |  #{link_to("contact@rdv-solidarites.fr", "mailto:contact@rdv-solidarites.fr?subject=Retours sur la synchronisation d'agenda").html_safe}.
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 
 = simple_form_for(@agent, url: agents_calendar_sync_path) do |f|
-  = f.submit "Réinitialiser mon lien de synchronisation", class: "btn btn-secondary", data: { confirm: "Attention, si vous réinitialisez votre lien de partage, vous devrez entrer le nouveau lien dans votre agenda externe" }
+  = f.submit "Réinitialiser mon lien de synchronisation", class: "btn btn-secondary", data: { confirm: "Attention, si vous réinitialisez votre lien de synchronisation, vous devrez entrer le nouveau lien dans votre agenda externe" }

--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -9,7 +9,7 @@ p
   =  link_to(calendar_url, calendar_url, class: "mb-1")
 
 p Tous vos rendez-vous de RDV Solidarités seront copiés automatiquement au fur et à mesure de leur création (ou modification).
-p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", faq_url)}.
+p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", faq_url, target: :blank)}.
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -32,6 +32,8 @@ html lang="fr"
                     li
                       h5= link_to t("agents.preferences.show.title"), agents_preferences_path
                     li
+                      h5= link_to "Synchronisation d'agenda", agents_calendar_sync_path
+                    li
                       h5= link_to "Mes organisations", admin_organisations_path
                     li
                       h5= link_to "Me déconnecter", destroy_agent_session_path, method: :delete

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -2,7 +2,7 @@ fr:
   agents:
     calendar_sync:
       show:
-        title: Synchronisation avec un agenda externe
+        title: Export vers un agenda externe
     preferences:
       show:
         title: Préférences de notifications


### PR DESCRIPTION
Cette PR finit le travail sur https://github.com/betagouv/rdv-solidarites.fr/issues/2598

Myriam a confirmé que suite aux discussions avec les différentes référentes, on peut ouvrir la synchro à tout le monde.

On ajoute le lien vers la synchronisation de calendrier au menu des agents, et on le met en avant dans l'onboarding des CNFS.
La nouvelle version de la FAQ est rédigée dans notion, il faudra mettre à jour la FAQ au moment du déploiement.

Avant :

![Capture d’écran 2022-07-26 à 10 38 18](https://user-images.githubusercontent.com/1840367/180962741-998ef70f-dd93-4692-8fbf-5ced246996ff.png)

![Capture d’écran 2022-07-26 à 10 38 50](https://user-images.githubusercontent.com/1840367/180962874-5fb610a9-494a-4af9-812b-bb0b9f519a43.png)


Après : 
![Capture d’écran 2022-07-26 à 10 38 08](https://user-images.githubusercontent.com/1840367/180962745-39f306e7-7862-4e13-9815-fb5d5c926202.png)
![Capture d’écran 2022-07-26 à 10 39 00](https://user-images.githubusercontent.com/1840367/180962871-cc60aa8f-e650-44bc-bbaf-b1bd7630e70d.png)

## Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
