### PR TITLE
Réinviter les CNFS dont l'invitation a expiré

### DIFF
--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -5,7 +5,7 @@ require "csv"
 conseillers_numeriques = CSV.read("/tmp/uploads/export-cnfs.csv", headers: true, col_sep: ";")
 
 conseillers_numeriques.each do |conseiller_numerique|
-  AddConseillerNumerique.process!({
+  agent = AddConseillerNumerique.process!({
     external_id: conseiller_numerique["Email @conseiller-numerique.fr"],
     email: conseiller_numerique["Email @conseiller-numerique.fr"],
     first_name: conseiller_numerique["Prénom"],
@@ -16,6 +16,11 @@ conseillers_numeriques.each do |conseiller_numerique|
       address: conseiller_numerique["Adresse de la structure"],
     },
   }.with_indifferent_access)
+
+  # Re-invite the agent if the invitation has expired
+  if agent.invitation_accepted_at.nil? && agent.invitation_sent_at < 1.month.ago
+    agent.invite!(nil, validate: false)
+  end
 
   puts "Import ou mise à jour réussie pour #{conseiller_numerique['Email @conseiller-numerique.fr']}"
 end


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-solidarites.fr/issues/2688

On a actuellement plus de 1700 CNFS dont l'invitation a expiré, et pour qui on voudrait envoyer une relance.

Cette PR est une implémentation simple de ce mécanisme de relance. J'ai testé en local, ça fonctionne comme prévu

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
