### PR TITLE
Correctif pour les stats d'agents actifs après relances.

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -109,10 +109,10 @@
 
         h5 Il y a 30 jours
 
-        - active_agents = active_agents.where("invitation_sent_at < ?", 30.days.ago)
+        - active_agents = active_agents.where("agents.created_at < ?", 30.days.ago)
         p #{active_agents.count} agents avaient été invités
 
-        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("invitation_accepted_at < ?", 30.days.ago).count
+        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("agents.created_at < ?", 30.days.ago).count
         p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
 
         - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count


### PR DESCRIPTION
Maintenant qu'on modifie la date d'invitation en faisant des relances, les statistiques du mois précédent sont faussées. Il vaut donc mieux se servir de la date de création de l'agent, qui elle reste inchangée.

Avant :
![Capture d’écran 2022-07-28 à 09 58 01](https://user-images.githubusercontent.com/1840367/181453035-ac298142-93bb-46f0-acd7-2cee1dee924f.png)

Après : on devrait retrouver des chiffres normaux.

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
