### PR TITLE
Affiche le contexte sans possibilité de navigation dans le cadre d'une invitation usager

### DIFF
--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -24,6 +24,10 @@ module UserRdvWizard
       @rdv.duration_in_min ||= @rdv.motif.default_duration_in_min if @rdv.motif.present?
     end
 
+    def invitation?
+      @attributes[:invitation_token].present?
+    end
+
     def params_to_selections
       if @rdv.present?
         return @attributes.merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,23 +1,24 @@
 section.bg-light.p-4
   .container
-    .card.card-hoverable
-      .card-body
-        = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
-          .row
-            .col-auto.align-self-center
-              i.fa.fa-chevron-left
-            .col
-              h2.pb-1.mb-1
-                = motif_name_with_location_type(context.selected_motif)
-    .card.card-hoverable
-      .card-body
-        = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
-          .row
-            .col-auto.align-self-center
-              i.fa.fa-chevron-left
-            .col
-              h2.pb-1.mb-1.card-title= context.lieu.name
-              .card-subtitle= context.lieu.address
+    - unless context.invitation?
+      .card.card-hoverable
+        .card-body
+          = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
+            .row
+              .col-auto.align-self-center
+                i.fa.fa-chevron-left
+              .col
+                h2.pb-1.mb-1
+                  = motif_name_with_location_type(context.selected_motif)
+      .card.card-hoverable
+        .card-body
+          = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+            .row
+              .col-auto.align-self-center
+                i.fa.fa-chevron-left
+              .col
+                h2.pb-1.mb-1.card-title= context.lieu.name
+                .card-subtitle= context.lieu.address
     h3.font-weight-bold = "Sélectionnez un créneau :"
     .card.mb-3
       .card-body

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,6 +1,13 @@
 section.bg-light.p-4
   .container
-    - unless context.invitation?
+    - if context.invitation?
+      .card
+        .card-body
+          h2.pb-1.mb-1
+            = motif_name_with_location_type(context.selected_motif)
+            .card-subtitle= context.lieu.address
+
+    - else
       .card.card-hoverable
         .card-body
           = link_to path_to_motif_selection(params), class: "d-block stretched-link" do

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -1,6 +1,11 @@
 section.bg-light.p-4
   .container
-    - unless context.invitation?
+    - if context.invitation?
+      .card
+        .card-body
+          h2.pb-1.mb-1
+            = motif_name_with_location_type(context.selected_motif)
+    - else
       .card.card-hoverable
         .card-body
           = link_to path_to_motif_selection(params), class: "d-block stretched-link" do

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -1,14 +1,15 @@
 section.bg-light.p-4
   .container
-    .card.card-hoverable
-      .card-body
-        = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
-          .row
-            .col-auto.align-self-center
-              i.fa.fa-chevron-left
-            .col
-              h2.pb-1.mb-1
-                = motif_name_with_location_type(context.selected_motif)
+    - unless context.invitation?
+      .card.card-hoverable
+        .card-body
+          = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
+            .row
+              .col-auto.align-self-center
+                i.fa.fa-chevron-left
+              .col
+                h2.pb-1.mb-1
+                  = motif_name_with_location_type(context.selected_motif)
     h3.font-weight-bold = t(".select_lieu")
     p = t(".lieu_available", count: context.lieux.size)
     - context.lieux.each do |lieu|

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -5,8 +5,7 @@ ul.list-group.list-group-flush
         i.fa.fa-check.fa-fw.mr-1.text-success
         | Motif :&nbsp;
         = rdv_wizard.motif.name
-    
-      - unless rdv_wizard.invitation? 
+      - unless rdv_wizard.invitation?
         .col-auto
           = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
   - if rdv_wizard.motif.phone?
@@ -20,7 +19,7 @@ ul.list-group.list-group-flush
           i.fa.fa-check.fa-fw.mr-1.text-success
           | Lieu :&nbsp;
           = rdv_wizard.lieu_full_name
-        - unless rdv_wizard.invitation? 
+        - unless rdv_wizard.invitation?
           .col-auto
             = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
   li.list-group-item
@@ -29,7 +28,7 @@ ul.list-group.list-group-flush
         i.fa.fa-check.fa-fw.mr-1.text-success
         | Date du rendez-vous :&nbsp;
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
-      - unless rdv_wizard.invitation? 
+      - unless rdv_wizard.invitation?
         .col-auto
         = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
   - if rdv_wizard.is_a?(UserRdvWizard::Step3)

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -5,8 +5,10 @@ ul.list-group.list-group-flush
         i.fa.fa-check.fa-fw.mr-1.text-success
         | Motif :&nbsp;
         = rdv_wizard.motif.name
-      .col-auto
-        = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
+    
+      - unless rdv_wizard.invitation? 
+        .col-auto
+          = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
   - if rdv_wizard.motif.phone?
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
@@ -18,15 +20,17 @@ ul.list-group.list-group-flush
           i.fa.fa-check.fa-fw.mr-1.text-success
           | Lieu :&nbsp;
           = rdv_wizard.lieu_full_name
-        .col-auto
-          = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
+        - unless rdv_wizard.invitation? 
+          .col-auto
+            = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
   li.list-group-item
     .row
       .col
         i.fa.fa-check.fa-fw.mr-1.text-success
         | Date du rendez-vous :&nbsp;
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
-      .col-auto
+      - unless rdv_wizard.invitation? 
+        .col-auto
         = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
   - if rdv_wizard.is_a?(UserRdvWizard::Step3)
     li.list-group-item
@@ -35,8 +39,9 @@ ul.list-group.list-group-flush
           i.fa.fa-check.fa-fw.mr-1.text-success
           | Usager :&nbsp;
           = users_to_sentence(rdv_wizard.users)
-        .col-auto
-          = link_to "modifier", new_users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query)
+        - unless rdv_wizard.invitation?
+          .col-auto
+            = link_to "modifier", new_users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query)
     li.list-group-item
       .row
         .col


### PR DESCRIPTION
Pour tester https://production-rdv-solidarites-pr2694.osc-secnum-fr1.scalingo.io/

Les modifications faites dans #2636 propos à un usager de pouvoir revenir en arrière, changer de modif, de lieu, de créneaux. Or, dans le cadre d'une invitation, le contexte est « proposé » et n'a pas de raison d'être modifié.

Cette PR propose donc d'affiche le contexte sans proposer de navigation.

Avant

![Screenshot 2022-07-28 at 12-15-59 RDV Solidarités](https://user-images.githubusercontent.com/42057/181482304-25b3be2b-d1da-4ce4-8b30-8670a643340f.png)
![Screenshot 2022-07-28 at 12-15-51 RDV Solidarités](https://user-images.githubusercontent.com/42057/181482307-056f1334-8711-4843-ab2d-2ac3a53257eb.png)
![Screenshot 2022-07-28 at 12-15-43 RDV Solidarités](https://user-images.githubusercontent.com/42057/181482310-a6d46430-5687-43f2-b1f6-f824ec9a0c0a.png)


Après

![Screenshot 2022-07-28 at 12-15-21 RDV Solidarités](https://user-images.githubusercontent.com/42057/181482362-d77959d7-863e-44f5-a37a-bd5e323267c8.png)
![Screenshot 2022-07-28 at 12-15-02 RDV Solidarités](https://user-images.githubusercontent.com/42057/181482366-ceb1b9b1-0eee-412d-bd04-3f898de644a0.png)
![Screenshot 2022-07-28 at 12-14-53 RDV Solidarités](https://user-images.githubusercontent.com/42057/181482370-7b3bc8fb-385f-43d1-9c25-7a2a3f891bca.png)




Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
