### PR TITLE
reutilise le lieu existant

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -101,7 +101,7 @@ class Admin::RdvsController < AgentAuthController
                                                  agent_ids: [],
                                                  user_ids: [],
                                                  rdvs_users_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy],
-                                                 lieu_attributes: %i[name address latitude longitude])
+                                                 lieu_attributes: %i[name address latitude longitude id])
 
     # Quand un lieu ponctuel est saisi, il faut faire en sorte qu'il soit créé dans l'organisation courante.
     # Nous le faisons ici, côté serveur pour empêcher de spécifier une valeur arbitraire.

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -73,6 +73,18 @@ describe Admin::RdvsController, type: :controller do
         end.not_to change(rdv, :duration_in_min)
       end
     end
+
+    context "with single_use lieu" do
+      it "does not create a new lieu" do
+        lieu = create(:lieu, availability: :single_use)
+        rdv = create(:rdv, motif: motif, agents: [agent], users: [user], organisation: organisation, lieu: lieu)
+        new_lieu_attributes = { name: lieu.name, address: lieu.address, latitude: lieu.latitude, longitude: lieu.longitude, id: lieu.id }
+        new_attributes = { context: "RDV avec un changement de contexte", lieu_attributes: new_lieu_attributes }
+        expect do
+          put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
+        end.not_to change(Lieu, :count)
+      end
+    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
Dans le contexte de la PR #2681 nous avons découvert un bug.
Un nouveau lieu ponctuel était créé à chaque mise-à-jour du rdv

Cette PR fait en sorte de réutiliser le lieu ponctuel.

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
