### PR TITLE
Simplifie le filtre sur les lieux

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -163,9 +163,13 @@ class SearchContext
                available_motifs
              end
     motifs = motifs.where(service: service) if service.present?
-    motifs = motifs.joins(:lieux).where(lieux: lieu) if lieu.present?
     motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
     motifs = motifs.where(category: @motif_category) if @motif_category.present?
+
+    # filtrer sur le `lieu_id` dans la table des plages d'ouverture permet de limiter de combiner et construire trop d'objet
+    # voir https://github.com/betagouv/rdv-solidarites.fr/issues/2686
+    motifs = motifs.joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: @lieu_id }) if @lieu_id.present?
+
     motifs
   end
 end

--- a/spec/features/allocation_for_search_context_spec.rb
+++ b/spec/features/allocation_for_search_context_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe "Allocation For Search Context" do
+  it "stay under 2500" do
+    departement_number = "75"
+    address = "20 avenue de Ségur 75007 Paris"
+    city_code = "75007"
+
+    organisation = create(:organisation)
+    motif = create(:motif, name: "RSA orientation sur site", category: "rsa_orientation", organisation: organisation)
+
+    create_list(:plage_ouverture, 300, lieu: create(:lieu), motifs: [motif])
+    lieu = create(:lieu, organisation: organisation)
+
+    geo_search = instance_double(Users::GeoSearch, available_motifs: Motif.where(id: motif.id))
+    allow(Users::GeoSearch).to receive(:new)
+      .with(departement: departement_number, city_code: city_code, street_ban_id: nil)
+      .and_return(geo_search)
+    create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: 1.day.from_now, organisation: organisation)
+
+    params = { address: address, departement: departement_number, city_code: city_code, lieu_id: lieu.id, motif_name_with_location_type: "#{motif.name}-#{motif.location_type}" }
+
+    search_context = SearchContext.new(nil, params)
+
+    before = GC.stat[:total_allocated_objects]
+    search_context.unique_motifs_by_name_and_location_type
+    after = GC.stat[:total_allocated_objects]
+    # Le chiffre est baser sur l'expérimentation.
+    # Sur l'ancienne façon de faire le filtre sur les lieux, nous avons
+    # 3342 allocations, avec la nouvelle 2166.
+    expect(after - before).to be <= 2200
+  end
+end


### PR DESCRIPTION
Nous avons constaté une fuite mémoire nous obligeant à redémarrer les serveurs une à deux fois par jour.

Ce problème était présent sur le parcours `prendre_rdv` réalisé plus tôt pour le contexte des invitations via data.insertion. Une fois fusionné, ce parcours a été utilisé dans un plus grand nombre de cas, dont des cas où la requête pose un problème (trop grand nombre d'objets créés).


Plutôt que de combiner les lieux et les plages d'ouverture dans la requête, nous utilisons directement le `lieu_id` sur la table `plage_ouvertures`. Ça réduit de beaucoup les allocations mémoires.

- avant : **11 465 932 allocations**
- après :    **101 774 allocations**

Le pad de notre exploration qui a permis d'arriver à ce résultat : https://pad.incubateur.net/jeLsvF9LTdWN4nM-IIl1FQ?edit

Closes #2686 

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
