### PR TITLE
Renvoie aucun jours fériés sur une période vide

### DIFF
--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -46,6 +46,8 @@ class OffDays
   ].freeze
 
   def self.all_in_date_range(date_range)
+    return [] if date_range.blank?
+
     date_range = date_range.begin.to_date..date_range.end.to_date unless date_range.begin.is_a?(Date)
     date_range.select do |d|
       case d.year

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -45,5 +45,11 @@ describe OffDays, type: :service do
 
       it { is_expected.to match_array([Date.new(2022, 1, 1)]) } if Time.zone.now > Date.new(2021, 1, 1)
     end
+
+    context "with a nil date_range given" do
+      it "returns empty array" do
+        expect(described_class.all_in_date_range(nil)).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Il semble que parfois, nous demandions la liste des jours féries sur une période vide... Possible lorsque la période est réduite en fonction des contraintes des motifs (période de réservation)

Cette PR ajoute une garde pour pallier ce type d'erreur

Ref : [sentry issue 3276720900](https://sentry.io/organizations/rdv-solidarites/issues/3276720900/?project=1811205&query=is%3Aunresolved+sdk.name%3Asentry.ruby.rails&sort=date&statsPeriod=14d)

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
