### PR TITLE
Affiche une erreur plutôt qu'une page 422 lors d'un problème de fusion d'usager

### DIFF
--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -13,6 +13,7 @@ class MergeUsersForm
 
   validates_presence_of :user1, :user2
   validate :different_users?
+  validate :dont_destroy_franceconnected_values
 
   def initialize(organisation, **kwargs)
     @organisation = organisation
@@ -109,6 +110,12 @@ class MergeUsersForm
   end
 
   def different_users?
+    return true if user1.nil? || user2.nil?
+
+    errors.add(:base, "Mauvaise sélection d'usagers") if user1.id == user2.id
+  end
+
+  def dont_destroy_franceconnected_values
     return true if user1.nil? || user2.nil?
 
     errors.add(:base, "Mauvaise sélection d'usagers") if user1.id == user2.id

--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -118,6 +118,16 @@ class MergeUsersForm
   def dont_destroy_franceconnected_values
     return true if user1.nil? || user2.nil?
 
-    errors.add(:base, "Mauvaise sélection d'usagers") if user1.id == user2.id
+    User::FranceconnectFrozenFieldsConcern::FROZEN_FIELDS.each do |frozen_field|
+      if frozen_field_update?(frozen_field, user1, user2)
+        errors.add(frozen_field, "ne peut être modifié.e car un des usagers utilise FranceConnect")
+      end
+    end
+  end
+
+  def frozen_field_update?(frozen_field, user1, user2)
+    send(frozen_field).present? &&
+      ((user1.logged_once_with_franceconnect? && send(frozen_field) != user1.send(frozen_field)) ||
+       (user2.logged_once_with_franceconnect? && send(frozen_field) != user2.send(frozen_field)))
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,7 +46,8 @@ module ApplicationHelper
   end
 
   def errors_full_messages(object)
-    object.not_benign_errors.map do |error|
+    errors = object.respond_to?(:not_benign_errors) ? object.not_benign_errors : object.errors
+    errors.map do |error|
       if error.attribute.to_s.starts_with?("responsible.")
         att = error.attribute.to_s.sub(/^responsible./, "")
         "Responsable: #{object.errors.full_message(att, error.message)}"

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe MergeUsersForm, type: :form do
+  describe "validations" do
+    {
+      first_name: %w[Dominique Camille],
+      birth_date: [Date.new(1970, 4, 25), Date.new(1980, 6, 25)],
+      birth_name: %w[Nicolas Mathieu],
+    }.each do |frozen_field, values|
+      let(:organisation) { create(:organisation) }
+      it "invalid when merge #{frozen_field} on franceConnected user1" do
+        user1 = create(:user, frozen_field => values[0], logged_once_with_franceconnect: true)
+        user2 = create(:user, frozen_field => values[1])
+        merge_users_params = { frozen_field => user2.send(frozen_field) }
+        merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
+        expect(merge_users_form).to be_invalid
+      end
+
+      it "invalid when merge #{frozen_field} on franceConnected user2" do
+        user2 = create(:user, frozen_field => values[0], logged_once_with_franceconnect: true)
+        user1 = create(:user, frozen_field => values[1])
+        merge_users_params = { frozen_field => user1.send(frozen_field) }
+        merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
+        expect(merge_users_form).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/merge_users_form_spec.rb
+++ b/spec/merge_users_form_spec.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-describe MergeUsersForm, type: :form do
-
-end

--- a/spec/merge_users_form_spec.rb
+++ b/spec/merge_users_form_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe MergeUsersForm, type: :form do
+
+end


### PR DESCRIPTION
Pour tester https://production-rdv-solidarites-pr2702.osc-secnum-fr1.scalingo.io/

Closes #1762
Closes #2391 

mise en place du message d'erreur de fusion d'usager quand l'un utilise FranceConnect

## Captures :

- avant : 

![image](https://user-images.githubusercontent.com/60173782/182895539-5f8f3a0a-f264-4914-8025-fa82bf942502.png)


![image](https://user-images.githubusercontent.com/60173782/182895688-342490f0-195b-4dd2-b327-f8b29e6e34db.png)

- après : 

![image](https://user-images.githubusercontent.com/60173782/183368727-7a5ca19c-86fa-4ba4-b70a-e0da7b609df7.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
