### PR TITLE
badge FranceConnect lors de la fusion d'usagers

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -40,6 +40,10 @@ module UsersHelper
     user.relative? ? tag.span("Proche", class: "badge badge-info") : nil
   end
 
+  def user_logged_franceconnect_tag(user)
+    user.logged_once_with_franceconnect? ? tag.span("FranceConnect", class: "badge badge-info") : nil
+  end
+
   def user_soft_deleted_tag(organisation, user)
     user.organisations.include?(organisation) ? nil : tag.span("Supprimé", class: "badge badge-danger")
   end

--- a/app/views/admin/merge_users/_user_selection.html.slim
+++ b/app/views/admin/merge_users/_user_selection.html.slim
@@ -4,6 +4,7 @@
       div
         b>= user.reverse_full_name
         span>= relative_tag(user)
+        span>= user_logged_franceconnect_tag(user)
         = link_to "changer...", ".collapse-#{attribute}", data: { toggle: "collapse" }
 
     = f.input attribute, as: :hidden, input_html: { id: attribute }, wrapper: false


### PR DESCRIPTION
Pour tester https://production-rdv-solidarites-pr2709.osc-secnum-fr1.scalingo.io/

Closes #2705

Mise en place d'un badge pour identifier un usager utilisant FranceConnect lors de la fusion de deux usagers.
![image](https://user-images.githubusercontent.com/60173782/183667865-cb3e4554-6f0f-4ce3-836e-e62a371a92be.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
