### PR TITLE
Correctifs pour les notifications sur les rdv collectifs

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -52,11 +52,11 @@ class Admin::RdvsCollectifsController < AgentAuthController
     @rdv = Rdv.find(params[:id])
     authorize(@rdv, :update?)
 
-    previous_participant_ids = @rdv.participants_with_life_cycle_notification_ids
+    previous_participations = @rdv.rdvs_users
 
     if @rdv.update(update_users_params)
       flash[:notice] = "Participants mis à jour"
-      Notifiers::RdvCollectifParticipations.perform_with(@rdv, current_agent, previous_participant_ids)
+      Notifiers::RdvCollectifParticipations.perform_with(@rdv, current_agent, previous_participations)
       redirect_to admin_organisation_rdvs_collectifs_path(current_organisation)
     else
       render :edit

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -246,10 +246,6 @@ class Rdv < ApplicationRecord
     Time.zone.now + motif.max_booking_delay
   end
 
-  def participants_with_life_cycle_notification_ids
-    rdvs_users.where(send_lifecycle_notifications: true).pluck(:user_id)
-  end
-
   def remaining_seats?
     return true unless max_participants_count
 

--- a/app/services/notifiers/rdv_cancelled.rb
+++ b/app/services/notifiers/rdv_cancelled.rb
@@ -2,9 +2,7 @@
 
 class Notifiers::RdvCancelled < Notifiers::RdvBase
   def notify_user_by_mail(user)
-    # Only send sms for excused cancellations (not for no-show)
-    # if the rdv is collectif, there can still be cancellation notification if a participant is removed (regardless of the rdv status)
-    return unless @rdv.status.in?(%w[excused revoked]) || @rdv.collectif?
+    return unless notify_cancellation?
 
     user_mailer(user).rdv_cancelled.deliver_later
   end
@@ -12,12 +10,20 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
   def notify_user_by_sms(user)
     # Only send sms for excused cancellations by an Agent (not for no-show, not for self-cancellation)
     return unless @author.is_a? Agent
-    return unless @rdv.status.in?(%w[excused revoked]) || @rdv.collectif?
+    return unless notify_cancellation?
 
     Users::RdvSms.rdv_cancelled(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
   end
 
   protected
+
+  def notify_cancellation?
+    # if the rdv is collectif, there can still be cancellation notification if a participant is removed (regardless of the rdv status)
+    return true if @rdv.collectif?
+
+    # Only send sms for excused cancellations (not for no-show)
+    @rdv.status.in?(%w[excused revoked])
+  end
 
   def rdvs_users_to_notify
     @rdv.rdvs_users.where(send_lifecycle_notifications: true)

--- a/app/services/notifiers/rdv_cancelled.rb
+++ b/app/services/notifiers/rdv_cancelled.rb
@@ -3,6 +3,7 @@
 class Notifiers::RdvCancelled < Notifiers::RdvBase
   def notify_user_by_mail(user)
     # Only send sms for excused cancellations (not for no-show)
+    # if the rdv is collectif, there can still be cancellation notification if a participant is removed (regardless of the rdv status)
     return unless @rdv.status.in?(%w[excused revoked]) || @rdv.collectif?
 
     user_mailer(user).rdv_cancelled.deliver_later

--- a/app/services/notifiers/rdv_cancelled.rb
+++ b/app/services/notifiers/rdv_cancelled.rb
@@ -12,7 +12,7 @@ class Notifiers::RdvCancelled < Notifiers::RdvBase
   def notify_user_by_sms(user)
     # Only send sms for excused cancellations by an Agent (not for no-show, not for self-cancellation)
     return unless @author.is_a? Agent
-    return unless @rdv.status.in? %w[excused revoked]
+    return unless @rdv.status.in?(%w[excused revoked]) || @rdv.collectif?
 
     Users::RdvSms.rdv_cancelled(@rdv, user, @rdv_users_tokens_by_user_id[user.id]).deliver_later
   end

--- a/app/services/notifiers/rdv_collectif_participations.rb
+++ b/app/services/notifiers/rdv_collectif_participations.rb
@@ -11,12 +11,12 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
     return if @rdv.starts_at < Time.zone.now
 
     # FIXME: this is not ideal but it's the simplest workaround to avoid notifying the agent
-    rdv_created = Notifiers::RdvCreated.new(@rdv, @author, new_participants)
+    rdv_created = Notifiers::RdvCreated.new(@rdv, @author, new_participants_to_notify)
     rdv_created_invitation_tokens = rdv_created.generate_invitation_tokens
     rdv_created.notify_users_by_mail
     rdv_created.notify_users_by_sms
 
-    rdv_cancelled = Notifiers::RdvCancelled.new(@rdv, @author, removed_participants_with_lifecycle_notifications)
+    rdv_cancelled = Notifiers::RdvCancelled.new(@rdv, @author, removed_participants_to_notify)
     # we don't generate token in this case since the user won't be linked to the rdv
     rdv_cancelled.notify_users_by_mail
     rdv_cancelled.notify_users_by_sms
@@ -26,12 +26,22 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
 
   private
 
-  def new_participants
-    User.where(id: current_participations.select(&:send_lifecycle_notifications).map(&:user_id) - @previous_participations.map(&:user_id))
+  def new_participations
+    current_participations.where.not(user_id: @previous_participations.map(&:user_id))
   end
 
-  def removed_participants_with_lifecycle_notifications
-    User.where(id: @previous_participations.select(&:send_lifecycle_notifications).map(&:user_id) - current_participations.map(&:user_id))
+  def new_participants_to_notify
+    new_participations.select(&:send_lifecycle_notifications).map(&:user)
+  end
+
+  def removed_participations
+    # Using the in-memory records instead of using SQL because
+    # the previous participations have been removed from the DB
+    @previous_participations.select { |p| !p.user_id.in?(current_participations.map(&:user_id)) } # rubocop:disable Style/InverseMethods
+  end
+
+  def removed_participants_to_notify
+    removed_participations.select(&:send_lifecycle_notifications).map(&:user)
   end
 
   def current_participations

--- a/app/services/rdv_updater.rb
+++ b/app/services/rdv_updater.rb
@@ -12,13 +12,13 @@ module RdvUpdater
         rdv_params[:cancelled_at] = rdv_params[:status].in?(%w[excused revoked noshow]) ? Time.zone.now : nil
       end
 
-      previous_participant_ids = rdv.participants_with_life_cycle_notification_ids
+      previous_participations = rdv.rdvs_users.to_a
 
       success = rdv.update(rdv_params)
 
       Result.new(
         success: success,
-        rdv_users_tokens_by_user_id: success ? notify!(author, rdv, previous_participant_ids) : {}
+        rdv_users_tokens_by_user_id: success ? notify!(author, rdv, previous_participations) : {}
       )
     end
 
@@ -27,7 +27,7 @@ module RdvUpdater
         rdv.status == "unknown"
     end
 
-    def notify!(author, rdv, previous_participant_ids)
+    def notify!(author, rdv, previous_participations)
       rdv_users_tokens_by_user_id = {}
       if rdv_cancelled?(rdv)
         rdv.file_attentes.destroy_all
@@ -43,7 +43,7 @@ module RdvUpdater
       end
 
       if rdv.collectif?
-        rdv_users_tokens_by_user_id = Notifiers::RdvCollectifParticipations.perform_with(rdv, author, previous_participant_ids)
+        rdv_users_tokens_by_user_id = Notifiers::RdvCollectifParticipations.perform_with(rdv, author, previous_participations)
       end
 
       rdv_users_tokens_by_user_id

--- a/spec/features/agents/rdvs_collectifs/editing_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/editing_spec.rb
@@ -29,6 +29,6 @@ describe "Agent can edit a Rdv collectif" do
       expect(page).to have_content("Atelier Collectif") # to wait for the request to complete before checking sent emails
     end.not_to change { ActionMailer::Base.deliveries.size }
 
-    expect(rdv.reload.rdvs_users.first.send_lifecycle_notifications).to be_false
+    expect(rdv.reload.rdvs_users.first.send_lifecycle_notifications).to be_falsey
   end
 end

--- a/spec/features/agents/rdvs_collectifs/editing_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/editing_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe "Agent can edit a Rdv collectif" do
+  let!(:organisation) { create(:organisation) }
+  let!(:service) { create(:service) }
+  let!(:agent) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, :collectif, service: service, organisation: organisation, name: "Atelier Collectif") }
+
+  let(:user) do
+    create(:user, phone_number: "+33611223344", email: "test@exemple.fr")
+  end
+  let(:rdv) do
+    create(:rdv, motif: motif, organisation: organisation, agents: [agent], users: [],
+                 lieu: create(:lieu, organisation: organisation))
+  end
+
+  before do
+    rdv.rdvs_users.create(user: create(:user), send_lifecycle_notifications: true)
+  end
+
+  # js: true is necessary for the lieu selection
+  it "doesn't send a cancellation notification if the notifications for the participant are removed", js: true do
+    login_as(agent, scope: :agent)
+    visit edit_admin_organisation_rdv_path(organisation, rdv)
+    find(:label, text: "Notifications de création et modification").click
+
+    expect do
+      click_button "Enregistrer"
+      expect(page).to have_content("Atelier Collectif") # to wait for the request to complete before checking sent emails
+    end.not_to change { ActionMailer::Base.deliveries.size }
+
+    expect(rdv.reload.rdvs_users.first.send_lifecycle_notifications).to be_false
+  end
+end

--- a/spec/features/agents/rdvs_collectifs/editing_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/editing_spec.rb
@@ -29,6 +29,6 @@ describe "Agent can edit a Rdv collectif" do
       expect(page).to have_content("Atelier Collectif") # to wait for the request to complete before checking sent emails
     end.not_to change { ActionMailer::Base.deliveries.size }
 
-    expect(rdv.reload.rdvs_users.first.send_lifecycle_notifications).to be_falsey
+    expect(rdv.reload.rdvs_users.first.send_lifecycle_notifications).to be false
   end
 end

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -153,8 +153,11 @@ describe RdvUpdater, type: :service do
     let(:user_removed) { create(:user, first_name: "Remove") }
 
     let(:token) { "some-token" }
+    let(:sms_sender_double) { instance_double(SmsSender) }
 
     it "notifies the new participant, and the one that is removed" do
+      expect(SmsSender).to receive(:new).and_return(sms_sender_double).twice
+      expect(sms_sender_double).to receive(:perform).twice
       described_class.update(agent, rdv, rdv_params)
       expect(ActionMailer::Base.deliveries.count).to eq 2
 


### PR DESCRIPTION
Ce correctif est motivé par ce message sur le mattermost des cnfs
<img width="698" alt="Capture d’écran 2022-08-16 à 15 23 11" src="https://user-images.githubusercontent.com/1840367/184890373-ca791a6f-4d58-4dc6-915a-6add3089737b.png">
(https://discussion.conseiller-numerique.gouv.fr/cnum/pl/nobz17ucptn5fcd59675g36uow)

Le protocole pour reproduire ce premier bug était le suivant : 
- inscrire un usager avec une adresse email à un rdv collectif en activant les notifications de création et modification
- désactiver les notifications de création et modification
- bug: l'usager reçoit un mail d'annulation.

Le premier commit ajoute un test de non-régression pour ce bug.

En regardant l'implémentation, je me suis rendu compte qu'il y avait le bug symétrique pour l'activation des notifications de création et modification.

Le deuxième commit corrige ces deux bugs en regardant les détails des participations, et non pas juste la liste des usagers avec les notifications activées.
On ajoute aussi une spec unitaire pour tester le deuxième bug.

Enfin, en relisant le code je me suis rendu compte qu'on n'envoyait pas de sms en cas de désinscription d'un rdv collectif. Le troisième commit corrige ce bug.


# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
