### PR TITLE
Précise la table utilisé pour le tri de la recherche

### DIFF
--- a/app/models/concerns/text_search.rb
+++ b/app/models/concerns/text_search.rb
@@ -28,7 +28,7 @@ module TextSearch
   included do
     include PgSearch::Model
 
-    pg_search_scope(:search_on_search_terms, against: :search_terms, using: { tsearch: { prefix: true, any_word: true } }, order_within_rank: "search_terms asc")
+    pg_search_scope(:search_on_search_terms, against: :search_terms, using: { tsearch: { prefix: true, any_word: true } }, order_within_rank: "#{table_name}.search_terms asc")
 
     before_save :refresh_search_terms
   end

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe "Agent can search plage ouverture" do
+  specify do
+    organisation = create(:organisation)
+    agent = create(:agent, organisations: [organisation])
+
+    perm_enfance = create(:plage_ouverture, title: "Permanence Enfance", agent: agent, organisation: organisation)
+    perm_scolaire = create(:plage_ouverture, title: "Permanence Scolaire", agent: agent, organisation: organisation)
+
+    login_as(agent, scope: :agent)
+    visit admin_organisation_agent_plage_ouvertures_path(organisation, agent)
+
+    expect(page).to have_content(perm_enfance.title)
+    expect(page).to have_content(perm_scolaire.title)
+
+    fill_in :search, with: "sco"
+    click_button "Rechercher"
+
+    expect(page).not_to have_content(perm_enfance.title)
+    expect(page).to have_content(perm_scolaire.title)
+  end
+end


### PR DESCRIPTION
_Pour tester https://production-rdv-solidarites-pr2726.osc-secnum-fr1.scalingo.io/_

Cette PR précise le nom de la table utilisée dans le tri.

Sans vraiment avoir creusé pourquoi lorsqu'un agent admin faire une recherche de plage d'ouverture, cela fonctionne, alors que pour un agent non admin, ça fait une erreur 500, cette précision ici permet de résoudre le problème.

_Il serait intéressant d'explorer POURQUOI ce contexte différent ajoute ce problème, mais ça pourrait être abordé dans une autre PR, ou plus tard en tout cas_

avant (erreur 500 en dev)
![Screenshot 2022-08-18 at 12-31-20 ActiveRecord StatementInvalid at admin organisations 1 agents 2 plage_ouvertures](https://user-images.githubusercontent.com/42057/185374697-2e6cf78b-b673-43c9-9dca-6b0bc1967010.png)

après

![Screenshot 2022-08-18 at 12-31-06 Vos plages d'ouvertures - RDV Solidarités](https://user-images.githubusercontent.com/42057/185374703-d32e882c-7646-4729-aa65-0037d394399e.png)

Closes #2701 
Ferme aussi https://sentry.io/organizations/rdv-solidarites/issues/3405099935/?project=1811205&query=is%3Aunresolved+sdk.name%3Asentry.ruby.rails&sort=date&statsPeriod=14d

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
