### PR TITLE
RDV uniquement avec des agents du même service que le motif (reprise de la PR #2650)

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -9,6 +9,7 @@ class Admin::AgentsController < AgentAuthController
       .includes(:service, :roles, :organisations)
       .active
     @invited_agents_count = @agents.invitation_not_accepted.created_by_invite.count
+    @agents = @agents.joins(:motifs).where(motifs: {id: index_params[:motif]}) if index_params[:motif]
     @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.order_by_last_name
     @agents = @agents.complete.page(params[:page])
   end
@@ -34,6 +35,6 @@ class Admin::AgentsController < AgentAuthController
   private
 
   def index_params
-    @index_params ||= params.permit(:term)
+    @index_params ||= params.permit(:term, :motif)
   end
 end

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -9,7 +9,7 @@ class Admin::AgentsController < AgentAuthController
       .includes(:service, :roles, :organisations)
       .active
     @invited_agents_count = @agents.invitation_not_accepted.created_by_invite.count
-    @agents = @agents.joins(:motifs).where(motifs: {id: index_params[:motif]}) if index_params[:motif]
+    @agents = @agents.joins(:motifs).where(motifs: { id: index_params[:motif] }) if index_params[:motif]
     @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.order_by_last_name
     @agents = @agents.complete.page(params[:page])
   end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -53,6 +53,7 @@ class Rdv < ApplicationRecord
   validate :starts_at_is_plausible
   validate :duration_is_plausible
   validates :max_participants_count, numericality: { greater_than: 0, allow_nil: true }
+  validate :motif_available_to_agents, if: Proc.new { |rdv| rdv.created_at > Date.new(2022, 8, 17) } # Remove condition in august 2024
 
   # Hooks
   after_save :associate_users_with_organisation
@@ -293,6 +294,11 @@ class Rdv < ApplicationRecord
     return if starts_at.nil? || ends_at.nil?
 
     errors.add(:duration_in_min, :must_be_positive) if starts_at >= ends_at
+  end
+
+  def motif_available_to_agents
+    return if agents.all? { |agent| agent.service == motif.service }
+    errors.add(:agents, :motif_not_available)
   end
 
   def lieu_is_not_disabled_if_needed

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -53,7 +53,7 @@ class Rdv < ApplicationRecord
   validate :starts_at_is_plausible
   validate :duration_is_plausible
   validates :max_participants_count, numericality: { greater_than: 0, allow_nil: true }
-  validate :motif_available_to_agents, if: proc { |rdv| rdv.created_at > Date.new(2022, 8, 17) } # Remove condition in august 2024
+  validate :motif_available_to_agents, if: proc { |rdv| rdv.created_at.nil? || rdv.created_at > Date.new(2022, 8, 17) } # Remove condition in august 2024
 
   # Hooks
   after_save :associate_users_with_organisation

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -53,7 +53,7 @@ class Rdv < ApplicationRecord
   validate :starts_at_is_plausible
   validate :duration_is_plausible
   validates :max_participants_count, numericality: { greater_than: 0, allow_nil: true }
-  validate :motif_available_to_agents, if: Proc.new { |rdv| rdv.created_at > Date.new(2022, 8, 17) } # Remove condition in august 2024
+  validate :motif_available_to_agents, if: proc { |rdv| rdv.created_at > Date.new(2022, 8, 17) } # Remove condition in august 2024
 
   # Hooks
   after_save :associate_users_with_organisation
@@ -298,6 +298,7 @@ class Rdv < ApplicationRecord
 
   def motif_available_to_agents
     return if agents.all? { |agent| agent.service == motif.service }
+
     errors.add(:agents, :motif_not_available)
   end
 

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -63,7 +63,7 @@
                       data: { \
                         "select-options": { \
                           ajax: { \
-                            url: admin_organisation_agents_path(current_organisation),
+                            url: admin_organisation_agents_path(current_organisation, motif: @rdv_form.motif.id), \
                             dataType: "json", delay: 250, \
                           }, \
                         }, \

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -17,6 +17,8 @@ fr:
               must_be_positive: doit être supérieur à 0
             lieu:
               must_not_be_disabled: "doit être un lieu ouvert de l’organisation, ou un lieu ponctuel."
+            agents:
+              motif_not_available: "doivent avoir accès au motif"
     models:
       rdv: Rendez-vous
     attributes:

--- a/spec/controllers/admin/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/agents/rdvs_controller_spec.rb
@@ -5,7 +5,8 @@ describe Admin::Agents::RdvsController, type: :controller do
     context "with a signed in agent" do
       let(:organisation) { create(:organisation) }
       let(:other_organisation) { create(:organisation) }
-      let(:agent) { create(:agent, admin_role_in_organisations: [organisation, other_organisation]) }
+      let(:motif) { create(:motif) }
+      let(:agent) { create(:agent, service: motif.service, admin_role_in_organisations: [organisation, other_organisation]) }
 
       before { sign_in agent }
 
@@ -18,9 +19,9 @@ describe Admin::Agents::RdvsController, type: :controller do
         now = Time.zone.parse("2020-12-23 15h00")
         travel_to(now)
         given_agent = create(:agent, basic_role_in_organisations: [organisation], service: agent.service)
-        create(:rdv, agents: [agent])
-        rdv = create(:rdv, agents: [given_agent], organisation: organisation, starts_at: now + 3.days)
-        rdv_from_other_organisation = create(:rdv, agents: [given_agent], organisation: other_organisation, starts_at: now + 4.days)
+        create(:rdv, motif: motif, agents: [agent])
+        rdv = create(:rdv, motif: motif, agents: [given_agent], organisation: organisation, starts_at: now + 3.days)
+        rdv_from_other_organisation = create(:rdv, motif: motif, agents: [given_agent], organisation: other_organisation, starts_at: now + 4.days)
         get :index, params: { agent_id: given_agent.id, organisation_id: organisation.id, format: :json }
         expect(assigns(:rdvs).sort).to eq([rdv, rdv_from_other_organisation].sort)
         travel_back
@@ -30,9 +31,9 @@ describe Admin::Agents::RdvsController, type: :controller do
         now = Time.zone.parse("2021-01-23 10h00")
 
         travel_to(now - 2.days)
-        create(:rdv, agents: [agent], organisation: organisation, starts_at: now - 1.day)
-        rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 2.days)
-        create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 8.days)
+        create(:rdv, motif: motif, agents: [agent], organisation: organisation, starts_at: now - 1.day)
+        rdv = create(:rdv, motif: motif, agents: [agent], organisation: organisation, starts_at: now + 2.days)
+        create(:rdv, motif: motif, agents: [agent], organisation: organisation, starts_at: now + 8.days)
         travel_to(now)
 
         get :index, params: { agent_id: agent.id, organisation_id: organisation.id, start: now, end: now + 7.days, format: :json }

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     end
 
     describe "when there is an available creneau" do
-      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
       let(:mock_creneau) do
         instance_double(Creneau, agent: agent, motif: motif, lieu: lieu, starts_at: starts_at, duration_in_min: 30)
       end
@@ -374,7 +374,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:user) { create(:user) }
     let(:motif) { create(:motif, organisation: organisation) }
     let(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
-    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: "user") }
     let(:token) { "12345" }
 

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
   factory :plage_ouverture do
     organisation { create(:organisation) }
-    agent { create(:agent, basic_role_in_organisations: [organisation]) }
+    agent { create(:agent, service: motifs.first&.service || build(:service), basic_role_in_organisations: [organisation]) }
     lieu { create(:lieu, organisation: organisation) }
 
     title { generate(:plage_title) }

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     lieu { build(:lieu, organisation: organisation) }
     motif { build(:motif, organisation: organisation) }
     users { [build(:user, organisations: [organisation])] }
-    agents { [build(:agent, organisations: [organisation])] }
+    agents { [build(:agent, service: motif.service, organisations: [organisation])] }
 
     duration_in_min { 45 }
     starts_at { 3.days.from_now }

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -132,7 +132,7 @@ describe "Agent can create a Rdv with wizard" do
 
       before do
         # Creating a duplicate RDV with same attributes but different user / agent
-        create(:rdv, organisation: organisation, users: [create(:user)], agents: [create(:agent)], motif: motif,
+        create(:rdv, organisation: organisation, users: [create(:user)], agents: [create(:agent, service: motif.service)], motif: motif,
                      lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
       end
 

--- a/spec/features/agents/agent_only_see_service_motif.rb
+++ b/spec/features/agents/agent_only_see_service_motif.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe "Agent can create a Rdv with creneau search" do
+  include UsersHelper
+
+  before do
+    login_as(agent, scope: :agent)
+  end
+
+  let!(:organisation) { create(:organisation) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+
+  context "default" do
+    let!(:organisation) { create(:organisation) }
+    let!(:service) { create(:service) }
+    let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
+    let!(:motif) { create(:motif, name: "MOTIFAVAILABLE", reservable_online: true, service: service, organisation: organisation) }
+    let!(:motif2) { create(:motif, name: "OTHERMOTIF", reservable_online: true, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif1, motif2, motif3], lieu: lieu, agent: agent, organisation: organisation) }
+
+    it "can only see motifs of service", js: true do
+      visit admin_organisation_agent_searches_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      
+      expect(page).to have_content("MOTIFAVAILABLE")
+      expect(page).to_not have_content("OTHERMOTIF")
+      select(motif.name, from: "motif_id")
+      click_button("Afficher les créneaux")
+
+      expect(page).to have_content(plage_ouverture.lieu.address)
+    end
+  end
+end

--- a/spec/features/agents/agent_only_see_service_motif_spec.rb
+++ b/spec/features/agents/agent_only_see_service_motif_spec.rb
@@ -16,7 +16,7 @@ describe "Agent can create a Rdv with creneau search" do
     let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
     let!(:motif) { create(:motif, name: "MOTIFAVAILABLE", reservable_online: true, service: service, organisation: organisation) }
     let!(:motif2) { create(:motif, name: "OTHERMOTIF", reservable_online: true, organisation: organisation) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif1, motif2, motif3], lieu: lieu, agent: agent, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif, motif2], lieu: lieu, agent: agent, organisation: organisation) }
 
     it "can only see motifs of service", js: true do
       visit admin_organisation_agent_searches_path(organisation)

--- a/spec/features/agents/agent_only_see_service_motif_spec.rb
+++ b/spec/features/agents/agent_only_see_service_motif_spec.rb
@@ -21,9 +21,9 @@ describe "Agent can create a Rdv with creneau search" do
     it "can only see motifs of service", js: true do
       visit admin_organisation_agent_searches_path(organisation)
       expect(page).to have_content("Trouver un RDV")
-      
+
       expect(page).to have_content("MOTIFAVAILABLE")
-      expect(page).to_not have_content("OTHERMOTIF")
+      expect(page).not_to have_content("OTHERMOTIF")
       select(motif.name, from: "motif_id")
       click_button("Afficher les créneaux")
 

--- a/spec/features/agents/calendar_export_spec.rb
+++ b/spec/features/agents/calendar_export_spec.rb
@@ -38,11 +38,11 @@ describe "Agents can export their calendar to other tools, such as Outlook or Go
   it "displays rdvs in the proper format for calendars, without including personal information" do
     travel_to(Time.zone.local(2022, 7, 8))
     org = create(:organisation, id: 123_000)
-    agent = create(:agent, calendar_uid: SecureRandom.uuid, first_name: "Marceau", last_name: "COLIN")
     motif = create(:motif, name: "Accompagnement individuel")
+    agent = create(:agent, service: motif.service, calendar_uid: SecureRandom.uuid, first_name: "Marceau", last_name: "COLIN")
     create(:rdv, motif: motif, agents: [agent], status: "unknown", starts_at: 1.day.from_now, uuid: "e0a8dbac-d06c-4d18-98c6-a48f47fddd4c", organisation: org, id: 456_000)
     create(:rdv, motif: motif, agents: [agent], status: "revoked", starts_at: 2.days.from_now, uuid: "749336ce-eaca-40a3-8c28-246ed8d18849", organisation: org, id: 789_000)
-    motif_collectif = create(:motif, :collectif, name: "Atelier collectif", organisation: org)
+    motif_collectif = create(:motif, :collectif, service: motif.service, name: "Atelier collectif", organisation: org)
     create(:rdv, motif: motif_collectif, agents: [agent], status: "unknown", starts_at: 3.days.from_now, uuid: "abb701a5-381a-4fae-9157-129b5843834c", organisation: org, id: 123_123,
                  max_participants_count: 5)
 

--- a/spec/features/super_admin/migrating_an_agent_spec.rb
+++ b/spec/features/super_admin/migrating_an_agent_spec.rb
@@ -4,9 +4,10 @@ describe "Migrating an agent from one organisation to another" do
   let(:super_admin) { create :super_admin }
   let!(:old_organisation) { create :organisation }
   let!(:new_organisation) { create :organisation, territory: old_organisation.territory }
-  let(:agent) { create :agent, admin_role_in_organisations: [old_organisation] }
+  let(:motif) { create :motif }
+  let(:agent) { create :agent, service: motif.service, admin_role_in_organisations: [old_organisation] }
 
-  let!(:rdv) { create :rdv, organisation: old_organisation, agents: [agent] }
+  let!(:rdv) { create :rdv, motif: motif, organisation: old_organisation, agents: [agent] }
 
   before do
     login_as(super_admin, scope: :super_admin)
@@ -28,8 +29,8 @@ describe "Migrating an agent from one organisation to another" do
   end
 
   context "when the agent has a rdv with another agent that is not being migrated" do
-    let!(:rdv) { create :rdv, organisation: old_organisation, agents: [agent, other_agent] }
-    let(:other_agent) { create(:agent, admin_role_in_organisations: [old_organisation]) }
+    let!(:rdv) { create :rdv, motif: motif, organisation: old_organisation, agents: [agent, other_agent] }
+    let(:other_agent) { create(:agent, service: motif.service, admin_role_in_organisations: [old_organisation]) }
 
     it "doesn't migrate the records and shows an error" do
       click_button "Migrer"

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -18,7 +18,7 @@ describe "User can be invited" do
     user.invite! { |u| u.skip_invitation = true }
     user.raw_invitation_token
   end
-  let!(:agent) { create(:agent) }
+  let!(:agent) { create(:agent, service: motif.service) }
   let!(:departement_number) { "26" }
   let!(:city_code) { "26000" }
   let!(:territory26) { create(:territory, departement_number: departement_number) }
@@ -26,8 +26,8 @@ describe "User can be invited" do
   let!(:motif) { create(:motif, name: "RSA orientation sur site", reservable_online: true, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:autre_lieu) { create(:lieu, organisation: organisation) }
-  let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
-  let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: autre_lieu, organisation: organisation) }
+  let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 31.days, motifs: [motif], lieu: lieu, organisation: organisation) }
+  let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 31.days, motifs: [motif], lieu: autre_lieu, organisation: organisation) }
 
   let!(:organisation2) { create(:organisation) }
 
@@ -104,7 +104,7 @@ describe "User can be invited" do
 
   describe "invitation to motifs selection" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
-    let!(:motif2) { create(:motif, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2) }
+    let!(:motif2) { create(:motif, service: motif.service, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2) }
     let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
 
     before do
@@ -159,7 +159,7 @@ describe "User can be invited" do
 
   describe "when no motifs found through geo search" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.none) }
-    let!(:motif2) { create(:motif, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2) }
+    let!(:motif2) { create(:motif, service: motif.service, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2) }
     let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
 
     before do

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -2,14 +2,15 @@
 
 describe Admin::EditRdvForm, type: :form do
   let(:organisation) { create(:organisation) }
-  let(:agent) { create(:agent) }
+  let(:motif) { create(:motif) }
+  let(:agent) { create(:agent, service: motif.service) }
   let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
 
   describe "#update" do
     it "updates rdv's lieu" do
       now = Time.zone.parse("2020-12-12 13h50")
       travel_to(now)
-      rdv = create(:rdv, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
+      rdv = create(:rdv, motif: motif, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
       new_lieu = create(:lieu, organisation: organisation)
 
       edit_rdv_form = described_class.new(rdv, agent_context)
@@ -21,7 +22,7 @@ describe Admin::EditRdvForm, type: :form do
     it "updates the requested rdv status" do
       now = Time.zone.parse("2020-12-12 13h50")
       travel_to(now)
-      rdv = create(:rdv, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
+      rdv = create(:rdv, motif: motif, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
 
       edit_rdv_form = described_class.new(rdv, agent_context)
       edit_rdv_form.update(status: "waiting")
@@ -33,7 +34,7 @@ describe Admin::EditRdvForm, type: :form do
       now = Time.zone.parse("2020-08-03 9h00")
 
       travel_to(now - 2.days)
-      rdv = create(:rdv, cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
+      rdv = create(:rdv, motif: motif, cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
 
       travel_to(now)
 
@@ -48,7 +49,7 @@ describe Admin::EditRdvForm, type: :form do
     it "when status is excused, cancelled_at should not be nil" do
       now = Time.zone.parse("2020-08-03 9h00")
       travel_to(now - 3.days)
-      rdv = create(:rdv, starts_at: now - 2.days, agents: [agent], organisation: organisation)
+      rdv = create(:rdv, motif: motif, starts_at: now - 2.days, agents: [agent], organisation: organisation)
       travel_to(now)
 
       edit_rdv_form = described_class.new(rdv, agent_context)
@@ -62,7 +63,7 @@ describe Admin::EditRdvForm, type: :form do
     it "when status is excused, changing status should reset cancelled_at" do
       now = Time.zone.parse("2020-08-03 9h00")
       travel_to(now - 4.days)
-      rdv = create(:rdv, cancelled_at: 2.days.ago, starts_at: now - 2.days, agents: [agent], organisation: organisation, status: "excused")
+      rdv = create(:rdv, motif: motif, cancelled_at: 2.days.ago, starts_at: now - 2.days, agents: [agent], organisation: organisation, status: "excused")
       travel_to(now)
 
       edit_rdv_form = described_class.new(rdv, agent_context)

--- a/spec/form_models/admin/rdv_form_concern_spec.rb
+++ b/spec/form_models/admin/rdv_form_concern_spec.rb
@@ -65,9 +65,10 @@ describe Admin::RdvFormConcern, type: :form do
     end
 
     context "rdv is valid but there is another rdv ending shortly before" do
-      let!(:agent_new_rdv) { create(:agent) }
-      let(:rdv) { build(:rdv, agents: [agent_new_rdv]) }
-      let!(:rdv2) { create(:rdv, agents: [agent_new_rdv]) }
+      let(:motif) { create(:motif) }
+      let!(:agent_new_rdv) { create(:agent, service: motif.service) }
+      let(:rdv) { build(:rdv, motif: motif, agents: [agent_new_rdv]) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [agent_new_rdv]) }
 
       before do
         allow(rdv).to receive(:valid?).and_return(true)
@@ -94,11 +95,12 @@ describe Admin::RdvFormConcern, type: :form do
 
     context "rdv is valid but there are multiple other RDVs ending shortly before" do
       let(:now) { Time.zone.parse("2021-12-13 10:45") }
-      let!(:agent_giono) { build(:agent, first_name: "Jean", last_name: "GIONO") }
-      let!(:agent_maceo) { build(:agent, first_name: "Maceo", last_name: "PARKER") }
-      let(:rdv) { build(:rdv, agents: [agent_giono, agent_maceo], starts_at: now + 1.week) }
-      let!(:rdvs_giono) { build_list(:rdv, 2, agents: [agent_giono]) }
-      let!(:rdvs_maceo) { build_list(:rdv, 2, agents: [agent_maceo]) }
+      let(:motif) { create(:motif) }
+      let!(:agent_giono) { build(:agent, service: motif.service, first_name: "Jean", last_name: "GIONO") }
+      let!(:agent_maceo) { build(:agent, service: motif.service, first_name: "Maceo", last_name: "PARKER") }
+      let(:rdv) { build(:rdv, motif: motif, agents: [agent_giono, agent_maceo], starts_at: now + 1.week) }
+      let!(:rdvs_giono) { build_list(:rdv, 2, motif: motif, agents: [agent_giono]) }
+      let!(:rdvs_maceo) { build_list(:rdv, 2, motif: motif, agents: [agent_maceo]) }
 
       before do
         travel_to(now)
@@ -129,9 +131,10 @@ describe Admin::RdvFormConcern, type: :form do
     end
 
     context "rdv is valid but there are an other RDV that start before this ending" do
-      let!(:agent_new_rdv) { create(:agent) }
-      let(:rdv) { build(:rdv, agents: [agent_new_rdv]) }
-      let!(:rdv2) { create(:rdv, agents: [agent_new_rdv]) }
+      let(:motif) { create(:motif) }
+      let!(:agent_new_rdv) { create(:agent, service: motif.service) }
+      let(:rdv) { build(:rdv, motif: motif, agents: [agent_new_rdv]) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [agent_new_rdv]) }
 
       before do
         allow(rdv).to receive(:valid?).and_return(true)

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -28,6 +28,7 @@ describe OrganisationsHelper do
 
     context "for a conseiller numérique" do
       let(:service_cnfs) { create(:service, name: "Conseiller Numérique") }
+      let(:motif) { create(:motif, service: service_cnfs) }
 
       it "returns true with a 21 days old organisation and 13 days old agent, until the agent has 2 rdvs" do
         agent = create(:agent, admin_role_in_organisations: [organisation],
@@ -36,7 +37,7 @@ describe OrganisationsHelper do
 
         expect(show_checklist?(organisation, agent)).to be_truthy
 
-        create_list(:rdv, 2, agents: [agent])
+        create_list(:rdv, 2, motif: motif, agents: [agent])
 
         expect(show_checklist?(organisation, agent)).to be_falsey
       end

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TransferEmailReplyJob do
     # Set a fixed date so we can assert on dates within email body
     travel_to(Time.zone.parse("2022-05-17 16:00:00"))
   end
+
   let(:motif) { create(:motif) }
   let!(:user) { create(:user, email: "bene_ficiaire@lapin.fr", first_name: "Bénédicte", last_name: "Ficiaire") }
   let!(:agent) { create(:agent, service: motif.service, email: "je_suis_un_agent@departement.fr") }

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe TransferEmailReplyJob do
     # Set a fixed date so we can assert on dates within email body
     travel_to(Time.zone.parse("2022-05-17 16:00:00"))
   end
-
+  let(:motif) { create(:motif) }
   let!(:user) { create(:user, email: "bene_ficiaire@lapin.fr", first_name: "Bénédicte", last_name: "Ficiaire") }
-  let!(:agent) { create(:agent, email: "je_suis_un_agent@departement.fr") }
+  let!(:agent) { create(:agent, service: motif.service, email: "je_suis_un_agent@departement.fr") }
   let(:rdv_uuid) { "8fae4d5f-4d63-4f60-b343-854d939881a3" }
-  let!(:rdv) { create(:rdv, users: [user], agents: [agent], uuid: rdv_uuid) }
+  let!(:rdv) { create(:rdv, motif: motif, users: [user], agents: [agent], uuid: rdv_uuid) }
 
   let(:sendinblue_valid_payload) do
     # The usual payload has more info, but I removed non-essential fields for readability.

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -2,10 +2,11 @@
 
 RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_created" do
-    let(:agent) { build(:agent) }
+    let(:motif) { build(:motif) }
+    let(:agent) { build(:agent, service: motif.service) }
     let(:t) { DateTime.parse("2020-03-01 10:20") }
     let(:mail) { described_class.with(rdv: rdv, agent: agent).rdv_created }
-    let(:rdv) { create(:rdv, starts_at: t + 2.hours, agents: [agent]) }
+    let(:rdv) { create(:rdv, starts_at: t + 2.hours, motif: motif, agents: [agent]) }
 
     before { travel_to(t) }
 
@@ -14,7 +15,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
     end
 
     context "in 2 hours" do
-      let(:rdv) { create(:rdv, starts_at: t + 10.minutes, agents: [agent]) }
+      let(:rdv) { create(:rdv, starts_at: t + 10.minutes, motif: motif, agents: [agent]) }
 
       it "has a correct subject" do
         expect(mail.subject).to eq("Nouveau RDV ajouté sur votre agenda rdv-solidarités pour aujourd’hui")
@@ -22,7 +23,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
     end
 
     context "tomorrow" do
-      let(:rdv) { create(:rdv, starts_at: t + 1.day, agents: [agent]) }
+      let(:rdv) { create(:rdv, starts_at: t + 1.day, motif: motif, agents: [agent]) }
 
       it "has a correct subject" do
         expect(mail.subject).to eq("Nouveau RDV ajouté sur votre agenda rdv-solidarités pour demain")

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -21,22 +21,25 @@ describe Agent, type: :model do
     end
 
     it "keep old mail in an `email_original` attribute" do
-      agent = create(:agent, email: "karim@le64.fr", organisations: [])
-      create(:rdv, agents: [agent])
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service, email: "karim@le64.fr", organisations: [])
+      create(:rdv, motif: motif, agents: [agent])
       agent.soft_delete
       expect(agent.email_original).to eq("karim@le64.fr")
     end
 
     it "update mail with a unique value" do
-      agent = create(:agent, basic_role_in_organisations: [])
-      create(:rdv, agents: [agent])
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service, basic_role_in_organisations: [])
+      create(:rdv, motif: motif, agents: [agent])
       agent.soft_delete
       expect(agent.email).to eq("agent_#{agent.id}@deleted.rdv-solidarites.fr")
     end
 
     it "update UID with a unique value" do
-      agent = create(:agent, basic_role_in_organisations: [])
-      create(:rdv, agents: [agent])
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service, basic_role_in_organisations: [])
+      create(:rdv, motif: motif, agents: [agent])
       agent.soft_delete
       expect(agent.uid).to eq("agent_#{agent.id}@deleted.rdv-solidarites.fr")
     end
@@ -73,8 +76,9 @@ describe Agent, type: :model do
     it "update with 1 with one past RDV" do
       now = Time.zone.parse("20211123 10:45")
       travel_to(now)
-      agent = create(:agent)
-      create(:rdv, starts_at: now - 1.day, status: :unknown, agents: [agent])
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      create(:rdv, starts_at: now - 1.day, status: :unknown, motif: motif, agents: [agent])
       agent.update_unknown_past_rdv_count!
       expect(agent.reload.unknown_past_rdv_count).to eq(1)
     end

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -16,7 +16,7 @@ describe FileAttente, type: :model do
     let!(:organisation) { create(:organisation) }
     let(:motif) { create(:motif, organisation: organisation) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
-    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
     let!(:plage_ouverture) { create(:plage_ouverture, first_day: now + 2.weeks, start_time: Tod::TimeOfDay.new(10), agent: agent, lieu: lieu, motifs: [motif], organisation: organisation) }
     let!(:rdv_user) { build(:rdvs_user, user: user, rdv: rdv) }
     let!(:rdv) { create(:rdv, starts_at: now + 2.weeks, lieu: lieu, motif: motif, users: [user], agents: [agent], organisation: organisation) }

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -686,7 +686,7 @@ describe Rdv, type: :model do
     end
 
     it "is not valid if one agent doesn't share the service" do
-      expect(build(:rdv, motif: motif, agents: [agent1, agent_other], created_at: Date.new(2022, 8, 18))).to_not be_valid
+      expect(build(:rdv, motif: motif, agents: [agent1, agent_other], created_at: Date.new(2022, 8, 18))).not_to be_valid
     end
 
     it "is valid if it's an old rdv" do

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -15,7 +15,7 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
       let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
-      let(:motif) { create(:motif)}
+      let(:motif) { create(:motif) }
       let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
       let!(:rdv_context) { create(:rdv, organisation: organisation, agents: [agent], motif: motif, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
@@ -27,7 +27,7 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "rdv from other agent but still in scope" do
       let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
-      let(:motif) { create(:motif)}
+      let(:motif) { create(:motif) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent, service: motif.service), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
       let!(:rdv_context) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
@@ -40,7 +40,7 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "rdv from other agent and not in scope" do
       let(:in_scope_mock_value) { false }
       let!(:organisation) { create(:organisation) }
-      let(:motif) { create(:motif)}
+      let(:motif) { create(:motif) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent, service: motif.service), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
       let!(:rdv_context) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -15,10 +15,11 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
       let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
-      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let(:motif) { create(:motif)}
+      let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
-      let!(:rdv_context) { create(:rdv, organisation: organisation, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
-      let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
+      let!(:rdv_context) { create(:rdv, organisation: organisation, agents: [agent], motif: motif, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
+      let!(:rdv) { create(:rdv, motif: motif, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
 
       it { is_expected.to match(%r{Vous avez <a .*>un RDV</a> finissant à 08h30 avec Milos FORMAN, vous allez laisser un trou de 30 minutes dans votre agenda}) }
     end
@@ -26,11 +27,12 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "rdv from other agent but still in scope" do
       let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
-      let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent), organisation: organisation) }
+      let(:motif) { create(:motif)}
+      let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent, service: motif.service), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
-      let!(:rdv_context) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
-      let!(:agent) { create(:agent, first_name: "Maya", last_name: "JOAO", basic_role_in_organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
+      let!(:rdv_context) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
+      let!(:agent) { create(:agent, service: motif.service, first_name: "Maya", last_name: "JOAO", basic_role_in_organisations: [organisation]) }
+      let!(:rdv) { create(:rdv, motif: motif, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
 
       it { is_expected.to match(%r{Maya JOAO a <a .*>un RDV</a> finissant à 08h30 avec Milos FORMAN, vous allez laisser un trou de 30 minutes dans son agenda}) }
     end
@@ -38,11 +40,12 @@ describe RdvEndingShortlyBeforePresenter, type: :presenter do
     context "rdv from other agent and not in scope" do
       let(:in_scope_mock_value) { false }
       let!(:organisation) { create(:organisation) }
-      let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent), organisation: organisation) }
+      let(:motif) { create(:motif)}
+      let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent, service: motif.service), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
-      let!(:rdv_context) { create(:rdv, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
-      let!(:agent) { create(:agent, first_name: "Maya", last_name: "JOAO", basic_role_in_organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
+      let!(:rdv_context) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.today.next_week(:monday).in_time_zone + 9.hours) }
+      let!(:agent) { create(:agent, service: motif.service, first_name: "Maya", last_name: "JOAO", basic_role_in_organisations: [organisation]) }
+      let!(:rdv) { create(:rdv, motif: motif, organisation: organisation, agents: [agent], users: [user], starts_at: rdv_context.starts_at - 1.hour, duration_in_min: 30) }
 
       it {
         expect(subject).to eq "Maya JOAO a un RDV finissant à 08h30, vous allez laisser un trou de 30 minutes dans son agenda "\

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -38,7 +38,7 @@ describe AgentRemoval, type: :service do
 
   context "agent has upcoming RDVs" do
     let!(:organisation) { create(:organisation) }
-    let(:motif) { create(:motif)}
+    let(:motif) { create(:motif) }
     let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif: motif, agents: [agent], organisation: organisation, starts_at: Time.zone.today.next_week(:monday) + 10.hours) }
 

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -38,8 +38,9 @@ describe AgentRemoval, type: :service do
 
   context "agent has upcoming RDVs" do
     let!(:organisation) { create(:organisation) }
-    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let!(:rdv) { create(:rdv, agents: [agent], organisation: organisation, starts_at: Time.zone.today.next_week(:monday) + 10.hours) }
+    let(:motif) { create(:motif)}
+    let!(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif: motif, agents: [agent], organisation: organisation, starts_at: Time.zone.today.next_week(:monday) + 10.hours) }
 
     it "does not succeed" do
       expect(agent).not_to receive(:soft_delete)
@@ -54,8 +55,9 @@ describe AgentRemoval, type: :service do
       now = Time.zone.parse("2021-2-13 13h00")
       travel_to(now - 2.weeks)
       organisation = create(:organisation)
-      agent = create(:agent, basic_role_in_organisations: [organisation])
-      create(:rdv, agents: [agent], organisation: organisation, starts_at: now.prev_week(:monday) + 10.hours)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service, basic_role_in_organisations: [organisation])
+      create(:rdv, agents: [agent], motif: motif, organisation: organisation, starts_at: now.prev_week(:monday) + 10.hours)
       travel_to(now)
 
       expect(agent).to receive(:soft_delete)

--- a/spec/services/next_availability_service_spec.rb
+++ b/spec/services/next_availability_service_spec.rb
@@ -6,7 +6,7 @@ describe NextAvailabilityService, type: :service do
 
   let(:organisation) { create(:organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }
-  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
   let(:motif) { create(:motif, name: "Vaccination", default_duration_in_min: 30, organisation: organisation) }
 
   before { travel_to(now) }

--- a/spec/services/notifiers/rdv_base_spec.rb
+++ b/spec/services/notifiers/rdv_base_spec.rb
@@ -105,7 +105,7 @@ describe Notifiers::RdvBase, type: :service do
   describe "agent notifications" do
     context "motif is not_notified" do
       let(:author) { build(:agent) }
-      let(:agent) { build(:agent) }
+      let(:agent) { build(:agent, service: motif.service) }
       let(:motif) { build(:motif, :visible_and_not_notified) }
       let(:rdv) { create(:rdv, starts_at: 1.day.from_now, agents: [agent], motif: motif) }
 
@@ -116,9 +116,10 @@ describe Notifiers::RdvBase, type: :service do
     end
 
     describe "agents_rdv_notifications_level" do
-      let(:agent) { build(:agent, rdv_notifications_level: rdv_notifications_level) }
+      let(:motif) { build(:motif) }
+      let(:agent) { build(:agent, service: motif.service, rdv_notifications_level: rdv_notifications_level) }
       let(:user) { build(:user) }
-      let(:rdv) { create(:rdv, starts_at: rdv_date, agents: [agent], users: [user]) }
+      let(:rdv) { create(:rdv, motif: motif, starts_at: rdv_date, agents: [agent], users: [user]) }
 
       context "level is all" do
         let(:author) { agent }

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -2,11 +2,11 @@
 
 describe Notifiers::RdvCancelled, type: :service do
   subject { described_class.perform_with(rdv, author) }
-
-  let(:agent1) { build(:agent) }
-  let(:agent2) { build(:agent) }
+  let(:motif) { build(:motif) }
+  let(:agent1) { build(:agent, service: motif.service) }
+  let(:agent2) { build(:agent, service: motif.service) }
   let(:user) { build(:user) }
-  let(:rdv) { build(:rdv, starts_at: starts_at, agents: [agent1, agent2]) }
+  let(:rdv) { build(:rdv, motif: motif, starts_at: starts_at, agents: [agent1, agent2]) }
   let(:rdv_user) { create(:rdvs_user, user: user, rdv: rdv) }
   let(:rdvs_users) { RdvsUser.where(id: rdv_user.id) }
   let(:token) { "123456" }

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -2,6 +2,7 @@
 
 describe Notifiers::RdvCancelled, type: :service do
   subject { described_class.perform_with(rdv, author) }
+
   let(:motif) { build(:motif) }
   let(:agent1) { build(:agent, service: motif.service) }
   let(:agent2) { build(:agent, service: motif.service) }

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -2,11 +2,11 @@
 
 describe Notifiers::RdvCreated, type: :service do
   subject { described_class.perform_with(rdv, user1) }
-
+  let(:motif) { build(:motif) }
   let(:user1) { build(:user) }
   let(:user2) { build(:user) }
-  let(:agent1) { build(:agent) }
-  let(:agent2) { build(:agent) }
+  let(:agent1) { build(:agent, service: motif.service) }
+  let(:agent2) { build(:agent, service: motif.service) }
   let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, agents: [agent1, agent2]) }
   let(:rdv_user1) { create(:rdvs_user, user: user1, rdv: rdv) }
   let(:rdv_user2) { create(:rdvs_user, user: user2, rdv: rdv) }

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -2,6 +2,7 @@
 
 describe Notifiers::RdvCreated, type: :service do
   subject { described_class.perform_with(rdv, user1) }
+
   let(:motif) { build(:motif) }
   let(:user1) { build(:user) }
   let(:user2) { build(:user) }

--- a/spec/services/notifiers/rdv_updated_spec.rb
+++ b/spec/services/notifiers/rdv_updated_spec.rb
@@ -2,12 +2,12 @@
 
 describe Notifiers::RdvUpdated, type: :service do
   subject { described_class.perform_with(rdv, agent1) }
-
+  let(:motif) { build(:motif) }
   let(:user1) { build(:user) }
   let(:user2) { build(:user) }
-  let(:agent1) { build(:agent, first_name: "Sean", last_name: "PAUL") }
-  let(:agent2) { build(:agent) }
-  let(:rdv) { create(:rdv, starts_at: starts_at_initial, agents: [agent1, agent2]) }
+  let(:agent1) { build(:agent, service: motif.service, first_name: "Sean", last_name: "PAUL") }
+  let(:agent2) { build(:agent, service: motif.service) }
+  let(:rdv) { create(:rdv, starts_at: starts_at_initial, motif: motif, agents: [agent1, agent2]) }
   let(:rdv_user1) { create(:rdvs_user, user: user1, rdv: rdv) }
   let(:rdv_user2) { create(:rdvs_user, user: user2, rdv: rdv) }
   let(:rdvs_users_relation) { RdvsUser.where(id: [rdv_user1.id, rdv_user2.id]) }

--- a/spec/services/notifiers/rdv_updated_spec.rb
+++ b/spec/services/notifiers/rdv_updated_spec.rb
@@ -2,6 +2,7 @@
 
 describe Notifiers::RdvUpdated, type: :service do
   subject { described_class.perform_with(rdv, agent1) }
+
   let(:motif) { build(:motif) }
   let(:user1) { build(:user) }
   let(:user2) { build(:user) }

--- a/spec/services/rdv_start_coherence_spec.rb
+++ b/spec/services/rdv_start_coherence_spec.rb
@@ -3,27 +3,28 @@
 describe RdvStartCoherence, type: :service do
   describe "#rdvs_ending_shortly_before" do
     subject { described_class.new(rdv).rdvs_ending_shortly_before }
+    let(:motif) { build(:motif) }
 
     context "ends shortly before, agent in common" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent, build(:agent)], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [build(:agent), agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      let!(:agent) { create(:agent, service: motif.service) }
+      let!(:rdv) { create(:rdv, motif: motif, agents: [agent, build(:agent, service: motif.service)], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [build(:agent, service: motif.service), agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
 
       it { is_expected.to include(rdv2) }
     end
 
     context "ends shortly before but is canceled" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15, status: :excused, cancelled_at: 10.minutes.ago) }
+      let!(:agent) { create(:agent, service: motif.service) }
+      let!(:rdv) { create(:rdv, motif: motif, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15, status: :excused, cancelled_at: 10.minutes.ago) }
 
       it { is_expected.not_to include(rdv2) }
     end
 
     context "ends shortly but is in the past" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      let!(:agent) { create(:agent, service: motif.service) }
+      let!(:rdv) { create(:rdv, motif: motif, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [agent], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
 
       before { travel_to(rdv.starts_at - 10.minutes) }
 
@@ -31,17 +32,17 @@ describe RdvStartCoherence, type: :service do
     end
 
     context "ends shortly before but no agent in common" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [build(:agent)], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
+      let!(:agent) { create(:agent, service: motif.service) }
+      let!(:rdv) { create(:rdv, motif: motif, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [build(:agent, service: motif.service)], starts_at: rdv.starts_at - 30.minutes, duration_in_min: 15) }
 
       it { is_expected.not_to include(rdv2) }
     end
 
     context "does not end shortly" do
-      let!(:agent) { create(:agent) }
-      let!(:rdv) { create(:rdv, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
-      let!(:rdv2) { create(:rdv, agents: [agent], starts_at: rdv.starts_at - 2.hours, duration_in_min: 15) }
+      let!(:agent) { create(:agent, service: motif.service) }
+      let!(:rdv) { create(:rdv, motif: motif, agents: [agent], starts_at: Time.zone.today.next_week(:monday).in_time_zone + 16.hours) }
+      let!(:rdv2) { create(:rdv, motif: motif, agents: [agent], starts_at: rdv.starts_at - 2.hours, duration_in_min: 15) }
 
       it { is_expected.not_to include(rdv2) }
     end

--- a/spec/services/rdv_start_coherence_spec.rb
+++ b/spec/services/rdv_start_coherence_spec.rb
@@ -3,6 +3,7 @@
 describe RdvStartCoherence, type: :service do
   describe "#rdvs_ending_shortly_before" do
     subject { described_class.new(rdv).rdvs_ending_shortly_before }
+
     let(:motif) { build(:motif) }
 
     context "ends shortly before, agent in common" do

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -4,9 +4,10 @@ describe RdvUpdater, type: :service do
   describe "#update" do
     describe "return value" do
       it "true when everything is ok" do
-        agent = create(:agent)
+        motif = create(:motif)
+        agent = create(:agent, service: motif.service)
         lieu = create(:lieu)
-        rdv = create(:rdv, lieu: lieu, agents: [agent], status: "waiting")
+        rdv = create(:rdv, motif: motif, lieu: lieu, agents: [agent], status: "waiting")
         rdv.reload
         rdv_params = {}
         expect(RdvUpdater::Result).to receive(:new).with(success: true, rdv_users_tokens_by_user_id: {})
@@ -14,8 +15,9 @@ describe RdvUpdater, type: :service do
       end
 
       it "return false when update fail" do
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent])
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent])
         rdv_params = { agents: [] }
         expect(RdvUpdater::Result).to receive(:new).with(success: false, rdv_users_tokens_by_user_id: {})
         described_class.update(agent, rdv, rdv_params)
@@ -24,8 +26,9 @@ describe RdvUpdater, type: :service do
 
     describe "clear the file_attentes" do
       it "destroy all file_attentes" do
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent])
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent])
         create(:file_attente, rdv: rdv)
         rdv_params = { status: "excused" }
         described_class.update(agent, rdv, rdv_params)
@@ -35,33 +38,37 @@ describe RdvUpdater, type: :service do
 
     describe "sends relevant notifications" do
       it "notifies when rdv cancelled" do
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], status: "waiting")
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], status: "waiting")
         rdv_params = { status: "excused" }
         expect(Notifiers::RdvCancelled).to receive(:perform_with).with(rdv, agent)
         described_class.update(agent, rdv, rdv_params)
       end
 
       it "does not notify when status does not change" do
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], status: "waiting")
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], status: "waiting")
         rdv_params = { status: "waiting" }
         expect(Notifiers::RdvCancelled).not_to receive(:perform_with)
         described_class.update(agent, rdv, rdv_params)
       end
 
       it "notifies when date changes" do
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], status: "waiting")
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], status: "waiting")
         rdv_params = { starts_at: 1.day.from_now }
         expect(Notifiers::RdvUpdated).to receive(:perform_with).with(rdv, agent)
         described_class.update(agent, rdv, rdv_params)
       end
 
       it "does not notify when date does not change" do
-        agent = create(:agent)
+        motif = create(:motif)
+        agent = create(:agent, service: motif.service)
         lieu = create(:lieu)
-        rdv = create(:rdv, lieu: lieu, agents: [agent], status: "waiting")
+        rdv = create(:rdv, motif: motif, lieu: lieu, agents: [agent], status: "waiting")
         rdv.reload
         rdv_params = { starts_at: rdv.starts_at }
         expect(Notifiers::RdvUpdated).not_to receive(:perform_with)
@@ -69,9 +76,10 @@ describe RdvUpdater, type: :service do
       end
 
       it "does not notify when other attributes change" do
-        agent = create(:agent)
+        motif = create(:motif)
+        agent = create(:agent, service: motif.service)
         lieu = create(:lieu)
-        rdv = create(:rdv, lieu: lieu, agents: [agent], status: "waiting")
+        rdv = create(:rdv, motif: motif, lieu: lieu, agents: [agent], status: "waiting")
         rdv.reload
         rdv_params = { context: "some context" }
         expect(Notifiers::RdvCancelled).not_to receive(:perform_with)
@@ -86,8 +94,9 @@ describe RdvUpdater, type: :service do
         travel_to(now)
         previous_date = now - 3.days
 
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], updated_at: previous_date, context: "")
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], updated_at: previous_date, context: "")
         rdv_params = { context: "un nouveau context" }
         described_class.update(agent, rdv, rdv_params)
         expect(rdv.reload.updated_at).to be_within(3.seconds).of now
@@ -98,8 +107,9 @@ describe RdvUpdater, type: :service do
     describe "sets and resets cancelled_at" do
       it "reset cancelled_at when status change" do
         cancelled_at = Time.zone.local(2020, 1, 12, 12, 56)
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], status: "noshow", cancelled_at: cancelled_at)
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], status: "noshow", cancelled_at: cancelled_at)
         rdv_params = { status: "waiting" }
         described_class.update(agent, rdv, rdv_params)
         expect(rdv.reload.cancelled_at).to eq(nil)
@@ -107,8 +117,9 @@ describe RdvUpdater, type: :service do
 
       it "dont reset cancelled_at when no status change" do
         cancelled_at = Time.zone.local(2020, 1, 12, 12, 56)
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: cancelled_at, context: "")
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], status: "excused", cancelled_at: cancelled_at, context: "")
         rdv_params = { context: "something new" }
         described_class.update(agent, rdv, rdv_params)
         expect(rdv.reload.cancelled_at).to be_within(3.seconds).of cancelled_at
@@ -117,16 +128,18 @@ describe RdvUpdater, type: :service do
       it "where status change from excused to noshow, cancelled_at should be refresh" do
         now = Time.zone.local(2020, 4, 23, 12, 56)
         travel_to(now)
-        agent = build :agent
-        rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
+        motif = build :motif
+        agent = build :agent, service: motif.service
+        rdv = create(:rdv, motif: motif, agents: [agent], status: "excused", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
         described_class.update(agent, rdv, { status: "noshow" })
         expect(rdv.reload.cancelled_at).to be_within(3.seconds).of now
       end
     end
 
     it "call Notifiers::RdvCreated when reloaded status from cancelled status" do
-      agent = build(:agent)
-      rdv = create(:rdv, agents: [agent], status: "excused", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
+      motif = build(:motif)
+      agent = build(:agent, service: motif.service)
+      rdv = create(:rdv, motif: motif, agents: [agent], status: "excused", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
 
       expect(Notifiers::RdvCreated).to receive(:perform_with)
       described_class.update(agent, rdv, { status: "unknown" })
@@ -145,7 +158,7 @@ describe RdvUpdater, type: :service do
     end
     # The reload makes sure we have the proper .previous_changes
     let(:rdv) { create(:rdv, agents: [agent], motif: motif, users: [user_staying, user_removed]).reload }
-    let(:agent) { create :agent }
+    let(:agent) { create :agent, service: motif.service }
     let(:motif) { create(:motif, :collectif) }
 
     let(:user_staying) { create(:user, first_name: "Stay") }

--- a/spec/services/rdvs_overlapping_spec.rb
+++ b/spec/services/rdvs_overlapping_spec.rb
@@ -5,9 +5,10 @@ describe RdvsOverlapping, type: :service do
     it "return rdvs that end during rdv" do
       now = Time.zone.parse("2020-12-23 12h40")
       travel_to(now)
-      agent = create(:agent)
-      overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
-      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day + 15.minutes)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      overlapped_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      created_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day + 15.minutes)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
       travel_back
     end
@@ -15,9 +16,10 @@ describe RdvsOverlapping, type: :service do
     it "return rdvs that starts during rdv" do
       now = Time.zone.parse("2020-12-23 12h40")
       travel_to(now)
-      agent = create(:agent)
-      overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
-      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      overlapped_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      created_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
       travel_back
     end
@@ -25,9 +27,10 @@ describe RdvsOverlapping, type: :service do
     it "return rdvs that starts before and end after rdv" do
       now = Time.zone.parse("2020-12-23 12h40")
       travel_to(now)
-      agent = create(:agent)
-      overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 30.minutes, duration_in_min: 60)
-      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      overlapped_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day - 30.minutes, duration_in_min: 60)
+      created_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
       travel_back
     end
@@ -35,9 +38,10 @@ describe RdvsOverlapping, type: :service do
     it "do not return rdv that starts just at rdv's end" do
       now = Time.zone.parse("2020-12-23 12h40")
       travel_to(now)
-      agent = create(:agent)
-      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
-      create(:rdv, agents: [agent], starts_at: now + 1.day + 30.minutes, duration_in_min: 30)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      created_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day + 30.minutes, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([])
       travel_back
     end
@@ -45,9 +49,10 @@ describe RdvsOverlapping, type: :service do
     it "do not return rdv that end just at rdv's start" do
       now = Time.zone.parse("2020-12-23 12h40")
       travel_to(now)
-      agent = create(:agent)
-      create(:rdv, agents: [agent], starts_at: now + 1.day - 30.minutes, duration_in_min: 30)
-      created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      create(:rdv, agents: [agent], motif: motif, starts_at: now + 1.day - 30.minutes, duration_in_min: 30)
+      created_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([])
       travel_back
     end
@@ -55,9 +60,10 @@ describe RdvsOverlapping, type: :service do
     it "returns RDV with exact same times" do
       now = Time.zone.parse("2020-12-23 12h40")
       travel_to(now)
-      agent = create(:agent)
-      existing_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
-      new_rdv = build(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      motif = create(:motif)
+      agent = create(:agent, service: motif.service)
+      existing_rdv = create(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
+      new_rdv = build(:rdv, motif: motif, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       expect(described_class.new(new_rdv).rdvs_overlapping_rdv).to eq([existing_rdv])
       travel_back
     end

--- a/spec/services/slot_builder/busy_time_spec.rb
+++ b/spec/services/slot_builder/busy_time_spec.rb
@@ -3,7 +3,8 @@
 describe SlotBuilder::BusyTime, type: :service do
   let(:monday) { Time.zone.parse("20211025 10:00") }
   let(:range) { Time.zone.parse("2021-10-26 8:00")..Time.zone.parse("2021-10-29 12:00") }
-  let(:plage_ouverture) { create(:plage_ouverture) }
+  let(:motif) { create(:motif) }
+  let(:plage_ouverture) { create(:plage_ouverture, motifs: [motif]) }
 
   before { travel_to(monday) }
 
@@ -13,17 +14,17 @@ describe SlotBuilder::BusyTime, type: :service do
 
   context "with a RDV" do
     it "returns BusyTime object in array with a RDV" do
-      create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"))
+      create(:rdv, motif: motif, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"))
       expect(described_class.busy_times_for(range, plage_ouverture).first).to be_a(described_class)
     end
 
     it "returns BusyTime that starts_at as RDV starts_at" do
-      create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"))
+      create(:rdv, motif: motif, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"))
       expect(described_class.busy_times_for(range, plage_ouverture).first.starts_at).to eq(Time.zone.parse("20211027 9:00"))
     end
 
     it "returns BusyTime that ends_at as RDV ends_at" do
-      create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"), ends_at: Time.zone.parse("20211027 9:40"))
+      create(:rdv, motif: motif, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"), ends_at: Time.zone.parse("20211027 9:40"))
       expect(described_class.busy_times_for(range, plage_ouverture).first.ends_at).to eq(Time.zone.parse("20211027 9:40"))
     end
   end

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -201,7 +201,7 @@ describe SlotBuilder, type: :service do
 
   describe "#calculate_free_times" do
     let(:motif) { create(:motif, default_duration_in_min: 60, organisation: organisation) }
-    let(:agent) { create(:agent, organisations: [organisation]) }
+    let(:agent) { create(:agent, service: motif.service, organisations: [organisation]) }
 
     it "return one free time from plage ouverture date range" do
       plage_ouverture = build(:plage_ouverture, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
@@ -305,9 +305,9 @@ describe SlotBuilder, type: :service do
     it "return range without only range of multi RDV on same range with same duration" do
       starts_at = Time.zone.parse("20211027 9:00")
       ends_at = Time.zone.parse("20211027 11:00")
-      create(:rdv, starts_at: starts_at + 45.minutes, agents: [agent])
-      prev_rdv = create(:rdv, starts_at: starts_at - 30.minutes, agents: [agent])
-      rdv = create(:rdv, starts_at: starts_at + 45.minutes, agents: [agent])
+      create(:rdv, motif: motif, starts_at: starts_at + 45.minutes, agents: [agent])
+      prev_rdv = create(:rdv, motif: motif, starts_at: starts_at - 30.minutes, agents: [agent])
+      rdv = create(:rdv, motif: motif, starts_at: starts_at + 45.minutes, agents: [agent])
       plage_ouverture = build(:plage_ouverture, first_day: starts_at.to_date, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent)
       range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 
@@ -318,9 +318,9 @@ describe SlotBuilder, type: :service do
     it "return range without only range of longer overlapped RDV on same range with same duration" do
       starts_at = Time.zone.parse("20211027 9:00")
       ends_at = Time.zone.parse("20211027 11:00")
-      create(:rdv, motif: create(:motif, organisation: organisation, default_duration_in_min: 30), starts_at: starts_at + 45.minutes, agents: [agent])
-      prev_rdv = create(:rdv, starts_at: starts_at - 30.minutes, agents: [agent])
-      rdv = create(:rdv, motif: create(:motif, organisation: organisation, default_duration_in_min: 30), starts_at: starts_at + 45.minutes, agents: [agent])
+      create(:rdv, motif: create(:motif, service: agent.service, organisation: organisation, default_duration_in_min: 30), starts_at: starts_at + 45.minutes, agents: [agent])
+      prev_rdv = create(:rdv, motif: motif, starts_at: starts_at - 30.minutes, agents: [agent])
+      rdv = create(:rdv, motif: create(:motif, service: agent.service, organisation: organisation, default_duration_in_min: 30), starts_at: starts_at + 45.minutes, agents: [agent])
       plage_ouverture = build(:plage_ouverture, first_day: starts_at.to_date, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent)
       range = Date.new(2021, 10, 26)..Date.new(2021, 10, 29)
 

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -23,9 +23,9 @@ describe Users::RdvSms, type: :service do
 
     context "with a follow_up rdv" do
       it "contains referent name" do
-        agent = create(:agent, first_name: "James", last_name: "Bond")
-        user = create(:user, agents: [agent])
         motif = create(:motif, follow_up: true)
+        agent = create(:agent, service: motif.service, first_name: "James", last_name: "Bond")
+        user = create(:user, agents: [agent])
         rdv = create(:rdv, motif: motif, users: [user], agents: [agent])
         token = "12345"
 


### PR DESCRIPTION
_Pour tester https://my.osc-secnum-fr1.scalingo.com/apps/production-rdv-solidarites-pr2727/deployments/699e8944-7a3e-4ada-a097-a085454de075_

Closes #2650 

Reprise de la PR #2650 réalisé par @simkim 

L'idée est de pouvoir déclencher l'intégralité de la CI ici.

Cette PR vise à empêcher d'avoir, sur un RDV, un agent d'un service qui n'est pas le service du motif du RDV.
Quand nous attaquerons les RDV en binôme, après avoir ajouté des éléments de contrôle sur la disponibilité des agents, nous pourrons sans doute revoir cette validation pour dire qu'il faut au moins un agent du service du motif du RDV participant au RDV.

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
