### PR TITLE
Ne pas afficher les versions des champs désactivés de la fiche usagers

### DIFF
--- a/app/presenters/paper_trail_augmented_version.rb
+++ b/app/presenters/paper_trail_augmented_version.rb
@@ -49,7 +49,7 @@ class PaperTrailAugmentedVersion
   def enabled_field?(attribute_name, territory)
     toggle_name = Territory::SOCIAL_FIELD_TOGGLES.key(attribute_name.to_sym)
 
-    # Fields that don't have toggles are enabled
+    # Les champs qui n'ont pas de toggle sont enabled
     return true unless toggle_name
 
     territory[toggle_name]

--- a/app/presenters/paper_trail_augmented_version.rb
+++ b/app/presenters/paper_trail_augmented_version.rb
@@ -23,13 +23,19 @@ class PaperTrailAugmentedVersion
   end
 
   IGNORED_ATTRIBUTES = %w[id updated_at encrypted_password].freeze
-  def changes
+
+  # territory est le territoire dans lequel on est en train de faire l'affichage
+  def changes(territory = nil)
     @changes ||= begin
       c = @version.changeset.except(*IGNORED_ATTRIBUTES).to_h
       c = c.filter { |_attribute, change| change.first.present? || change.last.present? }
       c = c.merge(virtual_changes)
       allowed_attributes = @version.item.class.paper_trail_options[:only]
       c = c.slice(*allowed_attributes) if allowed_attributes.present?
+
+      if territory
+        c = c.select { |attribute, _| enabled_field?(attribute, territory) }
+      end
       c
     end
   end
@@ -39,6 +45,15 @@ class PaperTrailAugmentedVersion
   end
 
   private
+
+  def enabled_field?(attribute_name, territory)
+    toggle_name = Territory::SOCIAL_FIELD_TOGGLES.key(attribute_name.to_sym)
+
+    # Fields that don't have toggles are enabled
+    return true unless toggle_name
+
+    territory[toggle_name]
+  end
 
   def virtual_changes
     virtual_changes_array.to_h do |property_name, new_value|

--- a/app/views/admin/versions/_version.html.slim
+++ b/app/views/admin/versions/_version.html.slim
@@ -1,6 +1,6 @@
 / We’re spanning multiple table rows, one for each attribute.
 / The first table row has the change date and author spanning over the following rows.
-- changes = version.changes
+- changes = version.changes(current_territory)
 - length = version.changes.length
 - if length > 0
   tr.border-top

--- a/spec/features/agents/disabled_fields_spec.rb
+++ b/spec/features/agents/disabled_fields_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "some fields that are specific to a certain domain can be disabled and hidden from the interface" do
+  let!(:organisation) { create(:organisation, territory: territory) }
+  let!(:service) { create(:service) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let!(:user) { create(:user, organisations: [organisation]) }
+  let(:territory) do
+    create(:territory, enable_affiliation_number_field: true)
+  end
+
+  before do
+    login_as(agent, scope: :agent)
+    user.update(affiliation_number: "numero_affiliation_123")
+  end
+
+  it "shows the restricted fields only if they are enabled" do
+    visit admin_organisation_user_path(organisation, user)
+
+    # It shows the
+    expect(page).to have_content("numero_affiliation_123", count: 2)
+  end
+end

--- a/spec/features/agents/disabled_fields_spec.rb
+++ b/spec/features/agents/disabled_fields_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "some fields that are specific to a certain domain can be disable
 
   before do
     login_as(agent, scope: :agent)
-    user.update(affiliation_number: "numero_affiliation_123")
+    user.update(affiliation_number: "numero_affiliation_123") # Pour créer une version Papertail
   end
 
   it "shows the restricted fields only if they are enabled", js: true do

--- a/spec/features/agents/disabled_fields_spec.rb
+++ b/spec/features/agents/disabled_fields_spec.rb
@@ -1,9 +1,9 @@
-require "rails_helper"
+# frozen_string_literal: true
 
 RSpec.describe "some fields that are specific to a certain domain can be disabled and hidden from the interface" do
   let!(:organisation) { create(:organisation, territory: territory) }
   let!(:service) { create(:service) }
-  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
   let!(:user) { create(:user, organisations: [organisation]) }
   let(:territory) do
     create(:territory, enable_affiliation_number_field: true)
@@ -14,10 +14,18 @@ RSpec.describe "some fields that are specific to a certain domain can be disable
     user.update(affiliation_number: "numero_affiliation_123")
   end
 
-  it "shows the restricted fields only if they are enabled" do
+  it "shows the restricted fields only if they are enabled", js: true do
     visit admin_organisation_user_path(organisation, user)
 
-    # It shows the
+    expect(page).to have_content("Numéro d'allocataire : numero_affiliation_123")
+
+    click_button("Historique des changements")
     expect(page).to have_content("numero_affiliation_123", count: 2)
+
+    territory.update!(enable_affiliation_number_field: false)
+
+    visit admin_organisation_user_path(organisation, user)
+    click_button("Historique des changements")
+    expect(page).not_to have_content("numero_affiliation_123")
   end
 end


### PR DESCRIPTION
Un petit fix pour un bug qu'on a repéré ce matin, lié à https://github.com/betagouv/rdv-solidarites.fr/pull/2204 et https://github.com/betagouv/rdv-solidarites.fr/issues/2192

## Description du bug

- Un usager est dans 2 territoires différents (par exemple un territoire médico-social et le territoire cnfs)
- Un agent modifie une valeur spécifique au médico-social dans le territoire médico-social (par exemple le nombre d'enfants
- Côté cnfs, ce champs n'apparait pas sur la fiche usager, mais il apparait dans l'historique de changements

Ce correctif filtre les champs désactivés dans la l'historique de changements

## Avant 

![Capture d’écran 2022-08-22 à 16 20 09](https://user-images.githubusercontent.com/1840367/185951025-31ef607f-de27-428b-9bad-69f0053f5a9b.png)


## Après 
![Capture d’écran 2022-08-22 à 16 19 55](https://user-images.githubusercontent.com/1840367/185951021-9baaad7a-3fe9-4d26-9fe5-b41dd23e1aa1.png)

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
