### PR TITLE
Anticipe les problèmes de fusion d'usagers ayant utilisé FranceConnect

### DIFF
--- a/app/models/concerns/user/franceconnect_frozen_fields_concern.rb
+++ b/app/models/concerns/user/franceconnect_frozen_fields_concern.rb
@@ -9,6 +9,10 @@ module User::FranceconnectFrozenFieldsConcern
     validate :prevent_frozen_fields_from_changing
   end
 
+  def concerned_by_franceconnect?(attribute)
+    logged_once_with_franceconnect? && FROZEN_FIELDS.include?(attribute)
+  end
+
   protected
 
   def prevent_frozen_fields_from_changing

--- a/app/models/concerns/user/franceconnect_frozen_fields_concern.rb
+++ b/app/models/concerns/user/franceconnect_frozen_fields_concern.rb
@@ -9,7 +9,7 @@ module User::FranceconnectFrozenFieldsConcern
     validate :prevent_frozen_fields_from_changing
   end
 
-  def concerned_by_franceconnect?(attribute)
+  def frozen_by_franceconnect?(attribute)
     logged_once_with_franceconnect? && FROZEN_FIELDS.include?(attribute)
   end
 

--- a/app/views/admin/merge_users/new.html.slim
+++ b/app/views/admin/merge_users/new.html.slim
@@ -42,9 +42,9 @@
               div.pr-2
                 label.d-flex.justify-content-end for="merge_users_form_#{attribute}_1"
                   - value = user1_presenter.send(attribute)
-                  - if @merge_users_form.user1.concerned_by_franceconnect?(attribute)
+                  - if @merge_users_form.user1.frozen_by_franceconnect?(attribute)
                     div = value
-                  - elsif @merge_users_form.user2.present? && @merge_users_form.user2.concerned_by_franceconnect?(attribute)
+                  - elsif @merge_users_form.user2.present? && @merge_users_form.user2.frozen_by_franceconnect?(attribute)
                     del = value
                   - else
                     - if value&.present?
@@ -59,9 +59,9 @@
               div.pr-2
                 label.d-flex.justify-content-start for="merge_users_form_#{attribute}_2"
                   - value = user2_presenter.send(attribute)
-                  - if @merge_users_form.user2.concerned_by_franceconnect?(attribute)
+                  - if @merge_users_form.user2.frozen_by_franceconnect?(attribute)
                     div = value
-                  - elsif @merge_users_form.user1.present? && @merge_users_form.user1.concerned_by_franceconnect?(attribute)
+                  - elsif @merge_users_form.user1.present? && @merge_users_form.user1.frozen_by_franceconnect?(attribute)
                     del = value
 
                   - else

--- a/app/views/admin/merge_users/new.html.slim
+++ b/app/views/admin/merge_users/new.html.slim
@@ -25,6 +25,11 @@
         td
         td= render "user_selection", user: @merge_users_form.user1, attribute: "user1_id", f: f, other_user_id: @merge_users_form.user2&.id
         td= render "user_selection", user: @merge_users_form.user2, attribute: "user2_id", f: f, other_user_id: @merge_users_form.user1&.id
+      -if @merge_users_form.user1.present?
+        - user1_presenter = DisplayableUserPresenter.new(@merge_users_form.user1, current_organisation)
+      -if @merge_users_form.user2.present?
+        - user2_presenter = DisplayableUserPresenter.new(@merge_users_form.user2, current_organisation)
+
       - @merge_users_form.available_attributes.each do |attribute|
         tr class=@merge_users_form.attribute_comparison(attribute)
           - if %i[logement notes].include?(attribute)
@@ -36,23 +41,36 @@
             - if @merge_users_form.user1
               div.pr-2
                 label.d-flex.justify-content-end for="merge_users_form_#{attribute}_1"
-                  - value = DisplayableUserPresenter.new(@merge_users_form.user1, current_organisation).send(attribute)
-                  - if value&.present?
-                    div= value
+                  - value = user1_presenter.send(attribute)
+                  - if @merge_users_form.user1.concerned_by_franceconnect?(attribute)
+                    div = value
+                  - elsif @merge_users_form.user2.present? && @merge_users_form.user2.concerned_by_franceconnect?(attribute)
+                    del = value
                   - else
-                    i.text-muted N/A
-                  - if @merge_users_form.attribute_comparison(attribute) == :different
-                    span.ml-2= f.radio_button attribute, "1", required: true
+                    - if value&.present?
+                      div= value
+                    - else
+                      i.text-muted N/A
+                    - if @merge_users_form.attribute_comparison(attribute) == :different
+                      span.ml-2= f.radio_button attribute, "1", required: true
+
           td.text-left.pl-3
             - if @merge_users_form.user2
-              label for="merge_users_form_#{attribute}_2"
-                - if @merge_users_form.attribute_comparison(attribute) == :different
-                  span.mr-2= f.radio_button attribute, "2", required: true
-                - value = DisplayableUserPresenter.new(@merge_users_form.user2, current_organisation).send(attribute)
-                - if value&.present?
-                  = value
-                - else
-                  i.text-muted N/A
+              div.pr-2
+                label.d-flex.justify-content-start for="merge_users_form_#{attribute}_2"
+                  - value = user2_presenter.send(attribute)
+                  - if @merge_users_form.user2.concerned_by_franceconnect?(attribute)
+                    div = value
+                  - elsif @merge_users_form.user1.present? && @merge_users_form.user1.concerned_by_franceconnect?(attribute)
+                    del = value
+
+                  - else
+                    - if @merge_users_form.attribute_comparison(attribute) == :different
+                      span.mr-2= f.radio_button attribute, "2", required: true
+                    - if value&.present?
+                      div= value
+                    - else
+                      i.text-muted N/A
       tr
         td= "🔒 RDVs"
         td.text-right= render "user_rdvs", user: @merge_users_form.user1


### PR DESCRIPTION
Closes #2706 

Mise en place d'un blocage qui empèche la fusion des champs utilisés par franceconnect.
Permet de guider les agents lors de la fusion d'usagers.

avant :

![image](https://user-images.githubusercontent.com/60173782/188192225-f12cd96c-fd89-4f09-8ea4-3404b0fb5bce.png)


après :

![image](https://user-images.githubusercontent.com/60173782/188191963-5da0995d-1fef-4219-991e-d1e70659c32b.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
