### PR TITLE
Correction de bug: les SMS ne partent plus car sender_name est vide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -158,6 +158,7 @@ RSpec/DescribeClass:
   Exclude:
     - "spec/features/**/*"
     - "spec/requests/**/*"
+    - "spec/sms/**/*"
 
 Style/AsciiComments:
   Enabled: false

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -7,16 +7,14 @@ class SmsSender < BaseService
 
   attr_reader :phone_number, :content, :tags, :provider, :key
 
-  def initialize(phone_number, content, tags, provider, key, receipt_params)
+  def initialize(sender_name, phone_number, content, tags, provider, key, receipt_params)
+    @sender_name = sender_name
     @phone_number = phone_number
     @content = formatted_content(content)
     @tags = tags
     @receipt_params = receipt_params
 
-    if Rails.env.test?
-      @provider = :debug_logger
-      @key = nil
-    elsif Rails.env.development?
+    if Rails.env.development?
       @provider = ENV["DEVELOPMENT_FORCE_SMS_PROVIDER"].presence || provider || ENV["DEFAULT_SMS_PROVIDER"].presence || :debug_logger
       @key = ENV["DEVELOPMENT_FORCE_SMS_PROVIDER_KEY"].presence || key || ENV["DEFAULT_SMS_PROVIDER_KEY"]
     else

--- a/app/sms/application_sms.rb
+++ b/app/sms/application_sms.rb
@@ -53,7 +53,7 @@ class ApplicationSms
   def deliver_later(queue: :sms)
     raise InvalidMobilePhoneNumberError, "#{phone_number} is not a valid mobile phone number" unless PhoneNumberValidation.number_is_mobile?(phone_number)
 
-    SmsSender.delay(queue: queue).perform_with(phone_number, content, tags, provider, key, receipt_params)
+    SmsSender.delay(queue: queue).perform_with(@sender_name, phone_number, content, tags, provider, key, receipt_params)
   end
 
   private

--- a/app/sms/users/base_sms.rb
+++ b/app/sms/users/base_sms.rb
@@ -8,8 +8,11 @@ class Users::BaseSms < ApplicationSms
     @phone_number = user.phone_number_formatted
 
     @rdv = rdv
+
     @provider = rdv.organisation&.territory&.sms_provider
     @key = rdv.organisation&.territory&.sms_configuration
+
+    @sender_name = rdv.domain.sms_sender_name
 
     @tags = [
       ENV["APP"]&.gsub("-rdv-solidarites", ""), # shorter names

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -4,22 +4,18 @@ class Users::RdvSms < Users::BaseSms
   include Rails.application.routes.url_helpers
 
   def rdv_created(rdv, user, token)
-    @sender_name = rdv.domain.sms_sender_name
     @content = "RDV #{rdv.motif&.service&.short_name} #{starts_at(rdv)}.\n#{rdv_footer(rdv, user, token)}"
   end
 
   def rdv_updated(rdv, user, token)
-    @sender_name = rdv.domain.sms_sender_name
     @content = "RDV modifié: #{rdv.motif.service.short_name} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token)}"
   end
 
   def rdv_upcoming_reminder(rdv, user, token)
-    @sender_name = rdv.domain.sms_sender_name
     @content = "Rappel RDV #{rdv.motif.service.short_name} le #{starts_at(rdv)}.\n#{rdv_footer(rdv, user, token)}"
   end
 
   def rdv_cancelled(rdv, _user, token)
-    @sender_name = rdv.domain.sms_sender_name
     base_message = "RDV #{rdv.motif.service.short_name} #{I18n.l(rdv.starts_at, format: :short)} a été annulé."
     url = prendre_rdv_short_url(host: domain_host, tkn: token)
 

--- a/scripts/sms_sender_test.rb
+++ b/scripts/sms_sender_test.rb
@@ -16,4 +16,4 @@
 #
 # DEFAULT_SMS_PROVIDER=contact_experience DEFAULT_SMS_PROVIDER_KEY=<dev_code> TEST_PHONE_NUMBER=<0639981234> rails runner scripts/sms_sender_test.rb
 
-SmsSender.perform_with(ENV["TEST_PHONE_NUMBER"], "this is a test " * 20, ["test"], nil, nil, {})
+SmsSender.perform_with("RdvSoli", ENV["TEST_PHONE_NUMBER"], "this is a test " * 20, ["test"], nil, nil, {})

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -46,6 +46,8 @@ describe Admin::RdvsController, type: :controller do
 
   describe "PUT #update" do
     context "with valid params" do
+      before { stub_netsize_ok }
+
       it "redirects to the rdv" do
         now = Time.zone.parse("2020-11-23 14h00")
         travel_to(now)

--- a/spec/factories/territory.rb
+++ b/spec/factories/territory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
   factory :territory do
     name { generate(:territory_name) }
     departement_number { generate(:departement_number) }
-    sms_provider { "send_in_blue" }
+    sms_provider { "netsize" }
     sms_configuration { "a_key" }
   end
 end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -14,6 +14,7 @@ describe "Agent can create a Rdv with wizard" do
   let!(:user) { create(:user, organisations: [organisation]) }
 
   before do
+    stub_netsize_ok
     travel_to(Time.zone.local(2019, 10, 2))
     login_as(agent, scope: :agent)
     visit new_admin_organisation_rdv_wizard_step_path(organisation_id: organisation.id)

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -6,6 +6,7 @@ describe "Agent can update a RDV", js: true do
   let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
 
   before do
+    stub_netsize_ok
     login_as(agent, scope: :agent)
   end
 

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -17,6 +17,7 @@ describe "Agent can create a Rdv collectif" do
   let(:now) { Time.zone.parse("20220123 13:00") }
 
   before do
+    stub_netsize_ok
     travel_to(now)
     login_as(agent, scope: :agent)
     visit admin_organisation_agent_agenda_path(organisation, agent)

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -3,6 +3,7 @@
 describe "User can be invited" do
   # needed for encrypted cookies
   before do
+    stub_netsize_ok
     allow_any_instance_of(ActionDispatch::Request).to receive(:cookie_jar).and_return(page.cookies)
     allow_any_instance_of(ActionDispatch::Request).to receive(:cookies).and_return(page.cookies)
   end

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -5,6 +5,8 @@ describe Admin::EditRdvForm, type: :form do
   let(:agent) { create(:agent) }
   let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
 
+  before { stub_netsize_ok }
+
   describe "#update" do
     it "updates rdv's lieu" do
       now = Time.zone.parse("2020-12-12 13h50")

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -4,6 +4,8 @@ describe FileAttente, type: :model do
   let(:now) { DateTime.parse("01-01-2019 09:00 +0100") }
 
   before do
+    stub_netsize_ok
+
     travel_to(now)
   end
 

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -12,6 +12,8 @@ describe Notifiers::RdvCancelled, type: :service do
   let(:token) { "123456" }
 
   before do
+    stub_netsize_ok
+
     rdv.update!(status: new_status)
 
     allow(Agents::RdvMailer).to receive(:with).and_call_original

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -16,6 +16,8 @@ describe Notifiers::RdvCreated, type: :service do
   let(:token2) { "56789" }
 
   before do
+    stub_netsize_ok
+
     allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(Agents::RdvMailer).to receive(:with).and_call_original
     allow(rdv).to receive(:rdvs_users).and_return(rdvs_users_relation)

--- a/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
+++ b/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
@@ -10,6 +10,8 @@ describe Notifiers::RdvUpcomingReminder, type: :service do
   let(:token) { "123456" }
 
   before do
+    stub_netsize_ok
+
     allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(Users::RdvSms).to receive(:rdv_upcoming_reminder).and_call_original
     allow(rdv).to receive(:rdvs_users).and_return(rdvs_users)

--- a/spec/services/notifiers/rdv_updated_spec.rb
+++ b/spec/services/notifiers/rdv_updated_spec.rb
@@ -16,6 +16,8 @@ describe Notifiers::RdvUpdated, type: :service do
   let(:token2) { "56789" }
 
   before do
+    stub_netsize_ok
+
     rdv.update!(starts_at: 4.days.from_now)
 
     allow(Users::RdvMailer).to receive(:with).and_call_original

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 describe RdvUpdater, type: :service do
+  before do
+    stub_netsize_ok
+  end
+
   describe "#update" do
     describe "return value" do
       it "true when everything is ok" do

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -4,7 +4,7 @@ describe SmsSender, type: :service do
   describe "#content" do
     subject { test_sms.content }
 
-    let(:test_sms) { described_class.new("0612345678", content, [], nil, nil, nil) }
+    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, [], nil, nil, nil) }
 
     context "remove accents and weird chars" do
       let(:content) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }
@@ -44,7 +44,7 @@ describe SmsSender, type: :service do
     let(:user) { create(:user) }
 
     before do
-      described_class.perform_with("0612345678", "content", [], nil, nil, { event: "rdv_created", rdv: rdv, user: user })
+      described_class.perform_with("RdvSoli", "0612345678", "content", [], nil, nil, { event: "rdv_created", rdv: rdv, user: user })
     end
 
     it do

--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe "using netsize to send an SMS" do
+  it "calls netsize API" do
+    territory = create(:territory, sms_provider: "netsize")
+    organisation = create(:organisation, territory: territory)
+    user = create(:user, phone_number: "+33601020304")
+    rdv = create(:rdv, organisation: organisation, users: [user])
+
+    stubbed_body = {
+      responseCode: 0,
+      messageIds: [123, 456],
+    }.to_json
+
+    stub_request(:post, "https://europe.ipx.com/restapi/v1/sms/send")
+      .to_return(status: 200, body: stubbed_body, headers: {})
+
+    Users::RdvSms.rdv_created(rdv, rdv.users.first, "t0k3n").deliver_later
+
+    valid_request = lambda do |req|
+      body = URI.decode_www_form(req.body).to_h
+      expected_body = {
+        "campaignName" => "dpt-1 org-1 rdv_sms",
+        "destinationAddress" => "+33601020304",
+        "maxConcatenatedMessages" => "10",
+        "originatingAddress" => "RdvSoli",
+        "originatorTON" => "1",
+      }
+      expect(body).to include(expected_body)
+    end
+    expect(WebMock).to(have_requested(:post, "https://europe.ipx.com/restapi/v1/sms/send").with(&valid_request))
+  end
+end

--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
 describe "using netsize to send an SMS" do
+  before do
+    stub_netsize_ok
+  end
+
   it "calls netsize API" do
     territory = create(:territory, sms_provider: "netsize")
     organisation = create(:organisation, territory: territory)
     user = create(:user, phone_number: "+33601020304")
     rdv = create(:rdv, organisation: organisation, users: [user])
-
-    stubbed_body = {
-      responseCode: 0,
-      messageIds: [123, 456],
-    }.to_json
-
-    stub_request(:post, "https://europe.ipx.com/restapi/v1/sms/send")
-      .to_return(status: 200, body: stubbed_body, headers: {})
 
     Users::RdvSms.rdv_created(rdv, rdv.users.first, "t0k3n").deliver_later
 

--- a/spec/support/sms_stubbing.rb
+++ b/spec/support/sms_stubbing.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+def stub_netsize_ok
+  stubbed_body = {
+    responseCode: 0,
+    messageIds: [123, 456],
+  }.to_json
+
+  stub_request(:post, "https://europe.ipx.com/restapi/v1/sms/send")
+    .to_return(status: 200, body: stubbed_body, headers: {})
+end


### PR DESCRIPTION
Suite à #2720 les SMS n'étaient plus envoyés car la valeur de `@sender_name` fournie aux APIs d'envoi de SMS était vide.

# Checklist

Avant la revue :
- [ ] ~~Préparer des captures de l’interface avant et après~~
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
