### PR TITLE
:broom: Supprime du code devenu inutilisé à propos de l'embarquement autonome

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -23,12 +23,7 @@ class OrganisationsController < ApplicationController
       @organisation.territory.roles.build(agent: agent_role.agent)
     end
 
-    if @organisation.save
-      agent = @organisation.agents.first
-      agent.deliver_invitation if agent.from_safe_domain?
-    else
-      render :new
-    end
+    render :new unless @organisation.save
   end
 
   def organisation_params

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -104,14 +104,6 @@ class Agent < ApplicationRecord
     first_name.present? && last_name.present?
   end
 
-  def from_safe_domain?
-    return false if ENV["SAFE_DOMAIN_LIST"].blank?
-
-    pattern = "@(#{ENV['SAFE_DOMAIN_LIST'].split&.join('|')})$"
-    regex = Regexp.new(pattern)
-    regex.match? email
-  end
-
   def soft_delete
     raise SoftDeleteError, "agent still has attached resources" if organisations.any? || plage_ouvertures.any? || absences.any?
 

--- a/app/views/mailers/admins/organisation_mailer/organisation_created.html.slim
+++ b/app/views/mailers/admins/organisation_mailer/organisation_created.html.slim
@@ -6,8 +6,6 @@ p
   |.
 - if @agent.invitation_accepted?
   p L'agent ayant créé cette organisation était déjà admin d'une autre organisation, la création a donc été validée automatiquement.
-- elsif @agent.from_safe_domain?
-  p Le domaine du mail de l'agent ayant été reconnu, une invitation lui a automatiquement été envoyée.
 - else
   p Une invitation doit être envoyée pour permettre l'accès à la plateforme.
 p


### PR DESCRIPTION
Lors d'une promenade dans le code, j'ai été surpris par cette variable d'environnement qui n'est plus utilisé. Après vérification, tout ceci n'est plus utilisé. Autant le supprimer donc.


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
