### PR TITLE
Traiter les emails bloqués

### DIFF
--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -26,7 +26,7 @@ class Agents::RdvMailer < ApplicationMailer
 
   def rdv_updated(starts_at:, lieu_id:)
     @starts_at = starts_at
-    @address_name = Lieu.find(lieu_id).full_name
+    @address_name = Lieu.find(lieu_id).full_name if lieu_id
 
     self.ics_payload = @rdv.payload(:update, @agent)
     subject = t("agents.rdv_mailer.rdv_updated.title", date: relative_date(@starts_at))

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -23,7 +23,7 @@ class Users::RdvMailer < ApplicationMailer
 
   def rdv_updated(starts_at:, lieu_id:)
     @starts_at = starts_at
-    @address_name = Lieu.find(lieu_id).full_name
+    @address_name = Lieu.find(lieu_id).full_name if lieu_id
 
     self.ics_payload = @rdv.payload(:update, @user)
     subject = t("users.rdv_mailer.rdv_updated.title", date: l(@rdv.starts_at, format: :human))

--- a/app/views/mailers/agents/rdv_mailer/rdv_updated.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_updated.html.slim
@@ -1,6 +1,9 @@
 div
   p Bonjour,
-  p Un de vos RDV qui devait avoir lieu le #{relative_date @starts_at} à #{l(@starts_at, format: "%H:%M")} à l'adresse #{@address_name} a été modifié par #{@author.full_name}.
+  p
+    | Un de vos RDV qui devait avoir lieu le #{relative_date @starts_at} à #{l(@starts_at, format: "%H:%M")}
+    = " à l'adresse #{@address_name}" if @address_name
+    |  a été modifié par #{@author.full_name}.
   p Veuillez prendre note des nouvelles informations.
 
   = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent, token: @token

--- a/app/views/mailers/users/rdv_mailer/rdv_updated.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_updated.html.slim
@@ -1,6 +1,9 @@
 div
   p Bonjour,
-  p Votre RDV qui devait avoir lieu le #{relative_date @starts_at} à #{l(@starts_at, format: "%H:%M")} à l'adresse #{@address_name} a été modifié.
+  p
+    | Votre RDV qui devait avoir lieu le #{relative_date @starts_at} à #{l(@starts_at, format: "%H:%M")}
+    = " à l'adresse #{@address_name}" if @address_name
+    |  a été modifié.
   p Veuillez prendre note des nouvelles informations.
 
   = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :user

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,6 +3,14 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN_RAILS"]
 
+  # Par défault, Sentry ignore les erreurs ActiveRecord::RecordNotFound pour éviter de faire remonter
+  # des erreurs en cas de visite de page obsolètes
+  # par exemple pour des ids non trouvés.
+  # Dans le contexte des jobs, on a besoin de savoir s'il y a cette erreur
+  # Par ailleurs, on préfère mettre une règle dans Sentry pour ignorer ces erreurs en dessous d'un
+  # certain volume plutôt que de les rendre complètement invisibles.
+  config.excluded_exceptions -= [ActiveRecord::RecordNotFound]
+
   # Most 4xx errors are excluded by default.
   # See Sentry::Configuration::IGNORE_DEFAULT
   # and Sentry::Rails::IGNORE_DEFAULT

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,7 +9,7 @@ Sentry.init do |config|
   # Dans le contexte des jobs, on a besoin de savoir s'il y a cette erreur
   # Par ailleurs, on préfère mettre une règle dans Sentry pour ignorer ces erreurs en dessous d'un
   # certain volume plutôt que de les rendre complètement invisibles.
-  config.excluded_exceptions -= [ActiveRecord::RecordNotFound]
+  config.excluded_exceptions -= ['ActiveRecord::RecordNotFound']
 
   # Most 4xx errors are excluded by default.
   # See Sentry::Configuration::IGNORE_DEFAULT

--- a/spec/mailers/previews/agents/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/agents/rdv_mailer_preview.rb
@@ -28,11 +28,11 @@ class Agents::RdvMailerPreview < ActionMailer::Preview
     rdv_mailer(rdv, rdv.users.first).rdv_cancelled
   end
 
-  def rdv_date_updated
+  def rdv_updated
     rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
 
-    rdv_mailer(rdv).rdv_date_updated(2.hours.from_now)
+    rdv_mailer(rdv).rdv_updated(starts_at: 2.hours.from_now, lieu_id: nil)
   end
 
   private

--- a/spec/mailers/previews/users/rdv_mailer_preview.rb
+++ b/spec/mailers/previews/users/rdv_mailer_preview.rb
@@ -31,11 +31,11 @@ class Users::RdvMailerPreview < ActionMailer::Preview
     rdv_mailer(rdv).rdv_created
   end
 
-  def rdv_date_updated
+  def rdv_updated
     rdv = Rdv.joins(:users).not_cancelled.last
     rdv.starts_at = Time.zone.today + 10.days + 10.hours
 
-    rdv_mailer(rdv).rdv_date_updated(2.hours.from_now)
+    rdv_mailer(rdv).rdv_updated(starts_at: 2.hours.from_now, lieu_id: nil)
   end
 
   def rdv_cancelled

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -31,6 +31,38 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     end
   end
 
+  describe "#rdv_updated" do
+    let(:previous_starting_time) { 2.days.from_now }
+    let(:new_starting_time) { 3.days.from_now }
+    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade") }
+    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous") }
+    let(:rdv) { create(:rdv, lieu: new_lieu, starts_at: new_starting_time) }
+    let(:user) { rdv.users.first }
+    let(:token) { "12345" }
+
+    before { travel_to(Time.zone.parse("2022-08-24 09:00:00")) }
+
+    it "indicates the previous and current values" do
+      mail = described_class.with(rdv: rdv, user: user, token: token)
+        .rdv_updated(starts_at: previous_starting_time, lieu_id: previous_lieu.id)
+
+      previous_details = "Votre RDV qui devait avoir lieu le 26 août à 09:00 à l&#39;adresse MJC Aix (rue du Previous) a été modifié"
+      expect(mail.html_part.body.to_s).to include(previous_details)
+
+      # new details
+      expect(mail.html_part.body.to_s).to include("samedi 27 août 2022 à 09h00")
+      expect(mail.html_part.body.to_s).to include("Stade de France (rue du Stade)")
+    end
+
+    it "works when no lieu_id is passed" do
+      mail = described_class.with(rdv: rdv, user: user, token: token)
+        .rdv_updated(starts_at: previous_starting_time, lieu_id: nil)
+
+      previous_details = "Votre RDV qui devait avoir lieu le 26 août à 09:00 a été modifié"
+      expect(mail.html_part.body.to_s).to include(previous_details)
+    end
+  end
+
   describe "#rdv_cancelled" do
     before { travel_to Time.zone.parse("2020-06-10 12:30") }
 


### PR DESCRIPTION
Closes #2728

Je suis allé au plus simple, j'ai fait en sorte qu'on ne mentionne pas l'ancienne adresse si on a pas de `lieu_id`.

Une amélioration possible serait d'afficher "Chez vous" ou "au téléphone", mais la conception logicielle actuelle rend la chose un peu complexe, et l'urgence est de permettre de débloquer les notifications bloquées (et qui continuent de s'accumuler) !

Au moment du merge de cette PR je lancerai le script suivant pour supprimer les notifications de jobs passés (qui n'auront donc jamais l'info).

```ruby
Delayed::Job.where("last_error LIKE ?", "%Lieu without an ID%").find_each do |job|
  (%r{/lapin/Rdv/(?<rdv_id>\d+)} =~ job.handler)
  rdv = Rdv.find(rdv_id)
  job.destroy if rdv.starts_at < Time.zone.now
end
```

Note : j'en ai profité pour corriger les previews, qui n'avaient pas été mis à jour.

# Captures d'écran

Côté agent : 

![image](https://user-images.githubusercontent.com/6357692/186370346-ef5e8f56-175a-457c-ab4d-92cc1f0fe94c.png)

Côté usager : 

![image](https://user-images.githubusercontent.com/6357692/186370377-dffe6d0f-7a10-4e76-a825-41fad76bc14f.png)


# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
