### PR TITLE
Utiliser un délai de debounce équilibré

### DIFF
--- a/app/javascript/components/places-inputs.js
+++ b/app/javascript/components/places-inputs.js
@@ -17,7 +17,7 @@ class PlacesInput {
       { hint: false },
       [{
         source: this.getSuggestions,
-        debounce: 100,
+        debounce: 800,
         templates: { suggestion: this.suggestionTemplate }
       }]
     ).on('autocomplete:selected', (_event, suggestion, _dataset, _context) =>


### PR DESCRIPTION
Le temps de debounce configuré pour la recherche de lieu était de 100 ms, ce qui a pour effet de lancer la recherche à presque chaque frappe de touche !

Le problème est donc que l'on va envoyer une vingtaine de requêtes à [l'API](https://adresse.data.gouv.fr/api-doc/adresse), ce qui la surcharge inutilement, risque potentiellement de ralentir le navigateur et n'augmente pas particulièrement notre temps de réponse à nous !

J'ai testé plusieurs valeurs, et 800 ms m'a paru équilibré : suffisamment long pour laisser le temps de taper, mais sans trop attendre pour lancer la requête.

# Avant (100ms)

![image](https://user-images.githubusercontent.com/6357692/187215312-9b044929-ac89-493c-885d-dc113f30e123.png)

# Après (800ms)

![image](https://user-images.githubusercontent.com/6357692/187215663-6d414c1b-1587-41f2-b663-92427b35a212.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
