### PR TITLE
S'assurer de la disponibilité des clés de traduction en env de test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,8 +57,9 @@ Rails.application.configure do
 
   # https://github.com/JackC/tod/#activemodel-serializable-attribute-support
   config.active_record.time_zone_aware_types = [:datetime]
+
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Faker fails for certains attributes if :en isn't available
   config.i18n.available_locales = %i[fr en]


### PR DESCRIPTION
L'activation de cette fonctionnalité ne nous coûte rien et pourrait nous aider à détecter des erreurs dans les clés de traduction.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
