### PR TITLE
Correctif de l'affichage de domaine

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -72,4 +72,8 @@ class Domain
   def self.find_matching(domain_name)
     ALL_BY_URL.fetch(domain_name) { RDV_SOLIDARITES }
   end
+
+  def to_s
+    name
+  end
 end

--- a/app/views/static_pages/domaines.html.slim
+++ b/app/views/static_pages/domaines.html.slim
@@ -8,7 +8,7 @@
 
   .row.align-items-center.mb-4.content
     .col-lg-8
-      p Les usagers qui ont un compte sur #{Domain::RDV_SOLIDARITES.name} peuvent s’en servir pour se connecter à #{Domain::RDV_AIDE_NUMERIQUE.name}, et vice-versa. Leurs rendez-vous avec les services médico-sociaux sont visibles uniquement sur RDV Solidarités, et leurs rendez-vous liés à l'aide au numérique sont visibles uniquement sur #{Domain::RDV_AIDE_NUMERIQUE}
+      p Les usagers qui ont un compte sur #{Domain::RDV_SOLIDARITES.name} peuvent s’en servir pour se connecter à #{Domain::RDV_AIDE_NUMERIQUE.name}, et vice-versa. Leurs rendez-vous avec les services médico-sociaux sont visibles uniquement sur RDV Solidarités, et leurs rendez-vous liés à l'aide au numérique sont visibles uniquement sur #{Domain::RDV_AIDE_NUMERIQUE.name}
 
   .row
     .col-lg-8


### PR DESCRIPTION
Il y avait un petit oubli sur la page d'explication de différence entre les deux domaines.

avant : 

![Capture d’écran 2022-08-30 à 11 21 12](https://user-images.githubusercontent.com/1840367/187400476-cdfb68bd-ef73-4973-baa2-3aec2dba50f7.png)

après : 
![Capture d’écran 2022-08-30 à 11 21 17](https://user-images.githubusercontent.com/1840367/187400483-63b5a4ec-ab4b-43b6-9124-4bf41e2421f8.png)

Pour faire un fix un peu ceinture-bretelles, j'ai aussi modifié la méthode `Domain#to_s` pour que si on fait à nouveau cet oubli ça soit moins un problème

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
