### PR TITLE
Supprimer le lien vers la synchro webcal dans l'onboarding des cnfs

### DIFF
--- a/app/views/admin/organisations/setup_checklists/show_conseiller_numerique.slim
+++ b/app/views/admin/organisations/setup_checklists/show_conseiller_numerique.slim
@@ -47,13 +47,10 @@
 
         h5.mb-2 Synchroniser votre agenda externe
         p Si vous utilisez déjà un agenda comme Outlook ou Google Calendar, vous pouvez synchroniser votre agenda #{current_domain.name} vers votre agenda externe, pour que vos rendez-vous y soient visibles aussi.
-        ul.mb-4.list-unstyled
-          li.mb-2
-            span>= setup_checklist_item(current_agent.calendar_uid.present?)
-            span>= link_to "Si vous utilisez Outlook, nous vous conseillons d'utiliser un lien de synchronisation", agents_calendar_sync_path
-          li.mb-2
-            span>= setup_checklist_item(current_agent.rdv_notifications_level_all?)
-            span>= link_to "Si vous utilisez Google Calendar, nous vous conseillons d'activer les notifications pour chaque modification de rdv", agents_preferences_path
+        p
+          = "Vous pouvez trouver plus d'information à ce sujet dans notre "
+          = link_to "FAQ", faq_url
+          = "."
 
         h5 Recherche de créneaux
         p Lorsque vous avez plusieurs rendez-vous de prévus, vous pouvez définir des plages d’ouverture pour trouver le prochain créneau disponible plus facilement.


### PR DESCRIPTION
On a eu pas mal de cnfs qui se plaignaient via le mattermost et le support de la lenteur de la synchro webcal, donc on a décidé avec Nesserine de plutôt mettre un lien vers la FAQ, qui explique en détails les avantages et inconvénients des différents modes de synchro, plutôt que de leur proposer directement la synchro, qui ensuite les déçoit s'ils ne connaissent pas bien son fonctionnement.

![Capture d’écran 2022-08-31 à 10 25 00](https://user-images.githubusercontent.com/1840367/187633264-69c031e6-20c1-4e0a-84f2-6bddaa88168a.png)

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
