### PR TITLE
Correction de flaky specs sur les envois de SMS par netsize

### DIFF
--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -6,13 +6,11 @@ describe "using netsize to send an SMS" do
   let(:user) { create(:user, phone_number: "+33601020304") }
   let(:rdv) { create(:rdv, organisation: organisation, users: [user]) }
 
-  before do
-    stub_netsize_ok
-  end
-
   stub_sentry_events
 
   it "calls netsize API" do
+    stub_netsize_ok
+
     Users::RdvSms.rdv_created(rdv, rdv.users.first, "t0k3n").deliver_later
 
     valid_request = lambda do |req|


### PR DESCRIPTION
Le fait d'appeler `stub_netsize_ok` avant chaque spec faisait qu'on stubbait, pour les specs d'erreur :
- d'abord une réponse OK 
- puis une réponse d'erreur

Il semblerait que lorsque la suite de test est exécuté dan un certain ordre, le stub OK était joué plutôt que le stub d'erreur. Je ne suis pas arrivé à reproduire le cas, mais si on fait en sorte de ne pas appeler deux fois `stub_request`, on ne devrait pas avoir de souci.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
