### PR TITLE
info alert: old appointments are deleted

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -140,5 +140,10 @@
                 temporal_status: temporal_status, \
                 count: @rdvs.status(temporal_status).count,
                 path: admin_organisation_rdvs_path(current_organisation, status: temporal_status, user_id: @user.id, breadcrumb_page: "user")
+      .card-footer
+        .alert.alert-info.d-flex.align-items-center
+          .mr-3
+            i.fa.fa-info
+          | Les RDV sont supprimés au bout de 2 ans.
 
 = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @user


### PR DESCRIPTION
Closes #2433

Pour informer les agent·es de la suppression automatique des RDV au bout de deux ans, on ajoute un petit texte d'information : 

# Avant

![image](https://user-images.githubusercontent.com/1193334/187930235-dcbaca26-aa9f-4fe4-8e03-527a9aa5dd17.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/187929620-3162157b-b32d-43c9-9024-c3abd791dcb5.png)

J'ai choisi de mettre un `alert-info` dans le footer de la card parce que c'est ce qui me semblait à la fois le plus lisible et le moins envahissant. C'est discutable toutefois, on peut tout à fait le mettre ailleurs ou challenger le texte.

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
