### PR TITLE
Définir le nom de l'envoyeur des e-mails

### DIFF
--- a/app/mailers/admins/grc_92_mailer.rb
+++ b/app/mailers/admins/grc_92_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admins::Grc92Mailer < ApplicationMailer
-  default from: "ne-pas-repondre-grc@hauts-de-seine.fr", reply_to: nil
+  default reply_to: nil
 
   def send_sms(recipient, phone_number, message)
     headers["Content-Type"] = "text/plain"
@@ -21,5 +21,11 @@ class Admins::Grc92Mailer < ApplicationMailer
 
   def domain
     Domain::RDV_SOLIDARITES
+  end
+
+  private
+
+  def default_from
+    "ne-pas-repondre-grc@hauts-de-seine.fr"
   end
 end

--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -7,8 +7,7 @@ class Agents::AbsenceMailer < ApplicationMailer
     @absence = params[:absence]
   end
 
-  default from: "secretariat-auto@rdv-solidarites.fr",
-          to: -> { @absence.agent.email }
+  default to: -> { @absence.agent.email }
 
   def absence_created
     self.ics_payload = @absence.payload(:created)
@@ -29,5 +28,9 @@ class Agents::AbsenceMailer < ApplicationMailer
 
   def domain
     @absence.agent.domain
+  end
+
+  def default_from
+    SECRETARIAT_EMAIL
   end
 end

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -12,7 +12,6 @@ class Agents::ExportMailer < ApplicationMailer
     }
 
     mail(
-      from: "secretariat-auto@rdv-solidarites.fr",
       to: agent.email,
       subject: I18n.t("mailers.agents.export_mailer.rdv_export.subject", organisation_name: organisation.name, date: I18n.l(now))
     )
@@ -20,5 +19,9 @@ class Agents::ExportMailer < ApplicationMailer
 
   def domain
     @agent.domain
+  end
+
+  def default_from
+    SECRETARIAT_EMAIL
   end
 end

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -8,8 +8,7 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
     @plage_ouverture = params[:plage_ouverture]
   end
 
-  default from: "secretariat-auto@rdv-solidarites.fr",
-          to: -> { @plage_ouverture.agent.email }
+  default to: -> { @plage_ouverture.agent.email }
 
   def plage_ouverture_created
     self.ics_payload = @plage_ouverture.payload(:create)
@@ -30,5 +29,9 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
 
   def domain
     @plage_ouverture.agent.domain
+  end
+
+  def default_from
+    SECRETARIAT_EMAIL
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,22 +3,8 @@
 class ApplicationMailer < ActionMailer::Base
   self.deliver_later_queue_name = :mailers
 
+  include CommonMailer
   prepend IcsMultipartAttached
 
   append_view_path Rails.root.join("app/views/mailers")
-  layout "mailer"
-  helper RdvSolidaritesInstanceNameHelper
-  helper_method :domain
-
-  after_action { mail.from %("#{domain.name}" <#{default_from}>) }
-
-  def default_url_options
-    super.merge(host: domain.dns_domain_name)
-  end
-
-  private
-
-  def default_from
-    SUPPORT_EMAIL
-  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,9 +10,15 @@ class ApplicationMailer < ActionMailer::Base
   helper RdvSolidaritesInstanceNameHelper
   helper_method :domain
 
-  after_action { mail.from %("#{domain.name}" <#{SUPPORT_EMAIL}>) }
+  after_action { mail.from %("#{domain.name}" <#{default_from}>) }
 
   def default_url_options
     super.merge(host: domain.dns_domain_name)
+  end
+
+  private
+
+  def default_from
+    SUPPORT_EMAIL
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,11 +5,12 @@ class ApplicationMailer < ActionMailer::Base
 
   prepend IcsMultipartAttached
 
-  default from: SUPPORT_EMAIL
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"
   helper RdvSolidaritesInstanceNameHelper
   helper_method :domain
+
+  after_action { mail.from %("#{domain.name}" <#{SUPPORT_EMAIL}>) }
 
   def default_url_options
     super.merge(host: domain.dns_domain_name)

--- a/app/mailers/concerns/common_mailer.rb
+++ b/app/mailers/concerns/common_mailer.rb
@@ -11,13 +11,17 @@ module CommonMailer
     helper RdvSolidaritesInstanceNameHelper
     helper_method :domain
 
-    after_action { mail.from %("#{domain.name}" <#{default_from}>) }
+    after_action :set_default_from_with_display_name
   end
 
   private
 
   def default_url_options
     super.merge(host: domain.dns_domain_name)
+  end
+
+  def set_default_from_with_display_name
+    mail.from %("#{domain.name}" <#{default_from}>) if mail.from.blank?
   end
 
   def default_from

--- a/app/mailers/concerns/common_mailer.rb
+++ b/app/mailers/concerns/common_mailer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Ce concern permet d'inclure des comportements à la fois dans
+# ApplicationMailer et dans CustomDeviseMailer, qui ont toutes
+# deux des classe mères.
+module CommonMailer
+  extend ActiveSupport::Concern
+
+  included do
+    layout "mailer"
+    helper RdvSolidaritesInstanceNameHelper
+    helper_method :domain
+
+    after_action { mail.from %("#{domain.name}" <#{default_from}>) }
+  end
+
+  private
+
+  def default_url_options
+    super.merge(host: domain.dns_domain_name)
+  end
+
+  def default_from
+    SUPPORT_EMAIL
+  end
+end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -3,15 +3,11 @@
 class CustomDeviseMailer < Devise::Mailer
   self.deliver_later_queue_name = :devise
 
+  include CommonMailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application
   default template_path: "devise/mailer"
-  layout "mailer"
-  helper RdvSolidaritesInstanceNameHelper
-  helper_method :domain
-
-  after_action { mail.from %("#{domain.name}" <#{default_from}>) }
 
   def invitation_instructions(record, token, opts = {})
     @token = token
@@ -58,13 +54,5 @@ class CustomDeviseMailer < Devise::Mailer
     else
       Domain::RDV_SOLIDARITES
     end
-  end
-
-  def default_from
-    SUPPORT_EMAIL
-  end
-
-  def default_url_options
-    super.merge(host: domain.dns_domain_name)
   end
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -11,6 +11,8 @@ class CustomDeviseMailer < Devise::Mailer
   helper RdvSolidaritesInstanceNameHelper
   helper_method :domain
 
+  after_action { mail.from %("#{domain.name}" <#{SUPPORT_EMAIL}>) }
+
   def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -11,7 +11,7 @@ class CustomDeviseMailer < Devise::Mailer
   helper RdvSolidaritesInstanceNameHelper
   helper_method :domain
 
-  after_action { mail.from %("#{domain.name}" <#{SUPPORT_EMAIL}>) }
+  after_action { mail.from %("#{domain.name}" <#{default_from}>) }
 
   def invitation_instructions(record, token, opts = {})
     @token = token
@@ -58,6 +58,10 @@ class CustomDeviseMailer < Devise::Mailer
     else
       Domain::RDV_SOLIDARITES
     end
+  end
+
+  def default_from
+    SUPPORT_EMAIL
   end
 
   def default_url_options

--- a/app/models/concerns/ical_helpers/ics.rb
+++ b/app/models/concerns/ical_helpers/ics.rb
@@ -61,7 +61,7 @@ module IcalHelpers
       event.rrule = payload[:recurrence]
       event.sequence = payload[:sequence]
       event.description = payload[:description]
-      event.organizer = "mailto:secretariat-auto@rdv-solidarites.fr"
+      event.organizer = "mailto:#{SECRETARIAT_EMAIL}"
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,13 +1,33 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "10112e021e73eda7078e59a3f6829945a1e001e587e729a0ca7f028e06ffe380",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/mailers/custom_devise_mailer.rb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "mail.from(\"\\\"#{domain.name}\\\" <#{default_from}>\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CustomDeviseMailer",
+        "method": null
+      },
+      "user_input": "domain.name",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "2355405acc689e021f5b074103ed57c71e0b53346937c2a247ee732bb991ea03",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/plage_ouvertures/index.html.slim",
-      "line": 38,
+      "line": 36,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => policy_scope(PlageOuverture).includes(:lieu, :organisation, :motifs, :agent).where(:agent_id => filter_params[:agent_id]).order(:updated_at => :desc).where(:expired_cached => (filter_params[:current_tab] == \"expired\")).page(filter_params[:page]).search_by_text(params[:search]), {})",
       "render_path": [
@@ -63,13 +83,33 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "a11853eedf49dbc6bafea7075b2392c9dc7f44929311c3900ab4f7bfb6c8f4a9",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/mailers/application_mailer.rb",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "mail.from(\"\\\"#{domain.name}\\\" <#{default_from}>\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplicationMailer",
+        "method": null
+      },
+      "user_input": "domain.name",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "d8dbbc60b51eb0beb5bc2f943b01142aad77a449260029dedf5a293e96f074a8",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
-      "line": 46,
+      "line": 50,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
@@ -77,7 +117,7 @@
           "type": "controller",
           "class": "Admin::MotifsController",
           "method": "index",
-          "line": 19,
+          "line": 18,
           "file": "app/controllers/admin/motifs_controller.rb",
           "rendered": {
             "name": "admin/motifs/index",
@@ -100,7 +140,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
-      "line": 72,
+      "line": 76,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
@@ -108,7 +148,7 @@
           "type": "controller",
           "class": "Admin::MotifsController",
           "method": "index",
-          "line": 19,
+          "line": 18,
           "file": "app/controllers/admin/motifs_controller.rb",
           "rendered": {
             "name": "admin/motifs/index",
@@ -125,6 +165,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-03-10 15:17:14 +0100",
+  "updated": "2022-09-05 10:01:23 +0200",
   "brakeman_version": "5.2.0"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "10112e021e73eda7078e59a3f6829945a1e001e587e729a0ca7f028e06ffe380",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/mailers/custom_devise_mailer.rb",
-      "line": 14,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "mail.from(\"\\\"#{domain.name}\\\" <#{default_from}>\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CustomDeviseMailer",
-        "method": null
-      },
-      "user_input": "domain.name",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "2355405acc689e021f5b074103ed57c71e0b53346937c2a247ee732bb991ea03",
@@ -85,18 +65,18 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "a11853eedf49dbc6bafea7075b2392c9dc7f44929311c3900ab4f7bfb6c8f4a9",
+      "fingerprint": "787302e7f4a074407ad77b97c161fca6cb5746c2e24e60ff5f331f1b66608995",
       "check_name": "SQL",
       "message": "Possible SQL injection",
-      "file": "app/mailers/application_mailer.rb",
-      "line": 13,
+      "file": "app/mailers/concerns/common_mailer.rb",
+      "line": 24,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "mail.from(\"\\\"#{domain.name}\\\" <#{default_from}>\")",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "ApplicationMailer",
-        "method": null
+        "class": "CommonMailer",
+        "method": "set_default_from_with_display_name"
       },
       "user_input": "domain.name",
       "confidence": "Weak",
@@ -165,6 +145,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-09-05 10:01:23 +0200",
+  "updated": "2022-09-05 14:47:19 +0200",
   "brakeman_version": "5.2.0"
 }

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
+# L'adresse support@rdv-solidarites.fr est utilisée comme adresse de support
+# à la fois sur le domaine RDV Solidarité et le domaine RDV Aide Numérique.
+# En revanche on adapte le nom affiché pour que ce soit dans l'inbox du destinataire.
 SUPPORT_EMAIL = "support@rdv-solidarites.fr"
 SECRETARIAT_EMAIL = "secretariat-auto@rdv-solidarites.fr"

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 SUPPORT_EMAIL = "support@rdv-solidarites.fr"
+SECRETARIAT_EMAIL = "secretariat-auto@rdv-solidarites.fr"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = SUPPORT_EMAIL
+  # config.mailer_sender = "sender@example.com"
 
   # Configure the class responsible to send e-mails.
   config.mailer = "CustomDeviseMailer"

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -36,6 +36,7 @@ describe "User resets his password spec" do
         fill_in "user_email", with: user.email
         click_on "Envoyer"
         open_email(user.email)
+        expect(current_email.base.email[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-solidarites.fr>))
         expect(current_email.html_part.body.to_s).to include('<a href="http://www.rdv-aide-numerique-test.localhost/users/password/edit?reset_password_token=')
       end
     end

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe TransferEmailReplyJob do
       expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
       transferred_email = ActionMailer::Base.deliveries.last
       expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
-      expect(transferred_email.from).to eq(["support@rdv-solidarites.fr"])
+      expect(transferred_email[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
       expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
       expect(transferred_email.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -8,6 +8,7 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
 
       it "mail to plage ouverture's agent" do
         mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
+        expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
         expect(mail.to).to eq(["bob@demo.rdv-solidarites.fr"])
       end
 
@@ -44,6 +45,7 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
 
           it "works" do
             mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
+            expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-solidarites.fr>))
             expect(mail.subject).to start_with("RDV Aide Numérique - Plage d’ouverture")
             expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
             expect(mail.html_part.body.to_s).to include("Voir sur RDV Aide Numérique") unless action == :destroyed

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -8,7 +8,7 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
 
       it "mail to plage ouverture's agent" do
         mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
-        expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+        expect(mail[:from].to_s).to eq(%("RDV Solidarités" <secretariat-auto@rdv-solidarites.fr>))
         expect(mail.to).to eq(["bob@demo.rdv-solidarites.fr"])
       end
 
@@ -45,7 +45,7 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
 
           it "works" do
             mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
-            expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-solidarites.fr>))
+            expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <secretariat-auto@rdv-solidarites.fr>))
             expect(mail.subject).to start_with("RDV Aide Numérique - Plage d’ouverture")
             expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
             expect(mail.html_part.body.to_s).to include("Voir sur RDV Aide Numérique") unless action == :destroyed

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
     before { travel_to(t) }
 
     it "renders the headers" do
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([agent.email])
     end
 
@@ -66,6 +67,12 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
     let(:token) { "12345" }
 
     before { travel_to(Time.zone.parse("2022-08-24 09:00:00")) }
+
+    it "renders the headers" do
+      mail = described_class.with(rdv: rdv, agent: agent, author: agent).rdv_updated(starts_at: previous_starting_time, lieu_id: nil)
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+      expect(mail.to).to eq([agent.email])
+    end
 
     it "indicates the previous and current values" do
       mail = described_class.with(rdv: rdv, agent: agent, author: agent)

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -8,6 +8,9 @@ describe CustomDeviseMailer, "#domain" do
 
   def expect_to_use_domain(domain)
     expect(sent_email.body).to include(domain.dns_domain_name)
+    # L'adresse support@rdv-solidarites.fr est utilisée comme adresse de support
+    # à la fois sur le domaine RDV Solidarité et le domaine RDV Aide Numérique.
+    # En revanche on adapte le nom affiché pour que ce soit dans l'inbox du destinataire.
     expect(sent_email[:from].to_s).to eq(%("#{domain.name}" <support@rdv-solidarites.fr>))
   end
 

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -1,36 +1,49 @@
 # frozen_string_literal: true
 
 describe CustomDeviseMailer, "#domain" do
-  subject(:user_domain) { described_class.reset_password_instructions(user, "t0k3n").body }
+  subject(:sent_email) { described_class.reset_password_instructions(user, "t0k3n") }
 
   let(:motif_solidarites) { create(:motif, service: create(:service, :social)) }
   let(:motif_numerique) { create(:motif, service: create(:service, :conseiller_numerique)) }
 
+  def expect_to_use_domain(domain)
+    expect(sent_email.body).to include(domain.dns_domain_name)
+    expect(sent_email[:from].to_s).to eq(%("#{domain.name}" <support@rdv-solidarites.fr>))
+  end
+
   context "when user has no RDV" do
     let(:user) { create(:user, rdvs: []) }
 
-    it { is_expected.to include(Domain::RDV_SOLIDARITES.dns_domain_name) }
+    it "uses RDV_SOLIDARITES" do
+      expect_to_use_domain(Domain::RDV_SOLIDARITES)
+    end
   end
 
   context "when user only RDV Solidarité RDVs" do
     let!(:organisation) { create(:organisation, new_domain_beta: true) }
     let(:user) { create(:user, rdvs: create_list(:rdv, 2, organisation: organisation, motif: motif_solidarites)) }
 
-    it { is_expected.to include(Domain::RDV_SOLIDARITES.dns_domain_name) }
+    it "uses RDV_SOLIDARITES" do
+      expect_to_use_domain(Domain::RDV_SOLIDARITES)
+    end
   end
 
   context "when user only RDV Aide Numérique RDVs but organisation not in beta program" do
     let!(:organisation) { create(:organisation, new_domain_beta: false) }
     let(:user) { create(:user, rdvs: create_list(:rdv, 2, organisation: organisation, motif: motif_numerique)) }
 
-    it { is_expected.to include(Domain::RDV_SOLIDARITES.dns_domain_name) }
+    it "uses RDV_SOLIDARITES" do
+      expect_to_use_domain(Domain::RDV_SOLIDARITES)
+    end
   end
 
   context "when user only RDV Aide Numérique RDVs and organisation is in beta program" do
     let!(:organisation) { create(:organisation, new_domain_beta: true) }
     let(:user) { create(:user, rdvs: create_list(:rdv, 2, organisation: organisation, motif: motif_numerique)) }
 
-    it { is_expected.to include(Domain::RDV_AIDE_NUMERIQUE.dns_domain_name) }
+    it "uses RDV_SOLIDARITES" do
+      expect_to_use_domain(Domain::RDV_AIDE_NUMERIQUE)
+    end
   end
 
   context "when user has mixed RDV domains (and organisation is in beta program)" do
@@ -45,6 +58,8 @@ describe CustomDeviseMailer, "#domain" do
       create(:user, rdvs: mixed_rdvs)
     end
 
-    it { is_expected.to include(Domain::RDV_AIDE_NUMERIQUE.dns_domain_name) }
+    it "uses RDV_SOLIDARITES" do
+      expect_to_use_domain(Domain::RDV_AIDE_NUMERIQUE)
+    end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let(:mail) { described_class.with(rdv: rdv, user: user, token: token).rdv_created }
 
     it "renders the headers" do
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
       expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
@@ -42,6 +43,13 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     before { travel_to(Time.zone.parse("2022-08-24 09:00:00")) }
 
+    it "renders the headers" do
+      mail = described_class.with(rdv: rdv, user: user, token: token).rdv_updated(starts_at: previous_starting_time, lieu_id: nil)
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+      expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
+    end
+
     it "indicates the previous and current values" do
       mail = described_class.with(rdv: rdv, user: user, token: token)
         .rdv_updated(starts_at: previous_starting_time, lieu_id: previous_lieu.id)
@@ -73,6 +81,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       user = rdv.users.first
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
       expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
@@ -130,6 +139,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     it "send mail to user" do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_upcoming_reminder
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
       expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
@@ -149,6 +159,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
+          expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Solidarités))
@@ -160,6 +171,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
+          expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-solidarites.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-aide-numerique-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Aide Numérique))


### PR DESCRIPTION
Lorsque les usager⋅es et agents reçoivent un e-mail, ils voient qu'il provient de "support@rdv-solidarites.fr".

Cette PR fait en sorte que le l'expéditeur soit nommé en fonction du domaine. 

Au passage, j'ai déplacé dans un concern `CommonMailer` les choses qui étaient en commun entre `ApplicationMailer` et `CustomDeviseMailer`.

# Captures d'écran

## Avant

![image](https://user-images.githubusercontent.com/6357692/187975231-59308077-b5cf-4f08-a725-7e267a23b405.png)

## Après 

![image](https://user-images.githubusercontent.com/6357692/187975249-6692619d-a1c1-44cd-87b4-98ef2bdec141.png)

![image](https://user-images.githubusercontent.com/6357692/187975759-b2853175-4847-4908-b9bb-0cfc1b66990c.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
