### PR TITLE
allow to create a collective Motif if needed and possible

### DIFF
--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -15,11 +15,11 @@
       .card-body
         - if @motifs.empty?
           - if current_agent_can?(:create, Motif)
-            div Il n'existe aucun motif collectif. Veuillez en créer un pour continuer.
+            div Il n'existe aucun motif de RDV collectif. Veuillez en créer un pour continuer.
             .d-flex.justify-content-center.my-2
               = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-primary"
           - else
-            div Il n'existe aucun motif collectif et vous ne pouvez pas en créer un. Demandez à un administrateur ou une administratrice.
+            div Il n'existe aucun motif de RDV collectif et vous ne pouvez pas en créer un. Demandez à un administrateur ou une administratrice.
         - else
           - @motifs.each do |motif|
             = link_to new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id }) do

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -13,9 +13,17 @@
         h3.text-center Choisissez un motif
 
       .card-body
-        - @motifs.each do |motif|
-          = link_to new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id }) do
-            .mb-3
-              = motif.name
-              br
-              = "#{motif.default_duration_in_min} minutes"
+        - if @motifs.empty?
+          - if current_agent_can?(:create, Motif)
+            div Il n'existe aucun motif collectif. Veuillez en créer un pour continuer.
+            .d-flex.justify-content-center.my-2
+              = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-primary"
+          - else
+            div Il n'existe aucun motif collectif et vous ne pouvez pas en créer un. Demandez à un administrateur ou une administratrice.
+        - else
+          - @motifs.each do |motif|
+            = link_to new_admin_organisation_rdvs_collectif_path(current_organisation, { motif_id: motif.id }) do
+              .mb-3
+                = motif.name
+                br
+                = "#{motif.default_duration_in_min} minutes"

--- a/spec/controllers/admin/rdvs_collectifs/motifs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_collectifs/motifs_controller_spec.rb
@@ -20,7 +20,7 @@ describe Admin::RdvsCollectifs::MotifsController, type: :controller do
         it "shows a message indicating that there is no collective Motif" do
           get :index, params: { organisation_id: organisation.id }
 
-          expect(response.body).to include("Il n'existe aucun motif collectif")
+          expect(response.body).to include("Il n'existe aucun motif de RDV collectif")
         end
 
         context "when the current agent can create a Motif" do

--- a/spec/controllers/admin/rdvs_collectifs/motifs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_collectifs/motifs_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe Admin::RdvsCollectifs::MotifsController, type: :controller do
+  describe "GET index" do
+    context "with a signed in agent" do
+      let(:organisation) { create(:organisation) }
+      let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      before { sign_in agent }
+
+      it "returns success" do
+        get :index, params: { organisation_id: organisation.id }
+
+        expect(response).to be_successful
+      end
+
+      context "when there is no collective Motif" do
+        render_views
+
+        it "shows a message indicating that there is no collective Motif" do
+          get :index, params: { organisation_id: organisation.id }
+
+          expect(response.body).to include("Il n'existe aucun motif collectif")
+        end
+
+        context "when the current agent can create a Motif" do
+          let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+          it "shows a button to create a Motif" do
+            get :index, params: { organisation_id: organisation.id }
+
+            expect(response.body).to include("Créer un motif")
+            expect(response.body).not_to include("Demandez à un administrateur")
+          end
+        end
+
+        context "when the current agent can't create a Motif" do
+          it "shows a message indicating that they should ask for help" do
+            get :index, params: { organisation_id: organisation.id }
+
+            expect(response.body).not_to include("Créer un motif")
+            expect(response.body).to include("Demandez à un administrateur")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #2708

Lors de la création d'un RDV collectif, s'il n'y a pas de motif collectif : 
- et que l'agent·e est admin : on lui ajoute un bouton pour créer un motif
- et que l'agent·e n'est pas admin : on lui met un message pour l'informer qu'il lui faut de l'aide

# Avant

![image](https://user-images.githubusercontent.com/1193334/188162578-770b3524-31da-4751-80c0-ace30e0fe2fe.png)

# Après

## Avec les droits admin

![image](https://user-images.githubusercontent.com/1193334/188162294-c9d41716-64d8-4d96-aff9-bf4ef23ea85a.png)


## Sans les droits admin

![image](https://user-images.githubusercontent.com/1193334/188161959-b8ff7bbb-fc92-4b84-bf5c-fd0237487834.png)



# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
