### PR TITLE
Duplicates RDV validations now use NOT_CANCELLED_STATUSES enum in rdv form concern

### DIFF
--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -38,9 +38,9 @@ module Admin::RdvFormConcern
         lieu: rdv.lieu,
         starts_at: rdv.starts_at,
         ends_at: rdv.ends_at,
-        motif: rdv.motif
+        motif: rdv.motif,
+        status: Rdv::NOT_CANCELLED_STATUSES
       )
-      .where(status: Rdv::NOT_CANCELLED_STATUSES)
       .select do |existing_rdv|
         participants_of_existing_rdv = Set.new(existing_rdv.users + existing_rdv.agents)
         # Not using `rdv.users` because it does a db call, which returns an empty array because `rdv` is not persisted.
@@ -99,8 +99,7 @@ module Admin::RdvFormConcern
       suspicious_rdvs = Rdv
         .on_day(rdv.starts_at)
         .with_user(user)
-        .where(motif: motif)
-        .where(status: Rdv::NOT_CANCELLED_STATUSES)
+        .where(motif: motif, status: Rdv::NOT_CANCELLED_STATUSES)
 
       if suspicious_rdvs.any?
         user_path = admin_organisation_user_path(rdv.organisation, user)

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -31,19 +31,23 @@ module Admin::RdvFormConcern
   end
 
   def check_duplicates
-    suspicious_rdvs = Rdv.includes(:users, :agents).where(
-      organisation: rdv.organisation,
-      lieu: rdv.lieu,
-      starts_at: rdv.starts_at,
-      ends_at: rdv.ends_at,
-      motif: rdv.motif
-    ).select do |existing_rdv|
-      participants_of_existing_rdv = Set.new(existing_rdv.users + existing_rdv.agents)
-      # Not using `rdv.users` because it does a db call, which returns an empty array because `rdv` is not persisted.
-      # Using rdv_users/agents_rdvs is safe because they are built from the nested attributes.
-      participants_of_current_rdv = Set.new(rdv.rdvs_users.map(&:user) + rdv.agents_rdvs.map(&:agent))
-      participants_of_existing_rdv == participants_of_current_rdv
-    end
+    suspicious_rdvs = Rdv
+      .includes(:users, :agents)
+      .where(
+        organisation: rdv.organisation,
+        lieu: rdv.lieu,
+        starts_at: rdv.starts_at,
+        ends_at: rdv.ends_at,
+        motif: rdv.motif
+      )
+      .where(status: Rdv::NOT_CANCELLED_STATUSES)
+      .select do |existing_rdv|
+        participants_of_existing_rdv = Set.new(existing_rdv.users + existing_rdv.agents)
+        # Not using `rdv.users` because it does a db call, which returns an empty array because `rdv` is not persisted.
+        # Using rdv_users/agents_rdvs is safe because they are built from the nested attributes.
+        participants_of_current_rdv = Set.new(rdv.rdvs_users.map(&:user) + rdv.agents_rdvs.map(&:agent))
+        participants_of_existing_rdv == participants_of_current_rdv
+      end
 
     errors.add(:base, :duplicate) if suspicious_rdvs.any?
   end
@@ -96,6 +100,7 @@ module Admin::RdvFormConcern
         .on_day(rdv.starts_at)
         .with_user(user)
         .where(motif: motif)
+        .where(status: Rdv::NOT_CANCELLED_STATUSES)
 
       if suspicious_rdvs.any?
         user_path = admin_organisation_user_path(rdv.organisation, user)


### PR DESCRIPTION
First Commit and PR for beta gouv, :D yay

Closes #2763 

Je n'ai pas accés à Zammad pour voir le ticket de l'issue d'origine mais j'ai réussi à reproduire en local et à fix le problème décrit.
J'ai également du modifier la methode "check_duplicates" qui ajoutait l'erreur à l'enregistrement active record y compris pour les rdv annulés.
Il y a peut être possibilité de refacto les 2 methodes qui me semblent redondantes mais je n'ai pas assez de connaissance sur le projet pour l'instant.