### PR TITLE
Bugfix: les review apps utilisent le domaine "RDV Aide Numérique" au lieu de "RDV Solidarités"

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -70,6 +70,10 @@ class Domain
   ALL_BY_URL = ALL.index_by(&:dns_domain_name)
 
   def self.find_matching(domain_name)
+    # Les review apps utilisent un domaine de Scalingo, elles
+    # ne permettent donc pas d'utiliser plusieurs domaines.
+    return RDV_SOLIDARITES if ENV["RDV_SOLIDARITES_IS_REVIEW_APP"] == "true"
+
     ALL_BY_URL.fetch(domain_name) { RDV_SOLIDARITES }
   end
 


### PR DESCRIPTION
La constante `ALL_BY_URL` n'est pas fiable dans les review apps car elle contient

```ruby
{
  "production-rdv-solidarites-pr2734.osc-secnum-fr1.scalingo.io" => <Domain:0x00007f89fe07f708 @name="RDV Aide Numérique">
}
```

Le piège c'est que l'on veut du code qui permet de déterminer le domaine à partir de l'URL demandée, mais aussi une fonction qui permet de déterminer le host à partir d'un `Domain` donné, et que ces deux fonctions ne sont pas symétriques pour les review apps. Si vous avez une idée pour expliciter ça de façon claire dans le code, je suis preneur !

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
