### PR TITLE
Corriger une spec qui est flaky à cause de Sentry::TestHelper

### DIFF
--- a/spec/support/sentry_helper.rb
+++ b/spec/support/sentry_helper.rb
@@ -7,5 +7,6 @@ def stub_sentry_events
     setup_sentry_test
     example.run
     teardown_sentry_test
+    Sentry.get_current_scope.clear_breadcrumbs
   end
 end


### PR DESCRIPTION
Il y a un bug dans la gem `sentry-ruby` : le `Sentry::TestHelper#teardown_sentry_test` ne clear pas les breadcrumbs.

[J'ai ouvert une PR pour corriger la gem](https://github.com/getsentry/sentry-ruby/pull/1881), mais en attendant on peut merger ce fix dans notre code.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
