### PR TITLE
Corrige un label incohérent dans l'écran des préférences de notification agents

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -63,6 +63,6 @@ class Absence < ApplicationRecord
   def no_recurrence_for_absence_for_several_days
     return if recurrence.blank? || end_day.blank? || first_day == end_day
 
-    errors.add(:recurrence, "pas possible avec une absence de plusieurs jours")
+    errors.add(:recurrence, "pas possible avec une indisponibilité de plusieurs jours")
   end
 end

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -8,7 +8,7 @@ fr:
         title: Préférences de notifications
         rdv_notifications_header: "Recevoir un email de notification pour mes rendez-vous :"
         plage_ouverture_notifications_header: "Recevoir un email de notification pour mes plages d'ouverture :"
-        absence_notifications_header: "Recevoir un email de notification pour mes absences :"
+        absence_notifications_header: "Recevoir un email de notification pour mes indisponibilités :"
         technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra, etc.) avec RDV Solidarités.
       update:
         done: Préférences de notifications mises à jour.


### PR DESCRIPTION
Nous avons changé le terme « absence » pour « indisponibilité » il y a un certain temps. Un label est passé à travers les mailles du filet.

Signalé ce matin par la Somme (80), il 

Avant 

![Screenshot 2022-09-06 at 15-17-46 RDV Solidarités](https://user-images.githubusercontent.com/42057/188645374-078f157d-9fbc-41b2-8f16-ff42e21a4c0e.png)

Après

![Screenshot 2022-09-06 at 15-17-30 RDV Solidarités](https://user-images.githubusercontent.com/42057/188645381-adf26343-a15f-453a-9aa2-0717f3031cc2.png)




Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
