### PR TITLE
Arrête le redémarrage auto en dehors de Scalingo

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -107,6 +107,7 @@ class CronJob < ApplicationJob
     def perform
       # Avoid restarting production many times from review apps
       return if ENV["RDV_SOLIDARITES_IS_REVIEW_APP"] == "true"
+      return if ENV["SCALINGO_RESTARTER_APP_ID"].blank?
       return if Rails.env.development?
 
       ScalingoAppRestarter.perform_with(ENV["SCALINGO_RESTARTER_APP_ID"], ENV["SCALINGO_RESTARTER_API_TOKEN"])

--- a/app/services/scalingo_app_restarter.rb
+++ b/app/services/scalingo_app_restarter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Service to restart scalingo app
+# call only when deploying on scalingo
 class ScalingoAppRestarter < BaseService
   class ApiError < StandardError; end
 


### PR DESCRIPTION
Suite à une fuite mémoire assez lente, pour laquelle nous n'avons pas trouvé de résolution, nous avons mis en place un cronjob de redémarrage nocturne. Chaque nuit à 2 heures du matin.

Pour le déploiement sur OVH/Kubernetes, nous ne pouvons pas fonctionner avec le même mécanisme (il y a un appel à l'API Scalingo). 

Cette PR propose donc de ne pas déclencher ce job s'il n'y a pas la variable d'environnement `SCALINGO_RESTARTER_APP_ID`

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
