### PR TITLE
Améliorer la pertinence de la recherche texte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ coverage/
 # This directory is used by jsbundling-rails
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Postgres dumps
+**/20*.tar.gz
+**/20*.pgsql

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,7 +27,7 @@ class Admin::UsersController < AgentAuthController
   end
 
   def search
-    @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.limit(10)
+    @users = policy_scope(User).where.not(id: params[:exclude_ids]).active.limit(20)
     @users = search_params[:term].present? ? @users.search_by_text(search_params[:term]) : @users.none
     skip_authorization
   end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -11,8 +11,14 @@ class Agent < ApplicationRecord
   include DeviseInvitable::Inviter
   include FullNameConcern
   include TextSearch
-
-  def self.search_keys = %i[last_name first_name email]
+  def self.search_against
+    {
+      last_name: "A",
+      first_name: "B",
+      email: "D",
+      id: "D",
+    }
+  end
 
   devise :invitable, :database_authenticatable,
          :recoverable, :rememberable, :validatable, :confirmable, :async, validate_on_invite: true

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -2,7 +2,7 @@
 
 class PlageOuverture < ApplicationRecord
   # Mixins
-  has_paper_trail
+  has_paper_trail(ignore: :search_terms)
   include RecurrenceConcern
   include WebhookDeliverable
   include IcalHelpers::Ics

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -2,7 +2,7 @@
 
 class PlageOuverture < ApplicationRecord
   # Mixins
-  has_paper_trail(ignore: :search_terms)
+  has_paper_trail
   include RecurrenceConcern
   include WebhookDeliverable
   include IcalHelpers::Ics
@@ -10,7 +10,12 @@ class PlageOuverture < ApplicationRecord
   include Payloads::PlageOuverture
   include Expiration
   include TextSearch
-  def self.search_keys = %i[title]
+  def self.search_against
+    {
+      title: "A",
+      id: "D",
+    }
+  end
 
   # Attributes
   auto_strip_attributes :title

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -8,7 +8,12 @@ class Team < ApplicationRecord
   )
 
   include TextSearch
-  def self.search_keys = %i[name]
+  def self.search_against
+    {
+      name: "A",
+      id: "D",
+    }
+  end
 
   # Attributes
   auto_strip_attributes :name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,21 @@ class User < ApplicationRecord
   include PhoneNumberValidation::HasPhoneNumber
   include WebhookDeliverable
   include TextSearch
-  def self.search_keys = %i[last_name first_name email birth_name phone_number_formatted]
+
+  def self.search_against
+    {
+      last_name: "A",
+      first_name: "B",
+      birth_name: "C",
+
+      # Ces champs sont moins pondérés car on ne veut leur
+      # donner de l'importance que si le match est très proche ou exact.
+      email: "D",
+      phone_number_formatted: "D",
+      id: "D",
+    }
+  end
+
   devise :invitable, :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable, :async,
          :trackable

--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -76,6 +76,25 @@ describe TextSearch, type: :concern do
       expect(described_class.search_by_text("Jean Paul Petit").first).to eq(jean_paul)
     end
 
+    # Ce test a été introduit au moment de la mise en place de
+    # la pondération des colonnes lors de la recherche textuelle.
+    # Avant la pondération, les résultats pour "durand clem" étaient :
+    #   1. clement_berut_avec_email
+    #   2. clementine_dupond_ne_durand
+    #   3. clementine_durand
+    # ce qui est l'inverse de ce que l'on peut considérer comme pertinent.
+    it "orders results by relevance, weighing last name and first name above birth name and email" do
+      clementine_dupond_ne_durand = create(:user, first_name: "Clémentine", last_name: "DUPOND", birth_name: "DURAND")
+      clement_berut_avec_email = create(:user, first_name: "Clément", last_name: "BERUT", email: "clem.berut@example.com")
+      clementine_durand = create(:user, first_name: "Clémentine", last_name: "DURAND")
+      expected_order = [
+        clementine_durand,
+        clementine_dupond_ne_durand,
+        clement_berut_avec_email,
+      ]
+      expect(described_class.search_by_text("durand clem").to_a).to eq(expected_order)
+    end
+
     it "orders results by search terms" do
       marie = create(:user, first_name: "Marie", last_name: "Petit")
       frederic = create(:user, first_name: "Frédéric", last_name: "Petit")


### PR DESCRIPTION
_Pour tester https://production-rdv-solidarites-pr2791.osc-secnum-fr1.scalingo.io/_

Closes #2790

Comme décrit dans l'issue, le but ici est de passer d'un système de recherche textuel non pondéré à un système pondéré.

Je vous conseille de lire également le [ticket Zammad](https://zammad10.ethibox.fr/#ticket/zoom/2595) pour comprendre le contexte de ce besoin.

## Comment ça fonctionnait avant

Les modèles sur lesquels on voulait pouvoir chercher par texte (`User`, `Agent`, `Team` et `PlageOuverture`) avaient une colonne `search_terms`, dont la valeur était une concaténation de la valeur d'une liste de champs (nom, prénom, email pour les users / agents ou le nom de l'équipe pour les teams). Ce champ était donc **un vrac de termes** issus d'autres colonnes. Le problème, c'est que certaines colonnes devraient avoir plus d'importances que d'autres (typiquement, le nom de famille d'un⋅e usager⋅e devrait avoir plus d'importance que son nom de naissance ou même son e-mail).

Note : c'est le concern `TextSearch` qui définit cette stratégie de recherche.

## Comment ça fonctionne maintenant

La gem que l'on utilisait jusqu'ici pour chercher sur la colonne `search_terms` (vrac) offre [des fonctionnalités de pondérations](https://github.com/Casecommons/pg_search#weighting) ! J'ai donc choisi de les utiliser pour améliorer la pertinence des résultats. Le test que j'ai ajouté devrait aider à comprendre le changement de comportement que la pondération crée.

Note : l'usage d'index est recommandé pour améliorer les performances de recherche, mais il est complexe de les mettre en place si l'on veut aussi utiliser `unaccent` (et il semble préférable de l'utiliser pour la pertinence). Je n'ai donc pas créé d'index, ce qui semble acceptable car les volumes sur lesquels nous faisons des recherches sont limités. Si nous constatons des lenteurs sur ces actions nous pourrons étudier les options d'optimisation.

## La suite

Nous avons décidé de laisser en place le système qui calcule et enregistre les `search_terms`, ce qui nous permet de repasser à ce système si nous rencontrons des soucis avec la pondération introduire dans cette PR.

Je me suis mis un rappel dans deux semaines pour faire le point et supprimer la colonne si tout va bien. :wink: 

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
