### PR TITLE
Utiliser RDV Aide Numérique pour les nouveaux comptes de CNFS

### DIFF
--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -55,7 +55,8 @@ class AddConseillerNumerique
     organisation = Organisation.create!(
       external_id: @structure.external_id,
       name: next_available_organisation_name,
-      territory: territory
+      territory: territory,
+      new_domain_beta: true
     )
     create_motifs(organisation)
     create_lieu(organisation)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,7 +58,8 @@ org_cnfs = Organisation.create!(
   name: "Mediathèque Paris Nord",
   phone_number: "0123456789",
   human_id: "mediatheque-paris-nord",
-  territory: territory_cnfs
+  territory: territory_cnfs,
+  new_domain_beta: true
 )
 org_drome1 = Organisation.create!(
   name: "Plateforme mutualisée d'orientation",


### PR DESCRIPTION
Maintenant qu'on a fait l'annonce pour le nouveau nom de domaine, on peut directement créer des comptes sur RDV Aide Numérique pour les nouveaux cnfs qu'on invite.
