### PR TITLE
Bannière de communication sur le nouveau nom de domaine

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -88,4 +88,8 @@ class Organisation < ApplicationRecord
 
     Admins::OrganisationMailer.organisation_created(agents.first, self).deliver_later
   end
+
+  def domain
+    new_domain_beta? ? Domain::RDV_AIDE_NUMERIQUE : Domain::RDV_SOLIDARITES
+  end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -287,9 +287,7 @@ class Rdv < ApplicationRecord
     results.exclude?("failure") ? "processed" : "failure"
   end
 
-  def domain
-    organisation.new_domain_beta ? Domain::RDV_AIDE_NUMERIQUE : Domain::RDV_SOLIDARITES
-  end
+  delegate :domain, to: :organisation
 
   private
 

--- a/app/views/layouts/_domain_change_banner.html.slim
+++ b/app/views/layouts/_domain_change_banner.html.slim
@@ -1,0 +1,11 @@
+- if organisation.present? && organisation.domain != current_domain && organisation.new_domain_beta
+  .navbar.alert-warning.p-2
+    div
+      .fa.fa-exclamation-circle.alert-link>
+      span.ml-1.alert-link
+        = "RDV Solidarités devient RDV Aide Numérique ! "
+        = "Vos usagers reçoivent maintenant des notifications de la part de RDV Aide Numérique, et vous pouvez vous connecter sur "
+        = link_to("https://#{organisation.domain.dns_domain_name}", "https://#{organisation.domain.dns_domain_name}")
+        = " pour planifier vos rendez-vous."
+      = link_to(domaines_path)
+        button.btn.mt-3.rdv-status-unknown_past.float-right = "En savoir plus"

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -12,6 +12,7 @@ html lang="fr"
         .content-page
           .content
             = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: defined?(current_organisation) ? current_organisation : nil
+            = render "layouts/domain_change_banner", agent: current_agent, organisation: defined?(current_organisation) ? current_organisation : nil
             .container-fluid
               - if content_for :title
                 .row.justify-content-md-center


### PR DESCRIPTION
La communication sur le mattermost des cnfs n'a pas touché autant de monde que ce qu'on espérait (principalement parce qu'on n'a pas pu faire une notification générale `@all`), donc pour s'assurer que les gens concernés par le nouveau nom de domaine soient au courant, on ajoute un peu de communication directement dans l'appli lorsqu'ils se connectent sur le mauvais domaine.

<img width="1207" alt="Capture d’écran 2022-09-12 à 11 00 16" src="https://user-images.githubusercontent.com/1840367/189614290-480e017d-59df-440e-b3c8-5f766e7e7f71.png">


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
