### PR TITLE
Mise à jour du lien vers le mattermost d'entraide pour les CNFS

### DIFF
--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -34,8 +34,8 @@
 
 <p>
   <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
-        mattermost: link_to("Aide RDV Solidarités", "https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites"),
-        support_email: link_to("support@rdv-solidarités.fr", "mailto:support@rdv-solidarités.fr")
+        mattermost: link_to("RDV Aide Numérique", "https://discussion.conseiller-numerique.gouv.fr/cnum/channels/rdv-aide-numerique"),
+        support_email: link_to("support@rdv-solidarites.fr", "mailto:support@rdv-solidarites.fr")
        ).html_safe %>
 </p>
 

--- a/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
@@ -27,8 +27,8 @@ Activer mon compte: <%= accept_invitation_url(@resource, invitation_token: @toke
 
 
 <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
-      mattermost: "Aide RDV Solidarités: https://discussion.conseiller-numerique.gouv.fr/cnum/channels/aide-rdv-solidarites",
-      support_email: "support@rdv-solidarités.fr"
+      mattermost: "RDV Aide Numérique: https://discussion.conseiller-numerique.gouv.fr/cnum/channels/rdv-aide-numerique",
+      support_email: "support@rdv-solidarites.fr"
      ).html_safe %>
 
 


### PR DESCRIPTION
Dans le mail d'invitation des CNFS, on leur met un lien vers le canal d'entraide pour RDV Aide Numérique sur leur mattermost.
Maintenant que le canal mattermost a été renommé (et qu'un canal utilisant l'ancienne url a été créé pour que les anciens liens ne mènent pas vers une 404), on peut changer le lien dans le mail d'invitation.

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
