### PR TITLE
Permettre de prendre RDV via un lien public, sans sectorisation

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
       :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category,
-      :invitation_token, organisation_ids: []
+      :invitation_token, :organisation_id, organisation_ids: []
     )
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -25,7 +25,7 @@ class SearchController < ApplicationController
 
   def redirect_to_organisation_search(organisation)
     if organisation
-      redirect_to root_path(address: "1", organisation_id: organisation.id, departement: organisation.territory.departement_number)
+      redirect_to root_path(organisation_id: organisation.id, departement: organisation.territory.departement_number)
     else
       flash[:alert] = "Organisation non trouvée"
       redirect_to root_path

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -10,7 +10,27 @@ class SearchController < ApplicationController
     @context = SearchContext.new(current_user, search_params.to_h)
   end
 
+  def public_link_with_internal_organisation_id
+    organisation = Organisation.find(params[:organisation_id])
+    redirect_to_organisation_search(organisation)
+  end
+
+  def public_link_with_external_organisation_id
+    territory = Territory.find_by!(departement_number: params[:territory_slug])
+    organisation = territory.organisations.find_by!(external_id: params[:organisation_external_id])
+    redirect_to_organisation_search(organisation)
+  end
+
   private
+
+  def redirect_to_organisation_search(organisation)
+    if organisation
+      redirect_to root_path(address: "1", organisation_id: organisation.id, departement: organisation.territory.departement_number)
+    else
+      flash[:alert] = "Organisation non trouvée"
+      redirect_to root_path
+    end
+  end
 
   def search_params
     params.permit(

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -35,11 +35,7 @@ class Organisation < ApplicationRecord
 
   # Validation
   validates :name, presence: true, uniqueness: { scope: :territory }
-  # Rubocop doesn't seem to see the index that exists for this column, so we have to ignore the warning here
-  # This could be fixed by upgrading rubocop to at least 2.11.3 (see https://github.com/rubocop/rubocop-rails/pull/517)
-  # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :external_id, uniqueness: { scope: :territory, allow_nil: true }
-  # rubocop:enable Rails/UniqueValidationWithoutIndex
   validates :phone_number, phone: { allow_blank: true }
   validates(
     :human_id,

--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -32,7 +32,7 @@ class AddConseillerNumerique
   end
 
   def find_or_create_organisation
-    Organisation.find_by(external_id: @structure.external_id) || create_organisation
+    Organisation.find_by(territory: territory, external_id: @structure.external_id) || create_organisation
   end
 
   private

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -27,7 +27,7 @@ class SearchContext
   # *** Method that outputs the next step for the user to complete its rdv journey ***
   # *** It is used in #to_partial_path to render the matching partial view ***
   def current_step
-    if address.blank?
+    if address.blank? && @organisation_id.blank?
       :address_selection
     elsif !service_selected?
       :service_selection

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -14,7 +14,8 @@ class SearchContext
     @city_code = query[:city_code]
     @departement = query[:departement]
     @street_ban_id = query[:street_ban_id]
-    @organisation_ids = query[:organisation_ids]
+    @organisation_id = query[:organisation_id]
+    @fallback_organisation_ids = query[:organisation_ids]
     @motif_search_terms = query[:motif_search_terms]
     @motif_category = query[:motif_category]
     @motif_name_with_location_type = query[:motif_name_with_location_type]
@@ -146,7 +147,7 @@ class SearchContext
         # we retrieve the geolocalised matching motifs, if there are none we fallback
         # on the matching motifs for the organisations passed in the query
         filter_motifs(geo_search.available_motifs).presence || filter_motifs(
-          Motif.available_with_plages_ouvertures.where(organisation_id: @organisation_ids)
+          Motif.available_with_plages_ouvertures.where(organisation_id: @fallback_organisation_ids)
         )
       else
         filter_motifs(geo_search.available_motifs)
@@ -162,6 +163,7 @@ class SearchContext
     motifs = motifs.where(service: service) if @service_id.present?
     motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
     motifs = motifs.where(category: @motif_category) if @motif_category.present?
+    motifs = motifs.where(organisations: { id: @organisation_id }) if @organisation_id.present?
 
     # filtrer sur le `lieu_id` dans la table des plages d'ouverture permet de limiter de combiner et construire trop d'objet
     # voir https://github.com/betagouv/rdv-solidarites.fr/issues/2686

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -114,12 +114,12 @@
           span.ml-1= Motif.human_attribute_value(:visibility_type, value)
           p.text-muted.font-14= Motif.human_attribute_value(:visibility_type, value, context: :hint)
 
-    .card
-      .card-body
-        h5 Instructions
-        p.text-muted.font-14 Ces instructions sont affichées à l'usager avant et après sa prise de RDV. Laissez ces champs vides si vous ne souhaitez pas donner d'instructions.
-        = f.input :restriction_for_rdv, input_html: {rows: 6}
-        = f.input :instruction_for_rdv, input_html: {rows: 6}
+  .card
+    .card-body
+      h5 Instructions
+      p.text-muted.font-14 Ces instructions sont affichées à l'usager avant et après sa prise de RDV. Laissez ces champs vides si vous ne souhaitez pas donner d'instructions.
+      = f.input :restriction_for_rdv, input_html: {rows: 6}
+      = f.input :instruction_for_rdv, input_html: {rows: 6}
 
   .card
     .card-body

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -57,21 +57,21 @@
         span.ml-1=  Motif.human_attribute_value(:collectif, true)
         p.text-muted.font-14= Motif.human_attribute_value(:collectif, true, context: :hint)
 
+  .card
+    .card-body
+      h5.card-title= Motif.human_attribute_name("reservable_online_title")
+      p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
+      = f.input :reservable_online
+
+      .form-row
+        .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
+        .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
+
+      .js-rdvs-editable
+        = f.input(:rdvs_editable_by_user)
+        p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
+
   - unless current_agent.conseiller_numerique?
-    .card
-      .card-body
-        h5.card-title= Motif.human_attribute_name("reservable_online_title")
-        p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
-        = f.input :reservable_online
-
-        .form-row
-          .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
-          .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
-
-        .js-rdvs-editable
-          = f.input(:rdvs_editable_by_user)
-          p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
-
     .card.js-sectorisation-card
       .card-body
         h5.mb-2= Motif.human_attribute_name("sectorisation_level_title")

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -34,10 +34,9 @@
           motif_option_value(@motif, :for_secretariat)
         hr
 
-        - unless current_agent.conseiller_numerique?
-          = motif_attribute_row \
-            Motif.human_attribute_name(:reservable_online), \
-            motif_option_value(@motif, :reservable_online)
+        = motif_attribute_row \
+          Motif.human_attribute_name(:reservable_online), \
+          motif_option_value(@motif, :reservable_online)
         = motif_attribute_row \
           Motif.human_attribute_name(:min_booking_delay_short), \
           @motif.reservable_online? && \

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -26,13 +26,13 @@
             | #{display_value_or_na_placeholder(@organisation.horaires)}
         .text-right= link_to "Modifier", edit_admin_organisation_path(@organisation), class: "btn btn-primary"
 
-
-.row.justify-content-center
-  .col-md-8
-    .card
-      h4.card-header Lien public
-      .card-body
-        label.form-control-label for="public_link" Ce lien permet aux usagers de prendre RDV auprès de votre organisation
-        input.form-control id="public_link" readonly=true value=public_link_to_org_url(organisation_id: @organisation.id)
+- if current_agent.conseiller_numerique?
+  .row.justify-content-center
+    .col-md-8
+      .card
+        h4.card-header Lien public
+        .card-body
+          label.form-control-label for="public_link" Ce lien permet aux usagers de prendre RDV auprès de votre organisation
+          input.form-control id="public_link" readonly=true value=public_link_to_org_url(organisation_id: @organisation.id)
 
 = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @organisation

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -26,13 +26,4 @@
             | #{display_value_or_na_placeholder(@organisation.horaires)}
         .text-right= link_to "Modifier", edit_admin_organisation_path(@organisation), class: "btn btn-primary"
 
-- if current_agent.conseiller_numerique?
-  .row.justify-content-center
-    .col-md-8
-      .card
-        h4.card-header Lien public
-        .card-body
-          label.form-control-label for="public_link" Ce lien permet aux usagers de prendre RDV auprès de votre organisation
-          input.form-control id="public_link" readonly=true value=public_link_to_org_url(organisation_id: @organisation.id)
-
 = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @organisation

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -8,7 +8,7 @@
     .card
       h4.card-header Informations générales
       .card-body
-        ul.list-unstyled.mb-5
+        ul.list-unstyled
           li.mb-2
             strong> Nom :
             | #{@organisation.name}
@@ -25,5 +25,14 @@
             strong> Horaires :
             | #{display_value_or_na_placeholder(@organisation.horaires)}
         .text-right= link_to "Modifier", edit_admin_organisation_path(@organisation), class: "btn btn-primary"
+
+
+.row.justify-content-center
+  .col-md-8
+    .card
+      h4.card-header Lien public
+      .card-body
+        label.form-control-label for="public_link" Ce lien permet aux usagers de prendre RDV auprès de votre organisation
+        input.form-control id="public_link" readonly=true value=public_link_to_org_url(organisation_id: @organisation.id)
 
 = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @organisation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,8 +257,8 @@ Rails.application.routes.draw do
   end
 
   # short public link
-  get "p/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id"
-  get "e/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id"
+  get "p/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
+  get "e/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
 
   ##
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,10 @@ Rails.application.routes.draw do
     params.values.any? ? "?#{params.to_query}" : ''
   end
 
+  # short public link
+  get "p/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id"
+  get "e/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id"
+
   ##
 
   get "accueil_mds" => "static_pages#rdv_solidarites_presentation_for_agents"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,8 +257,8 @@ Rails.application.routes.draw do
   end
 
   # short public link
-  get "p/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
-  get "e/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
+  get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
+  get "org/ext/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
 
   ##
 

--- a/db/migrate/20220920123327_scope_external_id_uniqueness_to_territory.rb
+++ b/db/migrate/20220920123327_scope_external_id_uniqueness_to_territory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ScopeExternalIdUniquenessToTerritory < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :organisations, :external_id, unique: true
+    add_index :organisations, %i[external_id territory_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_14_164205) do
+ActiveRecord::Schema.define(version: 2022_09_20_123327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -370,7 +370,7 @@ ActiveRecord::Schema.define(version: 2022_09_14_164205) do
     t.bigint "territory_id", null: false
     t.string "external_id", comment: "The organisation's unique and immutable id in the system managing them and adding them to our application"
     t.boolean "new_domain_beta", default: false, null: false, comment: "en mettant ce boolean a true, on active l'utilisation du nouveau domaine pour les conseillers numeriques de cette organisation"
-    t.index ["external_id"], name: "index_organisations_on_external_id", unique: true
+    t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["human_id", "territory_id"], name: "index_organisations_on_human_id_and_territory_id", unique: true, where: "((human_id)::text <> ''::text)"
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true
     t.index ["name"], name: "index_organisations_on_name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -256,6 +256,7 @@ Motif.create!(
   color: "#99CC99",
   default_duration_in_min: 60,
   location_type: :public_office,
+  reservable_online: true,
   organisation: org_cnfs,
   service: service_cnfs
 )

--- a/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe "user can use a link that points to RDV search scoped to an organisation" do
+  before { travel_to(Time.zone.parse("2022-09-12 15:00:00")) }
+
+  let!(:territory) { create(:territory, departement_number: "CN") }
+  let!(:organisation_a) { create(:organisation, territory: territory, external_id: "123") }
+  let!(:organisation_b) { create(:organisation, territory: territory, external_id: "456") }
+
+  let!(:motif_a) { create(:motif, :sectorisation_level_departement, organisation: organisation_a, name: "Motif A") }
+  let!(:motif_b) { create(:motif, :sectorisation_level_departement, organisation: organisation_b, name: "Motif B") }
+
+  let!(:lieu_a) { create(:lieu, organisation: organisation_a) }
+  let!(:lieu_b) { create(:lieu, organisation: organisation_b) }
+
+  let!(:plage_ouverture_a) { create(:plage_ouverture, motifs: [motif_a], lieu: lieu_a) }
+  let!(:plage_ouverture_b) { create(:plage_ouverture, motifs: [motif_b], lieu: lieu_b) }
+
+  describe "scoping the results to the provided organisation" do
+    context "when providing the internal organisation id" do
+      it "scopes the motifs to the organisation" do
+        visit "/p/#{organisation_a.id}"
+        expect(page).to have_content("Motif A")
+        expect(page).not_to have_content("Motif B")
+      end
+    end
+
+    context "when providing the external organisation id + territory slug" do
+      it "scopes the motifs to the organisation" do
+        visit "/e/#{territory.departement_number}/#{organisation_a.external_id}"
+        expect(page).to have_content("Motif A")
+        expect(page).not_to have_content("Motif B")
+      end
+    end
+  end
+
+  describe "the complete process of taking a RDV from a public link" do
+    it "works" do
+      visit "/e/#{territory.departement_number}/#{organisation_a.external_id}"
+      expect(page).to have_content("1 lieu est disponible")
+      expect(page).to have_content(lieu_a.name)
+      expect(page).to have_content(motif_a.service.name)
+      click_on("Prochaine disponibilité lemardi 20 septembre 2022 à 08h00")
+
+      expect(page).to have_content("Sélectionnez un créneau")
+      click_on("08:00")
+
+      expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
+      click_on("Je m'inscris")
+
+      fill_in "user_first_name", with: "David"
+      fill_in "user_last_name", with: "Nchicode"
+      fill_in "user_email", with: "davidnchicode@crotonmail.com"
+      click_on("Je m'inscris")
+
+      open_email("davidnchicode@crotonmail.com")
+      current_email.click_link("Confirmer mon compte")
+      fill_in "password", with: "123456"
+      click_on("Enregistrer")
+
+      # Page de formulaire où l'on peut ajouter le nom de naissance, la date de naissance, le téléphone...
+      fill_in "user_birth_date", with: "02/04/1990"
+      click_on("Continuer")
+
+      # Pour l'instant cette page s'affiche même si l'on a une seule personne dans la liste des choix. :/
+      expect(page).to have_content("Pour qui prenez-vous rendez-vous ?") # David est sélectionné par défaut
+      click_on("Continuer")
+
+      # Page finale de confirmation
+      expect(page).to have_content("Confirmation")
+      expect(page).to have_content("Date du rendez-vous : mardi 20 septembre 2022 à 08h00 (45 minutes)")
+      expect { click_on("Confirmer mon RDV") }.to change(Rdv, :count).by(1)
+    end
+  end
+end

--- a/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
   describe "scoping the results to the provided organisation" do
     context "when providing the internal organisation id" do
       it "scopes the motifs to the organisation" do
-        visit "/p/#{organisation_a.id}"
+        visit "/org/#{organisation_a.id}"
         expect(page).to have_content("Motif A")
         expect(page).not_to have_content("Motif B")
       end
@@ -27,7 +27,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
     context "when providing the external organisation id + territory slug" do
       it "scopes the motifs to the organisation" do
-        visit "/e/#{territory.departement_number}/#{organisation_a.external_id}"
+        visit "/org/ext/#{territory.departement_number}/#{organisation_a.external_id}"
         expect(page).to have_content("Motif A")
         expect(page).not_to have_content("Motif B")
       end
@@ -36,7 +36,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
   describe "the complete process of taking a RDV from a public link" do
     it "works" do
-      visit "/e/#{territory.departement_number}/#{organisation_a.external_id}"
+      visit "/org/ext/#{territory.departement_number}/#{organisation_a.external_id}"
       expect(page).to have_content("1 lieu est disponible")
       expect(page).to have_content(lieu_a.name)
       expect(page).to have_content(motif_a.service.name)

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -85,7 +85,7 @@ describe AddConseillerNumerique do
 
   describe "special cases for organisations" do
     context "when there is already an organisation with this external id" do
-      before { create(:organisation, external_id: "123456") }
+      before { create(:organisation, external_id: "123456", territory: Territory.find_by!(name: "Conseillers Numériques")) }
 
       it "does nothing" do
         expect { described_class.process!(params) }.not_to change(Organisation, :count)


### PR DESCRIPTION
Voir : https://www.notion.so/juvenile-limburger-f93/Prise-de-RDV-par-des-usagers-227911452f5645e3bb5599a51a6da746

Le but est de proposer un lien par lequel les usagers peuvent prendre RDV auprès d'une organisation. La référence à cette organisation peut être fait soit :
- par un ID d'organisation
- par un ID externe d'organisation, qui correspond à l'ID du CNFS dans l'espace coop des CNFS, que l'on stocke dans `external_id`

Note : L'espace coop est la source de vérité, c'est à dire que l'on utilise les IDs de cette base pour retrouver une organisation de notre côté, et les services de cartographie qui sont nos partenaires utiliseront aussi ces mêmes IDs.

## Choix techniques

- On a ajouté un paramètre `organisation_id` au `SearchContext`. Si il est présent, on filtre les motifs sur l'organisation pointée.
- Les URLs partagées publiquement doivent être stables, elles ne contiennent donc qu'une référence vers l'orga, et ensuite on redirige vers une route câblée sur le `SearchContext` en passant un `organisation_id`. Ainsi, on reste libres de changer notre routage autour de la fonctionnalité de prise de RDV, il suffira simplement de modifier la redirection.
- La colonne `organisations.external_id` a des valeurs uniques par territoires (`territory_id`). Un index a été ajouté en ce sens.
- Dans le formulaire d'édition / création d'un motif, la section qui permet de rendre le motif réservable "en ligne" (c'est à dire publiquement) est désormais affichée aux CNFS

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
