### PR TITLE
Bug : la base de donnée de test (features) est seedée sur la CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Precompile assets
         run: RAILS_ENV=test bundle exec rake assets:precompile
       - name: Setup tests
-        run: bundle exec rake db:setup RAILS_ENV=test
+        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432


### PR DESCRIPTION
La commande `db:setup` :
1. crée la base (`db:create`)
2. charge le schéma (enums, tables, colonnes, index) (`db:schema:load`)
3. **charge seeds.rb** (`db:seed`)

Sauf erreur de ma part, nous ne voulons pas que les seeds soient fait en environnement de test ! :zany_face: 

J'ai donc remplacé par les commandes qui font les étapes 1 et 2. :wink: 

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
