### PR TITLE
autorise le choix de l'usager franceconnecté

### DIFF
--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -126,8 +126,10 @@ class MergeUsersForm
   end
 
   def frozen_field_update?(frozen_field, user1, user2)
-    send(frozen_field).present? &&
-      ((user1.logged_once_with_franceconnect? && send(frozen_field) != user1.send(frozen_field)) ||
-       (user2.logged_once_with_franceconnect? && send(frozen_field) != user2.send(frozen_field)))
+    return false if send(frozen_field).blank?
+
+    selected_value = number_to_user(send(frozen_field)).send(frozen_field)
+    ((user1.logged_once_with_franceconnect? && selected_value != user1.send(frozen_field)) ||
+         (user2.logged_once_with_franceconnect? && selected_value != user2.send(frozen_field)))
   end
 end

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -1,28 +1,29 @@
 # frozen_string_literal: true
 
 describe MergeUsersForm, type: :form do
-  describe "validations" do
-    {
-      first_name: %w[Dominique Camille],
-      birth_date: [Date.new(1970, 4, 25), Date.new(1980, 6, 25)],
-      birth_name: %w[Nicolas Mathieu],
-    }.each do |frozen_field, values|
-      let(:organisation) { create(:organisation) }
-      it "invalid when merge #{frozen_field} on franceConnected user1" do
-        user1 = create(:user, frozen_field => values[0], logged_once_with_franceconnect: true)
-        user2 = create(:user, frozen_field => values[1])
-        merge_users_params = { frozen_field => user2.send(frozen_field) }
-        merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
-        expect(merge_users_form).to be_invalid
-      end
+  let(:organisation) { create(:organisation) }
 
-      it "invalid when merge #{frozen_field} on franceConnected user2" do
-        user2 = create(:user, frozen_field => values[0], logged_once_with_franceconnect: true)
-        user1 = create(:user, frozen_field => values[1])
-        merge_users_params = { frozen_field => user1.send(frozen_field) }
-        merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
-        expect(merge_users_form).to be_invalid
-      end
-    end
+  it "is valid when no franceConnected user" do
+    user1 = create(:user, logged_once_with_franceconnect: false)
+    user2 = create(:user, logged_once_with_franceconnect: false)
+    merge_users_params = { email: "1", first_name: "1", last_name: "1", birth_name: "1", birth_date: "1", phone_number: "2", address: "2" }
+    merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
+    expect(merge_users_form).to be_valid
+  end
+
+  it "is valid when franceconencted user frozen fields are selected" do
+    user2 = create(:user, birth_name: "Henri", first_name: "Bob", birth_date: Date.new(2000, 11, 13), logged_once_with_franceconnect: true)
+    user1 = create(:user, birth_name: nil, first_name: "Bob", birth_date: Date.new(2000, 11, 13))
+    merge_users_params = { email: "1", first_name: "2", last_name: "1", birth_name: "2", birth_date: "2", phone_number: "1", address: "2" }
+    merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
+    expect(merge_users_form).to be_valid
+  end
+
+  it "is invalid when not franceconnected user frozn field are selected" do
+    user1 = create(:user, first_name: "Malika", last_name: "PAUL", email: nil, phone_number: "01 23 23 23 23", birth_date: "1967-07-05", birth_name: "GONE", logged_once_with_franceconnect: nil)
+    user2 = create(:user, first_name: "Malika", last_name: "GONE", email: "exemple@mail.com", phone_number: nil, birth_date: "1994-12-22", birth_name: "GONE", logged_once_with_franceconnect: true)
+    merge_users_params = { email: "1", first_name: "1", last_name: "1", birth_name: "1", birth_date: "1", phone_number: "2", address: "2" }
+    merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
+    expect(merge_users_form).to be_invalid
   end
 end


### PR DESCRIPTION
ref https://zammad10.ethibox.fr/#ticket/zoom/2543 et https://zammad10.ethibox.fr/#ticket/zoom/2633

Dans le processus de fusion usager ;
Lorsqu'un usager a utilisé FranceConnect pour s'authentifier ;
Nous ne pouvons pas modifier son prénom, son nom de naissance ni sa date de naissance ;
Mais si nous sélectionnons les valeurs de cet usager ayant utilité FranceConnect ;
Alors, nous avons un message qui nous bloque, en disant que ce n'est pas possible de mettre à jour parce qu'il y a un utilisateur qui a utilisé FranceConnect

Cette PR modifie le contrôle en question pour ne pas bloquer si les valeurs sélectionnées sont celles de l'utilisateur ayant utilisé FranceConnect.

Cette PR est une sécurité supplémentaire, mais devrait plus être utile (sauf à vérifier aussi coté serveur) lorsque nous aurons mis en place la PR #2734. Cette PR reste malgré tout pertinente (vérification serveur).

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
