### PR TITLE
Pas de modification des RDV passés de plus de 48h

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 class Admin::RdvsController < AgentAuthController
-  include AdminHelper
-
   respond_to :html, :json
 
   before_action :set_rdv, :set_optional_agent, except: %i[index create export]
-  before_action :check_rdv_updatable, only: %i[edit update]
 
   # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3268196907
   before_action :log_params_to_sentry, only: %i[index export]
@@ -97,13 +94,6 @@ class Admin::RdvsController < AgentAuthController
 
   def set_rdv
     @rdv = policy_scope(Rdv).find(params[:id])
-  end
-
-  def check_rdv_updatable
-    return if @rdv.updatable?(current_agent, current_organisation)
-
-    flash[:error] = "Ce rendez-vous ne peut pas être modifié."
-    redirect_to admin_organisation_rdv_path(current_organisation, @rdv, agent_id: params[:agent_id])
   end
 
   def rdv_params

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -100,7 +100,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def check_rdv_updatable
-    return if current_agent_role.admin? || @rdv.updatable?
+    return if @rdv.updatable?(current_agent, current_organisation)
 
     flash[:error] = "Ce rendez-vous ne peut pas être modifié."
     redirect_to admin_organisation_rdv_path(current_organisation, @rdv, agent_id: params[:agent_id])

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -289,6 +289,10 @@ class Rdv < ApplicationRecord
 
   delegate :domain, to: :organisation
 
+  def updatable?
+    starts_at >= 2.days.ago
+  end
+
   private
 
   def starts_at_is_plausible

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -289,20 +289,16 @@ class Rdv < ApplicationRecord
 
   delegate :domain, to: :organisation
 
-  def updatable?(agent, organisation)
-    agent.admin_in_organisation?(organisation) || !starts_too_long_ago?
+  def starts_long_ago?
+    starts_at < 2.days.ago
   end
 
   private
 
-  def starts_too_long_ago?
-    starts_at < 2.days.ago
-  end
-
   def starts_at_is_plausible
     return unless will_save_change_to_attribute?("starts_at")
 
-    if starts_too_long_ago?
+    if starts_long_ago?
       errors.add(:starts_at, :must_be_future)
     elsif starts_at > Time.zone.now + 2.years
       errors.add(:starts_at, :must_be_within_two_years)

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -289,16 +289,20 @@ class Rdv < ApplicationRecord
 
   delegate :domain, to: :organisation
 
-  def updatable?
-    starts_at >= 2.days.ago
+  def updatable?(agent, organisation)
+    agent.admin_in_organisation?(organisation) || !starts_too_long_ago?
   end
 
   private
 
+  def starts_too_long_ago?
+    starts_at < 2.days.ago
+  end
+
   def starts_at_is_plausible
     return unless will_save_change_to_attribute?("starts_at")
 
-    if starts_at < 2.days.ago
+    if starts_too_long_ago?
       errors.add(:starts_at, :must_be_future)
     elsif starts_at > Time.zone.now + 2.years
       errors.add(:starts_at, :must_be_within_two_years)

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -9,6 +9,10 @@ class Agent::RdvPolicy < DefaultAgentPolicy
     true
   end
 
+  def update?
+    super && (current_agent.admin_in_organisation?(current_organisation) || !@record.starts_long_ago?)
+  end
+
   def destroy?
     admin_and_same_org?
   end

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -44,7 +44,8 @@
       .card-footer
         .d-flex.justify-content-end
           .btn-group
-            = link_to t(".update"), edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
+            - if current_agent_role.admin? || @rdv.updatable?
+              = link_to t(".update"), edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
             - if @rdv.individuel?
               = link_to t(".duplicate"), admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, motif_id: @rdv.motif_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context, lieu_ids: [@rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary"
             - else

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -44,7 +44,7 @@
       .card-footer
         .d-flex.justify-content-end
           .btn-group
-            - if current_agent_role.admin? || @rdv.updatable?
+            - if @rdv.updatable?(current_agent, current_organisation)
               = link_to t(".update"), edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
             - if @rdv.individuel?
               = link_to t(".duplicate"), admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, motif_id: @rdv.motif_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context, lieu_ids: [@rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary"

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -44,7 +44,7 @@
       .card-footer
         .d-flex.justify-content-end
           .btn-group
-            - if @rdv.updatable?(current_agent, current_organisation)
+            - if policy([:agent, @rdv]).update?
               = link_to t(".update"), edit_admin_organisation_rdv_path(@rdv.organisation, @rdv, agent_id: @agent&.id), class: "btn btn-outline-primary"
             - if @rdv.individuel?
               = link_to t(".duplicate"), admin_organisation_agent_searches_path(current_organisation, service_id: @rdv.motif.service_id, motif_id: @rdv.motif_id, from_date: @rdv.starts_at + 1.day, user_ids: @rdv.user_ids, context: @rdv.context, lieu_ids: [@rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary"

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -64,9 +64,8 @@ describe Admin::RdvsController, type: :controller do
       end
 
       context "when the current agent isn't admin" do
-        it "redirects to show with an error message" do
-          expect(flash[:error]).to match(/Ce rendez-vous ne peut pas être modifié/)
-          expect(response).to redirect_to(admin_organisation_rdv_path(rdv.organisation, rdv))
+        it "redirects" do
+          expect(response).to redirect_to(root_path)
         end
       end
     end
@@ -105,10 +104,9 @@ describe Admin::RdvsController, type: :controller do
         end
 
         context "when the current agent isn't admin" do
-          it "redirects to show with an error message" do
-            update_request
-            expect(flash[:error]).to match(/Ce rendez-vous ne peut pas être modifié/)
-            expect(response).to redirect_to(admin_organisation_rdv_path(rdv.organisation, rdv))
+          it "doesn't update and redirects" do
+            expect { update_request }.not_to change { rdv.reload.lieu }
+            expect(response).to redirect_to(root_path)
           end
         end
       end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -2,17 +2,37 @@
 
 describe Rdv, type: :model do
   describe "#updatable?" do
-    context "when the rdv starts more than two days ago" do
-      it "returns false" do
-        rdv = build :rdv, starts_at: 49.hours.ago
-        expect(rdv.updatable?).to eq false
+    let(:organisation) { create(:organisation) }
+
+    context "when the rdv starts less than two days ago" do
+      let(:rdv) { build :rdv, starts_at: 47.hours.ago }
+
+      context "when the agent role is admin" do
+        let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+        it { expect(rdv.updatable?(agent, organisation)).to eq true }
+      end
+
+      context "when the agent role is not admin" do
+        let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+        it { expect(rdv.updatable?(agent, organisation)).to eq true }
       end
     end
 
-    context "when the rdv starts less than two days ago" do
-      it "returns true" do
-        rdv = build :rdv, starts_at: 47.hours.ago
-        expect(rdv.updatable?).to eq true
+    context "when the rdv starts more than two days ago" do
+      let(:rdv) { build :rdv, starts_at: 49.hours.ago }
+
+      context "when the agent role is admin" do
+        let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+        it { expect(rdv.updatable?(agent, organisation)).to eq true }
+      end
+
+      context "when the agent role is not admin" do
+        let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+        it { expect(rdv.updatable?(agent, organisation)).to eq false }
       end
     end
   end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -1,39 +1,17 @@
 # frozen_string_literal: true
 
 describe Rdv, type: :model do
-  describe "#updatable?" do
-    let(:organisation) { create(:organisation) }
-
+  describe "#starts_long_ago?" do
     context "when the rdv starts less than two days ago" do
       let(:rdv) { build :rdv, starts_at: 47.hours.ago }
 
-      context "when the agent role is admin" do
-        let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-
-        it { expect(rdv.updatable?(agent, organisation)).to eq true }
-      end
-
-      context "when the agent role is not admin" do
-        let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-
-        it { expect(rdv.updatable?(agent, organisation)).to eq true }
-      end
+      it { expect(rdv.starts_long_ago?).to eq false }
     end
 
     context "when the rdv starts more than two days ago" do
       let(:rdv) { build :rdv, starts_at: 49.hours.ago }
 
-      context "when the agent role is admin" do
-        let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-
-        it { expect(rdv.updatable?(agent, organisation)).to eq true }
-      end
-
-      context "when the agent role is not admin" do
-        let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-
-        it { expect(rdv.updatable?(agent, organisation)).to eq false }
-      end
+      it { expect(rdv.starts_long_ago?).to eq true }
     end
   end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
 describe Rdv, type: :model do
+  describe "#updatable?" do
+    context "when the rdv starts more than two days ago" do
+      it "returns false" do
+        rdv = build :rdv, starts_at: 49.hours.ago
+        expect(rdv.updatable?).to eq false
+      end
+    end
+
+    context "when the rdv starts less than two days ago" do
+      it "returns true" do
+        rdv = build :rdv, starts_at: 47.hours.ago
+        expect(rdv.updatable?).to eq true
+      end
+    end
+  end
+
   describe "#starts_at_is_plausible" do
     let(:now) { Time.zone.parse("2021-05-03 14h00") }
     let(:rdv) { build :rdv, starts_at: starts_at }

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -42,6 +42,23 @@ describe Agent::RdvPolicy, type: :policy do
     it_behaves_like "permit actions", :show?, :edit?, :update?
     it_behaves_like "not permit actions", :destroy?
     it_behaves_like "included in scope"
+
+    context "when the rdv starts long ago" do
+      before do
+        rdv.starts_at = 49.hours.ago
+        rdv.save(validation: false)
+      end
+
+      context "when the agent is admin of the organisation" do
+        let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+
+        it_behaves_like "permit actions", :update?
+      end
+
+      context "when the agent is not admin of the organisation" do
+        it_behaves_like "not permit actions", :update?
+      end
+    end
   end
 
   context "existing RDV from other agent from other service" do


### PR DESCRIPTION
Closes #2437

On rend le RDV non modifiable s'il a plus de 48h, sauf si l'agent·e est admin.

# Avant

![image](https://user-images.githubusercontent.com/1193334/190092374-ccae4ebe-9d34-43ee-853a-290556a67207.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/190092509-da18cdc0-0cc8-4e77-b4cb-7a61171a7160.png)

Si l'agent·e parvient tout de même sur l'édition, par exemple grâce à un vieux lieu lien, iel est redirigé·e : 

![image](https://user-images.githubusercontent.com/1193334/190093091-d496c60f-4fae-4642-aa34-e3a6be54ad24.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
