### PR TITLE
Envoi des emails d'invitations des cnfs à leurs adresses pro non-cnfs

### DIFF
--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -4,7 +4,7 @@ class AddConseillerNumerique
   class ConseillerNumerique
     include ActiveModel::Model
 
-    attr_accessor :email, :first_name, :last_name, :external_id
+    attr_accessor :email, :first_name, :last_name, :external_id, :alternate_email
   end
 
   class Structure
@@ -41,13 +41,19 @@ class AddConseillerNumerique
     agent = Agent.where(deleted_at: nil).find_by(external_id: @conseiller_numerique.external_id)
 
     agent || Agent.invite!(
-      email: @conseiller_numerique.email,
-      first_name: @conseiller_numerique.first_name.capitalize,
-      last_name: @conseiller_numerique.last_name,
-      external_id: @conseiller_numerique.external_id,
-      service: service,
-      password: SecureRandom.hex,
-      roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }]
+      {
+        email: @conseiller_numerique.email,
+        first_name: @conseiller_numerique.first_name.capitalize,
+        last_name: @conseiller_numerique.last_name,
+        external_id: @conseiller_numerique.external_id,
+        service: service,
+        password: SecureRandom.hex,
+        roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }],
+      },
+      nil,
+      {
+        cc: @conseiller_numerique.alternate_email,
+      }
     )
   end
 

--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -6,13 +6,9 @@
   <%= t("devise.mailer.invitation_instructions_cnfs.create_account", domain_name: domain.name) %>
 </p>
 
-<div class="btn-wrapper">
-  <%= link_to("Activer mon compte", accept_invitation_url(@resource, invitation_token: @token, user: @user_params),  class: "btn btn-primary") %>
-</div>
-
-<h1><%= t("devise.mailer.invitation_instructions_cnfs.title1") %></h1>
-
-<p><%= t("devise.mailer.invitation_instructions_cnfs.paragraph1", domain_name: domain.name) %></p>
+<p>
+  <%= t("devise.mailer.invitation_instructions_cnfs.usage_info", domain_name: domain.name) %>
+</p>
 
 <%= t("devise.mailer.invitation_instructions_cnfs.use1") %>
 <br>
@@ -20,17 +16,27 @@
 <br>
 <%= t("devise.mailer.invitation_instructions_cnfs.use3") %>
 <br>
+<%= t("devise.mailer.invitation_instructions_cnfs.use4") %>
 
 <br>
 
-<h1><%= t("devise.mailer.invitation_instructions_cnfs.title2") %></h1>
+<div class="btn-wrapper">
+  <%= link_to("Activer mon compte", accept_invitation_url(@resource, invitation_token: @token, user: @user_params),  class: "btn btn-primary") %>
+</div>
+
+<p><%= t("devise.mailer.invitation_instructions_cnfs.account_info", email: @resource.email) %></p>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.account_info2") %></p>
+
+<br>
+<h1><%= t("devise.mailer.invitation_instructions_cnfs.title1") %></h1>
 
 
-<p><%= t("devise.mailer.invitation_instructions_cnfs.paragraph2", video_link: link_to("ici", "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV")).html_safe %></p>
+<p><%= t("devise.mailer.invitation_instructions_cnfs.paragraph1", video_link: link_to("ici", "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV")).html_safe %></p>
+
 <p><%= t("devise.mailer.invitation_instructions_cnfs.first_steps_info") %></p>
 
 <br>
-<h1><%= t("devise.mailer.invitation_instructions_cnfs.title3") %></h1>
+<h1><%= t("devise.mailer.invitation_instructions_cnfs.title2") %></h1>
 
 <p>
   <%= t("devise.mailer.invitation_instructions_cnfs.help_info",

--- a/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
@@ -4,27 +4,30 @@
 <%= t("devise.mailer.invitation_instructions_cnfs.create_account", domain_name: domain.name) %>
 
 
+<%= t("devise.mailer.invitation_instructions_cnfs.usage_info", domain_name: domain.name) %>
+<%= t("devise.mailer.invitation_instructions_cnfs.use1") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.use2") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.use3") %>
+<%= t("devise.mailer.invitation_instructions_cnfs.use4") %>
+
+
 Activer mon compte: <%= accept_invitation_url(@resource, invitation_token: @token, user: @user_params) %>
+
+
+<%= t("devise.mailer.invitation_instructions_cnfs.account_info", email: @resource.email) %>
+<%= t("devise.mailer.invitation_instructions_cnfs.account_info2") %>
+
+
 
 <%= t("devise.mailer.invitation_instructions_cnfs.title1") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.paragraph1", domain_name: domain.name) %>
+<%= t("devise.mailer.invitation_instructions_cnfs.paragraph1", video_link: "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV") %>
 
-<%= t("devise.mailer.invitation_instructions_cnfs.use1") %>
-
-<%= t("devise.mailer.invitation_instructions_cnfs.use2") %>
-
-<%= t("devise.mailer.invitation_instructions_cnfs.use3") %>
-
-
-<%= t("devise.mailer.invitation_instructions_cnfs.title2") %>
-
-<%= t("devise.mailer.invitation_instructions_cnfs.paragraph2", video_link: "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV") %>
 <%= t("devise.mailer.invitation_instructions_cnfs.first_steps_info") %>
 
 
-<%= t("devise.mailer.invitation_instructions_cnfs.title3") %>
 
+<%= t("devise.mailer.invitation_instructions_cnfs.title2") %>
 
 <%= t("devise.mailer.invitation_instructions_cnfs.help_info",
       mattermost: "RDV Aide Numérique: https://discussion.conseiller-numerique.gouv.fr/cnum/channels/rdv-aide-numerique",

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -44,16 +44,18 @@ fr:
       invitation_instructions_cnfs:
         subject: "Vous avez été invité sur %{domain_name}"
         hello: "Hello 👋"
-        create_account: "Vos missions de Conseiller•ère Numérique vous donnent accès à %{domain_name}, un outil fourni par l'ANCT."
-        title1: A quoi ça sert ?
-        paragraph1: "%{domain_name} est un outil de gestion des RDV qui vous permet de :"
-        use1: "✅ gérer vos RDV individuels et collectifs"
-        use2: "✅ envoyer des rappels SMS et mail aux usagers."
-        use3: "✅ partager vos créneaux disponibles à une personne tiers."
-        title2: Comment ça marche ?
-        paragraph2: Pour mieux comprendre, nous vous proposons de regarder la vidéo de présentation de l’outil %{video_link}.
+        create_account: "Dans le cadre de vos mission de Conseiller-ère Numérique, l'ANCT vous fournit un accès à %{domain_name}."
+        usage_info: "%{domain_name} est un outil de gestion de rendez-vous qui vous permet de :"
+        use1: "✅ Gérer vos rendez-vous individuels et collectifs"
+        use2: "✅ Envoyer des rappels SMS et mail aux usagers"
+        use3: "✅ Partager vos créneaux disponibles avec vos collègues ou votre secrétariat"
+        use4: "✅ Importer vos rendez-vous dans vos agendas externes (Outlook, Google Agenda, etc...) "
+        title1: Comment ça marche ?
+        paragraph1: Pour mieux comprendre, nous vous proposons de regarder la vidéo de présentation de l’outil %{video_link}.
+        account_info: "💡 La connexion à votre compte se fait via votre adresse %{email}."
+        account_info2: "Une fois le compte activé, vous pouvez changer cette adresse dans vos paramètres."
         first_steps_info: Vous trouverez  également un guide “premiers pas” dans l’interface de l’outil.
-        title3: Besoin d’aide ?
+        title2: Besoin d’aide ?
         help_info: "Vous pouvez  nous contacter sur le Mattermost dans le canal : %{mattermost}  ou bien par mail à %{support_email}"
         sign_off: En vous souhaitant un bon embarquement !
         signature: L'équipe %{domain_name}

--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -15,6 +15,7 @@ conseillers_numeriques.each do |conseiller_numerique|
   agent = AddConseillerNumerique.process!({
     external_id: external_id,
     email: conseiller_numerique["Email @conseiller-numerique.fr"],
+    alternate_email: conseiller_numerique["Email"],
     first_name: conseiller_numerique["Prénom"],
     last_name: conseiller_numerique["Nom"],
     structure: {

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -14,6 +14,7 @@ describe AddConseillerNumerique do
     {
       external_id: "exemple@conseiller-numerique.fr",
       email: "exemple@conseiller-numerique.fr",
+      alternate_email: "exemple@ccas-paris.fr",
       first_name: "Camille",
       last_name: "Clavier",
       structure: {
@@ -25,7 +26,7 @@ describe AddConseillerNumerique do
   end
 
   context "when the conseiller numerique and their structure have never been imported before" do
-    it "creates the agent for the conseiller numerique" do
+    it "creates the agent for the conseiller numerique and notifies them on both email addresses" do
       described_class.process!(params)
       expect(Agent.count).to eq 1
       expect(Agent.last).to have_attributes(
@@ -43,6 +44,12 @@ describe AddConseillerNumerique do
       expect(Agent.last.roles.last).to have_attributes(
         level: "admin",
         organisation_id: Organisation.last.id
+      )
+      invitation_email = ActionMailer::Base.deliveries.last
+
+      expect(invitation_email).to have_attributes(
+        to: ["exemple@conseiller-numerique.fr"],
+        cc: ["exemple@ccas-paris.fr"]
       )
     end
   end


### PR DESCRIPTION
L'export qu'on obtient depuis l'espace coop fournit une adresse email pour chaque conseiller numérique différente de leur adresse mail "officielle" qui se termine par `conseiller-numerique.fr`.
L'équipe betagouv cnfs nous a confirmé qu'ils utilisaient cette adresse mail pour la communication auprès des cnfs, puisque la plupart d'entre eux n'utilisent pas beaucoup leur adresse officielle. C'est souvent leur adresse mail pro dont il se servent au sein de leur structure.

Pour gagner en visibilité, on va donc envoyer les mails d'invitation à cette adresse pro en plus de l'adresse officielle. On espère que ça augmentera la proportion de cnfs qui se mettront à se servir de RDV Aide Numérique (le nom sous lequel ils connaissent RDV Solidarités).
L'objectif final est de maximiser le nombre de cnfs qui sont actifs et qui proposent des réservations en ligne, afin de faciliter le lancement de la carte des cnfs.

Au passage, on met un peu à jour le texte du mail, principalement pour leur indiquer quelle adresse mail utiliser pour se connecter.


Avant : 

![Capture d’écran 2022-09-14 à 17 08 26](https://user-images.githubusercontent.com/1840367/190192991-89eb36fc-916f-42cb-944e-3aba4dc6e1c1.png)

Après :

![Capture d’écran 2022-09-14 à 17 08 12](https://user-images.githubusercontent.com/1840367/190192997-0ca9f6a2-858b-4532-bb39-0aca13c91985.png)



# Checklist

Revue :
- [x] Relecture du code
- [ ] Test sur la review app / en local
