### PR TITLE
Add group type to motifs select in RDV creation

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -7,6 +7,10 @@ module MotifsHelper
     "#{motif.name} (#{motif.human_attribute_value(:location_type)})"
   end
 
+  def motif_name_with_location_and_group_type(motif)
+    "#{motif.name} (#{motif.human_attribute_value(:location_type)} - #{human_group_type_value(motif)})"
+  end
+
   def motif_name_and_service(motif)
     "#{motif.name} - #{motif.service.name}"
   end
@@ -77,5 +81,9 @@ module MotifsHelper
     value += tag.div(hint, class: "text-muted") if arg_value.present? && hint.present?
     tag.div(tag.div(legend, class: "col-md-4 text-right") +
         tag.div(value, class: "col-md-8 text-bold"), class: "row")
+  end
+
+  def human_group_type_value(motif)
+    t("activerecord.attributes.motif/collectifs.#{motif.collectif?}")
   end
 end

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -24,7 +24,7 @@
       collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
       as: :grouped_select, \
       group_method: :last,
-      label_method: -> { motif_name_with_location_type(_1) }, \
+      label_method: -> { motif_name_with_location_and_group_type(_1) }, \
       input_html: { \
         data: { placeholder: "Sélectionnez un motif" },
         class: "js-filtered-motifs", \

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -8,7 +8,7 @@ describe "Agent can create a Rdv with wizard" do
   let(:service) { create(:service) }
   let!(:agent) { create(:agent, first_name: "Alain", last_name: "DIALO", service: service, basic_role_in_organisations: [organisation]) }
   let!(:agent2) { create(:agent, first_name: "Robert", last_name: "Martin", service: service, basic_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, service: service, organisation: organisation) }
+  let!(:motif) { create(:motif, :collectif, :at_public_office, service: service, organisation: organisation, name: "Super Motif") }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:disabled_lieu) { create(:lieu, organisation: organisation, enabled: false) }
   let!(:user) { create(:user, organisations: [organisation]) }
@@ -23,8 +23,8 @@ describe "Agent can create a Rdv with wizard" do
   def step1
     expect_page_title("Nouveau RDV pour le 02/10/2019 à 00:00")
     expect(page).to have_selector(".card-title", text: "1. Motif")
-
     select(motif.name, from: "rdv_motif_id")
+    expect(page).to have_select("rdv_motif_id", text: "Super Motif (Sur place - RDV collectif)", exact: true)
     click_button("Continuer")
   end
 


### PR DESCRIPTION
Closes #2788

L'idée de @Holist de grouper les motifs collectifs et individuels ensembles me paraissait moins facile à mettre en place car un niveau de groupage par nom de service est déjà mis en place et select2 n'autorise qu'un niveau de groupage par défaut (https://select2.org/options#hierarchical-options)

#### Avant:
![image](https://user-images.githubusercontent.com/8105430/190199115-1228b3c6-ac7c-48dd-a109-fdc8e2a1b0bb.png)

#### Après:
![image](https://user-images.githubusercontent.com/8105430/190199286-120a341d-9898-43d3-9ac7-b27a92e1da0d.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
