### PR TITLE
Suppression de 'Détails Usager' dans la liste des RDV

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -118,13 +118,11 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def parsed_params
-    params.permit(:organisation_id, :agent_id, :user_id, :lieu_id, :motif_id, :status, :show_user_details, :start, :end,
+    params.permit(:organisation_id, :agent_id, :user_id, :lieu_id, :motif_id, :status, :start, :end,
                   lieu_attributes: %i[name address latitude longitude]).to_hash.to_h do |param_name, param_value|
       case param_name
       when "start", "end"
         [param_name, parse_date_from_params(param_value)]
-      when "show_user_details"
-        [param_name, %w[1 true].include?(param_value)]
       else
         [param_name, param_value]
       end

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -3,7 +3,7 @@
 class Admin::RdvSearchForm
   include ActiveModel::Model
 
-  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :show_user_details, :motif_id
+  attr_accessor :organisation_id, :start, :end, :agent_id, :user_id, :lieu_id, :status, :motif_id
 
   def organisation
     @organisation ||= Organisation.find(organisation_id) if organisation_id.present?
@@ -22,7 +22,7 @@ class Admin::RdvSearchForm
   end
 
   def to_query
-    %i[organisation_id start end agent_id user_id status show_user_details lieu_id motif_id]
+    %i[organisation_id start end agent_id user_id status lieu_id motif_id]
       .map { [_1, send(_1)] }.to_h
   end
 end

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -33,7 +33,7 @@
            = f.submit Agent.human_attribute_value(:display_saturdays, !current_agent.display_saturdays), class: "fc-button fc-button-primary", style: "text-transform: none;"
 
     .mt-2
-      = link_to admin_organisation_rdvs_path(current_organisation, agent_id: @agent.id, start: @date, end: @date, show_user_details: true, breadcrumb_page: "agenda"), class: "js-link-print-rdvs" do
+      = link_to admin_organisation_rdvs_path(current_organisation, agent_id: @agent.id, start: @date, end: @date, breadcrumb_page: "agenda"), class: "js-link-print-rdvs" do
         - if current_agent == @agent
           ' 🖨 Liste détaillée des RDVs du
           span.js-date

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -8,32 +8,4 @@
 
   .card-body
     p.card-text
-    - if local_assigns[:show_user_details]
-      .row
-        .col-md-6.mb-2
-          = render "admin/rdvs/rdv_details", rdv: rdv, show_users: false
-        .col-md-6
-          .card-text
-            strong> #{User.model_name.human(count: rdv.users.count)} :
-            .pl-2.pt-1
-              - rdv.users.order_by_last_name.each do |user|
-                div
-                  b= user_to_link(user)
-                - if user.responsible.present?
-                  div= "proche de #{user_to_link(user.responsible)}".html_safe
-                div
-                  ul.list-unstyled
-                    - user_profile = user.profile_for(current_organisation)
-                    li= object_attribute_tag(user, :birth_date, birth_date_and_age(user))
-                    li= object_attribute_tag(user, :phone_number, clickable_user_phone_number(user))
-                    li= object_attribute_tag(user, :address)
-                    li= object_attribute_tag(user, :email, clickable_user_email(user))
-                    - if current_territory.enable_notes_field && user_profile
-                      li= object_attribute_tag(user_profile, :notes, formatted_user_notes(user_profile))
-                    - if current_territory.enable_logement_field && user_profile
-                      li= object_attribute_tag(user_profile, :logement)
-                    - Territory::SOCIAL_FIELD_TOGGLES.each do |toggle, field_name|
-                      - if current_territory.attributes.with_indifferent_access[toggle]
-                        li= object_attribute_tag(user, field_name)
-    - else
-      = render "admin/rdvs/rdv_details", rdv: rdv
+    = render "admin/rdvs/rdv_details", rdv: rdv

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -36,7 +36,6 @@
               wrapper: "horizontal_form"
 
       = f.input :lieu_id, collection: policy_scope(Lieu).enabled.order(:name), label: "Lieu", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
-      = f.input :show_user_details, as: :boolean, wrapper: "horizontal_form", label: "Détails usagers"
     .col-md-6
       = f.input :motif_id, collection: policy_scope(Motif), label: "Motifs", label_method: :name, input_html: { class: "select2-input" }, wrapper: "horizontal_form"
       - temporal_statuses = Rdv.statuses.keys - ["unknown"] + ["unknown_past", "unknown_future"]

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -44,13 +44,12 @@
         input.btn.btn-small.btn-link.d-print-none type="submit" value="Imprimer 🖨" onclick="window.print();return false;"
 
 .row.justify-content-center.pb-3
-  div class=(@form.show_user_details ? "col-md-12" : "col-md-6")
+  .col-md-6
     - if @rdvs.any?
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
       = render(partial: "admin/rdvs/rdv",
               collection: @rdvs.includes(:organisation, :lieu, :motif, agents: :service, users: %i[responsible organisations]),
-              locals: {show_user_details: @form.show_user_details},
-              cached: ->(rdv) { [rdv, @form.show_user_details, locale_cache_key] })
+              cached: ->(rdv) { [rdv, locale_cache_key] })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
     - else
       .card

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -33,7 +33,6 @@
     - if @rdvs.any?
       = render(partial: "admin/rdvs_collectifs/rdv",
               collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service),
-              locals: {show_user_details: false},
               cached: ->(rdv) { [rdv, false, locale_cache_key] })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
     - else

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -24,7 +24,6 @@ describe Admin::RdvSearchForm do
         organisation_id: organisation.id,
         lieu_id: lieu.id,
         motif_id: motif.id,
-        show_user_details: nil,
         status: nil,
         user_id: nil,
       }


### PR DESCRIPTION
Closes #2707 

Suppression de "Détails Usager". 
Cela poserai problème en terme d'UX pour les rdv collectifs et cette feature n'est presque pas utilisée.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
