### PR TITLE
Ne pas fuiter les variables d'ENV dans les review apps

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -33,7 +33,7 @@ class Domain
   def dns_domain_name
     case Rails.env.to_sym
     when :production
-      if ENV["RDV_SOLIDARITES_IS_REVIEW_APP"] == "true"
+      if ENV["IS_REVIEW_APP"] == "true"
         # Les review apps utilisent un domaine de Scalingo, elles
         # ne permettent donc pas d'utiliser plusieurs domaines.
         URI.parse(ENV["HOST"]).host
@@ -72,7 +72,7 @@ class Domain
   def self.find_matching(domain_name)
     # Les review apps utilisent un domaine de Scalingo, elles
     # ne permettent donc pas d'utiliser plusieurs domaines.
-    return RDV_SOLIDARITES if ENV["RDV_SOLIDARITES_IS_REVIEW_APP"] == "true"
+    return RDV_SOLIDARITES if ENV["IS_REVIEW_APP"] == "true"
 
     ALL_BY_URL.fetch(domain_name) { RDV_SOLIDARITES }
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,17 +71,23 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+
   config.action_mailer.default_url_options = { protocol: "https", host: ENV["HOST"].sub(%r{^https?://}, ""), utm_source: "rdv-solidarites", utm_medium: "email", utm_campaign: "auto" }
-  config.action_mailer.smtp_settings = {
-    address: "smtp-relay.sendinblue.com",
-    port: "587",
-    authentication: :plain,
-    user_name: ENV["SENDINBLUE_USERNAME"],
-    password: ENV["SENDINBLUE_PASSWORD"],
-    domain: "rdv-solidarites.fr",
-  }
-  config.action_mailer.delivery_method = :smtp
   config.action_mailer.asset_host = ENV["HOST"]
+
+  if ENV["DISABLE_SENDING_EMAILS"]
+    config.action_mailer.delivery_method = :file
+  else
+    config.action_mailer.smtp_settings = {
+      address: "smtp-relay.sendinblue.com",
+      port: "587",
+      authentication: :plain,
+      user_name: ENV["SENDINBLUE_USERNAME"],
+      password: ENV["SENDINBLUE_PASSWORD"],
+      domain: "rdv-solidarites.fr",
+    }
+    config.action_mailer.delivery_method = :smtp
+  end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/scalingo.json
+++ b/scalingo.json
@@ -15,7 +15,7 @@
       "generator": "template",
       "template": "PR %PR_NUMBER%"
     },
-    "RDV_SOLIDARITES_IS_REVIEW_APP": {
+    "IS_REVIEW_APP": {
       "value": "true"
     },
     "SENTRY_CURRENT_ENV": {

--- a/scalingo.json
+++ b/scalingo.json
@@ -6,8 +6,13 @@
       "description": "HOST",
       "generator": "url"
     },
+
     "ADMIN_BASIC_AUTH_PASSWORD": {
       "description": "Basic auth password for review apps super admin",
+      "generator": "secret"
+    },
+    "SECRET_KEY_BASE": {
+      "description": "See: https://guides.rubyonrails.org/security.html#custom-credentials",
       "generator": "secret"
     },
     "RDV_SOLIDARITES_INSTANCE_NAME": {
@@ -20,6 +25,33 @@
     },
     "SENTRY_CURRENT_ENV": {
       "value": "review_app"
+    },
+
+    "DISABLE_SENDING_EMAILS": {
+      "description": "Delete that variable (and setup Sendinblue password) to enable sending email in a review app",
+      "value": "true"
+    },
+    "SENDINBLUE_PASSWORD": {
+      "description": "Password pour Sendinblue",
+      "value": "change_me_if_needed"
+    },
+
+    "ALTERNATE_SMTP_USERNAME": {
+      "description": "Config SMTP du système SFR with mail2SMS - seulement utilisée par le 92",
+      "value": "change_me_if_needed"
+    },
+    "ALTERNATE_SMTP_PASSWORD": {
+      "description": "Config SMTP du système SFR with mail2SMS - seulement utilisée par le 92",
+      "value": "change_me_if_needed"
+    },
+
+    "DEFAULT_SMS_PROVIDER": {
+      "description": "Système d'envoi des SMS par défaut : cette valeur ne fait que logger l'envoi mais n'envoie rien",
+      "value": "debug_logger"
+    },
+    "DEFAULT_SMS_PROVIDER_KEY": {
+      "description": "Credentials des SMS par défaut : définir cette valeur si l'on veut tester un système d'envoi",
+      "value": "change_me_if_needed"
     }
   },
   "scripts": {


### PR DESCRIPTION
Suite à une alerte sur le fait de ne pas utiliser l'app Scalingo de prod comme app parente des review apps :
https://mattermost.incubateur.net/betagouv/pl/jgxs346bq7gmid5j5c6msimfpw

**Proposition : faire de l'app `demo-rdv-solidarites` la parente de nos review apps.**

:warning:  J'ai aussi pris pour parti pris de désactiver l'envoi de mails et SMS par défaut sur les review apps, mais c'est à discuter.

Cette PR a pour but d'override les variables d'ENV sensibles afin de ne pas les utiliser dans les review apps. En effet, une faille de sécurité présente dans une review app pourrait compromettre les secrets stockés en ENV.

Lecture intéressante : https://doc.scalingo.com/platform/app/review-apps

## Propositions de modifications du code

Pour les variables suivantes, définir une valeur `change_me_if_needed` à la place de la valeur héritée : 
- `SENDINBLUE_PASSWORD`
- `ALTERNATE_SMTP_USERNAME` / `ALTERNATE_SMTP_PASSWORD`
- `DEFAULT_SMS_PROVIDER_KEY`

Pour la variable `DEFAULT_SMS_PROVIDER`, définir `debug_logger` afin de désactiver l'envoi de SMS.

Renommer `RDV_SOLIDARITES_IS_REVIEW_APP` en `REVIEW_APP` car ça semble être le nom [conventionnel](https://doc.scalingo.com/platform/app/review-apps).

Définir une nouvelle variable `DISABLE_SENDING_EMAILS` qui permet simplement de désactiver les envois d'emails, et la mettre à `"true"` dans les review apps.

Faire en sorte que la variable `SECRET_KEY_BASE` soit générée au premier déploiement de la review app, plutôt que de l'hésiter de la démo.

## Propositions de choses à faire en dehors du code

Générer une `SECRET_KEY_BASE` différente en démo qu'en prod ?

Supprimer les clés suivantes, non utilisées : 
- `NETSIZE_API_USERPWD`
- `PLACES_API_KEY`
- `PLACES_APP_ID`
 -`SENDINBLUE_SMS_API_KEY`

Sentry et Skylight : OK d'utiliser les credentials de prod ?