### PR TITLE
Supprime le redémarrage nocture de RDV-Solidarités

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,10 +11,6 @@ SIGN_IN_AS_ALLOWED=true
 FRANCECONNECT_DISABLED=true
 SAFE_DOMAIN_LIST=
 
-# Scalingo auto-restart job
-SCALINGO_RESTARTER_API_TOKEN=
-SCALINGO_RESTARTER_APP_ID=production-rdv-solidarites
-
 # Third-party tools
 ## Monitoring
 SENTRY_DSN_RAILS=

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -99,18 +99,4 @@ class CronJob < ApplicationJob
       end
     end
   end
-
-  class ScalingoAppRestarterJob < CronJob
-    # At 2:00 every day
-    self.cron_expression = "0 2 * * *"
-
-    def perform
-      # Avoid restarting production many times from review apps
-      return if ENV["RDV_SOLIDARITES_IS_REVIEW_APP"] == "true"
-      return if ENV["SCALINGO_RESTARTER_APP_ID"].blank?
-      return if Rails.env.development?
-
-      ScalingoAppRestarter.perform_with(ENV["SCALINGO_RESTARTER_APP_ID"], ENV["SCALINGO_RESTARTER_API_TOKEN"])
-    end
-  end
 end


### PR DESCRIPTION
Nous avons eu, à une époque, des problèmes de fuite mémoire ;
Nous n'avons pas trouvé d'où ça venait ;
Nous avons donc mis en place un redémarrage automatique.

Avoir une variable d'environnement API TOKEN de scalingo dans les variables d'environnement est un peu délicat. Et la solution de redémarrage automatique qui a été mis en place s'appuie là-dessus.

Pour des raisons de sécurité, et parce que nous avons travaillé sur certains sujets de fuite mémoire depuis, cette PR propose de supprimer ce redémarrage automatique.

Si jamais nous avons besoin de le remettre, nous pourrons étudier
- la correction des fuites mémoires
- le redémarrage par un autre moyen

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
