### PR TITLE
Preserve plage search when tab changes

### DIFF
--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -13,15 +13,16 @@
     div= link_to t("helpers.reset"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: class_names("btn", "btn-link", "d-none": params[:search].blank?)
     = simple_form_for "", url: admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
       = f.input :search, placeholder: t(".search_placeholder"), label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+      = f.hidden_field :current_tab, value: params[:current_tab]
       = f.button :submit, t("helpers.search")
 
 .card.pb-3
   - if @display_tabs
     ul.nav.nav-tabs.px-2.mt-2
       li.nav-item
-        = active_link_to t(".in_progress"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: "nav-link", active: :exact
+        = active_link_to t(".in_progress"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, search: params[:search]), class: "nav-link", active: params[:current_tab] != "expired"
       li.nav-item
-        = active_link_to t(".past"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, current_tab: "expired"), class: "nav-link", active: :exact
+        = active_link_to t(".past"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, current_tab: "expired", search: params[:search]), class: "nav-link", active: { current_tab: "expired" }
 
   - if @plage_ouvertures.any?
     table.table

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -37,5 +37,14 @@ FactoryBot.define do
     after(:build) do |plage_ouverture|
       plage_ouverture.motifs << create(:motif, organisation: plage_ouverture.organisation) if plage_ouverture.motifs.empty?
     end
+
+    trait :expired do
+      # Used to avoid refresh_expired_cached callback when needed for test
+      # rubocop:disable Rails/SkipsModelValidations
+      after(:create) do |plage_ouverture|
+        plage_ouverture.update_column(:expired_cached, true)
+      end
+      # rubocop:enable Rails/SkipsModelValidations
+    end
   end
 end

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -1,23 +1,60 @@
 # frozen_string_literal: true
 
 describe "Agent can search plage ouverture" do
-  specify do
-    organisation = create(:organisation)
-    agent = create(:agent, organisations: [organisation])
+  let(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:perm_enfance) { create(:plage_ouverture, title: "Permanence Enfance en cours", agent: agent, organisation: organisation) }
+  let!(:perm_scolaire) { create(:plage_ouverture, title: "Permanence Scolaire en cours", agent: agent, organisation: organisation) }
+  let!(:expired_perm_enfance) { create(:plage_ouverture, :expired, title: "Permanence Enfance passée", agent: agent, organisation: organisation) }
+  let!(:expired_perm_scolaire) { create(:plage_ouverture, :expired, title: "Permanence Scolaire passée", agent: agent, organisation: organisation) }
 
-    perm_enfance = create(:plage_ouverture, title: "Permanence Enfance", agent: agent, organisation: organisation)
-    perm_scolaire = create(:plage_ouverture, title: "Permanence Scolaire", agent: agent, organisation: organisation)
-
+  before do
     login_as(agent, scope: :agent)
     visit admin_organisation_agent_plage_ouvertures_path(organisation, agent)
+  end
 
-    expect(page).to have_content(perm_enfance.title)
-    expect(page).to have_content(perm_scolaire.title)
+  it "displays the correct elements before search" do
+    expect(find_link("En cours")[:class]).to include("active")
+    expect(find_link("Passées")[:class]).not_to include("active")
+    expect(page).to have_content(perm_enfance.title).once
+    expect(page).to have_content(perm_scolaire.title).once
+    expect(page).not_to have_content(expired_perm_enfance.title)
+    expect(page).not_to have_content(expired_perm_scolaire.title)
+  end
 
+  it "displays the correct elements after search" do
     fill_in :search, with: "sco"
     click_button "Rechercher"
 
     expect(page).not_to have_content(perm_enfance.title)
-    expect(page).to have_content(perm_scolaire.title)
+    expect(page).to have_content(perm_scolaire.title).once
+    expect(page).not_to have_content(expired_perm_enfance.title)
+    expect(page).not_to have_content(expired_perm_scolaire.title)
+  end
+
+  it "preserve the search after tab changes" do
+    fill_in :search, with: "sco"
+    click_button "Rechercher"
+    click_link("Passées")
+
+    expect(find_link("En cours")[:class]).not_to include("active")
+    expect(find_link("Passées")[:class]).to include("active")
+    expect(page).not_to have_content(perm_enfance.title)
+    expect(page).not_to have_content(perm_scolaire.title)
+    expect(page).not_to have_content(expired_perm_enfance.title)
+    expect(page).to have_content(expired_perm_scolaire.title).once
+  end
+
+  it "preserve the tab after search" do
+    click_link("Passées")
+    fill_in :search, with: "sco"
+    click_button "Rechercher"
+
+    expect(find_link("En cours")[:class]).not_to include("active")
+    expect(find_link("Passées")[:class]).to include("active")
+    expect(page).not_to have_content(perm_enfance.title)
+    expect(page).not_to have_content(perm_scolaire.title)
+    expect(page).not_to have_content(expired_perm_enfance.title)
+    expect(page).to have_content(expired_perm_scolaire.title).once
   end
 end

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -32,7 +32,7 @@ describe "Agent can search plage ouverture" do
     expect(page).not_to have_content(expired_perm_scolaire.title)
   end
 
-  it "preserve the search after tab changes" do
+  it "preserves the search after tab changes" do
     fill_in :search, with: "sco"
     click_button "Rechercher"
     click_link("Passées")

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -45,7 +45,7 @@ describe "Agent can search plage ouverture" do
     expect(page).to have_content(expired_perm_scolaire.title).once
   end
 
-  it "preserve the tab after search" do
+  it "preserves the tab after search" do
     click_link("Passées")
     fill_in :search, with: "sco"
     click_button "Rechercher"


### PR DESCRIPTION
Closes #2725

Avant:
Lorsqu'on lance une recherche, l'onglet sélectionné est oublié

Après:
L'onglet est conservé lorsqu'on fait une recherche. La recherche est préservée au changement d'onglet.
Point d'attention: par défaut la vue n'avance que les plage non expirées. J'ai fait en sorte que l'onglet correspondant soit actif au chargement de la page sans params du coup. Vérifier que ce soit le comportement voulu. J'ai aussi améliorer les tests sur cette partie.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
