### PR TITLE
Ajouts des colonnes du module "trackable" pour cibler les agents inactifs

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -20,7 +20,7 @@ class Agent < ApplicationRecord
     }
   end
 
-  devise :invitable, :database_authenticatable,
+  devise :invitable, :database_authenticatable, :trackable,
          :recoverable, :rememberable, :validatable, :confirmable, :async, validate_on_invite: true
 
   include DeviseTokenAuth::Concerns::ConfirmableSupport

--- a/db/migrate/20220916084456_add_devise_trackable_columns_to_agents.rb
+++ b/db/migrate/20220916084456_add_devise_trackable_columns_to_agents.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDeviseTrackableColumnsToAgents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :agents, :sign_in_count, :integer, default: 0, null: false
+    add_column :agents, :current_sign_in_at, :datetime
+    add_column :agents, :last_sign_in_at, :datetime
+    add_column :agents, :current_sign_in_ip, :string
+    add_column :agents, :last_sign_in_ip, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_14_164205) do
+ActiveRecord::Schema.define(version: 2022_09_16_084456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,6 +226,11 @@ ActiveRecord::Schema.define(version: 2022_09_14_164205) do
     t.enum "absence_notification_level", default: "all", enum_type: "agents_absence_notification_level"
     t.string "external_id", comment: "The agent's unique and immutable id in the system managing them and adding them to our application"
     t.string "calendar_uid", comment: "the uid used for the url of the agent's ics calendar"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index "to_tsvector('simple'::regconfig, COALESCE(search_terms, ''::text))", name: "index_agents_search_terms", using: :gin
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true
@@ -420,8 +425,10 @@ ActiveRecord::Schema.define(version: 2022_09_14_164205) do
     t.string "name"
     t.integer "max_participants_count"
     t.integer "users_count", default: 0
+    t.datetime "deleted_at"
     t.index "tsrange(starts_at, ends_at, '[)'::text)", name: "index_rdvs_on_tsrange_starts_at_ends_at", using: :gist
     t.index ["created_by"], name: "index_rdvs_on_created_by"
+    t.index ["deleted_at"], name: "index_rdvs_on_deleted_at"
     t.index ["ends_at"], name: "index_rdvs_on_ends_at"
     t.index ["lieu_id"], name: "index_rdvs_on_lieu_id"
     t.index ["max_participants_count"], name: "index_rdvs_on_max_participants_count"

--- a/docs/domain_model.svg
+++ b/docs/domain_model.svg
@@ -111,8 +111,8 @@
 <!-- m_Agent&#45;&gt;m_Absence -->
 <g id="edge10" class="edge">
 <title>m_Agent&#45;&gt;m_Absence</title>
-<path fill="none" stroke="black" d="M1182.81,-1176.23C1178.17,-1171.56 1173.33,-1167.14 1168.26,-1163 1115.15,-1119.64 1073.46,-1167.65 1018.26,-1127 994.18,-1109.27 975.61,-1082.6 961.98,-1056.98"/>
-<polygon fill="black" stroke="black" points="964.65,-1055.28 957.73,-1048.71 959.05,-1058.16 964.65,-1055.28"/>
+<path fill="none" stroke="black" d="M1181.28,-1177.05C1176.59,-1172.11 1171.67,-1167.42 1166.52,-1163 1114.45,-1118.39 1071.72,-1167.65 1016.52,-1127 992.44,-1109.27 973.87,-1082.6 960.24,-1056.98"/>
+<polygon fill="black" stroke="black" points="962.91,-1055.28 955.99,-1048.71 957.3,-1058.16 962.91,-1055.28"/>
 </g>
 <!-- m_AgentRole -->
 <g id="node3" class="node">
@@ -126,8 +126,8 @@
 <!-- m_Agent&#45;&gt;m_AgentRole -->
 <g id="edge12" class="edge">
 <title>m_Agent&#45;&gt;m_AgentRole</title>
-<path fill="none" stroke="black" d="M1182.97,-1174.91C1178.29,-1170.67 1173.39,-1166.68 1168.26,-1163 1050.9,-1078.79 966.67,-1205.25 845.26,-1127 803.7,-1100.22 779.49,-1045.62 767.86,-1011.74"/>
-<polygon fill="black" stroke="black" points="770.85,-1010.75 765.04,-1003.19 764.87,-1012.73 770.85,-1010.75"/>
+<path fill="none" stroke="black" d="M1181.45,-1175.64C1176.71,-1171.16 1171.74,-1166.94 1166.52,-1163 1051.19,-1076.03 964.93,-1205.25 843.52,-1127 801.96,-1100.22 777.75,-1045.62 766.12,-1011.74"/>
+<polygon fill="black" stroke="black" points="769.11,-1010.75 763.3,-1003.19 763.13,-1012.73 769.11,-1010.75"/>
 </g>
 <!-- m_AgentTeam -->
 <g id="node4" class="node">
@@ -138,8 +138,8 @@
 <!-- m_Agent&#45;&gt;m_AgentTeam -->
 <g id="edge15" class="edge">
 <title>m_Agent&#45;&gt;m_AgentTeam</title>
-<path fill="none" stroke="black" d="M1183.15,-1169.81C1156.03,-1104.58 1130.04,-1042.09 1116.01,-1008.34"/>
-<polygon fill="black" stroke="black" points="1118.74,-1006.71 1112.37,-999.61 1112.92,-1009.13 1118.74,-1006.71"/>
+<path fill="none" stroke="black" d="M1181.41,-1184.45C1153.81,-1112.88 1127.39,-1044.38 1113.54,-1008.47"/>
+<polygon fill="black" stroke="black" points="1116.31,-1006.92 1110.13,-999.65 1110.43,-1009.18 1116.31,-1006.92"/>
 </g>
 <!-- m_AgentTerritorialAccessRight -->
 <g id="node5" class="node">
@@ -181,8 +181,8 @@
 <!-- m_Agent&#45;&gt;m_AgentsRdv -->
 <g id="edge11" class="edge">
 <title>m_Agent&#45;&gt;m_AgentsRdv</title>
-<path fill="none" stroke="black" d="M1394.26,-980.5C1338.17,-813 1381.27,-238.87 1392,-108.14"/>
-<polygon fill="black" stroke="black" points="1395.17,-108.07 1392.77,-98.84 1388.89,-107.55 1395.17,-108.07"/>
+<path fill="none" stroke="black" d="M1392.52,-980.5C1334.8,-813.35 1379.26,-237.76 1390.23,-107.74"/>
+<polygon fill="black" stroke="black" points="1393.4,-107.74 1391.02,-98.5 1387.12,-107.2 1393.4,-107.74"/>
 </g>
 <!-- m_PlageOuverture -->
 <g id="node14" class="node">
@@ -226,8 +226,8 @@
 <!-- m_Agent&#45;&gt;m_SectorAttribution -->
 <g id="edge14" class="edge">
 <title>m_Agent&#45;&gt;m_SectorAttribution</title>
-<path fill="none" stroke="black" d="M1278.26,-1163.45C1278.26,-1102.97 1278.26,-1045.6 1278.26,-1012.25"/>
-<polygon fill="black" stroke="black" points="1281.41,-1012.09 1278.26,-1003.09 1275.11,-1012.09 1281.41,-1012.09"/>
+<path fill="none" stroke="black" d="M1276.52,-1163.31C1276.52,-1101.92 1276.52,-1045.06 1276.52,-1012.07"/>
+<polygon fill="black" stroke="black" points="1279.67,-1012.01 1276.52,-1003.01 1273.37,-1012.01 1279.67,-1012.01"/>
 </g>
 <!-- m_User -->
 <g id="node24" class="node">
@@ -327,8 +327,8 @@
 <!-- m_Agent&#45;&gt;m_User -->
 <g id="edge3" class="edge">
 <title>m_Agent&#45;&gt;m_User</title>
-<path fill="none" stroke="black" d="M1394.26,-980.5C1373.43,-918.3 1406.12,-886.5 1364.26,-836 1181.73,-615.83 831.65,-537.84 655.33,-511.73"/>
-<polygon fill="black" stroke="black" points="655.65,-508.6 646.29,-510.42 654.75,-514.83 655.65,-508.6"/>
+<path fill="none" stroke="black" d="M1392.52,-980.5C1371.11,-918.5 1404.38,-886.5 1362.52,-836 1179.99,-615.83 829.91,-537.84 653.59,-511.73"/>
+<polygon fill="black" stroke="black" points="653.91,-508.6 644.55,-510.42 653,-514.83 653.91,-508.6"/>
 </g>
 <!-- m_AgentWithTokenAuth -->
 <g id="node7" class="node">
@@ -446,8 +446,8 @@
 <!-- m_Lieu&#45;&gt;m_PlageOuverture -->
 <g id="edge27" class="edge">
 <title>m_Lieu&#45;&gt;m_PlageOuverture</title>
-<path fill="none" stroke="black" d="M349.26,-907.97C349.26,-818.15 349.26,-665.89 349.26,-574.81"/>
-<polygon fill="black" stroke="black" points="352.41,-574.65 349.26,-565.65 346.11,-574.65 352.41,-574.65"/>
+<path fill="none" stroke="black" d="M347.52,-907.97C347.52,-818.15 347.52,-665.89 347.52,-574.81"/>
+<polygon fill="black" stroke="black" points="350.67,-574.65 347.52,-565.65 344.37,-574.65 350.67,-574.65"/>
 </g>
 <!-- m_Rdv -->
 <g id="node15" class="node">
@@ -483,8 +483,8 @@
 <!-- m_Lieu&#45;&gt;m_Rdv -->
 <g id="edge28" class="edge">
 <title>m_Lieu&#45;&gt;m_Rdv</title>
-<path fill="none" stroke="black" d="M311.02,-907.9C294.76,-875.41 276.35,-836.32 262.26,-800 237.01,-734.92 214.49,-659.69 198.28,-600.77"/>
-<polygon fill="black" stroke="black" points="201.25,-599.68 195.84,-591.83 195.18,-601.34 201.25,-599.68"/>
+<path fill="none" stroke="black" d="M309.28,-907.9C293.02,-875.41 274.61,-836.32 260.52,-800 236.16,-737.22 214.34,-664.98 198.28,-607.06"/>
+<polygon fill="black" stroke="black" points="201.28,-606.1 195.85,-598.26 195.21,-607.77 201.28,-606.1"/>
 </g>
 <!-- m_Motif -->
 <g id="node11" class="node">
@@ -536,15 +536,15 @@
 <!-- m_Motif&#45;&gt;m_PlageOuverture -->
 <g id="edge32" class="edge">
 <title>m_Motif&#45;&gt;m_PlageOuverture</title>
-<path fill="none" stroke="black" d="M248.17,-829.34C253.21,-819.55 257.96,-809.72 262.26,-800 294.94,-726.15 319,-636.72 333.44,-574.71"/>
-<polygon fill="black" stroke="black" points="245.26,-828.11 243.88,-837.55 250.84,-831.04 245.26,-828.11"/>
-<polygon fill="black" stroke="black" points="336.55,-575.24 335.5,-565.77 330.41,-573.83 336.55,-575.24"/>
+<path fill="none" stroke="black" d="M246.43,-829.34C251.47,-819.55 256.21,-809.72 260.52,-800 293.19,-726.15 317.26,-636.72 331.7,-574.71"/>
+<polygon fill="black" stroke="black" points="243.52,-828.11 242.14,-837.55 249.1,-831.04 243.52,-828.11"/>
+<polygon fill="black" stroke="black" points="334.81,-575.24 333.76,-565.77 328.67,-573.83 334.81,-575.24"/>
 </g>
 <!-- m_Motif&#45;&gt;m_Rdv -->
 <g id="edge31" class="edge">
 <title>m_Motif&#45;&gt;m_Rdv</title>
-<path fill="none" stroke="black" d="M157.56,-836.18C160.87,-760.31 164.85,-669.14 167.83,-600.82"/>
-<polygon fill="black" stroke="black" points="170.98,-600.89 168.23,-591.76 164.69,-600.62 170.98,-600.89"/>
+<path fill="none" stroke="black" d="M155.82,-836.18C159.02,-762.84 162.85,-675.21 165.79,-607.74"/>
+<polygon fill="black" stroke="black" points="168.96,-607.49 166.2,-598.36 162.66,-607.21 168.96,-607.49"/>
 </g>
 <!-- m_MotifsPlageOuverture -->
 <g id="node12" class="node">
@@ -585,26 +585,26 @@
 <!-- m_Organisation&#45;&gt;m_Absence -->
 <g id="edge21" class="edge">
 <title>m_Organisation&#45;&gt;m_Absence</title>
-<path fill="none" stroke="black" d="M658.36,-1331.44C712.99,-1278.68 788.15,-1201.83 845.26,-1127 862.02,-1105.04 878.24,-1079.64 892.04,-1056.32"/>
-<polygon fill="black" stroke="black" points="894.79,-1057.86 896.63,-1048.5 889.36,-1054.67 894.79,-1057.86"/>
+<path fill="none" stroke="black" d="M652.46,-1358.2C706.9,-1298.28 783.78,-1210.01 843.52,-1127 859.43,-1104.89 875.27,-1079.76 888.98,-1056.74"/>
+<polygon fill="black" stroke="black" points="891.87,-1058.04 893.74,-1048.69 886.45,-1054.83 891.87,-1058.04"/>
 </g>
 <!-- m_Organisation&#45;&gt;m_AgentRole -->
 <g id="edge22" class="edge">
 <title>m_Organisation&#45;&gt;m_AgentRole</title>
-<path fill="none" stroke="black" d="M616.59,-1325.56C655.28,-1232.53 720.37,-1076 747.17,-1011.56"/>
-<polygon fill="black" stroke="black" points="750.15,-1012.61 750.69,-1003.1 744.33,-1010.2 750.15,-1012.61"/>
+<path fill="none" stroke="black" d="M612.51,-1358.44C651.22,-1258.08 719.37,-1081.4 746.2,-1011.83"/>
+<polygon fill="black" stroke="black" points="749.26,-1012.65 749.56,-1003.12 743.38,-1010.39 749.26,-1012.65"/>
 </g>
 <!-- m_Organisation&#45;&gt;m_Lieu -->
 <g id="edge26" class="edge">
 <title>m_Organisation&#45;&gt;m_Lieu</title>
-<path fill="none" stroke="black" d="M544.71,-1325.56C502.88,-1252.16 438.54,-1139.21 395.22,-1063.17"/>
-<polygon fill="black" stroke="black" points="397.76,-1061.27 390.57,-1055 392.28,-1064.38 397.76,-1061.27"/>
+<path fill="none" stroke="black" d="M546.18,-1358.44C503.47,-1277.62 434.61,-1147.32 390.22,-1063.31"/>
+<polygon fill="black" stroke="black" points="392.99,-1061.81 386,-1055.33 387.42,-1064.75 392.99,-1061.81"/>
 </g>
 <!-- m_Organisation&#45;&gt;m_Motif -->
 <g id="edge29" class="edge">
 <title>m_Organisation&#45;&gt;m_Motif</title>
-<path fill="none" stroke="black" d="M519.73,-1325.88C471.33,-1275.86 402.42,-1210.17 333.26,-1163 302.71,-1142.17 286.76,-1150.55 258.26,-1127 255.64,-1124.83 253.05,-1122.59 250.49,-1120.28"/>
-<polygon fill="black" stroke="black" points="252.51,-1117.86 243.78,-1114.02 248.21,-1122.47 252.51,-1117.86"/>
+<path fill="none" stroke="black" d="M528.5,-1358.27C480.85,-1299.97 408.12,-1218.95 331.52,-1163 301.66,-1141.19 285.02,-1150.55 256.52,-1127 253.9,-1124.83 251.31,-1122.59 248.75,-1120.28"/>
+<polygon fill="black" stroke="black" points="250.77,-1117.86 242.04,-1114.02 246.47,-1122.47 250.77,-1117.86"/>
 </g>
 <!-- m_Organisation&#45;&gt;m_PlageOuverture -->
 <g id="edge36" class="edge">
@@ -616,14 +616,14 @@
 <!-- m_Organisation&#45;&gt;m_Rdv -->
 <g id="edge33" class="edge">
 <title>m_Organisation&#45;&gt;m_Rdv</title>
-<path fill="none" stroke="black" d="M513.85,-1386.84C391.79,-1362.86 148.22,-1295.35 44.26,-1127 -57.66,-961.95 38.79,-730.41 110.57,-599.67"/>
-<polygon fill="black" stroke="black" points="113.44,-600.99 115.04,-591.59 107.93,-597.94 113.44,-600.99"/>
+<path fill="none" stroke="black" d="M512.29,-1415.22C389.93,-1384.15 145.16,-1302.25 42.52,-1127 -53.73,-962.66 36.13,-737.32 106.13,-606.17"/>
+<polygon fill="black" stroke="black" points="109,-607.48 110.5,-598.06 103.46,-604.49 109,-607.48"/>
 </g>
 <!-- m_Organisation&#45;&gt;m_SectorAttribution -->
 <g id="edge35" class="edge">
 <title>m_Organisation&#45;&gt;m_SectorAttribution</title>
-<path fill="none" stroke="black" d="M658.61,-1346.57C737.55,-1292.44 869.51,-1209.19 995.26,-1163 1078.39,-1132.46 1118.42,-1177.39 1191.26,-1127 1231.76,-1098.98 1256.6,-1045.41 1268.87,-1011.95"/>
-<polygon fill="black" stroke="black" points="1271.97,-1012.62 1272,-1003.09 1266.03,-1010.52 1271.97,-1012.62"/>
+<path fill="none" stroke="black" d="M656.73,-1370.67C734.77,-1308.73 865.25,-1214.36 993.52,-1163 1075.74,-1130.08 1116.68,-1177.39 1189.52,-1127 1230.02,-1098.98 1254.85,-1045.41 1267.13,-1011.95"/>
+<polygon fill="black" stroke="black" points="1270.23,-1012.62 1270.26,-1003.09 1264.29,-1010.52 1270.23,-1012.62"/>
 </g>
 <!-- m_UserProfile -->
 <g id="node25" class="node">
@@ -639,8 +639,8 @@
 <!-- m_Organisation&#45;&gt;m_UserProfile -->
 <g id="edge37" class="edge">
 <title>m_Organisation&#45;&gt;m_UserProfile</title>
-<path fill="none" stroke="black" d="M470.26,-980.5C465.34,-915.18 452.95,-882.33 499.26,-836 556.63,-778.61 625.25,-861.44 678.26,-800 852.44,-598.12 761.86,-233.33 726.96,-117.69"/>
-<polygon fill="black" stroke="black" points="729.9,-116.53 724.25,-108.85 723.87,-118.38 729.9,-116.53"/>
+<path fill="none" stroke="black" d="M468.52,-980.5C464.21,-915.14 451.21,-882.33 497.52,-836 554.89,-778.61 623.51,-861.44 676.52,-800 850.7,-598.12 760.12,-233.33 725.22,-117.69"/>
+<polygon fill="black" stroke="black" points="728.16,-116.53 722.51,-108.85 722.13,-118.38 728.16,-116.53"/>
 </g>
 <!-- m_WebhookEndpoint -->
 <g id="node26" class="node">
@@ -658,14 +658,14 @@
 <!-- m_Organisation&#45;&gt;m_WebhookEndpoint -->
 <g id="edge34" class="edge">
 <title>m_Organisation&#45;&gt;m_WebhookEndpoint</title>
-<path fill="none" stroke="black" d="M586.26,-1325.56C586.26,-1238.59 586.26,-1096.11 586.26,-1025.27"/>
-<polygon fill="black" stroke="black" points="589.41,-1025.17 586.26,-1016.17 583.11,-1025.17 589.41,-1025.17"/>
+<path fill="none" stroke="black" d="M584.52,-1358.44C584.52,-1264.17 584.52,-1102.58 584.52,-1025.65"/>
+<polygon fill="black" stroke="black" points="587.67,-1025.26 584.52,-1016.26 581.37,-1025.26 587.67,-1025.26"/>
 </g>
 <!-- m_Rdv&#45;&gt;m_AgentsRdv -->
 <g id="edge24" class="edge">
 <title>m_Rdv&#45;&gt;m_AgentsRdv</title>
-<path fill="none" stroke="black" d="M173.46,-405.49C179.71,-336.72 200.31,-246.41 262.26,-197 309.18,-159.57 741.54,-166.99 801.26,-161 984.65,-142.6 1198.72,-111.51 1312.82,-94.17"/>
-<polygon fill="black" stroke="black" points="1313.45,-97.26 1321.87,-92.79 1312.5,-91.03 1313.45,-97.26"/>
+<path fill="none" stroke="black" d="M172.38,-398.69C179.35,-330.87 200.59,-244.79 260.52,-197 307.44,-159.57 739.8,-166.99 799.52,-161 982.91,-142.6 1196.98,-111.51 1311.08,-94.17"/>
+<polygon fill="black" stroke="black" points="1311.7,-97.26 1320.13,-92.79 1310.76,-91.03 1311.7,-97.26"/>
 </g>
 <!-- m_Rdv&#45;&gt;m_FileAttente -->
 <g id="edge25" class="edge">
@@ -734,8 +734,8 @@
 <!-- m_Rdv&#45;&gt;m_Receipt -->
 <g id="edge39" class="edge">
 <title>m_Rdv&#45;&gt;m_Receipt</title>
-<path fill="none" stroke="black" d="M175.37,-405.38C182.74,-337.95 203.93,-249.42 262.26,-197 327.16,-138.67 377.16,-199.92 455.26,-161 457.62,-159.82 459.96,-158.56 462.28,-157.23"/>
-<polygon fill="black" stroke="black" points="464.06,-159.84 470.09,-152.45 460.77,-154.47 464.06,-159.84"/>
+<path fill="none" stroke="black" d="M174.36,-398.99C182.36,-332.45 204.01,-247.78 260.52,-197 325.42,-138.67 375.42,-199.92 453.52,-161 455.88,-159.82 458.22,-158.56 460.54,-157.23"/>
+<polygon fill="black" stroke="black" points="462.32,-159.84 468.35,-152.45 459.03,-154.47 462.32,-159.84"/>
 </g>
 <!-- m_Sector -->
 <g id="node18" class="node">
@@ -793,14 +793,14 @@
 <!-- m_Service&#45;&gt;m_Agent -->
 <g id="edge7" class="edge">
 <title>m_Service&#45;&gt;m_Agent</title>
-<path fill="none" stroke="black" d="M1278.26,-1886.75C1278.26,-1840.26 1278.26,-1741.21 1278.26,-1644.57"/>
-<polygon fill="black" stroke="black" points="1281.41,-1644.53 1278.26,-1635.53 1275.11,-1644.53 1281.41,-1644.53"/>
+<path fill="none" stroke="black" d="M1276.52,-1984.37C1276.52,-1933.97 1276.52,-1820.89 1276.52,-1710.17"/>
+<polygon fill="black" stroke="black" points="1279.67,-1709.84 1276.52,-1700.84 1273.37,-1709.84 1279.67,-1709.84"/>
 </g>
 <!-- m_Service&#45;&gt;m_Motif -->
 <g id="edge30" class="edge">
 <title>m_Service&#45;&gt;m_Motif</title>
-<path fill="none" stroke="black" d="M1206.19,-1905.81C1057.51,-1885.5 712.85,-1820.38 499.26,-1636 344.59,-1502.49 247.83,-1282.82 196.69,-1135.46"/>
-<polygon fill="black" stroke="black" points="199.6,-1134.23 193.69,-1126.74 193.64,-1136.28 199.6,-1134.23"/>
+<path fill="none" stroke="black" d="M1204.34,-2000.66C1054.72,-1974.74 707.2,-1896.15 497.52,-1701 331.6,-1546.58 235.65,-1296.25 187.99,-1135.56"/>
+<polygon fill="black" stroke="black" points="190.9,-1134.29 185.33,-1126.54 184.85,-1136.07 190.9,-1134.29"/>
 </g>
 <!-- m_SuperAdmin -->
 <g id="node21" class="node">
@@ -825,8 +825,8 @@
 <!-- m_Team&#45;&gt;m_AgentTeam -->
 <g id="edge23" class="edge">
 <title>m_Team&#45;&gt;m_AgentTeam</title>
-<path fill="none" stroke="black" d="M1083.77,-1371.21C1087.96,-1295.43 1099.69,-1083.19 1103.81,-1008.72"/>
-<polygon fill="black" stroke="black" points="1106.96,-1008.71 1104.32,-999.55 1100.67,-1008.36 1106.96,-1008.71"/>
+<path fill="none" stroke="black" d="M1081.9,-1403.95C1086.01,-1323.86 1098.08,-1088.53 1102.16,-1009.06"/>
+<polygon fill="black" stroke="black" points="1105.32,-1008.9 1102.63,-999.75 1099.03,-1008.57 1105.32,-1008.9"/>
 </g>
 <!-- m_Territory -->
 <g id="node23" class="node">
@@ -917,20 +917,20 @@
 <!-- m_User&#45;&gt;m_Receipt -->
 <g id="edge6" class="edge">
 <title>m_User&#45;&gt;m_Receipt</title>
-<path fill="none" stroke="black" d="M543.93,-197.38C543.76,-185.49 543.59,-174.1 543.44,-163.42"/>
-<polygon fill="black" stroke="black" points="546.59,-163.18 543.31,-154.23 540.29,-163.27 546.59,-163.18"/>
+<path fill="none" stroke="black" d="M542.19,-197.38C542.02,-185.49 541.85,-174.1 541.7,-163.42"/>
+<polygon fill="black" stroke="black" points="544.85,-163.18 541.57,-154.23 538.55,-163.27 544.85,-163.18"/>
 </g>
 <!-- m_User&#45;&gt;m_User -->
 <g id="edge4" class="edge">
 <title>m_User&#45;&gt;m_User</title>
-<path fill="none" stroke="black" d="M646.5,-571.82C663.48,-561.92 675.26,-537.48 675.26,-498.5 675.26,-465.61 666.87,-443.07 654.05,-430.88"/>
-<polygon fill="black" stroke="black" points="655.58,-428.09 646.5,-425.18 651.79,-433.12 655.58,-428.09"/>
+<path fill="none" stroke="black" d="M644.76,-571.82C661.74,-561.92 673.52,-537.48 673.52,-498.5 673.52,-465.61 665.13,-443.07 652.31,-430.88"/>
+<polygon fill="black" stroke="black" points="653.84,-428.09 644.76,-425.18 650.04,-433.12 653.84,-428.09"/>
 </g>
 <!-- m_User&#45;&gt;m_UserProfile -->
 <g id="edge1" class="edge">
 <title>m_User&#45;&gt;m_UserProfile</title>
-<path fill="none" stroke="black" d="M646.37,-253.1C667.85,-199.6 688,-149.4 700.89,-117.29"/>
-<polygon fill="black" stroke="black" points="703.9,-118.25 704.33,-108.73 698.05,-115.91 703.9,-118.25"/>
+<path fill="none" stroke="black" d="M644.63,-253.1C666.11,-199.6 686.26,-149.4 699.15,-117.29"/>
+<polygon fill="black" stroke="black" points="702.16,-118.25 702.59,-108.73 696.31,-115.91 702.16,-118.25"/>
 </g>
 </g>
 </svg>


### PR DESCRIPTION
ref #2678

Dans l'objectif d'afficher l'inactivité d'un agent, utilisation du modude trackable de devise.
Cette PR ajoute le module et les colonnes associées dans la table agents.

L'objectif par la suite : attendre un ou deux mois pour mettre en place le badge en prenant en compte les valeurs nulles de la colonne "last_sign_in_at"


# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
