### PR TITLE
Rend la branche recette compatible avec la prod

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -70,4 +70,4 @@ POSTGRES_PASSWORD=
 DOMAIN_NAME=
 
 #Log level (info, warn, debug)
-LOG_LEVEL=
+LOG_LEVEL=info

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.log_level = ENV["LOG_LEVEL"]
+  config.log_level = ENV["LOG_LEVEL"].presence || :info
   # config.log_level = :debug # debug logs all the SQL queries made by ActiveRecord
 
   # allows to see debug logs when running with foreman / overmind

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = ENV["LOG_LEVEL"]
+  config.log_level = ENV["LOG_LEVEL"].presence || :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,12 +254,9 @@ Rails.application.routes.draw do
   end
 
   ##
+  get "accueil_mds" => "static_pages#rdv_solidarites_presentation_for_agents"
+
   get '.well-known/acme-challenge/:challenge' => 'acme_plugin/application#index'
-  get "accueil_mds" => "welcome#welcome_agent"
-  post "/" => "welcome#search"
-  get "departement/:departement", to: "welcome#welcome_departement", as: "welcome_departement"
-  post "departement/:departement" => "welcome#search_departement"
-  get "departement/:departement/:service", to: "welcome#welcome_service", as: "welcome_service"
   resources :lieux, only: %i[index show]
   root "search#search_rdv"
 


### PR DESCRIPTION
Cette PR est pour qu'on puisse merger celle-ci: https://github.com/betagouv/rdv-solidarites.fr/pull/2774/files

En testant en local, j'ai vu que l'appli ne démarrait pas s'il n'y avait pas de variable d'env LOG_LEVEL, donc pour être compatible avec le setup qu'on a actuellement en production et en demo, j'ai ajouté une valeur de fallback, et une valeur recommandée pour le `.env.sample`.

J'ai aussi réparé les routes modifiées. D'après ce que je comprends, on veut ajouter la route `get '.well-known/acme-challenge/:challenge' => 'acme_plugin/application#index'`, sans changer les routes métier.