### PR TITLE
Bugfix : 3 copies du fichier ICS dans les mails de notifs

### DIFF
--- a/spec/mailers/concerns/ics_multipart_attached_spec.rb
+++ b/spec/mailers/concerns/ics_multipart_attached_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This specs checks that the ICS attachments are added correctly.
+# It was after a bug was discovered: several copies of the ICS file were present.
+describe IcsMultipartAttached, type: :mailer do
+  let(:agent) { create(:agent, email: "bob@demo.rdv-solidarites.fr") }
+  let(:plage_ouverture) { create :plage_ouverture, agent: agent }
+
+  describe "when creating event" do
+    it "email parts should include application/ics and text/calendar" do
+      mail = Agents::PlageOuvertureMailer.with(plage_ouverture: plage_ouverture).plage_ouverture_created
+
+      expect(mail.attachments.size).to eq(1)
+
+      expected_parts_order = [
+        "text/html; charset=UTF-8",
+        "application/ics",
+        "text/calendar; charset=utf-8; method=PUBLISH",
+      ]
+      expect(mail.all_parts.map(&:content_type)).to eq(expected_parts_order)
+    end
+  end
+
+  describe "when updating event" do
+    it "email parts should include application/ics and text/calendar" do
+      mail = Agents::PlageOuvertureMailer.with(plage_ouverture: plage_ouverture).plage_ouverture_updated
+
+      expect(mail.attachments.size).to eq(1)
+
+      expected_parts_order = [
+        "text/html; charset=UTF-8",
+        "application/ics",
+        "text/calendar; charset=utf-8; method=PUBLISH",
+      ]
+      expect(mail.all_parts.map(&:content_type)).to eq(expected_parts_order)
+    end
+  end
+
+  describe "when deleting event" do
+    it "email parts should include application/ics and text/calendar" do
+      mail = Agents::PlageOuvertureMailer.with(plage_ouverture: plage_ouverture).plage_ouverture_destroyed
+
+      expect(mail.attachments.size).to eq(1)
+
+      expected_parts_order = [
+        "text/html; charset=UTF-8",
+        "application/ics",
+        "text/calendar; charset=utf-8; method=CANCEL",
+      ]
+      expect(mail.all_parts.map(&:content_type)).to eq(expected_parts_order)
+    end
+  end
+end


### PR DESCRIPTION
Peut-être que c'est aussi la cause de #2823 ?

Depuis #2768, nous avons 3 copies de la pièce jointe ICS.

La raison, c'est que la méthode `mail` est appelée ici :

https://github.com/betagouv/rdv-solidarites.fr/blob/02f470b7490cfdad7a58181b15459d173bb6da71/app/mailers/concerns/common_mailer.rb#L24

Et donc la méthode `mail` surchargée dans `IcsMultipartAttached` est bien appelée 3 fois plutôt qu'une.

J'ai tenté un fix à base de `after_action`, mais j'ai eu des complications, donc je suis partie sur une stratégie de détection des attachments déjà en place.

Pour info, j'ai checkout un commit du mois de juillet pour rédiger mon test, qui était au vert, puis j'ai checkout la production actuelle, le test est passé au rouge, puis j'ai appliqué les correctifs.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
