### PR TITLE
Utiliser des fichiers .env distincts en test et en dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # Rails configuration
 HOST=http://localhost:3000
-PORT=3000 # foreman passes its default port (5000) if unspecified
+# foreman passes its default port (5000) if unspecified
+PORT=3000
 CSP_REPORT_URI=change_me
 SECRET_KEY_BASE=
 

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+# Rails configuration
+HOST=www.rdv-solidarites-test.localhost:3000
+SECRET_KEY_BASE=123456

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,0 @@
-# Rails configuration
-HOST=www.rdv-solidarites-test.localhost:3000
-SECRET_KEY_BASE=123456

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-debug.log*
 
 .DS_Store
 .env
+.env.development
 .ruby-gemset
 lapins.kdbx
 

--- a/bin/setup
+++ b/bin/setup
@@ -25,8 +25,10 @@ FileUtils.chdir APP_ROOT do
   unless File.exist?('config/database.yml')
     FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   end
-  unless File.exist?('.env')
-    FileUtils.cp '.env.sample', '.env'
+
+  # See https://github.com/bkeepers/dotenv/tree/45b712a#what-other-env-files-can-i-use
+  unless File.exist?('.env.development')
+    FileUtils.cp '.env.sample', '.env.development'
   end
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
La semaine dernière j'ai lancé la suite de tests localement et la spec suivante a échoué :  
https://github.com/betagouv/rdv-solidarites.fr/blob/83a8acb07b06b63ebd570dfd0f29b79dae06b618/spec/features/super_admin/migrating_an_agent_spec.rb

Le message d'erreur m'indiquait que la page était indisponible car elle demandait une authentification Basic Auth ! La raison, c'était que dans mon fichier local (gitignoré) `.env`, j'avais défini `ADMIN_BASIC_AUTH_PASSWORD=123456`, et donc le système de protection par Basic Auth était activé.

**J'ai alors lu [la doc de `dotenv`](https://github.com/bkeepers/dotenv/tree/45b712a#what-other-env-files-can-i-use) et j'ai appris que le fichier `.env` était utilisé dans tous les environnements, et donc mon fichier `.env` était utilisé par les tests ! La doc explique aussi que l'on peut définir des fichiers séparés par environnement (`.env.development`, `.env.test`).**

Je propose donc de renommer `.env` en `.env.development`.

On pourrait aussi créer un fichier `.env.test` pour définir l'ENV lors des tests, mais on dirait qu'ils n'ont pas besoin de variables d'ENV pour passer. C'est pas super rassurant vis-à-vis de la fidélité de nos tests par rapport à la prod, mais c'est l'état actuel des choses.

## À faire après cette PR

Toustes les devs devront donc lancer la commande suivante une fois cette PR mergée : 

```
mv .env .env.development
```

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
