### PR TITLE
Ne pas réessayer d'envoyer un SMS quand le numéro est invalide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -178,8 +178,7 @@ Style/FrozenStringLiteralComment:
     - "config.ru"
 
 Style/GuardClause:
-  Exclude:
-    - 'db/migrate/20211215182150_add_service_name_to_active_storage_blobs.active_storage.rb'
+  Enabled: false
 
 Style/IfUnlessModifier:
   Enabled: false


### PR DESCRIPTION
Closes #2748

Le plus simple m'a paru d'introduire une méthode `handle_failure` à qui ont peut commander de retry ou non.

Pour rappel, la liste des erreurs netsize est dispo ici : 
https://linkmobility.it/wp-content/uploads/sites/11/2020/09/Netsize-Implementation-Guide-REST-API-1.pdf

J'ai inclus `117 Invalid campaign name` à la liste des erreurs permanentes, car visiblement [on en a quelques-unes](https://sentry.io/organizations/rdv-solidarites/issues/3527994850/events/1621b9e39b524ffc9604317b84af2f10/?project=1811205&statsPeriod=14d) et j'imagine que le retry ne sert à rien dans ce cas non plus. :thinking: 

Chaud pour discuter de mon approche, je suis pas 100 % convaincu.

## Modification des messages d’exception

J'en ai profité pour faire en sorte qu'on ajoute un message lorsqu'on raise l'exception, afin d'avoir plus de lisibilité dans Sentry, car actuellement c'est vraiment pas pratique :

![image](https://user-images.githubusercontent.com/6357692/191465059-cb312348-1402-4933-81dc-b23c3622cf48.png)

À priori ça créer une issue Sentry séparée par provider, et avec ce changement je ne sais pas si ça va aussi créer une issue Sentry séparée pour chaque type d'erreur, mais si c'est le cas c'est tant mieux pour la lisibilité je pense.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
