### PR TITLE
Corrige le crash `ActionDispatch::Cookies::CookieOverflow`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,6 +80,8 @@ class ApplicationController < ActionController::Base
   end
 
   def storable_location?
+    return false if current_agent || current_user
+
     request.get? && is_navigational_format? && !devise_controller? && !request.xhr? && request.fullpath != root_path
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,11 +8,8 @@ class ApplicationController < ActionController::Base
   before_action :set_sentry_context
 
   def after_sign_in_path_for(resource)
-    if resource.instance_of?(Agent)
-      authenticated_agent_root_path
-    elsif resource.instance_of?(User)
-      stored_location_for(resource) || users_rdvs_path
-    end
+    home_page_when_logged = resource.is_a?(Agent) ? authenticated_agent_root_path : users_rdvs_path
+    stored_location_for(resource) || home_page_when_logged
   end
 
   def after_sign_out_path_for(resource)


### PR DESCRIPTION
Closes #2540

# Description du problème

L'exception `ActionDispatch::Cookies::CookieOverflow` est levée lorsque le cookie que l'on veut écrire lors de la réponse HTTP dépasse 4096 octets ([voir source Rails](https://github.com/rails/rails/blob/977868b3389f1cbf4e7083cff59057a4cb6e9622/actionpack/lib/action_dispatch/middleware/cookies.rb#L635)).

Le problème est donc ici que l'on écrire trop de données dans le cookie. La raison, c'est que l'on stocke la session dans le cookie. C'est le mécanisme de stockage de session par défaut de Rails, et c'est le plus simple et le plus fonctionnel [^1]. 

On peut alors se demander : que stocke-t-on de potentiellement volumineux dans la session, dans le contexte où cette erreur est rencontrée ? On voit qu'elle apparaît principalement dans un contexte de création de RDV [via le wizard](https://user-images.githubusercontent.com/6357692/191769456-608cf91c-bf2b-43a3-b905-3c450d593818.png), dans lequel les URL sont potentiellement assez longues. 

On voit aussi qu'à chaque requête GET, on stocke l'URL courante dans la session ([dans `ApplicationController`](https://github.com/betagouv/rdv-solidarites.fr/blob/9d090df4e21b667acadf461baf766ce5a728a242/app/controllers/application_controller.rb#L7)). On fait cela pour implémenter cette fonctionnalité, qui nous intéresse : [How To: Redirect back to current page after sign in](https://github.com/heartcombo/devise/wiki/How-To:-Redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update). 

# Solution choisie

On voit donc que l'on stocke à chaque requête une URL potentiellement longue dans la session (et donc dans les cookies). Hors, ce n'est pas nécessaire de faire ce stockage lorsque l'agent (ou l'usager) est déjà connecté⋅e !

J'ai donc fait en sorte de ne pas stocker d'URL `if current_agent || current_user`. Ça devrait nous permet de grandement mitiger les erreurs que l'on voit apparaître lors du wizard de RDV.

Avant ce fix, si le champ "Contexte" d'un RDV était très long, on avait cette erreur, mais plus après le fix.

# Solutions alternatives

Il est difficile d'être certain de ce qui prend trop de place dans les cookies. Pour en avoir le cœur net, il faudrait les remonter dans Sentry, en [activant l'option send_default_pii](https://docs.sentry.io/platforms/ruby/configuration/options/), ce qui pose des questions RGPD / HDS.

Tant qu'on est dans le noir quant à la cause précise de l'explosion du cookie, nos options sont :
- limiter ce qu'on stocke dans la session, comme proposé dans cette PR
- ajouter un rescue des `ActionDispatch::Cookies::CookieOverflow` et remonte alors dans Sentry le contenu du cookie : j'étais parti là-dessus, mais ça implique [un middleware Rack](https://privatebin.net/?c768ca4c5c4a504d#BXaYB34FvDBCjxt8YB9grwupELtTTFxW7CdxNtwwJdzB), pas trop élégant
- stocker la session ailleurs : dans Redis ça serait pratique, mais il faudrait alors ajouter Redis en env de test pour être fidèle à la prod. Sinon dans Postgres mais les perfs sont peut-être pas ouf. L'avantage de stocker les sessions ailleurs, c'est la sécurité, j'en parle plus longuement dans #2676.

**Je pense donc qu'il serait avantageux de stocker la session ailleurs que dans le cookie.**

[^1]: https://www.justinweiss.com/articles/how-rails-sessions-work/

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
