### PR TITLE
fix-2826: dédoublonne les agents sur les statistiques

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -38,14 +38,10 @@ class StatsController < ApplicationController
   def scope_rdv_to_territory
     if params[:territory].present?
       @territory = Territory.find(params[:territory])
-      @rdvs = Rdv.joins(organisation: :territory)
-        .where(organisations: { territories: [@territory] })
-      @users = User.joins(organisations: :territory)
-        .where(organisations: { territories: [@territory] })
-      @agents = Agent.joins(organisations: :territory)
-        .where(organisations: { territories: [@territory] })
-      @organisations = Organisation.joins(:territory)
-        .where(territories: { departement_number: [@territory] })
+      @rdvs = @territory.rdvs
+      @users = @territory.users
+      @agents = @territory.organisations_agents
+      @organisations = @territory.organisations
       @receipts = @territory.receipts
     else
       @rdvs = Rdv.all

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -24,11 +24,13 @@ class Territory < ApplicationRecord
   has_many :agent_territorial_access_rights, dependent: :destroy
 
   # Through relations
-  has_many :organisations_agents, through: :organisations, source: :agents
+  has_many :organisations_agents, -> { distinct }, through: :organisations, source: :agents
   has_many :agents, through: :roles
   has_many :zones, through: :sectors
   has_many :rdvs, through: :organisations
   has_many :receipts, through: :rdvs
+  has_many :user_profiles, through: :organisations
+  has_many :users, -> { distinct }, through: :user_profiles
 
   # Validations
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -25,7 +25,7 @@ class Territory < ApplicationRecord
 
   # Through relations
   has_many :organisations_agents, -> { distinct }, through: :organisations, source: :agents
-  has_many :agents, through: :roles
+  has_many :admin_agents, through: :roles
   has_many :zones, through: :sectors
   has_many :rdvs, through: :organisations
   has_many :receipts, through: :rdvs

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -5,6 +5,17 @@ describe Territory, type: :model do
     expect(build(:territory)).to be_valid
   end
 
+  describe "#organisations_agents request don't include duplicates" do
+    context "when an agent is attached to 2 organisations" do
+      let(:territory) { create(:territory) }
+      let(:organisation1) { create(:organisation, territory: territory) }
+      let(:organisation2) { create(:organisation, territory: territory) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation1, organisation2]) }
+
+      it { expect(territory.organisations_agents.count).to eq(1) }
+    end
+  end
+
   describe "departement_number uniqueness validation" do
     context "no collision" do
       let(:territory) { build(:territory, name: "Oise", departement_number: "60") }


### PR DESCRIPTION
_pour tester https://demo-rdv-solidarites-pr2837.osc-secnum-fr1.scalingo.io/_

Issue #2826 
vue : `/stats?territory=:id`

- fix doublons des agents reliés à un territoire via les organisations
- suppression des requêtes via le controller au profit des relations activerecord via les modèles

**avant**
<img width="661" alt="Capture d’écran 2022-09-22 à 16 19 56" src="https://user-images.githubusercontent.com/11738628/191772557-565a62c3-d063-441a-bc1b-d75af162fea2.png">

**après**
<img width="654" alt="Capture d’écran 2022-09-22 à 16 19 44" src="https://user-images.githubusercontent.com/11738628/191772588-6dbda92a-5bee-44ec-97b4-d1720e587770.png">

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
