### PR TITLE
Envoyer des webhooks pour les motifs

### DIFF
--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -3,5 +3,5 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :reservable_online, :service_id, :category
+  fields :name, :location_type, :deleted_at, :reservable_online, :service_id, :category, :organisation_id
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -4,6 +4,8 @@ class Motif < ApplicationRecord
   # Mixins
   has_paper_trail
 
+  include WebhookDeliverable
+
   include PgSearch::Model
 
   pg_search_scope(:search_by_text,
@@ -41,6 +43,7 @@ class Motif < ApplicationRecord
 
   # Through relations
   has_many :lieux, through: :plage_ouvertures
+  has_many :webhook_endpoints, through: :organisation
 
   # Delegates
   delegate :service_social?, to: :service

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -9,5 +9,5 @@ class WebhookEndpoint < ApplicationRecord
   validates :target_url, presence: true
   validates :secret, presence: true
 
-  ALL_SUBSCRIPTIONS = %w[rdv absence plage_ouverture user user_profile organisation].freeze
+  ALL_SUBSCRIPTIONS = %w[rdv absence plage_ouverture user user_profile organisation motif].freeze
 end

--- a/app/views/admin/territories/webhook_endpoints/_form.html.slim
+++ b/app/views/admin/territories/webhook_endpoints/_form.html.slim
@@ -3,9 +3,9 @@
   = f.input :organisation_id, collection: current_territory.organisations
   = f.input :target_url
   = f.input :secret
-  .form-inline.py-2
+  .row.col-md-6
     = f.input :subscriptions, as: :check_boxes, collection: WebhookEndpoint::ALL_SUBSCRIPTIONS,
-    label_method: -> { _1.classify.constantize.model_name.human }, checked: webhook.subscriptions, include_hidden: false, input_html: { class: "m-2" }
+    label_method: -> { _1.classify.constantize.model_name.human }, checked: webhook.subscriptions, include_hidden: false
 
   .text-right
     = link_to "Retour", admin_territory_webhook_endpoints_path(current_territory), class: "btn btn-link"


### PR DESCRIPTION
Suite à des évolutions sur RDV-Insertion, nous avons besoin de rapatrier les motifs sur notre application.
Du coup j'active ici l'envoi des webhooks lors des ajouts / modifications / destruction de motifs en incluant le module `WebhookDeliverable` au niveau du model. 
Ces webhooks ne seront envoyés que si on coche la case "motifs" sur la page d'édition du webhook dans le module de configuration.
J'ajoute également l'id de l'organisation associée dont nous avons besoin dans le payload envoyé. 

Avant:
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/7602809/191801840-db47fb78-4237-4f0e-9367-0a75474a1404.png">

Après:
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/7602809/191801943-75f3c2db-421d-4c01-89c9-a4137644ac3e.png">

