### PR TITLE
Implémenter landing page CNFS pour la NEC

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -16,6 +16,10 @@ class StaticPagesController < ApplicationController
   end
 
   def rdv_solidarites_presentation_for_agents
-    redirect_to agent_session_path unless current_domain == Domain::RDV_SOLIDARITES
+    redirect_to root_path unless current_domain == Domain::RDV_SOLIDARITES
+  end
+
+  def presentation_for_cnfs
+    redirect_to root_path unless current_domain == Domain::RDV_AIDE_NUMERIQUE
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,11 +15,7 @@ class StaticPagesController < ApplicationController
     Territory.count # check connection to DB is working
   end
 
-  def rdv_solidarites_presentation_for_agents
-    redirect_to root_path unless current_domain == Domain::RDV_SOLIDARITES
-  end
-
-  def presentation_for_cnfs
-    redirect_to root_path unless current_domain == Domain::RDV_AIDE_NUMERIQUE
+  def presentation_for_agents
+    render current_domain.presentation_for_agents_template_name
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -13,6 +13,7 @@
 @import "./components/backgrounds";
 @import "./components/types";
 @import "./components/search_form";
+@import "./components/bubble";
 @import "./components/forms";
 @import "./components/cards";
 @import "./components/utilities";

--- a/app/javascript/stylesheets/components/_bubble.scss
+++ b/app/javascript/stylesheets/components/_bubble.scss
@@ -1,0 +1,10 @@
+.bubble {
+  border-radius: 100%;
+  padding: 0.5em;
+  font-size: 3em;
+  font-weight: bold;
+
+  .small {
+    font-size: 80%  ;
+  }
+}

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -36,6 +36,10 @@ a[disabled] {
   gap: 0 1em;
 }
 
+.flex-v-gap-1em {
+  gap: 1em 0;
+}
+
 ul.horizontal-border-between-items {
   li {
     border-bottom: 1px solid #eee;

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
 class Domain
-  def initialize(logo_path:, public_logo_path:, dark_logo_path:, name:, sms_sender_name:, default: false) # rubocop:disable Metrics/ParameterLists
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(
+    logo_path:,
+    public_logo_path:,
+    dark_logo_path:,
+    name:,
+    presentation_for_agents_template_name:,
+    sms_sender_name:,
+    default: false
+  )
     @logo_path = logo_path
     @public_logo_path = public_logo_path
     @dark_logo_path = dark_logo_path
     @name = name
+    @presentation_for_agents_template_name = presentation_for_agents_template_name
     @sms_sender_name = sms_sender_name
     @default = default
   end
-  attr_reader :logo_path, :public_logo_path, :dark_logo_path, :name, :sms_sender_name, :default
+  # rubocop:enable Metrics/ParameterLists
+
+  attr_reader :logo_path, :public_logo_path, :dark_logo_path, :name, :presentation_for_agents_template_name, :sms_sender_name, :default
 
   ALL = [
     RDV_SOLIDARITES = new(
@@ -18,6 +30,7 @@ class Domain
       public_logo_path: "/logo_solidarites.png",
       dark_logo_path: "logos/logo_sombre_solidarites.svg",
       name: "RDV Solidarités",
+      presentation_for_agents_template_name: "rdv_solidarites_presentation_for_agents",
       sms_sender_name: "RdvSoli"
     ),
 
@@ -26,6 +39,7 @@ class Domain
       public_logo_path: "/logo_aide_numerique.png",
       dark_logo_path: "logos/logo_sombre_aide_numerique.svg",
       name: "RDV Aide Numérique",
+      presentation_for_agents_template_name: "presentation_for_cnfs",
       sms_sender_name: "RdvAideNum"
     ),
   ].freeze

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -86,14 +86,13 @@ class Domain
   def self.find_matching(domain_name)
     # Les review apps utilisent un domaine de Scalingo, elles
     # ne permettent donc pas d'utiliser plusieurs domaines.
-    return default_domain if ENV["IS_REVIEW_APP"] == "true"
+    return review_app_domain if ENV["IS_REVIEW_APP"] == "true"
 
-    ALL_BY_URL.fetch(domain_name) { default_domain }
+    ALL_BY_URL.fetch(domain_name) { RDV_SOLIDARITES }
   end
 
-  def self.default_domain
-    # This is meant to be used in review apps, which can't determine domain from URL
-    if ENV["DEFAULT_DOMAIN"] == "RDV_AIDE_NUMERIQUE"
+  def self.review_app_domain
+    if ENV["REVIEW_APP_DOMAIN"] == "RDV_AIDE_NUMERIQUE"
       RDV_AIDE_NUMERIQUE
     else
       RDV_SOLIDARITES

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -72,9 +72,18 @@ class Domain
   def self.find_matching(domain_name)
     # Les review apps utilisent un domaine de Scalingo, elles
     # ne permettent donc pas d'utiliser plusieurs domaines.
-    return RDV_SOLIDARITES if ENV["IS_REVIEW_APP"] == "true"
+    return default_domain if ENV["IS_REVIEW_APP"] == "true"
 
-    ALL_BY_URL.fetch(domain_name) { RDV_SOLIDARITES }
+    ALL_BY_URL.fetch(domain_name) { default_domain }
+  end
+
+  def self.default_domain
+    # This is meant to be used in review apps, which can't determine domain from URL
+    if ENV["DEFAULT_DOMAIN"] == "RDV_AIDE_NUMERIQUE"
+      RDV_AIDE_NUMERIQUE
+    else
+      RDV_SOLIDARITES
+    end
   end
 
   def to_s

--- a/app/views/common/_header.html.slim
+++ b/app/views/common/_header.html.slim
@@ -13,6 +13,7 @@ nav.navbar.navbar-expand-lg.bg-transparent
 
         - else
           li.list-inline-item
-            = link_to t("links.agent_space"), accueil_mds_path, class: "btn btn-link text-white"
+            - presentation_path = current_domain == Domain::RDV_AIDE_NUMERIQUE ? accueil_cnfs_path : accueil_mds_path
+            = link_to t("links.agent_space"), presentation_path, class: "btn btn-link text-white"
           li.list-inline-item
             = link_to t("links.session"), new_user_session_path, class: "btn btn-outline-white"

--- a/app/views/common/_header.html.slim
+++ b/app/views/common/_header.html.slim
@@ -13,7 +13,6 @@ nav.navbar.navbar-expand-lg.bg-transparent
 
         - else
           li.list-inline-item
-            - presentation_path = current_domain == Domain::RDV_AIDE_NUMERIQUE ? accueil_cnfs_path : accueil_mds_path
-            = link_to t("links.agent_space"), presentation_path, class: "btn btn-link text-white"
+            = link_to t("links.agent_space"), presentation_agent_path, class: "btn btn-link text-white"
           li.list-inline-item
             = link_to t("links.session"), new_user_session_path, class: "btn btn-outline-white"

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -1,6 +1,13 @@
+section.bg-white.p-5
+  .container
+    .row
+      .col-md-12.text-center
+        p.alert-link La prise de rendez-vous en ligne n'est pas encore ouverte au public.
+        p Vous pouvez prendre contact avec un conseiller numérique via la #{link_to("carte des Conseiller Numérique France service", "https://carte.conseiller-numerique.gouv.fr/")}.
+
 section.bg-lightturquoise.p-5
   .container
     .row
       .col-md-12.text-center
-        p La prise de rendez-vous en ligne n'est pas encore ouverte au public.
-        p Vous pouvez prendre contact avec un conseiller numérique via la #{link_to("carte des Conseiller Numérique France service", "https://carte.conseiller-numerique.gouv.fr/")}.
+        h3 Vous êtes conseiller⋅numérique ?
+        = link_to("En savoir plus", accueil_cnfs_path, class: "btn btn-tertiary")

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -10,4 +10,4 @@ section.bg-lightturquoise.p-5
     .row
       .col-md-12.text-center
         h3 Vous êtes conseiller⋅numérique ?
-        = link_to("En savoir plus", accueil_cnfs_path, class: "btn btn-tertiary")
+        = link_to("En savoir plus", presentation_agent_path, class: "btn btn-tertiary")

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -9,5 +9,5 @@ section.bg-lightturquoise.p-5
   .container
     .row
       .col-md-12.text-center
-        h3 Vous êtes conseiller⋅numérique ?
+        h3 Vous êtes conseiller numérique ?
         = link_to("En savoir plus", presentation_agent_path, class: "btn btn-tertiary")

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -1,0 +1,138 @@
+- content_for :header
+  section.pb-0.py-5
+    .container
+      .row
+        .col-md-9.m-auto
+          h1.mb-3.text-white Faciliter la gestion des rendez-vous avec vos apprenants
+          .mt-4= link_to "Connectez-vous", new_agent_session_path, class: "btn btn-outline-white"
+          p.text-white.mt-4
+            | RDV Aide Numérique est un outil de prise de rendez-vous en ligne,
+              simplifiant votre organisation et rappelant aux usagers leurs rendez-vous.
+
+section.bg-white.py-5
+  .container
+    .text-center.m-auto
+      h2.mb-4 RDV Aide Numérique offre des fonctionnalités adaptées à vos besoins&nbsp;:
+    .divider
+    .row
+      .col-md-4
+        .w-50.p-3.m-auto
+          = image_tag "welcome/illu-prise-rdv.svg", alt: ""
+        h3 Définir vos plages de disponibilités
+        p
+          | Informez vos apprenants et vos collègues
+            des créneaux disponibles.
+
+      .col-md-4
+        .w-50.p-3.m-auto
+          = image_tag "welcome/illu-rappel-rdv.svg", alt: ""
+        h3 Envoyer une notification de rappel
+        p
+          | Vos apprenants recevront un SMS et/ou un
+            e-mail de rappel de RDV. Ils pourront
+            également modifier ou annuler le RDV.
+
+      .col-md-4
+        .w-50.p-3.m-auto
+          = image_tag "welcome/illu-gestion.svg", alt: ""
+        h3 Importer vos RDVs sur votre agenda
+        p
+          | Synchroniser RDV Aide Numérique et votre
+            agenda du quotidien.
+
+section.bg-lightturquoise.py-5.row
+  .container.col-6.mx-auto
+    .row
+      h2.mb-3 Qui sommes-nous&nbsp;?
+    .row.m-auto
+      p
+        | Les produits RDV Solidarités et RDV Aide Numérique sont portés par l’une des équipes de
+        =< link_to("l’Incubateur des Territoires qui", "https://incubateur.anct.gouv.fr/", target: "_blank")
+        |  suit une approche
+        =< link_to("beta.gouv.fr", "https://beta.gouv.fr", target: "_blank")
+        | . L’équipe développe une solution numérique de gestion des RDVs qui répond au mieux aux
+          besoins des utilisateurs.
+      p
+        | Initialement déployée auprès des services médico-sociaux, la solution numérique s’est élargie auprès des conseillers
+          numériques France Service. Aujourd’hui, le produit est en phase de généralisation auprès d’autres acteurs publics.
+          Découvrez
+        =< link_to("notre histoire", "https://beta.gouv.fr/startups/lapins.html", target: "_blank")
+        | .
+
+section.bg-white.py-5
+  .container.col-6.mx-auto
+    .row
+      h2.mb-3 Pourquoi choisir RDV Aide Numérique&nbsp;?
+    .row.m-auto
+      h3 ✅ Un outil souple
+      p
+        | Créez les motifs selon vos ateliers, invitez votre hiérarchie à consulter votre
+          planning ou permettez au service d’accueil de poser des RDVs selon vos disponibilités.
+
+      h3 ✅ Un outil libre
+      p
+        | Faites vos retours en direct à l’équipe en charge de RDV Aide Numérique et
+          participez ainsi au développement d’un commun numérique.
+
+      h3 ✅ Un outil souverain et sécurisé
+      p
+        | Soutenez un éco-système public qui développe des solutions
+          numériques souveraines et protégez les données de vos apprenants. Celles-ci sont hébergées en France et
+        =< link_to("certifiées HDS", "https://esante.gouv.fr/labels-certifications/hds/certification-des-hebergeurs-de-donnees-de-sante", target: "_blank")
+        | .
+
+section.bg-lightturquoise.py-5
+  .container
+    .row
+      .text-center.m-auto
+        h2.mb-2 Ça vous intéresse&nbsp;?
+    .row
+      p.m-auto Vous souhaitez intégrer RDV Aide Numérique dans votre quotidien et simplifier le parcours des usagers&nbsp;?
+    .row.mt-4
+      .col-md-9.m-auto
+        .d-flex.justify-content-around.flex-column.flex-md-row.flex-md-nowrap.align-items-center.flex-v-gap-1em
+          = link_to "Connectez-vous", new_agent_session_path, class: "btn btn-tertiary"
+          = link_to "Testez l’outil", new_agent_session_path, class: "btn btn-tertiary"
+          = link_to "Contactez-nous", "mailto:#{SUPPORT_EMAIL}", class: "btn btn-tertiary"
+
+section.bg-white.py-5
+  .container
+    .row
+      .text-center.m-auto
+        h2.mb-2 Aide Numérique en quelques chiffres c’est :
+    .row.mt-4.d-flex.justify-content-around.flex-sm-column.flex-md-row.flex-md-nowrap
+      .d-flex.flex-column.align-items-center.flex-v-gap-1em
+        .bubble.bg-lightturquoise.text-primary
+          | 78
+          span.small %
+        .text-center des conseillers numériques qui utilisent l’outil le recommande
+      .d-flex.flex-column.align-items-center.flex-v-gap-1em
+        .bubble.bg-lightturquoise.text-primary
+          | 27018
+        .text-center RDVs créés par des conseillers numériques
+      .d-flex.flex-column.align-items-center.flex-v-gap-1em
+        .bubble.bg-lightturquoise.text-primary
+          | 47
+          span.small %
+        .text-center de conseillers numériques ont intégrés l’outil dans le quotidien
+
+section.bg-lightturquoise.py-5
+  .container
+    .row
+      h2.mb-2 Les conseillers numériques en parlent
+    .row.mt-3
+      .col-md-9.mx-auto
+        blockquote.blockquote
+          | J'ai réduis de 30% mes lapins grâce à l'outil RDV.S c'est un outil vraiment top !
+          .blockquote-footer Une conseillère numérique France service de la Nièvre
+        blockquote.blockquote
+          | J'ai cherché pendant longtemps un outil qui permettait de prendre des rendez-vous selon
+            des plages horaires définies avec un temps donné. RDV Solidarités, une solution qui m'a
+            permit une meilleure gestion des rendez-vous et de travailler en équipe.
+          .blockquote-footer Un conseiller numérique, Ville du Mans
+        blockquote.blockquote
+          | Les médiateur⋅rices numériques que je connais qui utilisent RDV Aide
+            Numérique et moi-même sommes ravis de cette plateforme.
+          .blockquote-footer Témoignage recueilli via sondage
+      .col-3.text-center.d-none.d-lg-flex
+        = image_tag "static_pages/social.svg", class: "img-fluid p-3", alt: "Une agente travaille sur son ordinateur"

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -96,7 +96,7 @@ section.bg-lightturquoise.py-5
       p.m-auto
         ' Si vous n'avez jamais utilisé votre compte, vous pouvez réinitialiser votre mot de passe en indiquant votre adresse
         em
-          | ___@conseiller-numerique.fr
+          | @conseiller-numerique.fr
         | .
       p.m-auto
         | Des questions ?

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -94,6 +94,11 @@ section.bg-lightturquoise.py-5
           = link_to "Connectez-vous", new_agent_session_path, class: "btn btn-primary"
     .row.mt-4
       p.m-auto
+        ' Si vous n'avez jamais utilisé votre compte, vous pouvez réinitialiser votre mot de passe en indiquant votre adresse
+        em
+          | ___@conseiller-numerique.fr
+        | .
+      p.m-auto
         | Des questions ?
         =< link_to("Contactez-nous", "mailto:#{SUPPORT_EMAIL}", target: "_blank")
         | .

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -90,10 +90,13 @@ section.bg-lightturquoise.py-5
       p.m-auto Vous souhaitez intégrer RDV Aide Numérique dans votre quotidien et simplifier le parcours des usagers&nbsp;?
     .row.mt-4
       .col-md-9.m-auto
-        .d-flex.justify-content-around.flex-column.flex-md-row.flex-md-nowrap.align-items-center.flex-v-gap-1em
-          = link_to "Connectez-vous", new_agent_session_path, class: "btn btn-tertiary"
-          = link_to "Testez l’outil", new_agent_session_path, class: "btn btn-tertiary"
-          = link_to "Contactez-nous", "mailto:#{SUPPORT_EMAIL}", class: "btn btn-tertiary"
+        .d-flex.justify-content-around
+          = link_to "Connectez-vous", new_agent_session_path, class: "btn btn-primary"
+    .row.mt-4
+      p.m-auto
+        | Des questions ?
+        =< link_to("Contactez-nous", "mailto:#{SUPPORT_EMAIL}", target: "_blank")
+        | .
 
 section.bg-white.py-5
   .container

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -263,6 +263,7 @@ Rails.application.routes.draw do
   ##
 
   get "accueil_mds" => "static_pages#rdv_solidarites_presentation_for_agents"
+  get "accueil_cnfs" => "static_pages#presentation_for_cnfs"
 
   resources :lieux, only: %i[index show]
   root "search#search_rdv"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,8 +262,8 @@ Rails.application.routes.draw do
 
   ##
 
-  get "accueil_mds" => "static_pages#rdv_solidarites_presentation_for_agents"
-  get "accueil_cnfs" => "static_pages#presentation_for_cnfs"
+  get "accueil_mds", to: redirect("presentation_agent", status: 307)
+  get "presentation_agent" => "static_pages#presentation_for_agents"
 
   resources :lieux, only: %i[index show]
   root "search#search_rdv"

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -10,7 +10,16 @@ describe "public pages", js: true do
   end
 
   it "accueil_mds_path page is accessible" do
-    expect_page_to_be_axe_clean(accueil_mds_path)
+    visit "http://www.rdv-solidarites-test.localhost/presentation_agent"
+    expect(page).to have_current_path("/presentation_agent")
+    expect(page).to be_axe_clean
+  end
+
+  it "presentaion for aide numérique page is accessible" do
+    visit "http://www.rdv-aide-numerique-test.localhost/presentation_agent"
+    expect(page).to have_current_path("/presentation_agent")
+    # TODO: make it accessible
+    # expect(page).to be_axe_clean
   end
 
   it "mds_path page is accessible" do


### PR DESCRIPTION
Cette première version de la landing page a été conçue par l'équipe support, afin d'avoir une page de présentation acceptable pendant la [NEC](https://www.rdv-aide-numerique.fr/) la semaine prochaine.

**Voir la page ici :** 
https://demo-rdv-solidarites-pr2842.osc-secnum-fr1.scalingo.io/accueil_cnfs

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
