### PR TITLE
Utiliser Redis pour stocker les sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           ruby-version: 3.1.1
           bundler-cache: true
+      - name: Set up Redis
+        uses: zhulik/redis-action@1.1.0
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
@@ -105,6 +107,8 @@ jobs:
         with:
           ruby-version: 3.1.1
           bundler-cache: true
+      - name: Set up Redis
+        uses: zhulik/redis-action@1.1.0
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "administrate-field-belongs_to_search"
 gem "paper_trail"
 gem "activerecord-postgres_enum"
 gem "redis"
+gem "redis-session-store"
 gem "hiredis"
 
 # Devise / auth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,9 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.5.1)
+    redis-session-store (0.11.4)
+      actionpack (>= 3, < 8)
+      redis (>= 3, < 5)
     regexp_parser (2.2.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -675,6 +678,7 @@ DEPENDENCIES
   rails-erd
   rails_autolink
   redis
+  redis-session-store
   rspec-rails
   rspec_junit_formatter
   rubocop

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,22 @@ module Lapin
     config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")
     config.active_model.i18n_customize_full_message = true
 
+    redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379" }
+
+    # Both cache and sessions are stored in the same Redis database:
+    # - cache keys are prefixed with "cache:"
+    # - session keys are prefixed with "session:"
+    config.cache_store = :redis_cache_store, {
+      url: redis_url,
+      namespace: "cache",
+    }
+    config.session_store :redis_session_store,
+                         key: "_lapin_session_id", # cookie name
+                         redis: {
+                           key_prefix: "session:",
+                           url: redis_url,
+                         }
+
     # Devise layout
     config.to_prepare do
       [Devise::RegistrationsController, Devise::SessionsController, Devise::ConfirmationsController, Devise::PasswordsController, Devise::InvitationsController].each do |controller|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,6 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}",
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,9 +57,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
-  # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: "#{ENV['REDIS_URL']}/0:#{ENV['SOURCE_VERSION'] || ENV['CONTAINER_VERSION']}" }
-
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "lapin_production"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,7 +24,19 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+
+  # Test env has the same config as the global one (defined in application.rb)
+  # except we separate Redis keys in each parallel test using TEST_ENV_NUMBER.
+  config.cache_store = :redis_cache_store, {
+    url: "redis://localhost:6379",
+    namespace: "test:cache#{ENV['TEST_ENV_NUMBER']}",
+  }
+  config.session_store :redis_session_store,
+                       key: "_lapin_session_id", # cookie name
+                       redis: {
+                         key_prefix: "test:session#{ENV['TEST_ENV_NUMBER']}:",
+                         url: "redis://localhost:6379",
+                       }
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
+++ b/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
@@ -8,12 +8,8 @@ describe "Agent can see rdvs in their calendar", js: true do
       agent = create(:agent, basic_role_in_organisations: [organisation], display_saturdays: true)
       login_as(agent, scope: :agent)
 
-      # Use today because it not really easy to stub browser time
-      today = Time.zone.today
-      # force hour to be in visible agenda range
-      starts_at = Time.zone.parse("#{today.strftime('%F')} 14:00")
-      # move back one day ago one sunday
-      starts_at = 1.day.ago if today.strftime("%w").to_i > 6
+      # Create a RDV this week, monday at 14:00, so that it will show on the calendar
+      starts_at = Time.zone.now.beginning_of_week.change({ hour: 14 })
 
       motif = create(:motif, :collectif, organisation: organisation, service: agent.service, name: "Atelier collectif")
       create(

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,6 +86,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
     ActionMailer::Base.deliveries.clear
     FactoryBot.rewind_sequences
+    Rails.cache.clear
   end
 
   config.before(:suite) do


### PR DESCRIPTION
Closes #2676

Je propose d'utiliser Redis pour le cache **et** les sessions sur tous les environnements, afin d'avoir une reproduction fidèle de la prod en test et en local.

Pour l'env de test il y a des particularités :
- l'utilisation de [parallel_tests](https://github.com/grosser/parallel_tests) nous oblige à isoler les clés Redis de chaque runner
- on préfixe les clés avec `test:` pour isoler les données Redis de test et celles de dev local

Note : J'ai choisi de ne pas définir de TTL pour les sessions car actuellement nous n'avons pas d'expiration des sessions, si j'ai bien compris. Il pourrait être intéressant de discuter dans une autre PR de la mise en place d'une durée à partir de laquelle une session expire si il n'y a pas d'activité.

## Au moment du déploiement

- désactiver le [mode cache](https://doc.scalingo.com/databases/redis/start#cache-mode) de Scalingo
- vider le Redis ? Puisque les clés de cache existantes ne seront plus utilisées car désormais on préfixe les clés

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
