### PR TITLE
Utiliser les helpers ActiveJob dans les tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :test
   Delayed::Worker.delay_jobs = false
 
   # Print deprecation notices to the stderr.

--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -68,9 +68,11 @@ describe Admin::AbsencesController, type: :controller do
         end
 
         it "send notification after create" do
-          expect do
-            post :create, params: { organisation_id: organisation.id, absence: valid_attributes }
-          end.to change { ActionMailer::Base.deliveries.size }.by(1)
+          perform_enqueued_jobs do
+            expect do
+              post :create, params: { organisation_id: organisation.id, absence: valid_attributes }
+            end.to change { ActionMailer::Base.deliveries.size }.by(1)
+          end
 
           expect(ActionMailer::Base.deliveries.last.subject).to include("RDV Solidarités - Indisponibilité créée")
         end
@@ -129,9 +131,11 @@ describe Admin::AbsencesController, type: :controller do
         end
 
         it "send notification after update" do
-          expect do
-            put :update, params: { organisation_id: organisation.id, id: absence.to_param, absence: new_attributes }
-          end.to change { ActionMailer::Base.deliveries.size }.by(1)
+          perform_enqueued_jobs do
+            expect do
+              put :update, params: { organisation_id: organisation.id, id: absence.to_param, absence: new_attributes }
+            end.to change { ActionMailer::Base.deliveries.size }.by(1)
+          end
           expect(ActionMailer::Base.deliveries.last.subject).to include("RDV Solidarités - Indisponibilité modifiée - Le nouveau nom")
         end
 

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -195,6 +195,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
 
       it "sends an email" do
         subject
+        perform_enqueued_jobs
         expect(Devise.mailer.deliveries.count).to eq(1)
       end
     end

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -127,7 +127,9 @@ describe Admin::PlageOuverturesController, type: :controller do
         end
 
         it "send notification after create" do
-          expect { post(:create, params: valid_params) }.to change { ActionMailer::Base.deliveries.size }.by(1)
+          perform_enqueued_jobs do
+            expect { post(:create, params: valid_params) }.to change { ActionMailer::Base.deliveries.size }.by(1)
+          end
           expect(ActionMailer::Base.deliveries.last.subject).to eq("RDV Solidarités - Plage d’ouverture créée - Permanence ecole")
         end
 
@@ -182,6 +184,7 @@ describe Admin::PlageOuverturesController, type: :controller do
         it "send notification after update" do
           ActionMailer::Base.deliveries.clear
           put :update, params: { organisation_id: organisation.id, id: plage_ouverture.to_param, plage_ouverture: { title: "Le nouveau nom" } }
+          perform_enqueued_jobs
           expect(ActionMailer::Base.deliveries.size).to eq(1)
           expect(ActionMailer::Base.deliveries.last.subject).to eq("RDV Solidarités - Plage d’ouverture modifiée - Le nouveau nom")
         end

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -14,6 +14,8 @@ describe "Admin can configure the organisation" do
   let(:le_nouveau_motif) { build(:motif, name: "Motif 2", service: pmi, organisation: organisation) }
   let(:la_nouvelle_org) { build(:organisation) }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   before do
     login_as(agent_admin, scope: :agent)
     visit authenticated_agent_root_path

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -13,6 +13,8 @@ describe "Agent can create a Rdv with wizard" do
   let!(:disabled_lieu) { create(:lieu, organisation: organisation, enabled: false) }
   let!(:user) { create(:user, organisations: [organisation]) }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   before do
     stub_netsize_ok
     travel_to(Time.zone.local(2019, 10, 2))

--- a/spec/features/agents/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/agent_can_reset_his_password_spec.rb
@@ -3,6 +3,8 @@
 describe "Agent resets his password spec" do
   let!(:agent) { create(:agent) }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   it "works by sending a reset email" do
     visit new_agent_password_path
     expect(page).to have_content("Mot de passe oublié ?")

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -13,6 +13,8 @@ describe "Agent can organize a rdv collectif", js: true do
 
   before { stub_netsize_ok }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   def create_rdv_collectif(lieu_availability)
     travel_to(Time.zone.local(2022, 3, 14))
     agent = create(:agent, basic_role_in_organisations: [organisation], service: service, first_name: "Alain", last_name: "DIALO")

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -7,6 +7,8 @@ describe "Agent can create user" do
     create(:user, first_name: "Jean", last_name: "LEGENDE", email: "jean@legende.com", organisations: [organisation])
   end
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -7,6 +7,8 @@ describe "Agent can update user" do
     create(:user, first_name: "Jean", last_name: "LEGENDE", email: "jean@legende.com", organisations: [organisation])
   end
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   before do
     login_as(agent, scope: :agent)
     visit authenticated_agent_root_path

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "User can be invited" do
+  around { |example| perform_enqueued_jobs { example.run } }
+
   # needed for encrypted cookies
   before do
     stub_netsize_ok

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -3,6 +3,8 @@
 describe "User resets his password spec" do
   let!(:user) { create(:user) }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   it "works by sending a reset email" do
     visit new_user_password_path
     expect(page).to have_content("Mot de passe oublié ?")

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -16,9 +16,9 @@ describe "User can search for rdvs" do
   let!(:lieu2) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
 
-  before do
-    travel_to(now)
-  end
+  around { |example| perform_enqueued_jobs { example.run } }
+
+  before { travel_to(now) }
 
   describe "default" do
     it "default", js: true do

--- a/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe "user can use a link that points to RDV search scoped to an organisation" do
   before { travel_to(Time.zone.parse("2022-09-12 15:00:00")) }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   let!(:territory) { create(:territory, departement_number: "CN") }
   let!(:organisation_a) { create(:organisation, territory: territory, external_id: "123") }
   let!(:organisation_b) { create(:organisation, territory: territory, external_id: "456") }

--- a/spec/features/users/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/user_signs_up_and_signs_in_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "User signs up and signs in" do
+  around { |example| perform_enqueued_jobs { example.run } }
+
   context "through home page" do
     before { visit root_path }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
   config.include Select2SpecHelper
   config.include ApiSpecHelper
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveJob::TestHelper
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Warden::Test::Helpers, type: :feature
   config.include Sentry::TestHelper

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -45,6 +45,8 @@ describe AddConseillerNumerique do
         level: "admin",
         organisation_id: Organisation.last.id
       )
+
+      perform_enqueued_jobs
       invitation_email = ActionMailer::Base.deliveries.last
 
       expect(invitation_email).to have_attributes(

--- a/spec/services/rdv_updater_spec.rb
+++ b/spec/services/rdv_updater_spec.rb
@@ -177,8 +177,11 @@ describe RdvUpdater, type: :service do
     it "notifies the new participant, and the one that is removed" do
       expect(SmsSender).to receive(:new).and_return(sms_sender_double).twice
       expect(sms_sender_double).to receive(:perform).twice
+
       rdv.assign_attributes(rdv_params)
       described_class.perform!(agent, rdv)
+      perform_enqueued_jobs
+
       expect(ActionMailer::Base.deliveries.count).to eq 2
 
       added_email = ActionMailer::Base.deliveries.first

--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -6,6 +6,8 @@ describe "using netsize to send an SMS" do
   let(:user) { create(:user, phone_number: "+33601020304") }
   let(:rdv) { create(:rdv, organisation: organisation, users: [user]) }
 
+  around { |example| perform_enqueued_jobs { example.run } }
+
   stub_sentry_events
 
   it "calls netsize API" do


### PR DESCRIPTION
Actuellement, nous avons la config suivante dans `test.rb` : 

```ruby
   config.active_job.queue_adapter = :inline
```

Avec cette config, lorsque nous appelons `perform_later` (ou `deliver_later` pour un mail), le job n'est pas mis à la queue comme en prod, mais exécuté immédiatement, de façon synchrone.

Cette configuration a pour avantage d'être simple : on ne reproduit pas le comportement de la prod, mais on a un comportement proche, puisque les jobs s'exécutent en général assez rapidement en prod.

Le problème, c'est que : 
- cette simplification est mensongère, elle communique mal le fonctionnement réel de notre app
- elle nous empêche de vérifier si un job a bien été mis à la queue, ou de vérifier qu'ucn job n'a été mis à la queue (ce qu'on veut faire dans #2843 par exemple)

Je propose donc de définir `queue_adapter = :test`, afin d'utiliser [les helpers de `ActiveJob::TestHelper`](https://api.rubyonrails.org/v6.1.6.1/classes/ActiveJob/TestHelper.html#method-i-perform_enqueued_jobs). L'avantage, c'est qu'on maîtrise le mode d'exécution des jobs au cas par car, c'est à dire qu'on peut appeler `perform_enqueued_jobs` ponctuellement pour exécuter les jobs en attente, ou déclarer :

```ruby
around { |example| perform_enqueued_jobs { example.run } }
```

dans des feature specs où l'on juge acceptable de considérer que les jobs s'exécutent de façon synchrone.

L'inclusion de ces helpers permet également d'utiliser le matche RSpec `have_enqueued_job`, qui permet de vérifier qu'un job a bien été mis à la file.


# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
