### PR TITLE
Motif: Affichage conditionné pour les prises de RDV en ligne

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -23,12 +23,6 @@ module MotifsHelper
     tag.span(motif_name_with_location_type(motif)) + motif_badges(motif)
   end
 
-  def motif_info_tooltip(value)
-    tag.span data: { toggle: "tooltip" }, title: value, class: "text-muted" do
-      tag.i class: "ml-1 fa fa-circle-info"
-    end
-  end
-
   def motif_badges(motif, only: %i[reservable_online secretariat follow_up collectif])
     safe_join(only.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) })
   end
@@ -76,15 +70,14 @@ module MotifsHelper
 
   def motif_option_value(motif, option_name)
     if motif.send("#{option_name}?")
-      tag.span("Oui") + motif_info_tooltip(Motif.human_attribute_name("#{option_name}_hint"))
+      tag.span("☑️ ") + tag.span(Motif.human_attribute_name("#{option_name}_hint"))
     else
       tag.span("désactivée", class: "text-muted")
     end
   end
 
-  def motif_attribute_row(legend, arg_value = nil, hint: nil, tooltip: nil, &block)
+  def motif_attribute_row(legend, arg_value = nil, hint: nil, &block)
     value = block.present? ? capture(&block) : display_value_or_na_placeholder(arg_value)
-    value += motif_info_tooltip(tooltip) if arg_value.present? && tooltip.present?
     value += tag.div(hint, class: "text-muted") if arg_value.present? && hint.present?
     tag.div(tag.div(legend, class: "col-md-4 text-right") +
         tag.div(value, class: "col-md-8 text-bold"), class: "row")

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -23,6 +23,12 @@ module MotifsHelper
     tag.span(motif_name_with_location_type(motif)) + motif_badges(motif)
   end
 
+  def motif_info_tooltip(value)
+    tag.span data: { toggle: "tooltip" }, title: value, class: "text-muted" do
+      tag.i class: "ml-1 fa fa-circle-info"
+    end
+  end
+
   def motif_badges(motif, only: %i[reservable_online secretariat follow_up collectif])
     safe_join(only.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) })
   end
@@ -70,14 +76,15 @@ module MotifsHelper
 
   def motif_option_value(motif, option_name)
     if motif.send("#{option_name}?")
-      tag.span("☑️ ") + tag.span(Motif.human_attribute_name("#{option_name}_hint"))
+      tag.span("Oui") + motif_info_tooltip(Motif.human_attribute_name("#{option_name}_hint"))
     else
       tag.span("désactivée", class: "text-muted")
     end
   end
 
-  def motif_attribute_row(legend, arg_value = nil, hint: nil, &block)
+  def motif_attribute_row(legend, arg_value = nil, hint: nil, tooltip: nil, &block)
     value = block.present? ? capture(&block) : display_value_or_na_placeholder(arg_value)
+    value += motif_info_tooltip(tooltip) if arg_value.present? && tooltip.present?
     value += tag.div(hint, class: "text-muted") if arg_value.present? && hint.present?
     tag.div(tag.div(legend, class: "col-md-4 text-right") +
         tag.div(value, class: "col-md-8 text-bold"), class: "row")

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -76,9 +76,17 @@ module MotifsHelper
     end
   end
 
+  def motif_option_activated(motif, option_name)
+    if motif.send("#{option_name}?")
+      tag.span("Oui")
+    else
+      tag.span("désactivée", class: "text-muted")
+    end
+  end
+
   def motif_attribute_row(legend, arg_value = nil, hint: nil, &block)
     value = block.present? ? capture(&block) : display_value_or_na_placeholder(arg_value)
-    value += tag.div(hint, class: "text-muted") if arg_value.present? && hint.present?
+    value += tag.div(hint, class: "text-muted") if arg_value.present? && arg_value.exclude?("text-muted") && hint.present?
     tag.div(tag.div(legend, class: "col-md-4 text-right") +
         tag.div(value, class: "col-md-8 text-bold"), class: "row")
   end

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -19,7 +19,7 @@ class MotifForm {
   }
 
   toggleSectorisation = () => {
-    const enabled = !!document.querySelector("#motif_reservable_online:checked")
+    const enabled = this.reservableOnlineCheckbox.checked
     if (enabled == this.sectorisationEnabled) return;
 
     if (!enabled) {
@@ -34,10 +34,19 @@ class MotifForm {
     this.sectorisationEnabled = enabled
   }
 
-  toggleRdvsEditable() {
-    const enabled = !!document.querySelector("#motif_reservable_online:checked")
-    document.querySelector(".js-rdvs-editable").classList.toggle('translucent', !enabled)
+
+  toggleOnlineSubFields() {
+    const enabled = this.reservableOnlineCheckbox.checked
+    document.querySelectorAll(".js-rdvs-editable").forEach(rdvEditableElement =>
+      rdvEditableElement.classList.toggle('hidden', !enabled)
+    )
   }
+
+  toggleRdvsEditable() {
+    const enabled = this.reservableOnlineCheckbox.checked
+    document.querySelector("#motif_rdvs_editable_by_user").checked = enabled
+  }
+
 
   constructor() {
     this.secretariatCheckbox = document.querySelector('#motif_for_secretariat')
@@ -50,12 +59,13 @@ class MotifForm {
     )
     this.reservableOnlineCheckbox.addEventListener('change', e => {
       if (document.querySelector(".js-sectorisation-card") !== null) { this.toggleSectorisation() }
+      this.toggleOnlineSubFields()
       this.toggleRdvsEditable()
     })
 
     this.toggleSecretariat()
     if (document.querySelector(".js-sectorisation-card") !== null) { this.toggleSectorisation() }
-    this.toggleRdvsEditable()
+    this.toggleOnlineSubFields()
   }
 
 }

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -30,7 +30,7 @@ class MotifForm {
     document.
       querySelectorAll('input[name="motif[sectorisation_level]"]').
       forEach(i => i.disabled = !enabled)
-    document.querySelector(".js-sectorisation-card").classList.toggle('hidden', !enabled)
+    document.querySelector(".js-sectorisation-card").classList.toggle('translucent', !enabled)
     this.sectorisationEnabled = enabled
   }
 

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -30,7 +30,7 @@ class MotifForm {
     document.
       querySelectorAll('input[name="motif[sectorisation_level]"]').
       forEach(i => i.disabled = !enabled)
-    document.querySelector(".js-sectorisation-card").classList.toggle('translucent', !enabled)
+    document.querySelector(".js-sectorisation-card").classList.toggle('hidden', !enabled)
     this.sectorisationEnabled = enabled
   }
 

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -4,6 +4,11 @@
 
 .translucent {
   opacity: 0.5;
+  pointer-events: none;
+}
+
+.hidden {
+  display: none;
 }
 
 .strikethrough {

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -63,7 +63,7 @@
       p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
       = f.input :reservable_online
 
-      .form-row
+      .form-row.js-rdvs-editable
         .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options
         .col-md-4= f.input :max_booking_delay, collection: min_max_delay_options
 

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -28,15 +28,18 @@
 
         = motif_attribute_row \
           Motif.human_attribute_name(:follow_up_short), \
-          motif_option_value(@motif, :follow_up)
+          motif_option_activated(@motif, :follow_up), \
+          hint: Motif.human_attribute_name(:follow_up_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:for_secretariat_short), \
-          motif_option_value(@motif, :for_secretariat)
+          motif_option_activated(@motif, :for_secretariat), \
+          hint: Motif.human_attribute_name(:for_secretariat_hint)
         hr
 
         = motif_attribute_row \
           Motif.human_attribute_name(:reservable_online), \
-          motif_option_value(@motif, :reservable_online)
+          motif_option_activated(@motif, :reservable_online), \
+          hint: Motif.human_attribute_name(:reservable_online_hint)
         - if @motif.reservable_online
           = motif_attribute_row \
             Motif.human_attribute_name(:min_booking_delay_short), \
@@ -50,15 +53,16 @@
             hint: Motif.human_attribute_name(:max_booking_delay_hint)
           = motif_attribute_row \
             Motif.human_attribute_name(:rdvs_editable_by_user), \
-            motif_option_value(@motif, :rdvs_editable_by_user)
+            motif_option_activated(@motif, :rdvs_editable_by_user), \
+            hint: Motif.human_attribute_name(:rdvs_editable_by_user_hint)
 
-        - unless current_agent.conseiller_numerique?
-          = motif_attribute_row("Sectorisation") do
-            - if @motif.reservable_online?
-              div= @motif.human_attribute_value(:sectorisation_level)
-              div.text-muted= @motif.human_attribute_value(:sectorisation_level, context: :hint)
-            - else
-              span.text-muted N/A
+          - unless current_agent.conseiller_numerique?
+            = motif_attribute_row("Sectorisation") do
+              - if @motif.reservable_online?
+                div= @motif.human_attribute_value(:sectorisation_level)
+                div.text-muted= @motif.human_attribute_value(:sectorisation_level, context: :hint)
+              - else
+                span.text-muted N/A
         hr
 
         = motif_attribute_row(Motif.human_attribute_name(:visibility_type)) do

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -37,19 +37,20 @@
         = motif_attribute_row \
           Motif.human_attribute_name(:reservable_online), \
           motif_option_value(@motif, :reservable_online)
-        = motif_attribute_row \
-          Motif.human_attribute_name(:min_booking_delay_short), \
-          @motif.reservable_online? && \
-            min_max_delay_int_to_human(@motif.min_booking_delay), \
-          hint: Motif.human_attribute_name(:min_booking_delay_hint)
-        = motif_attribute_row \
-          Motif.human_attribute_name(:max_booking_delay_short), \
-          @motif.reservable_online? && \
-            min_max_delay_int_to_human(@motif.max_booking_delay), \
-          hint: Motif.human_attribute_name(:max_booking_delay_hint)
-        = motif_attribute_row \
-          Motif.human_attribute_name(:rdvs_editable_by_user), \
-           motif_option_value(@motif, :rdvs_editable_by_user)
+        - if @motif.reservable_online
+          = motif_attribute_row \
+            Motif.human_attribute_name(:min_booking_delay_short), \
+            @motif.reservable_online? && \
+              min_max_delay_int_to_human(@motif.min_booking_delay), \
+            hint: Motif.human_attribute_name(:min_booking_delay_hint)
+          = motif_attribute_row \
+            Motif.human_attribute_name(:max_booking_delay_short), \
+            @motif.reservable_online? && \
+              min_max_delay_int_to_human(@motif.max_booking_delay), \
+            hint: Motif.human_attribute_name(:max_booking_delay_hint)
+          = motif_attribute_row \
+            Motif.human_attribute_name(:rdvs_editable_by_user), \
+            motif_option_value(@motif, :rdvs_editable_by_user)
 
         - unless current_agent.conseiller_numerique?
           = motif_attribute_row("Sectorisation") do

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -22,8 +22,7 @@
         = motif_attribute_row("Type de RDV") do
           div
             = "#{@motif.human_attribute_value(:collectif)} #{@motif.human_attribute_value(:location_type).downcase}"
-          div.text-muted
-            = @motif.human_attribute_value(:location_type, context: :hint)
+            = motif_info_tooltip(@motif.human_attribute_value(:location_type, context: :hint))
         hr
 
         = motif_attribute_row \
@@ -39,46 +38,47 @@
           motif_option_value(@motif, :reservable_online)
         - if @motif.reservable_online
           = motif_attribute_row \
-            Motif.human_attribute_name(:min_booking_delay_short), \
+          Motif.human_attribute_name(:min_booking_delay_short), \
             @motif.reservable_online? && \
               min_max_delay_int_to_human(@motif.min_booking_delay), \
-            hint: Motif.human_attribute_name(:min_booking_delay_hint)
+              tooltip: Motif.human_attribute_name(:min_booking_delay_hint)
           = motif_attribute_row \
             Motif.human_attribute_name(:max_booking_delay_short), \
             @motif.reservable_online? && \
               min_max_delay_int_to_human(@motif.max_booking_delay), \
-            hint: Motif.human_attribute_name(:max_booking_delay_hint)
+              tooltip: Motif.human_attribute_name(:max_booking_delay_hint)
           = motif_attribute_row \
             Motif.human_attribute_name(:rdvs_editable_by_user), \
             motif_option_value(@motif, :rdvs_editable_by_user)
 
-        - unless current_agent.conseiller_numerique?
-          = motif_attribute_row("Sectorisation") do
-            - if @motif.reservable_online?
-              div= @motif.human_attribute_value(:sectorisation_level)
-              div.text-muted= @motif.human_attribute_value(:sectorisation_level, context: :hint)
-            - else
-              span.text-muted N/A
+          - unless current_agent.conseiller_numerique?
+            = motif_attribute_row("Sectorisation") do
+              - if @motif.reservable_online?
+                div
+                  = @motif.human_attribute_value(:sectorisation_level)
+                  = motif_info_tooltip(@motif.human_attribute_value(:sectorisation_level, context: :hint))
+              - else
+                span.text-muted N/A
         hr
 
         = motif_attribute_row(Motif.human_attribute_name(:visibility_type)) do
-          div= @motif.human_attribute_value(:visibility_type)
-          div.text-muted
-            = @motif.human_attribute_value(:visibility_type, context: :hint)
+          div
+            = @motif.human_attribute_value(:visibility_type)
+            = motif_info_tooltip(@motif.human_attribute_value(:visibility_type, context: :hint))
         hr
 
         = motif_attribute_row \
           Motif.human_attribute_name(:restriction_for_rdv_short), \
           @motif.restriction_for_rdv, \
-          hint: Motif.human_attribute_name(:restriction_for_rdv_hint)
+          tooltip: Motif.human_attribute_name(:restriction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:instruction_for_rdv_short), \
           @motif.instruction_for_rdv, \
-          hint: Motif.human_attribute_name(:instruction_for_rdv_hint)
+          tooltip: Motif.human_attribute_name(:instruction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:custom_cancel_warning_message), \
           @motif.custom_cancel_warning_message, \
-          hint: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
+          tooltip: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
 
       - if motif_policy.edit? || motif_policy.destroy?
         .card-footer

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -22,7 +22,8 @@
         = motif_attribute_row("Type de RDV") do
           div
             = "#{@motif.human_attribute_value(:collectif)} #{@motif.human_attribute_value(:location_type).downcase}"
-            = motif_info_tooltip(@motif.human_attribute_value(:location_type, context: :hint))
+          div.text-muted
+            = @motif.human_attribute_value(:location_type, context: :hint)
         hr
 
         = motif_attribute_row \
@@ -38,47 +39,46 @@
           motif_option_value(@motif, :reservable_online)
         - if @motif.reservable_online
           = motif_attribute_row \
-          Motif.human_attribute_name(:min_booking_delay_short), \
+            Motif.human_attribute_name(:min_booking_delay_short), \
             @motif.reservable_online? && \
               min_max_delay_int_to_human(@motif.min_booking_delay), \
-              tooltip: Motif.human_attribute_name(:min_booking_delay_hint)
+            hint: Motif.human_attribute_name(:min_booking_delay_hint)
           = motif_attribute_row \
             Motif.human_attribute_name(:max_booking_delay_short), \
             @motif.reservable_online? && \
               min_max_delay_int_to_human(@motif.max_booking_delay), \
-              tooltip: Motif.human_attribute_name(:max_booking_delay_hint)
+            hint: Motif.human_attribute_name(:max_booking_delay_hint)
           = motif_attribute_row \
             Motif.human_attribute_name(:rdvs_editable_by_user), \
             motif_option_value(@motif, :rdvs_editable_by_user)
 
-          - unless current_agent.conseiller_numerique?
-            = motif_attribute_row("Sectorisation") do
-              - if @motif.reservable_online?
-                div
-                  = @motif.human_attribute_value(:sectorisation_level)
-                  = motif_info_tooltip(@motif.human_attribute_value(:sectorisation_level, context: :hint))
-              - else
-                span.text-muted N/A
+        - unless current_agent.conseiller_numerique?
+          = motif_attribute_row("Sectorisation") do
+            - if @motif.reservable_online?
+              div= @motif.human_attribute_value(:sectorisation_level)
+              div.text-muted= @motif.human_attribute_value(:sectorisation_level, context: :hint)
+            - else
+              span.text-muted N/A
         hr
 
         = motif_attribute_row(Motif.human_attribute_name(:visibility_type)) do
-          div
-            = @motif.human_attribute_value(:visibility_type)
-            = motif_info_tooltip(@motif.human_attribute_value(:visibility_type, context: :hint))
+          div= @motif.human_attribute_value(:visibility_type)
+          div.text-muted
+            = @motif.human_attribute_value(:visibility_type, context: :hint)
         hr
 
         = motif_attribute_row \
           Motif.human_attribute_name(:restriction_for_rdv_short), \
           @motif.restriction_for_rdv, \
-          tooltip: Motif.human_attribute_name(:restriction_for_rdv_hint)
+          hint: Motif.human_attribute_name(:restriction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:instruction_for_rdv_short), \
           @motif.instruction_for_rdv, \
-          tooltip: Motif.human_attribute_name(:instruction_for_rdv_hint)
+          hint: Motif.human_attribute_name(:instruction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:custom_cancel_warning_message), \
           @motif.custom_cancel_warning_message, \
-          tooltip: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
+          hint: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
 
       - if motif_policy.edit? || motif_policy.destroy?
         .card-footer

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe "Agent can CRUD motifs" do
+  let(:organisation) { create(:organisation) }
+  let!(:service) { create(:service, name: "PMI") }
+  let!(:motif) { create(:motif, name: "Suivi bonjour", service: service, organisation: organisation) }
+  let!(:agent) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }
+
+  before do
+    login_as(agent, scope: :agent)
+    visit authenticated_agent_root_path
+    click_link "Vos motifs"
+  end
+
+  context "when agent from organisation reach motifs#index" do
+    it "can CRUD motifs" do
+      expect_page_title("Vos motifs")
+      click_link motif.name
+
+      expect(page).to have_content(motif.name)
+      click_link "Éditer"
+
+      expect_page_title("Modifier le motif")
+      fill_in "Nom", with: "Suivi bonsoir"
+      click_button("Enregistrer")
+
+      expect(page).to have_content("Suivi bonsoir")
+      click_link("Supprimer")
+
+      expect_page_title("Vos motifs")
+      expect(page).to have_content("Vous n'avez pas encore créé de motif.")
+      click_link "Créer un motif", match: :first
+
+      expect_page_title("Nouveau motif")
+      find("#motif_service_id").find(:option, service.name).select_option
+      fill_in "Nom", with: "Suivi bonne nuit"
+      fill_in "Couleur", with: "#000"
+      click_button "Enregistrer"
+
+      expect_page_title("Vos motifs")
+      expect(page).to have_content("Suivi bonne nuit")
+    end
+  end
+end


### PR DESCRIPTION
Closes #2721 & #2808 


# Avant pour l'édition d'un motif
![Capture d’écran 2022-09-30 à 09 56 55](https://user-images.githubusercontent.com/11738628/193221265-dc4fd7e1-7699-493e-badd-36303d6ae1f7.png)

# Après pour l'édition d'un motif
![Capture d’écran 2022-09-30 à 09 57 21](https://user-images.githubusercontent.com/11738628/193221400-5dff331b-bd13-4e75-8536-4121d88718c7.png)
- les champs dépendants de la réservation en ligne sont masqués à l'utilisateur

# Avant pour la show d'un motif non réservable en ligne
![Capture d’écran 2022-09-30 à 09 46 47](https://user-images.githubusercontent.com/11738628/193221552-beec343e-4243-4da6-a012-b0aabce124cc.png)

# Après pour la show d'un motif non réservable en ligne
![Capture d’écran 2022-09-30 à 09 47 03](https://user-images.githubusercontent.com/11738628/193221659-30bc53e1-8a9a-4c55-8366-982a136f05dc.png)
- les champs liés à la réservation en ligne sont masqués à l'utilisateur

# Avant pour la show d'un motif dûment rempli
![Capture d’écran 2022-09-30 à 09 44 23](https://user-images.githubusercontent.com/11738628/193221834-fcc97ce5-d65e-4e32-8b7b-a293e40a6616.png)

# Après pour la show d'un motif dûment rempli
![Capture d’écran 2022-09-30 à 09 44 37](https://user-images.githubusercontent.com/11738628/193221903-27f0f36d-f79b-4315-b28c-93decb1e124d.png)
- les champs qui comprenaient des checkbox ont été remplacés par des "Oui" et les explications sont passées en `hint`


# Live test : 
+ https://demo-rdv-solidarites-pr2848.osc-secnum-fr1.scalingo.io/
+ se log en tant que martine@demo.rdv-solidarites.fr
+ aller dans `paramètres` -> `vos motifs`

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
