### PR TITLE
Éviter les crash JS sur le formulaire d'édition des motifs (RDV Aide Numérique)

### DIFF
--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -18,13 +18,17 @@ class MotifForm {
       !document.querySelector("#motif_follow_up:checked")
   }
 
+  // This method enables and initializes the sectorisation section when
+  // motif_reservable_online is checked or unchecked.
   toggleSectorisation = () => {
     const enabled = !!document.querySelector("#motif_reservable_online:checked")
     if (enabled == this.sectorisationEnabled) return;
 
+    const sectorisationCard = document.querySelector(".js-sectorisation-card")
+    if (!sectorisationCard) return; // not all domains have sectorisation config enabled
+
     if (!enabled) {
-      document.querySelector('#motif_sectorisation_level_agent').checked = false
-      document.querySelector('#motif_sectorisation_level_organisation').checked = false
+      // reset radio button to default value
       document.querySelector('#motif_sectorisation_level_departement').checked = true
     }
     document.


### PR DESCRIPTION
Depuis #2798, le formulaire d'édition / création d'un motif s'est mis à afficher la checkbox "Réservable en ligne" sur RDV Aide Numérique (CNFS).

Côté JS, au toggle de cette checkbox, nous rendons actif / inactif la section "Sectorisation géographique" du formulaire.

Or, cette section est absente du formulaire sur RDV Aide Numérique, car les CNFS n'utilisent pas la sectorisation. Le JS plantait donc car il cherchait cette section de la page.

Est-ce qu'il y a une leçon à apprendre vis-à-vis du contexte de cette erreur ? La notion de "feature flag" nous aiderait-elle à donner de la visibilité à ces variations de cas selon le "domaine" ?

## Issues Sentry

- https://sentry.io/organizations/rdv-solidarites/issues/3608185278
- https://sentry.io/organizations/rdv-solidarites/issues/3608928677

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
