### PR TITLE
conserve les attributs franceconnect lors de la fusion d'usagers

### DIFF
--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -26,6 +26,8 @@ class MergeUsersService < BaseService
     user_attributes_to_merge.each do |attribute|
       @user_target.send("#{attribute}=", @user_to_merge.send(attribute))
     end
+    # Si le user_target s'est déjà connecté avec FranceConnect,
+    # les attributs ne sont pas écrasés lors de la fusion
     if @user_to_merge.logged_once_with_franceconnect?
       @user_target.logged_once_with_franceconnect = true
       @user_target.franceconnect_openid_sub = @user_to_merge.franceconnect_openid_sub

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -26,6 +26,10 @@ class MergeUsersService < BaseService
     user_attributes_to_merge.each do |attribute|
       @user_target.send("#{attribute}=", @user_to_merge.send(attribute))
     end
+    if @user_to_merge.logged_once_with_franceconnect?
+      @user_target.logged_once_with_franceconnect = true
+      @user_target.franceconnect_openid_sub = @user_to_merge.franceconnect_openid_sub
+    end
     @user_target.save!
   end
 

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -267,4 +267,24 @@ describe MergeUsersService, type: :service do
       end
     end
   end
+
+  context "one user is connected by FranceConnect" do
+    it "keep FranceConnect attributes when merged user logged once with franceconnect" do
+      user_to_merge = create(:user, logged_once_with_franceconnect: true, franceconnect_openid_sub: "unechainedecharacteres", organisations: [organisation])
+      user_target = create(:user, organisations: [organisation])
+      described_class.perform_with(user_target, user_to_merge, attributes_to_merge, organisation)
+      user_target.reload
+      expect(user_target.logged_once_with_franceconnect).to be_truthy
+      expect(user_target.franceconnect_openid_sub).to eq("unechainedecharacteres")
+    end
+
+    it "keep FranceConnect attributes when user target logged once with franceconnect" do
+      user_to_merge = create(:user, organisations: [organisation])
+      user_target = create(:user, logged_once_with_franceconnect: true, franceconnect_openid_sub: "unechainedecharacteres", organisations: [organisation])
+      described_class.perform_with(user_target, user_to_merge, attributes_to_merge, organisation)
+      user_target.reload
+      expect(user_target.logged_once_with_franceconnect).to be_truthy
+      expect(user_target.franceconnect_openid_sub).to eq("unechainedecharacteres")
+    end
+  end
 end

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -268,7 +268,7 @@ describe MergeUsersService, type: :service do
     end
   end
 
-  context "one user is connected by FranceConnect" do
+  context "when one user is connected by FranceConnect" do
     it "keep FranceConnect attributes when merged user logged once with franceconnect" do
       user_to_merge = create(:user, logged_once_with_franceconnect: true, franceconnect_openid_sub: "unechainedecharacteres", organisations: [organisation])
       user_target = create(:user, organisations: [organisation])


### PR DESCRIPTION
Closes #2766

Permet de maintenir les informations de l'usager connecté via FranceConnect lors de la fusion d'usagers.
Ainsi, quelque soit l'usagé source ou modifié, les champs "franceconnect_openid_sub" et "logged_once_with_franceconnect" seront conservé.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
