### PR TITLE
Gestion d'un warning lorsqu'un motif dépasse la durée d'une plage d'ouverture

### DIFF
--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -88,6 +88,10 @@ module PlageOuverturesHelper
     weekdays[weekday]
   end
 
+  def overflow_motif_duration(plage_ouverture, motif)
+    (motif.default_duration_in_min - plage_ouverture.daily_max_duration.in_minutes).to_i
+  end
+
   def po_exceptionnelle_tag(plage_ouverture)
     tag.span("Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
   end

--- a/app/views/admin/plage_ouvertures/_motifs_duration_exceed.html.slim
+++ b/app/views/admin/plage_ouvertures/_motifs_duration_exceed.html.slim
@@ -1,4 +1,4 @@
 - model.overflow_motifs_duration.each do |motif|
   li.mb-1
     span>= link_to("#{motif.name}", edit_admin_organisation_motif_path(model.organisation, motif))
-    span> a une durée de #{motif.default_duration_in_min} minutes qui est supérieure aux plages journalières prévues
+    span> déborde de #{overflow_motif_duration(model, motif)} minutes. Il ne sera pas possible de prendre rendez-vous pour ce motif en l'état.

--- a/app/views/admin/plage_ouvertures/_motifs_duration_exceed.html.slim
+++ b/app/views/admin/plage_ouvertures/_motifs_duration_exceed.html.slim
@@ -1,0 +1,4 @@
+- model.overflow_motifs_duration.each do |motif|
+  li.mb-1
+    span>= link_to("#{motif.name}", edit_admin_organisation_motif_path(model.organisation, motif))
+    span> a une durée de #{motif.default_duration_in_min} minutes qui est supérieure aux plages journalières prévues

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -22,6 +22,8 @@ tr
       | Le #{l(plage_ouverture.first_day, format: :human)} #{display_time_range(plage_ouverture)}
     - if plage_ouverture.overlapping_plages_ouvertures?
       .alert.alert-warning.py-1.px-2.mt-1 ⚠️ Conflit de dates
+    - if plage_ouverture.overflow_motifs_duration?
+      .alert.alert-warning.py-1.px-2.mt-1 ⚠️ Certains motifs débordent sur la durée de la plage
   td
     .d-flex
       div.mr-3= link_to edit_admin_organisation_plage_ouverture_path(organisation, plage_ouverture),

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -51,10 +51,17 @@
         - if @plage_ouverture.overlapping_plages_ouvertures?
           div.mt-3
             .alert.alert-warning.mt-1.mb-0
-              | Conflit de dates et d'horaires avec d'autres plages d'ouvertures
+              = @plage_ouverture.send(:warn_overlapping_plage_ouvertures).type
             .border-left.border-right.border-bottom.rounded.border-warning
               ul.pl-3.py-2.mb-0
                 = render "overlapping_plage_ouvertures", model: @plage_ouverture
+        - if @plage_ouverture.overflow_motifs_duration?
+          div.mt-3
+            .alert.alert-warning.mt-1.mb-0
+              = @plage_ouverture.send(:warn_overflow_motifs_duration).type
+            .border-left.border-right.border-bottom.rounded.border-warning
+              ul.pl-3.py-2.mb-0
+                = render "motifs_duration_exceed", model: @plage_ouverture
 
       .card-footer.d-flex.justify-content-between
         div


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr2857.osc-secnum-fr1.scalingo.io/

Closes #2565 

# Avant :
- Depuis l'édition d'une plage d'ouverture, un agent pouvait ajouter un motif avec une durée supérieure aux durées prévues par la plage

# Après :
- L'interface gère différents warnings non bloquant afin que l'agent puisse rectifier, soit la plage d'ouverture, soit le motif

## sur l'index : 
![Capture d’écran 2022-09-29 à 18 09 13](https://user-images.githubusercontent.com/11738628/193083094-d5b10335-f394-4175-b0aa-e363edb508b2.png)

## sur la show : 
![Capture d’écran 2022-09-30 à 14 30 42](https://user-images.githubusercontent.com/11738628/193270188-e7f7613c-7574-4a72-a189-236f682056e7.png)


## sur l'edit / new :
![Capture d’écran 2022-09-29 à 18 08 59](https://user-images.githubusercontent.com/11738628/193083187-a7f3acbe-0ce8-489f-885b-09c55bfc19ad.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
