### PR TITLE
Permettre la prise de rdv via un lien public vers le service

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,6 +21,18 @@ class SearchController < ApplicationController
     redirect_to_organisation_search(organisation)
   end
 
+  def public_link_with_service_id
+    territory = Territory.find_by(departement_number: params[:territory_slug])
+    service = Service.find_by(id: params[:service_id])
+    if territory.nil?
+      redirect_to root_path, alert: "Territoire non trouvé"
+    elsif service.nil?
+      redirect_to root_path, alert: "Service non trouvé"
+    else
+      redirect_to root_path(departement: territory.departement_number, service_id: service.id)
+    end
+  end
+
   private
 
   def redirect_to_organisation_search(organisation)

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -27,7 +27,7 @@ class SearchContext
   # *** Method that outputs the next step for the user to complete its rdv journey ***
   # *** It is used in #to_partial_path to render the matching partial view ***
   def current_step
-    if address.blank? && @organisation_id.blank?
+    if address.blank? && @organisation_id.blank? && @service_id.blank?
       :address_selection
     elsif !service_selected?
       :service_selection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,9 +256,12 @@ Rails.application.routes.draw do
     params.values.any? ? "?#{params.to_query}" : ''
   end
 
-  # short public link
+  # short public links: to an organisation
   get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
   get "org/ext/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
+
+  # short public links: to a service
+  get "ser/:territory_slug/:service_id" => "search#public_link_with_service_id", as: :public_link_to_service
 
   ##
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -242,4 +242,34 @@ RSpec.describe SearchController, type: :controller do
       end
     end
   end
+
+  describe "#public_link_with_service_id" do
+    context "when the territory is not found" do
+      it "redirects to the root path with an alert" do
+        get :public_link_with_service_id, params: { territory_slug: "yo", service_id: "lo" }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to match(/Territoire non trouvé/)
+      end
+    end
+
+    context "when the service is not found" do
+      before { create(:territory, departement_number: departement_number) }
+
+      it "redirects to the root path with an alert" do
+        get :public_link_with_service_id, params: { territory_slug: departement_number, service_id: "lo" }
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to match(/Service non trouvé/)
+      end
+    end
+
+    context "when both the territory and the service exist" do
+      before { create(:territory, departement_number: departement_number) }
+
+      it "redirects to the root path with the departement_number and the service_id" do
+        get :public_link_with_service_id, params: { territory_slug: departement_number, service_id: service.id }
+        expect(response).to redirect_to(root_path(departement: departement_number, service_id: service.id))
+        expect(flash[:alert]).to be_blank
+      end
+    end
+  end
 end

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -26,11 +26,7 @@ describe SearchContext, type: :service do
 
   let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: motif.id)) }
 
-  before do
-    allow(Users::GeoSearch).to receive(:new)
-      .with(departement: departement_number, city_code: city_code, street_ban_id: nil)
-      .and_return(geo_search)
-  end
+  before { allow(Users::GeoSearch).to receive(:new).and_return(geo_search) }
 
   describe "#current_step" do
     context "when nothing is passed" do
@@ -55,6 +51,14 @@ describe SearchContext, type: :service do
 
       it "current step is lieu selection" do
         expect(subject.current_step).to eq(:lieu_selection)
+      end
+    end
+
+    context "when a service and a departement are passed" do
+      let!(:search_query) { { departement: departement_number, service_id: service.id } }
+
+      it "current step is motif selection" do
+        expect(subject.current_step).to eq(:motif_selection)
       end
     end
   end


### PR DESCRIPTION
Closes #2855

On ajoute une URL courte `/ser/:territory_slug/:service_id`, afin de permettre aux agent·es (notamment du médico-social) de partager un lien public de réservation auprès d'un service.

![image](https://user-images.githubusercontent.com/1193334/192729775-de055395-64b4-4d05-836e-7c7628491c0e.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
