### PR TITLE
Permettre la création de plages d'ouverture sans lieu

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -55,11 +55,11 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   end
 
   def creneaux_search_params
-    p = helpers.creneaux_search_params(@form)
+    creneaux_search_params = helpers.creneaux_search_params(@form)
     if only_one_lieu?
-      p.merge(lieu_ids: [@search_results.first.lieu.id])
+      creneaux_search_params.merge(lieu_ids: [@search_results.first.lieu.id])
     else
-      p
+      creneaux_search_params
     end
   end
 end

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -2,9 +2,12 @@
 
 class Admin::Creneaux::AgentSearchesController < AgentAuthController
   respond_to :html, :js
+
   before_action :set_form
   before_action :set_search_results
   before_action :set_search_results_without_lieu
+
+  helper_method :creneaux_without_lieu?
 
   def index
     if only_one_lieu? && !creneaux_without_lieu?

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -48,7 +48,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
 
   def set_search_results_without_lieu
     return unless (params[:commit].present? || request.format.js?) && @form.valid?
-    return unless @form.motif&.phone?
+    return if @form.motif&.requires_lieu?
 
     # Les motifs par téléphone sont nécessairement individuels
     @search_results_without_lieu = SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -2,12 +2,11 @@
 
 class Admin::Creneaux::AgentSearchesController < AgentAuthController
   respond_to :html, :js
+  before_action :set_form
+  before_action :set_search_results
+  before_action :set_search_results_without_lieu
 
   def index
-    @form = helpers.build_agent_creneaux_search_form(current_organisation, params)
-    @search_results = search_results
-    @search_results_without_lieu = search_results_without_lieu
-
     if only_one_lieu? && !creneaux_without_lieu?
       skip_policy_scope # TODO: improve pundit checks for creneaux
 
@@ -30,22 +29,26 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
 
   private
 
-  def search_results
-    return nil unless (params[:commit].present? || request.format.js?) && @form.valid?
-
-    if @form.motif.individuel?
-      SearchCreneauxForAgentsService.perform_with(@form)
-    else
-      SearchRdvCollectifForAgentsService.new(@form).lieu_search
-    end
+  def set_form
+    @form = helpers.build_agent_creneaux_search_form(current_organisation, params)
   end
 
-  def search_results_without_lieu
-    return nil unless (params[:commit].present? || request.format.js?) && @form.valid?
-    return nil unless @form.motif&.phone?
+  def set_search_results
+    return unless (params[:commit].present? || request.format.js?) && @form.valid?
+
+    @search_results = if @form.motif.individuel?
+                        SearchCreneauxForAgentsService.perform_with(@form)
+                      else
+                        SearchRdvCollectifForAgentsService.new(@form).lieu_search
+                      end
+  end
+
+  def set_search_results_without_lieu
+    return unless (params[:commit].present? || request.format.js?) && @form.valid?
+    return unless @form.motif&.phone?
 
     # Les motifs par téléphone sont nécessairement individuels
-    SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)
+    @search_results_without_lieu = SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)
   end
 
   def only_one_lieu?

--- a/app/controllers/admin/slots_controller.rb
+++ b/app/controllers/admin/slots_controller.rb
@@ -25,10 +25,14 @@ class Admin::SlotsController < AgentAuthController
   private
 
   def search_result
-    if @form.motif.individuel?
-      SearchCreneauxForAgentsService.perform_with(@form).first
+    if @form.motif.requires_lieu?
+      if @form.motif.individuel?
+        SearchCreneauxForAgentsService.perform_with(@form).first
+      else
+        SearchRdvCollectifForAgentsService.new(@form).slot_search
+      end
     else
-      SearchRdvCollectifForAgentsService.new(@form).slot_search
+      SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)
     end
   end
 end

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -95,12 +95,11 @@ class Users::RdvsController < UserAuthController
 
   def build_creneau
     @starts_at = Time.zone.parse(params[:starts_at])
-    lieu = @lieu.present? ? Lieu.find(@lieu.id) : nil
     @creneau = Users::CreneauSearch.creneau_for(
       user: current_user,
       starts_at: @starts_at,
       motif: @rdv.motif,
-      lieu: lieu
+      lieu: @lieu
     )
   end
 

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -22,12 +22,13 @@ class Users::RdvsController < UserAuthController
 
   def create
     motif = Motif.find(rdv_params[:motif_id])
+    lieu = new_rdv_extra_params[:lieu_id].present? ? Lieu.find(new_rdv_extra_params[:lieu_id]) : nil
     ActiveRecord::Base.transaction do
       @creneau = Users::CreneauSearch.creneau_for(
         user: current_user,
         starts_at: DateTime.parse(rdv_params[:starts_at]),
         motif: motif,
-        lieu: Lieu.find(new_rdv_extra_params[:lieu_id]),
+        lieu: lieu,
         geo_search: @geo_search
       )
       if @creneau.present?
@@ -94,11 +95,12 @@ class Users::RdvsController < UserAuthController
 
   def build_creneau
     @starts_at = Time.zone.parse(params[:starts_at])
+    lieu = @lieu.present? ? Lieu.find(@lieu.id) : nil
     @creneau = Users::CreneauSearch.creneau_for(
       user: current_user,
       starts_at: @starts_at,
       motif: @rdv.motif,
-      lieu: Lieu.find(@lieu.id)
+      lieu: lieu
     )
   end
 
@@ -137,7 +139,7 @@ class Users::RdvsController < UserAuthController
       starts_at: creneau.starts_at,
       organisation: creneau.motif.organisation,
       motif: creneau.motif,
-      lieu_id: creneau.lieu.id,
+      lieu_id: creneau.lieu&.id,
       users: [user_for_rdv],
       created_by: :user
     )

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -51,7 +51,7 @@ module UserRdvWizard
     end
 
     def lieu_full_name
-      creneau.lieu.full_name
+      creneau.lieu&.full_name
     end
 
     def to_query

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -12,6 +12,7 @@ module UserRdvWizard
 
     delegate :motif, :starts_at, :users, :service, to: :rdv
     delegate :errors, to: :rdv
+    delegate :lieu_full_name, to: :creneau
 
     def initialize(user, attributes)
       @user = user
@@ -48,10 +49,6 @@ module UserRdvWizard
 
     def geo_search
       @geo_search ||= Users::GeoSearch.new(**@attributes.slice(:departement, :city_code, :street_ban_id))
-    end
-
-    def lieu_full_name
-      creneau.lieu&.full_name
     end
 
     def to_query

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -40,7 +40,7 @@ module UserRdvWizard
       @creneau ||= Users::CreneauSearch.creneau_for(
         user: @user,
         motif: @rdv.motif,
-        lieu: Lieu.find(@attributes[:lieu_id]),
+        lieu: lieu,
         starts_at: @rdv.starts_at,
         geo_search: geo_search
       )
@@ -67,6 +67,12 @@ module UserRdvWizard
 
     def save
       true
+    end
+
+    private
+
+    def lieu
+      @lieu ||= @attributes[:lieu_id].present? ? Lieu.find(@attributes[:lieu_id]) : nil
     end
   end
 

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -14,7 +14,7 @@ module AgentsHelper
     params[:step] = 2
     params[:starts_at] = creneau.starts_at
     params[:motif_id] = creneau.motif.id
-    params[:lieu_id] = creneau.lieu.id
+    params[:lieu_id] = creneau.lieu&.id
     params[:organisation_id] = creneau.motif.organisation_id
     params[:duration_in_min] = creneau.motif.default_duration_in_min
     # Pour filtrer les agents depuis la recherche de créneaux coté agent

--- a/app/helpers/lieux_helper.rb
+++ b/app/helpers/lieux_helper.rb
@@ -11,4 +11,17 @@ module LieuxHelper
                                 "badge-danger" => lieu.disabled?,
                                 "badge-info" => lieu.single_use?))
   end
+
+  def lieu_tag(lieu)
+    if lieu.nil?
+      content_tag(:span, "N/A", class: "text-muted")
+    else
+      content_tag(:span) do
+        concat lieu.name
+        concat unavailability_tag(lieu)
+        concat tag.br
+        concat content_tag(:small, lieu.address)
+      end
+    end
+  end
 end

--- a/app/helpers/lieux_helper.rb
+++ b/app/helpers/lieux_helper.rb
@@ -13,15 +13,13 @@ module LieuxHelper
   end
 
   def lieu_tag(lieu)
-    if lieu.nil?
-      content_tag(:span, "N/A", class: "text-muted")
-    else
-      content_tag(:span) do
-        concat lieu.name
-        concat unavailability_tag(lieu)
-        concat tag.br
-        concat content_tag(:small, lieu.address)
-      end
+    return if lieu.nil?
+
+    content_tag(:span) do
+      concat lieu.name
+      concat unavailability_tag(lieu)
+      concat tag.br
+      concat content_tag(:small, lieu.address)
     end
   end
 end

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -190,7 +190,7 @@ class CalendarRdvSolidarites {
     const start = moment(info.event.start).utc().format('H:mm');
     const end = moment(info.event.end).utc().format('H:mm');
 
-    if(info.isStart && info.isEnd) {
+    if (info.isStart && info.isEnd) {
       title += `${start} - ${end}`;
     } else if(info.isStart) {
       title += `À partir de ${start}`;
@@ -203,10 +203,13 @@ class CalendarRdvSolidarites {
     if (info.event.rendering == 'background') {
       $el.append("<div class=\"fc-title\" style=\"color: white; padding: 2px 4px; font-size: 12px; font-weight: bold;\">" + info.event.title + "</div>");
 
-      if(extendedProps.organisationName) {
+      if (extendedProps.organisationName) {
         title += `<br>${extendedProps.organisationName}`;
       }
-      title += `<br><strong>${info.event.title}</strong><br> <small>Lieu : ${extendedProps.lieu}</small>`;
+      title += `<br><strong>${info.event.title}</strong>`;
+      if (extendedProps.lieu) {
+        title += `<br> <small>Lieu : ${extendedProps.lieu}</small>`;
+      }
     } else {
       if (extendedProps.duration) {
         title += ` <small>(${extendedProps.duration} min)</small>`;
@@ -215,7 +218,7 @@ class CalendarRdvSolidarites {
 
       title += `<br><strong>${info.event.title}</strong>`;
 
-      if(extendedProps.organisationName) {
+      if (extendedProps.organisationName) {
         title += `<br>${extendedProps.organisationName}`;
       }
       if (extendedProps.lieu) {

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -5,6 +5,8 @@ class Creneau
 
   attr_accessor :starts_at, :lieu_id, :motif, :agent
 
+  delegate :full_name, to: :lieu, prefix: true, allow_nil: true
+
   def ends_at
     starts_at + duration_in_min.minutes
   end

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -14,7 +14,7 @@ class Creneau
   end
 
   def lieu
-    Lieu.find(lieu_id)
+    Lieu.find(lieu_id) if lieu_id.present?
   end
 
   def duration_in_min

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -173,6 +173,10 @@ class Motif < ApplicationRecord
     !collectif?
   end
 
+  def phone?
+    location_type == Motif.location_types[:phone]
+  end
+
   private
 
   def booking_delay_validation

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -173,8 +173,8 @@ class Motif < ApplicationRecord
     !collectif?
   end
 
-  def phone?
-    location_type == Motif.location_types[:phone]
+  def requires_lieu?
+    public_office?
   end
 
   private

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -31,7 +31,7 @@ class PlageOuverture < ApplicationRecord
 
   # Validations
   validate :end_after_start
-  validates :lieu, presence: true, unless: -> { phone_motifs_only? }
+  validates :lieu, presence: true, if: -> { requires_lieu? }
   validate :lieu_is_enabled
   validates :motifs, :title, presence: true
   validate :warn_overlapping_plage_ouvertures
@@ -154,7 +154,7 @@ class PlageOuverture < ApplicationRecord
     add_benign_error("Certains motifs ont une durée supérieure à la plage d'ouverture prévue")
   end
 
-  def phone_motifs_only?
-    motifs.all?(&:phone?)
+  def requires_lieu?
+    motifs.any?(&:requires_lieu?)
   end
 end

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -23,7 +23,7 @@ class PlageOuverture < ApplicationRecord
   # Relations
   belongs_to :organisation
   belongs_to :agent
-  belongs_to :lieu
+  belongs_to :lieu, optional: true
   has_and_belongs_to_many :motifs, -> { distinct }
 
   # Through relations
@@ -31,6 +31,7 @@ class PlageOuverture < ApplicationRecord
 
   # Validations
   validate :end_after_start
+  validates :lieu, presence: true, unless: -> { phone_motifs_only? }
   validate :lieu_is_enabled
   validates :motifs, :title, presence: true
   validate :warn_overlapping_plage_ouvertures
@@ -127,7 +128,9 @@ class PlageOuverture < ApplicationRecord
   end
 
   def lieu_is_enabled
-    errors.add(:lieu, :must_be_enabled) unless lieu&.enabled?
+    return if lieu.blank? || lieu.enabled?
+
+    errors.add(:lieu, :must_be_enabled)
   end
 
   def warn_overlapping_plage_ouvertures
@@ -146,5 +149,9 @@ class PlageOuverture < ApplicationRecord
     return unless overflow_motifs_duration?
 
     add_benign_error("Certains motifs ont une durée supérieure à la plage d'ouverture prévue")
+  end
+
+  def phone_motifs_only?
+    motifs.all?(&:phone?)
   end
 end

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -54,6 +54,9 @@ class PlageOuverture < ApplicationRecord
   }
   scope :reservable_online, -> { joins(:motifs).where(motifs: { reservable_online: true }) }
 
+  # Delegations
+  delegate :name, :address, :enabled?, to: :lieu, prefix: true, allow_nil: true
+
   ## -
 
   def ical_uid

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -171,7 +171,7 @@ class Rdv < ApplicationRecord
 
   def creneaux_available(date_range)
     date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
-    lieu.present? ? SlotBuilder.available_slots(motif, lieu, date_range, OffDays.all_in_date_range(date_range)) : []
+    SlotBuilder.available_slots(motif, lieu, date_range, OffDays.all_in_date_range(date_range))
   end
 
   def user_for_home_rdv

--- a/app/presenters/plage_ouverture_presenter.rb
+++ b/app/presenters/plage_ouverture_presenter.rb
@@ -21,7 +21,7 @@ class PlageOuverturePresenter
     if in_scope?
       attrs.merge!(
         path: admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture),
-        lieu_name: plage_ouverture.lieu.name,
+        lieu_name: plage_ouverture.lieu_name,
         occurrence_text: plage_ouverture_occurrence_text(plage_ouverture),
         organisation_name: plage_ouverture.organisation.name
       )

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -133,10 +133,11 @@ class SearchContext
   private
 
   def creneaux_search_for(lieu, date_range)
+    motif = lieu.present? ? matching_motifs.where(organisation: lieu.organisation).first : selected_motif
     Users::CreneauxSearch.new(
       user: @current_user,
-      motif: matching_motifs.where(organisation: lieu.organisation).first,
-      lieu: lieu,
+      motif: motif,
+      lieu: lieu, # lieu can be nil when the selected motif is phone
       date_range: date_range,
       geo_search: geo_search
     )

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -33,7 +33,7 @@ class SearchContext
       :service_selection
     elsif !motif_selected?
       :motif_selection
-    elsif lieu.nil?
+    elsif selected_motif.requires_lieu? && lieu.nil?
       :lieu_selection
     else
       :creneau_selection

--- a/app/services/search_creneaux_for_agents_base.rb
+++ b/app/services/search_creneaux_for_agents_base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SearchCreneauxForAgentsBase < BaseService
+  def initialize(agent_creneaux_search_form)
+    @form = agent_creneaux_search_form
+  end
+
+  def all_agents
+    Agent.where(id: @form.agent_ids).or(Agent.where(id: Agent.joins(:teams).where(teams: @form.team_ids)))
+  end
+end

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-class SearchCreneauxForAgentsService < BaseService
-  def initialize(agent_creneaux_search_form)
-    @form = agent_creneaux_search_form
-  end
-
+class SearchCreneauxForAgentsService < SearchCreneauxForAgentsBase
   def perform
     lieux.map { build_result(_1) }.compact # NOTE: LOOP 1 over lieux.
   end
@@ -17,11 +13,6 @@ class SearchCreneauxForAgentsService < BaseService
     return nil if creneaux.empty? && next_availability.nil?
 
     OpenStruct.new(lieu: lieu, next_availability: next_availability, creneaux: creneaux)
-  end
-
-  def all_agents
-    Agent.where(id: @form.agent_ids)
-      .or(Agent.where(id: Agent.joins(:teams).where(teams: @form.team_ids)))
   end
 
   def lieux

--- a/app/services/search_creneaux_without_lieu_for_agents_service.rb
+++ b/app/services/search_creneaux_without_lieu_for_agents_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SearchCreneauxWithoutLieuForAgentsService < SearchCreneauxForAgentsBase
+  def perform
+    # utiliser les ids des agents pour ne pas faire de requêtes supplémentaire
+    # Utilise le date_range.end + 1 pour chercher la date suivante du créneau affiché
+    next_availability = NextAvailabilityService.find(@form.motif, nil, all_agents, from: @form.date_range.end + 1.day)
+    creneaux = SlotBuilder.available_slots(@form.motif, nil, @form.date_range, OffDays.all_in_date_range(@form.date_range), all_agents)
+    return nil if creneaux.empty? && next_availability.nil?
+
+    OpenStruct.new(lieu: nil, next_availability: next_availability, creneaux: creneaux)
+  end
+end

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -15,7 +15,7 @@ module SlotBuilder
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
         .includes(%i[organisation agent])
-        .where(({ agent: agents } if agents&.any?))
+      scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?
       scope
     end

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -11,16 +11,12 @@ module SlotBuilder
     end
 
     def plage_ouvertures_for(motif, lieu, datetime_range, agents)
-      scope = PlageOuverture.not_expired
+      PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
         .includes(%i[organisation agent])
         .where(({ agent: agents } if agents&.any?))
-      if lieu
-        scope.merge(lieu.plage_ouvertures)
-      else
-        scope.where(lieu: nil)
-      end
+        .where(lieu: lieu)
     end
 
     def free_times_from(plage_ouvertures, datetime_range, off_days)

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -11,12 +11,16 @@ module SlotBuilder
     end
 
     def plage_ouvertures_for(motif, lieu, datetime_range, agents)
-      PlageOuverture.not_expired
-        .merge(lieu.plage_ouvertures)
+      scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
         .includes(%i[organisation agent])
         .where(({ agent: agents } if agents&.any?))
+      if lieu
+        scope.merge(lieu.plage_ouvertures)
+      else
+        scope.where(lieu: nil)
+      end
     end
 
     def free_times_from(plage_ouvertures, datetime_range, off_days)

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -11,12 +11,13 @@ module SlotBuilder
     end
 
     def plage_ouvertures_for(motif, lieu, datetime_range, agents)
-      PlageOuverture.not_expired
+      scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
         .includes(%i[organisation agent])
         .where(({ agent: agents } if agents&.any?))
-        .where(lieu: lieu)
+      scope = scope.where(lieu: lieu) if lieu.present?
+      scope
     end
 
     def free_times_from(plage_ouvertures, datetime_range, off_days)

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -15,7 +15,7 @@ json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
   json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
   json.extendedProps do
     json.organisationName plage_ouverture.organisation.name
-    json.location plage_ouverture.lieu&.address&.presence
-    json.lieu plage_ouverture.lieu&.name&.presence
+    json.location plage_ouverture.lieu_address
+    json.lieu plage_ouverture.lieu_name
   end
 end

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -15,7 +15,7 @@ json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
   json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
   json.extendedProps do
     json.organisationName plage_ouverture.organisation.name
-    json.location plage_ouverture.lieu.address
-    json.lieu plage_ouverture.lieu.name
+    json.location plage_ouverture.lieu&.address&.presence || "N/A"
+    json.lieu plage_ouverture.lieu&.name&.presence || "N/A"
   end
 end

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -15,7 +15,7 @@ json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
   json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
   json.extendedProps do
     json.organisationName plage_ouverture.organisation.name
-    json.location plage_ouverture.lieu&.address&.presence || "N/A"
-    json.lieu plage_ouverture.lieu&.name&.presence || "N/A"
+    json.location plage_ouverture.lieu&.address&.presence
+    json.lieu plage_ouverture.lieu&.name&.presence
   end
 end

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -83,5 +83,17 @@
         p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
         - @search_results.each do |search_result|
           = render "lieu_search_results", search_result: search_result
-    - elsif @form.motif.present?
+
+    - if @search_results_without_lieu&.creneaux&.any?
+      .container
+        p.font-weight-bold= t(".available_slots_without_lieu")
+        .card
+          .card-body
+            = render "/admin/slots/slots", \
+              lieu: nil, \
+              creneaux: @search_results_without_lieu.creneaux, \
+              form: @form, \
+              next_availability: @search_results_without_lieu.next_availability
+
+    - if @form.motif.present? && !@search_results&.any? && !@search_results_without_lieu&.creneaux&.any?
       = t(".no_slot_available", motif_name: @form.motif.name)

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -83,17 +83,5 @@
         p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
         - @search_results.each do |search_result|
           = render "lieu_search_results", search_result: search_result
-
-    - if creneaux_without_lieu?
-      .container
-        p.font-weight-bold= t(".available_slots_without_lieu")
-        .card
-          .card-body
-            = render "/admin/slots/slots", \
-              lieu: nil, \
-              creneaux: @search_results_without_lieu.creneaux, \
-              form: @form, \
-              next_availability: @search_results_without_lieu.next_availability
-
-    - if @form.motif.present? && !@search_results&.any? && !creneaux_without_lieu?
+    - elsif motif_selected?
       = t(".no_slot_available", motif_name: @form.motif.name)

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -84,7 +84,7 @@
         - @search_results.each do |search_result|
           = render "lieu_search_results", search_result: search_result
 
-    - if @search_results_without_lieu&.creneaux&.any?
+    - if creneaux_without_lieu?
       .container
         p.font-weight-bold= t(".available_slots_without_lieu")
         .card
@@ -95,5 +95,5 @@
               form: @form, \
               next_availability: @search_results_without_lieu.next_availability
 
-    - if @form.motif.present? && !@search_results&.any? && !@search_results_without_lieu&.creneaux&.any?
+    - if @form.motif.present? && !@search_results&.any? && !creneaux_without_lieu?
       = t(".no_slot_available", motif_name: @form.motif.name)

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -4,7 +4,7 @@
     = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
       = f.input :title, hint: "Uniquement visible en interne", placeholder: "Ex: Permanence PMI exceptionnelle"
-      = f.association :lieu, collection: policy_scope(Lieu).enabled.ordered_by_name, label_method: :full_name, include_blank: false
+      = f.association :lieu, collection: policy_scope(Lieu).enabled.ordered_by_name, label_method: :full_name, include_blank: true
       = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes
 
       hr

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -5,7 +5,8 @@
     span>= link_to("Plage d'ouverture #{overlapping_plage_ouverture.id}", edit_admin_organisation_plage_ouverture_path(overlapping_plage_ouverture.organisation, overlapping_plage_ouverture))
     - if local_assigns[:display_agents]
       span> de #{overlapping_plage_ouverture.agent.full_name}
-    span> à #{overlapping_plage_ouverture.lieu.name}
+    - if overlapping_plage_ouverture.lieu.present?
+      span> à #{overlapping_plage_ouverture.lieu&.name}
     = plage_ouverture_occurrence_text(overlapping_plage_ouverture)
     - if overlapping_plage_ouverture.organisation != current_organisation
       span>= "(Organisation #{overlapping_plage_ouverture.organisation.name})"

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -6,7 +6,7 @@
     - if local_assigns[:display_agents]
       span> de #{overlapping_plage_ouverture.agent.full_name}
     - if overlapping_plage_ouverture.lieu.present?
-      span> à #{overlapping_plage_ouverture.lieu&.name}
+      span> à #{overlapping_plage_ouverture.lieu_name}
     = plage_ouverture_occurrence_text(overlapping_plage_ouverture)
     - if overlapping_plage_ouverture.organisation != current_organisation
       span>= "(Organisation #{overlapping_plage_ouverture.organisation.name})"

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -11,10 +11,7 @@ tr
       - plage_ouverture.motifs.each do |motif|
         li= motif_name_with_location_type_and_badges(motif)
   td
-    = plage_ouverture.lieu.name
-    = unavailability_tag(plage_ouverture.lieu)
-    br
-    small= plage_ouverture.lieu.address
+    = lieu_tag(plage_ouverture.lieu)
   td
     - if plage_ouverture.recurrence.present?
       = sanitize(display_recurrence(plage_ouverture).join("<br/>"))

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -28,10 +28,7 @@
           span= @plage_ouverture.agent.full_name
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Lieu :
-          span
-            = @plage_ouverture.lieu.name
-            = unavailability_tag(@plage_ouverture.lieu)
-            = " (#{@plage_ouverture.lieu.address})"
+          = lieu_tag(@plage_ouverture.lieu)
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Motifs :
           ul.pl-3.mb-0

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -33,5 +33,7 @@ ruby:
               = t(".existing_lieu_hint_html")
       - elsif @rdv.home?
         = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}"
+      - elsif @rdv.phone?
+        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique"
       = f.association :agents, collection: @rdv.motif.authorized_agents.includes(:service), label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input" }
       = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/slots/_slots.html.slim
+++ b/app/views/admin/slots/_slots.html.slim
@@ -1,6 +1,6 @@
-- search_params = creneaux_search_params(form).merge(lieu_ids: [lieu.id])
+- search_params = lieu.present? ? creneaux_search_params(form).merge(lieu_ids: [lieu.id]) : creneaux_search_params(form)
 
-div id="creneaux-lieu-#{lieu.id}"
+div id="creneaux-lieu-#{lieu&.id}"
   .row
     - if form.date_range.begin > Time.zone.today
       - previous_from_date = form.date_range.begin - 7.days

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -1,15 +1,10 @@
 .card
   .card-header
-    .d-flex.justify-content-between.flex-wrap
-      span
-        h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
-        - if @form.motif.requires_lieu?
-          = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
-        - else
-          = t(@form.motif.location_type)
-      span
-        = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,
-                creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"
+    h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
+    - if @form.motif.requires_lieu?
+      = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
+    - else
+      = t(@form.motif.location_type)
 
   - if @form.motif.individuel?
     .card-body

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -3,7 +3,10 @@
     .d-flex.justify-content-between.flex-wrap
       span
         h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
-        = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
+        - if @form.motif.requires_lieu?
+          = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
+        - else
+          = t(@form.motif.location_type)
       span
         = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,
                 creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -12,9 +12,9 @@
     span.title Lieu :
     span.float-right
       -if plage_ouverture.lieu.present?
-        = plage_ouverture.lieu.name
-        = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu.enabled?
-        = " (#{plage_ouverture.lieu.address})"
+        = plage_ouverture.lieu_name
+        = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu_enabled?
+        = " (#{plage_ouverture.lieu_address})"
     .clear
   div.row-result
     span.title Motifs :

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -11,9 +11,12 @@
   div.row-result
     span.title Lieu :
     span.float-right
-      = plage_ouverture.lieu.name
-      = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu.enabled?
-      = " (#{plage_ouverture.lieu.address})"
+      -if plage_ouverture.lieu.present?
+        = plage_ouverture.lieu.name
+        = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu.enabled?
+        = " (#{plage_ouverture.lieu.address})"
+      -else
+        | N/A
     .clear
   div.row-result
     span.title Motifs :

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -15,8 +15,6 @@
         = plage_ouverture.lieu.name
         = tag.span("Fermé", class: "badge badge-danger") unless plage_ouverture.lieu.enabled?
         = " (#{plage_ouverture.lieu.address})"
-      -else
-        | N/A
     .clear
   div.row-result
     span.title Motifs :

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -6,9 +6,10 @@ section.bg-light.p-4
           h2.py-1.my-1
             i.fa.fa-info-circle>
             = motif_name_with_location_type(context.selected_motif)
-            .card-subtitle.my-2.
-              i.fa.fa-map-marker-alt>
-              = context.lieu.address
+            - if context.lieu.present?
+              .card-subtitle.my-2.
+                i.fa.fa-map-marker-alt>
+                = context.lieu.address
 
     - else
       .card.card-hoverable
@@ -21,15 +22,16 @@ section.bg-light.p-4
                 h2.pb-1.mb-1
                   = motif_name_with_location_type(context.selected_motif)
                 = context.selected_motif.service.name
-      .card.card-hoverable
-        .card-body
-          = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
-            .row
-              .col-auto.align-self-center
-                i.fa.fa-chevron-left
-              .col
-                h2.pb-1.mb-1.card-title= context.lieu.name
-                .card-subtitle= context.lieu.address
+      - if context.lieu.present?
+        .card.card-hoverable
+          .card-body
+            = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+              .row
+                .col-auto.align-self-center
+                  i.fa.fa-chevron-left
+                .col
+                  h2.pb-1.mb-1.card-title= context.lieu.name
+                  .card-subtitle= context.lieu.address
     h3.font-weight-bold = "Sélectionnez un créneau :"
     .card.mb-3
       .card-body

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -1,4 +1,4 @@
-div id="creneaux-lieu-#{lieu.id}"
+div id="creneaux-lieu-#{lieu&.id}"
   .row
     - previous_from_date = date_range.begin - 7.days
     - if date_range.begin > Time.zone.today

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -12,6 +12,10 @@ ul.list-group.list-group-flush
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | RDV téléphonique
+  - elsif rdv_wizard.motif.home?
+    li.list-group-item
+      i.fa.fa-check.fa-fw.mr-1.text-success
+      | RDV à domicile
   - else
     li.list-group-item
       .row

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -31,7 +31,6 @@ fr:
         select_placeholder_single_use_lieu: Lieu ponctuel
     slots:
       index:
-        place_index: Revenir aux filtres
         available_slots_title_html: Créneaux disponibles pour <strong>%{motif}</strong>
         place_informations_html: <strong>%{place_name}</strong> <small>au %{place_address}</small>
     creneaux:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -88,7 +88,7 @@ fr:
         plage_ouverture:
           attributes:
             lieu:
-              blank: est obligatoire pour les motifs sur place ou à domicile
+              blank: est obligatoire pour les motifs sur place
   agents:
     export_mailer:
       rdv_export:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,8 +43,9 @@ fr:
           search_for_slots_subtitle: pour %{users_fullname}
           available_places_with_slots:
             zero: Aucun lieu ne propose de disponibilité
-            one: Un lieu propose des disponibilités
-            other: "%{count} lieux proposent des disponibilités"
+            one: "Un lieu propose des disponibilités :"
+            other: "%{count} lieux proposent des disponibilités :"
+          available_slots_without_lieu: "Ces créneaux sont disponibles sans lieu :"
     territories:
       agents:
         index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -45,7 +45,6 @@ fr:
             zero: Aucun lieu ne propose de disponibilité
             one: "Un lieu propose des disponibilités :"
             other: "%{count} lieux proposent des disponibilités :"
-          available_slots_without_lieu: "Ces créneaux sont disponibles sans lieu :"
     territories:
       agents:
         index:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -86,6 +86,10 @@ fr:
           attributes:
             agents:
               not_from_same_territory: doivent être du même territoire
+        plage_ouverture:
+          attributes:
+            lieu:
+              blank: est obligatoire pour les motifs sur place ou à domicile
   agents:
     export_mailer:
       rdv_export:

--- a/db/migrate/20220928093221_remove_plage_ouvertures_lieu_null_constraint.rb
+++ b/db/migrate/20220928093221_remove_plage_ouvertures_lieu_null_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemovePlageOuverturesLieuNullConstraint < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:plage_ouvertures, :lieu_id, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -391,7 +391,7 @@ ActiveRecord::Schema.define(version: 2022_10_06_081447) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "recurrence"
-    t.bigint "lieu_id", null: false
+    t.bigint "lieu_id"
     t.boolean "expired_cached", default: false
     t.datetime "recurrence_ends_at"
     t.index "tsrange((first_day)::timestamp without time zone, recurrence_ends_at, '[]'::text)", name: "index_plage_ouvertures_on_tsrange_first_day_recurrence_ends_at", using: :gist

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -727,6 +727,17 @@ _plage_ouverture_org_paris_nord_martine_classique = PlageOuverture.create!(
   end_time: Tod::TimeOfDay.new(12),
   recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday])
 )
+_plage_ouverture_org_paris_nord_martine_telephonique = PlageOuverture.create!(
+  title: "Permanence téléphonique",
+  organisation_id: org_paris_nord.id,
+  agent_id: agent_org_paris_nord_pmi_martine.id,
+  lieu_id: nil,
+  motif_ids: [motif_org_paris_nord_pmi_rappel.id],
+  first_day: Date.tomorrow,
+  start_time: Tod::TimeOfDay.new(12),
+  end_time: Tod::TimeOfDay.new(14),
+  recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday])
+)
 _plage_ouverture_org_paris_nord_martine_mercredi = PlageOuverture.create!(
   title: "Permanence enfant",
   organisation_id: org_paris_nord.id,

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -4,20 +4,28 @@ RSpec.describe Users::RdvsController, type: :controller do
   render_views
 
   describe "POST create" do
-    subject do
-      post :create, params: {
-        organisation_id: organisation.id, lieu_id: lieu.id, departement: "12", city_code: "12100", where: "1 rue de la, ville 12345",
-        motif_id: motif.id, starts_at: starts_at, organisation_ids: [organisation.id], invitation_token: "44444",
-      }
-    end
+    subject { post :create, params: params }
 
-    let!(:organisation) { create(:organisation) }
+    let(:organisation) { create(:organisation) }
     let(:user) { create(:user) }
     let(:motif) { create(:motif, organisation: organisation) }
     let(:lieu) { create(:lieu, organisation: organisation) }
     let(:starts_at) { DateTime.parse("2020-10-20 10h30") }
     let(:mock_geo_search) { instance_double(Users::GeoSearch) }
     let(:token) { "12345" }
+    let(:params) do
+      {
+        organisation_id: organisation.id,
+        lieu_id: lieu&.id,
+        departement: "12",
+        city_code: "12100",
+        where: "1 rue de la, ville 12345",
+        motif_id: motif.id,
+        starts_at: starts_at,
+        organisation_ids: [organisation.id],
+        invitation_token: "44444",
+      }
+    end
 
     before do
       travel_to(Time.zone.local(2019, 7, 20))
@@ -44,6 +52,17 @@ RSpec.describe Users::RdvsController, type: :controller do
         expect(Rdv.count).to eq(1)
         expect(response).to redirect_to users_rdv_path(Rdv.last, invitation_token: token)
         expect(user.rdvs.last.created_by_user?).to be(true)
+      end
+
+      context "when the motif is by phone and lieu is missing" do
+        let(:motif) { create(:motif, :by_phone, organisation: organisation) }
+        let(:lieu) { nil }
+
+        it "creates the rdv" do
+          expect(Rdv.count).to eq(1)
+          expect(response).to redirect_to users_rdv_path(Rdv.last, invitation_token: token)
+          expect(user.rdvs.last.created_by_user?).to be(true)
+        end
       end
     end
 
@@ -79,6 +98,22 @@ RSpec.describe Users::RdvsController, type: :controller do
         sign_in rdv.users.first
         put :cancel, params: { id: rdv.id }
         expect(response).to redirect_to users_rdv_path(rdv, invitation_token: token)
+      end
+
+      context "when the motif is by phone and lieu is missing" do
+        let(:rdv) { create(:rdv, motif: create(:motif, :by_phone), lieu: nil, starts_at: 5.hours.from_now) }
+
+        before { sign_in rdv.users.first }
+
+        it "calls update_and_notify function" do
+          expect_any_instance_of(Rdv).to receive(:update_and_notify).with(rdv.users.first, status: "excused").and_call_original
+          put :cancel, params: { id: rdv.id }
+        end
+
+        it "redirects to the rdv" do
+          put :cancel, params: { id: rdv.id }
+          expect(response).to redirect_to users_rdv_path(rdv, invitation_token: token)
+        end
       end
 
       context "when rdv is not cancellable" do
@@ -128,6 +163,20 @@ RSpec.describe Users::RdvsController, type: :controller do
       expect(response.body).to match(/Le mardi 20 octobre 2020/)
       expect(response.body).to match(/Déplacer le RDV/)
       expect(response.body).to match(/Annuler le RDV/)
+    end
+
+    context "when the motif is by phone and lieu is missing" do
+      let(:rdv) { create(:rdv, users: [user], motif: create(:motif, :by_phone), lieu: nil, starts_at: starts_at, created_by: "user") }
+
+      it "shows the rdv" do
+        get :show, params: { id: rdv.id }
+
+        expect(response).to be_successful
+        expect(response.body).to match(/Votre RDV/)
+        expect(response.body).to match(/Le mardi 20 octobre 2020/)
+        expect(response.body).to match(/Déplacer le RDV/)
+        expect(response.body).to match(/Annuler le RDV/)
+      end
     end
 
     context "when the rdv is past" do
@@ -226,8 +275,9 @@ RSpec.describe Users::RdvsController, type: :controller do
     subject { get :index }
 
     let!(:user) { create(:user) }
-    let!(:rdv1) { create(:rdv, users: [user], starts_at:  5.days.from_now) }
-    let!(:rdv2) { create(:rdv, users: [user], starts_at:  4.days.from_now) }
+    let!(:rdv1) { create(:rdv, users: [user], starts_at: 5.days.from_now) }
+    let!(:rdv2) { create(:rdv, users: [user], starts_at: 4.days.from_now) }
+    let!(:rdv3) { create(:rdv, motif: create(:motif, :by_phone), lieu: nil, users: [user], starts_at: 3.days.from_now) }
 
     context "when signed in" do
       before { sign_in user }
@@ -238,6 +288,7 @@ RSpec.describe Users::RdvsController, type: :controller do
         expect(response).to be_successful
         expect(response.body).to include(I18n.l(rdv1.starts_at, format: :human).to_s)
         expect(response.body).to include(I18n.l(rdv2.starts_at, format: :human).to_s)
+        expect(response.body).to include(I18n.l(rdv3.starts_at, format: :human).to_s)
       end
 
       context "when looking at rdvs on a different domain name" do
@@ -357,6 +408,14 @@ RSpec.describe Users::RdvsController, type: :controller do
 
       it { expect(response.body).to include("Modification du Rendez-vous") }
       it { expect(response.body).to include("Confirmer le nouveau créneau") }
+
+      context "when the motif is by phone and lieu is missing" do
+        let(:motif) { create(:motif, :by_phone, organisation: organisation) }
+        let(:lieu) { nil }
+
+        it { expect(response.body).to include("Modification du Rendez-vous") }
+        it { expect(response.body).to include("Confirmer le nouveau créneau") }
+      end
     end
 
     context "creneau isn't available" do
@@ -408,6 +467,19 @@ RSpec.describe Users::RdvsController, type: :controller do
         expect(flash[:success]).to eq("Votre RDV a bien été modifié")
         expect(rdv.reload.starts_at).to eq(starts_at)
         expect(rdv.reload.agent_ids).to eq([agent.id])
+      end
+
+      context "when the motif is by phone and lieu is missing" do
+        let(:motif) { create(:motif, :by_phone, organisation: organisation) }
+        let(:lieu) { nil }
+
+        it "respond success and update RDV" do
+          put :update, params: { id: rdv.id, starts_at: starts_at, agent_id: agent.id }
+          expect(response).to redirect_to(users_rdv_path(rdv, invitation_token: token))
+          expect(flash[:success]).to eq("Votre RDV a bien été modifié")
+          expect(rdv.reload.starts_at).to eq(starts_at)
+          expect(rdv.reload.agent_ids).to eq([agent.id])
+        end
       end
 
       context "when it cannot be updated" do

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -35,7 +35,15 @@ FactoryBot.define do
     end
 
     after(:build) do |plage_ouverture|
-      plage_ouverture.motifs << create(:motif, organisation: plage_ouverture.organisation) if plage_ouverture.motifs.empty?
+      if plage_ouverture.motifs.empty?
+        plage_ouverture.motifs << (
+          if plage_ouverture.lieu
+            create(:motif, organisation: plage_ouverture.organisation)
+          else
+            create(:motif, :by_phone, organisation: plage_ouverture.organisation)
+          end
+        )
+      end
     end
 
     trait :expired do

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -60,14 +60,8 @@ describe "Agent can create a Rdv with creneau search" do
         select(motif.name, from: "motif_id")
         click_button("Afficher les créneaux")
 
-        # Display plage d'ouvertures with lieu
-        expect(page).to have_content(plage_ouverture.lieu_address)
-
-        # Display plage d'ouvertures without lieu
-        expect(page).to have_content("Ces créneaux sont disponibles sans lieu")
-
         find(".creneau", match: :first).click
-        expect(page).to have_content("Nouveau RDV pour le #{I18n.l(plage_ouverture_without_lieu.first_day, format: :default)} à 08:00")
+        expect(page).to have_content("Nouveau RDV")
       end
     end
 

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -3,29 +3,17 @@
 describe "Agent can create a Rdv with creneau search" do
   include UsersHelper
 
-  before do
-    travel_to(now)
-    login_as(agent, scope: :agent)
-  end
+  before { login_as(agent, scope: :agent) }
 
   let!(:organisation) { create(:organisation) }
-  let!(:lieu) { create(:lieu, organisation: organisation) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
-  context "default" do
-    let!(:organisation) { create(:organisation) }
-    let!(:service) { create(:service) }
-    let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }
-    let!(:agent2) { create(:agent, first_name: "Robert", last_name: "Voila", service: service, basic_role_in_organisations: [organisation]) }
-    let!(:agent3) { create(:agent, first_name: "Michel", last_name: "Lapin", service: service, basic_role_in_organisations: [organisation]) }
-    let!(:motif) { create(:motif, reservable_online: true, service: service, organisation: organisation) }
-    let!(:user) { create(:user, organisations: [organisation]) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, agent: agent, organisation: organisation) }
-    let!(:lieu2) { create(:lieu, organisation: organisation) }
-    let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu2, agent: agent2, organisation: organisation) }
-    let!(:plage_ouverture3) { create(:plage_ouverture, :daily, first_day: Date.new(2019, 7, 22), motifs: [motif], lieu: lieu, agent: agent3, organisation: organisation) }
-    let(:now) { Time.zone.local(2019, 7, 22) }
+  context "when there are multiple plage d'ouverture and lieux" do
+    let!(:motif) { create(:motif, reservable_online: true, service: agent.service, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], agent: agent, organisation: organisation) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], organisation: organisation) }
 
-    it "default", js: true do
+    it "displays lieux and allow filtering on lieux", js: true do
       visit admin_organisation_agent_searches_path(organisation)
       expect(page).to have_content("Trouver un RDV")
       select(motif.name, from: "motif_id")
@@ -36,7 +24,7 @@ describe "Agent can create a Rdv with creneau search" do
       expect(page).to have_content(plage_ouverture2.lieu.address)
 
       # Add a filter on lieu
-      select(lieu.name, from: "lieu_ids")
+      select(plage_ouverture.lieu.name, from: "lieu_ids")
       click_button("Afficher les créneaux")
       expect(page).to have_content(plage_ouverture.lieu.address)
       expect(page).not_to have_content(plage_ouverture2.lieu.address)
@@ -46,12 +34,8 @@ describe "Agent can create a Rdv with creneau search" do
   end
 
   context "when the motif is bookable online and the next creneau is after the max booking delay" do
-    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-
     let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, max_booking_delay: 7.days, service: agent.service) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation) }
-
-    let(:now) { Time.zone.parse("2021-12-13 8:00") }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: 8.days.since, motifs: [motif], organisation: organisation) }
 
     it "still allows the agent to book a rdv, because the booking delays should only apply to agents", js: true do
       visit admin_organisation_agent_searches_path(organisation)
@@ -62,6 +46,28 @@ describe "Agent can create a Rdv with creneau search" do
       # Display results
       expect(page).to have_content(plage_ouverture.lieu.address)
       expect(page).to have_content("Créneaux disponibles")
+    end
+  end
+
+  context "when the motif is by phone and there is a plage d'ouverture without lieu" do
+    let!(:motif) { create(:motif, :by_phone, reservable_online: true, service: agent.service, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Time.zone.today, motifs: [motif], agent: agent, organisation: organisation) }
+    let!(:plage_ouverture_without_lieu) { create(:plage_ouverture, motifs: [motif], lieu: nil, organisation: organisation) }
+
+    it "stills allows the agent to book a rdv", js: true do
+      visit admin_organisation_agent_searches_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      select(motif.name, from: "motif_id")
+      click_button("Afficher les créneaux")
+
+      # Display plage d'ouvertures with lieu
+      expect(page).to have_content(plage_ouverture.lieu.address)
+
+      # Display plage d'ouvertures without lieu
+      expect(page).to have_content("Ces créneaux sont disponibles sans lieu")
+
+      find(".creneau", match: :first).click
+      expect(page).to have_content("Nouveau RDV pour le #{I18n.l(plage_ouverture_without_lieu.first_day, format: :default)} à 08:00")
     end
   end
 end

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -20,14 +20,14 @@ describe "Agent can create a Rdv with creneau search" do
       click_button("Afficher les créneaux")
 
       # Display results for both lieux
-      expect(page).to have_content(plage_ouverture.lieu.address)
-      expect(page).to have_content(plage_ouverture2.lieu.address)
+      expect(page).to have_content(plage_ouverture.lieu_address)
+      expect(page).to have_content(plage_ouverture2.lieu_address)
 
       # Add a filter on lieu
-      select(plage_ouverture.lieu.name, from: "lieu_ids")
+      select(plage_ouverture.lieu_name, from: "lieu_ids")
       click_button("Afficher les créneaux")
-      expect(page).to have_content(plage_ouverture.lieu.address)
-      expect(page).not_to have_content(plage_ouverture2.lieu.address)
+      expect(page).to have_content(plage_ouverture.lieu_address)
+      expect(page).not_to have_content(plage_ouverture2.lieu_address)
 
       # TODO : refaire un parcours jusqu'à l'enregistrement du RDV
     end
@@ -44,7 +44,7 @@ describe "Agent can create a Rdv with creneau search" do
       click_button("Afficher les créneaux")
 
       # Display results
-      expect(page).to have_content(plage_ouverture.lieu.address)
+      expect(page).to have_content(plage_ouverture.lieu_address)
       expect(page).to have_content("Créneaux disponibles")
     end
   end
@@ -61,7 +61,7 @@ describe "Agent can create a Rdv with creneau search" do
       click_button("Afficher les créneaux")
 
       # Display plage d'ouvertures with lieu
-      expect(page).to have_content(plage_ouverture.lieu.address)
+      expect(page).to have_content(plage_ouverture.lieu_address)
 
       # Display plage d'ouvertures without lieu
       expect(page).to have_content("Ces créneaux sont disponibles sans lieu")

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -42,7 +42,7 @@ describe "Agent can CRUD plage d'ouverture" do
       expect_page_title("Nouvelle plage d'ouverture")
 
       fill_in "Description", with: "Accueil"
-      select(lieu.full_name, from: "plage_ouverture_lieu_id")
+      select(lieu.full_name, from: "plage_ouverture_lieu_id") if lieu
       check "Suivi bonjour"
       click_button "Enregistrer"
 
@@ -58,6 +58,13 @@ describe "Agent can CRUD plage d'ouverture" do
       expect(page).not_to have_css("#calendar")
       click_link("Vue calendrier")
       expect(page).to have_css("#calendar")
+    end
+
+    context "when the motif doesn't require a lieu" do
+      let!(:motif) { create(:motif, :at_home, name: "Suivi bonjour", service: service, organisation: organisation) }
+      let!(:lieu) { nil }
+
+      it_behaves_like "can crud own plage ouvertures"
     end
   end
 
@@ -75,6 +82,13 @@ describe "Agent can CRUD plage d'ouverture" do
       let!(:plage_ouverture) { create(:plage_ouverture, lieu: lieu, agent: agent, motifs: [motif], organisation: organisation, title: "Permanence") }
 
       it_behaves_like "can crud own plage ouvertures"
+
+      context "when the motif doesn't require a lieu" do
+        let!(:motif) { create(:motif, :at_home, :for_secretariat, name: "Suivi bonjour", service: service, organisation: organisation) }
+        let!(:lieu) { nil }
+
+        it_behaves_like "can crud own plage ouvertures"
+      end
     end
   end
 
@@ -111,6 +125,41 @@ describe "Agent can CRUD plage d'ouverture" do
 
       expect_page_title("Accueil")
       click_link "Modifier"
+    end
+
+    context "when the motif doesn't require a lieu" do
+      let!(:motif) { create(:motif, :at_home, name: "Suivi bonjour", service: service, organisation: organisation) }
+      let!(:lieu) { nil }
+
+      it "still can crud a plage_ouverture" do
+        visit admin_organisation_agent_plage_ouvertures_path(organisation, other_agent.id)
+
+        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        click_link "Permanence"
+
+        expect_page_title("Permanence")
+        click_link "Modifier"
+
+        expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
+        fill_in "Description", with: "La belle plage"
+        click_button("Enregistrer")
+
+        expect_page_title("La belle plage")
+        click_link("Supprimer")
+
+        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
+
+        click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
+
+        expect_page_title("Nouvelle plage d'ouverture")
+        fill_in "Description", with: "Accueil"
+        check "Suivi bonjour"
+        click_button "Enregistrer"
+
+        expect_page_title("Accueil")
+        click_link "Modifier"
+      end
     end
   end
 end

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -42,6 +42,7 @@ describe "Agent can CRUD plage d'ouverture" do
       expect_page_title("Nouvelle plage d'ouverture")
 
       fill_in "Description", with: "Accueil"
+      select(lieu.full_name, from: "plage_ouverture_lieu_id")
       check "Suivi bonjour"
       click_button "Enregistrer"
 
@@ -104,6 +105,7 @@ describe "Agent can CRUD plage d'ouverture" do
 
       expect_page_title("Nouvelle plage d'ouverture")
       fill_in "Description", with: "Accueil"
+      select(lieu.full_name, from: "plage_ouverture_lieu_id")
       check "Suivi bonjour"
       click_button "Enregistrer"
 

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -8,7 +8,7 @@ describe "User can search for rdvs" do
   let(:service) { create(:service) }
   let!(:motif) { create(:motif, name: "Vaccination", reservable_online: true, organisation: organisation, restriction_for_rdv: nil, service: service) }
   let!(:autre_motif) { create(:motif, name: "Consultation", reservable_online: true, organisation: organisation, restriction_for_rdv: nil, service: service) }
-  let!(:motif_autre_service) { create(:motif, name: "Autre consultation", reservable_online: true, organisation: organisation, restriction_for_rdv: nil, service: create(:service)) }
+  let!(:motif_autre_service) { create(:motif, :by_phone, name: "Télé consultation", reservable_online: true, organisation: organisation, restriction_for_rdv: nil, service: create(:service)) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
   let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [autre_motif], lieu: lieu, organisation: organisation) }
@@ -18,91 +18,132 @@ describe "User can search for rdvs" do
 
   around { |example| perform_enqueued_jobs { example.run } }
 
-  before { travel_to(now) }
+  before do
+    travel_to(now)
+    stub_netsize_ok
+  end
 
   describe "default" do
     it "default", js: true do
       visit root_path
-      # Step 1
-      expect_page_h1("Prenez rendez-vous en ligne\navec votre département")
-      fill_in("search_where", with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
-
-      # fake algolia autocomplete to pass on Circle ci
-      page.execute_script("document.querySelector('#search_departement').value = '92'")
-      page.execute_script("document.querySelector('#search_submit').disabled = false")
-
-      click_button("Rechercher")
-
-      # Step 3
-      expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
-      expect(page).to have_content("Vous souhaitez prendre un RDV avec le service :")
-      find("h3", text: motif.service.name).click
-
-      expect(page).to have_content("Sélectionnez le motif de votre RDV")
-      find("h3", text: motif.name).click
-
-      # Step 4
-      expect(page).to have_content(lieu.name)
-      expect(page).to have_content(lieu2.name)
-
-      # Step 5
-      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
-      expect(page).to have_content(lieu.name)
-      first(:link, "11:00").click
-
-      # Login page
-      click_link("Je m'inscris")
-
-      # Sign up page
-      expect(page).to have_content("Inscription")
-      fill_in(:user_first_name, with: "Michel")
-      fill_in(:user_last_name, with: "Lapin")
-      fill_in("Email", with: "michel@lapin.fr")
-      click_button("Je m'inscris")
-
-      # Confirmation email
-      open_email("michel@lapin.fr")
-      expect(current_email).to have_content("Merci pour votre inscription")
-      current_email.click_link("Confirmer mon compte")
-
-      # Password reset page after confirmation
-      expect(page).to have_content("Votre compte a été validé")
-      expect(page).to have_content("Définir mon mot de passe")
-      fill_in(:password, with: "12345678")
-      click_button("Enregistrer")
-
-      # Step 4
-      expect(page).to have_content("Vos informations")
-      fill_in("Date de naissance", with: DateTime.yesterday.strftime("%d/%m/%Y"))
-      fill_in("Nom de naissance", with: "Lapinou")
-      click_button("Continuer")
-
-      # Step 5
-      expect(page).to have_content("Vaccination")
-      expect(page).to have_content("Michel LAPIN (Lapinou)")
-
-      # Add relative
-      click_link("Ajouter un proche")
-      expect(page).to have_selector("h1", text: "Ajouter un proche")
-      fill_in("Prénom", with: "Mathieu")
-      fill_in("Nom", with: "Lapin")
-      fill_in("Date de naissance", with: Date.yesterday)
-      click_button("Enregistrer")
-      expect(page).to have_content("Mathieu LAPIN")
-
-      click_button("Continuer")
-
-      # Step 6
-      expect(page).to have_content("Informations de contact")
-      expect(page).to have_content("Mathieu LAPIN")
-      click_link("Confirmer mon RDV")
-
-      # Step 7
-      expect(page).to have_content("Vos rendez-vous")
-      expect(page).to have_content(lieu.address)
-      expect(page).to have_content(motif.name)
-      expect(page).to have_content("11h00")
+      execute_search
+      choose_service(motif.service)
+      choose_motif(motif)
+      choose_lieu(lieu)
+      choose_creneau
+      sign_up
+      continue_to_rdv(motif)
+      add_relative
+      confirm_rdv(motif, lieu)
     end
+
+    it "can take a RDV when there are creneaux without lieu", js: true do
+      create(:plage_ouverture, lieu: nil, motifs: [motif_autre_service], organisation: organisation, first_day: 1.day.since)
+
+      visit root_path
+      execute_search
+      choose_service(motif_autre_service.service)
+      choose_creneau
+      sign_up
+      continue_to_rdv(motif_autre_service)
+      add_relative
+      confirm_rdv(motif_autre_service)
+    end
+  end
+
+  private
+
+  def execute_search
+    expect_page_h1("Prenez rendez-vous en ligne\navec votre département")
+    fill_in("search_where", with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
+
+    # fake algolia autocomplete to pass on Circle ci
+    page.execute_script("document.querySelector('#search_departement').value = '92'")
+    page.execute_script("document.querySelector('#search_submit').disabled = false")
+
+    click_button("Rechercher")
+  end
+
+  def choose_service(service)
+    expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
+    expect(page).to have_content("Vous souhaitez prendre un RDV avec le service :")
+
+    find("h3", text: service.name).click
+  end
+
+  def choose_motif(motif)
+    expect(page).to have_content("Sélectionnez le motif de votre RDV")
+    find("h3", text: motif.name).click
+  end
+
+  def choose_lieu(lieu)
+    expect(page).to have_content(lieu.name)
+    expect(page).to have_content(lieu2.name)
+
+    find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
+
+    expect(page).to have_content(lieu.name)
+  end
+
+  def choose_creneau
+    first(:link, "11:00").click
+  end
+
+  def sign_up
+    # Login page
+    click_link("Je m'inscris")
+
+    # Sign up page
+    expect(page).to have_content("Inscription")
+    fill_in(:user_first_name, with: "Michel")
+    fill_in(:user_last_name, with: "Lapin")
+    fill_in("Email", with: "michel@lapin.fr")
+    fill_in("Téléphone", with: "0612345678")
+    click_button("Je m'inscris")
+
+    # Confirmation email
+    open_email("michel@lapin.fr")
+    expect(current_email).to have_content("Merci pour votre inscription")
+    current_email.click_link("Confirmer mon compte")
+
+    # Password reset page after confirmation
+    expect(page).to have_content("Votre compte a été validé")
+    expect(page).to have_content("Définir mon mot de passe")
+    fill_in(:password, with: "12345678")
+    click_button("Enregistrer")
+  end
+
+  def continue_to_rdv(motif)
+    expect(page).to have_content("Vos informations")
+    fill_in("Date de naissance", with: DateTime.yesterday.strftime("%d/%m/%Y"))
+    fill_in("Nom de naissance", with: "Lapinou")
+    click_button("Continuer")
+
+    expect(page).to have_content(motif.name)
+    expect(page).to have_content("Michel LAPIN (Lapinou)")
+  end
+
+  def add_relative
+    click_link("Ajouter un proche")
+    expect(page).to have_selector("h1", text: "Ajouter un proche")
+    fill_in("Prénom", with: "Mathieu")
+    fill_in("Nom", with: "Lapin")
+    fill_in("Date de naissance", with: Date.yesterday)
+    click_button("Enregistrer")
+    expect(page).to have_content("Mathieu LAPIN")
+
+    click_button("Continuer")
+  end
+
+  def confirm_rdv(motif, lieu = nil)
+    expect(page).to have_content("Informations de contact")
+    expect(page).to have_content("Mathieu LAPIN")
+    click_link("Confirmer mon RDV")
+
+    expect(page).to have_content("Votre RDV")
+    expect(page).to have_content(lieu.address) if lieu.present?
+    expect(page).to have_content(motif.name)
+    expect(page).to have_content("11h00")
   end
 
   def expect_page_h1(title)

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -37,17 +37,33 @@ describe "User can search for rdvs" do
       confirm_rdv(motif, lieu)
     end
 
-    it "can take a RDV when there are creneaux without lieu", js: true do
-      create(:plage_ouverture, lieu: nil, motifs: [motif_autre_service], organisation: organisation, first_day: 1.day.since)
+    context "when the motif doesn't require a lieu" do
+      before { create(:plage_ouverture, lieu: nil, motifs: [motif_autre_service], organisation: organisation, first_day: 1.day.since) }
 
-      visit root_path
-      execute_search
-      choose_service(motif_autre_service.service)
-      choose_creneau
-      sign_up
-      continue_to_rdv(motif_autre_service)
-      add_relative
-      confirm_rdv(motif_autre_service)
+      shared_examples "take a rdv without lieu" do
+        it "can take a RDV when there are creneaux without lieu", js: true do
+          visit root_path
+          execute_search
+          choose_service(motif_autre_service.service)
+          choose_creneau
+          sign_up
+          continue_to_rdv(motif_autre_service)
+          add_relative
+          confirm_rdv(motif_autre_service)
+        end
+      end
+
+      context "when the motif is by phone" do
+        let!(:motif_autre_service) { create(:motif, :by_phone, name: "Télé consultation", reservable_online: true, organisation: organisation, restriction_for_rdv: nil, service: create(:service)) }
+
+        it_behaves_like "take a rdv without lieu"
+      end
+
+      context "when the motif is at home" do
+        let!(:motif_autre_service) { create(:motif, :at_home, name: "À domicile", reservable_online: true, organisation: organisation, restriction_for_rdv: nil, service: create(:service)) }
+
+        it_behaves_like "take a rdv without lieu"
+      end
     end
   end
 

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -8,20 +8,20 @@ describe UserRdvWizard do
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: DateTime.parse("2020-10-20 09h30")) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
-  let(:mock_geo_search) { instance_double(Users::GeoSearch) }
-
-  let(:attributes) do
-    {
-      starts_at: creneau.starts_at,
-      motif_id: motif.id,
-      lieu_id: lieu.id,
-      user_ids: [user_for_rdv.id],
-      departement: "62",
-      city_code: "62100",
-    }
-  end
 
   describe "#new" do
+    let(:mock_geo_search) { instance_double(Users::GeoSearch) }
+    let(:attributes) do
+      {
+        starts_at: creneau.starts_at,
+        motif_id: motif.id,
+        lieu_id: lieu.id,
+        user_ids: [user_for_rdv.id],
+        departement: "62",
+        city_code: "62100",
+      }
+    end
+
     it "works" do
       returned_creneau = Creneau.new
 
@@ -42,43 +42,75 @@ describe UserRdvWizard do
   end
 
   describe "Step1#save" do
-    it "return true when everything is ok" do
-      motif = create(:motif, :at_public_office, organisation: organisation)
-      attributes = {
-        starts_at: creneau.starts_at,
-        motif_id: motif.id,
-        lieu_id: lieu.id,
-        user_ids: [user_for_rdv.id],
-        user: {
-          first_name: "Léa",
-          last_name: "Boubakar",
-          phone_number: nil,
-        },
-        departement: "62",
-        city_code: "62100",
-      }
-      rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
-      expect(rdv_wizard.save).to be true
+    context "when everything is ok" do
+      let(:motif) { create(:motif, :at_public_office, organisation: organisation) }
+      let(:attributes) do
+        {
+          starts_at: creneau.starts_at,
+          motif_id: motif.id,
+          lieu_id: lieu.id,
+          user_ids: [user_for_rdv.id],
+          user: {
+            first_name: "Léa",
+            last_name: "Boubakar",
+            phone_number: nil,
+          },
+          departement: "62",
+          city_code: "62100",
+        }
+      end
+
+      it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be true }
     end
 
-    it "return false with a rdv by_phone and user without phone" do
-      motif = create(:motif, :by_phone, organisation: organisation)
-      attributes = {
-        starts_at: creneau.starts_at,
-        motif_id: motif.id,
-        lieu_id: lieu.id,
-        user_ids: [user_for_rdv.id],
-        user: {
-          first_name: "Léa",
-          last_name: "Boubakar",
-          phone_number: nil,
-        },
-        departement: "62",
-        city_code: "62100",
-      }
-      rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
-      expect(rdv_wizard.save).to be false
-      expect(rdv_wizard.errors.full_messages.join(", ")).to eq("Aucun usager n’a de numéro de téléphone renseigné alors que le rendez-vous est téléphonique.")
+    context "when the motif is by phone" do
+      let(:motif) { create(:motif, :by_phone, organisation: organisation) }
+
+      context "when the lieu is nil" do
+        let(:attributes) do
+          {
+            starts_at: creneau.starts_at,
+            motif_id: motif.id,
+            lieu_id: nil,
+            user_ids: [user_for_rdv.id],
+            user: {
+              first_name: "Léa",
+              last_name: "Boubakar",
+              phone_number: "0612345678",
+            },
+            departement: "62",
+            city_code: "62100",
+          }
+        end
+
+        it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be true }
+      end
+
+      context "when the phone number is blank" do
+        let(:attributes) do
+          {
+            starts_at: creneau.starts_at,
+            motif_id: motif.id,
+            lieu_id: lieu.id,
+            user_ids: [user_for_rdv.id],
+            user: {
+              first_name: "Léa",
+              last_name: "Boubakar",
+              phone_number: nil,
+            },
+            departement: "62",
+            city_code: "62100",
+          }
+        end
+
+        it { expect(UserRdvWizard::Step1.new(user, attributes).save).to be false }
+
+        it "return false with a rdv by_phone and user without phone" do
+          rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
+          rdv_wizard.valid?
+          expect(rdv_wizard.errors.full_messages.join(", ")).to eq("Aucun usager n’a de numéro de téléphone renseigné alors que le rendez-vous est téléphonique.")
+        end
+      end
     end
   end
 end

--- a/spec/helpers/agents_helper_spec.rb
+++ b/spec/helpers/agents_helper_spec.rb
@@ -55,5 +55,27 @@ describe AgentsHelper do
       form = AgentCreneauxSearchForm.new(context: "un super context")
       expect(build_link_to_rdv_wizard_params(creneau, form)["context"]).to eq("un super context")
     end
+
+    it "works without a lieu" do
+      creneau = Creneau.new
+      creneau.lieu_id = nil
+      motif = create(:motif)
+      creneau.motif = motif
+      agent = create(:agent)
+      creneau.agent = agent
+
+      form = AgentCreneauxSearchForm.new(user_ids: [])
+      expect(build_link_to_rdv_wizard_params(creneau, form).with_indifferent_access).to match(
+        {
+          agent_ids: [agent.id],
+          duration_in_min: creneau.motif.default_duration_in_min,
+          lieu_id: nil,
+          motif_id: creneau.motif.id,
+          organisation_id: creneau.motif.organisation.id,
+          starts_at: nil,
+          step: 2,
+        }
+      )
+    end
   end
 end

--- a/spec/helpers/lieux_helper_spec.rb
+++ b/spec/helpers/lieux_helper_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe LieuxHelper do
+  describe ".lieu_tag" do
+    context "when the lieu is nil" do
+      it "returns N/A" do
+        expect(lieu_tag(nil)).to eq(content_tag(:span, "N/A", class: "text-muted"))
+      end
+    end
+
+    context "when the lieu is present" do
+      it "returns the name, unavailability_tag and address" do
+        lieu = build(:lieu)
+        expected_tag = content_tag(:span) do
+          concat lieu.name
+          concat unavailability_tag(lieu)
+          concat tag.br
+          concat content_tag(:small, lieu.address)
+        end
+        expect(lieu_tag(lieu)).to eq(expected_tag)
+      end
+    end
+  end
+end

--- a/spec/helpers/lieux_helper_spec.rb
+++ b/spec/helpers/lieux_helper_spec.rb
@@ -3,9 +3,7 @@
 describe LieuxHelper do
   describe ".lieu_tag" do
     context "when the lieu is nil" do
-      it "returns N/A" do
-        expect(lieu_tag(nil)).to eq(content_tag(:span, "N/A", class: "text-muted"))
-      end
+      it { expect(lieu_tag(nil)).to be_nil }
     end
 
     context "when the lieu is present" do

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -201,4 +201,14 @@ describe Creneau, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#lieu" do
+    it "returns the lieu when the lieu_id is present" do
+      expect(build(:creneau, lieu_id: lieu.id).lieu).to eq(lieu)
+    end
+
+    it "returns nil when the lieu_id is blank" do
+      expect(build(:creneau, lieu_id: nil).lieu).to eq(nil)
+    end
+  end
 end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -209,4 +209,15 @@ describe Motif, type: :model do
       expect(motif.booking_delay_range).to eq((now + 30.minutes.in_seconds.seconds)..(now + 3.months.in_seconds.seconds))
     end
   end
+
+  describe "#phone?" do
+    it "returns true if the location_type is phone" do
+      expect(build(:motif, :by_phone).phone?).to eq(true)
+    end
+
+    it "returns false if the location_type is not phone" do
+      expect(build(:motif, :at_public_office).phone?).to eq(false)
+      expect(build(:motif, :at_home).phone?).to eq(false)
+    end
+  end
 end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -210,14 +210,14 @@ describe Motif, type: :model do
     end
   end
 
-  describe "#phone?" do
-    it "returns true if the location_type is phone" do
-      expect(build(:motif, :by_phone).phone?).to eq(true)
+  describe "#requires_lieu?" do
+    it "returns false if the location_type doesn't require a lieu" do
+      expect(build(:motif, :by_phone).requires_lieu?).to eq(false)
+      expect(build(:motif, :at_home).requires_lieu?).to eq(false)
     end
 
-    it "returns false if the location_type is not phone" do
-      expect(build(:motif, :at_public_office).phone?).to eq(false)
-      expect(build(:motif, :at_home).phone?).to eq(false)
+    it "returns true if the location_type requires a lieu" do
+      expect(build(:motif, :at_public_office).requires_lieu?).to eq(true)
     end
   end
 end

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -31,16 +31,16 @@ describe PlageOuverture, type: :model do
   end
 
   describe "lieu presence" do
-    context "when the motifs are only by phone" do
+    context "when no motif requires a lieu" do
       it "is valid without a lieu" do
-        plage_ouverture = build(:plage_ouverture, lieu: nil, motifs: [create(:motif, :by_phone), create(:motif, :by_phone)])
+        plage_ouverture = build(:plage_ouverture, lieu: nil, motifs: [create(:motif, :by_phone), create(:motif, :at_home)])
         expect(plage_ouverture).to be_valid
       end
     end
 
-    context "when at least one motif is not by phone" do
+    context "when at least one motif requires a lieu" do
       it "is invalid without a lieu" do
-        plage_ouverture = build(:plage_ouverture, lieu: nil, motifs: [create(:motif, :by_phone), create(:motif, :at_home)])
+        plage_ouverture = build(:plage_ouverture, lieu: nil, motifs: [create(:motif, :by_phone), create(:motif, :at_public_office)])
         expect(plage_ouverture).not_to be_valid
       end
     end

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -30,18 +30,28 @@ describe PlageOuverture, type: :model do
     end
   end
 
+  describe "lieu presence" do
+    context "when the motifs are only by phone" do
+      it "is valid without a lieu" do
+        plage_ouverture = build(:plage_ouverture, lieu: nil, motifs: [create(:motif, :by_phone), create(:motif, :by_phone)])
+        expect(plage_ouverture).to be_valid
+      end
+    end
+
+    context "when at least one motif is not by phone" do
+      it "is invalid without a lieu" do
+        plage_ouverture = build(:plage_ouverture, lieu: nil, motifs: [create(:motif, :by_phone), create(:motif, :at_home)])
+        expect(plage_ouverture).not_to be_valid
+      end
+    end
+  end
+
   describe "lieu_is_enabled" do
     subject { plage_ouverture.errors }
 
     let(:plage_ouverture) { build :plage_ouverture, lieu: lieu }
 
     before { plage_ouverture.validate }
-
-    context "invalid if lieu is nil" do
-      let(:lieu) { nil }
-
-      it { is_expected.to be_of_kind(:lieu, :blank) }
-    end
 
     context "invalid if lieu is disabled" do
       let(:lieu) { build :lieu, availability: :disabled }

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -139,4 +139,40 @@ describe SearchContext, type: :service do
       expect(search_context.service).to be_nil
     end
   end
+
+  describe "#creneaux_search" do
+    context "when lieu is present" do
+      it "returns a Users::CreneauxSearch using the lieu and the first matching motif" do
+        plage_ouverture = create(:plage_ouverture, motifs: [motif, motif2], organisation: organisation)
+        lieu = plage_ouverture.lieu
+        search_context = described_class.new(user, search_query.merge(lieu_id: lieu.id))
+
+        expect(Users::CreneauxSearch).to receive(:new).with(
+          user: user,
+          motif: motif,
+          lieu: lieu,
+          date_range: search_context.date_range,
+          geo_search: geo_search
+        )
+        search_context.creneaux_search
+      end
+    end
+
+    context "when lieu is nil" do
+      it "returns a Users::CreneauxSearch using no lieu and the selected motif" do
+        motif = create(:motif, :by_phone, organisation: organisation)
+        create(:plage_ouverture, lieu: nil, motifs: [motif], organisation: organisation)
+        search_context = described_class.new(user, search_query)
+
+        expect(Users::CreneauxSearch).to receive(:new).with(
+          user: user,
+          motif: search_context.selected_motif,
+          lieu: nil,
+          date_range: search_context.date_range,
+          geo_search: geo_search
+        )
+        search_context.creneaux_search
+      end
+    end
+  end
 end

--- a/spec/services/search_creneaux_for_agents_base_spec.rb
+++ b/spec/services/search_creneaux_for_agents_base_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe SearchCreneauxForAgentsBase, type: :service do
+  describe "#all_agents" do
+    subject { described_class.new(form).all_agents }
+
+    let(:form) do
+      instance_double(
+        AgentCreneauxSearchForm,
+        organisation: organisation,
+        motif: motif,
+        service: motif.service,
+        agent_ids: agents.map(&:id),
+        team_ids: teams.map(&:id),
+        lieu_ids: lieux.map(&:id),
+        date_range: Time.zone.today..(Time.zone.today + 6.days)
+      )
+    end
+
+    let(:organisation) { create(:organisation) }
+    let(:motif) { create :motif, organisation: organisation }
+
+    let(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }
+    let(:agent3) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+    let(:team1) { create(:team, agents: [agent1, agent2]) }
+
+    let(:lieux) { [] }
+
+    context "without agent or teams" do
+      let(:agents) { [] }
+      let(:teams) { [] }
+
+      it { is_expected.to be_empty }
+    end
+
+    context "with an agent" do
+      let(:agents) { [agent1] }
+      let(:teams) { [] }
+
+      it { is_expected.to contain_exactly(agent1) }
+    end
+
+    context "with a team" do
+      let(:agents) { [] }
+      let(:teams) { [team1] }
+
+      it { is_expected.to contain_exactly(agent1, agent2) }
+    end
+
+    context "with agents and a team" do
+      let(:agents) { [agent3] }
+      let(:teams) { [team1] }
+
+      it { is_expected.to contain_exactly(agent1, agent2, agent3) }
+    end
+  end
+end

--- a/spec/services/search_creneaux_for_agents_service_spec.rb
+++ b/spec/services/search_creneaux_for_agents_service_spec.rb
@@ -1,62 +1,6 @@
 # frozen_string_literal: true
 
 describe SearchCreneauxForAgentsService, type: :service do
-  describe "all_agents" do
-    subject { described_class.new(form).all_agents }
-
-    let(:form) do
-      instance_double(
-        AgentCreneauxSearchForm,
-        organisation: organisation,
-        motif: motif,
-        service: motif.service,
-        agent_ids: agents.map(&:id),
-        team_ids: teams.map(&:id),
-        lieu_ids: lieux.map(&:id),
-        date_range: Time.zone.today..(Time.zone.today + 6.days)
-      )
-    end
-
-    let(:organisation) { create(:organisation) }
-    let(:motif) { create :motif, organisation: organisation }
-
-    let(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:agent3) { create(:agent, basic_role_in_organisations: [organisation]) }
-
-    let(:team1) { create(:team, agents: [agent1, agent2]) }
-
-    let(:lieux) { [] }
-
-    context "without agent or teams" do
-      let(:agents) { [] }
-      let(:teams) { [] }
-
-      it { is_expected.to be_empty }
-    end
-
-    context "with an agent" do
-      let(:agents) { [agent1] }
-      let(:teams) { [] }
-
-      it { is_expected.to contain_exactly(agent1) }
-    end
-
-    context "with a team" do
-      let(:agents) { [] }
-      let(:teams) { [team1] }
-
-      it { is_expected.to contain_exactly(agent1, agent2) }
-    end
-
-    context "with agents and a team" do
-      let(:agents) { [agent3] }
-      let(:teams) { [team1] }
-
-      it { is_expected.to contain_exactly(agent1, agent2, agent3) }
-    end
-  end
-
   describe "lieux" do
     subject { described_class.new(form).lieux }
 

--- a/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
+++ b/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
@@ -11,7 +11,7 @@ describe SearchCreneauxWithoutLieuForAgentsService, type: :service do
         agent_ids: [],
         team_ids: [],
         lieu_ids: nil,
-        date_range: Time.zone.today..(Time.zone.today + 6.days)
+        date_range: Time.zone.today..15.days.since
       )
     end
     let(:organisation) { create(:organisation) }

--- a/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
+++ b/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe SearchCreneauxWithoutLieuForAgentsService, type: :service do
+  describe "creneaux" do
+    let(:form) do
+      instance_double(
+        AgentCreneauxSearchForm,
+        organisation: organisation,
+        motif: motif,
+        service: motif.service,
+        agent_ids: [],
+        team_ids: [],
+        lieu_ids: nil,
+        date_range: Time.zone.today..(Time.zone.today + 6.days)
+      )
+    end
+    let(:organisation) { create(:organisation) }
+    let(:motif) { create :motif, :by_phone, organisation: organisation }
+    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: nil, organisation: organisation) }
+
+    it "has results" do
+      expect(described_class.perform_with(form).creneaux).to be_any
+    end
+  end
+end

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -108,6 +108,17 @@ describe SlotBuilder, type: :service do
       expect(plage_ouvertures).to eq([matching_po])
     end
 
+    it "return plage_ouverture that match without a lieu" do
+      motif = create(:motif, :by_phone, default_duration_in_min: 60, organisation: organisation)
+      matching_po = create(:plage_ouverture, lieu: nil, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
+      unmatching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
+
+      plage_ouvertures = described_class.plage_ouvertures_for(motif, nil, date_range, [])
+
+      expect(plage_ouvertures).to include(matching_po)
+      expect(plage_ouvertures).not_to include(unmatching_po)
+    end
+
     it "returns all plage_ouverture for the range" do
       matching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
       other_matching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
@@ -117,7 +128,7 @@ describe SlotBuilder, type: :service do
       expect(plage_ouvertures).to eq([matching_po, other_matching_po])
     end
 
-    it "returns only without reccurrence PO where first_day is in range" do
+    it "returns only without recurrence PO where first_day is in range" do
       matching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
       create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day + 1.month, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
 

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -100,7 +100,7 @@ describe SlotBuilder, type: :service do
       expect(plage_ouvertures).to eq([])
     end
 
-    it "return plage_ouverture that match" do
+    it "return plage_ouverture that match when a lieu is given" do
       matching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
@@ -108,15 +108,14 @@ describe SlotBuilder, type: :service do
       expect(plage_ouvertures).to eq([matching_po])
     end
 
-    it "return plage_ouverture that match without a lieu" do
+    it "return plage_ouverture that match without no lieu given" do
       motif = create(:motif, :by_phone, default_duration_in_min: 60, organisation: organisation)
-      matching_po = create(:plage_ouverture, lieu: nil, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
-      unmatching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
+      matching_po1 = create(:plage_ouverture, lieu: nil, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
+      matching_po2 = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, nil, date_range, [])
 
-      expect(plage_ouvertures).to include(matching_po)
-      expect(plage_ouvertures).not_to include(unmatching_po)
+      expect(plage_ouvertures).to match([matching_po1, matching_po2])
     end
 
     it "returns all plage_ouverture for the range" do


### PR DESCRIPTION
Closes #2770

Le lieu n'est plus obligatoire pour une plage d'ouverture, lorsque **tous** ses motifs sont **par téléphone** ou **à domicile**. Il reste obligatoire pour les motifs **public office**.

## Agent·e / Édition de la plage d'ouverture sans lieu

On permet à l'agent·e d'éditer une plage d'ouverture sans lieu.

### Avant

![image](https://user-images.githubusercontent.com/1193334/192784839-047364a0-a177-437b-b001-dfa046b2a71d.png)

### Après

![image](https://user-images.githubusercontent.com/1193334/192784941-6afb6e34-46ca-48bd-9cfc-0ceb93bb40dc.png)

![image](https://user-images.githubusercontent.com/1193334/192786185-689689d7-38ca-4ad5-9a3d-f2916c6c2bf2.png)

![image](https://user-images.githubusercontent.com/1193334/192786237-fd3e12c4-4c1b-4138-8e47-668bbde697cd.png)

![image](https://user-images.githubusercontent.com/1193334/192786277-d8197728-b58f-4f53-b2c9-8bfb91b52fa6.png)

![image](https://user-images.githubusercontent.com/1193334/192786756-159ac2a0-4fab-428c-bc65-c94d81fc3bfd.png)

## Agent·e / Trouver un rendez-vous pour un·e usager·ère sans lieu

L'agent·e peut chercher et prendre un RDV pour un·e usager·ère sans lieu

![image](https://user-images.githubusercontent.com/1193334/194319913-648bf244-366c-4e6a-b934-be5607846931.png)

## Usager·ère / Recherche de créneau sans lieu

Lorsqu'une plage d'ouverture **sans lieu** existe, on peut sélectionner directement un créneau lors de la recherche, sans choisir de lieu :

![image](https://user-images.githubusercontent.com/1193334/194319524-3fa5689b-7d14-4340-a556-1f3890165e71.png)

## Usager·ère / Prise de RDV et édition du RDV sans lieu

L'usager·ère peut prendre un RDV sur un créneau sans lieu, le déplacer, le supprimer.

![image](https://user-images.githubusercontent.com/1193334/193841416-2e5a4da9-fbb5-443d-9223-0990a015d035.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
