### PR TITLE
Ajouter du logging Sentry autour de nos requêtes HTTP

### DIFF
--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -84,7 +84,6 @@ class SmsSender < BaseService
   # These errors should not trigger a retry, because it would only fail again
   NETSIZE_PERMANENT_ERRORS = [
     15, # Message concatenation limit exceeded
-    16, # Unable to route message.
     103, # Invalid account name
     117, # Invalid campaign name
   ].freeze

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Typhoeus.before do |request|
+  crumb = Sentry::Breadcrumb.new(
+    message: "HTTP request",
+    data: {
+      method: request.options[:method],
+      url: request.url,
+      headers: request.options[:headers],
+      body: request.encoded_body,
+    }
+  )
+  Sentry.add_breadcrumb(crumb)
+end
+
+Typhoeus.on_complete do |response|
+  crumb = Sentry::Breadcrumb.new(
+    message: "HTTP response",
+    data: {
+      code: response.code,
+      headers: response.headers,
+      body: response.body,
+    }
+  )
+  Sentry.add_breadcrumb(crumb)
+end

--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -44,8 +44,8 @@ describe "using netsize to send an SMS" do
     expect_error_to_be_logged
 
     breadcrumbs = sentry_events.last.breadcrumbs.compact
-    expect(breadcrumbs[0]).to have_attributes(message: 'Calling SMS provider "netsize"')
-    expect(breadcrumbs[1]).to have_attributes(message: "netsize HTTP response", data: { body: "", code: 0, headers: {} })
+    expect(breadcrumbs[0]).to have_attributes(message: "HTTP request")
+    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: "", code: 0, headers: {} })
   end
 
   it "warns Sentry when netsize responds with an HTTP error" do
@@ -55,8 +55,8 @@ describe "using netsize to send an SMS" do
     expect_error_to_be_logged
 
     breadcrumbs = sentry_events.last.breadcrumbs.compact
-    expect(breadcrumbs[0]).to have_attributes(message: 'Calling SMS provider "netsize"')
-    expect(breadcrumbs[1]).to have_attributes(message: "netsize HTTP response", data: { body: "", code: 500, headers: {} })
+    expect(breadcrumbs[0]).to have_attributes(message: "HTTP request")
+    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: "", code: 500, headers: {} })
   end
 
   it "warns Sentry when netsize responds with a business error" do
@@ -71,7 +71,7 @@ describe "using netsize to send an SMS" do
     expect_error_to_be_logged
 
     breadcrumbs = sentry_events.last.breadcrumbs.compact
-    expect(breadcrumbs[0]).to have_attributes(message: 'Calling SMS provider "netsize"')
-    expect(breadcrumbs[1]).to have_attributes(message: "netsize HTTP response", data: { body: stubbed_body, code: 200, headers: {} })
+    expect(breadcrumbs[0]).to have_attributes(message: "HTTP request")
+    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: stubbed_body, code: 200, headers: {} })
   end
 end


### PR DESCRIPTION
En ce moment on a une erreur fréquente lors de l'envoi des SMS : 

> NetSize error: Invalid campaign name

Mais nous n'avons pas de traçage de la requête que l'on envoie à Netsize, et donc nous ne savons pas quel `campaignName` nous leur fournissons.

Cette PR ajoute du logging autour de toutes les requêtes que nous faisons avec Typhoeus, et donc notamment celles faites par le `SmsSender`.

**Le but est de pouvoir avoir des données à fournir à Netsize au moment où l'on va leur faire une demande au support.**

J'ai essayé de tester sur la review app en activant temporairement l'envoi de SMS, mais j'ai bel et bien reçu les SMS sur mon téléphone, donc pas d’échec d'envoi, donc de remontée Sentry.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
