### PR TITLE
Copier le lien de réservation avec un bouton

### DIFF
--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -14,6 +14,7 @@ import { PlacesInputs } from './components/places-inputs.js';
 import { RdvWizardStep2 } from './components/rdv_wizard_step2.js';
 import { RdvLieu } from './components/rdv_lieu.js';
 import { PastDateAlert } from './components/past-date-alert.js';
+import { Clipboard } from './components/clipboard.js';
 import { MotifForm } from './components/motif-form.js';
 import { ZonesMap } from './components/zones-map.js';
 import { AgentUserForm } from './components/agent-user-form.js'
@@ -80,6 +81,8 @@ $(document).on('turbolinks:load', function() {
   new RdvLieu();
 
   new PastDateAlert();
+
+  new Clipboard();
 
   new ZonesMap();
 

--- a/app/javascript/components/clipboard.js
+++ b/app/javascript/components/clipboard.js
@@ -1,0 +1,49 @@
+//
+// This ClipboardController allows you to copy a value in the browser's clipboard.
+// Asking for 'clipboard-write' permission isn't supported by Firefox or Safari as it is automatically granted,
+// but we have to ask for it for Chrome and Edge.
+// https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
+// This is using Stimulus-style data attributes for targets, in the hope we modernize our js stack.
+
+class ClipboardController {
+  constructor(container) {
+    this.container = container
+    this.setupPermissions()
+    this.setupValues()
+    this.setupTargets()
+    this.setupActions()
+  }
+
+  setupPermissions() {
+    navigator.permissions
+      .query({name:'clipboard-write'})
+      .catch(_ => console.log("Asking for 'clipboard-write' permission not supported."))
+  }
+
+  setupValues() {
+    this.toCopyValue = this.container.dataset.clipboardToCopyValue
+  }
+
+  setupTargets() {
+    this.copyButton = this.container.querySelector('[data-clipboard-target="copy-button"]')
+  }
+
+  setupActions() {
+    this.copyButton.addEventListener('click', e => { this.copyToClipboard(e) })
+  }
+
+  copyToClipboard(e) {
+    navigator.clipboard.writeText(this.toCopyValue)
+    alert("Lien copié dans le presse-papiers !")
+    e.preventDefault()
+  }
+}
+
+class Clipboard {
+  constructor() {
+    document.querySelectorAll('[data-controller="clipboard"]').forEach(elt => new ClipboardController(elt))
+  }
+}
+
+export { Clipboard }

--- a/app/javascript/components/clipboard.js
+++ b/app/javascript/components/clipboard.js
@@ -1,31 +1,22 @@
 //
 // This ClipboardController allows you to copy a value in the browser's clipboard.
-// Asking for 'clipboard-write' permission isn't supported by Firefox or Safari as it is automatically granted,
-// but we have to ask for it for Chrome and Edge.
+// We'd love to use the clipboard directly, asking for the permission first, but it keeps raising a
+// "DOMException: Document is not focused" error on chromium browsers, so we have to use the old "execCommand" method 
+// for now.
 // https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
+//
 // This is using Stimulus-style data attributes for targets, in the hope we modernize our js stack.
 
 class ClipboardController {
   constructor(container) {
     this.container = container
-    this.setupPermissions()
-    this.setupValues()
     this.setupTargets()
     this.setupActions()
   }
 
-  setupPermissions() {
-    navigator.permissions
-      .query({name:'clipboard-write'})
-      .catch(_ => console.log("Asking for 'clipboard-write' permission not supported."))
-  }
-
-  setupValues() {
-    this.toCopyValue = this.container.dataset.clipboardToCopyValue
-  }
-
   setupTargets() {
+    this.inputToCopy = this.container.querySelector('[data-clipboard-target="input-to-copy"]')
     this.copyButton = this.container.querySelector('[data-clipboard-target="copy-button"]')
   }
 
@@ -34,7 +25,8 @@ class ClipboardController {
   }
 
   copyToClipboard(e) {
-    navigator.clipboard.writeText(this.toCopyValue)
+    this.inputToCopy.select()
+    document.execCommand('copy')
     alert("Lien copié dans le presse-papiers !")
     e.preventDefault()
   }

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -26,10 +26,10 @@
         |  et collez-y le lien ci-dessous.
     - else
       p Dès que les motifs et les plages d'ouverture seront paramétrés pour la réservation en ligne, vous pourrez copier et partager ce lien pour permettre à vos usagers de réserver un rendez-vous en ligne.
-    form data={ "controller": "clipboard", "clipboard-to-copy-value": booking_link }
+    form data={ "controller": "clipboard" }
       .form-row
         .col-8
-          = text_field_tag :booking_link, booking_link, disabled: !shareable_booking_link?, readonly: true, class: "form-control"
+          = text_field_tag :booking_link, booking_link, disabled: !shareable_booking_link?, readonly: true, class: "form-control", data: { "clipboard-target": "input-to-copy" }
         .col-4
           = button_tag disabled: !shareable_booking_link?, class: "ml-2 btn btn-primary", data: { "clipboard-target": "copy-button" }
             i.fa.fa-copy.mr-1

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -26,10 +26,14 @@
         |  et collez-y le lien ci-dessous.
     - else
       p Dès que les motifs et les plages d'ouverture seront paramétrés pour la réservation en ligne, vous pourrez copier et partager ce lien pour permettre à vos usagers de réserver un rendez-vous en ligne.
-    form
+    form data={ "controller": "clipboard", "clipboard-to-copy-value": booking_link }
       .form-row
         .col-8
           = text_field_tag :booking_link, booking_link, disabled: !shareable_booking_link?, readonly: true, class: "form-control"
+        .col-4
+          = button_tag disabled: !shareable_booking_link?, class: "ml-2 btn btn-primary", data: { "clipboard-target": "copy-button" }
+            i.fa.fa-copy.mr-1
+            | copier
 
 .card
   .card-header

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -13,7 +13,7 @@ describe "CNFS agent can configure online booking" do
 
   context "when there is no bookable motifs" do
     it "can't copy the booking link", js: true do
-      expect(page).to have_css("input[disabled]")
+      expect(page).to have_css('[data-clipboard-target="copy-button"][disabled]')
     end
   end
 
@@ -22,7 +22,7 @@ describe "CNFS agent can configure online booking" do
 
     context "when there is no related plage d'ouverture" do
       it "can't copy the booking link", js: true do
-        expect(page).to have_css("input[disabled]")
+        expect(page).to have_css('[data-clipboard-target="copy-button"][disabled]')
       end
     end
 
@@ -30,7 +30,11 @@ describe "CNFS agent can configure online booking" do
       before { motif.plage_ouvertures << create(:plage_ouverture, organisation: organisation, agent: agent) }
 
       it "can copy the booking link", js: true do
-        expect(page).not_to have_css("input[disabled]")
+        expect(page).not_to have_css('[data-clipboard-target="copy-button"][disabled]')
+        accept_alert do
+          click_button "copier"
+          expect(page.driver.browser.switch_to.alert.text).to eq("Lien copié dans le presse-papiers !")
+        end
       end
     end
   end


### PR DESCRIPTION
Lié à #2825 

On ajoute un bouton pour copier facilement le lien de réservation.

On utilise ici la vieille façon de faire (sélectionner le contenu de l'input, puis envoyer la commande `copy` avec `execCommand`). En effet, on devrait pouvoir demander la permission `clipboard-write` au navigateur et, le cas échéant, utiliser `navigator.clipboard.writeText`. Malheureusement ça ne semble toujours pas bien supporté par les navigateurs basés sur Chromium, avec un résultat erratique : des fois ça fonctionne, des fois pas...

# Avant

![image](https://user-images.githubusercontent.com/1193334/193245169-470d2ae9-9694-45e4-b156-935164b98706.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/193245223-70e2959c-3aa1-4395-b8ed-cbf8aefdac15.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
