### PR TITLE
Bloque la fusion de deux utilisateur utilisant FranceConnect

### DIFF
--- a/app/views/admin/merge_users/new.html.slim
+++ b/app/views/admin/merge_users/new.html.slim
@@ -43,7 +43,9 @@
                 label.d-flex.justify-content-end for="merge_users_form_#{attribute}_1"
                   - value = user1_presenter.send(attribute)
                   - if @merge_users_form.user1.frozen_by_franceconnect?(attribute)
-                    div = value
+                    div
+                      = value
+                    = f.input attribute, as: :hidden, input_html: { value: "1" }
                   - elsif @merge_users_form.user2.present? && @merge_users_form.user2.frozen_by_franceconnect?(attribute)
                     del = value
                   - else
@@ -60,7 +62,9 @@
                 label.d-flex.justify-content-start for="merge_users_form_#{attribute}_2"
                   - value = user2_presenter.send(attribute)
                   - if @merge_users_form.user2.frozen_by_franceconnect?(attribute)
-                    div = value
+                    div
+                      = value
+                    = f.input attribute, as: :hidden, input_html: { value: "2" }
                   - elsif @merge_users_form.user1.present? && @merge_users_form.user1.frozen_by_franceconnect?(attribute)
                     del = value
 

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -19,10 +19,18 @@ describe MergeUsersForm, type: :form do
     expect(merge_users_form).to be_valid
   end
 
-  it "is invalid when not franceconnected user frozn field are selected" do
+  it "is invalid when not franceconnected user frozen fields are selected" do
     user1 = create(:user, first_name: "Malika", last_name: "PAUL", email: nil, phone_number: "01 23 23 23 23", birth_date: "1967-07-05", birth_name: "GONE", logged_once_with_franceconnect: nil)
     user2 = create(:user, first_name: "Malika", last_name: "GONE", email: "exemple@mail.com", phone_number: nil, birth_date: "1994-12-22", birth_name: "GONE", logged_once_with_franceconnect: true)
     merge_users_params = { email: "1", first_name: "1", last_name: "1", birth_name: "1", birth_date: "1", phone_number: "2", address: "2" }
+    merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
+    expect(merge_users_form).to be_invalid
+  end
+
+  it "is invalid when two users logged once with franceconnect" do
+    user1 = create(:user, logged_once_with_franceconnect: true, franceconnect_openid_sub: "unechainedecharacteres", organisations: [organisation])
+    user2 = create(:user, logged_once_with_franceconnect: true, franceconnect_openid_sub: "uneautrechainedecharacteres", organisations: [organisation])
+    merge_users_params = { email: "1", first_name: "2", last_name: "1", birth_name: "1", birth_date: "1", phone_number: "2", address: "2" }
     merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
     expect(merge_users_form).to be_invalid
   end


### PR DESCRIPTION
Mise en place du test et amélioration de la vue pour bloquer la fusion de deux utilisateurs s'étant déjà connecté avec FranceConnect

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
