### PR TITLE
Ajouter une endpoint API qui retourne les créneaux

### DIFF
--- a/app/blueprints/creneau_blueprint.rb
+++ b/app/blueprints/creneau_blueprint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CreneauBlueprint < Blueprinter::Base
+  fields :starts_at, :ends_at
+
+  association :lieu, blueprint: LieuBlueprint
+  association :motif, blueprint: MotifBlueprint
+  association :agent, blueprint: AgentBlueprint
+end

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -10,9 +10,8 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     if @search_results&.count == 1
       skip_policy_scope # TODO: improve pundit checks for creneaux
 
-      redirect_to admin_organisation_slots_path(current_organisation,
-                                                helpers.creneaux_search_params(@form).merge(lieu_ids: [@search_results.first.lieu.id])),
-                  class: "d-block stretched-link"
+      path_params = helpers.creneaux_search_params(@form).merge(lieu_ids: [@search_results.first.lieu.id])
+      redirect_to admin_organisation_slots_path(current_organisation, path_params)
     else
       @motifs = policy_scope(Motif).active.ordered_by_name
       @services = policy_scope(Service)

--- a/app/controllers/api/v1/creneaux_controller.rb
+++ b/app/controllers/api/v1/creneaux_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Api::V1::CreneauxController < Api::V1::BaseController
+  def index
+    form = helpers.build_agent_creneaux_search_form(current_organisation, params)
+    creneaux = SearchCreneauxForAgentsService.perform_with(form).map(&:creneaux).flatten
+    render_collection(MonoPageCollection.new(creneaux, Creneau))
+  end
+end

--- a/app/models/mono_page_collection.rb
+++ b/app/models/mono_page_collection.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#
+# This is meant to behave live a pseudo-paginated collection
+# of objects, just like Kaminari::PaginatableArray does, but simpler
+# and with the ability to declare the class of the collection.
+#
+class MonoPageCollection < Array
+  def initialize(collection, collection_class)
+    @collection_class = collection_class
+    super(collection)
+  end
+
+  def klass
+    @collection_class
+  end
+
+  def page(*)
+    self
+  end
+
+  def per(*)
+    self
+  end
+
+  def current_page
+    1
+  end
+
+  def total_pages
+    1
+  end
+
+  def total_count
+    size
+  end
+
+  def prev_page
+    nil
+  end
+
+  def next_page
+    nil
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,7 @@
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular "lieu", "lieux"
+  inflect.irregular "creneau", "creneaux"
   inflect.uncountable "created_by"
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
       resources :absences, except: %i[new edit]
       resources :agents, only: %i[index]
+      resources :creneaux, only: %i[index]
       resources :users, only: %i[create index show update] do
         get :invite, on: :member
         post :invite, on: :member

--- a/spec/requests/api/v1/creneaux_request_spec.rb
+++ b/spec/requests/api/v1/creneaux_request_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe "api/v1/creneaux requests", type: :request do
+  subject(:run_request) { get api_v1_creneaux_path(params), headers: api_auth_headers_for_agent(agent_for_auth) }
+
+  let!(:organisation) { create(:organisation) }
+  let!(:agent_for_auth) { create(:agent, organisations: [organisation]) }
+  let!(:motif) { create(:motif, organisation: organisation, default_duration_in_min: 30) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+  let(:params) do
+    {
+      organisation_id: organisation.id,
+      motif_id: motif.id,
+    }
+  end
+
+  context "when no agent declared a creneau" do
+    it "returns an empty array" do
+      run_request
+      expected_body = {
+        "creneaux" => [],
+        "meta" => {
+          "current_page" => 1,
+          "next_page" => nil,
+          "prev_page" => nil,
+          "total_count" => 0,
+          "total_pages" => 1,
+        },
+      }
+      expect(JSON.parse(response.body)).to eq(expected_body)
+    end
+  end
+
+  context "when there are creneaux" do
+    before { travel_to(Time.zone.parse("2022-09-30 14:00")) }
+
+    let!(:agent_with_creneau) { create(:agent, organisations: [organisation]) }
+    let!(:plage_ouverture) do
+      create(
+        :plage_ouverture,
+        motifs: [motif],
+        agent: agent_with_creneau,
+        lieu: lieu,
+        first_day: Time.zone.parse("2022-10-03 14:00"),
+        start_time: Tod::TimeOfDay.new(9),
+        end_time: Tod::TimeOfDay.new(12)
+      )
+    end
+
+    it "returns the list" do
+      run_request
+      response_body = JSON.parse(response.body)
+      expected_occurrences = [
+        "2022-10-03 09:00:00 +0200",
+        "2022-10-03 09:30:00 +0200",
+        "2022-10-03 10:00:00 +0200",
+        "2022-10-03 10:30:00 +0200",
+        "2022-10-03 11:00:00 +0200",
+        "2022-10-03 11:30:00 +0200",
+      ]
+      expect(response_body["creneaux"].pluck("starts_at")).to eq(expected_occurrences)
+
+      expected_meta = {
+        "current_page" => 1,
+        "next_page" => nil,
+        "prev_page" => nil,
+        "total_count" => 6,
+        "total_pages" => 1,
+      }
+      expect(response_body["meta"]).to eq(expected_meta)
+    end
+  end
+end


### PR DESCRIPTION
Le besoin immédiat est pour la carto CNFS de savoir si elle affiche un lien "Prendre RDV" sur la fiche d'un CNFS ou pas. En effet, elle ne veut pas afficher ce lien si on a pas de créneau pour ce CNFS de notre côté.

Puisque chaque CNFS est lié à une orga séparée, on pourrait donc simplement offrir un endpoint `Organisation#show` avec un booléen `{ "creneaux_disponibles:" true|false }`. 

Ceci étant dit, nous sommes actuellement dans une démarche d'offrir des liens de réservation publics, auxquels on peut passer des paramètres (organisation, service, motif, lieu). Il semblerait donc judicieux de proposer une API qui permette de fournir la même liste de paramètres, et qui indique si il y a des résultats.

On pourrai alors simplement indiquer avec un booléen si il y a des résultats ou non, ce serait plus simple. Mais je me dis que, puisque l'on a besoin de faire des requêtages complexes pour déterminer la liste de créneaux pour offrir ce booléen, autant fournir la liste de créneaux directement.

## Architecture des classes

La classe qui permet actuellement de chercher des créneaux (`SearchCreneauxForAgentsService`) contient une logique de groupement par lieu, à nous de voir si elle est pertinente.

Aussi, cette classe attend un objet `AgentCreneauxSearchForm` ; ces deux classes sont couplées, nous pourrons voir si c'est une opportunité d'amélioration de la souplesse du code.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
