### PR TITLE
Cesser d'utiliser DateTime

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -189,6 +189,9 @@ Style/OpenStructUse:
 Style/HashSyntax:
   Enabled: false
 
+Style/DateTime:
+  Enabled: true
+
 Naming/BlockForwarding:
   Enabled: false
 

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -25,7 +25,7 @@ class Users::RdvsController < UserAuthController
     ActiveRecord::Base.transaction do
       @creneau = Users::CreneauSearch.creneau_for(
         user: current_user,
-        starts_at: DateTime.parse(rdv_params[:starts_at]),
+        starts_at: Time.zone.parse(rdv_params[:starts_at]),
         motif: motif,
         lieu: Lieu.find(new_rdv_extra_params[:lieu_id]),
         geo_search: @geo_search

--- a/app/form_models/admin/rdv_collectif_search_form.rb
+++ b/app/form_models/admin/rdv_collectif_search_form.rb
@@ -22,7 +22,7 @@ class Admin::RdvCollectifSearchForm
   end
 
   def from_date=(date)
-    @from_date = date.is_a?(String) ? DateTime.parse(date) : date
+    @from_date = date.is_a?(String) ? Time.zone.parse(date) : date
   rescue Date::Error
     Time.zone.today
   end

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -12,8 +12,8 @@ module Lapin
       end
 
       def ensure_date_range_with_time(date_range)
-        time_begin = date_range.begin.instance_of?(Date) ? date_range.begin.beginning_of_day : date_range.begin.to_time
-        time_end = date_range.end.instance_of?(Date) ? date_range.end.end_of_day : date_range.end.to_time
+        time_begin = date_range.begin.instance_of?(Date) ? date_range.begin.beginning_of_day : date_range.begin
+        time_end = date_range.end.instance_of?(Date) ? date_range.end.end_of_day : date_range.end
 
         time_begin..time_end
       end

--- a/app/services/next_availability_service.rb
+++ b/app/services/next_availability_service.rb
@@ -3,8 +3,9 @@
 class NextAvailabilityService
   def self.find(motif, lieu, agents, from:, to: nil)
     available_creneau = nil
-    from = from.to_datetime
-    to = to&.to_datetime || (from + 6.months)
+    from = from.beginning_of_day if from.is_a?(Date)
+    to = to.beginning_of_day if to.is_a?(Date)
+    to ||= from + 6.months
 
     from.step(to, 7).find do |date|
       # NOTE: LOOP 2 loop here for ~ 27 weeks

--- a/scripts/load_absences_csv.rb
+++ b/scripts/load_absences_csv.rb
@@ -31,9 +31,9 @@ csv.each do |row|
       title: row[5],
       organisation: organisation,
       first_day: Date.parse(row[0]),
-      start_time: Time.zone.parse(row[1]).to_time,
+      start_time: Time.zone.parse(row[1]),
       end_day: Date.parse(row[2]),
-      end_time: Time.zone.parse(row[3]).to_time,
+      end_time: Time.zone.parse(row[3]),
     }
   rescue StandardError
     puts "#{ligne} - erreur d'analyse de la ligne"

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::RdvWizardStepsController, type: :controller do
         duration_in_min: 30,
         motif_id: motif.id,
         lieu_id: 1,
-        starts_at: DateTime.new(2020, 4, 20, 8, 0, 0),
+        starts_at: Time.zone.parse("2020-04-20 08:00"),
       }
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SearchController, type: :controller do
     instance_double(
       Users::CreneauxSearch,
       creneaux: [],
-      next_availability: build(:creneau, starts_at: DateTime.parse("2019-08-05 08h00"))
+      next_availability: build(:creneau, starts_at: Time.zone.parse("2019-08-05 08h00"))
     )
   end
   let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id])) }
@@ -212,7 +212,7 @@ RSpec.describe SearchController, type: :controller do
         let!(:creneaux_search) do
           instance_double(
             Users::CreneauxSearch,
-            creneaux: [build(:creneau, starts_at: DateTime.parse("2019-07-22 08h00"))]
+            creneaux: [build(:creneau, starts_at: Time.zone.parse("2019-07-22 08h00"))]
           )
         end
 
@@ -229,7 +229,7 @@ RSpec.describe SearchController, type: :controller do
           instance_double(
             Users::CreneauxSearch,
             creneaux: [],
-            next_availability: build(:creneau, starts_at: DateTime.parse("2019-08-05 08h00"))
+            next_availability: build(:creneau, starts_at: Time.zone.parse("2019-08-05 08h00"))
           )
         end
 

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -6,7 +6,7 @@ describe Users::RdvWizardStepsController, type: :controller do
     let!(:user) { create(:user) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
-    let(:starts_at) { DateTime.parse("2020-03-03 10h00") }
+    let(:starts_at) { Time.zone.parse("2020-03-03 10h00") }
     let!(:mock_creneau) { instance_double(::Creneau) }
     let!(:mock_rdv) { build(:rdv, starts_at: starts_at, users: [user]) } # cannot use instance_double because it breaks pundit inference
     let(:mock_user_rdv_wizard) { instance_double(UserRdvWizard::Step2, creneau: mock_creneau, rdv: mock_rdv) }

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:user) { create(:user) }
     let(:motif) { create(:motif, organisation: organisation) }
     let(:lieu) { create(:lieu, organisation: organisation) }
-    let(:starts_at) { DateTime.parse("2020-10-20 10h30") }
+    let(:starts_at) { Time.zone.parse("2020-10-20 10h30") }
     let(:mock_geo_search) { instance_double(Users::GeoSearch) }
     let(:token) { "12345" }
 
@@ -115,11 +115,11 @@ RSpec.describe Users::RdvsController, type: :controller do
   describe "GET #show" do
     let(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], motif: motif, starts_at: starts_at, created_by: "user") }
-    let(:starts_at) { DateTime.parse("2020-10-20 10h30") }
+    let(:starts_at) { Time.zone.parse("2020-10-20 10h30") }
     let(:motif) { build(:motif, reservable_online: true, rdvs_editable_by_user: true, rdvs_cancellable_by_user: true) }
 
     before do
-      travel_to("01/01/2019".to_datetime)
+      travel_to(Time.zone.parse("01/01/2019"))
       sign_in user
     end
 
@@ -134,7 +134,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     end
 
     context "when the rdv is past" do
-      let!(:starts_at) { DateTime.parse("2018-12-31 10h30") }
+      let!(:starts_at) { Time.zone.parse("2018-12-31 10h30") }
 
       it "does show links to edit and cancel" do
         get :show, params: { id: rdv.id }
@@ -288,7 +288,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     end
 
     let(:organisation) { create(:organisation) }
-    let(:now) { "01/01/2019 10:00".to_datetime }
+    let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation, max_booking_delay: 2.weeks.to_i) }
@@ -338,7 +338,7 @@ RSpec.describe Users::RdvsController, type: :controller do
 
     let(:organisation) { create(:organisation) }
     let(:starts_at) { 3.days.from_now }
-    let(:now) { "01/01/2019 10:00".to_datetime }
+    let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation) }

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     password { "password" }
-    confirmed_at { DateTime.parse("2020-07-30 10:30").in_time_zone }
-    invitation_accepted_at { DateTime.parse("2020-07-30 10:30").in_time_zone }
+    confirmed_at { Time.zone.parse("2020-07-30 10:30").in_time_zone }
+    invitation_accepted_at { Time.zone.parse("2020-07-30 10:30").in_time_zone }
 
     transient do
       basic_role_in_organisations { [] }

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :rdv do
-    created_at { DateTime.parse("2020-06-5 13:51").in_time_zone }
-    updated_at { DateTime.parse("2020-06-5 13:51").in_time_zone }
+    created_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
+    updated_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
     organisation { create(:organisation) }
     lieu { build(:lieu, organisation: organisation) }
     motif { build(:motif, organisation: organisation) }
@@ -33,7 +33,7 @@ FactoryBot.define do
       lieu { nil }
     end
     trait :excused do
-      cancelled_at { DateTime.parse("2020-01-15 10:30").in_time_zone }
+      cancelled_at { Time.zone.parse("2020-01-15 10:30").in_time_zone }
       status { "excused" }
     end
   end

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -73,7 +73,7 @@ describe "User can search for rdvs" do
 
       # Step 4
       expect(page).to have_content("Vos informations")
-      fill_in("Date de naissance", with: DateTime.yesterday.strftime("%d/%m/%Y"))
+      fill_in("Date de naissance", with: Time.zone.yesterday.strftime("%d/%m/%Y"))
       fill_in("Nom de naissance", with: "Lapinou")
       click_button("Continuer")
 

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -6,7 +6,7 @@ describe UserRdvWizard do
   let!(:user_for_rdv) { create(:user) }
   let!(:motif) { create(:motif, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: DateTime.parse("2020-10-20 09h30")) }
+  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: Time.zone.parse("2020-10-20 09h30")) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
   let(:mock_geo_search) { instance_double(Users::GeoSearch) }
 
@@ -32,7 +32,7 @@ describe UserRdvWizard do
         user: user,
         motif: motif,
         lieu: lieu,
-        starts_at: DateTime.parse("2020-10-20 09h30"),
+        starts_at: Time.zone.parse("2020-10-20 09h30"),
         geo_search: mock_geo_search
       ).and_return(returned_creneau)
       rdv_wizard = UserRdvWizard::Step1.new(user, attributes)

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -72,24 +72,24 @@ describe RdvsHelper do
   describe "#rdv_starts_at_and_duration" do
     context "with :human format" do
       it "return starts_at hour, minutes and duration" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: 4)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 12:46), duration_in_min: 4)
         expect(rdv_starts_at_and_duration(rdv, :human)).to eq("lundi 23 mars 2020 à 13h46 (4 minutes)")
       end
 
       it "return only starts_at hour, minutes when no duration_in_min" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: nil)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 12:46), duration_in_min: nil)
         expect(rdv_starts_at_and_duration(rdv, :human)).to eq("lundi 23 mars 2020 à 13h46")
       end
     end
 
     context "with :time_only format" do
       it "return starts_at hour, minutes and duration" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: 4)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 12:46), duration_in_min: 4)
         expect(rdv_starts_at_and_duration(rdv, :time_only)).to eq("13h46 (4 minutes)")
       end
 
       it "return only starts_at hour, minutes when no duration_in_min" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: nil)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 12:46), duration_in_min: nil)
         expect(rdv_starts_at_and_duration(rdv, :time_only)).to eq("13h46")
       end
     end

--- a/spec/jobs/cron_job/file_attente_job_spec.rb
+++ b/spec/jobs/cron_job/file_attente_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe CronJob::FileAttenteJob, type: :job do
   describe "#perform" do
-    let(:now) { DateTime.parse("01-01-2019 09:00") }
+    let(:now) { Time.zone.parse("01-01-2019 09:00") }
     let(:plage_ouverture) { create(:plage_ouverture, first_day: 2.weeks.from_now, start_time: Tod::TimeOfDay.new(9)) }
     let(:rdv) { create(:rdv, starts_at: 2.weeks.from_now) }
     let(:file_attente) { create(:file_attente, rdv: rdv) }

--- a/spec/jobs/cron_job/reminder_job_spec.rb
+++ b/spec/jobs/cron_job/reminder_job_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CronJob::ReminderJob, type: :job do
   subject { described_class.perform_now }
 
-  let(:now) { DateTime.parse("01-01-2019 09:00") }
+  let(:now) { Time.zone.parse("01-01-2019 09:00") }
 
   before do
     travel_to(now)

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -5,13 +5,13 @@ describe Lapin::Range do
     subject { described_class.ensure_date_range_with_time(date_range) }
 
     let!(:date_range) { lower_bound..higher_bound }
-    let!(:now) { "2021-12-10 10:00".to_time }
+    let!(:now) { Time.zone.parse("2021-12-10 10:00") }
 
     before { travel_to(now) }
 
     context "when given datetime bounds" do
-      let!(:lower_bound) { "2021-12-20 11:00".to_datetime }
-      let!(:higher_bound) { "2021-12-21 18:00".to_datetime }
+      let!(:lower_bound) { Time.zone.parse("2021-12-20 11:00") }
+      let!(:higher_bound) { Time.zone.parse("2021-12-21 18:00") }
 
       it "returns range with same datetime bounds" do
         expect(subject).to eq(date_range)
@@ -19,8 +19,8 @@ describe Lapin::Range do
     end
 
     context "when given time bounds" do
-      let!(:lower_bound) { "2021-12-20 11:00".to_time }
-      let!(:higher_bound) { "2021-12-21 18:00".to_time }
+      let!(:lower_bound) { Time.zone.parse("2021-12-20 11:00") }
+      let!(:higher_bound) { Time.zone.parse("2021-12-21 18:00") }
 
       it "returns range with same time bounds" do
         expect(subject).to eq(date_range)

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_created" do
     let(:agent) { build(:agent) }
-    let(:t) { DateTime.parse("2020-03-01 10:20") }
+    let(:t) { Time.zone.parse("2020-03-01 10:20") }
     let(:mail) { described_class.with(rdv: rdv, agent: agent).rdv_created }
     let(:rdv) { create(:rdv, starts_at: t + 2.hours, agents: [agent]) }
 

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -31,7 +31,7 @@ describe RecurrenceConcern do
 
     it "returns starts_at from given first_day" do
       starts_at = Time.zone.parse("2019-08-15 10h00:00")
-      create(factory, first_day: starts_at.to_date, start_time: starts_at.to_time)
+      create(factory, first_day: starts_at.to_date, start_time: starts_at)
       period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
 
       occurrences = described_class.all_occurrences_for(period)

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe FileAttente, type: :model do
-  let(:now) { DateTime.parse("01-01-2019 09:00 +0100") }
+  let(:now) { Time.zone.parse("01-01-2019 09:00 +0100") }
 
   before do
     stub_netsize_ok

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -9,14 +9,14 @@ describe Stat, type: :model do
 
     it "return 2=>1 with one home rdv" do
       home_motif = create(:motif, location_type: :home)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
     end
 
     it "return 2=>2 with two home rdv" do
       home_motif = create(:motif, location_type: :home)
-      create_list(:rdv, 2, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
+      create_list(:rdv, 2, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(2)
     end
@@ -24,8 +24,8 @@ describe Stat, type: :model do
     it "return 2=>2 with two different motif of home rdv" do
       home_motif = create(:motif, location_type: :home)
       other_home_motif = create(:motif, location_type: :home)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
-      create(:rdv, motif: other_home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
+      create(:rdv, motif: other_home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(2)
     end
@@ -33,8 +33,8 @@ describe Stat, type: :model do
     it "return {2=>1, 1=>1} with one home rdv and one phone" do
       home_motif = create(:motif, location_type: :home)
       phone_motif = create(:motif, location_type: :phone)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
-      create(:rdv, motif: phone_motif, created_at: DateTime.new(2020, 4, 7, 11, 0))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
+      create(:rdv, motif: phone_motif, created_at: Time.zone.parse("2020-04-17 11:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
       expect(stats.rdvs_group_by_type[["par téléphone", "05/04/2020"]]).to eq(1)
@@ -44,9 +44,9 @@ describe Stat, type: :model do
       home_motif = create(:motif, location_type: :home)
       phone_motif = create(:motif, location_type: :phone)
       public_office_motif = create(:motif, location_type: :public_office)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
-      create(:rdv, motif: phone_motif, created_at: DateTime.new(2020, 4, 7, 11, 0))
-      create(:rdv, motif: public_office_motif, created_at: DateTime.new(2020, 4, 7, 9, 40))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
+      create(:rdv, motif: phone_motif, created_at: Time.zone.parse("2020-04-17 11:00"))
+      create(:rdv, motif: public_office_motif, created_at: Time.zone.parse("2020-04-07 09:40"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
       expect(stats.rdvs_group_by_type[["par téléphone", "05/04/2020"]]).to eq(1)

--- a/spec/services/users/creneau_search_spec.rb
+++ b/spec/services/users/creneau_search_spec.rb
@@ -5,7 +5,7 @@ describe Users::CreneauSearch do
   let(:user) { create(:user) }
   let(:motif) { create(:motif, name: "Coucou", location_type: :home, organisation: organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }
-  let(:starts_at) { DateTime.parse("2020-10-20 09h30") }
+  let(:starts_at) { Time.zone.parse("2020-10-20 09h30") }
   let(:now) { Time.zone.parse("2020-10-19 14:30") }
 
   describe ".creneau_for" do
@@ -26,9 +26,9 @@ describe Users::CreneauSearch do
     context "some matching creneaux" do
       let(:mock_creneaux) do
         [
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 09h30")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 09h30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10h00")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10h30")),
         ]
       end
 
@@ -38,9 +38,9 @@ describe Users::CreneauSearch do
     context "no matching creneaux" do
       let(:mock_creneaux) do
         [
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 11h30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10h00")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10h30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 11h30")),
         ]
       end
 


### PR DESCRIPTION
La [doc de Ruby](https://ruby-doc.org/stdlib-2.5.1/libdoc/date/rdoc/DateTime.html) indique que DateTime est désormais à réserver aux usages de dates historiques, et que la manipulation de dates récentes ou futures doit etre faite via `Time`, ou plutôt `Time.zone` pour un support des fuseaux horaires.

> However, if you need to deal with dates and times in a historical context you'll want to use DateTime

Cette cop de rubocop résume les usages recommandés : https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/DateTime

Et cette question StackOverflow apporte aussi du contexte : 
https://stackoverflow.com/questions/1261329/difference-between-datetime-and-time-in-ruby

Plus d'infos sur un sujet tangentiel : les timezones : 
https://thoughtbot.com/blog/its-about-time-zones

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
