### PR TITLE
Permet l'ajout des status utilistateurs des rdv dans l'API

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -8,6 +8,7 @@ class RdvBlueprint < Blueprinter::Base
 
   association :organisation, blueprint: OrganisationBlueprint
   association :motif, blueprint: MotifBlueprint
+  # DEPRECATED : Nous laissons l'association `:users` le temps que le 92, 26, 62, 64, et data-insertion mettent à jours leur système.
   association :users, blueprint: UserBlueprint
   association :rdvs_users, blueprint: RdvsUsersBlueprint
   association :agents, blueprint: AgentBlueprint

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -9,6 +9,7 @@ class RdvBlueprint < Blueprinter::Base
   association :organisation, blueprint: OrganisationBlueprint
   association :motif, blueprint: MotifBlueprint
   association :users, blueprint: UserBlueprint
+  association :rdvs_users, blueprint: RdvsUsersBlueprint
   association :agents, blueprint: AgentBlueprint
   association :lieu, blueprint: LieuBlueprint
 end

--- a/app/blueprints/rdvs_users_blueprint.rb
+++ b/app/blueprints/rdvs_users_blueprint.rb
@@ -3,5 +3,5 @@
 class RdvsUsersBlueprint < Blueprinter::Base
   fields :status, :send_lifecycle_notifications, :send_reminder_notification
 
-  association :users, blueprint: UserBlueprint
+  association :user, blueprint: UserBlueprint
 end

--- a/app/blueprints/rdvs_users_blueprint.rb
+++ b/app/blueprints/rdvs_users_blueprint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RdvsUsersBlueprint < Blueprinter::Base
+  fields :status, :send_lifecycle_notifications, :send_reminder_notification
+
+  association :users, blueprint: UserBlueprint
+end

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -25,4 +25,24 @@ describe RdvBlueprint do
                                      "name" => nil,
                                    })
   end
+
+  describe "users (DEPRECATED)" do
+    let(:user) { build(:user, first_name: "Jean") }
+    let(:rdv) { build(:rdv, users: [user]) }
+
+    it do
+      expect(json.dig("rdv", "users").first["first_name"]).to eq "Jean"
+    end
+  end
+
+  describe "rdvs_users contains user" do
+    let(:user) { build(:user, first_name: "Jean") }
+    let(:rdv) { build(:rdv, rdvs_users: [rdvs_user]) }
+    let(:rdvs_user) { build(:rdvs_user, status: "seen", user: user) }
+
+    it do
+      expect(json.dig("rdv", "rdvs_users").first["status"]).to eq "seen"
+      expect(json.dig("rdv", "rdvs_users").first["user"]["first_name"]).to eq "Jean"
+    end
+  end
 end


### PR DESCRIPTION
Closes #2865

Ajout du champ status de rdvs_users dans l'api

- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
