### PR TITLE
Permettre d'editer les équipes des agents

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Admin::Territories::AgentsController < Admin::Territories::BaseController
+  before_action :set_agent, only: %i[edit update]
+  before_action :authorize_agent, only: %i[edit update]
+
   def index
     @agents = find_agents(params[:q]).page(params[:page])
   end
@@ -18,8 +21,27 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
     end
   end
 
-  def edit
+  def edit; end
+
+  def update
+    if @agent.update(agent_params)
+      redirect_to admin_territory_agents_path(current_territory)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_agent
     @agent = Agent.find(params[:id])
+  end
+
+  def authorize_agent
     authorize @agent
+  end
+
+  def agent_params
+    params.require(:agent).permit(team_ids: [])
   end
 end

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -21,6 +21,7 @@ class Configuration::AgentPolicy
 
   alias display? territorial_admin_or_allowed_to_manage_agent_part?
   alias edit? territorial_admin_or_allowed_to_manage_agent_part?
+  alias update? territorial_admin_or_allowed_to_manage_agent_part?
 
   def create?
     territorial_admin? || @access_rights&.allow_to_invite_agents?

--- a/spec/controllers/admin/territories/agents_controller_spec.rb
+++ b/spec/controllers/admin/territories/agents_controller_spec.rb
@@ -37,4 +37,24 @@ describe Admin::Territories::AgentsController, type: :controller do
       expect(assigns(:agent)).to eq(agent)
     end
   end
+
+  describe "#update" do
+    it "redirect to agents index" do
+      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory], teams: [])
+      team = create(:team, territory: territory)
+      sign_in agent
+
+      post :update, params: { territory_id: territory.id, id: agent.id, agent: { team_ids: [team.id] } }
+      expect(response).to redirect_to(admin_territory_agents_path)
+    end
+
+    it "update agent's teams" do
+      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory], teams: [])
+      team = create(:team, territory: territory)
+      sign_in agent
+
+      post :update, params: { territory_id: territory.id, id: agent.id, agent: { team_ids: [team.id] } }
+      expect(agent.reload.teams).to eq([team])
+    end
+  end
 end

--- a/spec/policies/configuration/agent_policy_spec.rb
+++ b/spec/policies/configuration/agent_policy_spec.rb
@@ -27,35 +27,35 @@ describe Configuration::AgentPolicy, type: :policy do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory) }
 
-      it_behaves_like "not permit actions", :display?, :edit?, :create?
+      it_behaves_like "not permit actions", :display?, :edit?, :create?, :update?
     end
 
     context "admin access to this territory" do
       let(:agent) { create(:agent, role_in_territories: [territory]) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory) }
 
-      it_behaves_like "permit actions", :display?, :edit?, :create?
+      it_behaves_like "permit actions", :display?, :edit?, :create?, :update?
     end
 
     context "allowed to manage teams agent" do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_manage_teams: true) }
 
-      it_behaves_like "permit actions", :display?, :edit?
+      it_behaves_like "permit actions", :display?, :edit?, :update?
     end
 
     context "allowed to invite agents agent" do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_invite_agents: true) }
 
-      it_behaves_like "permit actions", :display?, :edit?, :create?
+      it_behaves_like "permit actions", :display?, :edit?, :create?, :update?
     end
 
     context "allowed to manage access rights agent" do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_manage_access_rights: true) }
 
-      it_behaves_like "permit actions", :display?, :edit?
+      it_behaves_like "permit actions", :display?, :edit?, :update?
     end
   end
 end


### PR DESCRIPTION
Pour tester https://demo-rdv-solidarites-pr2878.osc-secnum-fr1.scalingo.io/

Closes #2789

Normalement, le fix répond bien au bug soulevé par l'issue. Je n'ai pas réinventée la roue et j'ai juste repris ce qui était fait avant la PR suivante : https://github.com/betagouv/rdv-solidarites.fr/pull/2283

Par contre, mettre le nez dans le code m'a interrogé sur le niveau de finesse de nos autorisations sur cette page. Je crois que j'aurais préféré être plus granulaire et avoir des formulaires séparés avec chacun leur controller (dans notre cas un TeamMembership controller ou un truc du genre) et leurs policies associées. Au minimum, vu que l'update ne sert qu'à de l'update de team, ce serait pas mal d'avoir une policy dédiée sans passer par la `territorial_admin_or_allowed_to_manage_agent_part?` générique.

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
