### PR TITLE
Offrir une API qui permet de déterminer si il est possible de prendre RDV dans une organisation

### DIFF
--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class PublicApi::PublicLinksController < ActionController::Base
+  def index
+    departement = params.require(:departement).presence
+    org_ext_ids = params.require(:external_ids).compact_blank
+
+    territory = Territory.find_by!(departement_number: departement)
+    organisations = territory.organisations.where(external_id: org_ext_ids)
+
+    organisations
+      .joins("LEFT OUTER JOIN plage_ouvertures")
+
+
+    results = organisations.map do |organisation|
+      plages = PlageOuverture
+        .where(organisation: organisation)
+        .not_expired
+        .in_range((Time.zone.now..))
+        .reservable_online
+
+      {
+        organisation_external_id: organisation.external_id,
+        reservation_disponible: plages.any?,
+        public_url: public_link_to_org_url(organisation_id: organisation.id, host: organisation.domain.dns_domain_name),
+      }
+    end
+
+    render json: results.to_json
+  end
+end

--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -6,6 +6,17 @@ class PublicApi::PublicLinksController < ActionController::Base # rubocop:disabl
 
     territory = Territory.find_by!(departement_number: departement)
 
+    # Using cache to prevent overloading db in case of accidentally intensive API calls
+    response_body = Rails.cache.fetch("public_api/public_links/#{territory.id}", expires_in: 1.minute) do
+      { public_links: public_links_for(territory) }.to_json
+    end
+
+    render json: response_body
+  end
+
+  private
+
+  def public_links_for(territory)
     plage_ouvertures = PlageOuverture.where(organisations: { territory_id: territory.id })
       .not_expired
       .in_range((Time.zone.now..))
@@ -13,13 +24,11 @@ class PublicApi::PublicLinksController < ActionController::Base # rubocop:disabl
       .joins(:organisation)
       .distinct(:organisation_id)
 
-    results = plage_ouvertures.map do |plage_ouverture|
+    plage_ouvertures.map do |plage_ouverture|
       {
         external_id: plage_ouverture.organisation.external_id,
         public_link: public_link_to_org_url(organisation_id: plage_ouverture.organisation.id, host: plage_ouverture.organisation.domain.dns_domain_name),
       }
     end
-
-    render json: { public_links: results }.to_json
   end
 end

--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PublicApi::PublicLinksController < ActionController::Base
+class PublicApi::PublicLinksController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def index
     departement = params.require(:departement).presence
     org_ext_ids = params.require(:external_ids).compact_blank
@@ -14,12 +14,12 @@ class PublicApi::PublicLinksController < ActionController::Base
       .joins(:organisation)
       .distinct(:organisation_id)
 
-    results = plage_ouvertures.map do |plage_ouverture|
+    results = plage_ouvertures.to_h do |plage_ouverture|
       [
         plage_ouverture.organisation.external_id,
         public_link_to_org_url(organisation_id: plage_ouverture.organisation.id, host: plage_ouverture.organisation.domain.dns_domain_name),
       ]
-    end.to_h
+    end
 
     render json: results.to_json
   end

--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -13,13 +13,13 @@ class PublicApi::PublicLinksController < ActionController::Base # rubocop:disabl
       .joins(:organisation)
       .distinct(:organisation_id)
 
-    results = plage_ouvertures.to_h do |plage_ouverture|
-      [
-        plage_ouverture.organisation.external_id,
-        public_link_to_org_url(organisation_id: plage_ouverture.organisation.id, host: plage_ouverture.organisation.domain.dns_domain_name),
-      ]
+    results = plage_ouvertures.map do |plage_ouverture|
+      {
+        external_id: plage_ouverture.organisation.external_id,
+        public_link: public_link_to_org_url(organisation_id: plage_ouverture.organisation.id, host: plage_ouverture.organisation.domain.dns_domain_name),
+      }
     end
 
-    render json: results.to_json
+    render json: { public_links: results }.to_json
   end
 end

--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -27,7 +27,11 @@ class PublicApi::PublicLinksController < ActionController::Base # rubocop:disabl
     organisations.map do |organisation|
       {
         external_id: organisation.external_id,
-        public_link: public_link_to_org_url(organisation_id: organisation.id, host: organisation.domain.dns_domain_name),
+        public_link: public_link_to_external_org_url(
+          organisation_external_id: organisation.external_id,
+          territory: territory.departement_number,
+          host: organisation.domain.dns_domain_name
+        ),
       }
     end
   end

--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+#
+# Cette API a été introduite dans une démarche exploratoire décrit ici :
+# https://github.com/betagouv/rdv-solidarites.fr/issues/2874
+#
+# Ce code n'est pas sacré, au contraire, il a été conçu pour être jetable.
+# Il pourra donc :
+# - soit être jeté parce qu'il n'est plus utilisé
+# - soit être adapté / déplacé dans une API plus propre si
+#   le besoin auquel il répond se généralise.
+#
+# Les utilisateurs de cette API sont :
+# - l'équipe carto CNFS,
+# - l'équipe carto ANCT,
+# - Rés'In (métropole de Lyon)
+#
 class PublicApi::PublicLinksController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def index
     departement_number = params.require(:territory).presence

--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -3,11 +3,10 @@
 class PublicApi::PublicLinksController < ActionController::Base # rubocop:disable Rails/ApplicationController
   def index
     departement = params.require(:departement).presence
-    org_ext_ids = params.require(:external_ids).compact_blank
 
     territory = Territory.find_by!(departement_number: departement)
 
-    plage_ouvertures = PlageOuverture.where(organisations: { external_id: org_ext_ids, territory_id: territory.id })
+    plage_ouvertures = PlageOuverture.where(organisations: { territory_id: territory.id })
       .not_expired
       .in_range((Time.zone.now..))
       .reservable_online

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
   end
 
   def public_link_with_external_organisation_id
-    territory = Territory.find_by!(departement_number: params[:territory_slug])
+    territory = Territory.find_by!(departement_number: params[:territory])
     organisation = territory.organisations.find_by!(external_id: params[:organisation_external_id])
     redirect_to_organisation_search(organisation)
   end

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -37,6 +37,7 @@ class PlageOuverture < ApplicationRecord
   validate :warn_overflow_motifs_duration
 
   # Scopes
+  scope :reservable_online, -> { joins(:motifs).where(motifs: { reservable_online: true }) }
   scope :in_range, lambda { |range|
     return all if range.nil?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,7 +259,7 @@ Rails.application.routes.draw do
 
   # short public link
   get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
-  get "org/ext/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
+  get "org/ext/:territory/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
 
   namespace :public_api do
     resources :public_links, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,6 +261,10 @@ Rails.application.routes.draw do
   get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
   get "org/ext/:territory_slug/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
 
+  namespace :public_api do
+    resources :public_links, only: [:index]
+  end
+
   ##
 
   get "accueil_mds", to: redirect("presentation_agent", status: 307)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,6 +59,7 @@ org_cnfs = Organisation.create!(
   phone_number: "0123456789",
   human_id: "mediatheque-paris-nord",
   territory: territory_cnfs,
+  external_id: "666",
   new_domain_beta: true
 )
 org_drome1 = Organisation.create!(

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -6,7 +6,5 @@ FactoryBot.define do
   factory :organisation do
     name { generate(:orga_name) }
     territory
-
-    external_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
   factory :organisation do
     name { generate(:orga_name) }
     territory
+
+    external_id { SecureRandom.uuid }
   end
 end

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -11,7 +11,7 @@ describe "public_api/public_links requests", type: :request do
   context "when plages are defined" do
     let(:params) do
       {
-        external_ids: %w[ext_id_A ext_id_B ext_id_C ext_id_D ext_id_E, ext_id_F],
+        external_ids: %w[ext_id_A ext_id_B ext_id_C ext_id_D ext_id_E ext_id_F],
         departement: "CN",
       }
     end

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "api/v1/organisations/reservation_disponible requests", type: :request do
+describe "public_api/public_links requests", type: :request do
   let!(:territory) { create(:territory, departement_number: "CN") }
   let!(:organisation_a) { create(:organisation, new_domain_beta: true, external_id: "ext_id_A", territory: territory) }
   let!(:organisation_b) { create(:organisation, new_domain_beta: true, external_id: "ext_id_B", territory: territory) }
@@ -11,7 +11,7 @@ describe "api/v1/organisations/reservation_disponible requests", type: :request 
   context "when plages are defined" do
     let(:params) do
       {
-        external_ids: %w[ext_id_A ext_id_B ext_id_C ext_id_D ext_id_E],
+        external_ids: %w[ext_id_A ext_id_B ext_id_C ext_id_D ext_id_E, ext_id_F],
         departement: "CN",
       }
     end
@@ -27,30 +27,12 @@ describe "api/v1/organisations/reservation_disponible requests", type: :request 
       # Organisation B has a plage in 5 days
       # Organisation C has a plage that expired
       # Organisation D has no plage
-      # Organisation E is not in provided territory, it should be missing from response
-      # Organisation F does not exist, it should be missing from response
-      expected_response = [
-        {
-          "organisation_external_id" => "ext_id_A",
-          "reservation_disponible" => true,
-          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}",
-        },
-        {
-          "organisation_external_id" => "ext_id_B",
-          "reservation_disponible" => true,
-          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_b.id}",
-        },
-        {
-          "organisation_external_id" => "ext_id_C",
-          "reservation_disponible" => false,
-          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_c.id}",
-        },
-        {
-          "organisation_external_id" => "ext_id_D",
-          "reservation_disponible" => false,
-          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_d.id}",
-        },
-      ]
+      # Organisation E is not in provided territory
+      # Organisation F does not exist
+      expected_response = {
+        "ext_id_A" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}",
+        "ext_id_B" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_b.id}",
+      }
       expect(JSON.parse(response.body)).to match_array(expected_response)
     end
   end

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -10,19 +10,18 @@ describe "public_api/public_links requests", type: :request do
 
   context "when plages are defined" do
     let(:params) do
-      {
-        departement: "CN",
-      }
+      { territory: "CN" }
     end
 
     it "returns any organisation that has any open plage ouverture" do
+      create(:plage_ouverture, organisation: organisation_a)
       create(:plage_ouverture, organisation: organisation_a)
       create(:plage_ouverture, :no_recurrence, organisation: organisation_b, first_day: Time.zone.today + 5.days)
       create(:plage_ouverture, :expired, organisation: organisation_c)
 
       get "/public_api/public_links", params: params, headers: {}
 
-      # Organisation A has a normal recurring plage
+      # Organisation A has two recurring plages
       # Organisation B has a plage in 5 days
       # Organisation C has a plage that expired
       # Organisation D has no plage

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -31,11 +31,11 @@ describe "public_api/public_links requests", type: :request do
         "public_links" => [
           {
             "external_id" => "ext_id_A",
-            "public_link" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}",
+            "public_link" => "http://www.rdv-aide-numerique-test.localhost/org/ext/CN/ext_id_A",
           },
           {
             "external_id" => "ext_id_B",
-            "public_link" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_b.id}",
+            "public_link" => "http://www.rdv-aide-numerique-test.localhost/org/ext/CN/ext_id_B",
           },
         ],
       }

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -11,12 +11,11 @@ describe "public_api/public_links requests", type: :request do
   context "when plages are defined" do
     let(:params) do
       {
-        external_ids: %w[ext_id_A ext_id_B ext_id_C ext_id_D ext_id_E ext_id_F],
         departement: "CN",
       }
     end
 
-    it "returns the list of organisations" do
+    it "returns any organisation that has any open plage ouverture" do
       create(:plage_ouverture, organisation: organisation_a)
       create(:plage_ouverture, :no_recurrence, organisation: organisation_b, first_day: Time.zone.today + 5.days)
       create(:plage_ouverture, :expired, organisation: organisation_c)

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+describe "api/v1/organisations/reservation_disponible requests", type: :request do
+  let!(:territory) { create(:territory, departement_number: "CN") }
+  let!(:organisation_a) { create(:organisation, new_domain_beta: true, external_id: "ext_id_A", territory: territory) }
+  let!(:organisation_b) { create(:organisation, new_domain_beta: true, external_id: "ext_id_B", territory: territory) }
+  let!(:organisation_c) { create(:organisation, new_domain_beta: true, external_id: "ext_id_C", territory: territory) }
+  let!(:organisation_d) { create(:organisation, new_domain_beta: true, external_id: "ext_id_D", territory: territory) }
+  let!(:organisation_e) { create(:organisation, new_domain_beta: true, external_id: "ext_id_E", territory: create(:territory)) }
+
+  context "when plages are defined" do
+    let(:params) do
+      {
+        external_ids: %w[ext_id_A ext_id_B ext_id_C ext_id_D ext_id_E],
+        departement: "CN",
+      }
+    end
+
+    it "returns the list of organisations" do
+      create(:plage_ouverture, organisation: organisation_a)
+      create(:plage_ouverture, :no_recurrence, organisation: organisation_b, first_day: Time.zone.today + 5.days)
+      create(:plage_ouverture, :expired, organisation: organisation_c)
+
+      get "/public_api/public_links", params: params, headers: {}
+
+      # Organisation A has a normal recurring plage
+      # Organisation B has a plage in 5 days
+      # Organisation C has a plage that expired
+      # Organisation D has no plage
+      # Organisation E is not in provided territory, it should be missing from response
+      # Organisation F does not exist, it should be missing from response
+      expected_response = [
+        {
+          "organisation_external_id" => "ext_id_A",
+          "reservation_disponible" => true,
+          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}",
+        },
+        {
+          "organisation_external_id" => "ext_id_B",
+          "reservation_disponible" => true,
+          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_b.id}",
+        },
+        {
+          "organisation_external_id" => "ext_id_C",
+          "reservation_disponible" => false,
+          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_c.id}",
+        },
+        {
+          "organisation_external_id" => "ext_id_D",
+          "reservation_disponible" => false,
+          "public_url" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_d.id}",
+        },
+      ]
+      expect(JSON.parse(response.body)).to match_array(expected_response)
+    end
+  end
+end

--- a/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
+++ b/spec/requests/api/v1/organisations_reservation_disponible_spec.rb
@@ -28,11 +28,19 @@ describe "public_api/public_links requests", type: :request do
       # Organisation D has no plage
       # Organisation E is not in provided territory
       # Organisation F does not exist
-      expected_response = {
-        "ext_id_A" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}",
-        "ext_id_B" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_b.id}",
+      expected_body = {
+        "public_links" => [
+          {
+            "external_id" => "ext_id_A",
+            "public_link" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}",
+          },
+          {
+            "external_id" => "ext_id_B",
+            "public_link" => "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_b.id}",
+          },
+        ],
       }
-      expect(JSON.parse(response.body)).to match_array(expected_response)
+      expect(JSON.parse(response.body)).to match_array(expected_body)
     end
   end
 end


### PR DESCRIPTION
Closes #2874

Le contexte est décrit dans #2874. :wink: 

Nous avons fait le choix de permettre de passer seulement un territoire (à travers le paramètre `departement`), et de retourner toutes les organisations de ce territoire qui ont des plages d'ouverture ouvertes.

Comme les tests le décrivent, la réponse ne contient que les organisations qui ont des plages ouvertes, et celles qui n'ont pas de plages n'y sont pas listées. C'est un choix de design pour une première étape, qui simplifie légèrement l'implémentation. À l'avenir nous pourrons introduire un booléen pour indiquer si la réservation est ouverte ou non, tout en continuant à fournir le lien public de façon indépendante.

Nous avons essayé de proposer un format d'API qui soit un minimum compatible avec l'existant, sans pour autant suivre totalement le modèle (pas de pagination), car la mise en place de cet API est exploratoire dans le cadre de l'expérimentation avec la carto.

# Checklist

Avant la revue :

- [ ] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
