### PR TITLE
Permettre de retirer la catégorie d'un motif

### DIFF
--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -21,7 +21,7 @@
         p.text-muted.font-14= Motif.human_attribute_name("category_hint")
         .form-row
           .col-md-12
-              = f.input :category, collection: Motif.human_attribute_values(:categories), prompt: "", input_html: { class: "select2-input" }, label: false
+              = f.input :category, collection: Motif.human_attribute_values(:categories), include_blank: "", input_html: { class: "select2-input" }, label: false
 
   .card
     .card-body

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -21,7 +21,7 @@
         p.text-muted.font-14= Motif.human_attribute_name("category_hint")
         .form-row
           .col-md-12
-              = f.input :category, collection: Motif.human_attribute_values(:categories), include_blank: "", input_html: { class: "select2-input" }, label: false
+              = f.input :category, collection: Motif.human_attribute_values(:categories), include_blank: "Aucune", input_html: { class: "select2-input" }, label: false
 
   .card
     .card-body


### PR DESCRIPTION
Traite [le ticket #554 côté RDV-Insertion](https://github.com/betagouv/rdv-insertion/issues/554)
Cette PR permet de retirer la catégorie d'un motif, lorsqu'une catégorie a déjà été attribuée à un motif ; la page `edit` ne le permettait pas jusque là.
