### PR TITLE
visualiser un rdv d'un autre service

### DIFF
--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -15,12 +15,12 @@ class Agent::RdvPolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      if context.can_access_others_planning?
-        scope.where(organisation: current_organisation)
-      else
-        scope.joins(%i[motif agents_rdvs]).where(organisation: current_organisation, motifs: { service: current_agent.service })
+      organisation_scope = scope.where(organisation: current_organisation)
+      unless context.can_access_others_planning?
+        organisation_scope = organisation_scope.joins(%i[motif agents_rdvs]).where(motifs: { service: current_agent.service })
           .or(Rdv.where("agents_rdvs.agent_id": current_agent.id))
       end
+      organisation_scope
     end
   end
 

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -18,7 +18,8 @@ class Agent::RdvPolicy < DefaultAgentPolicy
       if context.can_access_others_planning?
         scope.where(organisation: current_organisation)
       else
-        scope.joins(:motif).where(organisation: current_organisation, motifs: { service: current_agent.service })
+        scope.joins(%i[motif agents_rdvs]).where(organisation: current_organisation, motifs: { service: current_agent.service })
+          .or(Rdv.where("agents_rdvs.agent_id": current_agent.id))
       end
     end
   end
@@ -28,9 +29,10 @@ class Agent::RdvPolicy < DefaultAgentPolicy
       if context.can_access_others_planning?
         scope.where(organisation: current_agent.organisations)
       else
-        scope.joins(:motif)
+        scope.joins(%i[motif agents_rdvs])
           .where(organisation: current_agent.organisations)
           .where(motifs: { service: current_agent.service })
+          .or(Rdv.where("agents_rdvs.agent_id": current_agent.id))
       end
     end
   end

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -31,6 +31,18 @@ describe Agent::RdvPolicy, type: :policy do
     end
   end
 
+  shared_examples "included in departement scope" do
+    it "is included in departement scope" do
+      expect(Agent::RdvPolicy::DepartementScope.new(pundit_context, Rdv).resolve).to include(rdv)
+    end
+  end
+
+  shared_examples "not included in departement scope" do
+    it "is not included in departement scope" do
+      expect(Agent::RdvPolicy::DepartementScope.new(pundit_context, Rdv).resolve).not_to include(rdv)
+    end
+  end
+
   context "existing RDV from same agent" do
     let(:organisation) { create(:organisation) }
     let(:service) { create(:service) }
@@ -55,6 +67,7 @@ describe Agent::RdvPolicy, type: :policy do
 
     it_behaves_like "not permit actions", :show?, :edit?, :update?, :destroy?
     it_behaves_like "not included in scope"
+    it_behaves_like "not included in departement scope"
 
     context "for secretariat" do
       let(:service_agent) { build(:service, :secretariat) }
@@ -62,6 +75,7 @@ describe Agent::RdvPolicy, type: :policy do
       it_behaves_like "permit actions", :show?, :edit?, :update?
       it_behaves_like "not permit actions", :destroy?
       it_behaves_like "included in scope"
+      it_behaves_like "included in departement scope"
     end
 
     context "for admin" do
@@ -69,6 +83,16 @@ describe Agent::RdvPolicy, type: :policy do
 
       it_behaves_like "permit actions", :show?, :edit?, :update?, :destroy?
       it_behaves_like "included in scope"
+      it_behaves_like "included in departement scope"
+    end
+
+    context "except if the rdv concerns the connected agent" do
+      let(:rdv) { create(:rdv, motif: motif, organisation: organisation, agents: [agent]) }
+
+      it_behaves_like "permit actions", :show?, :edit?, :update?
+      it_behaves_like "not permit actions", :destroy?
+      it_behaves_like "included in scope"
+      it_behaves_like "included in departement scope"
     end
   end
 


### PR DESCRIPTION
Closes #2829

Lorsqu'un agent "admin" ou "secretaire" modifie un rdv, il peut l'attribuer à un agent d'un autre service, d'une même organisation, que celui du motif de ce rdv. Mais ces rdvs ne sont pas visible des agents en question.

Cette PR permet à un agent d'un autre service de voir ses rdvs attribués au sein de ce service.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
