### PR TITLE
Bugfix: header not adapting on agents presentation page

### DIFF
--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -27,7 +27,7 @@
         li.mb-1 = link_to "Contact", contact_path, class: "footer-links"
         - if current_domain == Domain::RDV_SOLIDARITES
           li.mb-1 = link_to "Les solidarités dans votre département", mds_path
-        li.mb-1 = link_to "Espace professionnel", accueil_mds_path
+        li.mb-1 = link_to "Espace professionnel", presentation_agent_path
         li.mb-1 = link_to "Statistiques", stats_path
         li.mb-1 = link_to "Budget", budget_path
     .col-6.col-md

--- a/app/views/common/_header.html.slim
+++ b/app/views/common/_header.html.slim
@@ -5,7 +5,7 @@ nav.navbar.navbar-expand-lg.bg-transparent
       i.fa.fa-bars.text-white
     #navbarSupportedContent.collapse.navbar-collapse
       ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
-        - if current_page?(accueil_mds_path)
+        - if current_page?(presentation_agent_path)
           li.list-inline-item
             = link_to t("links.usager_space"), root_path, class: "btn btn-link text-white"
           li.list-inline-item

--- a/app/views/search/address_selection/_rdv_solidarites.html.slim
+++ b/app/views/search/address_selection/_rdv_solidarites.html.slim
@@ -50,4 +50,4 @@ section.bg-lightturquoise.p-5
       .col-md-9
         h3.mb-2.text-primary Vous êtes un agent ?
         p.lead Nous nous engageons à réduire le nombre de rendez-vous manqués dans les services sociaux départementaux.
-        = link_to "En savoir plus", accueil_mds_path, class: "btn btn-tertiary"
+        = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -10,7 +10,8 @@ describe "public pages", js: true do
   end
 
   it "accueil_mds_path page is accessible" do
-    visit "http://www.rdv-solidarites-test.localhost/presentation_agent"
+    visit "http://www.rdv-solidarites-test.localhost/accueil_mds"
+    # This path now redirects to the generic /presentation_agent page
     expect(page).to have_current_path("/presentation_agent")
     expect(page).to be_axe_clean
   end


### PR DESCRIPTION
Bug introduit dans #2842, lorsque la route `accueil_mds` a été dépréciée au profit du nom générique (médico-social et CNFS) `presentation_agent`.

Cependant, des références à `accueil_mds` avaient été laissées dans le code, ce qui avait notamment pour effet de casser l'adaptation du header lorsqu'on est sur la page de présentation aux agents.

En effet, lorsqu'on est sur la page de présentation agents on devrait voir ça

![image](https://user-images.githubusercontent.com/6357692/193853392-082343b6-820d-45d2-a4b4-6fc2c2902815.png)

mais avec le bug on avait ça :

![image](https://user-images.githubusercontent.com/6357692/193853449-4c396825-6505-485c-ad3f-96ed1fbcf12a.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
