### PR TITLE
Automatise l'accessibilité de la liste des RDV

### DIFF
--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -4,6 +4,7 @@
       = f.input :agent_id, collection: [form.agent].compact, \
               label: "Agent", \
               label_method: :reverse_full_name, \
+              prompt: "Tous",
               input_html: { \
                 class: "select2-input", \
                 data: { \
@@ -20,6 +21,7 @@
       = f.input :user_id, collection: [form.user].compact,
               label: "Usager",
               label_method: :reverse_full_name,
+              prompt: "Tous",
               input_html: { \
                 class: "select2-input", \
                 data: { \
@@ -36,22 +38,20 @@
       = f.input :lieu_id, collection: policy_scope(Lieu).enabled.order(:name),
               label: "Lieu",
               label_method: :name,
-              input_html: { \
-                class: "select2-input", \
-              },
+              prompt: "Tous",
+              input_html: { class: "select2-input" },
               wrapper: "horizontal_form"
     .col-md-6
       = f.input :motif_id, collection: policy_scope(Motif),
-              label: "Motifs",
-              label_method: -> { motif_name_with_location_and_group_type(_1) }, \
-              input_html: { \
-                data: { placeholder: "Sélectionnez un motif" },
-                class: "select2-input", \
-              },
-              wrapper: "horizontal_form"
+            label: "Motifs",
+            label_method: :name,
+            prompt: "Tous",
+            input_html: { class: "select2-input" },
+            wrapper: "horizontal_form"
       - temporal_statuses = Rdv.statuses.keys - ["unknown"] + ["unknown_past", "unknown_future"]
       = f.input :status, collection: temporal_statuses,
               label_method: -> { ::Rdv.human_attribute_value(:status, _1, disable_cast: true) },
+              prompt: "Tous",
               label: "Statut",
               wrapper: "horizontal_form",
               input_html: { class: "select2-input" }

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -33,8 +33,7 @@
 
 .card.border-info
   .card-header.border-white
-    h5.mb-0
-      strong> Filtrer les rendez-vous
+    h2.mb-0 Filtrer les rendez-vous
   .card-body
     = render "rdv_search_form", form: @form
   - if @rdvs.any?

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -67,4 +67,13 @@ describe "agents page", js: true do
     login_as agent
     expect_page_to_be_axe_clean(agents_preferences_path)
   end
+
+  it "RDV list is accessible" do
+    territory = create(:territory, departement_number: "75")
+    organisation = create(:organisation, territory: territory)
+    agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
+    login_as agent
+    create_list(:rdv, 3, agents: [agent])
+    expect_page_to_be_axe_clean(admin_organisation_rdvs_path(organisation))
+  end
 end


### PR DESCRIPTION
Cette PR ajoute un test automatisé sur la page de liste des RDV.

Elle apporte aussi une correction : pour l'accessibilité, ce n'est pas ok d'avoir des « dropdown » sans contenu. J'ai donc ajouté « Tous » pour indiquer ce que le filtre fait avec cette selection.

Avant 

![Screenshot 2022-10-04 at 18-09-40 Liste des RDV - RDV Solidarités](https://user-images.githubusercontent.com/42057/193870373-cc4859de-14ca-4077-8419-ce972652358c.png)

Après

![Screenshot 2022-10-04 at 18-09-25 Liste des RDV - RDV Solidarités](https://user-images.githubusercontent.com/42057/193870412-ce2d387c-d550-4a06-8cb2-871e5191dd3f.png)


Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
