### PR TITLE
Supprimer les RDV collectif depuis l'index

### DIFF
--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -1,8 +1,11 @@
 .card
-  .card-header
-    = link_to admin_organisation_rdv_path(rdv.organisation, rdv) do
-      h5= rdv_title_for_agent(rdv)
-    = I18n.l(rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
+  .card-header.d-flex.justify-content-between.align-items-center
+    div
+      = link_to admin_organisation_rdv_path(rdv.organisation, rdv) do
+        h5= rdv_title_for_agent(rdv)
+      = I18n.l(rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
+    div.mr-3= link_to admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: nil), method: :delete, title: t("helpers.delete"), data: { confirm: "Confirmez-vous la suppression de ce rendez-vous collectif ?"} do
+      i.fa.fa-trash-alt
   .card-body
     .row
       .col-md-6


### PR DESCRIPTION
Closes #2884

![image](https://user-images.githubusercontent.com/8105430/194124252-7465a55e-608f-4eb5-88bc-60983faad0d7.png)

J'ai repéré en faisant cette issue que le delete redirigeait forcément à l'index des rdv individuel, qu'on delete un rdv individuel ou collectif. Question: c'est voulu ou je peux corriger ça?

# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
