### PR TITLE
reste sur la liste des RDVS au changement de statut

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -50,7 +50,7 @@ class Admin::RdvsController < AgentAuthController
       format.js
       format.html do
         if success
-          redirect_to admin_organisation_rdv_path(current_organisation, @rdv, agent_id: params[:agent_id]), rdv_success_flash
+          redirect_to admin_organisation_rdvs_path(current_organisation, agent_id: params[:agent_id]), rdv_success_flash
         else
           render :edit
         end

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -50,7 +50,7 @@ class Admin::RdvsController < AgentAuthController
       format.js
       format.html do
         if success
-          redirect_to admin_organisation_rdvs_path(current_organisation, agent_id: params[:agent_id]), rdv_success_flash
+          redirect_to admin_organisation_rdv_path(current_organisation, @rdv, agent_id: params[:agent_id]), rdv_success_flash
         else
           render :edit
         end

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -14,7 +14,7 @@
             = l(rdv.starts_at.to_date, format: :human).capitalize
           .text-muted
             = rdv_starts_at_and_duration(rdv, :time_only)
-      = render "rdv_status_dropdown", rdv: rdv, agent: local_assigns[:agent]
+      = render "rdv_status_dropdown", rdv: rdv, agent: local_assigns[:agent], remote: true
   hr.my-0.mx-3
   .card-body.py-3.row
     .col-md-6.col-sm-12

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -1,40 +1,29 @@
 .card.rdv-card[id= "rdv-#{rdv.id}"]
   .card-header.border-white
     .d-flex.justify-content-between.flex-wrap
-      - if local_assigns[:thin]
-        div
-          h5.header.mb-1
-            span
-              = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
-            span.ml-4
-              = link_to "Voir dans l'agenda  >", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
-      - else
-        div
-          h5.header.mb-1
-            = l(rdv.starts_at.to_date, format: :human).capitalize
-          .text-muted
-            = rdv_starts_at_and_duration(rdv, :time_only)
+      div
+        h5.header.mb-1
+          span
+            = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
       = render "rdv_status_dropdown", rdv: rdv, agent: local_assigns[:agent], remote: true
   hr.my-0.mx-3
   .card-body.py-3.row
     .col-md-6.col-sm-12
-      - unless local_assigns[:thin]
-        .d-flex.justify-content-between.flex-wrap.mb-1
-          p.card-text
-            i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
-            = rdv_starts_at_and_duration(rdv, :time_only)
-            |&nbsp;
-            = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
+      .d-flex.justify-content-between.flex-wrap.mb-1
+        p.card-text
+          i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
+          = rdv_starts_at_and_duration(rdv, :time_only)
+          |&nbsp;
+          = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
       = render "rdv_details", rdv: rdv
 
-    - unless local_assigns[:thin]
-      .col-md-6.col-sm-12
-        div.d-flex.justify-content-end.mt-1
-          = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "btn btn-outline-primary btn-sm mr-2"
-          - if rdv.individuel?
-            = link_to t("admin.rdvs.show.duplicate"), admin_organisation_agent_searches_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary btn-sm"
-          - else
-            = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "btn btn-outline-primary btn-sm"
+    .col-md-6.col-sm-12
+      div.d-flex.justify-content-end.mt-1
+        = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "btn btn-outline-primary btn-sm mr-2"
+        - if rdv.individuel?
+          = link_to t("admin.rdvs.show.duplicate"), admin_organisation_agent_searches_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary btn-sm"
+        - else
+          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "btn btn-outline-primary btn-sm"
 
   - if rdv.users.any?
     div class=("users-details collapse p-3 pt-0")
@@ -61,7 +50,7 @@
 
       - if rdv.collectif?
         .d-flex.justify-content-start.mb-2
-          - if rdv.remaining_seats? && !local_assigns[:thin]
+          - if rdv.remaining_seats?
             = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "btn btn-outline-primary btn-sm" do
               span
                 = "Ajouter un participant"

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -57,7 +57,7 @@
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
       = render(partial: "rdv",
               collection: @rdvs.includes(:organisation, :lieu, :motif, agents: :service, users: %i[responsible organisations]),
-              locals: { agent: nil, thin: true },
+              locals: { agent: nil },
               cached: ->(rdv) { [rdv, locale_cache_key] } \
               )
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -15,7 +15,7 @@
 .row.justify-content-md-center
   .col-md-11
     / @agent is only used for links in breadcrumb and redirecting if update
-    = render partial: "rdv", collection: [@rdv], locals: { agent: @agent, thin: false }
+    = render partial: "rdv", collection: [@rdv], locals: { agent: @agent }
 
 .row.justify-content-center
   .col-md-11

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -91,6 +91,7 @@ describe "Agent can see RDV details correctly" do
         find(".btn", text: "À renseigner").click
         expect do
           find("span", text: "Rendez-vous honoré").click
+          sleep 1
         end.to change { rdv.reload.status }.to("seen")
       end
     end


### PR DESCRIPTION
Ref : https://zammad10.ethibox.fr/#ticket/zoom/2865

Lors des changements récents sur la fiche RDV pour afficher les participants, quelques modifications ont été apportées au design en général. Ces modifications ont fait disparaitre la possibilité de changer les statuts sans changer de page.

Cette PR corrige ce petit oubli.

Un phénomène intéressant apparait : la partie JavaScript qui recharge le bloc de RDV dans la liste fait apparaitre les boutons de modification et duplication. Je pense que nous pourrions les afficher en permanence, y compris dans cette liste. 

![Screenshot 2022-10-06 at 10-08-52 Liste des RDV - RDV Solidarités](https://user-images.githubusercontent.com/42057/194258390-7b5cf55b-dc17-4325-ab6e-945314a3f08e.png)


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
