### PR TITLE
Téléchargement des rdvs par usager sur plusieurs organisations

### DIFF
--- a/app/controllers/admin/territories/agent_territorial_access_rights_controller.rb
+++ b/app/controllers/admin/territories/agent_territorial_access_rights_controller.rb
@@ -11,6 +11,6 @@ class Admin::Territories::AgentTerritorialAccessRightsController < Admin::Territ
   end
 
   def agent_territorial_access_right_params
-    params.require(:agent_territorial_access_right).permit(:allow_to_manage_teams, :allow_to_manage_access_rights, :allow_to_invite_agents)
+    params.require(:agent_territorial_access_right).permit(:allow_to_manage_teams, :allow_to_manage_access_rights, :allow_to_invite_agents, :allow_to_download_metrics)
   end
 end

--- a/app/form_models/admin/rdv_search_form.rb
+++ b/app/form_models/admin/rdv_search_form.rb
@@ -26,7 +26,7 @@ class Admin::RdvSearchForm
   end
 
   def to_query
-    %i[organisation_id start end agent_id user_id status lieu_id motif_id]
+    %i[organisation_id start end agent_id user_id status lieu_id motif_id scoped_organisation_id]
       .map { [_1, send(_1)] }.to_h
   end
 end

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class Agents::ExportMailer < ApplicationMailer
-  def rdv_export(agent, organisation, options)
+  def rdv_export(agent, organisation_ids, options)
     @agent = agent
     now = Time.zone.now
-    rdvs = Rdv.search_for(organisation, options)
+    organisations = Organisation.where(id: organisation_ids)
+    rdvs = Rdv.search_for(organisations, options)
 
     # Le département du Var se base sur la position de chaque caractère du nom
     # de fichier pour extraire la date et l'ID d'organisation, donc
     # si on modifie le fichier il faut soit les prévenir soit ajouter à la fin.
-    file_name = "export-rdv-#{now.strftime('%Y-%m-%d')}-org-#{organisation.id.to_s.rjust(6, '0')}.xls"
+    file_name = "export-rdv-#{now.strftime('%Y-%m-%d')}.xls"
     mail.attachments[file_name] = {
       mime_type: "application/vnd.ms-excel",
       content: RdvExporter.export(rdvs.order(starts_at: :desc)),
@@ -17,7 +18,27 @@ class Agents::ExportMailer < ApplicationMailer
 
     mail(
       to: agent.email,
-      subject: I18n.t("mailers.agents.export_mailer.rdv_export.subject", organisation_name: organisation.name, date: I18n.l(now))
+      subject: I18n.t("mailers.agents.export_mailer.rdv_export.subject", date: I18n.l(now))
+    )
+  end
+
+  def rdvs_users_export(agent, organisation_ids, options)
+    @agent = agent
+    now = Time.zone.now
+    organisations = Organisation.where(id: organisation_ids)
+
+    rdvs = Rdv.search_for(organisations, options)
+    rdvs_users = RdvsUser.where(rdv_id: rdvs.ids)
+
+    file_name = "export-rdvs-user-#{now.strftime('%Y-%m-%d')}.xls"
+    mail.attachments[file_name] = {
+      mime_type: "application/vnd.ms-excel",
+      content: RdvsUserExporter.export(rdvs_users.order(id: :desc)),
+    }
+
+    mail(
+      to: agent.email,
+      subject: I18n.t("mailers.agents.export_mailer.full_rdvs_user_export.subject", date: I18n.l(now))
     )
   end
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -211,9 +211,9 @@ class Rdv < ApplicationRecord
     ""
   end
 
-  def self.search_for(organisation, options)
-    organisation_ids = [organisation.id] if organisation.is_a?(Organisation)
-    organisation_ids ||= organisation.ids
+  def self.search_for(organisations, options)
+    organisation_ids = [organisations.id] if organisations.is_a?(Organisation)
+    organisation_ids ||= organisations.ids
     rdvs = joins(:organisation).where(organisations: { id: organisation_ids })
     options.each do |key, value|
       next if value.blank?

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -33,6 +33,12 @@ class Agent::AgentPolicy < ApplicationPolicy
     admin_in_record_organisation? && record != current_agent
   end
 
+  def rdvs_users_export?
+    current_territory = context&.organisation&.territory
+    access_rights = current_agent.access_rights_for_territory(current_territory)
+    access_rights&.allow_to_download_metrics?
+  end
+
   class Scope < Scope
     include CurrentAgentInPolicyConcern
 

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -12,12 +12,11 @@ class Configuration::TerritoryPolicy
   end
 
   def show?
-    # FIXME: le safe operator (&) est fait pour que les nouveaux agents invités via le revert de la liste
-    # des agents dans le menu de gauche qui n'ont pas d'access_rights n'aient pas une erreur à l'affichage de la liste des organisations
     territorial_admin? ||
-      @access_rights&.allow_to_manage_teams? ||
-      @access_rights&.allow_to_manage_access_rights? ||
-      @access_rights&.allow_to_invite_agents?
+      allow_to_manage_teams? ||
+      allow_to_manage_access_rights? ||
+      allow_to_invite_agents? ||
+      allow_to_download_metrics?
   end
 
   def display_sms_configuration?
@@ -34,6 +33,10 @@ class Configuration::TerritoryPolicy
 
   def allow_to_manage_teams?
     @access_rights&.allow_to_manage_teams?
+  end
+
+  def allow_to_download_metrics?
+    @access_rights&.allow_to_download_metrics?
   end
 
   alias display_user_fields_configuration? territorial_admin?

--- a/app/services/rdvs_user_exporter.rb
+++ b/app/services/rdvs_user_exporter.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module RdvsUserExporter
+  HourFormat = Spreadsheet::Format.new(number_format: "hh:mm")
+  DateFormat = Spreadsheet::Format.new(number_format: "DD/MM/YYYY")
+  HEADER = [
+    "usager",
+    "rdv_id",
+    "année",
+    "date prise rdv",
+    "heure prise rdv",
+    "origine",
+    "date rdv",
+    "heure rdv",
+    "service",
+    "motif",
+    "contexte",
+    "statut",
+    "lieu",
+    "professionnel.le(s)",
+    "commune du responsable",
+    "usager mineur ?",
+    "résultat des notifications",
+    "Organisation",
+    "date naissance",
+    "code postal du responsable",
+    "créé par",
+    "email(s) professionnel.le(s)",
+  ].freeze
+
+  def self.export(rdv_users)
+    extract_string_from(build_excel_workbook_from(rdv_users))
+  end
+
+  def self.extract_string_from(workbook)
+    file = StringIO.new
+    workbook.write(file)
+    file.string
+  end
+
+  def self.build_excel_workbook_from(rdv_users)
+    Spreadsheet.client_encoding = "UTF-8"
+    book = Spreadsheet::Workbook.new
+    sheet = book.create_worksheet
+    sheet.row(0).concat(HEADER)
+
+    rdv_users = rdv_users.includes(:user, rdv: %i[motif agents receipts])
+
+    rdv_users.each_with_index do |rdv_user, index|
+      row = sheet.row(index + 1)
+      row.set_format 3, DateFormat
+      row.set_format 4, HourFormat
+      row.set_format 6, DateFormat
+      row.set_format 7, HourFormat
+
+      row.concat(row_array_from(rdv_user))
+    end
+    book
+  end
+
+  def self.row_array_from(rdv_user)
+    rdv = rdv_user.rdv
+    user = rdv_user.user
+    [
+      user.full_name,
+      rdv.id,
+      rdv.created_at.year,
+      I18n.l(rdv.created_at.to_date),
+      I18n.l(rdv.created_at, format: :time_only),
+      rdv.human_attribute_value(:created_by),
+      I18n.l(rdv.starts_at.to_date),
+      I18n.l(rdv.starts_at, format: :time_only),
+      rdv.motif.service.name,
+      rdv.motif.name,
+      rdv.context,
+      Rdv.human_attribute_value(:status, rdv.temporal_status, disable_cast: true),
+      rdv.address_without_personal_information || "",
+      rdv.agents.map(&:full_name).join(", "),
+      user.user_to_notify.city_name,
+      user.minor? ? "oui" : "non",
+      Receipt.human_attribute_value(:result, rdv.synthesized_receipts_result),
+      rdv.organisation.name,
+      user.birth_date.present? ? I18n.l(user.birth_date) : "",
+      extract_postal_code_from(user.user_to_notify.address),
+      rdv.author,
+      rdv.agents.map(&:email).join(", "),
+    ]
+  end
+
+  def self.extract_postal_code_from(address)
+    return "" if address.blank?
+
+    postal_code = address.match(/.*([0-9]{5}).*/)
+    return "" if postal_code.blank? || postal_code.captures.empty?
+
+    postal_code.captures.first
+  end
+end

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -36,9 +36,14 @@
     h2.mb-0 Filtrer les rendez-vous
   .card-body
     = render "rdv_search_form", form: @form
+
   - if @rdvs.any?
     .card-footer
       div.d-flex.justify-content-end
+        - if policy([:configuration, current_territory]).allow_to_download_metrics?
+          = link_to rdvs_users_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-small btn-link d-print-none" do
+            span> Exporter les #{@rdvs_users_count} RDVs par usager en XLS
+            i.fa.fa-download>
         = link_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-small btn-link d-print-none" do
           span> Exporter les #{@rdvs.total_count} RDVs en XLS
           i.fa.fa-download>

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -10,6 +10,7 @@
           = f.input :allow_to_manage_teams, as: :boolean, hint: t(".hint_allow_to_manage_teams")
           = f.input :allow_to_manage_access_rights, as: :boolean, hint: t(".hint_allow_to_manage_access_rights")
           = f.input :allow_to_invite_agents, as: :boolean, hint: t(".hint_allow_to_invite_agents")
+          = f.input :allow_to_download_metrics, as: :boolean, hint: t(".hint_allow_to_download_metrics")
         .card-footer
           .row
             .col.text-right

--- a/app/views/mailers/agents/export_mailer/rdvs_users_export.html.slim
+++ b/app/views/mailers/agents/export_mailer/rdvs_users_export.html.slim
@@ -1,0 +1,6 @@
+div
+  p = t("mailers.common.hello")
+
+  p = t(".description")
+
+  p = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -93,12 +93,16 @@ fr:
   agents:
     export_mailer:
       rdv_export:
-        description: Vous trouverez en pièce jointe l’export des RDV que vous avez demandé.
+        description: Vous trouverez en pièce jointe l’export des RDVs que vous avez demandé.
+      rdvs_users_export:
+        description: Vous trouverez en pièce jointe l’export des RDVs par usager que vous avez demandé.
   mailers:
     agents:
       export_mailer:
         rdv_export:
-          subject: Export RDV du %{date} pour l'organisation %{organisation_name}
+          subject: Export des RDVs du %{date}
+        full_rdvs_user_export:
+          subject: Export des RDVs par usager du %{date}
   date:
     helpers:
       tomorrow: demain
@@ -265,6 +269,7 @@ fr:
   layouts:
     flash:
       confirm_export_send_when_done: Le fichier Excel des RDV sera envoyé à %{agent_email}.
+      confirm_rdvs_users_export_send_when_done: Le fichier Excel de l'ensemble des rdvs par usager du territoire sera envoyé à %{agent_email}.
   number:
     currency:
       format:

--- a/config/locales/models/agent.fr.yml
+++ b/config/locales/models/agent.fr.yml
@@ -14,6 +14,7 @@ fr:
         allow_to_manage_teams: Autorisé à créer, supprimer, modifier des équipes
         allow_to_manage_access_rights: Autorisé à gérer les droits d'accès
         allow_to_invite_agents: Autorisé à inviter et affecter des agents sur des organisations
+        allow_to_download_metrics: Autorisé à télécharger les rendez-vous par usager sur plusieurs organisations
       agent/rdv_notifications_levels:
         all: À chaque modification
         others: Uniquement les modifications faites par un usager (ou par un autre agent)

--- a/config/locales/views/admin_territories_agents.yml
+++ b/config/locales/views/admin_territories_agents.yml
@@ -8,5 +8,6 @@ fr:
             submit: Enregistrer
           delete_agent_role: Retirer
           hint_allow_to_manage_teams: "Créer, supprimer, modifier toutes les équipes du territoires"
-          hint_allow_to_manage_access_rights: "Modifier les droits d'accès de tous les agents du territoire" 
+          hint_allow_to_manage_access_rights: "Modifier les droits d'accès de tous les agents du territoire"
           hint_allow_to_invite_agents: "Inviter d'autre personne sur le territoire, les affecter ou retirer de chacune des organisations du territoire"
+          hint_allow_to_download_metrics: "Recevoir par mail un fichier contenant tous les rendez-vous par usager sur plusieurs organisations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Rails.application.routes.draw do
             post :send_reminder_manually
           end
           collection do
+            post :rdvs_users_export
             post :export
           end
         end

--- a/db/migrate/20221004125920_add_allow_to_download_metrics_to_agent_territorial_access_rights.rb
+++ b/db/migrate/20221004125920_add_allow_to_download_metrics_to_agent_territorial_access_rights.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAllowToDownloadMetricsToAgentTerritorialAccessRights < ActiveRecord::Migration[6.1]
+  def up
+    add_column :agent_territorial_access_rights, :allow_to_download_metrics, :boolean, default: false, null: false
+    AgentTerritorialAccessRight.where(allow_to_manage_teams: true, allow_to_manage_access_rights: true, allow_to_invite_agents: true).update_all(allow_to_download_metrics: true)
+  end
+
+  def down
+    remove_column :agent_territorial_access_rights, :allow_to_download_metrics, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -180,6 +180,7 @@ ActiveRecord::Schema.define(version: 2022_10_20_152222) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "allow_to_manage_access_rights", default: false, null: false
     t.boolean "allow_to_invite_agents", default: false, null: false
+    t.boolean "allow_to_download_metrics", default: false, null: false
     t.index ["agent_id"], name: "index_agent_territorial_access_rights_on_agent_id"
     t.index ["territory_id"], name: "index_agent_territorial_access_rights_on_territory_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -535,6 +535,7 @@ agent_org_paris_nord_pmi_martine = Agent.new(
     allow_to_manage_teams: true,
     allow_to_manage_access_rights: true,
     allow_to_invite_agents: true,
+    allow_to_download_metrics: true,
   }]
 )
 agent_org_paris_nord_pmi_martine.skip_confirmation!
@@ -555,6 +556,7 @@ agent_org_paris_nord_pmi_marco = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
+    allow_to_download_metrics: false,
   }]
 )
 agent_org_paris_nord_pmi_marco.skip_confirmation!
@@ -574,6 +576,7 @@ agent_org_paris_nord_social_polo = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
+    allow_to_download_metrics: false,
   }]
 )
 agent_org_paris_nord_social_polo.skip_confirmation!
@@ -593,6 +596,7 @@ org_arques_pmi_maya = Agent.new(
     allow_to_manage_teams: true,
     allow_to_manage_access_rights: true,
     allow_to_invite_agents: true,
+    allow_to_download_metrics: true,
   }]
 )
 org_arques_pmi_maya.skip_confirmation!
@@ -612,6 +616,7 @@ agent_org_bapaume_pmi_bruno = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
+    allow_to_download_metrics: false,
   }]
 )
 agent_org_bapaume_pmi_bruno.skip_confirmation!
@@ -632,6 +637,7 @@ agent_org_bapaume_pmi_gina = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
+    allow_to_download_metrics: false,
   }]
 )
 agent_org_bapaume_pmi_gina.skip_confirmation!
@@ -651,6 +657,7 @@ agent_cnfs = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
+    allow_to_download_metrics: false,
   }]
 )
 agent_cnfs.skip_confirmation!
@@ -669,7 +676,10 @@ agent_orgs_rdv_insertion = Agent.new(
     { organisation: org_drome2, level: AgentRole::LEVEL_ADMIN },
     { organisation: org_yonne, level: AgentRole::LEVEL_ADMIN },
   ],
-  agent_territorial_access_rights_attributes: [{ territory: territory_drome, allow_to_manage_teams: true }, { territory: territory_yonne, allow_to_manage_teams: true }]
+  agent_territorial_access_rights_attributes: [
+    { territory: territory_drome, allow_to_manage_teams: true },
+    { territory: territory_yonne, allow_to_manage_teams: true },
+  ]
 )
 agent_orgs_rdv_insertion.skip_confirmation!
 agent_orgs_rdv_insertion.save!

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -26,6 +26,7 @@ describe Admin::RdvSearchForm do
         motif_id: motif.id,
         status: nil,
         user_id: nil,
+        scoped_organisation_id: nil,
       }
       expect(agent_rdv_search_form.to_query).to eq(expected_query)
     end

--- a/spec/mailers/agents/export_mailer_spec.rb
+++ b/spec/mailers/agents/export_mailer_spec.rb
@@ -1,15 +1,25 @@
 # frozen_string_literal: true
 
 describe Agents::ExportMailer do
-  describe "#rdv_export" do
-    subject(:rdv_export) { described_class.rdv_export(agent, organisation, {}) }
+  let!(:organisation) { create(:organisation, id: 666) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:territory) { organisation.territory }
 
-    let(:organisation) { create(:organisation, id: 666) }
-    let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  describe "#rdv_export" do
+    subject(:rdv_export) { described_class.rdv_export(agent, [organisation.id], {}) }
 
     it "has an attachment which contains the current date and org ID" do
       travel_to(Time.zone.parse("2022-09-14 09:00:00"))
-      expect(rdv_export.attachments.first.filename).to eq("export-rdv-2022-09-14-org-000666.xls")
+      expect(rdv_export.attachments.first.filename).to eq("export-rdv-2022-09-14.xls")
+    end
+  end
+
+  describe "#rdvs_users_export" do
+    subject(:rdvs_users_export) { described_class.rdvs_users_export(agent, [organisation.id], {}) }
+
+    it "has an attachment which contains the current date" do
+      travel_to(Time.zone.parse("2022-09-14 09:00:00"))
+      expect(rdvs_users_export.attachments.first.filename).to eq("export-rdvs-user-2022-09-14.xls")
     end
   end
 end

--- a/spec/mailers/previews/agents/export_mailer_preview.rb
+++ b/spec/mailers/previews/agents/export_mailer_preview.rb
@@ -9,4 +9,10 @@ class Agents::ExportMailerPreview < ActionMailer::Preview
     }
     Agents::ExportMailer.rdv_export(agent, agent.organisations.first, options)
   end
+
+  def rdvs_users_export
+    agent = Agent.first
+    territory = Territory.first
+    Agents::ExportMailer.rdvs_users_export(agent, territory)
+  end
 end

--- a/spec/policies/configuration/territory_policy_spec.rb
+++ b/spec/policies/configuration/territory_policy_spec.rb
@@ -116,5 +116,25 @@ describe Configuration::TerritoryPolicy, type: :policy do
                       :display_rdv_fields_configuration?,
                       :display_motif_fields_configuration?
     end
+
+    context "allowed to download metrics access right" do
+      let(:agent) { create(:agent, role_in_territories: []) }
+      let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_download_metrics: true) }
+
+      it_behaves_like "permit actions",
+                      :show?,
+                      :allow_to_download_metrics?
+
+      it_behaves_like "not permit actions",
+                      :update?,
+                      :edit?,
+                      :display_sms_configuration?,
+                      :allow_to_invite_agents?,
+                      :allow_to_manage_access_rights?,
+                      :allow_to_manage_teams?,
+                      :display_user_fields_configuration?,
+                      :display_rdv_fields_configuration?,
+                      :display_motif_fields_configuration?
+    end
   end
 end


### PR DESCRIPTION
Closes #2008 

# Synthèse
- En tant qu'admin d'un territoire, je peux donner droit à un agent de télécharger toutes les données dans un nouveau format de rdvs par usager sur l'ensemble des organisations auxquelles il accède
- En tant qu'agent ayant droit de télécharger toutes les données de rdvs par usager, j'accède à cette action depuis l'interface de la liste des RDV

# Test en démo
@NesserineZarouri @MYRIAMKEDDAD : https://demo-rdv-solidarites-pr2900.osc-secnum-fr1.scalingo.io/admin/organisations/1/rdvs en tant que martine@demo.rdv-solidarites.fr

# Avant gestion de droit
![Capture d’écran 2022-10-20 à 15 46 06](https://user-images.githubusercontent.com/11738628/196970915-cf0b98e2-c2c0-463d-8749-8cdf107ccd19.png)

# Après gestion de droit
![Capture d’écran 2022-10-21 à 11 41 17](https://user-images.githubusercontent.com/11738628/197166103-2dc815f7-a0b7-4272-9e24-9b515d277bde.png)


# Avant liste des RDV
![Capture d’écran 2022-10-20 à 15 46 40](https://user-images.githubusercontent.com/11738628/196970978-df7d62d8-7685-4c12-b59e-c0d6422eafe1.png)

# Après liste des RDV pour ayant droit
![Capture d’écran 2022-10-21 à 11 41 38](https://user-images.githubusercontent.com/11738628/197166134-bad3e90d-0002-45b9-b056-e7fc90c0c732.png)


# Existant : mail reçu au téléchargement des RDV
![Capture d’écran 2022-10-20 à 15 49 01](https://user-images.githubusercontent.com/11738628/196971241-f267c7bd-d2e8-4899-8e25-21fd24e98a8f.png)

# Après : nouveau mail reçu au téléchargement des rdvs par usager 
![Capture d’écran 2022-10-21 à 11 43 20](https://user-images.githubusercontent.com/11738628/197166266-af3f9a56-1fcf-43d0-8e0f-ea3eb3ae0384.png)



# Existant : format Excel des RDVs
![Capture d’écran 2022-10-20 à 15 53 05](https://user-images.githubusercontent.com/11738628/196971282-268f1152-ad9d-4023-a02c-d2dddecf5786.png)

# Après : nouveau format Excel des RDVs par usager
![Capture d’écran 2022-10-20 à 15 54 03](https://user-images.githubusercontent.com/11738628/196971331-bdadf604-d7a9-4706-90c3-f984792e30df.png)


Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
