### PR TITLE
Range la sectorisation derrière le menu du même nom

### DIFF
--- a/app/controllers/admin/territories/sectorizations_controller.rb
+++ b/app/controllers/admin/territories/sectorizations_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::Territories::SectorizationsController < Admin::Territories::BaseController
+  def show
+    skip_authorization
+  end
+end

--- a/app/views/admin/territories/sector_attributions/new.html.slim
+++ b/app/views/admin/territories/sector_attributions/new.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title", name: @sector.name), [link_to("Secteurs", admin_territory_sectors_path(current_territory))])
+= territory_navigation(t(".title", name: @sector.name), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/admin/territories/sectorisation_tests/search.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/search.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title"))
+= territory_navigation(t(".title"), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory))])
 
 = simple_form_for \
   @sectorisation_test_form, \

--- a/app/views/admin/territories/sectorizations/show.html.slim
+++ b/app/views/admin/territories/sectorizations/show.html.slim
@@ -1,0 +1,25 @@
+= territory_navigation(t(".title"))
+
+.row.justify-content-center
+
+  - if policy([:configuration, Sector]).display?
+    .col.col-md-4.p-2.rounded.settings-box
+      = link_to admin_territory_sectors_path(current_territory, current_agent) do
+        h2.fw-bold.mb-0
+          i.fa.fa-table>
+          | Secteurs
+        p Créer vos secteurs géographiques pour organiser votre sectorisation.
+
+    .col.col-md-4.p-2.rounded.settings-box
+      = link_to admin_territory_sectorisation_test_path(current_territory) do
+        h2.fw-bold.mb-0
+          i.fa.fa-check-square>
+          | Test
+        p Effectuer des tests de vérification des adresses et informations de code INSEE.
+
+    .col.col-md-4.p-2.rounded.settings-box
+      = link_to new_admin_territory_zone_import_path(current_territory) do
+        h2.fw-bold.mb-0
+          i.fa.fa-download>
+          | Import
+        p Importer un fichier de sectorisation pour faciliter la création de votre découpage géographique.

--- a/app/views/admin/territories/sectors/edit.html.slim
+++ b/app/views/admin/territories/sectors/edit.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title", name: @sector.name), [link_to("Secteurs", admin_territory_sectors_path(current_territory))])
+= territory_navigation(t(".title", name: @sector.name), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/admin/territories/sectors/index.html.slim
+++ b/app/views/admin/territories/sectors/index.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title"))
+= territory_navigation(t(".title"), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory))])
 
 .row.justify-content-center
   .col-md-10

--- a/app/views/admin/territories/sectors/index_map.html.slim
+++ b/app/views/admin/territories/sectors/index_map.html.slim
@@ -4,7 +4,7 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
   <link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
 
-= territory_navigation(t(".title"), [link_to("Secteurs", admin_territory_sectors_path(current_territory))])
+= territory_navigation(t(".title"), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 
 .row
   .col-md-12

--- a/app/views/admin/territories/sectors/new.html.slim
+++ b/app/views/admin/territories/sectors/new.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title"), [link_to("Secteurs", admin_territory_sectors_path(current_territory))])
+= territory_navigation(t(".title"), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/admin/territories/sectors/show.html.slim
+++ b/app/views/admin/territories/sectors/show.html.slim
@@ -4,7 +4,7 @@
   <script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
   <link href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css" rel="stylesheet" />
 
-= territory_navigation(t(".title", name: @sector.name), [link_to("Secteurs", admin_territory_sectors_path(current_territory))])
+= territory_navigation(t(".title", name: @sector.name), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory)), link_to("Secteurs", admin_territory_sectors_path(current_territory))])
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -43,35 +43,11 @@
 
   - if policy([:configuration, Sector]).display?
     .col.col-md-4.p-2.rounded.settings-box
-      = link_to admin_territory_sectors_path(current_territory, current_agent) do
+      = link_to admin_territory_sectorization_path(current_territory) do
         h2.fw-bold.mb-0
           i.fa.fa-table>
-          | Secteurs
-        p Créer vos secteurs géographiques pour organiser votre sectorisation.
-
-  - if policy([:configuration, Sector]).display?
-    .col.col-md-4.p-2.rounded.settings-box
-      = link_to admin_territory_sectors_path(current_territory, view: "map") do
-        h2.fw-bold.mb-0
-          i.fa.fa-map>
-          | Carte
-        p Visualiser les secteurs du territoire.
-
-  - if policy([:configuration, Sector]).display?
-    .col.col-md-4.p-2.rounded.settings-box
-      = link_to admin_territory_sectorisation_test_path(current_territory) do
-        h2.fw-bold.mb-0
-          i.fa.fa-check-square>
-          | Test
-        p Effectuer des tests de vérification des adresses et informations de code INSEE.
-
-  - if policy([:configuration, Sector]).display?
-    .col.col-md-4.p-2.rounded.settings-box
-      = link_to new_admin_territory_zone_import_path(current_territory) do
-        h2.fw-bold.mb-0
-          i.fa.fa-download>
-          | Import
-        p Importer un fichier de sectorisation pour faciliter la création de votre découpage géographique.
+          | Sectorisation
+        p Créer, importer, affecter vos secteurs géographiques.
 
   - if policy([:configuration, current_territory]).display_user_fields_configuration?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/admin/territories/zone_imports/create.html.slim
+++ b/app/views/admin/territories/zone_imports/create.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title", territoire: @current_territory))
+= territory_navigation(t(".title", territoire: @current_territory), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory))])
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/admin/territories/zone_imports/new.html.slim
+++ b/app/views/admin/territories/zone_imports/new.html.slim
@@ -1,4 +1,4 @@
-= territory_navigation(t(".title"))
+= territory_navigation(t(".title"), [link_to("Sectorisation", admin_territory_sectorization_path(current_territory))])
 
 .row.justify-content-center
   .col-md-6

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -1,6 +1,9 @@
 fr:
   admin:
     territories:
+      sectorizations:
+        show:
+          title: Sectorisation
       sector_attributions:
         new:
           title: Nouvelle attribution pour le secteur %{name}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,7 @@ Rails.application.routes.draw do
           resource :sms_configuration, only: %i[show edit update]
           resources :zone_imports, only: %i[new create]
           resources :zones, only: [:index] # exports only
+          resource :sectorization, only: [:show]
           resources :sectors do
             resources :zones
             resources :sector_attributions, only: %i[new create destroy], as: :attributions


### PR DESCRIPTION
_Pas une grosse priorité, mais j'ai fait ça en tant que participant à du logiciel libre, en dehors de mes heures factures_

Cette PR range les pages de configuration de la sectorisation derrière un menu approprié

Avant

![Screenshot 2022-10-06 at 17-04-42 RDV Solidarités](https://user-images.githubusercontent.com/42057/194348915-ff82afdf-6248-4f02-ae84-c73e4ea301ff.png)

Après

![Screenshot 2022-10-06 at 17-05-12 RDV Solidarités](https://user-images.githubusercontent.com/42057/194348966-dec8c523-94df-4a0b-8287-60ea30d3637d.png)


puis, dans le menu sectorisation 

![Screenshot 2022-10-06 at 17-11-48 RDV Solidarités](https://user-images.githubusercontent.com/42057/194350537-df04c914-1515-4284-b98d-ae53b210c727.png)

Je n'ai pas repris la carte, car le lien est déjà présent -et lié- aux secteurs 

![Screenshot 2022-10-06 at 17-11-57 RDV Solidarités](https://user-images.githubusercontent.com/42057/194350623-41cdd409-6576-42f9-935a-9bdc41fe81f1.png)

Je chemin de fer est enrichi

![Screenshot 2022-10-06 at 17-13-25 RDV Solidarités](https://user-images.githubusercontent.com/42057/194350907-1a1074af-18e9-4884-b2b2-bf7d4416e512.png)


Revue :
- [x] Relecture du code
- [x] Test sur la review app / en local
