### PR TITLE
Bugfix: le graphique de stats de notifications n'est pas scopé au territoire sélectionné

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -83,10 +83,10 @@
     .card.mb-5
       .card-body
         = self_anchor "notifications"
-          h2.card-title "#{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})"
+          h2.card-title #{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})
         - %i[event channel result].each do |attribute|
           h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
-          = column_chart receipts_stats_path(group_by: attribute, departement: @departement), stacked: true
+          = column_chart receipts_stats_path(group_by: attribute, departement: @departement, territory: @territory), stacked: true
 
     .card.mb-5
       .card-body


### PR DESCRIPTION
Actuellement, lorsqu'on visualise les stats d'un territoire, la section "Notifications envoyées" affiche un graphique dont les données sont issues de **tous les territoires**.

Avec ce fix, on s'assure d'afficher le graph du territoire. Exemples avec la Haute Garonne, qui n'a en réalité aucun RDV : 

## Avant

![image](https://user-images.githubusercontent.com/6357692/194371761-2249b12b-92c8-4dcb-ace6-933edbc508b2.png)

## Après

![image](https://user-images.githubusercontent.com/6357692/194371920-97a7df27-1eee-45df-b8b1-b3ebbcec7a99.png)

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
