### PR TITLE
fix(webhooks): Trigger webhooks when updating status

### DIFF
--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -49,6 +49,9 @@ module Rdv::Updatable
     if collectif?
       @rdv_users_tokens_by_user_id = Notifiers::RdvCollectifParticipations.perform_with(self, author, previous_participations)
     end
+
+    # we re-enable the webhooks that we deactivated during the notification process
+    self.skip_webhooks = false
   end
 
   def rdv_status_reloaded_from_cancelled?


### PR DESCRIPTION
Suite à un retour d'un département utilisant RDV-Insertion, on s'est rendu compte que les webhooks n'étaient plus envoyés lorsque le statut d'un rendez-vous était mis à jour depuis l'interface admin.
En creusant dans le code, j'ai remarqué que c'était parce que suite à la refacto récente et la mise en place du concern `Rdv::Updatable`, les mises à jour du rdv et les envois de notifications sont englobés dans une transaction (ce qui est une bonne chose).
Mais à cause de [cette ligne](https://github.com/betagouv/rdv-solidarites.fr/blob/7f2e8b7facc8955c5a750fce407f8b7f47a36dea/app/services/notifiers/rdv_base.rb#L56) dans le service de notifications,  les webhooks ne sont pas envoyés.

J'ai fait un hotfix qui consiste à réactiver l'envoi de webhook au sein de la transaction après l'envoi des notifications.
Cependant, à mon sens il ne faudrait peut-être pas empêcher l'envoi du webhook dans le service de notifications. @francois-ferrandis explique pourquoi ce changement a été introduit [ici](https://github.com/betagouv/rdv-solidarites.fr/pull/2663), et les raisons énoncées font sens. Mais je pense qu'il y a beaucoup d'autres endroits où les webhooks sont envoyés alors que l'état du rdv ne change pas, et je ne pense pas que ça pose de problèmes. En tant que consommateur de webhooks, je préfère largement en recevoir plus qu'il n'en faut que pas assez.

Je propose de merger ce hotfix en attendant de débattre de mon avis du dessus.
