### PR TITLE
notifier l'agent de l'arrivée d'un usager en salle d'attente

### DIFF
--- a/app/controllers/admin/territories/rdv_fields_controller.rb
+++ b/app/controllers/admin/territories/rdv_fields_controller.rb
@@ -15,6 +15,6 @@ class Admin::Territories::RdvFieldsController < Admin::Territories::BaseControll
   private
 
   def rdv_fields_params
-    params.require(:territory).permit(Territory::OPTIONAL_RDV_FIELD_TOGGLES.keys)
+    params.require(:territory).permit(Territory::OPTIONAL_RDV_FIELD_TOGGLES.keys + Territory::OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.keys)
   end
 end

--- a/app/controllers/admin/user_in_waiting_rooms_controller.rb
+++ b/app/controllers/admin/user_in_waiting_rooms_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Admin::UserInWaitingRoomsController < AgentAuthController
+  respond_to :js
+
+  def create
+    @rdv = Rdv.includes(:agents).find(params[:rdv_id])
+    authorize(@rdv)
+
+    if @rdv.status == "unknown" && @rdv.deleted_at.nil?
+      @rdv.set_user_in_waiting_room!
+
+      if current_organisation.territory.enable_waiting_room_mail_field
+        @rdv.agents.map do |agent|
+          Agents::WaitingRoomMailer.with(agent: agent, rdv: @rdv).user_in_waiting_room.deliver_later
+        end
+      end
+
+      render layout: false
+    end
+  end
+end

--- a/app/controllers/admin/user_in_waiting_rooms_controller.rb
+++ b/app/controllers/admin/user_in_waiting_rooms_controller.rb
@@ -4,7 +4,7 @@ class Admin::UserInWaitingRoomsController < AgentAuthController
   respond_to :js
 
   def create
-    @rdv = Rdv.includes(:agents).find(params[:rdv_id])
+    @rdv = Rdv.find(params[:rdv_id])
     authorize(@rdv)
 
     if @rdv.status == "unknown" && @rdv.deleted_at.nil?

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -181,6 +181,10 @@ class CalendarRdvSolidarites {
 
     $el.addClass("fc-event-"+ extendedProps.status);
 
+    if (extendedProps.userInWaitingRoom == true)  {
+      $el.addClass("fc-event-waiting");
+    }
+
     if (extendedProps.jour_feries == true) {
       return
     }

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -102,4 +102,13 @@ class CronJob < ApplicationJob
       end
     end
   end
+
+  class DestroyRedisWaitingRoomKeys < CronJob
+    # At 03:00 every day
+    self.cron_expression = "0 3 * * *"
+
+    def perform
+      Rdv.reset_user_in_waiting_room!
+    end
+  end
 end

--- a/app/mailers/agents/waiting_room_mailer.rb
+++ b/app/mailers/agents/waiting_room_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Agents::WaitingRoomMailer < ApplicationMailer
+  before_action do
+    @agent = params[:agent]
+    @rdv = params[:rdv]
+  end
+
+  default to: -> { @agent.email }
+
+  def user_in_waiting_room
+    mail(subject: t("agents.waiting_room_mailer.title", domain_name: domain.name))
+  end
+
+  def domain
+    @agent.domain
+  end
+end

--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -11,7 +11,7 @@ module Rdv::UsingWaitingRoom
   REDIS_WAITING_ROOM_KEY = "#{Rails.env}:user_in_waiting_room_rdv_id".freeze
 
   def user_in_waiting_room?
-    status == "unknown" && REDIS.lpos(REDIS_WAITING_ROOM_KEY).present?
+    status == "unknown" && REDIS.lpos(REDIS_WAITING_ROOM_KEY, id).present?
   end
 
   def set_user_in_waiting_room!

--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -2,25 +2,23 @@
 
 require "redis"
 
-redis_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
-REDIS = Redis.new(url: redis_url)
-
 module Rdv::UsingWaitingRoom
   extend ActiveSupport::Concern
 
+  REDIS_FOR_WAITING_ROOMS = Redis.new(url: ENV.fetch("REDIS_URL", "redis://localhost:6379"))
   REDIS_WAITING_ROOM_KEY = "#{Rails.env}:user_in_waiting_room_rdv_id".freeze
 
   def user_in_waiting_room?
-    status == "unknown" && REDIS.lpos(REDIS_WAITING_ROOM_KEY, id).present?
+    status == "unknown" && REDIS_FOR_WAITING_ROOMS.lpos(REDIS_WAITING_ROOM_KEY, id).present?
   end
 
   def set_user_in_waiting_room!
-    REDIS.lpush(REDIS_WAITING_ROOM_KEY, id)
+    REDIS_FOR_WAITING_ROOMS.lpush(REDIS_WAITING_ROOM_KEY, id)
   end
 
   class_methods do
     def reset_user_in_waiting_room!
-      REDIS.del(REDIS_WAITING_ROOM_KEY)
+      REDIS_FOR_WAITING_ROOMS.del(REDIS_WAITING_ROOM_KEY)
     end
   end
 end

--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "redis"
+
+redis_url = ENV.fetch("REDIS_URL", "redis://localhost:6379")
+REDIS = Redis.new(url: redis_url)
+
+module Rdv::UsingWaitingRoom
+  extend ActiveSupport::Concern
+
+  def user_in_waiting_room?
+    status == "unknown" && REDIS.get("#{Rails.env}:user_in_waiting_room_rdv_id:#{id}").to_bool
+  end
+
+  def set_user_in_waiting_room!
+    REDIS.set("#{Rails.env}:user_in_waiting_room_rdv_id:#{id}", true)
+  end
+
+  class_methods do
+    def reset_user_in_waiting_room!
+      REDIS.del(REDIS.keys("#{Rails.env}:user_in_waiting_room_rdv_id:*"))
+    end
+  end
+end

--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -8,17 +8,19 @@ REDIS = Redis.new(url: redis_url)
 module Rdv::UsingWaitingRoom
   extend ActiveSupport::Concern
 
+  REDIS_WAITING_ROOM_KEY = "#{Rails.env}:user_in_waiting_room_rdv_id".freeze
+
   def user_in_waiting_room?
-    status == "unknown" && REDIS.get("#{Rails.env}:user_in_waiting_room_rdv_id:#{id}").to_bool
+    status == "unknown" && REDIS.lpos(REDIS_WAITING_ROOM_KEY).present?
   end
 
   def set_user_in_waiting_room!
-    REDIS.set("#{Rails.env}:user_in_waiting_room_rdv_id:#{id}", true)
+    REDIS.lpush(REDIS_WAITING_ROOM_KEY, id)
   end
 
   class_methods do
     def reset_user_in_waiting_room!
-      REDIS.del(REDIS.keys("#{Rails.env}:user_in_waiting_room_rdv_id:*"))
+      REDIS.del(REDIS_WAITING_ROOM_KEY)
     end
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -11,6 +11,7 @@ class Rdv < ApplicationRecord
   include Rdv::AddressConcern
   include Rdv::AuthoredConcern
   include Rdv::Updatable
+  include Rdv::UsingWaitingRoom
   include IcalHelpers::Ics
   include Payloads::Rdv
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -84,9 +84,9 @@ class Rdv < ApplicationRecord
   scope :status, lambda { |status|
     case status.to_s
     when "unknown_past"
-      past.where(status: "unknown"])
+      past.where(status: "unknown")
     when "unknown_future"
-      future.where(status: "unknown"])
+      future.where(status: "unknown")
     else
       where(status: status)
     end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -16,7 +16,7 @@ class Rdv < ApplicationRecord
   include Payloads::Rdv
 
   # Attributes
-  enum status: { unknown: "unknown", waiting: "waiting", seen: "seen", excused: "excused", revoked: "revoked", noshow: "noshow" }
+  enum status: { unknown: "unknown", seen: "seen", excused: "excused", revoked: "revoked", noshow: "noshow" }
   # Commentaire pour les status explications
   # unknown : "A renseigner" ou "A venir" (si le rdv est passé ou pas)
   # seen : Présent au rdv
@@ -24,7 +24,7 @@ class Rdv < ApplicationRecord
   # excused : Annulé à l'initiative de l'usager
   # revoked : Annulé à l'initiative du service
   MIN_DELAY_FOR_CANCEL = 4.hours
-  NOT_CANCELLED_STATUSES = %w[unknown waiting seen noshow].freeze
+  NOT_CANCELLED_STATUSES = %w[unknown seen noshow].freeze
   CANCELLED_STATUSES = %w[excused revoked].freeze
   enum created_by: { agent: 0, user: 1, file_attente: 2, prescripteur: 3 }, _prefix: :created_by
 
@@ -84,9 +84,9 @@ class Rdv < ApplicationRecord
   scope :status, lambda { |status|
     case status.to_s
     when "unknown_past"
-      past.where(status: %w[unknown waiting])
+      past.where(status: "unknown"])
     when "unknown_future"
-      future.where(status: %w[unknown waiting])
+      future.where(status: "unknown"])
     else
       where(status: status)
     end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -51,6 +51,11 @@ class Territory < ApplicationRecord
     enable_context_field: :context,
   }.freeze
 
+  OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES = {
+    enable_waiting_room_mail_field: :mail_to_agent,
+    enable_waiting_room_color_field: :change_rdv_color,
+  }.freeze
+
   OPTIONAL_MOTIF_FIELD_TOGGLES = {
     enable_motif_categories_field: :category,
   }.freeze
@@ -75,6 +80,12 @@ class Territory < ApplicationRecord
 
   def to_s
     [name, departement_number.presence].compact.join(" - ")
+  end
+
+  def waiting_room_enabled?
+    OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.keys.any? do |waiting_room_field|
+      send(waiting_room_field)
+    end
   end
 
   private

--- a/app/views/admin/agents/rdvs/index.json.jbuilder
+++ b/app/views/admin/agents/rdvs/index.json.jbuilder
@@ -6,6 +6,9 @@ json.array! @rdvs do |rdv|
   json.extendedProps do
     json.organisationName rdv.organisation&.name
     json.status rdv.status
+    if @organisation.territory.enable_waiting_room_color_field
+      json.userInWaitingRoom rdv.user_in_waiting_room?
+    end
     json.readableStatus rdv.human_attribute_value(:status)
     json.motif rdv.motif.name
     json.lieu rdv.public_office? && rdv.lieu&.name

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -6,6 +6,7 @@
         h5.header.mb-1
           span
             = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
+      = render "admin/rdvs/waiting_room", rdv: rdv, remote: true
       = render "admin/rdvs/rdv_status_dropdown", rdv: rdv, agent: local_assigns[:agent], remote: true
   hr.my-0.mx-3
   .card-body.py-3.row

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -1,8 +1,8 @@
 .card.rdv-card[id= "rdv-#{rdv.id}"]
   .mx-3[id= "rdv-updated-flash-message-#{rdv.id}"]
   .card-header.border-white
-    .d-flex.justify-content-between.flex-wrap.align-items-center
-      div
+    .d-flex.flex-wrap.align-items-center.flex-gap-1em
+      .flex-grow-1
         h5.header
           span
             = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -1,9 +1,9 @@
 .card.rdv-card[id= "rdv-#{rdv.id}"]
   .mx-3[id= "rdv-updated-flash-message-#{rdv.id}"]
   .card-header.border-white
-    .d-flex.justify-content-between.flex-wrap
+    .d-flex.justify-content-between.flex-wrap.align-items-center
       div
-        h5.header.mb-1
+        h5.header
           span
             = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
       = render "admin/rdvs/waiting_room", rdv: rdv, remote: true

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -6,7 +6,7 @@
         h5.header
           span
             = link_to rdv_title(rdv), admin_organisation_rdv_path(rdv.organisation, rdv)
-      = render "admin/rdvs/waiting_room", rdv: rdv, remote: true
+      = render "admin/rdvs/waiting_room", rdv: rdv
       = render "admin/rdvs/rdv_status_dropdown", rdv: rdv, agent: local_assigns[:agent], remote: true
   hr.my-0.mx-3
   .card-body.py-3.row

--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -9,7 +9,6 @@
         = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "revoked", remote: remote
 
       - when "unknown_today"
-        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "waiting", remote: remote
         = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "seen", remote: remote
         - if rdv.in_the_past? # See issue #1642, I’d rather get rid of `temporal_status` than adding more variants.
           = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "noshow", remote: remote

--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -1,4 +1,4 @@
-.dropdown[id= "rdv-status-#{rdv.id}", class="mt-1 mb-auto"]
+.dropdown id="rdv-status-#{rdv.id}"
   = rdv_status_dropdown_toggle(rdv)
   - remote = local_assigns.fetch(:remote, false)
   .dropdown-menu

--- a/app/views/admin/rdvs/_waiting_room.html.slim
+++ b/app/views/admin/rdvs/_waiting_room.html.slim
@@ -1,6 +1,6 @@
 - if rdv.status == "unknown" && current_organisation.territory.waiting_room_enabled? && rdv.starts_at.today?
 
-  #waiting_room_button
+  div id="waiting_room_button-#{rdv.id}"
     - if rdv.user_in_waiting_room?
       | Usager en salle d'attente
     - else

--- a/app/views/admin/rdvs/_waiting_room.html.slim
+++ b/app/views/admin/rdvs/_waiting_room.html.slim
@@ -1,0 +1,7 @@
+- if rdv.status == "unknown" && current_organisation.territory.waiting_room_enabled? && rdv.starts_at.today?
+
+  #waiting_room_button
+    - if rdv.user_in_waiting_room?
+      | Usager en salle d'attente
+    - else
+      = link_to "Salle d'attente", admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv), method: :post, class: "btn btn-primary", remote: true

--- a/app/views/admin/territories/rdv_fields/edit.html.slim
+++ b/app/views/admin/territories/rdv_fields/edit.html.slim
@@ -3,21 +3,27 @@
 .row.justify-content-center
   .col-md-6
     .card
+      .card-header
+          h3= t(".card_title")
+          p.text-muted.font-14= t(".hint_1")
+          p.text-muted.font-14= t(".hint_2")
       .card-body
         = simple_form_for current_territory, url: admin_territory_rdv_fields_path(current_territory) do |f|
           = render "model_errors", model: current_territory
 
-          h5.card-title= t(".card_title")
-
-          p.text-muted.font-14= t(".hint_1")
-          p.text-muted.font-14= t(".hint_2")
           - Territory::OPTIONAL_RDV_FIELD_TOGGLES.each do |toggle, field_name|
             = f.input toggle, label: Rdv.human_attribute_name(field_name)
+          .text-right
+            = f.button :submit
 
-          p.text-bold.font-20= t(".hint_3")
-          p.text-muted.font-14= t(".hint_4")
+    .card
+      .card-header
+          h3= t(".waiting_room_title")
+          p.text-muted.font-14= t(".waiting_room_config_hint")
+      .card-body
+        = simple_form_for current_territory, url: admin_territory_rdv_fields_path(current_territory) do |f|
+          = render "model_errors", model: current_territory
           - Territory::OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.each do |toggle, field_name|
             = f.input toggle, label: Rdv.human_attribute_name(field_name)
-
           .text-right
             = f.button :submit

--- a/app/views/admin/territories/rdv_fields/edit.html.slim
+++ b/app/views/admin/territories/rdv_fields/edit.html.slim
@@ -14,5 +14,10 @@
           - Territory::OPTIONAL_RDV_FIELD_TOGGLES.each do |toggle, field_name|
             = f.input toggle, label: Rdv.human_attribute_name(field_name)
 
+          p.text-bold.font-20= t(".hint_3")
+          p.text-muted.font-14= t(".hint_4")
+          - Territory::OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.each do |toggle, field_name|
+            = f.input toggle, label: Rdv.human_attribute_name(field_name)
+
           .text-right
             = f.button :submit

--- a/app/views/admin/user_in_waiting_rooms/create.js.erb
+++ b/app/views/admin/user_in_waiting_rooms/create.js.erb
@@ -1,0 +1,8 @@
+
+<% waiting_room_html = render "admin/rdvs/waiting_room", rdv: @rdv %>
+(function() {
+    let element = document.getElementById('waiting_room_button');
+    if(element) {
+        element.innerHTML = "<%= escape_javascript waiting_room_html %>";
+    }
+})();

--- a/app/views/admin/user_in_waiting_rooms/create.js.erb
+++ b/app/views/admin/user_in_waiting_rooms/create.js.erb
@@ -6,3 +6,4 @@
         element.innerHTML = "<%= escape_javascript waiting_room_html %>";
     }
 })();
+

--- a/app/views/admin/user_in_waiting_rooms/create.js.erb
+++ b/app/views/admin/user_in_waiting_rooms/create.js.erb
@@ -1,7 +1,7 @@
 
 <% waiting_room_html = render "admin/rdvs/waiting_room", rdv: @rdv %>
 (function() {
-    let element = document.getElementById('waiting_room_button');
+    let element = document.getElementById('waiting_room_button-<%= @rdv.id %>');
     if(element) {
         element.innerHTML = "<%= escape_javascript waiting_room_html %>";
     }

--- a/app/views/mailers/agents/waiting_room_mailer/user_in_waiting_room.html.slim
+++ b/app/views/mailers/agents/waiting_room_mailer/user_in_waiting_room.html.slim
@@ -1,0 +1,7 @@
+p = t("mailers.common.hello")
+
+p= t(".description", users_name: @rdv.users.map(&:full_name).join(", "), count: @rdv.users.count)
+
+.btn-wrapper= link_to "Voir sur #{domain.name}", admin_organisation_rdv_url(@rdv.organisation, @rdv), class:"btn btn-primary"
+
+= t("mailers.common.farewell_html", domain_name: domain.name)

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -4,6 +4,13 @@ fr:
       hello: Bonjour,
       farewell_html: "<p>À bientôt,<br>L’équipe %{domain_name}</p>"
   agents:
+    waiting_room_mailer:
+      title: Un usager en salle d'attente
+      user_in_waiting_room:
+        description:
+          zero: "votre rdv va bientôt démarrer"
+          one: "%{users_name} vous attend pour son RDV"
+          other: "%{users_name} vous attendent pour leur RDV"
     absence_mailer:
       absence_created:
         title: "%{domain_name} - Indisponibilité créée - %{title}"

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -37,6 +37,8 @@ fr:
         status: Statut
         context: Contexte
         name: Intitulé
+        mail_to_agent: Envoyer un mail de notification à l'agent
+        change_rdv_color: Modifier la couleur du rdv dans l'agenda
       rdv/created_by:
         agent: "Créé par un agent"
         user: "RDV Pris sur internet"

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -121,8 +121,8 @@ fr:
           card_title: Champs optionnels pour la fiche RDV
           hint_1: Vous pouvez activer ou désactiver les champs suivants sur la fiche RDV.
           hint_2: "Les champs seront simplement masqués dans l’interface : les données préexistantes ne seront pas supprimées."
-          hint_3: "Salle d'attente :"
-          hint_4: "Vous pouvez choisir le mode de notification de l'agent lorsqu'un usager est en salle d'attente"
+          waiting_room_title: Salle d'attente
+          waiting_room_config_hint: Vous pouvez choisir le mode de notification de l'agent lorsqu'un usager est en salle d'attente
       user_fields:
         edit:
           title: Champs de la fiche usager

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -121,6 +121,8 @@ fr:
           card_title: Champs optionnels pour la fiche RDV
           hint_1: Vous pouvez activer ou désactiver les champs suivants sur la fiche RDV.
           hint_2: "Les champs seront simplement masqués dans l’interface : les données préexistantes ne seront pas supprimées."
+          hint_3: "Salle d'attente :"
+          hint_4: "Vous pouvez choisir le mode de notification de l'agent lorsqu'un usager est en salle d'attente"
       user_fields:
         edit:
           title: Champs de la fiche usager

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
         end
         resources :rdvs, except: [:new] do
           resources :participations, only: %i[update destroy]
+          resource :user_in_waiting_room, only: [:create]
           member do
             post :send_reminder_manually
           end

--- a/db/migrate/20221011071059_add_optionals_fields_to_territories.rb
+++ b/db/migrate/20221011071059_add_optionals_fields_to_territories.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOptionalsFieldsToTerritories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :territories, :enable_waiting_room_mail_field, :boolean, default: false
+    add_column :territories, :enable_waiting_room_color_field, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -575,6 +575,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_30_143520) do
     t.boolean "enable_address_details", default: false
     t.boolean "enable_context_field", default: false
     t.boolean "enable_motif_categories_field", default: false
+    t.boolean "enable_waiting_room_mail_field", default: false
+    t.boolean "enable_waiting_room_color_field", default: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", unique: true, where: "((departement_number)::text <> ''::text)"
   end
 

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -20,33 +20,6 @@ describe Admin::EditRdvForm, type: :form do
       expect(rdv.reload.lieu).to eq(new_lieu)
     end
 
-    it "updates the requested rdv status" do
-      now = Time.zone.parse("2020-12-12 13h50")
-      travel_to(now)
-      rdv = create(:rdv, agents: [agent], organisation: organisation, lieu: create(:lieu, organisation: organisation))
-
-      edit_rdv_form = described_class.new(rdv, agent_context)
-      edit_rdv_form.update(status: "waiting", ignore_benign_errors: "1")
-
-      expect(rdv.reload.status).to eq("waiting")
-    end
-
-    it "set cancelled_at to nil when change status from cancel to other" do
-      now = Time.zone.parse("2020-08-03 9h00")
-
-      travel_to(now - 2.days)
-      rdv = create(:rdv, cancelled_at: now - 1.day, status: "excused", starts_at: now - 2.days, agents: [agent], organisation: organisation)
-
-      travel_to(now)
-
-      edit_rdv_form = described_class.new(rdv, agent_context)
-      edit_rdv_form.update(status: "waiting", ignore_benign_errors: "1")
-
-      rdv.reload
-      expect(rdv.cancelled_at).to eq(nil)
-      expect(rdv.status).to eq("waiting")
-    end
-
     it "when status is excused, cancelled_at should not be nil" do
       now = Time.zone.parse("2020-08-03 9h00")
       travel_to(now - 3.days)

--- a/spec/mailers/previews/agents/waiting_room_mailer_preview.rb
+++ b/spec/mailers/previews/agents/waiting_room_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Agents::WaitingRoomMailerPreview < ActionMailer::Preview
+  def user_in_waiting_room
+    rdv = Rdv.last
+    Agents::WaitingRoomMailer.with(agent: rdv.agents.first, rdv: rdv).user_in_waiting_room
+  end
+end

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Rdv::Updatable, type: :concern do
       end
     end
 
-    %w[unknown waiting seen].each do |status|
+    %w[unknown seen].each do |status|
       context "when the status changed and is now #{status}" do
         before { rdv.update!(cancelled_at: 1.day.ago, status: "noshow") }
 
@@ -69,9 +69,9 @@ RSpec.describe Rdv::Updatable, type: :concern do
 
       it "does not notify when status does not change" do
         rdv.reload
-        rdv.update!(status: "waiting")
+        rdv.update!(status: "unknown")
         expect(Notifiers::RdvCancelled).not_to receive(:new)
-        rdv.update_and_notify(agent, status: "waiting")
+        rdv.update_and_notify(agent, status: "unknown")
         perform_enqueued_jobs
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end

--- a/spec/models/concerns/rdv/using_waiting_room_spec.rb
+++ b/spec/models/concerns/rdv/using_waiting_room_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Rdv::UsingWaitingRoom do
   it "Reset all `user_in_waiting_room` keys in redis" do
     list_rdv = create_list(:rdv, 3)
 
-    # On place les RDV dans le REDIS pour signaler
-    # que les usagers sont en salle d'attente
+    # On garde une trace des RDV
+    # pour signaler que les usagers 
+    # sont en salle d'attente
     list_rdv.map(&:set_user_in_waiting_room!)
 
     Rdv.reset_user_in_waiting_room!

--- a/spec/models/concerns/rdv/using_waiting_room_spec.rb
+++ b/spec/models/concerns/rdv/using_waiting_room_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Rdv::UsingWaitingRoom do
+  it "Reset all `user_in_waiting_room` keys in redis" do
+    list_rdv = create_list(:rdv, 3)
+
+    # On place les RDV dans le REDIS pour signaler
+    # que les usagers sont en salle d'attente
+    list_rdv.map(&:set_user_in_waiting_room!)
+
+    Rdv.reset_user_in_waiting_room!
+
+    expect(Rdv.all.map(&:user_in_waiting_room?)).to eq([false, false, false])
+  end
+end

--- a/spec/models/concerns/rdv/using_waiting_room_spec.rb
+++ b/spec/models/concerns/rdv/using_waiting_room_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe Rdv::UsingWaitingRoom do
     list_rdv = create_list(:rdv, 3)
 
     # On garde une trace des RDV
-    # pour signaler que les usagers 
+    # pour signaler que les usagers
     # sont en salle d'attente
     list_rdv.map(&:set_user_in_waiting_room!)
+    expect(Rdv.all.map(&:user_in_waiting_room?)).to eq([true, true, true])
 
     Rdv.reset_user_in_waiting_room!
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -237,8 +237,6 @@ describe Rdv, type: :model do
 
   describe "#temporal_status" do
     it "return status when not unknown" do
-      rdv = build(:rdv, status: "waiting")
-      expect(rdv.temporal_status).to eq("waiting")
       rdv = build(:rdv, status: "seen")
       expect(rdv.temporal_status).to eq("seen")
       rdv = build(:rdv, status: "excused")

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -104,4 +104,21 @@ describe Territory, type: :model do
       expect(territory.to_s).to eq("Seine Saint-Denis")
     end
   end
+
+  describe "#waiting_room_enabled?" do
+    it "returns false when no notification selected" do
+      territory = build(:territory, enable_waiting_room_mail_field: false, enable_waiting_room_color_field: false)
+      expect(territory.waiting_room_enabled?).to eq(false)
+    end
+
+    it "returns true when mail notification selected" do
+      territory = build(:territory, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: false)
+      expect(territory.waiting_room_enabled?).to eq(true)
+    end
+
+    it "returns true when agenda rdv color notification selected" do
+      territory = build(:territory, enable_waiting_room_mail_field: false, enable_waiting_room_color_field: true)
+      expect(territory.waiting_room_enabled?).to eq(true)
+    end
+  end
 end

--- a/spec/requests/admin/configure_user_in_waiting_room_spec.rb
+++ b/spec/requests/admin/configure_user_in_waiting_room_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "Configure les préférences de signalisation d'usager en salle d'attente", type: :request do
+  include Rails.application.routes.url_helpers
+
+  let(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], role_in_territories: [organisation.territory]) }
+
+  before { sign_in agent }
+
+  it "show user in waiting room options" do
+    get edit_admin_territory_rdv_fields_path(organisation)
+    expect(response).to be_successful
+    expect(response.body).to include("Salle d&#39;attente")
+    expect(response.body).to include("Envoyer un mail de notification à l&#39;agent")
+    expect(response.body).to include("Modifier la couleur du rdv dans l&#39;agenda")
+  end
+
+  it "update user in waiting room options" do
+    params = { territory: { enable_context_field: false, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: true } }
+    put admin_territory_rdv_fields_path(organisation.territory), params: params
+
+    expect(response).to redirect_to(edit_admin_territory_rdv_fields_path(organisation.territory))
+    territory = organisation.territory
+    territory.reload
+    expect(territory.enable_waiting_room_mail_field).to eq(true)
+    expect(territory.enable_waiting_room_color_field).to eq(true)
+  end
+end

--- a/spec/requests/admin/configure_user_in_waiting_room_spec.rb
+++ b/spec/requests/admin/configure_user_in_waiting_room_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Configure les préférences de signalisation d'usager en salle d
   before { sign_in agent }
 
   it "show user in waiting room options" do
-    get edit_admin_territory_rdv_fields_path(organisation)
+    get edit_admin_territory_rdv_fields_path(organisation.territory)
     expect(response).to be_successful
     expect(response.body).to include("Salle d&#39;attente")
     expect(response.body).to include("Envoyer un mail de notification à l&#39;agent")

--- a/spec/requests/admin/user_in_waiting_room_spec.rb
+++ b/spec/requests/admin/user_in_waiting_room_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+RSpec.describe "Admin::UserInWaitingRoomController", type: :request do
+  include Rails.application.routes.url_helpers
+
+  describe "POST /admin/organisations/:organisation_id/rdvs/:rdv_id/user_in_waiting_room" do
+    it "render JS" do
+      territory = create(:territory, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: true)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation)
+      sign_in agent
+
+      post admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv, format: :js)
+      expect(response.body).to include("waiting_room_button")
+    end
+
+    it "send email" do
+      territory = create(:territory, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: false)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation)
+      sign_in agent
+
+      expect do
+        post admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv, format: :js)
+      end.to have_enqueued_job(ActionMailer::MailDeliveryJob).on_queue(:mailers)
+
+      rdv.reload
+      expect(rdv.user_in_waiting_room?).to eq(true)
+    end
+
+    it "add redis key for this RDV" do
+      territory = create(:territory, enable_waiting_room_mail_field: false, enable_waiting_room_color_field: true)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation)
+      sign_in agent
+
+      post admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv, format: :js)
+
+      rdv.reload
+      expect(rdv.user_in_waiting_room?).to eq(true)
+    end
+  end
+
+  describe "waiting action visibility" do
+    it "hide waiting room action when no waiting room notifications configured" do
+      now = Time.zone.parse("2022-12-05 10:00")
+      travel_to(now)
+      territory = create(:territory, enable_waiting_room_mail_field: false, enable_waiting_room_color_field: false)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 2.hours)
+      sign_in agent
+
+      get admin_organisation_rdv_path(organisation, rdv)
+      expect(response.body).not_to include("Salle d&#39;attente")
+    end
+
+    it "hide waiting room action when rdv is not for today" do
+      now = Time.zone.parse("2022-12-05 10:00")
+      travel_to(now)
+      territory = create(:territory, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: true)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 4.days)
+      sign_in agent
+
+      get admin_organisation_rdv_path(organisation, rdv)
+      expect(response.body).not_to include("Salle d&#39;attente")
+    end
+
+    it "hide waiting room action when rdv is for today with an other statuts than unknown" do
+      now = Time.zone.parse("2022-12-05 10:00")
+      travel_to(now)
+      territory = create(:territory, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: true)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 4.hours, status: "revoked")
+      sign_in agent
+
+      get admin_organisation_rdv_path(organisation, rdv)
+      expect(response.body).not_to include("Salle d&#39;attente")
+    end
+
+    it "show user in waiting room button when email configure" do
+      now = Time.zone.parse("2022-12-05 10:00")
+      travel_to(now)
+      territory = create(:territory, enable_waiting_room_mail_field: true, enable_waiting_room_color_field: false)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 4.hours, status: "unknown")
+      sign_in agent
+
+      get admin_organisation_rdv_path(organisation, rdv)
+      expect(response.body).to include("Salle d&#39;attente")
+    end
+
+    it "show user in waiting room button when color configure" do
+      now = Time.zone.parse("2022-12-05 10:00")
+      travel_to(now)
+      territory = create(:territory, enable_waiting_room_mail_field: false, enable_waiting_room_color_field: true)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      rdv = create(:rdv, agents: [agent], organisation: organisation, starts_at: now + 4.hours, status: "unknown")
+      sign_in agent
+
+      get admin_organisation_rdv_path(organisation, rdv)
+      expect(response.body).to include("Salle d&#39;attente")
+    end
+  end
+end

--- a/spec/requests/admin/user_in_waiting_room_spec.rb
+++ b/spec/requests/admin/user_in_waiting_room_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Admin::UserInWaitingRoomController", type: :request do
 
       expect do
         post admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv, format: :js)
-      end.to have_enqueued_job(ActionMailer::MailDeliveryJob).on_queue(:mailers)
+      end.to have_enqueued_mail(Agents::WaitingRoomMailer, :user_in_waiting_room).with(params: { agent: agent, rdv: rdv }, args: [])
 
       rdv.reload
       expect(rdv.user_in_waiting_room?).to eq(true)


### PR DESCRIPTION
Nous utilisions un statut de RDV pour signaler un usager en salle d'attente.

La fonctionnalité est utilisée par les personnes à l'accueil pour prévenir les travailleurs et travailleuses médico-sociaux.

Certains départements auraient aimé pouvoir signaler un usager en salle d'attente par email. Jusqu'à présent, elle ne faisait qu'un remplissage hachuré du RDV dans l'agenda.

Cette PR propose d'extraire la gestion du signalement d'usager en salle d'attente des statuts de RDV.

## Configuration

Dans le module de configuration, à propos de la fiche RDV, nous pouvons activer l'utilisation de ce module en choisissant l'une des options de signalement (ou les deux) : email et/ou hachure dans l'agenda.

![Screenshot 2022-12-12 at 15-12-40 RDV Solidarités](https://user-images.githubusercontent.com/42057/207067085-645bc7bd-1cdd-4d00-beda-9fa59fdec198.png)

 ## Fiche RDV

Si une des deux options de notification est cochée, que le RDV est du jour, et qu'il a un statut `unknown`, alors nous affichons le bouton pour signaler un usager en salle d'attente.

![Screenshot 2022-12-12 at 15-14-03 Votre agendaRDV Joséphine DUROY 🏠 - RDV Solidarités](https://user-images.githubusercontent.com/42057/207067409-e75f358e-aa60-43e6-b8c0-725715e65070.png)

Une fois signalé en salle d'attente, un message apparait pour préciser que la notification à déjà été faite et que l'usager est en salle d'attente.

![Screenshot 2022-12-12 at 15-15-33 Votre agendaRDV Joséphine DUROY 🏠 - RDV Solidarités](https://user-images.githubusercontent.com/42057/207067732-7dffeee3-8e9a-4698-a2ad-89b38cb3c2bd.png)

La signalisation d'un usager en salle d'attente dans l'agenda se faire par des hachures de la représentation du RDV.

![Screenshot 2022-12-12 at 15-17-23 Votre agenda - RDV Solidarités](https://user-images.githubusercontent.com/42057/207068149-a6f45730-bcad-4c1c-b00b-6123dba3c5ec.png)

La signalisation d'un usager en salle d'attente par email envoie un simple texte avec un lien vers le RDV dans RDV-Solidarités

![Screenshot 2022-12-12 at 15-24-29 Mailer Preview for agents_waiting_room_mailer#user_in_waiting_room](https://user-images.githubusercontent.com/42057/207069708-28c525e0-2f34-4792-bfa0-6a7cccd03386.png)


## Choix technique


Nous avons fait le choix d'utiliser Redis pour lister les RDV ayant un usager en salle d'attente. Cela nous permet de ne pas modifier et utiliser le schéma de données pour une donnée temporaire. Chaque nuit, nous remettons à zero la liste des RDV en salle d'attente.


Closes #2901


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
