### PR TITLE
Corriger le crash de /public_api/public_links quand une org n'a pas d'external_id

### DIFF
--- a/app/controllers/public_api/public_links_controller.rb
+++ b/app/controllers/public_api/public_links_controller.rb
@@ -37,7 +37,12 @@ class PublicApi::PublicLinksController < ActionController::Base # rubocop:disabl
       .in_range((Time.zone.now..))
       .reservable_online
 
-    organisations = Organisation.where(territory: territory).joins(:plage_ouvertures).merge(plage_ouvertures_scope).distinct
+    organisations = Organisation
+      .where(territory: territory)
+      .where.not(external_id: nil)
+      .joins(:plage_ouvertures)
+      .merge(plage_ouvertures_scope)
+      .distinct
 
     organisations.map do |organisation|
       {

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -37,7 +37,6 @@ class PlageOuverture < ApplicationRecord
   validate :warn_overflow_motifs_duration
 
   # Scopes
-  scope :reservable_online, -> { joins(:motifs).where(motifs: { reservable_online: true }) }
   scope :in_range, lambda { |range|
     return all if range.nil?
 

--- a/spec/requests/public_api/public_links_spec.rb
+++ b/spec/requests/public_api/public_links_spec.rb
@@ -7,6 +7,7 @@ describe "public_api/public_links requests", type: :request do
   let!(:organisation_c) { create(:organisation, new_domain_beta: true, external_id: "ext_id_C", territory: territory) }
   let!(:organisation_d) { create(:organisation, new_domain_beta: true, external_id: "ext_id_D", territory: territory) }
   let!(:organisation_e) { create(:organisation, new_domain_beta: true, external_id: "ext_id_E", territory: create(:territory)) }
+  let!(:organisation_f) { create(:organisation, new_domain_beta: true, external_id: nil,        territory: territory) }
 
   context "when plages are defined" do
     let(:params) do
@@ -18,6 +19,7 @@ describe "public_api/public_links requests", type: :request do
       create(:plage_ouverture, organisation: organisation_a)
       create(:plage_ouverture, :no_recurrence, organisation: organisation_b, first_day: Time.zone.today + 5.days)
       create(:plage_ouverture, :expired, organisation: organisation_c)
+      create(:plage_ouverture, organisation: organisation_f)
 
       get "/public_api/public_links", params: params, headers: {}
 
@@ -26,7 +28,8 @@ describe "public_api/public_links requests", type: :request do
       # Organisation C has a plage that expired
       # Organisation D has no plage
       # Organisation E is not in provided territory
-      # Organisation F does not exist
+      # Organisation F does not have an external ID
+      # Organisation G does not exist
       expected_body = {
         "public_links" => [
           {


### PR DESCRIPTION
Issue Sentry : https://sentry.io/organizations/rdv-solidarites/issues/3660252449

Lorsqu'une organisation a des plages d'ouvertures, elle est censé figuré dans les résultats de l'API. Mais si elle n'a pas d'`external_id`, ça n'a pas de sens de l'inclure puisque les utilisateurs de l'API ne pourront pas faire la correspondance.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
