### PR TITLE
Problèmes de perfs, impact des hooks : after_update -> { rdvs.touch_all }

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -78,7 +78,7 @@ class Agent < ApplicationRecord
   validate :service_cannot_be_changed
 
   # Hooks
-  after_update -> { rdvs.touch_all }
+  after_update :touch_rdvs_for_cache
 
   # Scopes
   scope :complete, -> { where.not(first_name: nil).where.not(last_name: nil) }
@@ -189,5 +189,18 @@ class Agent < ApplicationRecord
     else
       Domain::RDV_SOLIDARITES
     end
+  end
+
+  private
+
+  # Les partials des RDVs sont mises en cache (la clé de cache contient `rdv.updated_at`).
+  # Si le profil agent change, le cache doit être invalidé.
+  def touch_rdvs_for_cache
+    # Ces champs sont mis à jour à chaque login, mais ne sont pas utilisés
+    # dans la partial des RDV, donc pas la peine d'invalider le cache.
+    sign_in_fields = %w[sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip last_sign_in_ip]
+    return if previous_changes.keys.intersection(sign_in_fields).any?
+
+    rdvs.touch_all
   end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -51,7 +51,7 @@ class Motif < ApplicationRecord
   delegate :name, to: :service, prefix: true
 
   # Hooks
-  after_update -> { rdvs.touch_all }
+  after_update :touch_rdvs_for_cache
 
   # Validation
   validates :visibility_type, inclusion: { in: VISIBILITY_TYPES }
@@ -198,5 +198,11 @@ class Motif < ApplicationRecord
     return unless collectif? && !public_office?
 
     errors.add(:base, :not_at_home_if_collectif)
+  end
+
+  # Les partials des RDVs sont mises en cache (la clé de cache contient `rdv.updated_at`).
+  # Si le motif change, le cache doit être invalidé.
+  def touch_rdvs_for_cache
+    rdvs.touch_all
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
 
   # Hooks
   before_save :set_email_to_null_if_blank
-  after_update -> { rdvs.touch_all }
+  after_update :touch_rdvs_for_cache
 
   # Scopes
   scope :active, -> { where(deleted_at: nil) }
@@ -268,5 +268,15 @@ class User < ApplicationRecord
     return save! if organisations.any? # only actually mark deleted when no orgas left
 
     update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email)
+  end
+
+  # Les partials des RDVs sont mises en cache (la clé de cache contient `rdv.updated_at`).
+  # Si le profil usager change, le cache doit être invalidé.
+  def touch_rdvs_for_cache
+    # Ce champ est mis à jour à chaque login, mais n'est pas utilisé
+    # dans la partial des RDV, donc pas la peine d'invalider le cache.
+    return if previous_changes.keys.include?("last_sign_in_at")
+
+    rdvs.touch_all
   end
 end


### PR DESCRIPTION
Closes #2915

Rappel : ce ticket a été créé car nous avons constaté des ralentissements, ainsi que des erreurs `PG::TRDeadlockDetected`. Nous supposons que des écritures concurrentes en base peuvent être la cause, et nous avons remarqué que depuis peur, nous avions un `agent.rdvs.touch_all` à chaque connection d'un agent.

On voit que le `touch_all` a bien été ajouté pour invalider le cache des partials des RDVs ici : #1847

Nous sommes donc face à a problématique suivante : **comment savoir quand invalider le cache d'une partial qui utilise potentiellement des dizaines de champs sur 4 ou 5 table ?**

La question est donc de savoir : est-ce que l'on peut définir une liste de champs utilisés dans la partial, et ensuite utiliser cette liste au moment de déclencher l'invalidation du cache (par `touch_all` dans les modèles). La réponse est : oui, mais ça demande pas mal de complexité, car il faut vérifier :
- que si un nouveau champ se met à être utilisé dans la partial, il faut que sa modification déclenche l’invalidation du cache
- que si aucun champ de la partial ne change, le cache ne soit pas invalidé

Les stratégies pour répondre à ces besoins semblent trop complexes par rapport à l'importance de la problématique. Nous avons donc choisi pour le moment de ne pas désactiver le cache lorsque [les champs de `Devise :trackable`](https://github.com/heartcombo/devise/blob/6d32d2447cc0f3739d9732246b5a5bde98d9e032/lib/devise/models/trackable.rb#L17) sont modifiés. Ça évite les écritures trop fréquentes

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
