### PR TITLE
Utiliser l'ID long lors de l'import des CNFS

### DIFF
--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -19,7 +19,7 @@ conseillers_numeriques.each do |conseiller_numerique|
     first_name: conseiller_numerique["Prénom"],
     last_name: conseiller_numerique["Nom"],
     structure: {
-      external_id: conseiller_numerique["Id de la structure"],
+      external_id: conseiller_numerique["Id long de la structure"],
       name: conseiller_numerique["Nom de la structure"],
       address: conseiller_numerique["Adresse de la structure"],
     },

--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -2,7 +2,7 @@
 
 require "csv"
 
-conseillers_numeriques = CSV.read("/tmp/uploads/export-cnfs.csv", headers: true, col_sep: ";")
+conseillers_numeriques = CSV.read("/tmp/uploads/export-cnfs.csv", headers: true, col_sep: ";", liberal_parsing: true)
 
 conseillers_numeriques.each do |conseiller_numerique|
   next if conseiller_numerique["Email @conseiller-numerique.fr"].blank?


### PR DESCRIPTION
L'ID court était un ID legacy côté espace Coop, c'est bien maintenant l'ID long qui sert de référence dans le modèle de données partagé avec la carto.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
