### PR TITLE
Réparer un crash à la migration d'un agent d'une org à une autre

### DIFF
--- a/app/controllers/super_admins/migrations_controller.rb
+++ b/app/controllers/super_admins/migrations_controller.rb
@@ -42,7 +42,7 @@ module SuperAdmins
         plage_ouvertures_for_organisation.where(organisation: old_organisation).update_all(organisation_id: new_organisation.id)
 
         # creer des duplicatas de motifs, et y associer les plages d'ouvertures, et les rdvs
-        Motif.joins(rdvs: :agents_rdvs).where(agents_rdvs: { agent_id: agent.id }).find_each do |old_motif|
+        Motif.joins(rdvs: :agents_rdvs).where(agents_rdvs: { agent_id: agent.id }).distinct.find_each do |old_motif|
           new_motif = old_motif.dup
           new_motif.organisation = new_organisation
           new_motif.save!

--- a/spec/features/super_admin/migrating_an_agent_spec.rb
+++ b/spec/features/super_admin/migrating_an_agent_spec.rb
@@ -6,7 +6,11 @@ describe "Migrating an agent from one organisation to another" do
   let!(:new_organisation) { create :organisation, territory: old_organisation.territory }
   let(:agent) { create :agent, admin_role_in_organisations: [old_organisation] }
 
-  let!(:rdv) { create :rdv, organisation: old_organisation, agents: [agent] }
+  let!(:motif1) { create :motif }
+  let!(:motif2) { create :motif }
+  let!(:rdv1) { create :rdv, organisation: old_organisation, agents: [agent], motif: motif1 }
+  let!(:rdv2) { create :rdv, organisation: old_organisation, agents: [agent], motif: motif1 }
+  let!(:rdv3) { create :rdv, organisation: old_organisation, agents: [agent], motif: motif2 }
 
   before do
     login_as(super_admin, scope: :super_admin)
@@ -22,19 +26,29 @@ describe "Migrating an agent from one organisation to another" do
 
     expect(agent.reload.organisations).to eq [new_organisation]
 
-    expect(rdv.reload.organisation).to eq new_organisation
-    expect([rdv.motif]).to eq new_organisation.motifs
-    expect(rdv.users).to eq new_organisation.users
+    # RDVs are moved to new org
+    expect(rdv1.reload.organisation).to eq(new_organisation)
+    expect(rdv2.reload.organisation).to eq(new_organisation)
+    expect(rdv3.reload.organisation).to eq(new_organisation)
+
+    # Motifs a copied to new org
+    expect(rdv1.motif).to have_attributes(motif1.attributes.except("id", "organisation_id", "created_at", "updated_at"))
+    expect(rdv2.motif).to have_attributes(motif1.attributes.except("id", "organisation_id", "created_at", "updated_at"))
+    expect(rdv3.motif).to have_attributes(motif2.attributes.except("id", "organisation_id", "created_at", "updated_at"))
+    expect([rdv1.motif, rdv3.reload.motif]).to match_array(new_organisation.motifs)
+
+    # RVS users are present in the new org
+    expect(rdv1.users + rdv2.users + rdv3.users).to match_array(new_organisation.users)
   end
 
   context "when the agent has a rdv with another agent that is not being migrated" do
-    let!(:rdv) { create :rdv, organisation: old_organisation, agents: [agent, other_agent] }
+    let!(:shared_rdv) { create :rdv, organisation: old_organisation, agents: [agent, other_agent] }
     let(:other_agent) { create(:agent, admin_role_in_organisations: [old_organisation]) }
 
     it "doesn't migrate the records and shows an error" do
       click_button "Migrer"
       expect(agent.reload.organisations).to eq [old_organisation]
-      expect(rdv.reload.organisation).to eq old_organisation
+      expect(shared_rdv.reload.organisation).to eq old_organisation
 
       expect(page).to have_content("Cet agent a des RDVs avec d'autres agents de cette organisation, et ne peut donc pas être migré automatiquement.")
     end
@@ -46,7 +60,9 @@ describe "Migrating an agent from one organisation to another" do
     it "doesn't migrate the records and shows an error" do
       click_button "Migrer"
       expect(agent.reload.organisations).to eq [old_organisation]
-      expect(rdv.reload.organisation).to eq old_organisation
+      expect(rdv1.reload.organisation).to eq old_organisation
+      expect(rdv2.reload.organisation).to eq old_organisation
+      expect(rdv3.reload.organisation).to eq old_organisation
 
       expect(page).to have_content("vous ne pouvez donc pas migrer d'agent entre ces deux organisations")
     end


### PR DESCRIPTION
@NesserineZarouri nous a signalé un crash lors d'une migration d'un agent d'une org à une autre :

> Nom est déjà utilisé pour un motif avec le même type de RDV

Le problème était que l'on itérait plusieurs fois sur le même motif car la jointure étais multiplicatrice. Et du coup on essayait de créer plusieurs copies du même motif, ce qui est interdit par les validations

On parle de l'action effectuée en cliquant ici : 

![image](https://user-images.githubusercontent.com/6357692/195385599-28cb1b82-5dd4-4f95-bd9d-0403490bf39b.png)


# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
