### PR TITLE
feat(search): Show available lieux only

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,7 +36,7 @@ class SearchController < ApplicationController
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
       :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category,
-      :invitation_token, :show_available_lieux_only, :organisation_id, organisation_ids: []
+      :invitation_token, :organisation_id, organisation_ids: []
     )
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -36,7 +36,7 @@ class SearchController < ApplicationController
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
       :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category,
-      :invitation_token, :organisation_id, organisation_ids: []
+      :invitation_token, :show_available_lieux_only, :organisation_id, organisation_ids: []
     )
   end
 end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -22,6 +22,7 @@ class SearchContext
     @service_id = query[:service_id]
     @lieu_id = query[:lieu_id]
     @start_date = query[:date]
+    @show_available_lieux_only = query[:show_available_lieux_only].to_b
   end
 
   # *** Method that outputs the next step for the user to complete its rdv journey ***
@@ -97,12 +98,17 @@ class SearchContext
   end
 
   def next_availability_by_lieux
-    @next_availability_by_lieux ||= lieux.to_h do |lieu|
-      [
-        lieu.id,
-        creneaux_search_for(lieu, date_range).next_availability,
-      ]
+    @next_availability_by_lieux ||= begin
+      next_availability_by_lieux = lieux.index_with do |lieu|
+        creneaux_search_for(lieu, date_range).next_availability
+      end
+      next_availability_by_lieux.compact! if @show_available_lieux_only
+      next_availability_by_lieux
     end
+  end
+
+  def shown_lieux
+    next_availability_by_lieux.keys
   end
 
   def start_date

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -22,7 +22,6 @@ class SearchContext
     @service_id = query[:service_id]
     @lieu_id = query[:lieu_id]
     @start_date = query[:date]
-    @show_available_lieux_only = query[:show_available_lieux_only].to_b
   end
 
   # *** Method that outputs the next step for the user to complete its rdv journey ***
@@ -98,13 +97,9 @@ class SearchContext
   end
 
   def next_availability_by_lieux
-    @next_availability_by_lieux ||= begin
-      next_availability_by_lieux = lieux.index_with do |lieu|
-        creneaux_search_for(lieu, date_range).next_availability
-      end
-      next_availability_by_lieux.compact! if @show_available_lieux_only
-      next_availability_by_lieux
-    end
+    @next_availability_by_lieux ||= lieux.index_with do |lieu|
+      creneaux_search_for(lieu, date_range).next_availability
+    end.compact
   end
 
   def shown_lieux

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -28,14 +28,11 @@ section.bg-light.p-4
               .card-subtitle= lieu.address
               .card-subtitle= context.selected_motif.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
-              - if next_availability
-                = link_to root_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
-                  .row
-                    .col
-                      = t(".next_availability")
-                      br
-                      strong= l(next_availability.starts_at, format: :human)
-                    .col-auto.align-self-center
+              = link_to root_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+                .row
+                  .col
+                    = t(".next_availability")
+                    br
+                    strong= l(next_availability.starts_at, format: :human)
+                  .col-auto.align-self-center
                       i.fa.fa-chevron-right
-              - else
-                em = t(".no_availability")

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -18,9 +18,8 @@ section.bg-light.p-4
                   = motif_name_with_location_type(context.selected_motif)
                 = context.selected_motif.service.name
     h3.font-weight-bold = t(".select_lieu")
-    p = t(".lieu_available", count: context.lieux.size)
-    - context.lieux.each do |lieu|
-      - next_availability = context.next_availability_by_lieux[lieu.id]
+    p = t(".lieu_available", count: context.shown_lieux.count)
+    - context.next_availability_by_lieux.each do |lieu, next_availability|
       .card.mb-3 class=("card-hoverable" if next_availability)
         .card-body
           .row

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -115,27 +115,15 @@ describe "User can be invited" do
         create(:motif, name: "RSA orientation sur site", max_booking_delay: 7.days, reservable_online: true, organisation: organisation, service: agent.service)
       end
 
-      it "shows the lieux with no availability" do
+      it "does not show the lieux" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
           address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
         )
-        expect(page).to have_content(lieu.name)
-        expect(page).to have_content(lieu2.name)
-        expect(page).to have_content("Aucune disponibilité")
-      end
 
-      context "when we show the available lieux only" do
-        it "does not show the lieux" do
-          visit prendre_rdv_path(
-            departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-            address: "16 rue de la résistance", motif_search_terms: "RSA orientation", show_available_lieux_only: true
-          )
-
-          expect(page).not_to have_content(lieu.name)
-          expect(page).not_to have_content(lieu2.name)
-          expect(page).to have_content("Nous n'avons pas trouvé de créneaux pour votre motif.")
-        end
+        expect(page).not_to have_content(lieu.name)
+        expect(page).not_to have_content(lieu2.name)
+        expect(page).to have_content("Nous n'avons pas trouvé de créneaux pour votre motif.")
       end
     end
   end

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -28,28 +28,28 @@ describe "User can be invited" do
   let!(:organisation) { create(:organisation, territory: territory26) }
   let!(:motif) { create(:motif, name: "RSA orientation sur site", reservable_online: true, organisation: organisation, service: agent.service) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:autre_lieu) { create(:lieu, organisation: organisation) }
+  let!(:lieu2) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
-  let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: autre_lieu, organisation: organisation) }
+  let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
 
   let!(:organisation2) { create(:organisation) }
 
-  describe "invitation to lieu selection new path" do
+  describe "in lieu selection page" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id])) }
 
     before do
       travel_to(now)
       allow(Users::GeoSearch).to receive(:new).and_return(geo_search)
-
-      visit prendre_rdv_path(
-        departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
-      )
       allow_any_instance_of(ActionDispatch::Request).to receive(:cookie_jar).and_return(page.cookies)
       allow_any_instance_of(ActionDispatch::Request).to receive(:cookies).and_return(page.cookies)
     end
 
-    it "default", js: true do
+    it "shows the available lieux to take a rdv", js: true do
+      visit prendre_rdv_path(
+        departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+        address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
+      )
+
       # Lieu selection
       expect(page).to have_content(lieu.name)
       find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
@@ -103,9 +103,44 @@ describe "User can be invited" do
       expect(page).to have_content(lieu.address)
       expect(page).to have_content("11h00")
     end
+
+    context "when lieux do not have availability" do
+      let!(:plage_ouverture) do
+        create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation)
+      end
+      let!(:plage_ouverture2) do
+        create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu2, organisation: organisation)
+      end
+      let!(:motif) do
+        create(:motif, name: "RSA orientation sur site", max_booking_delay: 7.days, reservable_online: true, organisation: organisation, service: agent.service)
+      end
+
+      it "shows the lieux with no availability" do
+        visit prendre_rdv_path(
+          departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+          address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
+        )
+        expect(page).to have_content(lieu.name)
+        expect(page).to have_content(lieu2.name)
+        expect(page).to have_content("Aucune disponibilité")
+      end
+
+      context "when we show the available lieux only" do
+        it "does not show the lieux" do
+          visit prendre_rdv_path(
+            departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+            address: "16 rue de la résistance", motif_search_terms: "RSA orientation", show_available_lieux_only: true
+          )
+
+          expect(page).not_to have_content(lieu.name)
+          expect(page).not_to have_content(lieu2.name)
+          expect(page).to have_content("Nous n'avons pas trouvé de créneaux pour votre motif.")
+        end
+      end
+    end
   end
 
-  describe "invitation to motifs selection" do
+  describe "in motifs selection page" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
     let!(:motif2) { create(:motif, name: "RSA orientation telephone", reservable_online: true, organisation: organisation2, service: agent.service) }
     let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
@@ -120,7 +155,7 @@ describe "User can be invited" do
       )
     end
 
-    it "default", js: true do
+    it "shows the geo search available motifs to take a rdv", js: true do
       # Motif selection
       expect(page).to have_content(motif.name)
       expect(page).to have_content(motif2.name)
@@ -176,43 +211,10 @@ describe "User can be invited" do
       )
     end
 
-    it "default", js: true do
+    it "shows the organisations available motifs", js: true do
       # Motif selection
       expect(page).to have_content(motif.name)
       expect(page).to have_content(motif2.name)
-      find(".card-title", text: /#{motif.name}/).click
-
-      # Restriction Page
-      expect(page).to have_content("À lire avant de prendre un rendez-vous")
-      expect(page).to have_content(motif.restriction_for_rdv)
-      click_link("Accepter")
-
-      # Lieu selection
-      expect(page).to have_content(lieu.name)
-      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
-
-      # Crenenau selection
-      expect(page).to have_content(lieu.name)
-      first(:link, "11:00").click
-
-      # RDV informations
-      expect(page).to have_content("Vos informations")
-      expect(page).not_to have_field("Date de naissance")
-      expect(page).not_to have_field("Adresse")
-      expect(page).to have_field("Email", with: user.email, disabled: true)
-      expect(page).to have_field("Téléphone", with: user.phone_number)
-      click_button("Continuer")
-
-      # Confirmation
-      expect(page).to have_content("Informations de contact")
-      expect(page).to have_content("johndoe@gmail.com")
-      expect(page).to have_content("0682605955")
-      click_link("Confirmer mon RDV")
-
-      # RDV page
-      expect(page).to have_content("Votre RDV")
-      expect(page).to have_content(lieu.address)
-      expect(page).to have_content("11h00")
     end
   end
 end

--- a/spec/features/users/user_can_search_for_creneaux_spec.rb
+++ b/spec/features/users/user_can_search_for_creneaux_spec.rb
@@ -30,7 +30,7 @@ describe "User can search for creneaux" do
 
       find("h3", text: motif.name).click
 
-      expect(page).to have_content("Aucune disponibilité")
+      expect(page).to have_content("Nous n'avons pas trouvé de créneaux pour votre motif")
     end
   end
 end


### PR DESCRIPTION
J'ajoute dans cette PR la possibilité de ne pas afficher aux utilisateurs les lieux n'ayant pas de prochaines disponibilités.

### Contexte 

Cela fait suite à la demande de nombreux départements utilisant RDV-Insertion, notamment ceux qui utilisent la sectorisation par agent. En effet, lorsqu'un motif est sectorisé par agent, on affiche tous les lieux pour lesquels il y a une plage d'ouverture pour ce motif, et ce n'est que lorsque l'on calcule la prochaine disponibilité [ici](https://github.com/betagouv/rdv-solidarites.fr/blob/dde3f21e1a71f1ae15a71a2fd864e3429c6adf6e/app/services/concerns/users/creneaux_search_concern.rb#L22) que le filtre se fait sur les agents du secteur. On affiche donc beaucoup de lieux avec seulement quelques-uns ayant des disponibilités, ce qui peut être perturbant.

### Mécanisme

Pour répondre à la problématique du dessus, j'aurais pu filtrer les lieux dans le `SearchContext` sur les agents concernés, mais je n'aurais pas pu pour autant enlever cette logique sur les agents dans le `Users::CreneauxSearchConcern` puisque celui-ci est utilisé à plusieurs endroits.
On a donc décidé de partir sur une solution plus simple, qui consiste simplement à passer un paramètre `show_available_lieux_only` dans l'url, qui lorsqu'il est passé dans l'URL filtre les lieux n'ayant pas de disponibilités.

### Preview 📸 

Avant
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/7602809/195400776-f69208b8-e317-4cb5-84dd-a643654e63ca.png">

Après
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/7602809/195400724-5fde72e6-5936-4bf0-86c3-50f6f1bcedad.png">


