### PR TITLE
feat(view): Improve recap UI for invitations

### DIFF
--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -3,9 +3,12 @@ section.bg-light.p-4
     - if context.invitation?
       .card
         .card-body
-          h2.pb-1.mb-1
+          h3.py-1.my-1
+            i.fa.fa-info-circle>
             = motif_name_with_location_type(context.selected_motif)
-            .card-subtitle= context.lieu.address
+            .card-subtitle.my-2.
+              i.fa.fa-map-marker-alt>
+              = context.lieu.address
 
     - else
       .card.card-hoverable

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -3,7 +3,7 @@ section.bg-light.p-4
     - if context.invitation?
       .card
         .card-body
-          h3.py-1.my-1
+          h2.py-1.my-1
             i.fa.fa-info-circle>
             = motif_name_with_location_type(context.selected_motif)
             .card-subtitle.my-2.

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -3,7 +3,8 @@ section.bg-light.p-4
     - if context.invitation?
       .card
         .card-body
-          h2.pb-1.mb-1
+          h3.py-1.my-1
+            i.fa.fa-info-circle>
             = motif_name_with_location_type(context.selected_motif)
     - else
       .card.card-hoverable

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -3,7 +3,7 @@ section.bg-light.p-4
     - if context.invitation?
       .card
         .card-body
-          h3.py-1.my-1
+          h2.py-1.my-1
             i.fa.fa-info-circle>
             = motif_name_with_location_type(context.selected_motif)
     - else

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -136,6 +136,68 @@ describe "public pages", js: true do
 
         expect_page_to_be_axe_clean(path)
       end
+
+      context "when invited" do
+        let!(:user) { create(:user) }
+        let!(:invitation_token) do
+          user.invite! { |u| u.skip_invitation = true }
+          user.raw_invitation_token
+        end
+
+        it "root path with a city_code and a service page is accessible" do
+          path = prendre_rdv_path(
+            departement: 75,
+            city_code: 75_056,
+            street_ban_id: nil,
+            latitude: 48.859,
+            longitude: 2.347,
+            address: "Paris 75001",
+            service_id: motif.service_id,
+            invitation_token: invitation_token
+          )
+          visit path
+          expect(page).to have_content("Sélectionnez le motif de votre RDV")
+
+          expect_page_to_be_axe_clean(path)
+        end
+
+        it "root path with a city_code and motif page is accessible" do
+          path = prendre_rdv_path(
+            motif_name_with_location_type: "Consultation prénatale-public_office",
+            address: "Paris 75001",
+            city_code: 75_056,
+            departement: 75,
+            latitude: 48.859,
+            longitude: 2.347,
+            street_ban_id: nil,
+            invitation_token: invitation_token
+          )
+          visit path
+          expect(page).to have_content("Sélectionnez un lieu de RDV")
+
+          expect_page_to_be_axe_clean(path)
+        end
+
+        it "root path with a city_code, motif and lieu page is accessible" do
+          path = prendre_rdv_path(
+            motif_name_with_location_type: "Consultation prénatale-public_office",
+            address: "Paris 75001",
+            city_code: 75_056,
+            departement: 75,
+            latitude: 48.859,
+            longitude: 2.347,
+            street_ban_id: nil,
+            lieu_id: lieu.id,
+            date: Time.zone.now,
+            invitation_token: invitation_token
+          )
+
+          visit path
+          expect(page).to have_content("dimanche")
+
+          expect_page_to_be_axe_clean(path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Je rends le recap des choix d'un usager invité plus lisible lors de la sélection du lieu et de la sélection du créneau.

### Preview 📸 

#### Choix du lieu 

Avant

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/7602809/195404211-791fce07-ad74-40f3-a5c2-69de79b168da.png">


Après 

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/7602809/195570429-e765a792-9d81-4fba-9e4a-cba8d5564d05.png">


#### Choix du créneau 

Avant 

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/7602809/195404168-e7c5a40e-52b8-48a7-bc14-8272e4883e7c.png">

Après

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/7602809/195570387-e585a140-ecc8-4616-ba62-b0688c805d3c.png">

