### PR TITLE
Permet la suppression d'un RDV collectif uniquement pour les admins d'organisation

### DIFF
--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -4,8 +4,9 @@
       = link_to admin_organisation_rdv_path(rdv.organisation, rdv) do
         h5= rdv_title_for_agent(rdv)
       = I18n.l(rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
-    div.mr-3= link_to admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: nil), method: :delete, title: t("helpers.delete"), data: { confirm: "Confirmez-vous la suppression de ce rendez-vous collectif ?"} do
-      i.fa.fa-trash-alt
+    - if current_agent.admin_in_organisation?(current_organisation)
+      div.mr-3= link_to admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: nil), method: :delete, title: t("helpers.delete"), data: { confirm: "Confirmez-vous la suppression de ce rendez-vous collectif ?"} do
+        i.fa.fa-trash-alt
   .card-body
     .row
       .col-md-6

--- a/spec/requests/admin/rdv_collectifs_spec.rb
+++ b/spec/requests/admin/rdv_collectifs_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe "Admin::RdvCollectifs", type: :request do
+  include Rails.application.routes.url_helpers
+
+  let(:organisation) { create(:organisation) }
+  let(:motif) { create(:motif, :collectif) }
+
+  describe "GET /admin/organisations/:organisation_id/rdv_collectifs" do
+    it "is successful" do
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      create(:rdv, motif: motif, organisation: organisation, agents: [agent])
+      sign_in agent
+
+      get admin_organisation_rdvs_collectifs_path(organisation)
+
+      expect(response).to be_successful
+    end
+
+    it "render index template" do
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      create(:rdv, motif: motif, organisation: organisation, agents: [agent])
+      sign_in agent
+
+      get admin_organisation_rdvs_collectifs_path(organisation)
+
+      expect(response).to render_template(:index)
+    end
+
+    it "show delete collective rdv icon" do
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      create(:rdv, motif: motif, organisation: organisation, agents: [agent])
+      sign_in agent
+
+      get admin_organisation_rdvs_collectifs_path(organisation)
+
+      expect(response.body).to include("Confirmez-vous la suppression de ce rendez-vous collectif ?")
+    end
+
+    context "with an basic role in organisation agent" do
+      it "dont show delete collective rdv icon" do
+        agent = create(:agent, basic_role_in_organisations: [organisation])
+        create(:rdv, motif: motif, organisation: organisation, agents: [agent])
+        sign_in agent
+
+        get admin_organisation_rdvs_collectifs_path(organisation)
+
+        expect(response.body).not_to include("Confirmez-vous la suppression de ce rendez-vous collectif ?")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dans la PR #2895 nous avons ajouté un bouton pour pouvoir supprimer un RDV Collectif depuis l'index des RDV Collectif.

La suppression n'est pas possible si nous ne sommes pas admin de l'organisation. Cette PR propose donc de ne pas afficher l'icône tant que l'agent n'est pas admin de l'organisation.



Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
