### PR TITLE
[Perfs] Cesser de mettre en cache les partials de RDV

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -14,7 +14,7 @@ class Admin::RdvsController < AgentAuthController
     @rdvs = policy_scope(Rdv).search_for(current_agent, current_organisation, parsed_params)
     @breadcrumb_page = params[:breadcrumb_page]
     @form = Admin::RdvSearchForm.new(parsed_params)
-    @rdvs = @rdvs.order(starts_at: :asc).page(params[:page])
+    @rdvs = @rdvs.order(starts_at: :asc).page(params[:page]).per(10)
   end
 
   def export

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -133,10 +133,6 @@ module UsersHelper
     end
   end
 
-  def users_to_links(users)
-    safe_join(users.order_by_last_name.map { user_to_link(_1) }, ", ")
-  end
-
   def email_tld_infos(email_tld)
     {
       "gmail.com" => { url: "https://mail.google.com", name: "GMail" },

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -78,7 +78,6 @@ class Agent < ApplicationRecord
   validate :service_cannot_be_changed
 
   # Hooks
-  after_update :touch_rdvs_for_cache
 
   # Scopes
   scope :complete, -> { where.not(first_name: nil).where.not(last_name: nil) }
@@ -189,18 +188,5 @@ class Agent < ApplicationRecord
     else
       Domain::RDV_SOLIDARITES
     end
-  end
-
-  private
-
-  # Les partials des RDVs sont mises en cache (la clé de cache contient `rdv.updated_at`).
-  # Si le profil agent change, le cache doit être invalidé.
-  def touch_rdvs_for_cache
-    # Ces champs sont mis à jour à chaque login, mais ne sont pas utilisés
-    # dans la partial des RDV, donc pas la peine d'invalider le cache.
-    sign_in_fields = %w[sign_in_count current_sign_in_at last_sign_in_at current_sign_in_ip last_sign_in_ip]
-    return if previous_changes.keys.intersection(sign_in_fields).any?
-
-    rdvs.touch_all
   end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -51,7 +51,6 @@ class Motif < ApplicationRecord
   delegate :name, to: :service, prefix: true
 
   # Hooks
-  after_update :touch_rdvs_for_cache
 
   # Validation
   validates :visibility_type, inclusion: { in: VISIBILITY_TYPES }
@@ -198,11 +197,5 @@ class Motif < ApplicationRecord
     return unless collectif? && !public_office?
 
     errors.add(:base, :not_at_home_if_collectif)
-  end
-
-  # Les partials des RDVs sont mises en cache (la clé de cache contient `rdv.updated_at`).
-  # Si le motif change, le cache doit être invalidé.
-  def touch_rdvs_for_cache
-    rdvs.touch_all
   end
 end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -175,7 +175,7 @@ class Rdv < ApplicationRecord
   end
 
   def user_for_home_rdv
-    responsibles = users.where.not(responsible_id: [nil])
+    responsibles = users.loaded? ? users.select(&:responsible_id) : users.where.not(responsible_id: [nil])
     [responsibles, users].flatten.select(&:address).first || users.first
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,8 +140,7 @@ class User < ApplicationRecord
   end
 
   def profile_for(organisation)
-    # Hash memoization: the block is called when a profile isn’t found in @profiles
-    @profiles ||= Hash.new { |h, org| h[org] = user_profiles.find_by(organisation: org) }
+    @profiles ||= user_profiles.index_by(&:organisation)
     @profiles[organisation]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,6 @@ class User < ApplicationRecord
 
   # Hooks
   before_save :set_email_to_null_if_blank
-  after_update :touch_rdvs_for_cache
 
   # Scopes
   scope :active, -> { where(deleted_at: nil) }
@@ -267,15 +266,5 @@ class User < ApplicationRecord
     return save! if organisations.any? # only actually mark deleted when no orgas left
 
     update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email)
-  end
-
-  # Les partials des RDVs sont mises en cache (la clé de cache contient `rdv.updated_at`).
-  # Si le profil usager change, le cache doit être invalidé.
-  def touch_rdvs_for_cache
-    # Ce champ est mis à jour à chaque login, mais n'est pas utilisé
-    # dans la partial des RDV, donc pas la peine d'invalider le cache.
-    return if previous_changes.keys.include?("last_sign_in_at")
-
-    rdvs.touch_all
   end
 end

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -29,7 +29,7 @@
     div class=("users-details collapse p-3 pt-0")
       h5.text-center.strong.mb-3> Participants :
       .row
-        - rdv.users.order_by_last_name.each do |user|
+        - rdv.users.sort_by { _1.last_name.downcase }.each do |user|
           .col-4
             .card.light-gray-card
               .card-body.p-2
@@ -43,7 +43,7 @@
         .d-none.d-sm-block
           = render "admin/rdvs/users_table", rdv: rdv
         .d-md-none.d-print-none
-          - rdv.rdvs_users.order_by_user_last_name.each do |rdvs_user|
+          - rdv.rdvs_users.sort_by { _1.user.last_name.downcase }.each do |rdvs_user|
             = render "admin/rdvs_users/user_card", rdvs_user: rdvs_user
       - else
         p Il n'y a pas encore de participant pour ce RDV

--- a/app/views/admin/rdvs/_short_rdvs_list.html.slim
+++ b/app/views/admin/rdvs/_short_rdvs_list.html.slim
@@ -3,6 +3,4 @@
     .text-muted aucun RDV
 - else
   ul.list-unstyled.horizontal-border-between-items
-    = render partial: "admin/rdvs/short_rdv",
-            collection: rdvs.includes(:motif),
-            cached: ->(rdv) { [rdv, locale_cache_key] }
+    = render partial: "admin/rdvs/short_rdv", collection: rdvs.includes(:motif)

--- a/app/views/admin/rdvs/_users_table.html.slim
+++ b/app/views/admin/rdvs/_users_table.html.slim
@@ -9,5 +9,5 @@
         th
         / th Participation
     tbody id="rdv-users-list"
-      - rdv.rdvs_users.includes(user: %i[responsible organisations]).order_by_user_last_name.each do |rdvs_user|
+      - rdv.rdvs_users.sort_by { _1.user.last_name.downcase }.each do |rdvs_user|
         = render "admin/rdvs_users/user_row", rdvs_user: rdvs_user

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -54,11 +54,8 @@
   .row.justify-content-center.pb-3
     .col-md-8
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
-      = render(partial: "rdv",
-              collection: @rdvs.includes(:organisation, :lieu, :motif, agents: :service, users: %i[responsible organisations]),
-              locals: { agent: nil },
-              cached: ->(rdv) { [rdv, locale_cache_key] } \
-              )
+      - @rdvs.includes(:organisation, :lieu, :motif, agents: :service, users: %i[responsible organisations]).each do |rdv|
+        = render(partial: "rdv", object: rdv, locals: { agent: nil })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
 - else
   .row.justify-content-center.pb-3

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -31,9 +31,7 @@
 .row.justify-content-center.pb-3
   .col-md-8
     - if @rdvs.any?
-      = render(partial: "admin/rdvs_collectifs/rdv",
-              collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service),
-              cached: ->(rdv) { [rdv, false, locale_cache_key] })
+      = render(partial: "admin/rdvs_collectifs/rdv", collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :service))
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
     - else
       .card


### PR DESCRIPTION
# Contexte

Il y a un an, dans #1847, [la liste des RDV a été mise en cache](https://github.com/betagouv/rdv-solidarites.fr/blob/5879b5cc1aecc8926d44fbe3144dad5868327b45/app/views/admin/rdvs/index.html.slim#L60) afin d'améliorer les performances. La partial de RDV contenant des données issues du motif, des agents et des usagers, il a fallu mettre en place un mécanisme d'invalidation de cache à base de `rdv.touch_all` lorsque ces associations sont modifiées.

La semaine dernière, nous avons découvert qu'à chaque connexion d'un agent, tous ses RDVs prenent un `touch_all` car des champs techniques (`last_sign_in_at`, etc) sont mis à jour à ce moment là. Nous avons donc tenté de limiter le nombre de cas où le `touch_all` est appelé dans #2916, mergé jeudi dernier.

Malheureusement, ce matin (le lundi suivant), nous avions à nouveau des soucis de performance très importants, et des traces sur Skylight de `touch_all` sur des opérations comme le logout agent. Nous avons également observé sur Skylight que le cache de la partial était utilisé **au mieux 1 fois sur 3**, ce qui signifie que l'on écrit le cache pour l'utilise entre 1 et 2 fois. Le coût de l'invalidation de cache semble donc largement dépasser les bénéfices de l'usage du cache. Nous avons donc décidé qu'il était stratégique cesser de mettre en cache les partials de RDV, et donc également de ne plus faire de `touch_all`.

Afin de s'affranchir des complexités du cache tout en gardant des performances acceptables, voici les améliorations de performances proposées dans cette PR :
- pagination des RDV par pages de 10 plutôt que par page de 20
- optimisations visant à éviter les appels N+1 à Postgres

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
