### PR TITLE
Améliorer l'observabilité des performances en local

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ group :development do
   gem "binding_of_caller" # Enable the REPL in better_errors
   gem "letter_opener_web" # Saves sent emails and serves them on /letter_opener
   gem "rails-erd" # Keeps docs/domain_model.svg up-to-date. See .erdconfig
+  gem "rack-mini-profiler"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,8 @@ GEM
       rack (~> 2.0)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-mini-profiler (3.0.0)
+      rack (>= 1.2.0)
     rack-oauth2 (1.19.0)
       activesupport
       attr_required
@@ -673,6 +675,7 @@ DEPENDENCIES
   puma
   pundit
   rack-cors
+  rack-mini-profiler
   rails (~> 6.0)
   rails-controller-testing
   rails-erd

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,8 +58,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.log_level = :info
-  # config.log_level = :debug # debug logs all the SQL queries made by ActiveRecord
+  # config.log_level = :info
+  config.log_level = :debug # debug logs all the SQL queries made by ActiveRecord
 
   # allows to see debug logs when running with foreman / overmind
   # cf https://github.com/rails/sprockets-rails/issues/376#issuecomment-287560399


### PR DESCRIPTION
Depuis quelques semaines nous avons à nouveau des soucis de performances (exemple : #2916, #2937), et donc j'ai régulièrement ressorti la gem `rack-mini-profiler` pour débugger manuellement les queries N+1. 

C'est un outil simple et efficace, je vous recommande cette [introduction de 9 minutes](https://www.youtube.com/watch?v=8SkjRkDZRZU) si vous ne connaissez pas.

J'ai toujours eu l'habitude de l'activer en local sur mes projets, et ça a pour effet de garder à l'esprit l'aspect "perf" lorsque l'on développe en local.

Je propose donc de l'ajouter au Gemfile, et donc de l'activer par défaut en environnement `development`.

Au passage, je propose de modifier le log level en local afin que les logs affichent les requêtes SQL, car la plupart du temps je trouve que c'est désirable.

Je vous lais me dire ce que vous en pensez.
