### PR TITLE
[Perfs] Lenteurs du feed ICS

### DIFF
--- a/app/controllers/ics_calendar_controller.rb
+++ b/app/controllers/ics_calendar_controller.rb
@@ -34,7 +34,10 @@ class IcsCalendarController < ActionController::Base
   end
 
   def rdvs
-    @agent.rdvs.order("starts_at desc").limit(500)
+    @agent.rdvs
+      .includes(:organisation, :lieu, :motif)
+      .order("starts_at desc")
+      .where("starts_at > ?", 1.month.ago)
   end
 
   def add_events(cal)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -183,10 +183,10 @@ class Agent < ApplicationRecord
   delegate :conseiller_numerique?, to: :service
 
   def domain
-    if organisations.where(new_domain_beta: true).any?
-      Domain::RDV_AIDE_NUMERIQUE
-    else
-      Domain::RDV_SOLIDARITES
-    end
+    @domain ||= if organisations.where(new_domain_beta: true).any?
+                  Domain::RDV_AIDE_NUMERIQUE
+                else
+                  Domain::RDV_SOLIDARITES
+                end
   end
 end


### PR DESCRIPTION
Pour les agents qui ont beaucoup de RDVs, l'appel au endpoint ICS est lent car on ne précharge pas les associations, et qu'on prend les 500 RDVs les plus récents, même si il sont vieux de plusieurs mois. J'ai donc décidé de corriger ces deux aspects.

Un exemple de gain de perf sur l'agent `id=312`, pour lequel on retournait auparavant les 500 RDVs les plus récents, et qui avec cette version du code retourne les RDVs qui ont moins d'un mois (231 RDVs), avec en plus le préchargement des associations : on passe de 6300 ms à 400 ms.

Le cache est aussi une options très valable pour ce cas d'usage, mais je ne l'ai pas utilisé afin de ne pas complexifier le potentiel débuggage d'une fonctionnalité qui déjà est soumise au bon vouloir du polling des clients iCalendar.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
