### PR TITLE
Point de terminaison de l'API publique : `groups`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,7 @@ Metrics/MethodLength:
 Rails/ApplicationController:
   Exclude:
     - 'app/controllers/api/v1/base_controller.rb'
+    - 'app/controllers/public_api/v1/base_controller.rb'
 
 Rails/CreateTableWithTimestamps:
   Exclude:

--- a/app/blueprints/group_blueprint.rb
+++ b/app/blueprints/group_blueprint.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class GroupBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :departement_number, name: :name
+  field :name, name: :label
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::BaseController < ActionController::Base
   skip_before_action :verify_authenticity_token
   include Pundit
   include DeviseTokenAuth::Concerns::SetUserByToken
+  include ApiResourcesRenderer
   respond_to :json
   before_action :authenticate_api_v1_agent_with_token_auth!
 
@@ -26,36 +27,6 @@ class Api::V1::BaseController < ActionController::Base
 
   def authorize(record, *args)
     super([:agent, record], *args)
-  end
-
-  def params
-    params = super
-    @page ||= params.delete(:page)&.to_i || 1
-    @per ||= params.delete(:per)&.to_i || 100
-    params
-  end
-
-  def render_record(record, **options)
-    record_klass = record.class
-    blueprint_klass = "#{record_klass.name}Blueprint".constantize
-    root = record.class.model_name.element
-    render json: blueprint_klass.render(record, root: root, **options)
-  end
-
-  def render_collection(objects)
-    objects = objects.page(@page).per(@per)
-    meta = {
-      current_page: objects.current_page,
-      next_page: objects.next_page,
-      prev_page: objects.prev_page,
-      total_pages: objects.total_pages,
-      total_count: objects.total_count,
-    }
-
-    objects_klass = objects.klass
-    blueprint_klass = "#{objects_klass.name}Blueprint".constantize
-    root = objects_klass.model_name.collection
-    render json: blueprint_klass.render(objects, root: root, meta: meta)
   end
 
   # Rescuable exceptions

--- a/app/controllers/concerns/api_resources_renderer.rb
+++ b/app/controllers/concerns/api_resources_renderer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ApiResourcesRenderer
+  extend ActiveSupport::Concern
+
+  protected
+
+  def render_record(record, **options)
+    record_klass = record.class
+    blueprint_klass = "#{record_klass.name}Blueprint".constantize
+    root = record.class.model_name.element
+    render json: blueprint_klass.render(record, root: root, **options)
+  end
+
+  def render_collection(objects, root: nil, blueprint_klass: nil)
+    objects = objects.page(page).per(per)
+    meta = {
+      current_page: objects.current_page,
+      next_page: objects.next_page,
+      prev_page: objects.prev_page,
+      total_pages: objects.total_pages,
+      total_count: objects.total_count,
+    }
+
+    objects_klass = objects.klass
+    blueprint_klass = "#{objects_klass.name}Blueprint".constantize if blueprint_klass.blank?
+    root = objects_klass.model_name.collection if root.blank?
+    render json: blueprint_klass.render(objects, root: root, meta: meta)
+  end
+
+  def page
+    @page ||= params[:page]&.to_i || 1
+  end
+
+  def per
+    @per ||= params[:per]&.to_i || 100
+  end
+end

--- a/app/controllers/public_api/v1/base_controller.rb
+++ b/app/controllers/public_api/v1/base_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PublicApi::V1::BaseController < ActionController::Base
+  include ApiResourcesRenderer
+
   respond_to :json
 
   protected

--- a/app/controllers/public_api/v1/base_controller.rb
+++ b/app/controllers/public_api/v1/base_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class PublicApi::V1::BaseController < ActionController::Base
+  respond_to :json
+end

--- a/app/controllers/public_api/v1/base_controller.rb
+++ b/app/controllers/public_api/v1/base_controller.rb
@@ -2,4 +2,15 @@
 
 class PublicApi::V1::BaseController < ActionController::Base
   respond_to :json
+
+  protected
+
+  def check_parameters_presence(*parameters)
+    missing_parameters = parameters.select { |param| params[param].nil? }
+    render_error :bad_request, missing: missing_parameters.to_sentence if missing_parameters.any?
+  end
+
+  def render_error(status, error = { error: :unknown })
+    render json: error, status: status
+  end
 end

--- a/app/controllers/public_api/v1/groups_controller.rb
+++ b/app/controllers/public_api/v1/groups_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PublicApi::V1::GroupsController < PublicApi::V1::BaseController
+  def index
+    render_collection(Territory, root: :groups, blueprint_klass: GroupBlueprint)
+  end
+end

--- a/app/controllers/public_api/v1/public_links_controller.rb
+++ b/app/controllers/public_api/v1/public_links_controller.rb
@@ -21,7 +21,7 @@ class PublicApi::V1::PublicLinksController < PublicApi::V1::BaseController
 
   def index
     # Using cache to prevent overloading db in case of accidentally intensive API calls
-    response_body = Rails.cache.fetch("public_api/public_links/#{@territory.id}", expires_in: 1.minute) do
+    response_body = Rails.cache.fetch("public_api/v1/public_links/#{@territory.id}", expires_in: 1.minute) do
       { public_links: public_links_for(@territory) }.to_json
     end
 

--- a/app/controllers/public_api/v1/public_links_controller.rb
+++ b/app/controllers/public_api/v1/public_links_controller.rb
@@ -16,6 +16,8 @@
 # - Rés'In (métropole de Lyon)
 #
 class PublicApi::V1::PublicLinksController < PublicApi::V1::BaseController
+  before_action -> { check_parameters_presence(:territory) }
+
   def index
     departement_number = params.require(:territory).presence
 

--- a/app/controllers/public_api/v1/public_links_controller.rb
+++ b/app/controllers/public_api/v1/public_links_controller.rb
@@ -15,7 +15,7 @@
 # - l'équipe carto ANCT,
 # - Rés'In (métropole de Lyon)
 #
-class PublicApi::PublicLinksController < ActionController::Base # rubocop:disable Rails/ApplicationController
+class PublicApi::V1::PublicLinksController < PublicApi::V1::BaseController
   def index
     departement_number = params.require(:territory).presence
 

--- a/config/initializers/routing_draw.rb
+++ b/config/initializers/routing_draw.rb
@@ -1,0 +1,9 @@
+# config/initializers/routing_draw.rb
+
+# Adds draw method into Rails routing
+# It allows us to keep routing splitted into files
+class ActionDispatch::Routing::Mapper
+  def draw(routes_name)
+    instance_eval(File.read(Rails.root.join("config/routes/#{routes_name}.rb")))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :public_links, only: [:index]
     end
+
+    # This one has been published before versioning the public API:
+    get :public_links, to: "v1/public_links#index"
   end
 
   resources :organisations, only: %i[new create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,35 +92,6 @@ Rails.application.routes.draw do
 
   get "/calendrier/:id", controller: :ics_calendar, action: :show, as: :ics_calendar
 
-  namespace :api do
-    namespace :v1 do
-      mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
-      resources :absences, except: %i[new edit]
-      resources :agents, only: %i[index]
-      resources :users, only: %i[create index show update] do
-        get :invite, on: :member
-        post :invite, on: :member
-      end
-      resources :user_profiles, only: [:create]
-      resources :organisations, only: %i[index] do
-        resources :users, only: %i[index show]
-        resources :motifs, only: %i[index]
-        resources :rdvs, only: %i[index]
-      end
-
-      resources :invitations, param: "token", only: [:show]
-    end
-  end
-
-  namespace :public_api do
-    namespace :v1 do
-      resources :public_links, only: [:index]
-    end
-
-    # This one has been published before versioning the public API:
-    get :public_links, to: "v1/public_links#index"
-  end
-
   resources :organisations, only: %i[new create]
 
   authenticate :agent do
@@ -301,4 +272,8 @@ Rails.application.routes.draw do
     # LetterOpener
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
+
+  ## APIs
+  draw :api
+  draw :public_api
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,12 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :public_api do
+    namespace :v1 do
+      resources :public_links, only: [:index]
+    end
+  end
+
   resources :organisations, only: %i[new create]
 
   authenticate :agent do
@@ -261,10 +267,6 @@ Rails.application.routes.draw do
   # short public link
   get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
   get "org/ext/:territory/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
-
-  namespace :public_api do
-    resources :public_links, only: [:index]
-  end
 
   ##
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :api do
+  namespace :v1 do
+    mount_devise_token_auth_for "AgentWithTokenAuth", at: "auth"
+    resources :absences, except: %i[new edit]
+    resources :agents, only: %i[index]
+    resources :users, only: %i[create index show update] do
+      get :invite, on: :member
+      post :invite, on: :member
+    end
+    resources :user_profiles, only: [:create]
+    resources :organisations, only: %i[index] do
+      resources :users, only: %i[index show]
+      resources :motifs, only: %i[index]
+      resources :rdvs, only: %i[index]
+    end
+
+    resources :invitations, param: "token", only: [:show]
+  end
+end

--- a/config/routes/public_api.rb
+++ b/config/routes/public_api.rb
@@ -2,7 +2,8 @@
 
 namespace :public_api do
   namespace :v1 do
-    resources :public_links, only: [:index]
+    resources :public_links, only: :index
+    resources :groups, only: :index
   end
 
   # This one has been published before versioning the public API:

--- a/config/routes/public_api.rb
+++ b/config/routes/public_api.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :public_api do
+  namespace :v1 do
+    resources :public_links, only: [:index]
+  end
+
+  # This one has been published before versioning the public API:
+  get :public_links, to: "v1/public_links#index"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
   config.include PageSpecHelper
   config.include SigninSpecHelper
   config.include Select2SpecHelper
-  config.include ApiSpecHelper
+  config.include ApiSpecHelper, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include Devise::Test::ControllerHelpers, type: :controller

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -13,8 +13,7 @@ describe "api/v1/absences requests", type: :request do
       it "returns empty array" do
         subject
         expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result["absences"]).to eq([])
+        expect(parsed_response_body["absences"]).to eq([])
       end
     end
 
@@ -31,9 +30,8 @@ describe "api/v1/absences requests", type: :request do
       it "returns policy scoped absences" do
         subject
         expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result["absences"].count).to eq(3)
-        expect(result["absences"].pluck("id")).to \
+        expect(parsed_response_body["absences"].count).to eq(3)
+        expect(parsed_response_body["absences"].pluck("id")).to \
           contain_exactly(absence1.id, absence2.id, absence_org2.id)
       end
 
@@ -42,7 +40,7 @@ describe "api/v1/absences requests", type: :request do
 
         it "does not include orga2 absences" do
           subject
-          expect(JSON.parse(response.body)["absences"].pluck("id")).to \
+          expect(parsed_response_body["absences"].pluck("id")).to \
             contain_exactly(absence1.id, absence2.id)
         end
       end
@@ -115,7 +113,7 @@ describe "api/v1/absences requests", type: :request do
       it "returns an error" do
         expect { subject }.not_to(change(Absence, :count))
         expect(response.status).to eq(422)
-        expect(JSON.parse(response.body)["error_messages"]).to include("start_time doit être rempli(e)")
+        expect(parsed_response_body["error_messages"]).to include("start_time doit être rempli(e)")
       end
     end
 
@@ -125,7 +123,7 @@ describe "api/v1/absences requests", type: :request do
       it "returns an error" do
         expect { subject }.not_to(change(Absence, :count))
         expect(response.status).to eq(422)
-        expect(JSON.parse(response.body)["error_messages"]).to include("ends_time doit être après le début.")
+        expect(parsed_response_body["error_messages"]).to include("ends_time doit être après le début.")
       end
     end
 
@@ -141,7 +139,7 @@ describe "api/v1/absences requests", type: :request do
         it "returns an error" do
           expect { subject }.not_to(change(Absence, :count))
           expect(response.status).to eq(403)
-          expect(JSON.parse(response.body)["error_messages"]).to include("Vous ne pouvez pas effectuer cette action.")
+          expect(parsed_response_body["error_messages"]).to include("Vous ne pouvez pas effectuer cette action.")
         end
       end
 
@@ -175,7 +173,7 @@ describe "api/v1/absences requests", type: :request do
       it "works" do
         subject
         expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
+        result = parsed_response_body
         expect(result["absence"]["title"]).to eq(absence.title)
       end
     end

--- a/spec/requests/api/v1/agents_request_spec.rb
+++ b/spec/requests/api/v1/agents_request_spec.rb
@@ -18,8 +18,7 @@ describe "api/v1/agents requests", type: :request do
         it "returns all agents of available organisations" do
           subject
           expect(response.status).to eq(200)
-          result = JSON.parse(response.body)
-          expect(result["agents"].pluck("id")).to match_array([agent.id, agent2.id])
+          expect(parsed_response_body["agents"].pluck("id")).to match_array([agent.id, agent2.id])
         end
       end
 
@@ -29,8 +28,7 @@ describe "api/v1/agents requests", type: :request do
         it "only includes specified organisation" do
           subject
           expect(response.status).to eq(200)
-          result = JSON.parse(response.body)
-          expect(result["agents"].pluck("id")).to match_array([agent.id])
+          expect(parsed_response_body["agents"].pluck("id")).to match_array([agent.id])
         end
       end
     end

--- a/spec/requests/api/v1/invitations_request_spec.rb
+++ b/spec/requests/api/v1/invitations_request_spec.rb
@@ -15,8 +15,7 @@ describe "api/v1/agents requests", type: :request do
       it "returns the user" do
         get api_v1_invitation_path(invitation_token), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]["id"]).to eq(user.id)
+        expect(parsed_response_body["user"]["id"]).to eq(user.id)
       end
 
       context "when not authorized" do
@@ -26,8 +25,7 @@ describe "api/v1/agents requests", type: :request do
         it "returns 403" do
           get api_v1_invitation_path(invitation_token), headers: api_auth_headers_for_agent(agent)
           expect(response.status).to eq(403)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["errors"]).to be_present
+          expect(parsed_response_body["errors"]).to be_present
         end
       end
     end

--- a/spec/requests/api/v1/motifs_request_spec.rb
+++ b/spec/requests/api/v1/motifs_request_spec.rb
@@ -14,8 +14,7 @@ describe "api/v1/motifs requests", type: :request do
       it "does not return the motifs list" do
         get api_v1_organisation_motifs_path(other_orga), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["motifs"]).to eq([])
+        expect(parsed_response_body["motifs"]).to eq([])
       end
     end
 
@@ -28,8 +27,7 @@ describe "api/v1/motifs requests", type: :request do
       it "returns the organisation motifs only" do
         get api_v1_organisation_motifs_path(organisation), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif1.id)
+        expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif1.id)
       end
     end
 
@@ -46,8 +44,7 @@ describe "api/v1/motifs requests", type: :request do
             params: { active: true }
           )
           expect(response.status).to eq(200)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif1.id)
+          expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif1.id)
         end
       end
 
@@ -59,9 +56,8 @@ describe "api/v1/motifs requests", type: :request do
             params: { active: false }
           )
           expect(response.status).to eq(200)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif2.id)
-          expect(response_parsed["motifs"].pluck("deleted_at")).to contain_exactly(deleted_at.to_s)
+          expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif2.id)
+          expect(parsed_response_body["motifs"].pluck("deleted_at")).to contain_exactly(deleted_at.to_s)
         end
       end
     end
@@ -78,8 +74,7 @@ describe "api/v1/motifs requests", type: :request do
             params: { reservable_online: true }
           )
           expect(response.status).to eq(200)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif1.id)
+          expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif1.id)
         end
       end
 
@@ -91,9 +86,8 @@ describe "api/v1/motifs requests", type: :request do
             params: { reservable_online: false }
           )
           expect(response.status).to eq(200)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif2.id)
-          expect(response_parsed["motifs"].pluck("reservable_online")).to contain_exactly(false)
+          expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif2.id)
+          expect(parsed_response_body["motifs"].pluck("reservable_online")).to contain_exactly(false)
         end
       end
     end
@@ -112,8 +106,7 @@ describe "api/v1/motifs requests", type: :request do
           params: { service_id: service.id }
         )
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["motifs"].pluck("id")).to contain_exactly(motif1.id)
+        expect(parsed_response_body["motifs"].pluck("id")).to contain_exactly(motif1.id)
       end
     end
   end

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -10,8 +10,7 @@ describe "api/v1/organisations requests", type: :request do
       it "returns empty array" do
         subject
         expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result["organisations"]).to eq([])
+        expect(parsed_response_body["organisations"]).to eq([])
       end
     end
 
@@ -25,9 +24,8 @@ describe "api/v1/organisations requests", type: :request do
       it "returns policy scoped organisations" do
         subject
         expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result["organisations"].count).to eq(2)
-        expect(result["organisations"].pluck("id")).to \
+        expect(parsed_response_body["organisations"].count).to eq(2)
+        expect(parsed_response_body["organisations"].pluck("id")).to \
           contain_exactly(organisation1.id, organisation2.id)
       end
     end
@@ -56,9 +54,8 @@ describe "api/v1/organisations requests", type: :request do
       it "returns the organisations attributed to the sector" do
         subject
         expect(response.status).to eq(200)
-        result = JSON.parse(response.body)
-        expect(result["organisations"].count).to eq(1)
-        expect(result["organisations"].pluck("id")).to \
+        expect(parsed_response_body["organisations"].count).to eq(1)
+        expect(parsed_response_body["organisations"].pluck("id")).to \
           contain_exactly(organisation2.id)
       end
     end

--- a/spec/requests/api/v1/paginated_requests_spec.rb
+++ b/spec/requests/api/v1/paginated_requests_spec.rb
@@ -13,9 +13,8 @@ describe "paginated requests", type: :request do
 
     it do
       expect(response.status).to eq(200)
-      result = JSON.parse(response.body)
-      expect(result["organisations"].count).to eq(100)
-      expect(result["meta"]).to eq({ "current_page" => 1, "next_page" => 2, "prev_page" => nil, "total_count" => 210, "total_pages" => 3 })
+      expect(parsed_response_body["organisations"].count).to eq(100)
+      expect(parsed_response_body["meta"]).to eq({ "current_page" => 1, "next_page" => 2, "prev_page" => nil, "total_count" => 210, "total_pages" => 3 })
     end
   end
 
@@ -24,9 +23,8 @@ describe "paginated requests", type: :request do
 
     it do
       expect(response.status).to eq(200)
-      result = JSON.parse(response.body)
-      expect(result["organisations"].count).to eq(10)
-      expect(result["meta"]).to eq({ "current_page" => 2, "next_page" => 3, "prev_page" => 1, "total_count" => 210, "total_pages" => 21 })
+      expect(parsed_response_body["organisations"].count).to eq(10)
+      expect(parsed_response_body["meta"]).to eq({ "current_page" => 2, "next_page" => 3, "prev_page" => 1, "total_count" => 210, "total_pages" => 21 })
     end
   end
 end

--- a/spec/requests/api/v1/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/rdvs_request_spec.rb
@@ -20,8 +20,7 @@ describe "api/v1/rdvs requests", type: :request do
         it "returns policy scoped rdvs" do
           get api_v1_organisation_rdvs_path(organisation), headers: api_auth_headers_for_agent(agent)
           expect(response.status).to eq(200)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["rdvs"].pluck("id")).to contain_exactly(rdv.id)
+          expect(parsed_response_body["rdvs"].pluck("id")).to contain_exactly(rdv.id)
         end
       end
 
@@ -31,8 +30,7 @@ describe "api/v1/rdvs requests", type: :request do
         it "returns policy scoped rdvs" do
           get api_v1_organisation_rdvs_path(organisation), headers: api_auth_headers_for_agent(agent)
           expect(response.status).to eq(200)
-          response_parsed = JSON.parse(response.body)
-          expect(response_parsed["rdvs"].pluck("id")).to contain_exactly(rdv.id, rdv3.id)
+          expect(parsed_response_body["rdvs"].pluck("id")).to contain_exactly(rdv.id, rdv3.id)
         end
       end
     end

--- a/spec/requests/api/v1/user_profiles_request_spec.rb
+++ b/spec/requests/api/v1/user_profiles_request_spec.rb
@@ -20,10 +20,9 @@ describe "api/v1/user_profiles requests", type: :request do
         )
         expect(response.status).to eq(200)
         expect(UserProfile.count).to eq(count_before + 1)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user_profile"]).to be_present
-        expect(response_parsed["user_profile"]["user"]["id"]).to eq(user.id)
-        expect(response_parsed["user_profile"]["organisation"]["id"]).to eq(organisation.id)
+        expect(parsed_response_body["user_profile"]).to be_present
+        expect(parsed_response_body["user_profile"]["user"]["id"]).to eq(user.id)
+        expect(parsed_response_body["user_profile"]["organisation"]["id"]).to eq(organisation.id)
         expect(user.reload.organisations).to include(organisation)
       end
     end
@@ -43,12 +42,11 @@ describe "api/v1/user_profiles requests", type: :request do
         )
         expect(response.status).to eq(200)
         expect(UserProfile.count).to eq(count_before + 1)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user_profile"]).to be_present
-        expect(response_parsed["user_profile"]["user"]["id"]).to eq(user.id)
-        expect(response_parsed["user_profile"]["organisation"]["id"]).to eq(organisation.id)
-        expect(response_parsed["user_profile"]["logement"]).to eq("heberge")
-        expect(response_parsed["user_profile"]["notes"]).to eq("Très pressé, vite vite")
+        expect(parsed_response_body["user_profile"]).to be_present
+        expect(parsed_response_body["user_profile"]["user"]["id"]).to eq(user.id)
+        expect(parsed_response_body["user_profile"]["organisation"]["id"]).to eq(organisation.id)
+        expect(parsed_response_body["user_profile"]["logement"]).to eq("heberge")
+        expect(parsed_response_body["user_profile"]["notes"]).to eq("Très pressé, vite vite")
         expect(user.reload.organisations).to include(organisation)
       end
     end
@@ -63,8 +61,7 @@ describe "api/v1/user_profiles requests", type: :request do
         )
         expect(response.status).to eq(403)
         expect(UserProfile.count).to eq(count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
 
@@ -78,8 +75,7 @@ describe "api/v1/user_profiles requests", type: :request do
         )
         expect(response.status).to eq(422)
         expect(UserProfile.count).to eq(count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
 
@@ -99,8 +95,7 @@ describe "api/v1/user_profiles requests", type: :request do
         )
         expect(response.status).to eq(403)
         expect(UserProfile.count).to eq(count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
 
@@ -119,8 +114,7 @@ describe "api/v1/user_profiles requests", type: :request do
         )
         expect(response.status).to eq(422)
         expect(UserProfile.count).to eq(count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
   end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -11,14 +11,13 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get api_v1_user_path(user), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to eq(user.id)
-        expect(response_parsed["user"]["first_name"]).to eq("Jean")
-        expect(response_parsed["user"]["last_name"]).to eq("JACQUES")
-        expect(response_parsed["user"]["user_profiles"]).to be_present
-        expect(response_parsed["user"]["user_profiles"].size).to eq 1
-        expect(response_parsed["user"]["user_profiles"][0]["organisation"]["id"]).to eq(organisation.id)
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to eq(user.id)
+        expect(parsed_response_body["user"]["first_name"]).to eq("Jean")
+        expect(parsed_response_body["user"]["last_name"]).to eq("JACQUES")
+        expect(parsed_response_body["user"]["user_profiles"]).to be_present
+        expect(parsed_response_body["user"]["user_profiles"].size).to eq 1
+        expect(parsed_response_body["user"]["user_profiles"][0]["organisation"]["id"]).to eq(organisation.id)
       end
     end
 
@@ -29,14 +28,13 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get api_v1_user_path(user), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to eq(user.id)
-        expect(response_parsed["user"]["first_name"]).to eq("Jean")
-        expect(response_parsed["user"]["last_name"]).to eq("JACQUES")
-        expect(response_parsed["user"]["user_profiles"]).to be_present
-        expect(response_parsed["user"]["user_profiles"].size).to eq 1
-        expect(response_parsed["user"]["user_profiles"][0]["organisation"]["id"]).to eq(organisation.id)
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to eq(user.id)
+        expect(parsed_response_body["user"]["first_name"]).to eq("Jean")
+        expect(parsed_response_body["user"]["last_name"]).to eq("JACQUES")
+        expect(parsed_response_body["user"]["user_profiles"]).to be_present
+        expect(parsed_response_body["user"]["user_profiles"].size).to eq 1
+        expect(parsed_response_body["user"]["user_profiles"][0]["organisation"]["id"]).to eq(organisation.id)
       end
     end
 
@@ -46,8 +44,7 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get api_v1_user_path(user), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(403)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
   end
@@ -67,10 +64,9 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(200)
         expect(User.count).to eq(user_count_before + 1)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to be_present
-        user = User.find(response_parsed["user"]["id"])
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to be_present
+        user = User.find(parsed_response_body["user"]["id"])
         expect(user.organisations).to match_array([organisation])
         expect(user.first_name).to eq("Jean")
         expect(user.last_name).to eq("Jacques")
@@ -101,10 +97,9 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(200)
         expect(User.count).to eq(user_count_before + 1)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to be_present
-        user = User.find(response_parsed["user"]["id"])
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to be_present
+        user = User.find(parsed_response_body["user"]["id"])
         expect(user.organisations).to match_array([organisation])
         expect(user.first_name).to eq("Jean")
         expect(user.last_name).to eq("Jacques")
@@ -138,10 +133,9 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(200)
         expect(User.count).to eq(user_count_before + 1)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to be_present
-        user = User.find(response_parsed["user"]["id"])
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to be_present
+        user = User.find(parsed_response_body["user"]["id"])
         expect(user.organisations).to match_array([organisation])
         expect(user.first_name).to eq("Jean")
         expect(user.last_name).to eq("Jacques")
@@ -161,8 +155,7 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(422)
         expect(User.count).to eq(user_count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
+        expect(parsed_response_body["errors"]).not_to be_empty
       end
     end
 
@@ -181,8 +174,7 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(422)
         expect(User.count).to eq(user_count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
+        expect(parsed_response_body["errors"]).not_to be_empty
       end
     end
 
@@ -203,8 +195,7 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(422)
         expect(User.count).to eq(user_count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
+        expect(parsed_response_body["errors"]).not_to be_empty
       end
     end
 
@@ -226,9 +217,8 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(422)
         expect(User.count).to eq(user_count_before)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
-        expect(response_parsed["errors"]["email"].first).to \
+        expect(parsed_response_body["errors"]).not_to be_empty
+        expect(parsed_response_body["errors"]["email"].first).to \
           eq({ "error" => "taken", "value" => "jean@jacques.fr", "id" => existing_user.id })
       end
     end
@@ -246,8 +236,7 @@ describe "api/v1/users requests", type: :request do
       it "returns policy scoped users" do
         get api_v1_users_path, headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["users"].pluck("id")).to contain_exactly(user.id, user2.id)
+        expect(parsed_response_body["users"].pluck("id")).to contain_exactly(user.id, user2.id)
       end
     end
 
@@ -262,8 +251,7 @@ describe "api/v1/users requests", type: :request do
           headers: api_auth_headers_for_agent(agent)
         )
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["users"].pluck("id")).to contain_exactly(user1.id)
+        expect(parsed_response_body["users"].pluck("id")).to contain_exactly(user1.id)
       end
     end
   end
@@ -276,8 +264,7 @@ describe "api/v1/users requests", type: :request do
       it "does not return the users list" do
         get api_v1_organisation_users_path(other_orga), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["users"]).to eq([])
+        expect(parsed_response_body["users"]).to eq([])
       end
     end
 
@@ -290,8 +277,7 @@ describe "api/v1/users requests", type: :request do
       it "returns the organisation users only" do
         get api_v1_organisation_users_path(organisation), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["users"].pluck("id")).to contain_exactly(user1.id)
+        expect(parsed_response_body["users"].pluck("id")).to contain_exactly(user1.id)
       end
     end
   end
@@ -303,9 +289,8 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get invite_api_v1_user_path(user), headers: api_auth_headers_for_agent(agent), as: :json
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["invitation_url"]).to be_present
-        expect(response_parsed["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=")
+        expect(parsed_response_body["invitation_url"]).to be_present
+        expect(parsed_response_body["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=")
         user.reload
         expect(user.invitation_due_at).to eq(user.invitation_created_at + User.invite_for)
         expect(user.invited_through).to eq("external")
@@ -318,8 +303,7 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get invite_api_v1_user_path(user), headers: api_auth_headers_for_agent(agent), as: :json
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["invitation_token"]).to be_present
+        expect(parsed_response_body["invitation_token"]).to be_present
         user.reload
         expect(user.invitation_due_at).to eq(user.invitation_created_at + User.invite_for)
       end
@@ -331,8 +315,7 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get invite_api_v1_user_path(user), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(403)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
   end
@@ -344,10 +327,9 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         post invite_api_v1_user_path(user), headers: api_auth_headers_for_agent(agent), as: :json
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["invitation_url"]).to be_present
-        expect(response_parsed["invitation_token"]).to be_present
-        expect(response_parsed["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=")
+        expect(parsed_response_body["invitation_url"]).to be_present
+        expect(parsed_response_body["invitation_token"]).to be_present
+        expect(parsed_response_body["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=")
         user.reload
         expect(user.invitation_due_at).to eq(user.invitation_created_at + User.invite_for)
         expect(user.invited_through).to eq("external")
@@ -360,9 +342,8 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         post invite_api_v1_user_path(user), headers: api_auth_headers_for_agent(agent), as: :json
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["invitation_token"]).to be_present
-        expect(response_parsed["invitation_url"]).to be_present
+        expect(parsed_response_body["invitation_token"]).to be_present
+        expect(parsed_response_body["invitation_url"]).to be_present
         user.reload
         expect(user.invitation_due_at).to eq(user.invitation_created_at + User.invite_for)
       end
@@ -381,9 +362,8 @@ describe "api/v1/users requests", type: :request do
           as: :json
         )
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["invitation_url"]).to be_present
-        expect(response_parsed["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=")
+        expect(parsed_response_body["invitation_url"]).to be_present
+        expect(parsed_response_body["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=")
         user.reload
         expect(user.invitation_due_at).to eq(user.invitation_created_at + 1.day)
       end
@@ -395,8 +375,7 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get invite_api_v1_user_path(user), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(403)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).to be_present
+        expect(parsed_response_body["errors"]).to be_present
       end
     end
   end
@@ -408,8 +387,7 @@ describe "api/v1/users requests", type: :request do
       it "works" do
         get api_v1_organisation_user_path(organisation, user), headers: api_auth_headers_for_agent(agent)
         expect(response.status).to eq(200)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]["id"]).to eq(user.id)
+        expect(parsed_response_body["user"]["id"]).to eq(user.id)
       end
     end
 
@@ -453,9 +431,8 @@ describe "api/v1/users requests", type: :request do
         user.reload
         expect(user.first_name).to eq("Alain")
         expect(user.last_name).to eq("Deloin")
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to be_present
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to be_present
       end
     end
 
@@ -494,9 +471,8 @@ describe "api/v1/users requests", type: :request do
         expect(user.number_of_children).to eq(3)
         expect(user.notify_by_sms).to eq(false)
         expect(user.notify_by_email).to eq(false)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
-        expect(response_parsed["user"]["id"]).to be_present
+        expect(parsed_response_body["user"]).to be_present
+        expect(parsed_response_body["user"]["id"]).to be_present
       end
     end
 
@@ -515,8 +491,7 @@ describe "api/v1/users requests", type: :request do
         )
         expect(response.status).to eq(200)
         user.reload
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["user"]).to be_present
+        expect(parsed_response_body["user"]).to be_present
         expect(user.first_name).to eq("Alain")
         expect(user.last_name).to eq("Deloin")
         expect(user.responsible).to eq(user_responsible)
@@ -535,8 +510,7 @@ describe "api/v1/users requests", type: :request do
           headers: api_auth_headers_for_agent(agent)
         )
         expect(response.status).to eq(422)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
+        expect(parsed_response_body["errors"]).not_to be_empty
       end
     end
 
@@ -554,9 +528,8 @@ describe "api/v1/users requests", type: :request do
           headers: api_auth_headers_for_agent(agent)
         )
         expect(response.status).to eq(422)
-        response_parsed = JSON.parse(response.body)
-        expect(response_parsed["errors"]).not_to be_empty
-        expect(response_parsed["errors"]["email"].first).to \
+        expect(parsed_response_body["errors"]).not_to be_empty
+        expect(parsed_response_body["errors"]["email"].first).to \
           eq({ "error" => "taken", "value" => "jean@jacques.fr", "id" => existing_user.id })
       end
     end

--- a/spec/requests/api_authentication_spec.rb
+++ b/spec/requests/api_authentication_spec.rb
@@ -70,7 +70,7 @@ describe "API auth", type: :request do
         }
       )
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)["absences"].count).to eq(1)
+      expect(parsed_response_body["absences"].count).to eq(1)
     end
   end
 
@@ -82,7 +82,7 @@ describe "API auth", type: :request do
     it "returns the agent credentials" do
       subject
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)["data"]["email"]).to eq("amine.dhobb@beta.gouv.fr")
+      expect(parsed_response_body["data"]["email"]).to eq("amine.dhobb@beta.gouv.fr")
     end
   end
 end

--- a/spec/requests/public_api/v1/groups_spec.rb
+++ b/spec/requests/public_api/v1/groups_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe "public_api/groups requests", type: :request do
+  it "returns the territories as groups" do
+    create(:territory)
+
+    get public_api_v1_groups_path
+    expect(response).to have_http_status(:ok)
+    expect(parsed_response_body[:groups]).to match(GroupBlueprint.render_as_hash(Territory.all))
+  end
+
+  context "when there is no territory" do
+    it "returns an empty list" do
+      get public_api_v1_groups_path
+      expect(response).to have_http_status(:ok)
+      expect(parsed_response_body[:groups]).to match([])
+    end
+  end
+
+  context "when there is a lot of territories" do
+    it "returns a paginated list" do
+      page1 = create_list(:territory, 2)
+      page2 = create_list(:territory, 2)
+      page3 = create_list(:territory, 1)
+
+      get public_api_v1_groups_path, params: { page: 0, per: 2 }
+      expect(parsed_response_body[:meta]).to match(current_page: 1, next_page: 2, prev_page: nil, total_count: 5, total_pages: 3)
+      expect(parsed_response_body[:groups]).to match(GroupBlueprint.render_as_hash(page1))
+
+      get public_api_v1_groups_path, params: { page: 1, per: 2 }
+      expect(parsed_response_body[:meta]).to match(current_page: 1, next_page: 2, prev_page: nil, total_count: 5, total_pages: 3)
+      expect(parsed_response_body[:groups]).to match(GroupBlueprint.render_as_hash(page1))
+
+      get public_api_v1_groups_path, params: { page: 2, per: 2 }
+      expect(parsed_response_body[:meta]).to match(current_page: 2, next_page: 3, prev_page: 1, total_count: 5, total_pages: 3)
+      expect(parsed_response_body[:groups]).to match(GroupBlueprint.render_as_hash(page2))
+
+      get public_api_v1_groups_path, params: { page: 3, per: 2 }
+      expect(parsed_response_body[:meta]).to match(current_page: 3, next_page: nil, prev_page: 2, total_count: 5, total_pages: 3)
+      expect(parsed_response_body[:groups]).to match(GroupBlueprint.render_as_hash(page3))
+    end
+  end
+end

--- a/spec/requests/public_api/v1/public_links_spec.rb
+++ b/spec/requests/public_api/v1/public_links_spec.rb
@@ -38,6 +38,7 @@ describe "public_api/public_links requests", type: :request do
           },
         ],
       }
+      expect(response).to have_http_status(:ok)
       expect(parsed_response_body).to match_array(expected_body)
     end
 
@@ -45,6 +46,12 @@ describe "public_api/public_links requests", type: :request do
       get path
       expect(response).to have_http_status(:bad_request)
       expect(parsed_response_body).to match(missing: "territory")
+    end
+
+    it "returns a not found error when the territory can't be found" do
+      get path, params: { territory: "unknown" }
+      expect(response).to have_http_status(:not_found)
+      expect(parsed_response_body).to match(not_found: "territory")
     end
   end
 

--- a/spec/requests/public_api/v1/public_links_spec.rb
+++ b/spec/requests/public_api/v1/public_links_spec.rb
@@ -17,7 +17,7 @@ describe "public_api/public_links requests", type: :request do
       create(:plage_ouverture, :expired, organisation: organisation_c)
       create(:plage_ouverture, organisation: organisation_f)
 
-      get path, params: { territory: territory.departement_number }, headers: {}
+      get path, params: { territory: territory.departement_number }
 
       # Organisation A has two recurring plages
       # Organisation B has a plage in 5 days
@@ -39,6 +39,12 @@ describe "public_api/public_links requests", type: :request do
         ],
       }
       expect(parsed_response_body).to match_array(expected_body)
+    end
+
+    it "returns a bad request error when the territory param is missing" do
+      get path
+      expect(response).to have_http_status(:bad_request)
+      expect(parsed_response_body).to match(missing: "territory")
     end
   end
 

--- a/spec/requests/public_api/v1/public_links_spec.rb
+++ b/spec/requests/public_api/v1/public_links_spec.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
 describe "public_api/public_links requests", type: :request do
-  let!(:territory) { create(:territory, departement_number: "CN") }
-  let!(:organisation_a) { create(:organisation, new_domain_beta: true, external_id: "ext_id_A", territory: territory) }
-  let!(:organisation_b) { create(:organisation, new_domain_beta: true, external_id: "ext_id_B", territory: territory) }
-  let!(:organisation_c) { create(:organisation, new_domain_beta: true, external_id: "ext_id_C", territory: territory) }
-  let!(:organisation_d) { create(:organisation, new_domain_beta: true, external_id: "ext_id_D", territory: territory) }
-  let!(:organisation_e) { create(:organisation, new_domain_beta: true, external_id: "ext_id_E", territory: create(:territory)) }
-  let!(:organisation_f) { create(:organisation, new_domain_beta: true, external_id: nil,        territory: territory) }
-
-  context "when plages are defined" do
-    let(:params) do
-      { territory: "CN" }
-    end
+  shared_examples "public links deliverer" do |path|
+    let!(:territory) { create(:territory, departement_number: "CN") }
+    let!(:organisation_a) { create(:organisation, new_domain_beta: true, external_id: "ext_id_A", territory: territory) }
+    let!(:organisation_b) { create(:organisation, new_domain_beta: true, external_id: "ext_id_B", territory: territory) }
+    let!(:organisation_c) { create(:organisation, new_domain_beta: true, external_id: "ext_id_C", territory: territory) }
+    let!(:organisation_d) { create(:organisation, new_domain_beta: true, external_id: "ext_id_D", territory: territory) }
+    let!(:organisation_e) { create(:organisation, new_domain_beta: true, external_id: "ext_id_E", territory: create(:territory)) }
+    let!(:organisation_f) { create(:organisation, new_domain_beta: true, external_id: nil,        territory: territory) }
 
     it "returns any organisation that has any open plage ouverture" do
       create(:plage_ouverture, organisation: organisation_a)
@@ -21,7 +17,7 @@ describe "public_api/public_links requests", type: :request do
       create(:plage_ouverture, :expired, organisation: organisation_c)
       create(:plage_ouverture, organisation: organisation_f)
 
-      get public_api_v1_public_links_path, params: params, headers: {}
+      get path, params: { territory: territory.departement_number }, headers: {}
 
       # Organisation A has two recurring plages
       # Organisation B has a plage in 5 days
@@ -45,4 +41,7 @@ describe "public_api/public_links requests", type: :request do
       expect(parsed_response_body).to match_array(expected_body)
     end
   end
+
+  it_behaves_like "public links deliverer", "/public_api/v1/public_links"
+  it_behaves_like "public links deliverer", "/public_api/public_links"
 end

--- a/spec/requests/public_api/v1/public_links_spec.rb
+++ b/spec/requests/public_api/v1/public_links_spec.rb
@@ -21,7 +21,7 @@ describe "public_api/public_links requests", type: :request do
       create(:plage_ouverture, :expired, organisation: organisation_c)
       create(:plage_ouverture, organisation: organisation_f)
 
-      get "/public_api/public_links", params: params, headers: {}
+      get public_api_v1_public_links_path, params: params, headers: {}
 
       # Organisation A has two recurring plages
       # Organisation B has a plage in 5 days
@@ -42,7 +42,7 @@ describe "public_api/public_links requests", type: :request do
           },
         ],
       }
-      expect(JSON.parse(response.body)).to match_array(expected_body)
+      expect(parsed_response_body).to match_array(expected_body)
     end
   end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -9,4 +9,8 @@ module ApiSpecHelper
     agent_with_token_auth.save!
     agent_with_token_auth.build_auth_header(token.token, token.client)
   end
+
+  def parsed_response_body
+    @parsed_response_body ||= JSON.parse(response.body).with_indifferent_access
+  end
 end

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -11,6 +11,6 @@ module ApiSpecHelper
   end
 
   def parsed_response_body
-    @parsed_response_body ||= JSON.parse(response.body).with_indifferent_access
+    JSON.parse(response.body).with_indifferent_access
   end
 end


### PR DESCRIPTION
Voici un premier point de terminaison de l'API publique : `/public_api/v1/groups`. 

![image](https://user-images.githubusercontent.com/1193334/196449008-27bea632-eec5-4607-9c2a-5be5ea87ec65.png)


Il s'agit d'un point de terminaison paginé, qui retourne les territoires sous forme de `Group`, tel que spécifié ici : https://pad.incubateur.net/s/04vFrfmjt#Group

Pour moi les points à discuter ici sont :

1. À quel point doit-on réutiliser ce qui est fait dans l'API privé ? Ici je me suis resservi du rendering existant, mais la conséquence (un peu) désagréable, que le endpoint répond avec deux éléments : "groups", qui contient la liste, et "meta", qui contient les infos de pagination. **J'aurais préféré qu'il réponde directement avec la liste et que les données de pagination soient dans les headers de la requête.**
2. C'est un détail, mais à garder à l'esprit : il n'y a pas de limite sur le paramètre `per` des listes paginées. Donc si je demande 100000 éléments, et qu'il y a effectivement 100000 éléments en base, je suis susceptible de faire tomber le serveur. Ça serait bien de mettre une borne supérieure, non ?
3. J'ai l'impression qu'on a ici un bon exemple de situation où on ne doit pas spécialement chercher à réutiliser l'API privée ; on a un code super simple, qui cohabite bien avec le reste AMHA. Mais je suis ouvert à la discussion.

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
