### PR TITLE
:ambulance: dont redirect to slots when no result

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -9,7 +9,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   helper_method :motif_selected?
 
   def index
-    if motif_selected? && (!requires_lieu? || only_one_lieu?)
+    if motif_selected? && (results_without_lieu? || only_one_lieu?)
       skip_policy_scope # TODO: improve pundit checks for creneaux
       redirect_to admin_organisation_slots_path(current_organisation, creneaux_search_params), class: "d-block stretched-link"
     else
@@ -38,6 +38,12 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
 
   def requires_lieu?
     @form.motif&.requires_lieu?
+  end
+
+  def results_without_lieu?
+    return false if requires_lieu?
+
+    SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)&.creneaux&.any?
   end
 
   def set_form


### PR DESCRIPTION
Hot fix pour le crash: https://sentry.io/organizations/rdv-solidarites/issues/3685202828/?project=1811205&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox

Ce qu'il se passe : lorsque le motif ne requiert pas de lieu, mais qu'il n'y a pas de  résultat, on allait quand même vers la page de sélection de créneau.

Ce qu'on fait pour corriger : on évite de rediriger vers la page des créneaux s'il n'y a pas de résultat pour un motif qui ne requiert pas de lieu.

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
