### PR TITLE
Upgrade webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :test do
   gem "capybara"
   gem "capybara-email"
   gem "capybara-screenshot"
-  gem "webdrivers", "~> 4.6.0"
+  gem "webdrivers"
   gem "database_cleaner"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     chartkick (3.4.2)
-    childprocess (3.0.0)
+    childprocess (4.1.0)
     choice (0.2.0)
     coderay (1.1.3)
     coercible (1.0.0)
@@ -337,7 +337,7 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.8)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth2 (1.4.7)
@@ -521,9 +521,11 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.5.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentry-rails (5.4.2)
       railties (>= 5.0)
       sentry-ruby (~> 5.4.2)
@@ -600,10 +602,10 @@ GEM
     wannabe_bool (0.7.1)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (4.6.1)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
+      selenium-webdriver (~> 4.0)
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
@@ -611,6 +613,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -704,7 +707,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   typhoeus
   wannabe_bool
-  webdrivers (~> 4.6.0)
+  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -164,7 +164,7 @@ RSpec.configure do |config|
 
     FileUtils.mkdir_p "tmp/capybara"
     %i[browser driver].each do |source|
-      errors = Capybara.page.driver.browser.manage.logs.get(source)
+      errors = Capybara.page.driver.browser.logs.get(source)
       fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"
       File.open(fp, "w") do |f|
         f << "// empty logs" if errors.empty?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,18 +50,17 @@ Capybara.javascript_driver = :chrome_headless
 
 Capybara.register_driver :selenium do |app|
   # these args seem to reduce test flakyness
-  # w3c false required for logs cf https://github.com/SeleniumHQ/selenium/issues/7270
-  chrome_options = { args: %w[headless no-sandbox disable-gpu window-size=1500,1000], w3c: false }
+  args = %w[headless no-sandbox disable-gpu window-size=1500,1000]
   chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
-  chrome_options[:binary] = chrome_bin if chrome_bin
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: chrome_options,
-    "goog:loggingPrefs" => { browser: "ALL" }
-  )
+  binary = chrome_bin if chrome_bin
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    capabilities: [Selenium::WebDriver::Chrome::Options.new(
+      args: args,
+      binary: binary,
+      "goog:loggingPrefs": { browser: "ALL" }
+    )]
   )
 end
 


### PR DESCRIPTION
Requis pour les M1 : https://github.com/SeleniumHQ/selenium/issues/11066

J'ai du adapter un peu le helper du driver qui a changé avec l'upgrade de version.
A priori c'est ok mais si quelqu'un qui maitrise mieux capybara que moi peut s'en assurer ce serait top :)

https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/#before
https://github.com/teamcapybara/capybara/issues/2511
https://support.smartbear.com/crossbrowsertesting/docs/automated-testing/frameworks/selenium/about/use-of-desiredcapabilities-has-been-deprecated.html
https://stackoverflow.com/questions/56522499/cromedriver-driver-manage-logs-getbrowser-fails-on-chromedriver-75-0-3770-8
