### PR TITLE
Plages d'ouverture et indisponibilités commençant au début du 20ème siècle

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -24,6 +24,7 @@ class Absence < ApplicationRecord
   validates :first_day, :title, presence: true
   validate :ends_at_should_be_after_starts_at
   validate :no_recurrence_for_absence_for_several_days
+  validate :date_is_realistic
 
   # Hooks
   before_validation :set_end_day
@@ -64,5 +65,20 @@ class Absence < ApplicationRecord
     return if recurrence.blank? || end_day.blank? || first_day == end_day
 
     errors.add(:recurrence, "pas possible avec une indisponibilité de plusieurs jours")
+  end
+
+  # Ce check a été ajouté pour éviter d'inexplicables saisies
+  # accidentelles, par exemple 1922 au lieu de 2022.
+  # Voir : https://github.com/betagouv/rdv-solidarites.fr/issues/2914
+  def date_is_realistic
+    return unless first_day
+
+    if first_day > 5.years.from_now
+      errors.add(:first_day, "est plus de 5 and dans le futur, est-ce une erreur ?")
+    end
+
+    if first_day.year < 2018
+      errors.add(:first_day, "est loin dans le passé, est-ce une erreur ?")
+    end
   end
 end

--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -9,6 +9,7 @@ class Absence < ApplicationRecord
   include IcalHelpers::Rrule
   include Payloads::Absence
   include Expiration
+  include EnsuresRealisticDate
 
   # Attributes
   auto_strip_attributes :title
@@ -24,7 +25,6 @@ class Absence < ApplicationRecord
   validates :first_day, :title, presence: true
   validate :ends_at_should_be_after_starts_at
   validate :no_recurrence_for_absence_for_several_days
-  validate :date_is_realistic
 
   # Hooks
   before_validation :set_end_day
@@ -65,20 +65,5 @@ class Absence < ApplicationRecord
     return if recurrence.blank? || end_day.blank? || first_day == end_day
 
     errors.add(:recurrence, "pas possible avec une indisponibilité de plusieurs jours")
-  end
-
-  # Ce check a été ajouté pour éviter d'inexplicables saisies
-  # accidentelles, par exemple 1922 au lieu de 2022.
-  # Voir : https://github.com/betagouv/rdv-solidarites.fr/issues/2914
-  def date_is_realistic
-    return unless first_day
-
-    if first_day > 5.years.from_now
-      errors.add(:first_day, "est plus de 5 and dans le futur, est-ce une erreur ?")
-    end
-
-    if first_day.year < 2018
-      errors.add(:first_day, "est loin dans le passé, est-ce une erreur ?")
-    end
   end
 end

--- a/app/models/concerns/ensures_realistic_date.rb
+++ b/app/models/concerns/ensures_realistic_date.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Ce check a été ajouté pour éviter d'inexplicables saisies
+# accidentelles, par exemple 1922 au lieu de 2022.
+# Voir : https://github.com/betagouv/rdv-solidarites.fr/issues/2914
+module EnsuresRealisticDate
+  extend ActiveSupport::Concern
+
+  included do
+    validate :date_is_realistic
+  end
+
+  private
+
+  def date_is_realistic
+    return unless first_day
+
+    if first_day > 5.years.from_now
+      errors.add(:base, "Le premier jour ne peut pas être loin dans le futur.")
+    end
+
+    if first_day.year < 2018
+      errors.add(:base, "Le premier jour ne peut pas être loin dans le passé.")
+    end
+  end
+end

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -9,6 +9,8 @@ class PlageOuverture < ApplicationRecord
   include IcalHelpers::Rrule
   include Payloads::PlageOuverture
   include Expiration
+  include EnsuresRealisticDate
+
   include TextSearch
   def self.search_against
     {
@@ -36,7 +38,6 @@ class PlageOuverture < ApplicationRecord
   validates :motifs, :title, presence: true
   validate :warn_overlapping_plage_ouvertures
   validate :warn_overflow_motifs_duration
-  validate :date_is_realistic
 
   # Scopes
   scope :in_range, lambda { |range|
@@ -153,21 +154,6 @@ class PlageOuverture < ApplicationRecord
     return unless overflow_motifs_duration?
 
     add_benign_error("Certains motifs ont une durée supérieure à la plage d'ouverture prévue")
-  end
-
-  # Ce check a été ajouté pour éviter d'inexplicables saisies
-  # accidentelles, par exemple 1922 au lieu de 2022.
-  # Voir : https://github.com/betagouv/rdv-solidarites.fr/issues/2914
-  def date_is_realistic
-    return unless first_day
-
-    if first_day > 5.years.from_now
-      errors.add(:first_day, "est plus de 5 and dans le futur, est-ce une erreur ?")
-    end
-
-    if first_day.year < 2018
-      errors.add(:first_day, "est loin dans le passé, est-ce une erreur ?")
-    end
   end
 
   def requires_lieu?

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -13,10 +13,6 @@ FactoryBot.define do
     end_time { Tod::TimeOfDay.new(15, 30) }
     no_recurrence
 
-    trait :past do
-      first_day { Date.new(2019, 7, 4) }
-    end
-
     trait :no_recurrence do
       recurrence { nil }
     end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -78,7 +78,7 @@ describe "Agent can CRUD absences" do
 
   context "view past absences" do
     let!(:future_absence) { create(:absence, agent: agent, organisation: organisation) }
-    let!(:past_absence) { create(:absence, :past, agent: agent, organisation: organisation) }
+    let!(:past_absence) { create(:absence, first_day: Date.new(2019, 7, 4), agent: agent, organisation: organisation) }
 
     it do
       click_link "Indisponibilités"

--- a/spec/models/concerns/ensures_realistic_date_spec.rb
+++ b/spec/models/concerns/ensures_realistic_date_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Ce check a été ajouté pour éviter d'inexplicables saisies
+# accidentelles, par exemple 1922 au lieu de 2022.
+# Voir : https://github.com/betagouv/rdv-solidarites.fr/issues/2914
+RSpec.describe EnsuresRealisticDate do
+  it "is invalid when first day is before 2018" do
+    expect(build(:plage_ouverture, first_day: Date.new(2017, 12, 24))).to be_invalid
+  end
+
+  it "is invalid when first day is more than 5 years from now" do
+    expect(build(:plage_ouverture, first_day: 6.years.from_now.to_date)).to be_invalid
+  end
+
+  it "is valid if date is after 2017 and not more than 5 years" do
+    expect(build(:plage_ouverture, first_day: Date.new(2020, 12, 24))).to be_valid
+  end
+end


### PR DESCRIPTION
Closes #2914

J'ai corrigé les années foireuses en base, j'ai supprimé les 5 absences qui avaient pour année 0200, 0201 ou 0202, car elles n'étaient pas récurrentes.

J'ai préféré une validation en back car c'est bien plus simple et robuste qu'une config de datepicker, et vu la rareté du phénomène, autant aller au plus simple.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
