### PR TITLE
Ne pas utilise DateTime pour manipuler des dates modernes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -194,6 +194,9 @@ Style/OpenStructUse:
 Style/HashSyntax:
   Enabled: false
 
+Style/DateTime:
+  Enabled: true
+
 Naming/BlockForwarding:
   Enabled: false
 

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -26,7 +26,7 @@ class Users::RdvsController < UserAuthController
     ActiveRecord::Base.transaction do
       @creneau = Users::CreneauSearch.creneau_for(
         user: current_user,
-        starts_at: DateTime.parse(rdv_params[:starts_at]),
+        starts_at: Time.zone.parse(rdv_params[:starts_at]),
         motif: motif,
         lieu: lieu,
         geo_search: @geo_search

--- a/app/form_models/admin/rdv_collectif_search_form.rb
+++ b/app/form_models/admin/rdv_collectif_search_form.rb
@@ -22,7 +22,7 @@ class Admin::RdvCollectifSearchForm
   end
 
   def from_date=(date)
-    @from_date = date.is_a?(String) ? DateTime.parse(date) : date
+    @from_date = date.is_a?(String) ? Time.zone.parse(date) : date
   rescue Date::Error
     Time.zone.today
   end

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -12,8 +12,8 @@ module Lapin
       end
 
       def ensure_date_range_with_time(date_range)
-        time_begin = date_range.begin.instance_of?(Date) ? date_range.begin.beginning_of_day : date_range.begin.to_time
-        time_end = date_range.end.instance_of?(Date) ? date_range.end.end_of_day : date_range.end.to_time
+        time_begin = date_range.begin.instance_of?(Date) ? date_range.begin.beginning_of_day : date_range.begin
+        time_end = date_range.end.instance_of?(Date) ? date_range.end.end_of_day : date_range.end
 
         time_begin..time_end
       end

--- a/app/services/next_availability_service.rb
+++ b/app/services/next_availability_service.rb
@@ -2,8 +2,7 @@
 
 class NextAvailabilityService
   def self.find(motif, lieu, agents, from:, to: nil)
-    available_creneau = nil
-    from = from.to_datetime
+    from = from.to_datetime # rubocop:disable Style/DateTime
     to = to&.to_datetime || (from + 6.months)
 
     from.step(to, 7).find do |date|
@@ -14,8 +13,9 @@ class NextAvailabilityService
 
       creneaux = SlotBuilder.available_slots(motif, lieu, date..max_creneau_date, OffDays.all_in_date_range(date..max_creneau_date), agents)
       # NOTE: We build the whole list of creneaux of the week just to return the first one.
-      available_creneau = creneaux.min_by(&:starts_at) if creneaux.any?
+      return creneaux.min_by(&:starts_at) if creneaux.any?
     end
-    available_creneau
+
+    nil # return nil if nothing found in loop
   end
 end

--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -31,6 +31,7 @@ Au delà du style de syntaxe, nous essayons de suivre quelques principes. RDVS-S
   - utiliser les relation through autant que possible pour construire les queries
 6. Pour les tests, utiliser les helpers et rspec avec parcimonie
   - Par exemple, les `let`, `subject`, etc, doivent rester proches de leur lieu d’utilisation, quitte à être répétés dans un autre `context`.
+7. Pour manipuler des dates et heures, il est recommandé d'utiliser `ActiveSupport::TimeWithZone` plutôt que des Time ou des DateTime. Plus d'explications dans [cette PR](https://github.com/betagouv/rdv-solidarites.fr/pull/2955).
 
 ## Linters
 

--- a/scripts/load_absences_csv.rb
+++ b/scripts/load_absences_csv.rb
@@ -31,9 +31,9 @@ csv.each do |row|
       title: row[5],
       organisation: organisation,
       first_day: Date.parse(row[0]),
-      start_time: Time.zone.parse(row[1]).to_time,
+      start_time: Time.zone.parse(row[1]),
       end_day: Date.parse(row[2]),
-      end_time: Time.zone.parse(row[3]).to_time,
+      end_time: Time.zone.parse(row[3]),
     }
   rescue StandardError
     puts "#{ligne} - erreur d'analyse de la ligne"

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -16,7 +16,7 @@ describe Admin::RdvWizardStepsController, type: :controller do
         duration_in_min: 30,
         motif_id: motif.id,
         lieu_id: 1,
-        starts_at: DateTime.new(2020, 4, 20, 8, 0, 0),
+        starts_at: Time.zone.parse("2020-04-20 08:00"),
       }
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SearchController, type: :controller do
     instance_double(
       Users::CreneauxSearch,
       creneaux: [],
-      next_availability: build(:creneau, starts_at: DateTime.parse("2019-08-05 08h00"))
+      next_availability: build(:creneau, starts_at: Time.zone.parse("2019-08-05 08h00"))
     )
   end
   let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id])) }
@@ -212,7 +212,7 @@ RSpec.describe SearchController, type: :controller do
         let!(:creneaux_search) do
           instance_double(
             Users::CreneauxSearch,
-            creneaux: [build(:creneau, starts_at: DateTime.parse("2019-07-22 08h00"))]
+            creneaux: [build(:creneau, starts_at: Time.zone.parse("2019-07-22 08h00"))]
           )
         end
 
@@ -229,7 +229,7 @@ RSpec.describe SearchController, type: :controller do
           instance_double(
             Users::CreneauxSearch,
             creneaux: [],
-            next_availability: build(:creneau, starts_at: DateTime.parse("2019-08-05 08h00"))
+            next_availability: build(:creneau, starts_at: Time.zone.parse("2019-08-05 08h00"))
           )
         end
 

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -6,7 +6,7 @@ describe Users::RdvWizardStepsController, type: :controller do
     let!(:user) { create(:user) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
-    let(:starts_at) { DateTime.parse("2020-03-03 10h00") }
+    let(:starts_at) { Time.zone.parse("2020-03-03 10h00") }
     let!(:mock_creneau) { instance_double(::Creneau) }
     let!(:mock_rdv) { build(:rdv, starts_at: starts_at, users: [user]) } # cannot use instance_double because it breaks pundit inference
     let(:mock_user_rdv_wizard) { instance_double(UserRdvWizard::Step2, creneau: mock_creneau, rdv: mock_rdv) }

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:user) { create(:user) }
     let(:motif) { create(:motif, organisation: organisation) }
     let(:lieu) { create(:lieu, organisation: organisation) }
-    let(:starts_at) { DateTime.parse("2020-10-20 10h30") }
+    let(:starts_at) { Time.zone.parse("2020-10-20 10h30") }
     let(:mock_geo_search) { instance_double(Users::GeoSearch) }
     let(:token) { "12345" }
     let(:params) do
@@ -147,11 +147,11 @@ RSpec.describe Users::RdvsController, type: :controller do
   describe "GET #show" do
     let(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], motif: motif, starts_at: starts_at, created_by: "user") }
-    let(:starts_at) { DateTime.parse("2020-10-20 10h30") }
+    let(:starts_at) { Time.zone.parse("2020-10-20 10h30") }
     let(:motif) { build(:motif, reservable_online: true, rdvs_editable_by_user: true, rdvs_cancellable_by_user: true) }
 
     before do
-      travel_to("01/01/2019".to_datetime)
+      travel_to(Time.zone.parse("01/01/2019"))
       sign_in user
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     end
 
     context "when the rdv is past" do
-      let!(:starts_at) { DateTime.parse("2018-12-31 10h30") }
+      let!(:starts_at) { Time.zone.parse("2018-12-31 10h30") }
 
       it "does show links to edit and cancel" do
         get :show, params: { id: rdv.id }
@@ -336,7 +336,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     end
 
     let(:organisation) { create(:organisation) }
-    let(:now) { "01/01/2019 10:00".to_datetime }
+    let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation, max_booking_delay: 2.weeks.to_i) }
@@ -386,7 +386,7 @@ RSpec.describe Users::RdvsController, type: :controller do
 
     let(:organisation) { create(:organisation) }
     let(:starts_at) { 3.days.from_now }
-    let(:now) { "01/01/2019 10:00".to_datetime }
+    let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation) }

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     password { "password" }
-    confirmed_at { DateTime.parse("2020-07-30 10:30").in_time_zone }
-    invitation_accepted_at { DateTime.parse("2020-07-30 10:30").in_time_zone }
+    confirmed_at { Time.zone.parse("2020-07-30 10:30").in_time_zone }
+    invitation_accepted_at { Time.zone.parse("2020-07-30 10:30").in_time_zone }
 
     transient do
       basic_role_in_organisations { [] }

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :rdv do
-    created_at { DateTime.parse("2020-06-5 13:51").in_time_zone }
-    updated_at { DateTime.parse("2020-06-5 13:51").in_time_zone }
+    created_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
+    updated_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
     organisation { create(:organisation) }
     lieu { build(:lieu, organisation: organisation) }
     motif { build(:motif, organisation: organisation) }
@@ -33,7 +33,7 @@ FactoryBot.define do
       lieu { nil }
     end
     trait :excused do
-      cancelled_at { DateTime.parse("2020-01-15 10:30").in_time_zone }
+      cancelled_at { Time.zone.parse("2020-01-15 10:30").in_time_zone }
       status { "excused" }
     end
   end

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -131,7 +131,7 @@ describe "User can search for rdvs" do
 
   def continue_to_rdv(motif)
     expect(page).to have_content("Vos informations")
-    fill_in("Date de naissance", with: DateTime.yesterday.strftime("%d/%m/%Y"))
+    fill_in("Date de naissance", with: Time.zone.yesterday.strftime("%d/%m/%Y"))
     fill_in("Nom de naissance", with: "Lapinou")
     click_button("Continuer")
 

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -6,7 +6,7 @@ describe UserRdvWizard do
   let!(:user_for_rdv) { create(:user) }
   let!(:motif) { create(:motif, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: DateTime.parse("2020-10-20 09h30")) }
+  let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: Time.zone.parse("2020-10-20 09h30")) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
 
   describe "#new" do
@@ -32,7 +32,7 @@ describe UserRdvWizard do
         user: user,
         motif: motif,
         lieu: lieu,
-        starts_at: DateTime.parse("2020-10-20 09h30"),
+        starts_at: Time.zone.parse("2020-10-20 09h30"),
         geo_search: mock_geo_search
       ).and_return(returned_creneau)
       rdv_wizard = UserRdvWizard::Step1.new(user, attributes)

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -72,24 +72,24 @@ describe RdvsHelper do
   describe "#rdv_starts_at_and_duration" do
     context "with :human format" do
       it "return starts_at hour, minutes and duration" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: 4)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 13:46"), duration_in_min: 4)
         expect(rdv_starts_at_and_duration(rdv, :human)).to eq("lundi 23 mars 2020 à 13h46 (4 minutes)")
       end
 
       it "return only starts_at hour, minutes when no duration_in_min" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: nil)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 13:46"), duration_in_min: nil)
         expect(rdv_starts_at_and_duration(rdv, :human)).to eq("lundi 23 mars 2020 à 13h46")
       end
     end
 
     context "with :time_only format" do
       it "return starts_at hour, minutes and duration" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: 4)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 13:46"), duration_in_min: 4)
         expect(rdv_starts_at_and_duration(rdv, :time_only)).to eq("13h46 (4 minutes)")
       end
 
       it "return only starts_at hour, minutes when no duration_in_min" do
-        rdv = build(:rdv, starts_at: DateTime.new(2020, 3, 23, 12, 46), duration_in_min: nil)
+        rdv = build(:rdv, starts_at: Time.zone.parse("2020-03-23 13:46"), duration_in_min: nil)
         expect(rdv_starts_at_and_duration(rdv, :time_only)).to eq("13h46")
       end
     end

--- a/spec/jobs/cron_job/file_attente_job_spec.rb
+++ b/spec/jobs/cron_job/file_attente_job_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe CronJob::FileAttenteJob, type: :job do
   describe "#perform" do
-    let(:now) { DateTime.parse("01-01-2019 09:00") }
+    let(:now) { Time.zone.parse("01-01-2019 09:00") }
     let(:plage_ouverture) { create(:plage_ouverture, first_day: 2.weeks.from_now, start_time: Tod::TimeOfDay.new(9)) }
     let(:rdv) { create(:rdv, starts_at: 2.weeks.from_now) }
     let(:file_attente) { create(:file_attente, rdv: rdv) }

--- a/spec/jobs/cron_job/reminder_job_spec.rb
+++ b/spec/jobs/cron_job/reminder_job_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe CronJob::ReminderJob, type: :job do
   subject { described_class.perform_now }
 
-  let(:now) { DateTime.parse("01-01-2019 09:00") }
+  let(:now) { Time.zone.parse("01-01-2019 09:00") }
 
   before do
     travel_to(now)

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -5,13 +5,13 @@ describe Lapin::Range do
     subject { described_class.ensure_date_range_with_time(date_range) }
 
     let!(:date_range) { lower_bound..higher_bound }
-    let!(:now) { "2021-12-10 10:00".to_time }
+    let!(:now) { Time.zone.parse("2021-12-10 10:00") }
 
     before { travel_to(now) }
 
     context "when given datetime bounds" do
-      let!(:lower_bound) { "2021-12-20 11:00".to_datetime }
-      let!(:higher_bound) { "2021-12-21 18:00".to_datetime }
+      let!(:lower_bound) { Time.zone.parse("2021-12-20 11:00") }
+      let!(:higher_bound) { Time.zone.parse("2021-12-21 18:00") }
 
       it "returns range with same datetime bounds" do
         expect(subject).to eq(date_range)
@@ -19,8 +19,8 @@ describe Lapin::Range do
     end
 
     context "when given time bounds" do
-      let!(:lower_bound) { "2021-12-20 11:00".to_time }
-      let!(:higher_bound) { "2021-12-21 18:00".to_time }
+      let!(:lower_bound) { Time.zone.parse("2021-12-20 11:00") }
+      let!(:higher_bound) { Time.zone.parse("2021-12-21 18:00") }
 
       it "returns range with same time bounds" do
         expect(subject).to eq(date_range)

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_created" do
     let(:agent) { build(:agent) }
-    let(:t) { DateTime.parse("2020-03-01 10:20") }
+    let(:t) { Time.zone.parse("2020-03-01 10:20") }
     let(:mail) { described_class.with(rdv: rdv, agent: agent).rdv_created }
     let(:rdv) { create(:rdv, starts_at: t + 2.hours, agents: [agent]) }
 

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -31,7 +31,7 @@ describe RecurrenceConcern do
 
     it "returns starts_at from given first_day" do
       starts_at = Time.zone.parse("2019-08-15 10h00:00")
-      create(factory, first_day: starts_at.to_date, start_time: starts_at.to_time)
+      create(factory, first_day: starts_at.to_date, start_time: starts_at)
       period = Date.new(2019, 8, 12)..Date.new(2019, 8, 19)
 
       occurrences = described_class.all_occurrences_for(period)

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe FileAttente, type: :model do
-  let(:now) { DateTime.parse("01-01-2019 09:00 +0100") }
+  let(:now) { Time.zone.parse("01-01-2019 09:00 +0100") }
 
   before do
     stub_netsize_ok

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -9,14 +9,14 @@ describe Stat, type: :model do
 
     it "return 2=>1 with one home rdv" do
       home_motif = create(:motif, location_type: :home)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
     end
 
     it "return 2=>2 with two home rdv" do
       home_motif = create(:motif, location_type: :home)
-      create_list(:rdv, 2, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
+      create_list(:rdv, 2, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(2)
     end
@@ -24,8 +24,8 @@ describe Stat, type: :model do
     it "return 2=>2 with two different motif of home rdv" do
       home_motif = create(:motif, location_type: :home)
       other_home_motif = create(:motif, location_type: :home)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
-      create(:rdv, motif: other_home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
+      create(:rdv, motif: other_home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(2)
     end
@@ -33,8 +33,8 @@ describe Stat, type: :model do
     it "return {2=>1, 1=>1} with one home rdv and one phone" do
       home_motif = create(:motif, location_type: :home)
       phone_motif = create(:motif, location_type: :phone)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
-      create(:rdv, motif: phone_motif, created_at: DateTime.new(2020, 4, 7, 11, 0))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
+      create(:rdv, motif: phone_motif, created_at: Time.zone.parse("2020-04-07 11:00"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
       expect(stats.rdvs_group_by_type[["par téléphone", "05/04/2020"]]).to eq(1)
@@ -44,9 +44,9 @@ describe Stat, type: :model do
       home_motif = create(:motif, location_type: :home)
       phone_motif = create(:motif, location_type: :phone)
       public_office_motif = create(:motif, location_type: :public_office)
-      create(:rdv, motif: home_motif, created_at: DateTime.new(2020, 4, 7, 10, 0))
-      create(:rdv, motif: phone_motif, created_at: DateTime.new(2020, 4, 7, 11, 0))
-      create(:rdv, motif: public_office_motif, created_at: DateTime.new(2020, 4, 7, 9, 40))
+      create(:rdv, motif: home_motif, created_at: Time.zone.parse("2020-04-07 10:00"))
+      create(:rdv, motif: phone_motif, created_at: Time.zone.parse("2020-04-07 11:00"))
+      create(:rdv, motif: public_office_motif, created_at: Time.zone.parse("2020-04-07 09:40"))
       stats = described_class.new(rdvs: Rdv.all)
       expect(stats.rdvs_group_by_type[["à domicile", "05/04/2020"]]).to eq(1)
       expect(stats.rdvs_group_by_type[["par téléphone", "05/04/2020"]]).to eq(1)

--- a/spec/services/users/creneau_search_spec.rb
+++ b/spec/services/users/creneau_search_spec.rb
@@ -5,7 +5,7 @@ describe Users::CreneauSearch do
   let(:user) { create(:user) }
   let(:motif) { create(:motif, name: "Coucou", location_type: :home, organisation: organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }
-  let(:starts_at) { DateTime.parse("2020-10-20 09h30") }
+  let(:starts_at) { Time.zone.parse("2020-10-20 09:30") }
   let(:now) { Time.zone.parse("2020-10-19 14:30") }
 
   describe ".creneau_for" do
@@ -26,9 +26,9 @@ describe Users::CreneauSearch do
     context "some matching creneaux" do
       let(:mock_creneaux) do
         [
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 09h30")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 09:30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10:00")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10:30")),
         ]
       end
 
@@ -38,9 +38,9 @@ describe Users::CreneauSearch do
     context "no matching creneaux" do
       let(:mock_creneaux) do
         [
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h00")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 10h30")),
-          build(:creneau, starts_at: DateTime.parse("2020-10-20 11h30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10:00")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 10:30")),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 11:30")),
         ]
       end
 


### PR DESCRIPTION
L'usage de la classe ruby `DateTime` est réservée aux dates historiques. La manipulation de dates "modernes" doit être faîte à travers `ActiveSupport::TimeWithZone`, qui gère les calculs en prenant compte la timezone.

Voici un exemple de piège quand on utilise `DateTime` :

```ruby
jeudi_14h = DateTime.new(2022, 10, 27, 14)
# 2022-10-27T14:00:00+00:00
jeudi_14h.in_time_zone("Paris")
# 2022-10-27 16:00:00 +0200
```

On peut voir que DateTime n'utilise pas l'offset de la timezone définie par défaut dans notre appli. Cela peut-être une source d'incompréhension. Mais il y a aussi un autre piège, qui est lié à l'usage d'un offset plutôt que d'une timezone :

```ruby
une_semaine_plus_tard = jeudi_14h + 7.days
# 2022-11-03T14:00:00+00:00
une_semaine_plus_tard.in_time_zone("Paris")
# 2022-11-03 15:00:00 +0100
```

Le changement d'heure ayant lieu le 29-30 octobre cette année, on peut voir que "une semaine plus tard", il n'est plus 16h mais 15h. L'opérateur `+ 7.days` a bien ajouté 7 x 24h,  mais on peut parier que ce que l'on voudrait plutôt, c'est avoir "la même heure 7 jours plus tard". Pour calculer ça, il faut connaître la timezone, un offset ne suffit pas.

Avec un `ActiveSupport::TimeWithZone`, les opérations conservent l'heure locale :

```ruby
jeudi_14h = Time.zone.parse("2022-10-27 14:00")
# 2022-10-27 14:00:00 +0200

une_semaine_plus_tard = jeudi_14h + 7.days
# 2022-11-03 14:00:00 +0100
```

C'est peut-être pour ces raisons que le Ruby Style Guide recommande de ne pas utiliser les `DateTime` : https://rubystyle.guide/#no-datetime

Si vous voulez creuser encore, StackOverflow est toujours une mine d'informations : https://stackoverflow.com/questions/1261329

Et cet article de Thoughtbot sur les timezones est aussi une bonne source si vous n'êtes pas à l'aise avec le sujet : https://thoughtbot.com/blog/its-about-time-zones

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
