### PR TITLE
replace le retour aux filtres dans l'affichage des créneaux

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -9,7 +9,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
 
   def index
     # nécessaire pour le `else`
-    # et pour le cas où nous sommes sur un 
+    # et pour le cas où nous sommes sur un
     # motif public_office pour vérifier qu'il n'y
     # qu'un lieu
     set_search_results
@@ -58,13 +58,19 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     return unless (params[:commit].present? || request.format.js?) && @form.valid?
 
     # Un RDV collectif peut-il avoir lieu à domicile ou au téléphone ?
-    @search_results = if @form.motif.individuel? && requires_lieu?
-                        SearchCreneauxForAgentsService.perform_with(@form)
-                      elsif @form.motif.individuel? && !requires_lieu?
-                        SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)
+    @search_results = if @form.motif.individuel?
+                        search_creneaux_service.perform_with(@form)
                       else
                         SearchRdvCollectifForAgentsService.new(@form).lieu_search
                       end
+  end
+
+  def search_creneaux_service
+    if requires_lieu?
+      SearchCreneauxForAgentsService
+    else
+      SearchCreneauxWithoutLieuForAgentsService
+    end
   end
 
   def creneaux_search_params

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -9,7 +9,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   helper_method :motif_selected?
 
   def index
-    if motif_selected? && (results_without_lieu? || only_one_lieu?)
+    if (params[:commit].present? || request.format.js?) && motif_selected? && (results_without_lieu? || only_one_lieu?)
       skip_policy_scope # TODO: improve pundit checks for creneaux
       redirect_to admin_organisation_slots_path(current_organisation, creneaux_search_params), class: "d-block stretched-link"
     else

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -83,5 +83,7 @@
         p.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
         - @search_results.each do |search_result|
           = render "lieu_search_results", search_result: search_result
-    - elsif motif_selected?
+    - elsif motif_selected? && params[:commit].present?
       = t(".no_slot_available", motif_name: @form.motif.name)
+    - else
+      .text-muted= t(".choose_filter_and_refresh")

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -12,7 +12,7 @@
          / lien très utilisé pour la duplication de RDV
          / il permet de reprendre un RDV, éventuellement pour un autre motif
          / https://zammad10.ethibox.fr/#ticket/zoom/3044
-         = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"
+         = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation, creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"
 
     .card-body
       - if @form.motif.individuel?

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -1,11 +1,18 @@
 - if @search_result.present?
   .card
     .card-header
-      h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
-      - if @form.motif.requires_lieu?
-        = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
-      - else
-        = t(@form.motif.location_type)
+     .d-flex.justify-content-between.flex-wrap
+       span
+         h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
+         - if @form.motif.requires_lieu?
+           = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
+         - else
+           = t(@form.motif.location_type)
+       span
+         / lien très utilisé pour la duplication de RDV
+         / il permet de reprendre un RDV, éventuellement pour un autre motif
+         / https://zammad10.ethibox.fr/#ticket/zoom/3044
+         = link_to t(".place_index"), admin_organisation_agent_searches_path(current_organisation,creneaux_search_params(@form)), class: "btn btn-outline-primary m-2"
 
     .card-body
       - if @form.motif.individuel?

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -31,6 +31,7 @@ fr:
         select_placeholder_single_use_lieu: Lieu ponctuel
     slots:
       index:
+        place_index: Revenir aux filtres
         available_slots_title_html: Créneaux disponibles pour <strong>%{motif}</strong>
         place_informations_html: <strong>%{place_name}</strong> <small>au %{place_address}</small>
         no_slot_available: Aucun créneau n’est disponible pour le motif « %{motif_name} » selon les critères sélectionnés.

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -4,3 +4,4 @@ fr:
       agent_searches:
         index:
           no_slot_available: Aucun créneau n’est disponible pour le motif « %{motif_name} » selon les critères sélectionnés.
+          choose_filter_and_refresh: Selectionné des filres et rafraichissez les résultats

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -4,4 +4,4 @@ fr:
       agent_searches:
         index:
           no_slot_available: Aucun créneau n’est disponible pour le motif « %{motif_name} » selon les critères sélectionnés.
-          choose_filter_and_refresh: Selectionné des filres et rafraichissez les résultats
+          choose_filter_and_refresh: Selectionnez des filtres et rafraichissez les résultats


### PR DESCRIPTION
« Retour aux filtres » le retour du bouton qui s'affiche en haut de la proposition de créneaux côté agents.

ref : https://zammad10.ethibox.fr/#ticket/zoom/3044

Dans le Pas-de-Calais (et ailleurs ?) ;
Un agent (souvent du secrétariat) réalise un RDV de préqualification (souvent au téléphone) avec un usager ;
L'agent note les informations recueillies dans le contexte du RDV ;
En fin de RDV, l'agent duplique le RDV courant, choisi un nouveau motif (et autres ?) pour un nouveau RDV avec l'usager ;
Cela permet de faire une orientation en maintenant les informations récoltées dans le contexte du RDV.

Le contexte et la duplication ont été créés dans RDV-Solidarité pour ce cas d'usage.


Nous avions enlevé ce bouton dans la PR #2860 parce que nous avions oublié pourquoi il était là.

Le voilà de retour.

![Screenshot 2022-10-24 at 12-39-30 RDV Solidarités](https://user-images.githubusercontent.com/42057/197507998-e843648a-2f6d-418e-a88b-2f118cab7fc8.png)


# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
