### PR TITLE
fix: crash when there is no slot search results

### DIFF
--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -1,20 +1,26 @@
-.card
-  .card-header
-    h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
-    - if @form.motif.requires_lieu?
-      = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
-    - else
-      = t(@form.motif.location_type)
+- if @search_result.present?
+  .card
+    .card-header
+      h3= t(".available_slots_title_html", motif: "#{@form.motif.name.downcase} (#{@form.motif.service.short_name})")
+      - if @form.motif.requires_lieu?
+        = t(".place_informations_html", place_name: @search_result.lieu.name, place_address: @search_result.lieu.address)
+      - else
+        = t(@form.motif.location_type)
 
-  - if @form.motif.individuel?
     .card-body
-      = render "/admin/slots/slots", \
-        lieu: @search_result.lieu, \
-        creneaux: @search_result.creneaux, \
-        form: @form, \
-        next_availability: @search_result.next_availability
-- if @form.motif.collectif?
-  .row.justify-content-center.pb-3
-    .col-md-8
-      - @search_result.creneaux.each do |search_result|
-        = render "admin/rdvs_collectifs/rdv", rdv: search_result
+      - if @form.motif.individuel?
+        = render "/admin/slots/slots", \
+          lieu: @search_result.lieu, \
+          creneaux: @search_result.creneaux, \
+          form: @form, \
+          next_availability: @search_result.next_availability
+
+  - if  @form.motif.collectif?
+    .row.justify-content-center.pb-3
+      .col-md-8
+        - @search_result.creneaux.each do |search_result|
+          = render "admin/rdvs_collectifs/rdv", rdv: search_result
+
+- else
+  .text-center.mt-2
+    = t(".no_slot_available", motif_name: @form.motif.name)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -33,6 +33,7 @@ fr:
       index:
         available_slots_title_html: Créneaux disponibles pour <strong>%{motif}</strong>
         place_informations_html: <strong>%{place_name}</strong> <small>au %{place_address}</small>
+        no_slot_available: Aucun créneau n’est disponible pour le motif « %{motif_name} » selon les critères sélectionnés.
     creneaux:
       agent_searches:
         index:

--- a/spec/controllers/admin/slots_controller_spec.rb
+++ b/spec/controllers/admin/slots_controller_spec.rb
@@ -28,5 +28,26 @@ describe Admin::SlotsController, type: :controller do
 
       expect(assigns(:search_result)).not_to be_nil
     end
+
+    describe "edge cases" do
+      render_views
+
+      context "when there is no search results" do
+        it "doesn't crash" do
+          agent = create(:agent, :secretaire, basic_role_in_organisations: [organisation])
+          motif = create(:motif, organisation: organisation)
+
+          sign_in agent
+
+          expect do
+            get :index, params: {
+              organisation_id: organisation.id,
+              motif_id: motif.id,
+            }
+          end.not_to raise_error
+          expect(response.body).to include(I18n.t("admin.slots.index.no_slot_available", motif_name: motif.name))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix le crash suivant : https://sentry.io/organizations/rdv-solidarites/issues/3693276826/?alert_rule_id=899770&alert_timestamp=1666616065780&alert_type=email&environment=production&project=1811205&referrer=alert_email

Il se produit sur la recherche de créneau côté agent·e lorsqu'il n'y a pas de résultats. On met un message pour informer l'agent·e : 

![image](https://user-images.githubusercontent.com/1193334/197541144-543c3c45-a6af-4f6c-99aa-56c606443b1b.png)




# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
