### PR TITLE
Hotfix: énorme requête SQL qui met Postgres à genoux

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -154,13 +154,13 @@ class SearchContext
   def lieu_filtered_motif_ids(motifs)
     # filtrer sur le `lieu_id` dans la table des plages d'ouverture permet de limiter de combiner et construire trop d'objet
     # voir https://github.com/betagouv/rdv-solidarites.fr/issues/2686
-    motif_ids = motifs.individuel.joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: @lieu_id }).pluck(:id)
+    motif_ids = motifs.individuel.joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: @lieu_id }).pluck(:id).uniq
 
     # Pour prendre en compte le filtre sur le lieu_id pour les RDV Collectif,
     # nous ne pouvons pas passer par une requête `or` qui nécessite les mêmes jointures des deux côtés.
     motifs.collectif.each { |motif| motif_ids << motif.id if Rdv.exists?(lieu_id: @lieu_id, motif: motif) }
 
-    motif_ids
+    motif_ids.uniq
   end
 
   def creneaux_search_for(lieu, date_range)


### PR DESCRIPTION
Perf : explosion combinatoire de motifs et plages: motifs_ids contient des doublons


# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
