### PR TITLE
Bugfix : l'ICS envoyé dans le mail #absence_destroyed n'a pas le bon statut

### DIFF
--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -20,7 +20,7 @@ class Agents::AbsenceMailer < ApplicationMailer
   end
 
   def absence_destroyed
-    self.ics_payload = @absence.payload(:destroyed)
+    self.ics_payload = @absence.payload(:destroy)
     mail(subject: t("agents.absence_mailer.absence_destroyed.title", domain_name: domain.name, title: @absence.title))
   end
 

--- a/spec/mailers/agents/absence_mailer_spec.rb
+++ b/spec/mailers/agents/absence_mailer_spec.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
-describe Agents::PlageOuvertureMailer, type: :mailer do
+describe Agents::AbsenceMailer, type: :mailer do
   { created: "créée", updated: "modifiée", destroyed: "supprimée" }.each do |action, verb|
     context "when #{action}" do
       let(:agent) { create(:agent, email: "bob@demo.rdv-solidarites.fr") }
-      let(:plage_ouverture) { create :plage_ouverture, agent: agent }
+      let(:absence) { create :absence, agent: agent }
 
-      it "mail to plage ouverture's agent" do
-        mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
+      it "mail to absence's agent" do
+        mail = described_class.with(absence: absence).send("absence_#{action}")
         expect(mail[:from].to_s).to eq(%("RDV Solidarités" <secretariat-auto@rdv-solidarites.fr>))
         expect(mail.to).to eq(["bob@demo.rdv-solidarites.fr"])
       end
 
       it "have a good subject" do
-        mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
-        expect(mail.subject).to eq("RDV Solidarités - Plage d’ouverture #{verb} - #{plage_ouverture.title}")
+        mail = described_class.with(absence: absence).send("absence_#{action}")
+        expect(mail.subject).to eq("RDV Solidarités - Indisponibilité #{verb} - #{absence.title}")
       end
 
       it "has a ICS file join with UID" do
-        mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
+        mail = described_class.with(absence: absence).send("absence_#{action}")
         cal = mail.find_first_mime_type("text/calendar")
-        expect(cal.decoded).to match("UID:plage_ouverture_#{plage_ouverture.id}@RDV Solidarités")
+        expect(cal.decoded).to match("UID:absence_#{absence.id}@RDV Solidarités")
       end
 
       describe "using the agent domain's branding" do
@@ -28,8 +28,8 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
           let(:agent) { build(:agent, service: build(:service, :social)) }
 
           it "works" do
-            mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
-            expect(mail.subject).to start_with("RDV Solidarités - Plage d’ouverture")
+            mail = described_class.with(absence: absence).send("absence_#{action}")
+            expect(mail.subject).to start_with("RDV Solidarités - Indisponibilité")
             expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
             expect(mail.html_part.body.to_s).to include("Voir sur RDV Solidarités") unless action == :destroyed
             expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/))
@@ -44,9 +44,9 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
           end
 
           it "works" do
-            mail = described_class.with(plage_ouverture: plage_ouverture).send("plage_ouverture_#{action}")
+            mail = described_class.with(absence: absence).send("absence_#{action}")
             expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <secretariat-auto@rdv-solidarites.fr>))
-            expect(mail.subject).to start_with("RDV Aide Numérique - Plage d’ouverture")
+            expect(mail.subject).to start_with("RDV Aide Numérique - Indisponibilité")
             expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
             expect(mail.html_part.body.to_s).to include("Voir sur RDV Aide Numérique") unless action == :destroyed
             expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-aide-numerique-test.localhost/))
@@ -56,11 +56,11 @@ describe Agents::PlageOuvertureMailer, type: :mailer do
     end
   end
 
-  describe "#plage_ouverture_destroyed" do
-    let(:plage_ouverture) { create :plage_ouverture }
+  describe "#absence_destroyed" do
+    let(:absence) { create :absence }
 
     it "have a STATUS:CANCELLED in ICS file joined" do
-      mail = described_class.with(plage_ouverture: plage_ouverture).plage_ouverture_destroyed
+      mail = described_class.with(absence: absence).absence_destroyed
       cal = mail.find_first_mime_type("text/calendar")
       expect(cal.decoded).to match("STATUS:CANCELLED")
     end


### PR DESCRIPTION
Actuellement, lorsqu'une absence (aka. indisponibilité) est supprimée, un mail est envoyé à l'agent, avec en pièce jointe un fichier ICS qui est censé indiquer au client mail / agenda de l'agent qu'il faut "annuler" cette absence. 

**Or, le champ "STATUS" indique actuellement `STATUS:CONFIRMED` alors qu'il devrait indiquer `STATUS:CANCELLED`.**

Cette PR corrige ce bug, et ajoute une une spec du `Agents::AbsenceMailer`, qui est un beau copié / collé de la spec de `Agents::PlageOuvertureMailer`.

Pour la petite histoire, j'ai ajouté la spec en bossant sur un autre sujet, et c'est comme ça que j'ai remarqué le bug (le dernier exemple échouait).

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
