### PR TITLE
Ignorer les jobs de mailers qui ne trouvent pas la plage / absence

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  discard_on ActiveJob::DeserializationError
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
-  discard_on ActiveJob::DeserializationError
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,4 +7,10 @@ class ApplicationMailer < ActionMailer::Base
   prepend IcsMultipartAttached
 
   append_view_path Rails.root.join("app/views/mailers")
+
+  # See https://www.bigbinary.com/blog/rails-5-2-allows-mailers-to-use-custom-active-job-class
+  class CustomMailerDeliveryJob < ActionMailer::MailDeliveryJob
+    discard_on ActiveJob::DeserializationError
+  end
+  self.delivery_job = CustomMailerDeliveryJob
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -8,9 +8,5 @@ class ApplicationMailer < ActionMailer::Base
 
   append_view_path Rails.root.join("app/views/mailers")
 
-  # See https://www.bigbinary.com/blog/rails-5-2-allows-mailers-to-use-custom-active-job-class
-  class CustomMailerDeliveryJob < ActionMailer::MailDeliveryJob
-    discard_on ActiveJob::DeserializationError
-  end
   self.delivery_job = CustomMailerDeliveryJob
 end

--- a/app/mailers/custom_mailer_delivery_job.rb
+++ b/app/mailers/custom_mailer_delivery_job.rb
@@ -8,7 +8,8 @@ class CustomMailerDeliveryJob < ActionMailer::MailDeliveryJob
     if exception.cause.instance_of?(ActiveRecord::RecordNotFound)
       Rails.logger.error(exception.message)
     else
-      raise exception
+      Sentry.capture_exception(exception)
+      retry_job
     end
   end
 end

--- a/app/mailers/custom_mailer_delivery_job.rb
+++ b/app/mailers/custom_mailer_delivery_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# See https://www.bigbinary.com/blog/rails-5-2-allows-mailers-to-use-custom-active-job-class
+class CustomMailerDeliveryJob < ActionMailer::MailDeliveryJob
+  # Only discard DeserializationError if it is caused by a ActiveRecord::RecordNotFound.
+  # We don't want to discard a job when deserialization failed because of a DB failure for example.
+  rescue_from ActiveJob::DeserializationError do |exception|
+    if exception.cause.instance_of?(ActiveRecord::RecordNotFound)
+      Rails.logger.error(exception.message)
+    else
+      raise exception
+    end
+  end
+end

--- a/spec/jobs/custom_mailer_delivery_job_spec.rb
+++ b/spec/jobs/custom_mailer_delivery_job_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe CustomMailerDeliveryJob do
     absence = create(:absence)
     mailer.a_sample_email(absence).deliver_later
     absence.destroy!
-    expect { perform_enqueued_jobs }.not_to raise_error(ActiveJob::DeserializationError)
+    expect { perform_enqueued_jobs }.not_to raise_error
   end
 
   # Sometimes we have DB failures, these should not cause the job to be discarded
   it "raises error when hitting a ActiveJob::DeserializationError error that is not a RecordNotFound" do
     mailer.a_sample_email(create(:absence)).deliver_later
     ActiveRecord::Base.remove_connection # Simulate a DB failure
-    expect { perform_enqueued_jobs }.to raise_error(ActiveJob::DeserializationError)
+    expect { perform_enqueued_jobs }.to raise_error(ActiveJob::DeserializationError, /Error while trying to deserialize arguments: No connection pool/)
     ActiveRecord::Base.establish_connection
   end
 end

--- a/spec/jobs/custom_mailer_delivery_job_spec.rb
+++ b/spec/jobs/custom_mailer_delivery_job_spec.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe CustomMailerDeliveryJob do
-  it "discards job when record can't be found" do
+  mailer = Class.new(ApplicationMailer) do
+    def a_sample_email(absence)
+      mail(body: "Voici l'info: #{absence}")
+    end
+  end
+
+  it "discards job when deserialization fails because if ActiveRecord::RecordNotFound" do
     absence = create(:absence)
-    Agents::AbsenceMailer.with(absence: absence).absence_created.deliver_later
+    mailer.a_sample_email(absence).deliver_later
     absence.destroy!
     expect { perform_enqueued_jobs }.not_to raise_error(ActiveJob::DeserializationError)
   end
 
   # Sometimes we have DB failures, these should not cause the job to be discarded
   it "raises error when hitting a ActiveJob::DeserializationError error that is not a RecordNotFound" do
-    Agents::AbsenceMailer.with(absence: create(:absence)).absence_created.deliver_later
+    mailer.a_sample_email(create(:absence)).deliver_later
     ActiveRecord::Base.remove_connection # Simulate a DB failure
     expect { perform_enqueued_jobs }.to raise_error(ActiveJob::DeserializationError)
     ActiveRecord::Base.establish_connection

--- a/spec/jobs/custom_mailer_delivery_job_spec.rb
+++ b/spec/jobs/custom_mailer_delivery_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe CustomMailerDeliveryJob do
+  it "discards job when record can't be found" do
+    absence = create(:absence)
+    Agents::AbsenceMailer.with(absence: absence).absence_created.deliver_later
+    absence.destroy!
+    expect { perform_enqueued_jobs }.not_to raise_error(ActiveJob::DeserializationError)
+  end
+
+  # Sometimes we have DB failures, these should not cause the job to be discarded
+  it "raises error when hitting a ActiveJob::DeserializationError error that is not a RecordNotFound" do
+    Agents::AbsenceMailer.with(absence: create(:absence)).absence_created.deliver_later
+    ActiveRecord::Base.remove_connection # Simulate a DB failure
+    expect { perform_enqueued_jobs }.to raise_error(ActiveJob::DeserializationError)
+    ActiveRecord::Base.establish_connection
+  end
+end


### PR DESCRIPTION
Actuellement, nous avons des jobs de mailer qui retry et qui remontent dans Sentry car ils ne trouvent pas la plage d'ouverture ou l'absence passée en paramètre.

Nous pouvons supposer qu'il s'agit d'une création / édition suivie d'une suppression. En effet, lorsqu'une plage / absence est modifiée, un job est mis à la file pour envoyer un mail d'information. Mais quand une plage / absence est supprimée, la suppression et l'envoi du mail sont synchrones. Il est donc possible que, lorsqu'un modifie puis supprimer dans la foulée, le job s'exécute une fois que l'élément soit supprimé.

Cette PR vise donc à passe sous silence les cas où le record n'est pas trouvé lors de la phase de dé-serialization du job. :wink: 

On a actuellement 82 jobs en retry, on pourra les supprimer avec 

```ruby
Delayed::Job.where("last_error LIKE '%Error while trying to deserialize arguments%'").delete_all
```

# L'issue sur Sentry

https://sentry.io/organizations/rdv-solidarites/issues/3548456389

![image](https://user-images.githubusercontent.com/6357692/198063831-516e284e-38bb-4d7a-b30e-6eff24acd681.png)

![image](https://user-images.githubusercontent.com/6357692/198064236-075a63d4-d30f-4617-8104-c706ea4adad3.png)



# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
