### PR TITLE
First draft pagination lieux for creneaux

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -35,7 +35,7 @@ class SearchController < ApplicationController
   def search_params
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
-      :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category,
+      :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category, :page,
       :invitation_token, :organisation_id, organisation_ids: []
     )
   end

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -3,6 +3,12 @@
 module SlotBuilder
   class << self
     # méthode publique
+    # Fonctionnement au 01/11/2022 documenté ci-dessous
+    # 1. Convertir le range de dates passé en argument en range de datetimes.
+    # 2. Déterminer les plages d’ouvertures existantes dans cette range (récurrentes y compris)
+    # 3. Convertir chacune de ces plages d’ouverture en range de datetime compatibles avec le range passé en arguments
+    # 4. Soustraire à ces ranges les temps occupés par des absences, des jours off ou des rdv déjà pris. A cette étape, on a hash qui associe pour chaque plage d’ouverture un array de ranges
+    # 5. Itérer sur l’array de range de chaque plage d’ouverture. Pour chaque range, construire les créneaux accessibles grâce à la durée du motif de rendez-vous. Regrouper tous ces créneaux dans un array et le retourner.
     def available_slots(motif, lieu, date_range, off_days, agents = [])
       datetime_range = Lapin::Range.ensure_date_range_with_time(date_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -36,3 +36,4 @@ section.bg-light.p-4
                     strong= l(next_availability.starts_at, format: :human)
                   .col-auto.align-self-center
                       i.fa.fa-chevron-right
+    = paginate context.lieux, theme: "twitter-bootstrap-4"


### PR DESCRIPTION
Petite tentative d'amélioration des perfs en paginant la page de recherche de créneaux.

Ca provoque une regression, que je ne trouve pas cata mais à évaluer: le nombre d'éléments par page ne sera pas toujours égale car on détermine la répartition dans les pages avant d'ignorer les éléments sans prochains créneaux. Sans ça, on aura beau paginer, on devra toujours faire le calcul de créneaux avant ça pour tous les lieux.

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
