### PR TITLE
Éviter les écritures en base inutiles dans les  factories

### DIFF
--- a/docs/bonnes-pratiques-de-tests.md
+++ b/docs/bonnes-pratiques-de-tests.md
@@ -210,10 +210,19 @@ RSpec.describe "performance of typical specs" do
   end
 
   # 14 seconds
-  describe "persisting data" do
+  describe "creating records in db" do
     100.times do
       it "creates a RDV and its many associations" do
         create(:rdv)
+      end
+    end
+  end
+
+  # 6 seconds
+  describe "building records" do
+    100.times do
+      it "creates a RDV and its many associations" do
+        build(:rdv)
       end
     end
   end

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
   describe "POST #create" do
     context "with valid params" do
       let(:valid_attributes) do
-        build(:motif).attributes
+        build(:motif, service: create(:service)).attributes
       end
 
       it "creates a new Motif" do
@@ -92,7 +92,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
 
       let!(:old_motif) { create(:motif, deleted_at: Time.zone.now) }
       let(:valid_attributes) do
-        build(:motif, name: old_motif.name).attributes
+        build(:motif, name: old_motif.name, service: create(:service)).attributes
       end
 
       it "creates a new Motif" do

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   sequence(:absence_title) { |n| "Indisponibilité #{n}" }
 
   factory :absence do
-    organisation { create(:organisation) }
-    agent { create(:agent, basic_role_in_organisations: [organisation]) }
+    organisation { association(:organisation) }
+    agent { association(:agent, basic_role_in_organisations: [organisation]) }
 
     title { generate(:absence_title) }
     first_day { Time.zone.tomorrow }

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   sequence(:agent_email) { |n| "agent_#{n}@lapin.fr" }
 
   factory :agent do
-    service { create(:service) }
+    service { association(:service) }
     email { generate(:agent_email) }
     uid { email }
     first_name { Faker::Name.first_name }
@@ -47,10 +47,10 @@ FactoryBot.define do
       confirmed_at { nil }
     end
     trait :secretaire do
-      service { Service.find_by(name: Service::SECRETARIAT) || create(:service, :secretariat) }
+      service { Service.find_by(name: Service::SECRETARIAT) || build(:service, :secretariat) }
     end
     trait :cnfs do
-      service { Service.find_by(name: Service::CONSEILLER_NUMERIQUE) || create(:service, :conseiller_numerique) }
+      service { Service.find_by(name: Service::CONSEILLER_NUMERIQUE) || build(:service, :conseiller_numerique) }
     end
   end
 end

--- a/spec/factories/factories_spec.rb
+++ b/spec/factories/factories_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.factories.each do |factory|
+  describe "The #{factory.name} factory" do
+    it "is valid" do
+      expect(build(factory.name)).to be_valid
+    end
+  end
+end

--- a/spec/factories/file_attente.rb
+++ b/spec/factories/file_attente.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :file_attente do
-    rdv { create(:organisation) }
-    user { create(:user) }
+    rdv
+    user
   end
 end

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   sequence(:motif_name) { |n| "Motif #{n}" }
 
   factory :motif do
-    organisation { create(:organisation) }
-    service { create(:service) }
+    organisation { association(:organisation) }
+    service { association(:service) }
 
     name { generate(:motif_name) }
     default_duration_in_min { 45 }

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   sequence(:plage_title) { |n| "Plage #{n}" }
 
   factory :plage_ouverture do
-    organisation { create(:organisation) }
-    agent { create(:agent, basic_role_in_organisations: [organisation]) }
-    lieu { create(:lieu, organisation: organisation) }
+    organisation { association(:organisation) }
+    agent { association(:agent, basic_role_in_organisations: [organisation]) }
+    lieu { association(:lieu, organisation: organisation) }
 
     title { generate(:plage_title) }
     sequence(:first_day) { |n| Time.zone.today.next_week(:monday) + n.days }
@@ -38,9 +38,9 @@ FactoryBot.define do
       if plage_ouverture.motifs.empty?
         plage_ouverture.motifs << (
           if plage_ouverture.lieu
-            create(:motif, organisation: plage_ouverture.organisation)
+            build(:motif, organisation: plage_ouverture.organisation)
           else
-            create(:motif, :by_phone, organisation: plage_ouverture.organisation)
+            build(:motif, :by_phone, organisation: plage_ouverture.organisation)
           end
         )
       end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :rdv do
     created_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
     updated_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
-    organisation { create(:organisation) }
+    organisation { association(:organisation) }
     lieu { build(:lieu, organisation: organisation) }
     motif { build(:motif, organisation: organisation) }
     users { [build(:user, organisations: [organisation])] }

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :team do
-    territory { create(:territory) }
+    territory { association(:territory) }
     name { Faker::Name.name }
   end
 end

--- a/spec/factories/territory.rb
+++ b/spec/factories/territory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
   factory :territory do
     name { generate(:territory_name) }
-    departement_number { generate(:departement_number) }
+    departement_number { generate(:departement_number).to_s.rjust(2, "0") }
     sms_provider { "netsize" }
     sms_configuration { "a_key" }
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -28,9 +28,6 @@ FactoryBot.define do
     trait :unconfirmed do
       confirmed_at { nil }
     end
-    trait :with_multiple_organisations do
-      organisations { create_list(:organisation, 3) }
-    end
     trait :with_no_email do
       email { nil }
     end
@@ -43,7 +40,7 @@ FactoryBot.define do
       password_confirmation { nil }
     end
     trait :relative do
-      responsible { create(:user) }
+      responsible { association(:user) }
       phone_number { nil }
       address { nil }
       password { nil }

--- a/spec/factories/webhook_endpoint.rb
+++ b/spec/factories/webhook_endpoint.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :webhook_endpoint do
-    organisation { create(:organisation) }
+    organisation { association(:organisation) }
 
     target_url { Faker::Internet.url }
     secret { SecureRandom.base58 }

--- a/spec/factories/zone.rb
+++ b/spec/factories/zone.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  sequence(:city_code) { |n| (62_001 + n).to_s }
-
   factory :zone do
     sector
 
     level { Zone::LEVEL_CITY }
-    city_code { generate(:city_code) }
+    city_code do
+      "#{sector.territory.departement_number}000"
+    end
     city_name { "ARQUES" }
 
     trait :level_street do

--- a/spec/form_models/admin/rdv_form_concern_spec.rb
+++ b/spec/form_models/admin/rdv_form_concern_spec.rb
@@ -158,7 +158,7 @@ describe Admin::RdvFormConcern, type: :form do
   end
 
   describe "#check_duplicates" do
-    let(:rdv) { build(:rdv) }
+    let(:rdv) { create(:rdv) }
 
     it "do nothing when no other RDV" do
       form.check_duplicates


### PR DESCRIPTION
Avant toute chose : **le cœur de cette PR, ce sont les modifications apportées aux factories**. Les autres modifs sont des corrections de tests et l'ajout d'un nouveau test.

Le problème : actuellement ous avons dans nos factories des appels à `create(:une_association)`, ce qui signifie que même si on appelle à travers un build(:mon_modele), on fait un appel en base à cause du `create`.

Je pense qu'en lisant cette section de la belle doc FactoryBot vous verrez de quoi je parle : https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#build-strategies-1

J'ai aussi ajouté un spec qui valide les factories (piqué chez [thoughtbot](https://thoughtbot.com/blog/testing-your-factories-first)), qui permet de voir dans les logs la quantité d'appels à la base faits quand on build une factory, et donc qui m'a aidé dans cette PR.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
