### PR TITLE
Utiliser les transactions Postgres dans les tests

### DIFF
--- a/docs/bonnes-pratiques-de-tests.md
+++ b/docs/bonnes-pratiques-de-tests.md
@@ -151,14 +151,14 @@ Proposition de pratique à discuter en équipe : mettre en place une GitHub acti
 
 On y constate les chose suivantes : 
 - un test de feature avec JS est 3 fois plus lent qu'un test de feature sans JS
-- un test de request est aussi rapide qu'un test feature sans JS
-- un test de contrôleur est environ 40 % plus rapide qu'un test de request (routage + middleware)
-- un test qui ne fait presque rien prend quand-même 16 à 18 ms à s'exécuter, très probablement à cause de la stratégie de base de données basée sur la troncation des tables plutôt que sur une transaction
+- un test de request a les mêmes perfs qu'un test feature sans JS
+- un test de contrôleur est environ 40 % plus rapide qu'un test de request (car il n'exécute pas le routage + middleware)
+- un test qui ne fait presque rien prend quand-même 3 ms à s'exécuter, car il exécute les setup et teardown internes à RSpec ainsi que les blocks `before` et `after` définirs dans `rails_helper.rb`
 - la création en base de données d'un simple RDV et ses dépendances est 2 fois plus lent que la visite d'une page de feature spec, et donc les différences de perfs entre types de specs sont à mettre en perspective
 
 ```ruby
 RSpec.describe "performance of typical specs" do
-  # ~23 seconds
+  # ~28 seconds (280ms per test)
   describe "feature spec with JS", type: :feature, js: true do
     100.times do
       it "visit page without DB hit" do
@@ -168,7 +168,7 @@ RSpec.describe "performance of typical specs" do
     end
   end
 
-  # ~7 seconds
+  # ~5 seconds (50ms per test)
   describe "feature spec wihtout JS", type: :feature do
     100.times do
       it "visit page without DB hit" do
@@ -178,7 +178,7 @@ RSpec.describe "performance of typical specs" do
     end
   end
 
-  # ~7 seconds
+  # ~5 seconds (50ms per test)
   describe "request spec", type: :request do
     100.times do
       it "visit page without DB hit" do
@@ -188,7 +188,7 @@ RSpec.describe "performance of typical specs" do
     end
   end
 
-  # ~5 seconds
+  # ~3.4 seconds (34ms per test)
   describe StaticPagesController, type: :controller do
     render_views
 
@@ -200,7 +200,7 @@ RSpec.describe "performance of typical specs" do
     end
   end
 
-  # 1600~1800 ms
+  # ~280 ms (3ms per test)
   describe "unit spec" do
     100.times do
       it "does something simple" do
@@ -209,7 +209,7 @@ RSpec.describe "performance of typical specs" do
     end
   end
 
-  # 14 seconds
+  # ~11 seconds (110ms per test)
   describe "creating records in db" do
     100.times do
       it "creates a RDV and its many associations" do
@@ -218,7 +218,7 @@ RSpec.describe "performance of typical specs" do
     end
   end
 
-  # 6 seconds
+  # ~1500 ms (15ms per test)
   describe "building records" do
     100.times do
       it "creates a RDV and its many associations" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,56 +29,6 @@ require "simplecov"
 SimpleCov.minimum_coverage 80
 SimpleCov.start
 
-WebMock.disable_net_connect!(allow: [
-                               "127.0.0.1",
-                               "localhost",
-                               "www.rdv-solidarites-test.localhost",
-                               "chromedriver.storage.googleapis.com", # Autorise Chromedrive storage pour l'execution de la CI
-                             ])
-
-Capybara.register_driver :chrome_headless do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless")
-  options.add_argument("--no-sandbox")
-  options.add_argument("--disable-dev-shm-usage")
-  options.add_argument("--window-size=1400,1400")
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-end
-
-Capybara.javascript_driver = :chrome_headless
-
-Capybara.register_driver :selenium do |app|
-  # these args seem to reduce test flakyness
-  args = %w[headless no-sandbox disable-gpu window-size=1500,1000]
-  chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
-  binary = chrome_bin if chrome_bin
-  Capybara::Selenium::Driver.new(
-    app,
-    browser: :chrome,
-    capabilities: [Selenium::WebDriver::Chrome::Options.new(
-      args: args,
-      binary: binary,
-      "goog:loggingPrefs": { browser: "ALL" }
-    )]
-  )
-end
-
-Capybara.configure do |config|
-  port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
-  config.app_host = "http://www.rdv-solidarites-test.localhost:#{port}"
-  # config.asset_host = "http://localhost:#{port}"  # for screenshots
-  config.server_host = "www.rdv-solidarites-test.localhost"
-  config.server_port = port
-  config.javascript_driver = :selenium
-  config.server = :puma, { Silent: true }
-  config.disable_animation = true
-
-  # This is necessary when using Selenium + custom .localhost domain.
-  # See: https://stackoverflow.com/a/63973323/2864020
-  config.always_include_port = true
-end
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -158,27 +108,4 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
-
-  config.after(:each, js: true) do |example|
-    next unless example.exception # only write logs for failed tests
-
-    FileUtils.mkdir_p "tmp/capybara"
-    %i[browser driver].each do |source|
-      errors = Capybara.page.driver.browser.logs.get(source)
-      fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"
-      File.open(fp, "w") do |f|
-        f << "// empty logs" if errors.empty?
-        errors.each do |e|
-          f << "#{e.timestamp} [#{e.level}]: #{e.message}"
-        end
-        f << "\n"
-      end
-    end
-  end
-end
-
-def expect_page_to_be_axe_clean(path)
-  visit path
-  expect(page).to have_current_path(path)
-  expect(page).to be_axe_clean
 end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+WebMock.disable_net_connect!(allow: [
+                               "127.0.0.1",
+                               "localhost",
+                               "www.rdv-solidarites-test.localhost",
+                               "chromedriver.storage.googleapis.com", # Autorise Chromedrive storage pour l'execution de la CI
+                             ])
+
+Capybara.register_driver :chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless")
+  options.add_argument("--no-sandbox")
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--window-size=1400,1400")
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+Capybara.register_driver :selenium do |app|
+  # these args seem to reduce test flakyness
+  args = %w[headless no-sandbox disable-gpu window-size=1500,1000]
+  chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
+  binary = chrome_bin if chrome_bin
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    capabilities: [Selenium::WebDriver::Chrome::Options.new(
+      args: args,
+      binary: binary,
+      "goog:loggingPrefs": { browser: "ALL" }
+    )]
+  )
+end
+
+Capybara.configure do |config|
+  port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
+  config.app_host = "http://www.rdv-solidarites-test.localhost:#{port}"
+  # config.asset_host = "http://localhost:#{port}"  # for screenshots
+  config.server_host = "www.rdv-solidarites-test.localhost"
+  config.server_port = port
+  config.javascript_driver = :selenium
+  config.server = :puma, { Silent: true }
+  config.disable_animation = true
+
+  # This is necessary when using Selenium + custom .localhost domain.
+  # See: https://stackoverflow.com/a/63973323/2864020
+  config.always_include_port = true
+end
+
+RSpec.configure do |config|
+  config.after(:each, js: true) do |example|
+    next unless example.exception # only write logs for failed tests
+
+    FileUtils.mkdir_p "tmp/capybara"
+    %i[browser driver].each do |source|
+      errors = Capybara.page.driver.browser.logs.get(source)
+      fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"
+      File.open(fp, "w") do |f|
+        f << "// empty logs" if errors.empty?
+        errors.each do |e|
+          f << "#{e.timestamp} [#{e.level}]: #{e.message}"
+        end
+        f << "\n"
+      end
+    end
+  end
+end
+
+def expect_page_to_be_axe_clean(path)
+  visit path
+  expect(page).to have_current_path(path)
+  expect(page).to be_axe_clean
+end


### PR DESCRIPTION
Actuellement on utilise la stratégie :truncation, qui est lente car à **chaque test** on écrit en base puis on exécute ceci : 

```
   (0.2ms)  DELETE FROM "active_storage_blobs"
   (0.2ms)  DELETE FROM "rdvs_users"
   (0.2ms)  DELETE FROM "rdvs"
   (0.1ms)  DELETE FROM "agent_territorial_access_rights"
   (0.3ms)  DELETE FROM "agents"
   (0.1ms)  DELETE FROM "agents_organisations"
   (0.2ms)  DELETE FROM "agents_rdvs"
   (0.2ms)  DELETE FROM "agents_users"
   (0.1ms)  DELETE FROM "delayed_jobs"
   [...]
```

Le but est donc ici d'utiliser les transactions, plus rapides, quand c'est possible. 

J'en profite pour déplacer la config capybara dans un fichier séparé, comme ça le fichier `spec_helper.rb` contient ce qu'il doit contenir : le minimum pour lancer un test sans avoir besoin de Rails.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
