### PR TITLE
api doc: add a macro to generate examples

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,12 +43,14 @@ RSpec.configure do |config|
   config.include SigninSpecHelper
   config.include Select2SpecHelper
   config.include ApiSpecHelper, type: :request
+  config.extend ApiSpecMacros, type: :request
   config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Warden::Test::Helpers, type: :feature
   config.include Sentry::TestHelper
   config.include DeviseRequestSpecHelpers, type: :request
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/requests/api/v1/groups_request_spec.rb
+++ b/spec/requests/api/v1/groups_request_spec.rb
@@ -3,6 +3,8 @@
 require "swagger_helper"
 
 describe "Groups API", swagger_doc: "v1/api.json" do
+  with_examples
+
   path "/api/v1/groups" do
     get "Lister les groupes (représentation des territoires)" do
       tags "Group"
@@ -12,20 +14,6 @@ describe "Groups API", swagger_doc: "v1/api.json" do
 
       parameter name: "page", in: :query, type: :integer, description: "La page souhaitée", example: "1", required: false
       parameter name: "per", in: :query, type: :integer, description: "Le nombre d'éléments souhaités par page", example: "10", required: false
-
-      after do |example|
-        content = example.metadata[:response][:content] || {}
-        example_spec = {
-          "application/json" => {
-            examples: {
-              example: {
-                value: JSON.parse(response.body, symbolize_names: true),
-              },
-            },
-          },
-        }
-        example.metadata[:response][:content] = content.deep_merge(example_spec)
-      end
 
       response 200, "Retourne des Groups" do
         let!(:page1) { create_list(:territory, 2) }

--- a/spec/requests/api/v1/invitations_request_spec.rb
+++ b/spec/requests/api/v1/invitations_request_spec.rb
@@ -3,6 +3,8 @@
 require "swagger_helper"
 
 describe "Invitations API", swagger_doc: "v1/api.json" do
+  with_examples
+
   path "/api/v1/invitations/{invitation_token}" do
     get "Récupérer un·e usager·ère" do
       tags "Invitation", "User"
@@ -16,20 +18,6 @@ describe "Invitations API", swagger_doc: "v1/api.json" do
       parameter name: "access-token", in: :header, type: :string, description: "Token d'accès (authentification)", example: "SFYBngO55ImjD1HOcv-ivQ"
       parameter name: "client", in: :header, type: :string, description: "Clé client d'accès (authentification)", example: "Z6EihQAY9NWsZByfZ47i_Q"
       parameter name: "uid", in: :header, type: :string, description: "Identifiant d'accès (authentification)", example: "martine@demo.rdv-solidarites.fr"
-
-      after do |example|
-        content = example.metadata[:response][:content] || {}
-        example_spec = {
-          "application/json" => {
-            examples: {
-              example: {
-                value: JSON.parse(response.body, symbolize_names: true),
-              },
-            },
-          },
-        }
-        example.metadata[:response][:content] = content.deep_merge(example_spec)
-      end
 
       response 200, "Renvoie l'usager·ère" do
         let!(:organisation) { create(:organisation) }

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -3,6 +3,8 @@
 require "swagger_helper"
 
 describe "Organisations API", swagger_doc: "v1/api.json" do
+  with_examples
+
   path "/api/v1/organisations" do
     get "Lister les organisations" do
       tags "Organisation"
@@ -21,20 +23,6 @@ describe "Organisations API", swagger_doc: "v1/api.json" do
 
       parameter name: "departement_number", in: :query, type: :string, description: "Le numéro ou code de département du territoire concerné", example: "26", required: false
       parameter name: "city_code", in: :query, type: :string, description: "Le code INSEE de la localité", example: "26323", required: false
-
-      after do |example|
-        content = example.metadata[:response][:content] || {}
-        example_spec = {
-          "application/json" => {
-            examples: {
-              example: {
-                value: JSON.parse(response.body, symbolize_names: true),
-              },
-            },
-          },
-        }
-        example.metadata[:response][:content] = content.deep_merge(example_spec)
-      end
 
       response 200, "Retourne des Organisations" do
         let!(:page1) { create_list(:organisation, 2) }

--- a/spec/requests/api/v1/organizations_request_spec.rb
+++ b/spec/requests/api/v1/organizations_request_spec.rb
@@ -3,6 +3,8 @@
 require "swagger_helper"
 
 describe "Organization API", swagger_doc: "v1/api.json" do
+  with_examples
+
   path "/api/v1/organizations" do
     get "Lister les organisations" do
       tags "Organization"
@@ -13,20 +15,6 @@ describe "Organization API", swagger_doc: "v1/api.json" do
       parameter name: "page", in: :query, type: :integer, description: "La page souhaitée", example: "1", required: false
       parameter name: "per", in: :query, type: :integer, description: "Le nombre d'éléments souhaités par page", example: "10", required: false
       parameter name: :group_id, in: :query, type: :integer, description: "ID du Group sur lequel filtrer les organisations", example: "1", required: false
-
-      after do |example|
-        content = example.metadata[:response][:content] || {}
-        example_spec = {
-          "application/json" => {
-            examples: {
-              example: {
-                value: JSON.parse(response.body, symbolize_names: true),
-              },
-            },
-          },
-        }
-        example.metadata[:response][:content] = content.deep_merge(example_spec)
-      end
 
       response 200, "Retourne les Organisations sous la forme Organizations" do
         let!(:page1) { create_list(:organisation, 2) }

--- a/spec/requests/api/v1/public_links_request_spec.rb
+++ b/spec/requests/api/v1/public_links_request_spec.rb
@@ -3,6 +3,8 @@
 require "swagger_helper"
 
 describe "Public links API", swagger_doc: "v1/api.json" do
+  with_examples
+
   path "/api/v1/public_links" do
     get "Lister les liens publics de recherche" do
       tags "PublicLink"
@@ -11,20 +13,6 @@ describe "Public links API", swagger_doc: "v1/api.json" do
       description "Renvoie les liens publics de recherche d'un territoire donné"
 
       parameter name: "territory", in: :query, type: :string, description: "Le numéro ou code de département du territoire concerné", example: "26"
-
-      after do |example|
-        content = example.metadata[:response][:content] || {}
-        example_spec = {
-          "application/json" => {
-            examples: {
-              example: {
-                value: JSON.parse(response.body, symbolize_names: true),
-              },
-            },
-          },
-        }
-        example.metadata[:response][:content] = content.deep_merge(example_spec)
-      end
 
       response 200, "Retourne les liens publics de recherche" do
         let!(:terr) { create(:territory, departement_number: "CN") }

--- a/spec/requests/api/v1/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/rdvs_request_spec.rb
@@ -3,6 +3,8 @@
 require "swagger_helper"
 
 describe "RDV authentified API", swagger_doc: "v1/api.json" do
+  with_examples
+
   let!(:organisation) { create(:organisation) }
   let!(:organisation2) { create(:organisation) }
 
@@ -37,21 +39,7 @@ describe "RDV authentified API", swagger_doc: "v1/api.json" do
       parameter name: "client", in: :header, type: :string, description: "Clé client d'accès (authentification)", example: "Z6EihQAY9NWsZByfZ47i_Q"
       parameter name: "uid", in: :header, type: :string, description: "Identifiant d'accès (authentification)", example: "martine@demo.rdv-solidarites.fr"
 
-      after do |example|
-        content = example.metadata[:response][:content] || {}
-        example_spec = {
-          "application/json" => {
-            examples: {
-              example: {
-                value: JSON.parse(response.body, symbolize_names: true),
-              },
-            },
-          },
-        }
-        example.metadata[:response][:content] = content.deep_merge(example_spec)
-      end
-
-      response(200, "Appel API réussi") do
+      response 200, "Appel API réussi" do
         let(:organisation_id) { organisation.id }
 
         context "basic role" do
@@ -93,7 +81,7 @@ describe "RDV authentified API", swagger_doc: "v1/api.json" do
         end
       end
 
-      response(401, "Problème d'authentification") do
+      response 401, "Problème d'authentification" do
         let(:access_admin_agent) { api_auth_headers_for_agent(admin_agent) }
         let(:"access-token") { "false" }
         let(:uid) { access_admin_agent["uid"].to_s }

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ApiSpecMacros
+  def with_examples
+    after do |example|
+      content = example.metadata[:response][:content] || {}
+      example_spec = {
+        "application/json" => {
+          examples: {
+            example: {
+              value: response.body.present? ? JSON.parse(response.body, symbolize_names: true) : "",
+            },
+          },
+        },
+      }
+      example.metadata[:response][:content] = content.deep_merge(example_spec)
+    end
+  end
+end

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -846,18 +846,18 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2022-10-27 10:14:15 +0200",
+                        "created_at": "2022-10-27 14:15:53 +0200",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
-                        "invitation_created_at": "2022-10-27 10:14:15 +0200",
+                        "invitation_created_at": "2022-10-27 14:15:53 +0200",
                         "last_name": "JACQUES",
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "635219849",
-                        "phone_number_formatted": "+33635219849",
+                        "phone_number": "06 46 67 14 76",
+                        "phone_number_formatted": "+33646671476",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": null
@@ -1297,8 +1297,8 @@
                             {
                               "id": 97,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Margot",
-                              "last_name": "Bertrand"
+                              "first_name": "Fleur",
+                              "last_name": "Renault"
                             }
                           ],
                           "cancelled_at": null,
@@ -1307,7 +1307,7 @@
                           "created_by": "agent",
                           "deleted_at": null,
                           "duration_in_min": 45,
-                          "ends_at": "2022-10-30 10:59:29 +0100",
+                          "ends_at": "2022-10-30 15:01:09 +0100",
                           "lieu": {
                             "id": 31,
                             "address": "1 rue de l'adresse 12345 Ville",
@@ -1348,25 +1348,25 @@
                                 "birth_name": null,
                                 "caisse_affiliation": "caf",
                                 "case_number": null,
-                                "created_at": "2022-10-27 10:14:29 +0200",
+                                "created_at": "2022-10-27 14:16:09 +0200",
                                 "email": "usager_1@lapin.fr",
                                 "family_situation": "divorced",
-                                "first_name": "Angilberte",
+                                "first_name": "Foulques",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "VIDAL",
+                                "last_name": "LOPÉZ",
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
                                 "number_of_children": 12,
-                                "phone_number": "6 84 94 46 66",
-                                "phone_number_formatted": "+33684944666",
+                                "phone_number": "07 32 57 32 51",
+                                "phone_number_formatted": "+33732573251",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
                               }
                             }
                           ],
-                          "starts_at": "2022-10-30 10:14:29 +0100",
+                          "starts_at": "2022-10-30 14:16:09 +0100",
                           "status": "unknown",
                           "users": [
                             {
@@ -1378,25 +1378,25 @@
                               "birth_name": null,
                               "caisse_affiliation": "caf",
                               "case_number": null,
-                              "created_at": "2022-10-27 10:14:29 +0200",
+                              "created_at": "2022-10-27 14:16:09 +0200",
                               "email": "usager_1@lapin.fr",
                               "family_situation": "divorced",
-                              "first_name": "Angilberte",
+                              "first_name": "Foulques",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "VIDAL",
+                              "last_name": "LOPÉZ",
                               "notify_by_email": true,
                               "notify_by_sms": true,
                               "number_of_children": 12,
-                              "phone_number": "6 84 94 46 66",
-                              "phone_number_formatted": "+33684944666",
+                              "phone_number": "07 32 57 32 51",
+                              "phone_number_formatted": "+33732573251",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "0ba0a1c4-5c2e-48c8-b77c-946c662ea235"
+                          "uuid": "34020f0b-6fb6-4f84-be8c-f55d4343dcdb"
                         },
                         {
                           "id": 16,
@@ -1405,8 +1405,8 @@
                             {
                               "id": 99,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Barbe",
-                              "last_name": "Rousseau"
+                              "first_name": "Alice",
+                              "last_name": "Carlier"
                             }
                           ],
                           "cancelled_at": null,
@@ -1415,7 +1415,7 @@
                           "created_by": "agent",
                           "deleted_at": null,
                           "duration_in_min": 45,
-                          "ends_at": "2022-10-30 10:59:29 +0100",
+                          "ends_at": "2022-10-30 15:01:09 +0100",
                           "lieu": {
                             "id": 33,
                             "address": "3 rue de l'adresse 12345 Ville",
@@ -1456,25 +1456,25 @@
                                 "birth_name": null,
                                 "caisse_affiliation": "caf",
                                 "case_number": null,
-                                "created_at": "2022-10-27 10:14:29 +0200",
+                                "created_at": "2022-10-27 14:16:09 +0200",
                                 "email": "usager_3@lapin.fr",
                                 "family_situation": "divorced",
-                                "first_name": "Géraud",
+                                "first_name": "Alcibiade",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "BLANCHARD",
+                                "last_name": "KLEIN",
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
                                 "number_of_children": 12,
-                                "phone_number": "07 88 40 38 25",
-                                "phone_number_formatted": "+33788403825",
+                                "phone_number": "6 86 10 89 21",
+                                "phone_number_formatted": "+33686108921",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
                               }
                             }
                           ],
-                          "starts_at": "2022-10-30 10:14:29 +0100",
+                          "starts_at": "2022-10-30 14:16:09 +0100",
                           "status": "unknown",
                           "users": [
                             {
@@ -1486,25 +1486,25 @@
                               "birth_name": null,
                               "caisse_affiliation": "caf",
                               "case_number": null,
-                              "created_at": "2022-10-27 10:14:29 +0200",
+                              "created_at": "2022-10-27 14:16:09 +0200",
                               "email": "usager_3@lapin.fr",
                               "family_situation": "divorced",
-                              "first_name": "Géraud",
+                              "first_name": "Alcibiade",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "BLANCHARD",
+                              "last_name": "KLEIN",
                               "notify_by_email": true,
                               "notify_by_sms": true,
                               "number_of_children": 12,
-                              "phone_number": "07 88 40 38 25",
-                              "phone_number_formatted": "+33788403825",
+                              "phone_number": "6 86 10 89 21",
+                              "phone_number_formatted": "+33686108921",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "826bb554-ca25-4fdb-bca9-797b91dfe2e3"
+                          "uuid": "15d74cc7-46d4-48a2-a82f-280dfd158711"
                         }
                       ],
                       "meta": {


### PR DESCRIPTION
J'ai fini par faire une macro pour DRY la génération des exemples dans la doc de l'API.

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
