### PR TITLE
Perfs - Optimisation RAM exports de RDVs

### DIFF
--- a/app/models/concerns/rdv/authored_concern.rb
+++ b/app/models/concerns/rdv/authored_concern.rb
@@ -3,8 +3,16 @@
 module Rdv::AuthoredConcern
   extend ActiveSupport::Concern
 
+  included do
+    has_many :versions_where_event_eq_create,
+             -> { where(event: "create") },
+             class_name: "PaperTrail::Version",
+             as: :item, dependent: :delete_all, inverse_of: :item
+  end
+
   def author
-    whodunnit = versions.where(event: "create").first&.whodunnit
+    creation_event = versions_where_event_eq_create.loaded? ? versions_where_event_eq_create.first : versions.where(event: "create").first
+    whodunnit = creation_event&.whodunnit
     return nil if whodunnit.blank?
 
     if whodunnit.starts_with?("[User] ")

--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -43,9 +43,17 @@ module RdvExporter
     sheet = book.create_worksheet
     sheet.row(0).concat(HEADER)
 
-    rdvs = rdvs.includes(:motif, :agents, :users, :receipts)
+    rdvs = rdvs.includes(
+      :organisation,
+      :agents,
+      :lieu,
+      :receipts,
+      :versions_where_event_eq_create,
+      motif: :service,
+      users: :responsible
+    )
 
-    rdvs.each_with_index do |rdv, index|
+    rdvs.find_each.with_index do |rdv, index|
       row = sheet.row(index + 1)
       row.set_format 1, DateFormat
       row.set_format 2, HourFormat

--- a/app/services/rdvs_user_exporter.rb
+++ b/app/services/rdvs_user_exporter.rb
@@ -44,9 +44,20 @@ module RdvsUserExporter
     sheet = book.create_worksheet
     sheet.row(0).concat(HEADER)
 
-    rdv_users = rdv_users.includes(:user, rdv: %i[motif agents receipts])
+    rdv_users = rdv_users.includes(
+      user: :responsible,
+      rdv: [
+        :organisation,
+        :agents,
+        :lieu,
+        :receipts,
+        :versions_where_event_eq_create,
+        :users,
+        { motif: :service },
+      ]
+    )
 
-    rdv_users.each_with_index do |rdv_user, index|
+    rdv_users.find_each.with_index do |rdv_user, index|
       row = sheet.row(index + 1)
       row.set_format 3, DateFormat
       row.set_format 4, HourFormat


### PR DESCRIPTION
# Améliorations contenues dans cette PR :
- usage de `find_each.with_index` plutôt que `each_with_index`
- préchargement des associations des RDVs afin d'éviter les requêtes N+1

# Contexte

Aujourd'hui (et plusieurs fois cette semaine), la RAM du worker de jobs a explosé : 

![image](https://user-images.githubusercontent.com/6357692/198326902-bc929be8-68c4-4588-9864-a0bdadf02ce9.png)

On peut voir que cette soudaine augmentation coincide avec l'exécution d'un job `Agents::ExportMailer#rdv_export sur l'orga 106 et pour l'agent 3028. 

# Amélioration des perfs

J'ai donc reproduit le phénomène en local, et voici les perfs (sur ma machine, Framework 11th Gen Core i5) : 
- 269 secondes (4 minutes 20 secondes)
- 1 373 536 ko de RAM (1,3 Go)

Après les améliorations effectuées dans cette PR : 
- 53 secondes
- 567800 ko de RAM (554 Mo)

La taille en octets est la taille du process ruby après chargement de Rails exécution de l'export, obtenue en exécutant ce script avec le runner Rails :


```ruby
agent = Agent.find(3028)
organisation_ids = [106]

start_time = Time.zone.now
Agents::ExportMailer.rdv_export(agent, organisation_ids, {}).deliver_now
end_time = Time.zone.now

puts (end_time - start_time)
puts `ps -o rss= -p #{Process.pid}`
```

J'ai aussi testé l'export des participations (`Agents::ExportMailer.rdvs_users_export`) : 
- avant : 7min50 1,4 Go de RAM
- après : 4min40 secondes et 585 Mo de RAM

Note : si on arrive à ne pas appeler `set_default_notifications_flags` à chaque itération, on peut passer à 2min10 ! À voir dans une autre PR.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
