### PR TITLE
Élargie la policy sur les RDV pour afficher tous les RDV des organisations auxquelles l'agent accède

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -10,9 +10,15 @@ class Admin::RdvsController < AgentAuthController
   # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3268196907
   before_action :log_params_to_sentry, only: %i[index export rdvs_users_export]
 
+  # Pour pouvoir agir sur le scope des organisations
+  # et voir plus large que l'orgasation courante
+  # en attendant de remanier les policies
+  skip_after_action :verify_policy_scoped, only: :index
+
   def index
     set_scoped_organisations
-    @rdvs = policy_scope(Rdv).search_for(@scoped_organisations, parsed_params)
+
+    @rdvs = Rdv.search_for(@scoped_organisations, parsed_params)
       .includes([:rdvs_users, :agents_rdvs, :organisation, :lieu, :motif, { agents: :service, users: %i[responsible organisations] }])
     @breadcrumb_page = params[:breadcrumb_page]
     @form = Admin::RdvSearchForm.new(parsed_params)

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -10,15 +10,9 @@ class Admin::RdvsController < AgentAuthController
   # TODO: remove when this is fixed: https://sentry.io/organizations/rdv-solidarites/issues/3268196907
   before_action :log_params_to_sentry, only: %i[index export rdvs_users_export]
 
-  # Pour pouvoir agir sur le scope des organisations
-  # et voir plus large que l'orgasation courante
-  # en attendant de remanier les policies
-  skip_after_action :verify_policy_scoped, only: :index
-
   def index
     set_scoped_organisations
-
-    @rdvs = Rdv.search_for(@scoped_organisations, parsed_params)
+    @rdvs = policy_scope(Rdv).search_for(@scoped_organisations, parsed_params)
       .includes([:rdvs_users, :agents_rdvs, :organisation, :lieu, :motif, { agents: :service, users: %i[responsible organisations] }])
     @breadcrumb_page = params[:breadcrumb_page]
     @form = Admin::RdvSearchForm.new(parsed_params)

--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
   def index
-    rdvs = policy_scope(Rdv)
+    rdvs = policy_scope(Rdv).where(params.permit(:organisation_id))
     render_collection(rdvs)
   end
 end

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -15,7 +15,7 @@ class Agent::RdvPolicy < DefaultAgentPolicy
 
   class Scope < Scope
     def resolve
-      organisation_scope = scope.where(organisation: current_organisation)
+      organisation_scope = scope.where(organisation: current_agent.organisations)
       unless context.can_access_others_planning?
         organisation_scope = organisation_scope.joins(%i[motif agents_rdvs]).where(motifs: { service: current_agent.service })
           .or(Rdv.where("agents_rdvs.agent_id": current_agent.id))


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3004.osc-secnum-fr1.scalingo.io/

Nous avons ajouté la possibilité de regarder les RDV d'une des organisations dont nous avons accès dans la liste des RDV.

Le problème vient des policies en place qui limite la visualisation des RDV à ceux de l'organisation courante.

Cette PR propose d'élargir la restriction de la policy sur les RDV pour autoriser la visualisation des RDV de toutes les organisations auxquelles l'agent accède.

Closes #3003

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
