### PR TITLE
Liste des RDVs : lenteurs pour compter les RdvsUsers

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -18,7 +18,7 @@ class Admin::RdvsController < AgentAuthController
     @form = Admin::RdvSearchForm.new(parsed_params)
     @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.ids }).enabled.order(:name)
     @motifs = Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.ids })
-    @rdvs_users_count = RdvsUser.where(rdv_id: @rdvs.ids).count
+    @rdvs_users_count = RdvsUser.where(rdv: @rdvs).count
     @rdvs = @rdvs.order(starts_at: :asc).page(params[:page]).per(10)
   end
 


### PR DESCRIPTION
# Comment reproduire

En local, après avoir chargé les seeds : 
- se connecter avec martine@demo.rdv-solidarites.fr / 123456
- visiter [la liste des RDVS](http://www.rdv-solidarites.localhost:3000/admin/organisations/1/rdvs)

Chez moi ça met 6 secondes car il y a un gros `WHERE id = [1, 2, 4]` avec tous les ids de tous les RDVs de toutes les pages dedans.

Après correction, on descend à 800 ms chez moi.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
