### PR TITLE
Fix flaky test with no time dependance

### DIFF
--- a/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
+++ b/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
@@ -2,6 +2,10 @@
 
 describe SearchCreneauxWithoutLieuForAgentsService, type: :service do
   describe "creneaux" do
+    before do
+      travel_to(Time.zone.local(2022, 10, 15, 10, 0, 0))
+    end
+
     let(:form) do
       instance_double(
         AgentCreneauxSearchForm,
@@ -11,12 +15,12 @@ describe SearchCreneauxWithoutLieuForAgentsService, type: :service do
         agent_ids: [],
         team_ids: [],
         lieu_ids: nil,
-        date_range: Time.zone.today..7.days.since
+        date_range: Date.new(2022, 10, 20)..Date.new(2022, 10, 30)
       )
     end
     let(:organisation) { create(:organisation) }
     let(:motif) { create :motif, :by_phone, organisation: organisation }
-    let!(:plage_ouverture) { create(:plage_ouverture, first_day: Time.zone.tomorrow, motifs: [motif], lieu: nil, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], first_day: Date.new(2022, 10, 25), lieu: nil, organisation: organisation) }
 
     it "has results" do
       expect(described_class.perform_with(form).creneaux).to be_any


### PR DESCRIPTION
J'utilise timecop pour enlever la dépendance aux périodes de l'année. Le test bugguait aujourd'hui à cause des jours fériés (1er novembre) par ex.

Aussi, j'ai cru me rendre compte en faisant ce petit debug que le `build_result` de `SearchCreneauxForAgentsService` n'était pas testé. C'est le cas ? C'est voulu?

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
