### PR TITLE
Ajouter un cache sur /stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -9,31 +9,44 @@ class StatsController < ApplicationController
   end
 
   def rdvs
-    stats = Stat.new(rdvs: @rdvs)
-    stats = if params[:by_territory].present?
-              stats.rdvs_group_by_territory_name
-            elsif params[:by_service].present?
-              stats.rdvs_group_by_service
-            elsif params[:by_location_type].present?
-              stats.rdvs_group_by_type
-            elsif params[:by_status].present?
-              stats.rdvs_group_by_status
-            else
-              stats.rdvs_group_by_week_fr
-            end
-    render json: stats.chart_json
+    cache_key = ["stats_rdvs", request.query_parameters, Time.zone.today]
+    chart_json = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      stats = Stat.new(rdvs: @rdvs)
+      results = if params[:by_territory].present?
+                  stats.rdvs_group_by_territory_name
+                elsif params[:by_service].present?
+                  stats.rdvs_group_by_service
+                elsif params[:by_location_type].present?
+                  stats.rdvs_group_by_type
+                elsif params[:by_status].present?
+                  stats.rdvs_group_by_status
+                else
+                  stats.rdvs_group_by_week_fr
+                end
+      results.chart_json
+    end
+    render json: chart_json
   end
 
   def receipts
-    attribute = params[:group_by]&.to_sym
-    attribute = :channel unless attribute.in?(%i[event channel result])
-    render json: Stat.new(receipts: @receipts).receipts_group_by(attribute).chart_json
+    cache_key = ["stats_receipts", request.query_parameters, Time.zone.today]
+    chart_json = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      attribute = params[:group_by]&.to_sym
+      attribute = :channel unless attribute.in?(%i[event channel result])
+      Stat.new(receipts: @receipts).receipts_group_by(attribute).chart_json
+    end
+    render json: chart_json
   end
 
   def active_agents
-    stats = Stat.new(rdvs: @rdvs).active_agents_group_by_month
-    render json: stats.chart_json
+    cache_key = ["stats_active_agents", request.query_parameters, Time.zone.today]
+    chart_json = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      Stat.new(rdvs: @rdvs).active_agents_group_by_month.chart_json
+    end
+    render json: chart_json
   end
+
+  private
 
   def scope_rdv_to_territory
     if params[:territory].present?

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -6,134 +6,135 @@
     | Statistiques
     = " pour le #{@territory}" if @territory.present?
 
-.container.mt-3
-  - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
-    h3 Cette structure n'utilise pas #{current_domain.name}.
-  - else
-    .card.mb-5
-      .card-body
-        h2.card-title Nombre de RDV par statut
-        .row
-          .col-lg-4
-            .px-1
-              - %i[seen excused revoked noshow].each do |temporal_status|
-                = render "stats/rdv_counter_without_link", \
-                  temporal_status: temporal_status, \
-                  count: @stats.rdvs.status(temporal_status).count
-          .col-lg-4
-            .px-1
-              = render "stats/rdv_counter_without_link", \
-                temporal_status: :unknown_past, \
-                count: @stats.rdvs.status(:unknown_past).count
-          .col-lg-4
-            .px-1
-              = render "stats/rdv_counter_without_link", \
-                temporal_status: :unknown_future, \
-                count: @stats.rdvs.status(:unknown_future).count
-        hr
-        .row
-          .col-lg-4
-            .px-1
-              = render "stats/rdv_counter_without_link", \
-                label: "Tous", \
-                count: @stats.rdvs.count
-
-    .card.mb-5
-      .card-body
-        = self_anchor "rdvs"
-         h2.card-title RDV créés (#{@stats.rdvs.count})
-        = column_chart rdvs_stats_path(territory: @territory), stacked: true
-
-    - unless @territory.present?
+- cache([@territory, Time.zone.today], expires_in: 24.hours) do
+  .container.mt-3
+    - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
+      h3 Cette structure n'utilise pas #{current_domain.name}.
+    - else
       .card.mb-5
         .card-body
-          = self_anchor "rdvs-territory"
-            h2.card-title RDV créés par structure (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(by_territory: true), stacked: true
+          h2.card-title Nombre de RDV par statut
+          .row
+            .col-lg-4
+              .px-1
+                - %i[seen excused revoked noshow].each do |temporal_status|
+                  = render "stats/rdv_counter_without_link", \
+                    temporal_status: temporal_status, \
+                    count: @stats.rdvs.status(temporal_status).count
+            .col-lg-4
+              .px-1
+                = render "stats/rdv_counter_without_link", \
+                  temporal_status: :unknown_past, \
+                  count: @stats.rdvs.status(:unknown_past).count
+            .col-lg-4
+              .px-1
+                = render "stats/rdv_counter_without_link", \
+                  temporal_status: :unknown_future, \
+                  count: @stats.rdvs.status(:unknown_future).count
+          hr
+          .row
+            .col-lg-4
+              .px-1
+                = render "stats/rdv_counter_without_link", \
+                  label: "Tous", \
+                  count: @stats.rdvs.count
 
-    .card.mb-5
-      .card-body
-        = self_anchor "rdvs-service"
-          h2.card-title RDV créés par service (#{@stats.rdvs.count})
-        = column_chart rdvs_stats_path(by_service: true, territory: @territory), stacked: true
+      .card.mb-5
+        .card-body
+          = self_anchor "rdvs"
+            h2.card-title RDV créés (#{@stats.rdvs.count})
+          = column_chart rdvs_stats_path(territory: @territory), stacked: true
 
-    .card.mb-5
-      .card-body
-        = self_anchor "rdvs-type"
-          h2.card-title RDV par type (#{@stats.rdvs.count})
-        = column_chart rdvs_stats_path(by_location_type: true, territory: @territory), stacked: true
+      - unless @territory.present?
+        .card.mb-5
+          .card-body
+            = self_anchor "rdvs-territory"
+              h2.card-title RDV créés par structure (#{@stats.rdvs.count})
+            = column_chart rdvs_stats_path(by_territory: true), stacked: true
 
-    .card.mb-5
-      .card-body
-        = self_anchor "rdvs-status"
-          h2.card-title RDV par statut
-        /
-          Note: colors are synced manually with the status css and the order of the stats.
-          From stat.rb, Stat#rdvs_group_by_status:
-            * stats are in this order: unknown seen excused revoked noshow
-          From _rdv_status.scss, the colors are:
-            "unknown": $info, #ffbc00
-            "seen": $success, #0acf97
-            "excused": $info, #39afd1
-            "revoked": $teal, #02a8b5
-            "noshow": $danger, #fa5c7c
-        - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
-        = column_chart rdvs_stats_path(by_status: true, territory: @territory), stacked: :percent, max: 100, suffix: "%", colors: colors
+      .card.mb-5
+        .card-body
+          = self_anchor "rdvs-service"
+            h2.card-title RDV créés par service (#{@stats.rdvs.count})
+          = column_chart rdvs_stats_path(by_service: true, territory: @territory), stacked: true
 
-    .card.mb-5
-      .card-body
-        = self_anchor "notifications"
-          h2.card-title #{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})
-        - %i[event channel result].each do |attribute|
-          h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
-          = column_chart receipts_stats_path(group_by: attribute, departement: @departement, territory: @territory), stacked: true
+      .card.mb-5
+        .card-body
+          = self_anchor "rdvs-type"
+            h2.card-title RDV par type (#{@stats.rdvs.count})
+          = column_chart rdvs_stats_path(by_location_type: true, territory: @territory), stacked: true
 
-    .card.mb-5
-      .card-body
-        = self_anchor "activations"
-          h2.card-title Activité des agents
-        - active_agents = @agents.active
+      .card.mb-5
+        .card-body
+          = self_anchor "rdvs-status"
+            h2.card-title RDV par statut
+          /
+            Note: colors are synced manually with the status css and the order of the stats.
+            From stat.rb, Stat#rdvs_group_by_status:
+              * stats are in this order: unknown seen excused revoked noshow
+            From _rdv_status.scss, the colors are:
+              "unknown": $info, #ffbc00
+              "seen": $success, #0acf97
+              "excused": $info, #39afd1
+              "revoked": $teal, #02a8b5
+              "noshow": $danger, #fa5c7c
+          - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
+          = column_chart rdvs_stats_path(by_status: true, territory: @territory), stacked: :percent, max: 100, suffix: "%", colors: colors
 
-        h5 Aujourd'hui
+      .card.mb-5
+        .card-body
+          = self_anchor "notifications"
+            h2.card-title #{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})
+          - %i[event channel result].each do |attribute|
+            h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
+            = column_chart receipts_stats_path(group_by: attribute, departement: @departement, territory: @territory), stacked: true
 
-        p #{active_agents.count} agents ont été invités
+      .card.mb-5
+        .card-body
+          = self_anchor "activations"
+            h2.card-title Activité des agents
+          - active_agents = @agents.active
 
-        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).count
-        p #{percent(accepted_count, active_agents.count)} ont accepté l'invitation (#{accepted_count})
+          h5 Aujourd'hui
 
-        - first_rdv_count = active_agents.joins(:rdvs).distinct.count
-        p #{percent(first_rdv_count, active_agents.count)} ont participé à au moins un rdv (#{first_rdv_count})
+          p #{active_agents.count} agents ont été invités
 
-        - active_count = active_agents.joins(:rdvs).where("rdvs.created_at > ?", 30.days.ago).distinct.count
-        p #{percent(active_count, active_agents.count)} ont participé à un rdv créé dans les 30 derniers jours (#{active_count})
+          - accepted_count = active_agents.where.not(invitation_accepted_at: nil).count
+          p #{percent(accepted_count, active_agents.count)} ont accepté l'invitation (#{accepted_count})
 
-        h5 Il y a 30 jours
+          - first_rdv_count = active_agents.joins(:rdvs).distinct.count
+          p #{percent(first_rdv_count, active_agents.count)} ont participé à au moins un rdv (#{first_rdv_count})
 
-        - active_agents = active_agents.where("agents.created_at < ?", 30.days.ago)
-        p #{active_agents.count} agents avaient été invités
+          - active_count = active_agents.joins(:rdvs).where("rdvs.created_at > ?", 30.days.ago).distinct.count
+          p #{percent(active_count, active_agents.count)} ont participé à un rdv créé dans les 30 derniers jours (#{active_count})
 
-        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("agents.created_at < ?", 30.days.ago).count
-        p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
+          h5 Il y a 30 jours
 
-        - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
-        p #{percent(first_rdv_count, active_agents.count)} avaient participé à au moins un rdv (#{first_rdv_count})
+          - active_agents = active_agents.where("agents.created_at < ?", 30.days.ago)
+          p #{active_agents.count} agents avaient été invités
 
-        - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
-        p #{percent(active_count, active_agents.count)} avaient participé à un rdv créé un rdv les 30 derniers jours précédents (#{active_count})
+          - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("agents.created_at < ?", 30.days.ago).count
+          p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
 
-        = self_anchor "active_agents"
-          h2.card-title Agents actifs par mois
-        p Nombre d'agents ayant participé à au moins un rdv chaque mois
-        = column_chart active_agents_stats_path(territory: @territory)
-    .card.mb-5
-      .card-header
-        = "#{@territories.count} structures utilisent RDV-Solidarités"
-      .card-body
-        ul
-          - @territories.order(:name).each do |territory|
-            li = link_to territory, stats_path(territory: territory)
-        .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
-        .alert.alert-info.d-flex.align-items-center
-          .mr-3
-            i.fa.fa-info
-          = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."
+          - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
+          p #{percent(first_rdv_count, active_agents.count)} avaient participé à au moins un rdv (#{first_rdv_count})
+
+          - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
+          p #{percent(active_count, active_agents.count)} avaient participé à un rdv créé un rdv les 30 derniers jours précédents (#{active_count})
+
+          = self_anchor "active_agents"
+            h2.card-title Agents actifs par mois
+          p Nombre d'agents ayant participé à au moins un rdv chaque mois
+          = column_chart active_agents_stats_path(territory: @territory)
+      .card.mb-5
+        .card-header
+          = "#{@territories.count} structures utilisent RDV-Solidarités"
+        .card-body
+          ul
+            - @territories.order(:name).each do |territory|
+              li = link_to territory, stats_path(territory: territory)
+          .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
+          .alert.alert-info.d-flex.align-items-center
+            .mr-3
+              i.fa.fa-info
+            = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."


### PR DESCRIPTION
Note : le diff est beaucoup plus lisible en [cachant le whitespace](https://user-images.githubusercontent.com/6357692/199018490-f3ae793b-a018-4046-9d2f-331b27bda39b.png).

# Actuellement

La page de stats publiques est très longue à charger car elle fait de grosses requêtes en base de données.

Cette page est utilisée assez régulièrement : en cette matinée du 31 octobre, on peut voir 22 requêtes vers cette page.

On peut voir sur Skylight que ce sont nos requêtes les plus lentes (quand on ordonne par "Typical response") : 

![image](https://user-images.githubusercontent.com/6357692/198994458-48a97c25-ecb7-4f21-9ad8-ccd95f154f88.png)


# Objectif de cette PR

Les objectifs ici : 
- soulager la base de données, qui a déjà beaucoup à faire
- améliorer l'UX en chargeant la page plus rapidement

# Implémentation

L'ajout d'un cache paraît assez évident dans cette situation. Les critères d'invalidation du cache sont :
- les filtres passés en paramètres
- une variable temporelle, j'ai choisi la date du jour mais il y a peut-être un choix plus pertinent

# Résultats

## Stats globales

### Avant

![image](https://user-images.githubusercontent.com/6357692/198994518-a933b98e-a12a-4207-ae07-766d4625cdae.png)

### Après

![image](https://user-images.githubusercontent.com/6357692/198994535-ac0a7419-377c-49d3-93b3-70d88091373f.png)

## Stats par département

### Avant

![image](https://user-images.githubusercontent.com/6357692/198994582-8c1ff62d-a532-46a2-ab5f-7a8a2e4fbecb.png)

### Après

![image](https://user-images.githubusercontent.com/6357692/198994594-5d0c5400-5943-417b-80fc-56be12440696.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
