### PR TITLE
Précise l'organisation dans le nom de fichier

### DIFF
--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -10,7 +10,11 @@ class Agents::ExportMailer < ApplicationMailer
     # Le département du Var se base sur la position de chaque caractère du nom
     # de fichier pour extraire la date et l'ID d'organisation, donc
     # si on modifie le fichier il faut soit les prévenir soit ajouter à la fin.
-    file_name = "export-rdv-#{now.strftime('%Y-%m-%d')}.xls"
+    file_name = if organisations.count == 1
+                  "export-rdv-#{now.strftime('%Y-%m-%d')}-org-#{organisations.first.id.to_s.rjust(6, '0')}.xls"
+                else
+                  "export-rdv-#{now.strftime('%Y-%m-%d')}.xls"
+                end
     mail.attachments[file_name] = {
       mime_type: "application/vnd.ms-excel",
       content: RdvExporter.export(rdvs.order(starts_at: :desc)),

--- a/spec/mailers/agents/export_mailer_spec.rb
+++ b/spec/mailers/agents/export_mailer_spec.rb
@@ -1,24 +1,41 @@
 # frozen_string_literal: true
 
 describe Agents::ExportMailer do
-  let!(:organisation) { create(:organisation, id: 666) }
-  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-  let!(:territory) { organisation.territory }
-
   describe "#rdv_export" do
-    subject(:rdv_export) { described_class.rdv_export(agent, [organisation.id], {}) }
+    it "has an attachment file name which contains the current date without org ID when more than one orga" do
+      organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation])
+      other_organisation = create(:organisation)
+      travel_to(Time.zone.parse("2022-09-14 09:00:00"))
+
+      rdv_export = described_class.rdv_export(agent, [organisation.id, other_organisation.id], {})
+
+      expect(rdv_export.attachments.first.filename).to eq("export-rdv-2022-09-14.xls")
+    end
 
     it "has an attachment which contains the current date and org ID" do
+      # Le département du Var se base sur la position de chaque caractère du nom
+      # de fichier pour extraire la date et l'ID d'organisation, donc
+      # si on modifie le fichier il faut soit les prévenir soit ajouter à la fin.
+
+      organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation])
       travel_to(Time.zone.parse("2022-09-14 09:00:00"))
-      expect(rdv_export.attachments.first.filename).to eq("export-rdv-2022-09-14.xls")
+
+      rdv_export = described_class.rdv_export(agent, [organisation.id], {})
+
+      expect(rdv_export.attachments.first.filename).to eq("export-rdv-2022-09-14-org-#{organisation.id.to_s.rjust(6, '0')}.xls")
     end
   end
 
   describe "#rdvs_users_export" do
-    subject(:rdvs_users_export) { described_class.rdvs_users_export(agent, [organisation.id], {}) }
-
     it "has an attachment which contains the current date" do
+      organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation])
       travel_to(Time.zone.parse("2022-09-14 09:00:00"))
+
+      rdvs_users_export = described_class.rdvs_users_export(agent, [organisation.id], {})
+
       expect(rdvs_users_export.attachments.first.filename).to eq("export-rdvs-user-2022-09-14.xls")
     end
   end


### PR DESCRIPTION
Lorsqu'il n'y a qu'une seule organisation dans le fichier exporté, nous précisons son identifiant dans le fichier exporté.

C'était le comportement habituel avant l'ajout du filtre sur les organisations accessibles. Ce changement à boulversé les mécanismes et habitude pour le département du var (ref : https://zammad10.ethibox.fr/#ticket/zoom/3070), aussi, cette PR remet en état le fonctionnement ancien.

Pas de modification sur le nouvel export, il est nouveau et ne casse donc aucun mécanisme existant. À voir si la demande est faite pour faire pareil plus tard.

Closes #3005

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
