### PR TITLE
Affiche les prochains créneaux disponibles dans les semaines qui suivent pour des motifs qui ne sont pas sur place

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -47,7 +47,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   def results_without_lieu?
     return false if requires_lieu?
 
-    SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)&.creneaux&.any?
+    search_creneaux_service.present?
   end
 
   def set_form
@@ -59,18 +59,18 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
 
     # Un RDV collectif peut-il avoir lieu à domicile ou au téléphone ?
     @search_results = if @form.motif.individuel?
-                        search_creneaux_service.perform_with(@form)
+                        search_creneaux_service
                       else
                         SearchRdvCollectifForAgentsService.new(@form).lieu_search
                       end
   end
 
   def search_creneaux_service
-    if requires_lieu?
-      SearchCreneauxForAgentsService
-    else
-      SearchCreneauxWithoutLieuForAgentsService
-    end
+    @search_creneaux_service ||= if requires_lieu?
+                                   SearchCreneauxForAgentsService.perform_with(@form)
+                                 else
+                                   SearchCreneauxWithoutLieuForAgentsService.perform_with(@form)
+                                 end
   end
 
   def creneaux_search_params

--- a/spec/requests/admin/creneaux/agent_searches_spec.rb
+++ b/spec/requests/admin/creneaux/agent_searches_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe "Admin::Organisations::OnlineBookings", type: :request do
+  include Rails.application.routes.url_helpers
+
+  let(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+  before { sign_in agent }
+
+  describe "GET /admin/organisations/:organisation_id/agent_searches" do
+    it "is successful" do
+      get admin_organisation_agent_searches_path(organisation)
+      expect(response).to be_successful
+    end
+
+    context "search for phone motif with availability in 2 weeks" do
+      it "redirect to slot controller for available slots" do
+        now = Time.zone.parse("2022-10-17 10:30")
+        travel_to(now)
+        motif = create(:motif, :by_phone, organisation: organisation)
+        create(:plage_ouverture,
+               motifs: [motif],
+               organisation: organisation,
+               lieu: nil,
+               agent: agent,
+               first_day: now + 2.weeks)
+
+        params = {
+          from_date: "2022-10-17",
+          motif_id: motif.id,
+          commit: true,
+        }
+
+        get admin_organisation_agent_searches_path(organisation, params)
+
+        expect(response).to redirect_to(admin_organisation_slots_path(organisation, from_date: "2022-10-17", motif_id: motif.id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dans le cas d'un motif de RDV téléphonique (ou à domicile) ; 
nous ne vérifions que si des créneaux étaient disponibles ; 
Si la date de dispo était sur la semaine d'après, donc dans `next_availability` alors, nous affichions un message : « aucun créneaux disponible » alors que c'est faux.

Cette PR ajoute un test sur ce cas et modifie cette vérification dans le contrôleur de recherche de créneaux des agents.

Closes #3019

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
