### PR TITLE
Incite à mettre l'url de review app dans la pr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+Pour tester : <`mettre ici l'url de la review app une fois déployé`>
+
+Décrire le pourquoi des modifications
+
 Closes #issue_number
 
 # Checklist


### PR DESCRIPTION
Pour faciliter les tests et revues en autonomie par l'équipe de support utilisateur, mettre le lien vers la review app dans la description permet de la rendre plus accessible.
