### PR TITLE
Masque par défaut les usagers marqués supprimé

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,11 +23,11 @@ class Admin::UsersController < AgentAuthController
 
   def index
     @form = Admin::UserSearchForm.new(**index_params)
-    @users = policy_scope(User).merge(@form.users).active.order_by_last_name.page(params[:page])
+    @users = policy_scope(User).merge(@form.users).order_by_last_name.page(params[:page])
   end
 
   def search
-    users = policy_scope(User).where.not(id: params[:exclude_ids]).active.limit(20)
+    users = policy_scope(User).where.not(id: params[:exclude_ids]).limit(20)
     @users = search_params[:term].present? ? users.search_by_text(search_params[:term]) : users.none
     skip_authorization
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -97,7 +97,7 @@ module UsersHelper
   end
 
   def user_soft_delete_confirm_message(user)
-    relatives = user.relatives.merge(current_organisation.users).active
+    relatives = user.relatives.merge(current_organisation.users)
     [
       "Confirmez-vous la suppression de cet usager ?",
       (I18n.t("users.soft_delete_confirm_message.relatives", count: relatives.size) if relatives.any?),

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,8 @@ class User < ApplicationRecord
   before_save :set_email_to_null_if_blank
 
   # Scopes
-  scope :active, -> { where(deleted_at: nil) }
+  default_scope { where(deleted_at: nil) }
+
   scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
   scope :responsible, -> { where(responsible_id: nil) }
   scope :relative, -> { where.not(responsible_id: nil) }
@@ -107,7 +108,7 @@ class User < ApplicationRecord
   end
 
   def available_users_for_rdv
-    User.where(responsible_id: id).or(User.where(id: id)).order("responsible_id DESC NULLS FIRST", first_name: :asc).active
+    User.where(responsible_id: id).or(User.where(id: id)).order("responsible_id DESC NULLS FIRST", first_name: :asc)
   end
 
   def self_and_relatives

--- a/app/services/duplicate_users_finder_service.rb
+++ b/app/services/duplicate_users_finder_service.rb
@@ -52,7 +52,7 @@ class DuplicateUsersFinderService < BaseService
     private
 
     def users_in_scope(user, organisation)
-      u = User.active
+      u = User.all
       u = u.where.not(id: user.id) if user.persisted?
       u = u.merge(organisation.users) if organisation.present?
       u

--- a/app/views/admin/merge_users/_user_relatives.html.slim
+++ b/app/views/admin/merge_users/_user_relatives.html.slim
@@ -1,4 +1,4 @@
-- relatives = user&.relatives&.active
+- relatives = user&.relatives
 - if relatives.present?
   = "#{relatives.count} proches"
 - else

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -95,10 +95,10 @@
         .card-header Proches
         .card-body
           ul.list-unstyled.mb-2
-            - if @user.relatives.merge(current_organisation.users).active.empty?
+            - if @user.relatives.merge(current_organisation.users).empty?
               li
                 em Aucun proche
-            - @user.relatives.merge(current_organisation.users).active.order(:birth_date).each do |relative|
+            - @user.relatives.merge(current_organisation.users).order(:birth_date).each do |relative|
               li
                 => link_to relative.full_name, admin_organisation_user_path(current_organisation, relative)
                 = "(#{age(relative)})" if relative.birth_date

--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -9,10 +9,10 @@
       .card-body
         h2.card-title = t(".my_relatives")
         ul.list-group.mb-2
-          - if @user.relatives.active.empty?
+          - if @user.relatives.empty?
             li.list-group-item
               em = t(".no_relatives")
-          - @user.relatives.active.order(:birth_date).each do |relative|
+          - @user.relatives.order(:birth_date).each do |relative|
             li.list-group-item
               .row
                 .col

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -19,10 +19,16 @@ RSpec.describe Admin::UsersController, type: :controller do
       end.to change(user, :organisation_ids).from([organisation.id]).to([])
     end
 
-    it "does not destroy user" do
+    it "appaers to destroy user" do
       expect do
         delete :destroy, params: { organisation_id: organisation.id, id: user.id }
-      end.not_to change(User, :count)
+      end.to change(User, :count)
+    end
+
+    it "not really destroy user" do
+      expect do
+        delete :destroy, params: { organisation_id: organisation.id, id: user.id }
+      end.not_to change { User.unscoped.count }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,7 +104,7 @@ describe User, type: :model do
         organisation = create(:organisation)
         user = create(:user, organisations: [organisation])
         user.soft_delete(organisation)
-        expect(user.organisations).to be_empty
+        expect(user.reload.organisations).to be_empty
       end
     end
 


### PR DESCRIPTION
Nous utilisions un scope `active` sur les usagers pour n'avoir que ceux qui n'était pas marqué comme supprimé par une opération de `soft_delete`.

Nous avons un retour sur un cas de figure où nous avons oublié d'utiliser ce scope (il y en a peut-être plusieurs ?).

Cette PR remplace le scope `active` par un `default_scope` qui écarte les usagers marqué comme supprimé. Comme nous avons fait pour les RDV.

Closes #3027


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
