### PR TITLE
Trois corrections mineures

### DIFF
--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -24,7 +24,7 @@
       1, \
       false, \
       class:"align-items-baseline ml-0"
-    |&nbsp; Inviter l'utilisateur à se créer un compte sur #{current_domain.name}.
+    |&nbsp; Inviter l'usager à se créer un compte sur #{current_domain.name}.
 
 .label Préférences de notifications
 .mb-2

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -34,7 +34,7 @@ ul.list-group.list-group-flush
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
       - unless rdv_wizard.invitation?
         .col-auto
-        = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
+          = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
   - if rdv_wizard.is_a?(UserRdvWizard::Step3)
     li.list-group-item
       .row


### PR DESCRIPTION
En préparant les maquettes sur la réservation en ligne, j'ai remarqué ces trois petits détails qui étaient rapides à corriger : 
- se servir du terme `usager` et non pas `utilisateur` de manière cohérente sur le formulaire côté agent
- correctif d'un mauvais alignement causé par un problème d'indentation
- suppression d'un fichier vide ajouté par erreur