### PR TITLE
Ajoute un parcours pour les RDV sur des motifs de suivi pour l'usager

### DIFF
--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -2,20 +2,29 @@
 
 module SearchContextHelper
   def path_to_motif_selection(params)
-    prendre_rdv_path(motif_selection(params))
+    prendre_rdv_path(
+      service_selection(params).merge(
+        service_id: params[:service_id]
+      )
+    )
+  end
+
+  def path_to_service_selection(params)
+    prendre_rdv_path(service_selection(params))
   end
 
   def path_to_lieu_selection(params)
     prendre_rdv_path(
-      motif_selection(params).merge(
-        motif_name_with_location_type: params[:motif_name_with_location_type]
+      service_selection(params).merge(
+        motif_name_with_location_type: params[:motif_name_with_location_type],
+        service_id: params[:service_id]
       )
     )
   end
 
   def path_to_organisation_selection(params)
     prendre_rdv_path(
-      motif_selection(params).merge(
+      service_selection(params).merge(
         motif_name_with_location_type: params[:motif_name_with_location_type],
         user_selected_organisation_id: nil
       )
@@ -24,7 +33,7 @@ module SearchContextHelper
 
   def path_to_creneau_selection(params)
     prendre_rdv_path(
-      motif_selection(params).merge(
+      service_selection(params).merge(
         motif_name_with_location_type: params[:motif_name_with_location_type],
         lieu_id: params[:lieu_id], user_selected_organisation_id: params[:user_selected_organisation_id]
       )
@@ -33,7 +42,7 @@ module SearchContextHelper
 
   private
 
-  def motif_selection(params)
+  def service_selection(params)
     {
       departement: params[:departement],
       city_code: params[:city_code],
@@ -41,7 +50,6 @@ module SearchContextHelper
       latitude: params[:latitude],
       street_ban_id: params[:street_ban_id],
       address: params[:address],
-      service_id: params[:service_id],
       public_link_organisation_id: params[:public_link_organisation_id],
       referent_ids: params[:referent_ids],
     }

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -126,7 +126,7 @@ class SearchContext
   def lieux
     @lieux ||= \
       Lieu
-        .with_open_slots_for_motifs(@matching_motifs)
+        .with_open_slots_for_motifs(matching_motifs)
         .includes(:organisation)
         .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
   end

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -8,8 +8,26 @@ section.bg-light.p-4
         .card
           .card-body
             h2.pb-1.mb-1 = context.service.name
+      - else
+        .card
+          .card-body
+            = link_to path_to_service_selection(params), class: "d-block stretched-link" do
+              .row
+                .col-auto.align-self-center
+                  i.fa.fa-chevron-left
+                .col
+                  h2.pb-1.mb-1 = context.service.name
     .container
        h2.font-weight-bold Sélectionnez le motif de votre RDV :
+       - unless context.invitation?
+         .card
+           .m-2
+            | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
+            span>
+            = link_to users_rdvs_path do
+              i.far.fa-calendar
+              span>
+              | vos rendez-vous
        - context.unique_motifs_by_name_and_location_type.each do |motif|
          .card.mb-3
            - if motif.restriction_for_rdv.blank?

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -3,12 +3,21 @@ section.bg-light.p-4
     - if context.unique_motifs_by_name_and_location_type.empty?
       / TODO redirect to this page directly from controler
       = render "nothing_to_show", context: context
-    - else
-      h2.font-weight-bold Vous souhaitez prendre un RDV avec le service :
-      - context.services.each do |service|
-        .card.mb-3
-          = link_to path_to_motif_selection(params.merge(service_id: service.id)) do
-            .card-body
-              .row
-                .col-md
-                  h3.card-title.mb-3.mt-0.text-success.font-weight-bold= service.name
+    h2.font-weight-bold Sélectionnez le service avec qui vous voulez prendre un RDV :
+    - unless context.invitation?
+      .card
+        .m-2
+          | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
+          span>
+          = link_to users_rdvs_path do
+            i.far.fa-calendar
+            span>
+            | vos rendez-vous
+
+    - context.services.each do |service|
+      .card.mb-3
+        = link_to path_to_motif_selection(context.query.merge(service_id: service.id)) do
+          .card-body
+            .row
+              .col-md
+                h3.card-title.mb-3.mt-0.text-success.font-weight-bold= service.name

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -2,7 +2,11 @@
   .col-md-6
     h1.text-dark.mb-3 Vos rendez-vous
     div.mb-3
-      .float-right= link_to "Prendre un RDV", prendre_rdv_path, class: "btn btn-primary"
+      .float-right
+        = link_to prendre_rdv_path, class: "btn btn-primary" do
+          i.fa.fa-calendar
+          span>
+          | Prendre un RDV
       - if params[:past].present?
         = link_to "Voir vos prochains RDV", users_rdvs_path, class: "btn btn-outline-primary"
       - else
@@ -14,7 +18,12 @@
               .card-body
                 = render "rdv", rdv: rdv
           .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
-          .text-center= link_to "Prendre un autre RDV", prendre_rdv_path, class: "btn btn-primary"
+          .text-center
+            = link_to prendre_rdv_path, class: "btn btn-primary" do
+              i.fa.fa-calendar
+              span>
+              | Prendre un autre RDV
+
     - else
       .card
         .card-body
@@ -22,10 +31,24 @@
             p.mb-2.lead= no_rdv_for_users
             span.fa-stack.fa-4x
               i.fa.fa-circle.fa-stack-2x.text-primary
-              i.far.fa-calendar.fa-stack-1x.text-white
+              i.fa.fa-calendar.fa-stack-1x.text-white
             .text-center.mt-2
-              = link_to "Prendre un RDV", prendre_rdv_path, class: "btn btn-primary"
+  .col-md-6
+    h1.text-dark.mb-3 Vos référents
+    - if current_user.agents.any?
+      - current_user.agents.each do |agent|
+        .card
+          .card-body
+            = agent.full_name_and_service
+          .card-footer.text-right
+            = link_to prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number, service_id: agent.service_id), class: "btn btn-primary " do
+              i.fa.fa-calendar
+              span>
+              | Prendre un RDV
+    - else
+      | Vous n'avez pas de référents
 
-    .text-center.my-5
-      = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
-        img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"
+.row.mt-3.justify-content-center
+  .text-center.my-5
+    = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
+      img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -81,7 +81,7 @@ describe "public pages", js: true do
           address: "Paris 75001"
         )
         visit path
-        expect(page).to have_content("Vous souhaitez prendre un RDV avec le service")
+        expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
 
         expect_page_to_be_axe_clean(path)
       end

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -12,7 +12,7 @@ describe "Agents can try the user-facing online booking pages" do
   it "shows the online booking forms, until" do
     login_as(agent, scope: :agent)
     visit public_link_to_org_path(organisation_id: organisation.id)
-    expect(page).to have_content("Vous souhaitez prendre un RDV avec le service :")
+    expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
     click_link(agent.service.name)
     expect(page).to have_content("Sélectionnez un lieu de RDV :")
     click_link("Prochaine disponibilité")

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -216,7 +216,7 @@ describe "User can search for rdvs" do
 
   def choose_service(service)
     expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
-    expect(page).to have_content("Vous souhaitez prendre un RDV avec le service :")
+    expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
 
     find("h3", text: service.name).click
   end

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe "Search", type: :request do
+  include Rails.application.routes.url_helpers
+
+  describe "GET /" do
+    context "without params" do
+      it "is successful" do
+        get root_path
+        expect(response).to be_successful
+      end
+
+      it "render adress_selection template" do
+        get root_path
+        expect(response).to render_template("search/address_selection/_rdv_solidarites")
+      end
+    end
+
+    context "with connected user" do
+      let(:organisation) { create(:organisation) }
+      let(:agent) { create(:agent, organisations: [organisation]) }
+      let(:user) { create(:user, organisations: [organisation], agents: [agent]) }
+
+      before do
+        login_as(user)
+      end
+
+      context "with agent_id params" do
+        it "render motif_selection template" do
+          motif = create(:motif, service: agent.service, follow_up: true, organisation: organisation)
+          create(:plage_ouverture, agent: agent, motifs: [motif], organisation: organisation)
+          get prendre_rdv_path(referent_ids: [agent.id], service: agent.service_id, departement: organisation.territory.departement_number)
+          expect(response).to render_template("search/_lieu_selection")
+        end
+      end
+    end
+
+    context "service selection" do
+      let(:territory) { create(:territory, departement_number: "75") }
+      let(:organisation) { create(:organisation, territory: territory) }
+      let(:motif) { create(:motif, reservable_online: true, organisation: organisation) }
+      let(:other_motif) { create(:motif, reservable_online: true, organisation: organisation) }
+      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif, other_motif], organisation: organisation) }
+
+      it "show text to invite to select motif" do
+        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+        expect(response.body).to include("Sélectionnez le service avec qui vous voulez prendre un RDV")
+      end
+
+      it "show link to user's RDV list and follower's agents" do
+        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+        expect(response.body).to include(users_rdvs_path)
+      end
+    end
+
+    context "motif selection" do
+      let(:territory) { create(:territory, departement_number: "75") }
+      let(:organisation) { create(:organisation, territory: territory) }
+      let(:motif) { create(:motif, reservable_online: true, organisation: organisation) }
+      let(:other_motif) { create(:motif, reservable_online: true, organisation: organisation, service: motif.service) }
+      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif, other_motif], organisation: organisation) }
+
+      it "show text to invite to select motif" do
+        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+        expect(response.body).to include("Sélectionnez le motif de votre RDV")
+      end
+
+      it "show link to user's RDV list and follower's agents" do
+        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+        expect(response.body).to include(users_rdvs_path)
+      end
+    end
+  end
+
+  describe "GET /prendre_rdv" do
+    it "is successful" do
+      get prendre_rdv_path
+      expect(response).to be_successful
+    end
+  end
+end


### PR DESCRIPTION
Lorsqu'un usager sans agent référent vient pour prendre RDV ;
Une fois son adresse saisie et le service choisi ;
Nous lui affichons l'ensemble des motifs (autorisé par la sectorisation) ;
Il peut donc prendre un RDV pour un motif de suivi SANS avoir d'agent référent affecté... C'est un bug.


Après discussion avec les référentes durant [la réunion du 15 novembre 2022](https://www.notion.so/rdvs/Tableau-de-Bord-Consortium-642af48b73d04187b1b10c62b6d7c3d9#4248cffd14314096b3592650e219606c) ; cette PR
- [x] ajoute un lien depuis la liste des motifs pour visualiser la liste des agents référents auxquels je suis associé (affecté ?)
- [x] ajoute la liste des agents référents dans la page « mes RDV »
- [x] n'affiche plus les motifs de suivi ouvert à la réservation publique dans le parcours « de base » (connecté ou non)
- [x] filtre le parcours en fonction d'un ID agent pour n'afficher que les motifs pour lesquelles il ou elle propose des créneaux.


![Screenshot 2022-11-21 at 10-05-38 RDV Solidarités](https://user-images.githubusercontent.com/42057/203009642-7c45ed11-d870-41c3-b3fe-9a81474c4fa0.png)


![Screenshot 2022-11-22 at 13-55-52 RDV Solidarités](https://user-images.githubusercontent.com/42057/203319318-62810de4-8daa-46bc-bc59-b6287017eaaa.png)


![Screenshot 2022-12-01 at 11-52-48 RDV Solidarités](https://user-images.githubusercontent.com/42057/205034782-8a56c6ab-174f-4648-8d08-b6d1b0677748.png)

![Screenshot 2022-11-22 at 13-56-16 RDV Solidarités](https://user-images.githubusercontent.com/42057/203319387-61d667fb-9a3a-4b80-be3e-3cf057c3cad0.png)

Ici, avec le paramètre `agent_id`, l'agent référent ne proposant qu'un seul motif de suivi à la réservation en ligne, nous arrivons directement au choix du lieu.


Closes #2966



# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
