### PR TITLE
Correction d'une flaky spec

### DIFF
--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -4,15 +4,15 @@ describe "CNFS agent can configure online booking" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, :cnfs, admin_role_in_organisations: [organisation]) }
 
-  before do
-    login_as(agent, scope: :agent)
-    visit authenticated_agent_root_path
-    click_link "Paramètres"
-    click_link "Réservation en ligne"
-  end
+  before { login_as(agent, scope: :agent) }
 
   context "when there is no bookable motifs" do
-    it "can't copy the booking link", js: true do
+    it "goes to the right apge but can't copy the booking link", js: true do
+      visit authenticated_agent_root_path
+      click_link "Paramètres"
+      click_link "Réservation en ligne"
+
+      expect(page).to have_current_path(admin_organisation_online_booking_path(organisation))
       expect(page).to have_css('[data-clipboard-target="copy-button"][disabled]')
     end
   end
@@ -21,7 +21,8 @@ describe "CNFS agent can configure online booking" do
     let!(:motif) { create(:motif, organisation: organisation, service: agent.service, reservable_online: true) }
 
     context "when there is no related plage d'ouverture" do
-      it "can't copy the booking link", js: true do
+      it "can't copy the booking link" do
+        visit admin_organisation_online_booking_path(organisation)
         expect(page).to have_css('[data-clipboard-target="copy-button"][disabled]')
       end
     end
@@ -29,7 +30,8 @@ describe "CNFS agent can configure online booking" do
     context "when there is a related plage d'ouverture" do
       before { motif.plage_ouvertures << create(:plage_ouverture, organisation: organisation, agent: agent) }
 
-      it "can copy the booking link", js: true do
+      it "can copy the booking link" do
+        visit admin_organisation_online_booking_path(organisation)
         expect(page).not_to have_css('[data-clipboard-target="copy-button"][disabled]')
         expect(page).to have_css('[data-clipboard-target="copy-button"]')
       end


### PR DESCRIPTION
Dans le code d'origine, la navigation qui se faisait dans le before ligne 7 était exécutée avant la création de la plage d'ouverture dans le before ligne 31 (les befores sont executés dans l'ordre de déclaration).
Pour que le test passe, il fallait donc qu'on soit dans le cas d'une race condition où l'écriture en base par le script de test se fasse avant la lecture par le serveur suite au click_link.

Le fix consiste donc à faire la navigation dans le `it`, qui est executé après l'écriture en base par le before.

En plus de ce fix, j'en ai profité pour enlever le `js: true` sur 2 des 3 exemples. Vu qu'on test juste le html, le `js: true` servait juste à ouvrir le sous-menu. Plutôt que de faire ça dans chaque test, on vérifie que la navigation marche bien dans le premier test, et ensuite on va directement à la bonne page. Ça permet donc de gagner un peu en rapidité de test, sans perdre en couverture.

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
