### PR TITLE
fix organisation scope for organisations stats

### DIFF
--- a/app/controllers/admin/organisations/stats_controller.rb
+++ b/app/controllers/admin/organisations/stats_controller.rb
@@ -5,7 +5,7 @@ class Admin::Organisations::StatsController < AgentAuthController
 
   def index
     @stats = Stat.new(
-      rdvs: policy_scope(Rdv),
+      rdvs: policy_scope(Rdv).where(organisation: current_organisation),
       agents: policy_scope(Agent)
         .joins(:organisations).where(organisations: { id: current_organisation.id }),
       users: policy_scope(User)


### PR DESCRIPTION
Emergency Fix pour les stats.
Cause : cette PR https://github.com/betagouv/rdv-solidarites.fr/pull/3004
Sur cette ligne : https://github.com/betagouv/rdv-solidarites.fr/blob/296891fc1b04cd410c5e669df836a584b7793534/app/policies/agent/rdv_policy.rb#L18
J'ai simplement scope les rdvs des stats des organisations au niveau du controlleur dédié à cela.
Avant la PR en question cela était fait au niveau de la policy. Cela me semble plus logique comme ca.