### PR TITLE
Correctif pour le retour en arrière dans la prise de rdv en ligne sur rdv aide numérique

### DIFF
--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -4,7 +4,7 @@ class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
     :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code,
-    :street_ban_id, :invitation_token, :address, :motif_search_terms, { organisation_ids: [] },
+    :street_ban_id, :invitation_token, :address, :motif_search_terms, :organisation_id, { organisation_ids: [] },
   ].freeze
   after_action :allow_iframe
   before_action :set_step_titles

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -1,33 +1,31 @@
 # frozen_string_literal: true
 
 module SearchContextHelper
-  def path_to_motif_selection(params)
-    root_path(
-      departement: params[:departement],
-      city_code: params[:city_code],
-      longitude: params[:longitude],
-      latitude: params[:latitude],
-      street_ban_id: params[:street_ban_id],
-      address: params[:address],
-      service_id: params[:service_id]
-    )
+  def path_to_motif_selection(_params)
+    root_path(common_params(params))
   end
 
   def path_to_lieu_selection(params)
     root_path(
-      departement: params[:departement],
-      city_code: params[:city_code],
-      longitude: params[:longitude],
-      latitude: params[:latitude],
-      street_ban_id: params[:street_ban_id],
-      address: params[:address],
-      service_id: params[:service_id],
-      motif_name_with_location_type: params[:motif_name_with_location_type]
+      common_params(params).merge(
+        motif_name_with_location_type: params[:motif_name_with_location_type]
+      )
     )
   end
 
   def path_to_creneau_selection(params)
     root_path(
+      common_params(params).merge(
+        motif_name_with_location_type: params[:motif_name_with_location_type],
+        lieu_id: params[:lieu_id]
+      )
+    )
+  end
+
+  private
+
+  def common_params(params)
+    {
       departement: params[:departement],
       city_code: params[:city_code],
       longitude: params[:longitude],
@@ -35,8 +33,7 @@ module SearchContextHelper
       street_ban_id: params[:street_ban_id],
       address: params[:address],
       service_id: params[:service_id],
-      motif_name_with_location_type: params[:motif_name_with_location_type],
-      lieu_id: params[:lieu_id]
-    )
+      organisation_id: params[:organisation_id],
+    }
   end
 end

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SearchContextHelper
-  def path_to_motif_selection(_params)
+  def path_to_motif_selection(params)
     root_path(common_params(params))
   end
 

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -3,7 +3,7 @@ section.bg-white.py-5
     .row
       .col-md-12.text-center
         p.alert-link La prise de rendez-vous en ligne n'est pas encore ouverte au public.
-        p Vous pouvez prendre contact avec un conseiller numérique via la #{link_to("carte des Conseiller Numérique France service", "https://carte.conseiller-numerique.gouv.fr/")}.
+        p Vous pouvez prendre contact avec un conseiller numérique via la #{link_to("carte des Conseillers numérique France Services", "https://carte.conseiller-numerique.gouv.fr/")}.
 
 section.bg-lightturquoise.py-5
   .container

--- a/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       expect(page).to have_content("Sélectionnez le motif de votre RDV")
     end
 
-    it "allows navigating back from sign in to motif selection", js: true do
+    it "allows navigating back from sign in to motif selection" do
       visit public_link_to_org_url(organisation_id: organisation_a.id, host: Domain::RDV_AIDE_NUMERIQUE.dns_domain_name)
       expect(page).to have_content("1 lieu est disponible")
       expect(page).to have_content(lieu_a.name)
@@ -103,7 +103,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
       click_on "modifier", match: :first
 
-      expect(page).to have_content("Sélectionnez le motif de votre RDV")
+      expect(page).to have_content("Sélectionnez un lieu de RDV")
     end
   end
 end

--- a/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
   end
 
   context "when using the RDV Aide Numérique domain" do
-    it "allows navigating back to motif selection", js: true do
+    it "allows navigating back from lieu to motif selection" do
       motif_c = create(:motif, :sectorisation_level_departement,
                        organisation: organisation_a, name: "Motif C", service: motif_a.service, restriction_for_rdv: nil)
       create(:plage_ouverture, motifs: [motif_c], lieu: lieu_a)
@@ -87,6 +87,22 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
       # retour au choix de motif
       click_on("Motif C")
+      expect(page).to have_content("Sélectionnez le motif de votre RDV")
+    end
+
+    it "allows navigating back from sign in to motif selection", js: true do
+      visit public_link_to_org_url(organisation_id: organisation_a.id, host: Domain::RDV_AIDE_NUMERIQUE.dns_domain_name)
+      expect(page).to have_content("1 lieu est disponible")
+      expect(page).to have_content(lieu_a.name)
+      expect(page).to have_content(motif_a.service.name)
+      click_on("Prochaine disponibilité lemardi 20 septembre 2022 à 08h00")
+
+      expect(page).to have_content("Sélectionnez un créneau")
+      click_on("08:00")
+
+      expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
+      click_on "modifier", match: :first
+
       expect(page).to have_content("Sélectionnez le motif de votre RDV")
     end
   end

--- a/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/user_can_use_link_to_take_rdv_in_organisation_spec.rb
@@ -74,4 +74,20 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       expect { click_on("Confirmer mon RDV") }.to change(Rdv, :count).by(1)
     end
   end
+
+  context "when using the RDV Aide Numérique domain" do
+    it "allows navigating back to motif selection", js: true do
+      motif_c = create(:motif, :sectorisation_level_departement,
+                       organisation: organisation_a, name: "Motif C", service: motif_a.service, restriction_for_rdv: nil)
+      create(:plage_ouverture, motifs: [motif_c], lieu: lieu_a)
+
+      visit public_link_to_org_url(organisation_id: organisation_a.id, host: Domain::RDV_AIDE_NUMERIQUE.dns_domain_name)
+      click_on("Motif C")
+      expect(page).to have_content("Motif C (Sur place)")
+
+      # retour au choix de motif
+      click_on("Motif C")
+      expect(page).to have_content("Sélectionnez le motif de votre RDV")
+    end
+  end
 end


### PR DESCRIPTION
Il y a un bug lors de la prise de RDVs par un usager. En passant par le lien du CnFS, une fois avoir renseigné motif, lieux et créneaux , l'usager n'a pas la possibilité de modifier son parcours. Il s'agit du ticket : https://zammad10.ethibox.fr/#ticket/zoom/3215 

Cette PR ajoute deux tests qui reproduisent le bug dans deux cas de figure, et les correctifs correspondants.
Le dernier commit est une correction d'orthographe remontée par le cnfs dans le même mail.