### PR TITLE
Bugfix: la mise en cache d'objets `ActiveRecord` cause parfois un crash

### DIFF
--- a/app/controllers/admin/agents/absences_controller.rb
+++ b/app/controllers/admin/agents/absences_controller.rb
@@ -9,10 +9,7 @@ class Admin::Agents::AbsencesController < ApplicationController
     @organisation = Organisation.find(params[:organisation_id])
 
     absences = policy_scope_admin(Absence).includes(:organisation).where(agent: agent)
-    # Cache occurrences for this relation
-    @absence_occurrences = cache([absences, :all_occurrences_for, date_range_params]) do
-      absences.all_occurrences_for(date_range_params)
-    end
+    @absence_occurrences = absences.all_occurrences_for(date_range_params)
   end
 
   private
@@ -22,6 +19,7 @@ class Admin::Agents::AbsencesController < ApplicationController
     end_param = Date.parse(params[:end])
     start_param..end_param
   end
+  helper_method :date_range_params
 
   def pundit_user
     AgentContext.new(current_agent)

--- a/app/controllers/admin/agents/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/agents/plage_ouvertures_controller.rb
@@ -7,10 +7,7 @@ class Admin::Agents::PlageOuverturesController < ApplicationController
   def index
     @agent = Agent.find(params[:agent_id])
     @organisation = Organisation.find(params[:organisation_id])
-    # Cache occurrences for this relation
-    @plage_ouverture_occurrences = cache([plage_ouvertures, :all_occurrences_for, date_range_params]) do
-      plage_ouvertures.all_occurrences_for(date_range_params)
-    end
+    @plage_ouverture_occurrences = plage_ouvertures.all_occurrences_for(date_range_params)
   end
 
   private
@@ -33,6 +30,7 @@ class Admin::Agents::PlageOuverturesController < ApplicationController
     end_param = Date.parse(params[:end])
     start_param..end_param
   end
+  helper_method :date_range_params
 
   def pundit_user
     AgentContext.new(current_agent)

--- a/app/views/admin/agents/absences/index.json.jbuilder
+++ b/app/views/admin/agents/absences/index.json.jbuilder
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-json.array! @absence_occurrences do |absence, occurrence|
-  json.title absence.title
-  json.start occurrence.starts_at.as_json
-  json.end occurrence.ends_at.as_json
-  json.backgroundColor "rgba(127, 140, 141, 0.7)"
+json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params], expires_in: 8.hours do
+  json.array! @absence_occurrences do |absence, occurrence|
+    json.title absence.title
+    json.start occurrence.starts_at.as_json
+    json.end occurrence.ends_at.as_json
+    json.backgroundColor "rgba(127, 140, 141, 0.7)"
 
-  # url pour éditer l'absence
-  # TODO trouver un meilleur nom à cet attribut pour en plus avoir besoin de ce commentaire
-  json.url edit_admin_organisation_absence_path(absence.organisation, absence) if absence.organisation == @organisation
+    # url pour éditer l'absence
+    # TODO trouver un meilleur nom à cet attribut pour en plus avoir besoin de ce commentaire
+    json.url edit_admin_organisation_absence_path(absence.organisation, absence) if absence.organisation == @organisation
 
-  json.extendedProps do
-    json.organisationName absence.organisation.name
+    json.extendedProps do
+      json.organisationName absence.organisation.name
+    end
   end
 end

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
-  json.title plage_ouverture.title
-  json.start occurrence.starts_at.as_json
-  json.end occurrence.ends_at.as_json
-  if plage_ouverture.organisation == @organisation
-    json.backgroundColor "#6fceff80"
-  else
-    json.backgroundColor "grey"
-  end
-  json.textColor "#313131"
-  json.rendering "background" if params[:in_background]
+json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params], expires_in: 8.hours do
+  json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
+    json.title plage_ouverture.title
+    json.start occurrence.starts_at.as_json
+    json.end occurrence.ends_at.as_json
+    if plage_ouverture.organisation == @organisation
+      json.backgroundColor "#6fceff80"
+    else
+      json.backgroundColor "grey"
+    end
+    json.textColor "#313131"
+    json.rendering "background" if params[:in_background]
 
-  json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
-  json.extendedProps do
-    json.organisationName plage_ouverture.organisation.name
-    json.location plage_ouverture.lieu_address
-    json.lieu plage_ouverture.lieu_name
+    json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
+    json.extendedProps do
+      json.organisationName plage_ouverture.organisation.name
+      json.location plage_ouverture.lieu_address
+      json.lieu plage_ouverture.lieu_name
+    end
   end
 end

--- a/spec/controllers/admin/agents/absences_controller_spec.rb
+++ b/spec/controllers/admin/agents/absences_controller_spec.rb
@@ -33,6 +33,33 @@ describe Admin::Agents::AbsencesController, type: :controller do
 
         expect(assigns(:absence_occurrences)).not_to be_nil
       end
+
+      describe "JSON response" do
+        render_views
+
+        let!(:absence) { create(:absence, agent: agent, first_day: Time.zone.today, organisation: organisation) }
+
+        it "is serialized for FullCalendar" do
+          start_date = Time.zone.today.monday
+          end_date = start_date.end_of_week
+
+          get :index, params: { agent_id: agent.id, organisation_id: organisation.id, start: start_date, end: end_date, format: :json }
+
+          expected_response = [
+            {
+              "title" => absence.title,
+              "start" => absence.starts_at.as_json,
+              "end" => absence.ends_at.as_json,
+              "backgroundColor" => "rgba(127, 140, 141, 0.7)",
+              "url" => "/admin/organisations/#{organisation.id}/absences/#{absence.id}/edit",
+              "extendedProps" => {
+                "organisationName" => organisation.name,
+              },
+            },
+          ]
+          expect(JSON.parse(response.body)).to eq(expected_response)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
@@ -36,6 +36,36 @@ describe Admin::Agents::PlageOuverturesController, type: :controller do
         get :index, params: { agent_id: agent.id, organisation_id: organisation.id, start: start_date, end: end_date, format: :json }
         expect(assigns(:organisation)).to eq(organisation)
       end
+
+      describe "JSON response" do
+        render_views
+
+        let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, first_day: Time.zone.today, organisation: organisation) }
+
+        it "is serialized for FullCalendar" do
+          start_date = Time.zone.today.monday
+          end_date = start_date.end_of_week
+
+          get :index, params: { agent_id: agent.id, organisation_id: organisation.id, start: start_date, end: end_date, format: :json }
+
+          expected_response = [
+            {
+              "title" => plage_ouverture.title,
+              "start" => plage_ouverture.starts_at.as_json,
+              "end" => plage_ouverture.ends_at.as_json,
+              "backgroundColor" => "#6fceff80",
+              "textColor" => "#313131",
+              "url" => "/admin/organisations/#{organisation.id}/plage_ouvertures/#{plage_ouverture.id}",
+              "extendedProps" => {
+                "organisationName" => organisation.name,
+                "location" => "1 rue de l'adresse 12345 Ville",
+                "lieu" => plage_ouverture.lieu.name,
+              },
+            },
+          ]
+          expect(JSON.parse(response.body)).to eq(expected_response)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Suite au déploiement de la PR #3050 (dans laquelle on met à jour Ruby et plein de gems), les requêtes de FullCalendar vers `Admin::Agents::PlageOuverturesController#index` et `Admin::Agents::AbsencesController#index` on commencé à échouer en remontant l'erreur :

> can't dump hash with default proc

Une [explication complète de cette erreur sur StackOverflow](https://stackoverflow.com/a/6392704/2864020) indique que la cause est qu'il est impossible de Marshal des objets (pour les mettre en cache par exemple) si ils ont pour variable d'instance des `proc`. Les objets `ActiveRecord` étant souvent dans ce cas, il est déconseillé de vouloir mettre ce type d'objet en cache.

Cette propose donc de mettre en case la réponse JSON de ces endpoints, plutôt que de mettre en cache les records.

Note : je ne suis pas parvenu à reproduire le crash ni en local ni en démo, mais je suspecte que ce soit la montée de ruby 3.1.1 -> 3.1.2 qui ait causé une erreur de marshalling. Je crois savoir que les changements de version de ruby sont souvent la cause de ces erreurs. La solution ici proposée s'affranchit de ce risque puisque l'on met une `String` (JSON) dans le cache.

Note 2 : après réflexion, la cause la plus probable du crash est qu'une gem mise à jour dans la PR introduise l'usage d'un `Hash` avec un `default_proc` qui serait inclus dans les objets mis en cache. Difficile à dire sans parvenir à reproduire l'erreur :thinking: 

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
