### PR TITLE
Amélioration de la lisibilité des avertissement

### DIFF
--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -9,7 +9,7 @@
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
-      small.form-text.text-muted.mb-2 Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
+      small.form-text.text-muted.mb-3 Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
       = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
       .d-flex.justify-content-between
         div

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,14 +1,15 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
-  .mb-1 Avertissements :
-  .alert.alert-warning.show
-    ul.m-0.pl-1
+  .alert.alert-warning.show.mb-0
+    ul.m-0.pl-1.list-unstyled
       - model.benign_errors.each do |msg|
-        li= msg.html_safe
+        li
+          i.fa-solid.fa-triangle-exclamation.mr-2
+          = msg.html_safe
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
-      .text-muted Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
+      small.form-text.text-muted.mb-2 Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
       = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
       .d-flex.justify-content-between
         div


### PR DESCRIPTION
Dans le cadre de la réservation par les prescripteurs, on utilise le partial de benign errors qui est bien pratique pour afficher des avertissements. A l'usage, on s'est rendu compte qu'il était parfois difficile à lire, et on propose donc ici quelques modifications de design pour améliorer ça.

Avant : 
<img width="784" alt="Capture d’écran 2022-11-14 à 10 10 00" src="https://user-images.githubusercontent.com/1840367/201621423-84590b45-f268-4132-b20b-0b346668e4f2.png">


Après : 
<img width="789" alt="Capture d’écran 2022-11-14 à 10 11 43" src="https://user-images.githubusercontent.com/1840367/201621447-93cdcb27-5a5f-4e04-aeeb-1319cb05fce2.png">


Il y a deux modifications :
- Pour mettre moins de texte mais quand même faire comprendre qu'il s'agit d'avertissements, on remplace le petit texte `Avertissement :` par des icônes `⚠️`
- Pour clarifier quelles sont les actions possibles, on change le style du texte d'explication pour utiliser le même style que les hints sur les champs de formulaire, et on ajoute un peu d'espace entre ce texte et les cta.
