### PR TITLE
Correction d'une flaky spec d'accessibilité

### DIFF
--- a/app/views/admin/agents/rdvs/index.json.jbuilder
+++ b/app/views/admin/agents/rdvs/index.json.jbuilder
@@ -23,6 +23,6 @@ json.array! @rdvs do |rdv|
     json.backgroundColor rdv.motif&.color
   else
     json.textColor "white"
-    json.backgroundColor "darkgrey"
+    json.backgroundColor "darkergrey"
   end
 end

--- a/app/views/admin/agents/rdvs/index.json.jbuilder
+++ b/app/views/admin/agents/rdvs/index.json.jbuilder
@@ -23,6 +23,6 @@ json.array! @rdvs do |rdv|
     json.backgroundColor rdv.motif&.color
   else
     json.textColor "white"
-    json.backgroundColor "darkergrey"
+    json.backgroundColor "#757575" # Use a dark enough gray to be accessible
   end
 end

--- a/config/initializers/css_color_names.rb
+++ b/config/initializers/css_color_names.rb
@@ -28,7 +28,6 @@ CSS_COLOR_NAMES = {
   "darkgray" => "#a9a9a9",
   "darkgreen" => "#006400",
   "darkgrey" => "#a9a9a9",
-  "darkergrey" => "#898989",
   "darkkhaki" => "#bdb76b",
   "darkmagenta" => "#8b008b",
   "darkolivegreen" => "#556b2f",

--- a/config/initializers/css_color_names.rb
+++ b/config/initializers/css_color_names.rb
@@ -28,6 +28,7 @@ CSS_COLOR_NAMES = {
   "darkgray" => "#a9a9a9",
   "darkgreen" => "#006400",
   "darkgrey" => "#a9a9a9",
+  "darkergrey" => "#898989",
   "darkkhaki" => "#bdb76b",
   "darkmagenta" => "#8b008b",
   "darkolivegreen" => "#556b2f",

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -24,7 +24,11 @@ describe "agents page", js: true do
     login_as agent
 
     path = admin_organisation_agent_agenda_path(organisation, agent)
-    expect_page_to_be_axe_clean(path)
+
+    visit path
+    expect(page).to have_current_path(path)
+    expect(page).to have_content(Rdv.last.users.last.full_name)
+    expect(page).to be_axe_clean
   end
 
   it "admin organisation plage_ouvertures path is accessible" do


### PR DESCRIPTION
Comme indiqué dans https://github.com/betagouv/rdv-solidarites.fr/pull/3059, la spec était souvent au vert parce que le test d'accessibilité était fait avant que les rdvs ne soient chargés en ajax.

Lorsque les rdvs avaient le temps de charger, on avait alors une erreur à juste titre : le fond gris était trop clair pour être accessible.

Cette PR modifie la spec pour qu'elle échoue de façon fiable, et met un gris plus sombre pour rendre le texte lisible.