### PR TITLE
Permettre aux usagers non connectés de s'inscrire et d'annuler leur participation à un rdv collectif (via le token)

### DIFF
--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -1,42 +1,70 @@
 # frozen_string_literal: true
 
 class Users::ParticipationsController < UserAuthController
+  before_action :set_rdv, :set_user
+
+  include TokenInvitable
+
   def index
     @rdv = policy_scope(Rdv).find(params[:rdv_id])
   end
 
   def new
-    add_participation_for(params)
+    add_participation
   end
 
   def create
-    add_participation_for(params)
+    add_participation
+  end
+
+  def cancel
+    remove_participation
   end
 
   private
 
-  def add_participation_for(params)
-    rdv = Rdv.find(params[:rdv_id])
-    user = User.find(params[:user_id]) if params[:user_id].present?
-    user ||= current_user
+  def set_rdv
+    @rdv = Rdv.find(params[:rdv_id])
+  end
+
+  def set_user
+    @user = User.find(params[:user_id]) if params[:user_id].present?
+    @user ||= current_user
     # C'est plus une mise à jour de la participation que vraiment une création
     # d'un point de vue des autorisations
-    authorize(user, :update?)
+    authorize(@user, :update?)
+  end
 
-    if rdv.users.include?(user.id)
+  def add_participation
+    if existing_participation.present? && !existing_participation.excused?
       flash[:notice] = "Usager déjà inscrit pour cet atelier."
-      redirect_to users_rdv_path(rdv) and return
-    end
-
-    if rdv.motif.collectif?
-      rdv.users = rdv.users - current_user.self_and_relatives
-      rdv.users << user
+      redirect_to users_rdv_path(@rdv, invitation_token: @rdv.rdv_user_token(current_user.id))
+    elsif existing_participation.present? && existing_participation.excused?
+      existing_participation.change_status_and_notify(current_user, "unknown")
+      flash[:notice] = "Ré-Inscription confirmée"
+      redirect_to users_rdv_path(@rdv, invitation_token: existing_participation.rdv_user_token)
     else
-      rdv.users = [user]
+      rdvs_users = @rdv.rdvs_users.to_a
+      rdvs_users.reject! { |rdv_user| rdv_user.user_id.in? current_user.self_and_relatives.map(&:id) }
+      rdvs_users << RdvsUser.new(rdv: @rdv, user: @user)
+      @rdv.update_and_notify(current_user, rdvs_users: rdvs_users)
+      flash[:notice] = "Inscription confirmée"
+      redirect_to users_rdv_path(@rdv, invitation_token: @rdv.rdv_user_token(current_user.id))
     end
-    rdv.save
+  end
 
-    flash[:notice] = "Inscription confirmée"
-    redirect_to users_rdv_path(rdv)
+  def remove_participation
+    if existing_participation.nil?
+      flash[:notice] = "Cet utilisateur n'est pas inscrit à cet atelier"
+      redirect_to users_rdv_path(@rdv, invitation_token: @rdv.rdv_user_token(current_user.id))
+    else
+      existing_participation.change_status_and_notify(current_user, "excused")
+      flash[:notice] = "Désinscription de l'atelier confirmée"
+      redirect_to users_rdv_path(@rdv, invitation_token: existing_participation.rdv_user_token)
+    end
+  end
+
+  def existing_participation
+    @existing_participation ||= @rdv.rdvs_users.find_by(user: @user)
   end
 end

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -32,6 +32,7 @@ class Users::ParticipationsController < UserAuthController
     @user ||= current_user
     # C'est plus une mise à jour de la participation que vraiment une création
     # d'un point de vue des autorisations
+    # participation scope à revoir
     authorize(@user, :update?)
   end
 

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -41,6 +41,7 @@ class Users::ParticipationsController < UserAuthController
       redirect_to users_rdv_path(@rdv, invitation_token: @rdv.rdv_user_token(current_user.id))
     elsif existing_participation.present? && existing_participation.excused?
       existing_participation.change_status_and_notify(current_user, "unknown")
+      set_user_name_initials_verified
       flash[:notice] = "Ré-Inscription confirmée"
       redirect_to users_rdv_path(@rdv, invitation_token: existing_participation.rdv_user_token)
     else
@@ -48,6 +49,7 @@ class Users::ParticipationsController < UserAuthController
       rdvs_users.reject! { |rdv_user| rdv_user.user_id.in? current_user.self_and_relatives.map(&:id) }
       rdvs_users << RdvsUser.new(rdv: @rdv, user: @user)
       @rdv.update_and_notify(current_user, rdvs_users: rdvs_users)
+      set_user_name_initials_verified
       flash[:notice] = "Inscription confirmée"
       redirect_to users_rdv_path(@rdv, invitation_token: @rdv.rdv_user_token(current_user.id))
     end
@@ -59,6 +61,7 @@ class Users::ParticipationsController < UserAuthController
       redirect_to users_rdv_path(@rdv, invitation_token: @rdv.rdv_user_token(current_user.id))
     else
       existing_participation.change_status_and_notify(current_user, "excused")
+      set_user_name_initials_verified
       flash[:notice] = "Désinscription de l'atelier confirmée"
       redirect_to users_rdv_path(@rdv, invitation_token: existing_participation.rdv_user_token)
     end

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -3,7 +3,7 @@
 class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
-    :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code,
+    :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code, :rdv_id,
     :street_ban_id, :invitation_token, :address, :motif_search_terms, :organisation_id, { organisation_ids: [] },
   ].freeze
   after_action :allow_iframe
@@ -15,7 +15,7 @@ class Users::RdvWizardStepsController < UserAuthController
     @rdv_wizard = rdv_wizard_for(current_user, query_params)
     @rdv = @rdv_wizard.rdv
     authorize(@rdv)
-    if @rdv_wizard.creneau.present?
+    if @rdv_wizard.creneau.present? || params[:rdv_id].present? || @rdv_wizard.rdv.persisted?
       render current_step
     else
       flash[:error] = "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre."

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -12,17 +12,20 @@ module UserRdvWizard
 
     delegate :motif, :starts_at, :users, :service, to: :rdv
     delegate :errors, to: :rdv
-    delegate :lieu_full_name, to: :creneau
 
     def initialize(user, attributes)
       @user = user
       @attributes = attributes.to_h.symbolize_keys
       rdv_defaults = { user_ids: [user&.id] }
-      @rdv = Rdv.new(
-        rdv_defaults
-          .merge(@attributes.slice(:starts_at, :user_ids, :motif_id))
-      )
-      @rdv.duration_in_min ||= @rdv.motif.default_duration_in_min if @rdv.motif.present?
+      if attributes[:rdv_id].present?
+        @rdv = Rdv.find(attributes[:rdv_id])
+      else
+        @rdv = Rdv.new(
+          rdv_defaults
+            .merge(@attributes.slice(:starts_at, :user_ids, :motif_id))
+        )
+        @rdv.duration_in_min ||= @rdv.motif.default_duration_in_min if @rdv.motif.present?
+      end
     end
 
     def invitation?
@@ -53,7 +56,7 @@ module UserRdvWizard
 
     def to_query
       { motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: rdv.users&.map(&:id) }
-        .merge(@attributes.slice(:where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id, :invitation_token, :address, :organisation_ids, :motif_search_terms))
+        .merge(@attributes.slice(:where, :rdv_id, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id, :invitation_token, :address, :organisation_ids, :motif_search_terms))
     end
 
     def to_search_query

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -18,6 +18,7 @@ module UserRdvWizard
       @attributes = attributes.to_h.symbolize_keys
       rdv_defaults = { user_ids: [user&.id] }
       if attributes[:rdv_id].present?
+        # Droits d'accés ? : S'inscrire à un RDV : Collectif ou déjà dans le rdv ou invité dessus.
         @rdv = Rdv.find(attributes[:rdv_id])
       else
         @rdv = Rdv.new(

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -160,7 +160,7 @@ class Rdv < ApplicationRecord
   end
 
   def cancellable_by_user?
-    !cancelled? && !collectif? && motif.rdvs_cancellable_by_user? && starts_at > 4.hours.from_now
+    !cancelled? && motif.rdvs_cancellable_by_user? && starts_at > 4.hours.from_now
   end
 
   def editable_by_user?

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -73,6 +73,10 @@ class RdvsUser < ApplicationRecord
     status.in? NOT_CANCELLED_STATUSES
   end
 
+  def cancelled?
+    status.in? CANCELLED_STATUSES
+  end
+
   def set_default_notifications_flags
     return if rdv&.motif.nil?
 

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -24,6 +24,7 @@ class RdvsUser < ApplicationRecord
   # Hooks
   after_initialize :set_default_notifications_flags
   before_validation :set_default_notifications_flags
+  # Pose problème : unknown par défaut et recalcul du statut du rdv ?
   before_create :set_status_from_rdv
   after_save :update_counter_cache
   after_destroy :update_counter_cache

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -69,6 +69,10 @@ class RdvsUser < ApplicationRecord
     end
   end
 
+  def not_cancelled?
+    status.in? NOT_CANCELLED_STATUSES
+  end
+
   def set_default_notifications_flags
     return if rdv&.motif.nil?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,7 +145,7 @@ class User < ApplicationRecord
   end
 
   def participation_for(rdv)
-    rdv.rdvs_users.to_a.find { |participation| participation.user_id == id }
+    rdv.rdvs_users.to_a.find { |participation| participation.user_id.in?(self_and_relatives_and_responsible.map(&:id)) }
   end
 
   def deleted_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,6 +144,10 @@ class User < ApplicationRecord
     @profiles[organisation]
   end
 
+  def participation_for(rdv)
+    rdv.rdvs_users.to_a.find { |participation| participation.user_id == id }
+  end
+
   def deleted_email
     "user_#{id}@deleted.rdv-solidarites.fr"
   end

--- a/app/policies/user/rdv_policy.rb
+++ b/app/policies/user/rdv_policy.rb
@@ -22,6 +22,11 @@ class User::RdvPolicy < ApplicationPolicy
     show? && record.cancellable_by_user?
   end
 
+  def cancel_participation?
+    existing_participation = record.rdvs_users.find_by(user: current_user)
+    cancel? && existing_participation.present? && existing_participation.not_cancelled?
+  end
+
   def edit?
     show? && record.editable_by_user?
   end

--- a/app/policies/user/rdv_policy.rb
+++ b/app/policies/user/rdv_policy.rb
@@ -4,6 +4,8 @@ class User::RdvPolicy < ApplicationPolicy
   alias current_user pundit_user
 
   def rdv_belongs_to_user_or_relatives?
+    return true if record.collectif?
+
     (record.user_ids & current_user.available_users_for_rdv.pluck(:id)).any?
   end
 
@@ -23,7 +25,7 @@ class User::RdvPolicy < ApplicationPolicy
   end
 
   def cancel_participation?
-    existing_participation = record.rdvs_users.find_by(user: current_user)
+    existing_participation = current_user.participation_for(record)
     cancel? && existing_participation.present? && existing_participation.not_cancelled?
   end
 

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -2,6 +2,7 @@
 
 class Notifiers::RdvBase < ::BaseService
   include DateHelper
+  attr_reader :rdv_users_tokens_by_user_id
 
   # Base class for Rdv notifiers.
   # Subclasses implement the notify_* methods:

--- a/app/services/notifiers/rdv_collectif_participations.rb
+++ b/app/services/notifiers/rdv_collectif_participations.rb
@@ -12,7 +12,7 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
 
     # FIXME: this is not ideal but it's the simplest workaround to avoid notifying the agent
     rdv_created = Notifiers::RdvCreated.new(@rdv, @author, new_participants_to_notify)
-    rdv_created_invitation_tokens = rdv_created.generate_invitation_tokens
+    rdv_created.generate_invitation_tokens
     rdv_created.notify_users_by_mail
     rdv_created.notify_users_by_sms
 
@@ -21,7 +21,7 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
     rdv_cancelled.notify_users_by_mail
     rdv_cancelled.notify_users_by_sms
 
-    rdv_created_invitation_tokens
+    rdv_created.rdv_users_tokens_by_user_id
   end
 
   private

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -17,6 +17,7 @@
       i.fa.fa-fw.fa-users>
       = show_participants_count(rdv)
 
+  / au moins une personne participe
   .card-footer
     - if current_user.participation_for(rdv) && current_user.participation_for(rdv).not_cancelled?
       .text-muted Vous êtes déjà inscrit pour cet atelier.

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -21,6 +21,6 @@
     - if current_user.participation_for(rdv) && current_user.participation_for(rdv).not_cancelled?
       .text-muted Vous êtes déjà inscrit pour cet atelier.
     - else
-      = link_to new_users_rdv_participation_path(rdv), class: "d-flex card-text mb-2" do
+      = link_to new_users_rdv_wizard_step_path(@context.query.merge(rdv_id: rdv.id)), class: "d-flex card-text mb-2" do
         i.fa.fa-fw.fa-user-plus>
         | &nbsp;S'inscrire

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -18,7 +18,7 @@
       = show_participants_count(rdv)
 
   .card-footer
-    - if current_user&.rdvs&.include?(rdv)
+    - if current_user.participation_for(rdv) && current_user.participation_for(rdv).not_cancelled?
       .text-muted Vous êtes déjà inscrit pour cet atelier.
     - else
       = link_to new_users_rdv_participation_path(rdv), class: "d-flex card-text mb-2" do

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -22,7 +22,7 @@ ul.list-group.list-group-flush
         .col
           i.fa.fa-check.fa-fw.mr-1.text-success
           | Lieu :&nbsp;
-          = rdv_wizard.lieu_full_name
+          = rdv_wizard.creneau&.lieu_full_name || rdv_wizard.rdv.lieu.full_name
         - unless rdv_wizard.invitation?
           .col-auto
             = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -6,7 +6,7 @@
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
-        = simple_form_for(@rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv))) do |f|
+        = simple_form_for(@rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv)), method: :post) do |f|
 
           = f.association :motif, as: :hidden, wrapper_html: { class: "mb-0" }
           = f.input :starts_at, as: :hidden, wrapper_html: { class: "mb-0" }

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -7,4 +7,7 @@
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
         .col.text-center
-            = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary"
+        - if @rdv_wizard.rdv.persisted?
+          = link_to "Confirmer ma participation", new_users_rdv_participation_path(@rdv_wizard.rdv), method: :get, class: "btn btn-primary"
+        - else
+          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary"

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -26,7 +26,7 @@ ul.list-group.list-group-flush
   li.list-group-item
     .fa.fa-user>
     = users_to_sentence(rdv.users)
-    - if current_user.present? && !current_user.only_invited?
+    - if current_user.present? && !current_user.only_invited? && current_user.participation_for(rdv).not_cancelled? && !rdv.in_the_past?
       span>
       = link_to t(".change_participant"), users_rdv_participations_path(rdv)
       .fa.fa-edit<
@@ -45,6 +45,11 @@ ul.list-group.list-group-flush
     li.list-group-item.font-italic
       i.fa.fa-ban>
       | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
+
+- if rdv.collectif? && current_user.participation_for(rdv).cancelled?
+  li.list-group-item.font-italic
+    i.fa.fa-ban>
+    | Votre participation à ce rdv a été annulé.
 
 .py-2.d-flex.justify-content-between.align-items-center
   .text-left.mt-2

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -26,9 +26,10 @@ ul.list-group.list-group-flush
   li.list-group-item
     .fa.fa-user>
     = users_to_sentence(rdv.users)
-    span>
-    = link_to t(".change_participant"), users_rdv_participations_path(rdv)
-    .fa.fa-edit<
+    - if current_user.present? && !current_user.only_invited?
+      span>
+      = link_to t(".change_participant"), users_rdv_participations_path(rdv)
+      .fa.fa-edit<
   - if @can_see_rdv_motif
     li.list-group-item
       i.fa.fa-info-circle>
@@ -50,8 +51,10 @@ ul.list-group.list-group-flush
     - if policy([:user, rdv]).edit?
        = link_to "Déplacer le RDV", creneaux_users_rdv_path(rdv), class: "btn btn-outline-primary"
   .text-right.mt-2
-    - if policy([:user, rdv]).cancel?
+    - if policy([:user, rdv]).cancel? && !rdv.collectif?
         = link_to "Annuler le RDV", "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: "btn btn-outline-danger"
+    - if policy([:user, rdv]).cancel_participation? && rdv.collectif?
+        = link_to "Annuler votre participation au RDV", "#", data: { toggle: "modal", target: "#js-cancel-participation-modal-#{rdv.id}" }, class: "btn btn-outline-danger"
 
 = render( \
   "common/modal_confirmation", \
@@ -60,5 +63,15 @@ ul.list-group.list-group-flush
   cancel_message: "Non", \
   confirm_path: cancel_users_rdv_path(rdv), \
   confirm_message: "Oui, annuler le RDV", \
+  confirm_link_options: { class: "btn btn-danger", method: :put } \
+)
+
+= render( \
+  "common/modal_confirmation", \
+  id: "js-cancel-participation-modal-#{rdv.id}", \
+  body_message: rdv.motif.cancellation_warning, \
+  cancel_message: "Non", \
+  confirm_path: users_rdv_participations_cancel_path(rdv), \
+  confirm_message: "Oui, annuler votre participation RDV", \
   confirm_link_options: { class: "btn btn-danger", method: :put } \
 )

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -26,6 +26,7 @@ ul.list-group.list-group-flush
   li.list-group-item
     .fa.fa-user>
     = users_to_sentence(rdv.users)
+    / Au moins une personne participe
     - if current_user.present? && !current_user.only_invited? && current_user.participation_for(rdv).not_cancelled? && !rdv.in_the_past?
       span>
       = link_to t(".change_participant"), users_rdv_participations_path(rdv)
@@ -46,6 +47,7 @@ ul.list-group.list-group-flush
       i.fa.fa-ban>
       | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
 
+/ tt le monde annule / Pas une seule personne participe, mettre la methode dans rdv ? renvoyer le boolean directement, dont ask, tell
 - if rdv.collectif? && current_user.participation_for(rdv).cancelled?
   li.list-group-item.font-italic
     i.fa.fa-ban>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
     resource :rdv_wizard_step, only: %i[new create]
     resources :rdvs, only: %i[index create show edit update] do
       resources :participations, only: %i[index new create]
+      put "participations/cancel", to: "participations#cancel"
+
       member do
         get :creneaux
         put :cancel


### PR DESCRIPTION
Cette PR couvre trop de perimetres différents et va être redécoupée plus fermée.

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3056 https://github.com/betagouv/rdv-solidarites.fr/issues/3002 https://github.com/betagouv/rdv-solidarites.fr/issues/3101

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
