### PR TITLE
:memo:  Ajout d'une section de doc sur les pratiques de merge de PRs

### DIFF
--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -96,3 +96,5 @@ Note : il est possible de réécrire son historique de commits juste avant de me
 Un point d'attention : si vous avez mergé la branche `production` dans votre branche de feature pendant la vie de votre PR, veillez à ce que ces commits de merge ne finissent pas dans `production`. Pour ce faire :
 - si vous utilisez un squash merge, ces commits vont disparaître
 - si vous mergez dans `production` le plus pratique est de rebase votre branche sur `prodcution` avant de merger.
+
+Note : lorsque votre feature branch n'est plus à jour par rapport à `production`, GitHub affiche un avertissement "This branch is out-of-date with the base branch" et vous propose de remédier à la situation. Ce faisant, on déclenche une CI qui teste le code tel qu'il serait s'il était mergé. Si cette CI passe, on peut alors merger.

--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -79,3 +79,16 @@ bin/rspec file_path/file_name_spec.rb
 ```bash
 bin/rspec file_path/file_name_spec.rb:line_number
 ```
+
+## Workflow de merge des pull requests
+
+Afin de garder un historique git lisible et navigable par `git blame`, nous recommandons l'une de ces deux façons de merger une PR :
+
+- Utiliser _"Squash and merge"_ si les commits de la PR n'apportent pas individuellement de valeur explicative sur le contexte.
+- Utiliser _"Create a merge commit"_ si la PR contient des commits qui permettent de mieux comprendre les différents changements indépendants introduits dans la PR.
+
+Au sein de notre projet, il est assumé que la majorité du contexte autour du changement est trouvable dans la PR et non dans les commits. Cependant, il est tout à fait possible de conserver ses commits si on les a bien créés pour qu'ils permettent d'obtenir rapidement une synthèse du contexte via `git blame`.
+
+Par exemple, si au sein d'une même PR on effectue un (petit 🤞) refactor puis une évolution fonctionnelle, il est apprécié que le refactor fasse l'objet d'un commit séparé.
+
+Note : il est possible de réécrire son historique de commits juste avant de merger, si des commits correctifs ont été ajoutés durant la revue.

--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -92,3 +92,7 @@ Au sein de notre projet, il est assumé que la majorité du contexte autour du c
 Par exemple, si au sein d'une même PR on effectue un (petit 🤞) refactor puis une évolution fonctionnelle, il est apprécié que le refactor fasse l'objet d'un commit séparé.
 
 Note : il est possible de réécrire son historique de commits juste avant de merger, si des commits correctifs ont été ajoutés durant la revue.
+
+Un point d'attention : si vous avez mergé la branche `production` dans votre branche de feature pendant la vie de votre PR, veillez à ce que ces commits de merge ne finissent pas dans `production`. Pour ce faire :
+- si vous utilisez un squash merge, ces commits vont disparaître
+- si vous mergez dans `production` le plus pratique est de rebase votre branche sur `prodcution` avant de merger.


### PR DESCRIPTION
Suite aux discussions sur nos pratiques de merge de PR de jeudi dernier, je propose ici une doc, qui pourra servir de base à des discussions au prochain point tech.

Une lecture utile pour comprendre les options offertes par GitHub : https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#squashing-your-merge-commits

