### PR TITLE
Bugfix: un agent peut passer un paramètre HTTP pour exporter une orga arbitraire

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -109,13 +109,13 @@ class Admin::RdvsController < AgentAuthController
   def set_scoped_organisations
     @scoped_organisations = if params[:scoped_organisation_id].blank?
                               # l'agent n'a pas accès au filtre d'organisations ou a rénitialisé la page
-                              Organisation.where(id: current_organisation.id)
+                              policy_scope(Organisation).where(id: current_organisation.id)
                             elsif params[:scoped_organisation_id] == "0"
                               # l'agent a sélectionné 'Toutes'
-                              current_agent.organisations
+                              policy_scope(Organisation)
                             else
                               # l'agent a sélectionné une organisation spécifique
-                              current_agent.organisations.where(id: parsed_params["scoped_organisation_id"])
+                              policy_scope(Organisation).where(id: parsed_params["scoped_organisation_id"])
                             end
   end
 

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -108,7 +108,7 @@ class Admin::RdvsController < AgentAuthController
 
   def set_scoped_organisations
     @scoped_organisations = if params[:scoped_organisation_id].blank?
-                              # l'agent n'a pas accès au filtre d'organisations ou a rénitialisé la page
+                              # l'agent n'a pas accès au filtre d'organisations ou a réinitialisé la page
                               policy_scope(Organisation).where(id: current_organisation.id)
                             elsif params[:scoped_organisation_id] == "0"
                               # l'agent a sélectionné 'Toutes'
@@ -117,6 +117,9 @@ class Admin::RdvsController < AgentAuthController
                               # l'agent a sélectionné une organisation spécifique
                               policy_scope(Organisation).where(id: parsed_params["scoped_organisation_id"])
                             end
+
+    # An empty scope means the agent tried to access a foreign organisation
+    raise Pundit::NotAuthorizedError unless @scoped_organisations.any?
   end
 
   def set_optional_agent

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -109,7 +109,7 @@ class Admin::RdvsController < AgentAuthController
   def set_scoped_organisations
     @scoped_organisations = if params[:scoped_organisation_id].blank?
                               # l'agent n'a pas accès au filtre d'organisations ou a rénitialisé la page
-                              current_agent.organisations.where(id: current_organisation.id)
+                              Organisation.where(id: current_organisation.id)
                             elsif params[:scoped_organisation_id] == "0"
                               # l'agent a sélectionné 'Toutes'
                               current_agent.organisations

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -109,13 +109,13 @@ class Admin::RdvsController < AgentAuthController
   def set_scoped_organisations
     @scoped_organisations = if params[:scoped_organisation_id].blank?
                               # l'agent n'a pas accès au filtre d'organisations ou a rénitialisé la page
-                              Organisation.where(id: current_organisation.id)
+                              current_agent.organisations.where(id: current_organisation.id)
                             elsif params[:scoped_organisation_id] == "0"
                               # l'agent a sélectionné 'Toutes'
                               current_agent.organisations
                             else
                               # l'agent a sélectionné une organisation spécifique
-                              Organisation.where(id: parsed_params["scoped_organisation_id"])
+                              current_agent.organisations.where(id: parsed_params["scoped_organisation_id"])
                             end
   end
 

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -2,6 +2,8 @@
 
 class Agents::ExportMailer < ApplicationMailer
   def rdv_export(agent, organisation_ids, options)
+    raise "Agent does not belong to all requested organisation(s)" if (organisation_ids - agent.organisation_ids).any?
+
     @agent = agent
     now = Time.zone.now
     organisations = agent.organisations.where(id: organisation_ids)
@@ -27,6 +29,8 @@ class Agents::ExportMailer < ApplicationMailer
   end
 
   def rdvs_users_export(agent, organisation_ids, options)
+    raise "Agent does not belong to all requested organisation(s)" if (organisation_ids - agent.organisation_ids).any?
+
     @agent = agent
     now = Time.zone.now
     organisations = agent.organisations.where(id: organisation_ids)

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -4,7 +4,7 @@ class Agents::ExportMailer < ApplicationMailer
   def rdv_export(agent, organisation_ids, options)
     @agent = agent
     now = Time.zone.now
-    organisations = Organisation.where(id: organisation_ids)
+    organisations = agent.organisations.where(id: organisation_ids)
     rdvs = Rdv.search_for(organisations, options)
 
     # Le département du Var se base sur la position de chaque caractère du nom
@@ -29,7 +29,7 @@ class Agents::ExportMailer < ApplicationMailer
   def rdvs_users_export(agent, organisation_ids, options)
     @agent = agent
     now = Time.zone.now
-    organisations = Organisation.where(id: organisation_ids)
+    organisations = agent.organisations.where(id: organisation_ids)
 
     rdvs = Rdv.search_for(organisations, options)
     rdvs_users = RdvsUser.where(rdv_id: rdvs.ids)

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -169,7 +169,7 @@ describe Admin::RdvsController, type: :controller do
       expect(response).to redirect_to(admin_organisation_rdvs_path)
     end
 
-    it "call Agents::ExportMailer" do
+    it "sends export email" do
       params = {
         start: nil,
         end: nil,
@@ -180,23 +180,9 @@ describe Admin::RdvsController, type: :controller do
         status: "",
       }
 
-      # rubocop:disable RSpec/StubbedMock
-      expect(Agents::ExportMailer).to receive(:rdv_export).with(
-        agent,
-        [organisation.id],
-        {
-          "start" => params[:start],
-          "end" => params[:end],
-          "organisation_id" => params[:organisation_id],
-          "agent_id" => params[:agent_id],
-          "user_id" => params[:user_id],
-          "lieu_id" => params[:lieu_id],
-          "status" => params[:status],
-        }
-      ).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
-      # rubocop:enable RSpec/StubbedMock
-
-      post :export, params: { organisation_id: organisation.id }.merge(params)
+      expect do
+        post :export, params: { organisation_id: organisation.id }.merge(params)
+      end.to have_enqueued_mail(Agents::ExportMailer, :rdv_export).with(agent, [organisation.id], params.stringify_keys)
     end
   end
 
@@ -209,7 +195,7 @@ describe Admin::RdvsController, type: :controller do
         expect(response).to redirect_to(admin_organisation_rdvs_path)
       end
 
-      it "call Agents::ExportMailer" do
+      it "sends export email" do
         params = {
           start: nil,
           end: nil,
@@ -220,23 +206,9 @@ describe Admin::RdvsController, type: :controller do
           status: "",
         }
 
-        # rubocop:disable RSpec/StubbedMock
-        expect(Agents::ExportMailer).to receive(:rdvs_users_export).with(
-          agent,
-          [organisation.id],
-          {
-            "start" => params[:start],
-            "end" => params[:end],
-            "organisation_id" => params[:organisation_id],
-            "agent_id" => params[:agent_id],
-            "user_id" => params[:user_id],
-            "lieu_id" => params[:lieu_id],
-            "status" => params[:status],
-          }
-        ).and_return(instance_double(ActionMailer::MessageDelivery, deliver_later: nil))
-        # rubocop:enable RSpec/StubbedMock
-
-        post :rdvs_users_export, params: { organisation_id: organisation.id }.merge(params)
+        expect do
+          post :rdvs_users_export, params: { organisation_id: organisation.id }.merge(params)
+        end.to have_enqueued_mail(Agents::ExportMailer, :rdvs_users_export).with(agent, [organisation.id], params.stringify_keys)
       end
     end
   end

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -184,6 +184,22 @@ describe Admin::RdvsController, type: :controller do
         post :export, params: { organisation_id: organisation.id }.merge(params)
       end.to have_enqueued_mail(Agents::ExportMailer, :rdv_export).with(agent, [organisation.id], params.stringify_keys)
     end
+
+    context "when passing scoped_organisation_id param to which agent not belong" do
+      it "does not enqueue e-mail" do
+        other_organisation = create(:organisation)
+        params = {
+          organisation_id: organisation.id,
+          scoped_organisation_id: other_organisation.id,
+        }
+
+        expect do
+          post :export, params: params
+        end.not_to have_enqueued_mail
+
+        expect(response).to have_http_status(:redirect) # Pundit redirects when authorization fails
+      end
+    end
   end
 
   describe "POST #rdvs_users_export" do
@@ -209,6 +225,22 @@ describe Admin::RdvsController, type: :controller do
         expect do
           post :rdvs_users_export, params: { organisation_id: organisation.id }.merge(params)
         end.to have_enqueued_mail(Agents::ExportMailer, :rdvs_users_export).with(agent, [organisation.id], params.stringify_keys)
+      end
+
+      context "when passing scoped_organisation_id param to which agent not belong" do
+        it "does not enqueue e-mail" do
+          other_organisation = create(:organisation)
+          params = {
+            organisation_id: organisation.id,
+            scoped_organisation_id: other_organisation.id,
+          }
+
+          expect do
+            post :rdvs_users_export, params: params
+          end.not_to have_enqueued_mail
+
+          expect(response).to have_http_status(:redirect) # Pundit redirects when authorization fails
+        end
       end
     end
   end

--- a/spec/mailers/agents/export_mailer_spec.rb
+++ b/spec/mailers/agents/export_mailer_spec.rb
@@ -4,8 +4,8 @@ describe Agents::ExportMailer do
   describe "#rdv_export" do
     it "has an attachment file name which contains the current date without org ID when more than one orga" do
       organisation = create(:organisation)
-      agent = create(:agent, admin_role_in_organisations: [organisation])
       other_organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation, other_organisation])
       travel_to(Time.zone.parse("2022-09-14 09:00:00"))
 
       rdv_export = described_class.rdv_export(agent, [organisation.id, other_organisation.id], {})
@@ -26,6 +26,16 @@ describe Agents::ExportMailer do
 
       expect(rdv_export.attachments.first.filename).to eq("export-rdv-2022-09-14-org-#{organisation.id.to_s.rjust(6, '0')}.xls")
     end
+
+    it "prevents agent from exporting an org in which she does not belong" do
+      agents_org = create(:organisation)
+      not_agents_org = create(:organisation)
+      agent = create(:agent, organisations: [agents_org])
+
+      rdv_export = described_class.rdv_export(agent, [agents_org.id, not_agents_org.id], {})
+
+      expect { rdv_export.deliver_now }.to raise_error("Agent does not belong to all requested organisation(s)")
+    end
   end
 
   describe "#rdvs_users_export" do
@@ -37,6 +47,16 @@ describe Agents::ExportMailer do
       rdvs_users_export = described_class.rdvs_users_export(agent, [organisation.id], {})
 
       expect(rdvs_users_export.attachments.first.filename).to eq("export-rdvs-user-2022-09-14.xls")
+    end
+
+    it "prevents agent from exporting an org in which she does not belong" do
+      agents_org = create(:organisation)
+      not_agents_org = create(:organisation)
+      agent = create(:agent, organisations: [agents_org])
+
+      rdvs_users_export = described_class.rdvs_users_export(agent, [agents_org.id, not_agents_org.id], {})
+
+      expect { rdvs_users_export.deliver_now }.to raise_error("Agent does not belong to all requested organisation(s)")
     end
   end
 end


### PR DESCRIPTION
Il est possible pour un agent de fournir le paramètre `scoped_organisation_id` qu'il veut pour exporter les RDVs de cette orga. :scream: 

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
