### PR TITLE
Calcul de créneau : simplification de la manipulation des jours fériés

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -178,7 +178,7 @@ class Rdv < ApplicationRecord
 
   def creneaux_available(date_range)
     date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
-    SlotBuilder.available_slots(motif, lieu, date_range, OffDays.all_in_date_range(date_range))
+    SlotBuilder.available_slots(motif, lieu, date_range)
   end
 
   def user_for_home_rdv

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -11,7 +11,7 @@ module Users::CreneauxSearchConcern
     reduced_date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
     return [] if reduced_date_range.blank?
 
-    SlotBuilder.available_slots(motif, @lieu, reduced_date_range, OffDays.all_in_date_range(reduced_date_range), agents)
+    SlotBuilder.available_slots(motif, @lieu, reduced_date_range, agents)
   end
 
   protected

--- a/app/services/next_availability_service.rb
+++ b/app/services/next_availability_service.rb
@@ -11,7 +11,7 @@ class NextAvailabilityService
 
       max_creneau_date = [to, date + 7.days].min
 
-      creneaux = SlotBuilder.available_slots(motif, lieu, date..max_creneau_date, OffDays.all_in_date_range(date..max_creneau_date), agents)
+      creneaux = SlotBuilder.available_slots(motif, lieu, date..max_creneau_date, agents)
       # NOTE: We build the whole list of creneaux of the week just to return the first one.
       return creneaux.min_by(&:starts_at) if creneaux.any?
     end

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -9,7 +9,7 @@ class SearchCreneauxForAgentsService < SearchCreneauxForAgentsBase
     # utiliser les ids des agents pour ne pas faire de requêtes supplémentaire
     # Utilise le date_range.end + 1 pour chercher la date suivante du créneau affiché
     next_availability = NextAvailabilityService.find(@form.motif, lieu, all_agents, from: @form.date_range.end + 1.day)
-    creneaux = SlotBuilder.available_slots(@form.motif, lieu, @form.date_range, OffDays.all_in_date_range(@form.date_range), all_agents)
+    creneaux = SlotBuilder.available_slots(@form.motif, lieu, @form.date_range, all_agents)
     return nil if creneaux.empty? && next_availability.nil?
 
     OpenStruct.new(lieu: lieu, next_availability: next_availability, creneaux: creneaux)

--- a/app/services/search_creneaux_without_lieu_for_agents_service.rb
+++ b/app/services/search_creneaux_without_lieu_for_agents_service.rb
@@ -5,7 +5,7 @@ class SearchCreneauxWithoutLieuForAgentsService < SearchCreneauxForAgentsBase
     # utiliser les ids des agents pour ne pas faire de requêtes supplémentaire
     # Utilise le date_range.end + 1 pour chercher la date suivante du créneau affiché
     next_availability = NextAvailabilityService.find(@form.motif, nil, all_agents, from: @form.date_range.end + 1.day)
-    creneaux = SlotBuilder.available_slots(@form.motif, nil, @form.date_range, OffDays.all_in_date_range(@form.date_range), all_agents)
+    creneaux = SlotBuilder.available_slots(@form.motif, nil, @form.date_range, all_agents)
     return nil if creneaux.empty? && next_availability.nil?
 
     OpenStruct.new(lieu: nil, next_availability: next_availability, creneaux: creneaux)

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -6,7 +6,7 @@ module SlotBuilder
     def available_slots(motif, lieu, date_range, agents = [])
       datetime_range = Lapin::Range.ensure_date_range_with_time(date_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)
-      free_times_po = free_times_from(plage_ouvertures, datetime_range) # dépendance sur RDV et Absence
+      free_times_po = free_times_from(plage_ouvertures, datetime_range) # dépendances implicite à Rdv, Absence et OffDays
       slots_for(free_times_po, motif)
     end
 

--- a/spec/services/slot_builder/busy_time_spec.rb
+++ b/spec/services/slot_builder/busy_time_spec.rb
@@ -91,32 +91,30 @@ describe SlotBuilder::BusyTime, type: :service do
 
   context "with an off_day in range" do
     context "with a range on a single day" do
-      let(:range) { Time.zone.parse("2021-10-27 8:00")..Time.zone.parse("2021-10-27 12:00") }
-
-      it "returns off_day from begninning of day to end of day" do
-        off_days = [Date.new(2021, 10, 27)]
-        expect(described_class.busy_times_for(range, plage_ouverture, off_days).first.starts_at).to eq(Time.zone.parse("20211027 0:00"))
-        expect(described_class.busy_times_for(range, plage_ouverture, off_days).first.ends_at).to be_within(1.second).of(Time.zone.parse("20211027 23:59:59"))
+      it "returns off_day from beginning of day to end of day" do
+        christmas_morning = Time.zone.parse("2021-12-25 8:00")..Time.zone.parse("2021-12-25 12:00")
+        busy_time = described_class.busy_times_for(christmas_morning, plage_ouverture).first
+        expect(busy_time.starts_at).to eq(Time.zone.parse("2021-12-25 0:00"))
+        expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2021-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
-        off_days = [Date.new(2021, 10, 30)]
-        expect(described_class.busy_times_for(range, plage_ouverture, off_days)).to be_empty
+        regular_monday_morning =  Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-13 12:00")
+        expect(described_class.busy_times_for(regular_monday_morning, plage_ouverture)).to be_empty
       end
     end
 
     context "with a range spanning several days" do
-      let(:range) { Time.zone.parse("2021-10-26 8:00")..Time.zone.parse("2021-10-29 12:00") }
-
-      it "returns off_day from begninning of day to end of day" do
-        off_days = [Date.new(2021, 10, 27)]
-        expect(described_class.busy_times_for(range, plage_ouverture, off_days).first.starts_at).to eq(Time.zone.parse("20211027 0:00"))
-        expect(described_class.busy_times_for(range, plage_ouverture, off_days).first.ends_at).to be_within(1.second).of(Time.zone.parse("20211027 23:59:59"))
+      it "returns off_day from beginning of day to end of day" do
+        christmas_week = Time.zone.parse("2021-12-20 8:00")..Time.zone.parse("2021-12-26 12:00")
+        busy_time = described_class.busy_times_for(christmas_week, plage_ouverture).first
+        expect(busy_time.starts_at).to eq(Time.zone.parse("2021-12-25 0:00"))
+        expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2021-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
-        off_days = [Date.new(2021, 10, 30)]
-        expect(described_class.busy_times_for(range, plage_ouverture, off_days)).to be_empty
+        all_work_week = Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-19 12:00")
+        expect(described_class.busy_times_for(all_work_week, plage_ouverture)).to be_empty
       end
     end
   end

--- a/spec/services/users/creneaux_search_spec.rb
+++ b/spec/services/users/creneaux_search_spec.rb
@@ -13,7 +13,7 @@ describe Users::CreneauxSearch, type: :service do
   it "call builder without special options" do
     user = create(:user)
     motif = create(:motif, name: "Coucou", organisation: organisation, location_type: :public_office)
-    expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [], [])
+    expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [])
     described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
   end
 
@@ -21,14 +21,14 @@ describe Users::CreneauxSearch, type: :service do
     motif = create(:motif, follow_up: true, organisation: organisation)
     agent = create(:agent, basic_role_in_organisations: [organisation])
     user = create(:user, organisations: [organisation], agents: [agent])
-    expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [], [agent])
+    expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [agent])
     described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
   end
 
   it "call without referents when user without referents" do
     motif = create(:motif, follow_up: true, organisation: organisation)
     user = create(:user, agents: [])
-    expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [], [])
+    expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [])
     described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
   end
 
@@ -39,14 +39,14 @@ describe Users::CreneauxSearch, type: :service do
       it "calls without agents filter" do
         mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: {})
         motif = create(:motif, :sectorisation_level_agent, organisation: organisation)
-        expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [], [])
+        expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [])
         described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
       end
 
       it "calls without agents filter when no attributed agents" do
         mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: { organisation => Agent.none })
         motif = create(:motif, organisation: organisation)
-        expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [], [])
+        expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [])
         described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
       end
 
@@ -68,7 +68,7 @@ describe Users::CreneauxSearch, type: :service do
       agent2 = create(:agent, basic_role_in_organisations: [organisation])
       motif = create(:motif, :sectorisation_level_agent, organisation: organisation)
       mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: { organisation => Agent.where(id: [agent1.id, agent2.id]) })
-      expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [], match_array([agent1, agent2]))
+      expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, match_array([agent1, agent2]))
       described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
     end
   end


### PR DESCRIPTION
En rajoutant les jours fériés de 2023, j'ai modifié l'implémentation de la méthode `OffDays.all_in_date_range` afin qu'elle utilise un `Set` plutôt qu'un `case` sur l'année. La nouvelle implémentation est 10x plus rapide que l'ancienne (on passe de 100 µs à 10 µs par appel).

En lisant le code du `SlotBuilder`, j'ai réalisé qu'il prenait en paramètre `off_days` et qu'il passait ce tableau à travers toute la stack des méthodes qui décomposent le calcul de créneaux. Ce fonctionnement a deux avantages :
1. on n'appelle `OffDays.all_in_date_range` qu'une seule fois (en haut de la stack)
2. la liste des jours fériés est une dépendance explicite

À mes yeux, ces deux avantages ne valent pas le coup face à la complexité apportée par un paramètre supplémentaire. 

Côté performance, imaginons que l'on ait 10 plages d'ouvertures pour un motif et un lieu spécifié, et que chacun de ces plages d'ouvertures a 10 occurences de répétées durant la semaine où l'on fait la recherche. On aura appelé 100 fois ma méthode `OffDays.all_in_date_range`, ce qui prend seulement 1 ms !

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
