### PR TITLE
Améliore le label d'un bouton

### DIFF
--- a/app/views/admin/users/_duplicate_alert.html.slim
+++ b/app/views/admin/users/_duplicate_alert.html.slim
@@ -24,4 +24,4 @@ div.flex-grow-1
       - else
         = link_to "Modifier cet usager", edit_admin_organisation_user_path(current_organisation, user), class: "btn btn-secondary btn-small"
     - else
-      = link_to "Associer cet usager à l'organisation #{current_organisation.name}", link_to_organisation_admin_organisation_user_path(current_organisation, user, return_location: return_location, modal: from_modal), class: "btn btn-warning"
+      = link_to "Associer cet usager à l'organisation courante", link_to_organisation_admin_organisation_user_path(current_organisation, user, return_location: return_location, modal: from_modal), class: "btn btn-warning"

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -42,7 +42,7 @@ describe "Agent can create user" do
       fill_in :user_email, with: "ceelo@green.com"
       click_button "Créer"
       expect(page).to have_content("Un usager avec le même email existe déjà dans une autre organisation")
-      click_link "Associer cet usager à l'organisation MDS des Champs"
+      click_link "Associer cet usager à l'organisation courante"
       expect_page_title("Cee-Lo GREEN")
       expect(page).to have_content("L'usager a été associé à votre organisation.")
       expect(existing_user.reload.organisations).to include(organisation)


### PR DESCRIPTION
Lors d'une discussion / démo avec @NesserineZarouri, nous nous sommes dits que le label du bouton proposant d'« Associer cet usager à l'organisation XXX » serait plus clair si nous disions « Associer cet usager à l'organisation courante ».

Pour tester : https://demo-rdv-solidarites-pr3103.osc-secnum-fr1.scalingo.io/

Avant :

![Screenshot 2022-11-18 at 21-13-38 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/202794227-ed4d527c-9480-4e49-92c2-a0dab5fafa94.png)


Après : 

![Screenshot 2022-11-18 at 21-12-58 Nouvel usager - RDV Solidarités](https://user-images.githubusercontent.com/42057/202794391-78fc7f98-62ee-4b04-9dcc-395032561e05.png)





Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
