### PR TITLE
Bugfix: Rails 7 remonte une erreur quand on redirect vers InclusionConnect

### DIFF
--- a/app/controllers/agents/preferences_controller.rb
+++ b/app/controllers/agents/preferences_controller.rb
@@ -8,7 +8,7 @@ class Agents::PreferencesController < AgentAuthController
   def disable_cnfs_online_booking_banner
     skip_authorization
     cookies.permanent[:disable_cnfs_online_booking_banner] = true
-    redirect_back(fallback_location: root_path)
+    redirect_back_or_to(root_path)
   end
 
   def show

--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -3,7 +3,7 @@
 class InclusionConnectController < ApplicationController
   def auth
     session[:ic_state] = Digest::SHA1.hexdigest("InclusionConnect - #{SecureRandom.hex(13)}")
-    redirect_to InclusionConnect.auth_path(session[:ic_state], inclusion_connect_callback_url)
+    redirect_to InclusionConnect.auth_path(session[:ic_state], inclusion_connect_callback_url), allow_other_host: true
   end
 
   def callback

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -35,4 +35,15 @@ class Users::SessionsController < Devise::SessionsController
       flash: { error: "Déconnectez-vous d'abord de votre compte agent pour vous connecter en tant qu'utilisateur" }
     )
   end
+
+  # Copied from devise-4.8.1/app/controllers/devise/sessions_controller.rb
+  # We needed to override the call to redirect_to to set `allow_other_host: true`.
+  def respond_to_on_destroy
+    # We actually need to hardcode this as Rails default responder doesn't
+    # support returning empty response on GET request
+    respond_to do |format|
+      format.all { head :no_content }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), allow_other_host: true }
+    end
+  end
 end


### PR DESCRIPTION
# Pourquoi ça s'est mis à planter suite à la MAJ Rails

[Depuis Rails 7](https://edgeguides.rubyonrails.org/configuring.html#config-action-controller-raise-on-open-redirects), la méthode `redirect_to` lève une exception  `ActionController::Redirecting::UnsafeRedirectError` si l'URL passé n'a pas le même host que la requête courante.

Ce comportement a été mis en place pour se protéger des "attaques par open redirect", c'est à dire pour éviter qu'un attaquant puisse passer une URL arbitraire vers laquelle rediriger.

# La connection InclusionConnect

Issue Sentry pour la connection InclusionConnect : https://sentry.io/organizations/rdv-solidarites/issues/3751755402

La première étape de connexion avec InclusionConnect consiste à rediriger vers `InclusionConnect.auth_path`. 

```ruby
redirect_to InclusionConnect.auth_path(session[:ic_state], inclusion_connect_callback_url)
```

La méthode `InclusionConnect.auth_path` renvoie une URL qui contient les paramètres d'auth et qui ressemble à ça :

```
https://connect.inclusion.beta.gouv.fr/realms/inclusion-connect/protocol/openid-connect/auth?[...]
```

On est donc bien dans un cas où l'on doit définir `allow_other_host: true`, car on redirige consciemment vers une URL externe.

# Le logout de FranceConnect

Issue Sentry pour le logout FranceConnect : https://sentry.io/organizations/rdv-solidarites/issues/3751762098

Lorsqu'un usager clique sur "Déconnexion", on appelle l'action `Users::SessionsController#destroy`, qui appelle super, c'est à dire `Devise::SessionsController#destroy`, qui fait appel à `respond_to_on_destroy`. Cette méthode utilise redirect_to sans stipuler `allow_other_host: true`, et on a donc une levée d'exception.

Pour corriger cela, on est obligés d'extraire la méthode de Devise.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
