### PR TITLE
Remontées 5xx sur les metrics Scalingo (requêtes PROPFIND)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "dotenv-rails" # dotenv should always be loaded before rails
 # Standard Rails stuff
 gem "rails", "~> 7.0.4"
 gem "sprockets-rails"
-gem "puma"
+gem "puma", "< 6.0" # Until Puma stops returning HTTP 501 on PROPFIND requests: https://github.com/puma/puma/issues/3014
 gem "jsbundling-rails"
 gem "turbolinks", "~> 5"
 gem "bootsnap", require: false # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,7 +362,7 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (5.0.0)
-    puma (6.0.0)
+    puma (5.6.5)
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)
@@ -655,7 +655,7 @@ DEPENDENCIES
   pg_search
   phonelib
   premailer-rails
-  puma
+  puma (< 6.0)
   pundit
   rack-attack
   rack-cors


### PR DESCRIPTION
Closes #3108 

Dans la mise à jour Rails 7 (#3066), nous sommes aussi passés de `puma (5.6.5)` à `puma (6.0.0)`. Or, depuis la version 6.0, puma retourne une 501 pour requête HTTP qui a une méthode exotique. 

Pourquoi est-ce problématique ? Tout est expliqué dans l'issue #3108 !

La solution pour le moment est de rester en version 5, puis de mettre à jour quand pua aura donné la possibilité de configurer son nouveau comportement, ça se discute déjà ici : https://github.com/puma/puma/issues/3014

# Pour tester

On peut tester en envoyant une requête HTTP similaire vers la prod et vers la review app : on passe bien à une erreu 404

```
curl -i -X PROPFIND https://www.rdv-solidarites.fr/principals/users/toto@exemple.fr
HTTP/2 501 
[...]

curl -i -X PROPFIND https://demo-rdv-solidarites-pr3109.osc-secnum-fr1.scalingo.io/principals/users/toto@exemple.fr
HTTP/2 404 
[...] (une page 404 standard, car la route est manquante)
```

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
