### PR TITLE
Factory RDV : timestamps trompeux

### DIFF
--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -2,8 +2,6 @@
 
 FactoryBot.define do
   factory :rdv do
-    created_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
-    updated_at { Time.zone.parse("2020-06-5 13:51").in_time_zone }
     organisation { association(:organisation) }
     lieu { build(:lieu, organisation: organisation) }
     motif { build(:motif, organisation: organisation) }
@@ -42,8 +40,13 @@ FactoryBot.define do
       after(:create) do |rdv|
         rdv.users = []
         rdv.rdvs_users = []
-        rdv.save
+        rdv.save!
       end
+    end
+
+    trait(:with_fake_timestamps) do
+      created_at { Time.zone.parse("2020-06-05 13:51") }
+      updated_at { Time.zone.parse("2020-06-05 13:51") }
     end
 
     after(:build) do |rdv|

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -60,99 +60,99 @@ describe RdvExporter, type: :service do
   describe "#row_array_from rdv" do
     describe "année" do
       it "return year of rdv creation" do
-        rdv = build(:rdv, created_at: Time.zone.parse("2020-03-23 12h54"))
+        rdv = build(:rdv, :with_fake_timestamps, created_at: Time.zone.parse("2020-03-23 12h54"))
         expect(described_class.row_array_from(rdv)[0]).to eq(2020)
       end
     end
 
     describe "date prise de RDV" do
       it "return year of rdv creation" do
-        rdv = build(:rdv, created_at: Time.zone.parse("2020-03-23 12h54"))
+        rdv = build(:rdv, :with_fake_timestamps, created_at: Time.zone.parse("2020-03-23 12h54"))
         expect(described_class.row_array_from(rdv)[1]).to eq("23/03/2020")
       end
     end
 
     describe "heure de prise de RDV" do
       it "return year of rdv creation" do
-        rdv = build(:rdv, created_at: Time.zone.parse("2020-03-23 12h54"))
+        rdv = build(:rdv, :with_fake_timestamps, created_at: Time.zone.parse("2020-03-23 12h54"))
         expect(described_class.row_array_from(rdv)[2]).to eq("12h54")
       end
     end
 
     describe "origine" do
       it "return « Créé par un agent » when rdv created by an agent" do
-        rdv = build(:rdv, created_by: :agent)
+        rdv = build(:rdv, :with_fake_timestamps, created_by: :agent)
         expect(described_class.row_array_from(rdv)[3]).to eq("Créé par un agent")
       end
 
       it "return « RDV pris sur internet » when rdv taken by user" do
-        rdv = build(:rdv, created_by: :user)
+        rdv = build(:rdv, :with_fake_timestamps, created_by: :user)
         expect(described_class.row_array_from(rdv)[3]).to eq("RDV Pris sur internet")
       end
 
       it "return « RDV en file d'attente? » when rdv created from file d'attente" do
-        rdv = build(:rdv, created_by: :file_attente)
+        rdv = build(:rdv, :with_fake_timestamps, created_by: :file_attente)
         expect(described_class.row_array_from(rdv)[3]).to eq("RDV en file d'attente")
       end
     end
 
     describe "date" do
       it "return rdv Starts_at date, formatted with default" do
-        rdv = build(:rdv, starts_at: Time.zone.parse("2020-12-07 12h50"))
+        rdv = build(:rdv, :with_fake_timestamps, starts_at: Time.zone.parse("2020-12-07 12h50"))
         expect(described_class.row_array_from(rdv)[4]).to eq("07/12/2020")
       end
     end
 
     describe "heure rdv" do
       it "return rdv Starts_at time, formatted with time_only" do
-        rdv = build(:rdv, starts_at: Time.zone.parse("2020-12-07 12h50"))
+        rdv = build(:rdv, :with_fake_timestamps, starts_at: Time.zone.parse("2020-12-07 12h50"))
         expect(described_class.row_array_from(rdv)[5]).to eq("12h50")
       end
     end
 
     describe "service" do
       it "return rdv motif's service name" do
-        rdv = build(:rdv, motif: build(:motif, service: build(:service, name: "PMI")))
+        rdv = build(:rdv, :with_fake_timestamps, motif: build(:motif, service: build(:service, name: "PMI")))
         expect(described_class.row_array_from(rdv)[6]).to eq("PMI")
       end
     end
 
     describe "motif" do
       it "return rdv's motif name" do
-        rdv = build(:rdv, motif: build(:motif, name: "Consultation"))
+        rdv = build(:rdv, :with_fake_timestamps, motif: build(:motif, name: "Consultation"))
         expect(described_class.row_array_from(rdv)[7]).to eq("Consultation")
       end
     end
 
     describe "contexte" do
       it "return rdv's contexte" do
-        rdv = build(:rdv, context: "en urgence")
+        rdv = build(:rdv, :with_fake_timestamps, context: "en urgence")
         expect(described_class.row_array_from(rdv)[8]).to eq("en urgence")
       end
     end
 
     describe "statut" do
       it "return rdv statut" do
-        rdv = build(:rdv, starts_at: 1.day.ago, status: "unknown")
+        rdv = build(:rdv, :with_fake_timestamps, starts_at: 1.day.ago, status: "unknown")
         expect(described_class.row_array_from(rdv)[9]).to eq("À renseigner")
       end
     end
 
     describe "lieu" do
       it "return « par Téléphone » when rdv by phone" do
-        rdv = build(:rdv, :by_phone)
+        rdv = build(:rdv, :with_fake_timestamps, :by_phone)
         expect(described_class.row_array_from(rdv)[10]).to eq("Par téléphone")
       end
 
       it "return « [domicile] adresse of user » when rdv is at home" do
         user = build(:user, address: "20 avenue de Ségur, Paris", first_name: "Lisa", last_name: "PAUL")
-        rdv = build(:rdv, :at_home, users: [user])
+        rdv = build(:rdv, :with_fake_timestamps, :at_home, users: [user])
         expect(described_class.row_array_from(rdv)[10]).to eq("À domicile")
       end
 
       it "return « lieu name and adresse » when rdv in place" do
         lieu = build(:lieu, name: "Centre ville", address: "3 place de la république 56700 Hennebont")
-        rdv = build(:rdv, lieu: lieu)
+        rdv = build(:rdv, :with_fake_timestamps, lieu: lieu)
         expect(described_class.row_array_from(rdv)[10]).to eq("Centre ville (3 place de la république 56700 Hennebont)")
       end
     end
@@ -161,7 +161,7 @@ describe RdvExporter, type: :service do
       it "return all agent's names" do
         caro = build(:agent, first_name: "Caroline", last_name: "DUPUIS")
         karima = build(:agent, first_name: "Karima", last_name: "CHARNI")
-        rdv = build(:rdv, agents: [karima, caro])
+        rdv = build(:rdv, :with_fake_timestamps, agents: [karima, caro])
         expect(described_class.row_array_from(rdv)[11]).to eq("Karima CHARNI, Caroline DUPUIS")
       end
     end
@@ -170,7 +170,7 @@ describe RdvExporter, type: :service do
       it "return all user's names" do
         ayoub = build(:user, first_name: "Ayoub", last_name: "PAUL")
         veronique = build(:user, first_name: "Véronique", last_name: "DIALO")
-        rdv = build(:rdv, users: [veronique, ayoub])
+        rdv = build(:rdv, :with_fake_timestamps, users: [veronique, ayoub])
         expect(described_class.row_array_from(rdv)[12]).to eq("Véronique DIALO, Ayoub PAUL")
       end
     end
@@ -208,7 +208,7 @@ describe RdvExporter, type: :service do
         travel_to(now)
         major = build(:user, birth_date: Date.new(2002, 3, 12))
         minor = build(:user, birth_date: Date.new(2016, 5, 30))
-        rdv = build(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
+        rdv = build(:rdv, :with_fake_timestamps, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
         expect(described_class.row_array_from(rdv)[14]).to eq("oui")
       end
     end
@@ -216,7 +216,7 @@ describe RdvExporter, type: :service do
 
   describe "synthesized_receipts_result (résultat des notifications)" do
     it "return rdv synthesized_receipts_result" do
-      rdv = build(:rdv, starts_at: 1.day.ago)
+      rdv = build(:rdv, :with_fake_timestamps, starts_at: 1.day.ago)
       allow(rdv).to receive(:synthesized_receipts_result).and_return(:processed)
       expect(described_class.row_array_from(rdv)[15]).to eq("Traité")
     end
@@ -225,7 +225,7 @@ describe RdvExporter, type: :service do
   describe "contient l'organisation courante" do
     it "return organisation name" do
       organisation = build(:organisation, name: "CMS du Brusc")
-      rdv = build(:rdv, organisation: organisation)
+      rdv = build(:rdv, :with_fake_timestamps, organisation: organisation)
       expect(described_class.row_array_from(rdv)[16]).to eq("CMS du Brusc")
     end
   end
@@ -234,7 +234,7 @@ describe RdvExporter, type: :service do
     it "return all user's birth dates" do
       ayoub = build(:user, first_name: "Ayoub", last_name: "PAUL")
       veronique = build(:user, first_name: "Véronique", last_name: "DIALO")
-      rdv = build(:rdv, users: [veronique, ayoub])
+      rdv = build(:rdv, :with_fake_timestamps, users: [veronique, ayoub])
       birth_dates = [veronique, ayoub].map(&:birth_date).map { |date| I18n.l(date) }.join(", ")
       expect(described_class.row_array_from(rdv)[17]).to eq(birth_dates)
     end
@@ -279,7 +279,7 @@ describe RdvExporter, type: :service do
     it "return all agent's emails" do
       caro = build(:agent, email: "caro@gemelle.com")
       karima = build(:agent, email: "karima@autremail.fr")
-      rdv = build(:rdv, agents: [karima, caro])
+      rdv = build(:rdv, :with_fake_timestamps, agents: [karima, caro])
       expect(described_class.row_array_from(rdv)[20]).to eq("karima@autremail.fr, caro@gemelle.com")
     end
   end


### PR DESCRIPTION
Dans #1064, on avait ajouté dans la factory des RDV une valeur forcée sur les timestamps : 

```ruby
FactoryBot.define do
  factory :rdv do
      created_at { Time.zone.parse("2020-06-05 13:51") }
      updated_at { Time.zone.parse("2020-06-05 13:51") }
```

Ces lignes ont été ajoutées pour tester l'export de RDVs sans avoir à persister les données en base (usage de `build` plutôt que `create`), ce qui est une bonne idée pour les perfs (la durée d'exécution est multipliée par 3-4 si on utilise `create` dans ce cas précis).

Cependant peut considérer que cet ajout dans la factory est dangereux car on a le comportement dans tous les tests

```ruby
create(:rdv).created_at.inspect
# Fri, 05 Jun 2020 13:51:00.000000000 CEST +02:00
```

Ce PR déplace donc ces défauts dans un `trait` et utilise ce `trait` dans la spec d'export.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
