### PR TITLE
Permet aux agents de tester les liens de prise de rdv

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -25,7 +25,7 @@ class SearchController < ApplicationController
 
   def redirect_to_organisation_search(organisation)
     if organisation
-      redirect_to root_path(
+      redirect_to prendre_rdv_path(
         public_link_organisation_id: organisation.id, departement: organisation.territory.departement_number
       )
     else

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -21,7 +21,7 @@ class Users::RdvWizardStepsController < UserAuthController
       render current_step
     else
       flash[:error] = "Ce créneau n'est plus disponible. Veuillez en sélectionner un autre."
-      redirect_to(root_path(@rdv_wizard.to_query))
+      redirect_to(prendre_rdv_path_path(@rdv_wizard.to_query))
     end
   end
 

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -2,11 +2,11 @@
 
 module SearchContextHelper
   def path_to_motif_selection(params)
-    root_path(motif_selection(params))
+    prendre_rdv_path(motif_selection(params))
   end
 
   def path_to_lieu_selection(params)
-    root_path(
+    prendre_rdv_path(
       motif_selection(params).merge(
         motif_name_with_location_type: params[:motif_name_with_location_type]
       )
@@ -14,7 +14,7 @@ module SearchContextHelper
   end
 
   def path_to_organisation_selection(params)
-    root_path(
+    prendre_rdv_path(
       motif_selection(params).merge(
         motif_name_with_location_type: params[:motif_name_with_location_type],
         user_selected_organisation_id: nil
@@ -23,7 +23,7 @@ module SearchContextHelper
   end
 
   def path_to_creneau_selection(params)
-    root_path(
+    prendre_rdv_path(
       motif_selection(params).merge(
         motif_name_with_location_type: params[:motif_name_with_location_type],
         lieu_id: params[:lieu_id], user_selected_organisation_id: params[:user_selected_organisation_id]

--- a/app/views/common/_search_form.html.slim
+++ b/app/views/common/_search_form.html.slim
@@ -1,5 +1,5 @@
 #search_form
-  = simple_form_for :search, url: @action_url.present? ? @action_url : root_path do |f|
+  = simple_form_for :search, url: @action_url.present? ? @action_url : prendre_rdv_path do |f|
     = f.input :departement, as: :hidden, input_html: { value: @departement }
     = f.input :city_code, as: :hidden, input_html: { value: @city_code }
     = f.input :street_ban_id, as: :hidden, input_html: { value: @street_ban_id }
@@ -9,7 +9,7 @@
       .form-row.d-flex.justify-content-md-center.mb-2
         .col-lg-9
           = f.input :where, label: t(".address"), readonly: true, input_html: { value: @where, class: "form-control-lg" }, wrapper_html: { class: "mb-1 mb-lg-0" }
-        .col-lg-3.align-self-end= link_to t(".change_address"), root_path, class: "btn btn-light btn-lg w-100 text-center"
+        .col-lg-3.align-self-end= link_to t(".change_address"), prendre_rdv_path, class: "btn btn-light btn-lg w-100 text-center"
 
       - if @service.present? && @geo_search.available_motifs.any?
         .form-row.d-flex.justify-content-md-center.mb-2

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -3,7 +3,7 @@ div id="creneaux-lieu-#{lieu&.id}"
     - previous_from_date = date_range.begin - 7.days
     - if date_range.begin > Time.zone.today
       .col-12.col-md-auto.mb-2.mb-md-0.d-flex.align-items-center.justify-content-center
-        = link_to root_path(query.merge(date: previous_from_date)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "Semaine précédente" } do
+        = link_to prendre_rdv_path(query.merge(date: previous_from_date)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "Semaine précédente" } do
           i.fa.fa-chevron-left
           span.d-md-none.ml-1<
             | sem. précédente
@@ -35,7 +35,7 @@ div id="creneaux-lieu-#{lieu&.id}"
 
         - if next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center
-            = link_to root_path(query.merge(date: next_availability.starts_at)), class: "btn btn-light", data: { disable_with: "..." } do
+            = link_to prendre_rdv_path(query.merge(date: next_availability.starts_at)), class: "btn btn-light", data: { disable_with: "..." } do
               .d-flex.align-items-center
                 div
                   | Prochaine disponibilité le
@@ -45,7 +45,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                   i.fa.fa-chevron-right
     - if params[:date].blank? || (params[:date].to_date + 6.days) < (Time.now + max_booking_delay.seconds).to_date
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
-        = link_to root_path(query.merge(date: date_range.end + 1.day)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "semaine suivante"} do
+        = link_to prendre_rdv_path(query.merge(date: date_range.end + 1.day)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "semaine suivante"} do
           span.d-md-none.mr-1
             | sem. prochaine
           i.fa.fa-chevron-right

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -12,7 +12,7 @@ section.bg-light.p-4
               .card-subtitle= lieu.address
               .card-subtitle= context.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
-              = link_to root_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+              = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
                 .row
                   .col
                     = t(".next_availability")

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -13,10 +13,10 @@ section.bg-light.p-4
        - context.unique_motifs_by_name_and_location_type.each do |motif|
          .card.mb-3
            - if motif.restriction_for_rdv.blank?
-             = link_to(root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+             = link_to(prendre_rdv_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))) do
                = render "motif_selection_card", motif: motif
            - else
              = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
                = render "motif_selection_card", motif: motif
-             = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: root_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
+             = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
                = ActionController::Base.helpers.auto_link(simple_format(motif.restriction_for_rdv), html: { target: "_blank"})

--- a/app/views/search/address_selection/_rdv_solidarites.html.slim
+++ b/app/views/search/address_selection/_rdv_solidarites.html.slim
@@ -1,7 +1,7 @@
 section.bg-primary.p-4
   .container.mb-4
     #search_form
-      = simple_form_for :search, url: root_path, method: :get do |f|
+      = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
         = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
         = f.input :city_code,  as: :hidden, input_html: { name: "city_code", value: context.city_code }
         = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -8,4 +8,4 @@
       .card-body
         = render "users/users/form", user: current_user, rdv_wizard: @rdv_wizard, service: @rdv_wizard.service
         .col
-          = link_to "Revenir en arrière", root_path(@rdv_wizard.to_query), class: "btn btn-link"
+          = link_to "Revenir en arrière", prendre_rdv_path(@rdv_wizard.to_query), class: "btn btn-link"

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -2,7 +2,7 @@
   .col-md-6
     h1.text-dark.mb-3 Vos rendez-vous
     div.mb-3
-      .float-right= link_to "Prendre un RDV", root_path, class: "btn btn-primary"
+      .float-right= link_to "Prendre un RDV", prendre_rdv_path, class: "btn btn-primary"
       - if params[:past].present?
         = link_to "Voir vos prochains RDV", users_rdvs_path, class: "btn btn-outline-primary"
       - else
@@ -14,7 +14,7 @@
               .card-body
                 = render "rdv", rdv: rdv
           .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
-          .text-center= link_to "Prendre un autre RDV", root_path, class: "btn btn-primary"
+          .text-center= link_to "Prendre un autre RDV", prendre_rdv_path, class: "btn btn-primary"
     - else
       .card
         .card-body
@@ -24,7 +24,7 @@
               i.fa.fa-circle.fa-stack-2x.text-primary
               i.far.fa-calendar.fa-stack-1x.text-white
             .text-center.mt-2
-              = link_to "Prendre un RDV", root_path, class: "btn btn-primary"
+              = link_to "Prendre un RDV", prendre_rdv_path, class: "btn btn-primary"
 
     .text-center.my-5
       = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe "Agents can try the user-facing online booking pages" do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+  before do
+    motif = create(:motif, organisation: organisation, service: agent.service, reservable_online: true)
+    motif.plage_ouvertures << create(:plage_ouverture, organisation: organisation, agent: agent)
+  end
+
+  it "shows the online booking forms, until" do
+    login_as(agent, scope: :agent)
+    visit public_link_to_org_path(organisation_id: organisation.id)
+    expect(page).to have_content("Vous souhaitez prendre un RDV avec le service :")
+    click_link(agent.service.name)
+    expect(page).to have_content("Sélectionnez un lieu de RDV :")
+    click_link("Prochaine disponibilité")
+    expect(page).to have_content("Sélectionnez un créneau :")
+  end
+end


### PR DESCRIPTION
Le but de cette PR est de permettre aux agents de tester le début de la prise de rdv côté usager, en évitant la redirection vers l'agenda s'ils cliquent sur leur liens de prise de rdv.

Ils ne pourront pas aller jusqu'à la fin de prise de rdv, puisque c'est bloqué par #949, mais ça permet déjà d'avoir un aperçu des motifs et créneaux disponibles.
C'est aussi une première étape pour faciliter la prise de rdv par agent prescripteur.

Normalement, rien ne change pour les usagers

Par ailleurs, d'un point de vue technique, ça a plus de sens d'utiliser explicitement une route de prise de rdv comme adresse de redirection quand on est en train de faire de la prise de rdv