### PR TITLE
Permettre l'usage de Spring avec Rails 7

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,8 +8,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  config.cache_classes = false # Required by Spring
+  config.action_view.cache_template_loading = true
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # When running tests locally, using Spring to speed up test start time requires to set config.cache_classes to false
-  # when running tests in the CI, we want our configuration to be as clase as possible to the production one, so we set this to true
+  # when running tests in the CI, we want our configuration to be as close as possible to the production one, so we set this to true
   # (we rely on the fact that ENV["CI"] is true in github actions)
   config.cache_classes = ENV["CI"].present?
   config.action_view.cache_template_loading = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,10 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false # Required by Spring
+  # When running tests locally, using Spring to speed up test start time requires to set config.cache_classes to false
+  # when running tests in the CI, we want our configuration to be as clase as possible to the production one, so we set this to true
+  # (we rely on the fact that ENV["CI"] is true in github actions)
+  config.cache_classes = ENV["CI"].present?
   config.action_view.cache_template_loading = true
 
   # Eager loading loads your whole application. When running a single test locally,


### PR DESCRIPTION
En lançant les specs avec spring en local, ça accélère le temps de chargement des specs d'environ 2.5s (ce qui est très appréciable)

Depuis la mise à jour à rails 7, on a changé cette option de config, et j'avais droit à cette erreur en lançant une spec avec spring :
```
/Users/victormours/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/spring-4.1.0/lib/spring/application.rb:100:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
 (RuntimeError)
```
Et maintenant ça marche mieux. Je n'ai pas l'impression que ça change le temps d'exécution des specs sans spring.

L'inconvénient potentiel que j'y vois, c'est que ça fait un point subtil sur lequel la config de test change de celle de prod, puisque dans `config/environments/production.rb` on a `config.cache_classes = true`. Du coup, on utilise une variable d'env pour que dans la CI on soit ai la même config qu'en prod