### PR TITLE
Désactiver la cop `Rails/DynamicFindBy`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,8 +72,7 @@ Rails/CreateTableWithTimestamps:
     - 'db/migrate/20211215182151_create_active_storage_variant_records.active_storage.rb'
 
 Rails/DynamicFindBy:
-  Exclude:
-    - 'spec/features/agents/admin_can_configure_the_organisation_spec.rb'
+  Enabled: false
 
 Rails/FilePath:
   Exclude:

--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -11,10 +11,8 @@ class Api::V1::InvitationsController < Api::V1::AgentAuthBaseController
   private
 
   def set_user
-    # rubocop:disable Rails/DynamicFindBy
     # find_by_invitation_token is a method added by the devise_invitable gem
     @user = User.find_by_invitation_token(params[:token], true)
-    # rubocop:enable Rails/DynamicFindBy
 
     render_error :not_found, not_found: :user unless @user
   end

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -59,10 +59,10 @@ module TokenInvitable
 
   def user_by_token
     # find_by_invitation_token is a method added by the devise_invitable gem
-    @user_by_token ||= User.find_by_invitation_token(session[:invitation_token], true) # rubocop:disable Rails/DynamicFindBy
+    @user_by_token ||= User.find_by_invitation_token(session[:invitation_token], true)
   end
 
   def rdv_user_by_token
-    @rdv_user_by_token ||= RdvsUser.find_by_invitation_token(session[:invitation_token], true) # rubocop:disable Rails/DynamicFindBy
+    @rdv_user_by_token ||= RdvsUser.find_by_invitation_token(session[:invitation_token], true)
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -15,9 +15,7 @@ class Users::InvitationsController < Devise::InvitationsController
     params[:invitation_token] = params[:invitation_token].upcase if params[:invitation_token]&.length == 8
 
     # if the token is invalid we remove it from the session
-    # rubocop:disable Rails/DynamicFindBy
     delete_token_from_session unless resource_class.find_by_invitation_token(params[:invitation_token], true)
-    # rubocop:enable Rails/DynamicFindBy
     super
   end
 


### PR DESCRIPTION
Il me semble qu'elle nous gêne plus qu'autre chose, car'en 2022 on n'a même plus idée d'utiliser les versions dynamiques, car ça fait des années qu'on ne les voit plus dans les guides.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
