### PR TITLE
Crash lors de d'un déplacement de RDV (`range lower bound must be...`)

### DIFF
--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -83,8 +83,8 @@ class Users::RdvsController < UserAuthController
     @all_creneaux = @rdv.creneaux_available(Time.zone.today..@rdv.reschedule_max_date)
     return if @all_creneaux.empty?
 
-    start_date = params[:date]&.to_date || @all_creneaux.first.starts_at.to_date
-    end_date = [start_date + 6.days, @all_creneaux.last.starts_at.to_date].min
+    start_date = params[:date]&.to_date || @all_creneaux.min.starts_at.to_date
+    end_date = [start_date + 6.days, @all_creneaux.max.starts_at.to_date].min
     @date_range = start_date..end_date
     @creneaux = @rdv.creneaux_available(@date_range)
     respond_to do |format|

--- a/app/models/creneau.rb
+++ b/app/models/creneau.rb
@@ -2,6 +2,7 @@
 
 class Creneau
   include ActiveModel::Model
+  include Comparable
 
   attr_accessor :starts_at, :lieu_id, :motif, :agent
 
@@ -21,6 +22,11 @@ class Creneau
 
   def duration_in_min
     motif.default_duration_in_min
+  end
+
+  # Required by the Comparable module
+  def <=>(other)
+    starts_at <=> other.starts_at
   end
 
   def respects_min_booking_delay?

--- a/app/services/next_availability_service.rb
+++ b/app/services/next_availability_service.rb
@@ -13,7 +13,7 @@ class NextAvailabilityService
 
       creneaux = SlotBuilder.available_slots(motif, lieu, date..max_creneau_date, agents)
       # NOTE: We build the whole list of creneaux of the week just to return the first one.
-      return creneaux.min_by(&:starts_at) if creneaux.any?
+      return creneaux.min if creneaux.any?
     end
 
     nil # return nil if nothing found in loop

--- a/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
@@ -1,7 +1,7 @@
 / On veut connaître le premier créneau, cette semaine ou plus tard.
 / `search_results.next_availability` contient le premier créneau à partir de la semaine suivante
 / `search_results.creneaux` contient les créneaux de la semaine courante
-- first_availability_this_week = search_result.creneaux.min_by(&:starts_at)
+- first_availability_this_week = search_result.creneaux.min
 - first_availability = first_availability_this_week || search_result.next_availability
 .card.mb-3 class=("card-hoverable" if first_availability)
   .card-body

--- a/app/views/admin/slots/_slots.html.slim
+++ b/app/views/admin/slots/_slots.html.slim
@@ -21,7 +21,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                 small aucune disponibilité
             - else
               - agents = creneaux.map(&:agent).uniq
-              - creneaux_for_date = creneaux.select { |c| c.starts_at.to_date == date }.sort_by(&:starts_at)
+              - creneaux_for_date = creneaux.select { |c| c.starts_at.to_date == date }.sort
               - creneaux_for_date.each do |creneau|
                 = link_to(new_admin_organisation_rdv_wizard_step_path(build_link_to_rdv_wizard_params(creneau, form)),
                   class: "creneau bg-light d-block w-100 text-center p-1 mb-1 rounded") do

--- a/app/views/common/_creneaux.html.slim
+++ b/app/views/common/_creneaux.html.slim
@@ -19,7 +19,7 @@ div id="creneaux-lieu-#{lieu.id}"
             - creneaux_for_date = extract_uniq_slots_for_date_and_time(creneaux, date)
             - if creneaux_for_date.any? && creneaux_for_date[date].first.respects_max_booking_delay?
               - creneaux_for_date.each do |date, creneaux|
-                - creneaux.sort_by(&:starts_at).each do |creneau|
+                - creneaux.sort.each do |creneau|
                   - if creneau.motif.restriction_for_rdv.blank?
                     = link_to new_users_rdv_wizard_step_path(@query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100" do
                       = l(creneau.starts_at, format: "%H:%M")

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -20,7 +20,7 @@ div id="creneaux-lieu-#{lieu&.id}"
 
             - if creneaux_for_date.any? && creneaux_for_date[date].first.respects_max_booking_delay?
               - creneaux_for_date.each do |date, creneaux|
-                - creneaux.sort_by(&:starts_at).each do |creneau|
+                - creneaux.sort.each do |creneau|
                   = link_to new_users_rdv_wizard_step_path(query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)), "data-turbolinks": false, class: "btn btn-light mr-1 mb-1 w-100", aria: { label: "Choisir le créneau de #{l(creneau.starts_at, format: '%H:%M')}"} do
                     = l(creneau.starts_at, format: "%H:%M")
                     - if creneau.motif.follow_up?

--- a/app/views/users/rdvs/_creneaux.html.slim
+++ b/app/views/users/rdvs/_creneaux.html.slim
@@ -20,7 +20,7 @@ div id="creneaux-lieu"
 
             - if creneaux_for_date.any?
               - creneaux_for_date.each do |date, creneaux|
-                - creneaux.sort_by(&:starts_at).each do |creneau|
+                - creneaux.sort.each do |creneau|
                   = link_to l(creneau.starts_at, format: "%H:%M"), edit_users_rdv_path(@rdv, starts_at: creneau.starts_at, agent_id: creneau.agent.id), class: "btn btn-light mr-1 mb-1 w-100"
     - if date_range.end < @all_creneaux.last.starts_at.to_date
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -357,14 +357,14 @@ RSpec.describe Users::RdvsController, type: :controller do
 
     context "creneaux available" do
       before do
-        # Première plage qui commence dans 3 jours, répétition quotidienne
+        # Une plage quotidienne qui commence dans 3 jours, ouvertures de 10h00 à 12h00
         create(:plage_ouverture, :daily,
                first_day: 3.days.from_now,
                start_time: Tod::TimeOfDay.new(10),
                end_time: Tod::TimeOfDay.new(12),
                lieu: lieu, agent: agent, motifs: [motif], organisation: organisation)
 
-        # Second plage ponctuelle qui a lieu dans 2 jours
+        # Une plage ponctuelle qui a lieu dans 2 jours, ouvertures de 16h00 à 17h00
         create(:plage_ouverture,
                first_day: 2.days.from_now,
                start_time: Tod::TimeOfDay.new(16),
@@ -381,8 +381,8 @@ RSpec.describe Users::RdvsController, type: :controller do
       it { expect(assigns(:creneaux)).not_to be_empty }
       it { expect(response.body).to include("Voici les créneaux disponibles pour modifier votre rendez-vous du") }
       it { expect(response.body).to include("dimanche 06 janvier 2019 à 10h00") }
-      it { expect(response.body).to include("16:00") } # heure de créneau pour la première plage
-      it { expect(response.body).to include("10:00") } # heure de créneau pour la seconde plage
+      it { expect(response.body).to include("10:00") } # heure de créneau pour la plage quotidienne
+      it { expect(response.body).to include("16:00") } # heure de créneau pour la plage ponctuelle
     end
 
     context "when the rdv cannot be edited" do


### PR DESCRIPTION
Issue Sentry : https://sentry.io/organizations/rdv-solidarites/issues/3270502722

Nous avons un crash lorsqu'un usager tente de déplacer un RDV sur un autre créneau (`Users::RdvsController#creneaux`) :

```
PG::DataException: ERROR: range lower bound must be less than or equal to range upper bound
```

La raison pour laquelle on passe un range "à l'envers", c'est que l'on récupère une liste de créneaux non ordonnés, et on prend le premier et le dernier élément de la liste. Et parfois, le premier créneau de la liste commence plus tard que le dernier créneau de la liste : 

```ruby
    @all_creneaux = @rdv.creneaux_available([...]) # créneaux dans lee désordre
    return if @all_creneaux.empty?

    start_date = @all_creneaux.first.starts_at.to_date
    end_date = [start_date + 6.days, @all_creneaux.last.starts_at.to_date].min
```

# Solution proposée

Au lieu d'utiliser `@all_creneaux.first` et `@all_creneaux.last`, je propose d'utiliser les méthodes `Enumerable#min` et `Enumerable#max`. Pour faire les choses de manière élégante, j'ai fait en sorte que les objets de la classe `Creneau` soit comparables, pour qu'on puisse faire `creneaux.sort` plutôt que `creneaux.sort_by(&:starts_at)`.

J'ai donc mis à jour les usages de listes de `Creneau` en conséquence. On obtient peut-être des usages moins explicites, mais j'ai envie qu'on puisse avoir confiance en nos objets pour répondre correctement à `sort`. :wink: 

Côté tests, j'ai augmenté et clarifié le cas de tests, et utilisant une seconde plage et en rendant les choses plus explicites et commentées.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
