### PR TITLE
Fix typo on accessibility

### DIFF
--- a/app/views/static_pages/accessibility.html.slim
+++ b/app/views/static_pages/accessibility.html.slim
@@ -11,8 +11,8 @@
         b> Agence Nationale de la Cohésion des Territoires
         | s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
       p
-        > Cette déclaration d’accessibilité s’applique à
-        b> RDV-Solidarités.
+        | Cette déclaration d’accessibilité s’applique à
+        b< RDV-Solidarités.
 
       h2 État de conformité
 

--- a/app/views/static_pages/accessibility.html.slim
+++ b/app/views/static_pages/accessibility.html.slim
@@ -11,7 +11,7 @@
         b> Agence Nationale de la Cohésion des Territoires
         | s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
       p
-        | Cette déclaration d’accessibilité s’applique à
+        > Cette déclaration d’accessibilité s’applique à
         b> RDV-Solidarités.
 
       h2 État de conformité


### PR DESCRIPTION
There was a missing space before RDV-Solidarités

Pour tester : <`mettre ici l'url de la review app une fois déployé`>

Décrire le pourquoi des modifications

Il manque un espace entre le `à` et `RDV-Solidarités` en gras, utiliser `>` à la place de `|` corrige ceci

Closes #issue_number

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
