### PR TITLE
Visualiser les agents inactifs

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -9,6 +9,12 @@ module AgentsHelper
     tag.span("Vous", class: "badge badge-info") if current_agent?(agent)
   end
 
+  def inactive_tag(agent)
+    if agent.last_sign_in_at.nil? || agent.last_sign_in_at <= 1.month.ago
+      tag.span("Inactif", class: "badge badge-warning")
+    end
+  end
+
   def build_link_to_rdv_wizard_params(creneau, form)
     params = {}
     params[:step] = 2

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -9,12 +9,6 @@ module AgentsHelper
     tag.span("Vous", class: "badge badge-info") if current_agent?(agent)
   end
 
-  def inactive_tag(agent)
-    if agent.last_sign_in_at.nil? || agent.last_sign_in_at <= 1.month.ago
-      tag.span("Inactif", class: "badge badge-warning")
-    end
-  end
-
   def build_link_to_rdv_wizard_params(creneau, form)
     params = {}
     params[:step] = 2

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -111,6 +111,10 @@ class Agent < ApplicationRecord
     first_name.present? && last_name.present?
   end
 
+  def inactive?
+    last_sign_in_at.nil? || last_sign_in_at <= 1.month.ago
+  end
+
   def soft_delete
     raise SoftDeleteError, "agent still has attached resources" if organisations.any? || plage_ouvertures.any? || absences.any?
 

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -4,6 +4,7 @@ tr id="agent_#{agent.id}"
   td
     - if agent.complete?
       - if policy([:agent, agent_role]).edit?
+        | ici !
         = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
       - else
         span.mr-2= agent.reverse_full_name

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -4,8 +4,8 @@ tr id="agent_#{agent.id}"
   td
     - if agent.complete?
       - if policy([:agent, agent_role]).edit?
-        | ici !
         = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
+        span>= inactive_tag(agent)
       - else
         span.mr-2= agent.reverse_full_name
       = me_tag(agent)

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -5,7 +5,8 @@ tr id="agent_#{agent.id}"
     - if agent.complete?
       - if policy([:agent, agent_role]).edit?
         = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
-        span>= inactive_tag(agent)
+        - if agent.inactive?
+          = tag.span("Inactif", class: "badge badge-warning")
       - else
         span.mr-2= agent.reverse_full_name
       = me_tag(agent)


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3132.osc-secnum-fr1.scalingo.io/

Mise en place d'un badge pour indiquer, dans la liste des agents, lesquels ont été actif durant le dernier mois ou non.

Closes #2678

avant mise en place du tag :

![image](https://user-images.githubusercontent.com/60173782/203998327-d4a706d8-dd7e-4ea9-ad02-f726af340d06.png)


après :

![image](https://user-images.githubusercontent.com/60173782/203998114-d074cf1e-8981-4da9-b4e4-70ea0138a4d0.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
