### PR TITLE
Affiche quels RDV peuvent être vues par l'agent

### DIFF
--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -13,6 +13,18 @@ class Agent::RdvPolicy < DefaultAgentPolicy
     admin_and_same_org?
   end
 
+  def self.explain(organisation, agent)
+    explainations = if agent.admin_in_organisation?(organisation)
+                      "En tant qu'administrateur de l'organisation, vous voyez les RDV de toute l'organisation #{organisation.name}."
+                    elsif agent.service.secretariat?
+                      "En tant que membre du service secrétariat, vous voyez les RDV de toute l'organisation #{organisation.name}."
+                    else
+                      "En tant qu'agent, Vous voyez uniquement les RDV de votre service ayant lieu dans l'organisation #{organisation.name}."
+                    end
+    explainations << " Vous voyez également les RDV auxquels vous êtes associé"
+    explainations
+  end
+
   class Scope < Scope
     def resolve
       organisation_scope = scope.where(organisation: current_agent.organisations)

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -44,3 +44,5 @@
           ' 🖨 Liste détaillée des RDVs du
           span.js-date>
           | pour #{@agent.full_name}
+
+    = render "admin/rdvs/rdv_visibility"

--- a/app/views/admin/rdvs/_rdv_visibility.html.slim
+++ b/app/views/admin/rdvs/_rdv_visibility.html.slim
@@ -1,0 +1,4 @@
+.alert.alert-info.d-flex.align-items-center
+  .mr-3
+    i.fa.fa-eye>
+    = Agent::RdvPolicy.explain(current_organisation, current_agent)

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -48,6 +48,7 @@
           span> Exporter les #{@rdvs.total_count} RDVs en XLS
           i.fa.fa-download>
         input.btn.btn-small.btn-link.d-print-none type="submit" value="Imprimer 🖨" onclick="window.print();return false;"
+      = render "admin/rdvs/rdv_visibility"
 
 - if @rdvs.any?
   .mb-2

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -129,6 +129,7 @@
             = link_to "Voir tous les rendez-vous de #{@user.full_name}", admin_organisation_rdvs_path(current_organisation, user_id: @user.id), class: "btn btn-outline-primary small"
       .card-body
         .row
+          = render "admin/rdvs/rdv_visibility"
           .col-lg-6
             - %i[seen excused revoked noshow].each do |temporal_status|
               = render "stats/rdv_counter_with_link", \


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3142.osc-secnum-fr1.scalingo.io/

En tant que professionnel attaché au service social ; 
Lorsque je vais voir la fiche d'un usager ;
Alors, je visualise ses RDV ayant un motif lié au service social.

Le problème, c'est que ça ne permet pas à ces professionnels de savoir si l'usager prend des RDV en PMI pour son ou ses enfants.
Dans le Pas-de-Calais, il n'y a pas d'application métier pour la PMI, aussi les agents utilise RDV Solidarités pour faire du suivi. Mais là, l'information n'est pas visible. Et depuis le début, les professionnels du service secrétariat et admin ne se rendent pas compte de ce non-visibilité des autres agents sur les RDV des autres services... Cela pose un problème.

Cette PR à un petit objectif très simple : documenté ce qui est visible pour la personne connectée sur le module métier.

À plus long terme, c'est la gestion des droits d'accès que nous devons affiner : dans le 62, les agents du social auront le droit de regarder les RDV pour des motifs PMI.

Ajout de textes pour clarifier la visibilité des RDV dans 
- la fiche usager (colonne des RDV)

![Screenshot 2022-12-01 at 17-54-19 Léa DUPONT - RDV Solidarités](https://user-images.githubusercontent.com/42057/205112699-f215ba8b-d74f-4f56-8b52-2e545dce1cd8.png)

- agenda

![Screenshot 2022-12-01 at 17-53-51 Votre agenda - RDV Solidarités](https://user-images.githubusercontent.com/42057/205112743-b6dbf4b9-bb83-4661-965f-1d4838722350.png)


- liste des RDV

![Screenshot 2022-12-01 at 17-53-34 Liste des RDV - RDV Solidarités](https://user-images.githubusercontent.com/42057/205112763-b9a31066-3c76-4d62-bd34-2088c7149536.png)


Closes #3136 

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
