### PR TITLE
Éviter que la spec sur l'allocation mémoire soit flaky

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = false
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/features/allocation_for_search_context_spec.rb
+++ b/spec/features/allocation_for_search_context_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Allocation For Search Context" do
-  it "stay under 2500" do
+  it "stay under 5500" do
     departement_number = "75"
     address = "20 avenue de Ségur 75007 Paris"
     city_code = "75007"


### PR DESCRIPTION
# Le problème

Depuis peu on a des échecs sur `allocation_for_search_context_spec.rb`.

Je pensais que la raison était l'usage l'instanciation de tableau d'IDs ici : 

https://github.com/betagouv/rdv-solidarites.fr/blob/04800e14a27354e2ce01bd95ec8ae50d2cf05515/app/models/motif.rb#L183

Mais en fait, la véritable cause était que nous chargions le fichier `app/models/rdv.rb` pour la première fois dans la méthode ci-dessus, et que ce chargement causait beaucoup d'allocation mémoires (légitimes).

# La solution

Je propose que l'on active le eager loading de l'application en CI. Je suis tenté de même l'activer pour les exécutions locales des tests également, qu'en pensez-vous ?

PS :  Pour devenir un pro du chargement de code, le guide officiel est comme toujours très bien fait ! https://guides.rubyonrails.org/autoloading_and_reloading_constants.html