### PR TITLE
Utiliser des sous-requêtes SQL plutôt que de passer des listes d'IDs

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -16,8 +16,8 @@ class Admin::RdvsController < AgentAuthController
       .includes([:rdvs_users, :agents_rdvs, :organisation, :lieu, :motif, { agents: :service, users: %i[responsible organisations] }])
     @breadcrumb_page = params[:breadcrumb_page]
     @form = Admin::RdvSearchForm.new(parsed_params)
-    @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.ids }).enabled.order(:name)
-    @motifs = Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.ids })
+    @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).enabled.order(:name)
+    @motifs = Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) })
     @rdvs_users_count = RdvsUser.where(rdv: @rdvs).count
     @rdvs = @rdvs.order(starts_at: :asc).page(params[:page]).per(10)
   end

--- a/app/controllers/api/v1/public_links_controller.rb
+++ b/app/controllers/api/v1/public_links_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::PublicLinksController < Api::V1::BaseController
     public_organisations = Organisation
       .where(territory: territory)
       .where.not(external_id: nil)
-      .where(id: organisations_with_public_plages.ids | organisations_with_public_rdv_collectifs.ids)
+      .where_id_in_subqueries([organisations_with_public_plages, organisations_with_public_rdv_collectifs])
       .distinct
 
     public_organisations.map do |organisation|

--- a/app/mailers/agents/export_mailer.rb
+++ b/app/mailers/agents/export_mailer.rb
@@ -36,7 +36,7 @@ class Agents::ExportMailer < ApplicationMailer
     organisations = agent.organisations.where(id: organisation_ids)
 
     rdvs = Rdv.search_for(organisations, options)
-    rdvs_users = RdvsUser.where(rdv_id: rdvs.ids)
+    rdvs_users = RdvsUser.where(rdv_id: rdvs.select(:id))
 
     file_name = "export-rdvs-user-#{now.strftime('%Y-%m-%d')}.xls"
     mail.attachments[file_name] = {

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -199,7 +199,7 @@ class Agent < ApplicationRecord
       .reservable_online
     agents_with_open_rdv_collectif = joins(:rdvs).merge(rdv_collectif_scope)
 
-    Agent.where(id: agents_with_open_plage.ids | agents_with_open_rdv_collectif.ids).distinct
+    where_id_in_subqueries([agents_with_open_plage, agents_with_open_rdv_collectif])
   end
 
   def to_s

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,4 +9,26 @@ class ApplicationRecord < ActiveRecord::Base
   def new_and_blank?
     new_record? && attributes == self.class.new.attributes
   end
+
+  # Allows combining structurally different queries using subqueries.
+  # The resulting query looks like this:
+  #     SELECT * FROM table
+  #     WHERE `table.deleted_at` IS NULL -- conditions previously defined on self
+  #     AND
+  #       (
+  #         `table.id` IN (SELECT... first subquery)
+  #         OR
+  #         `table.id` IN (SELECT... second subquery)
+  #         OR
+  #         ...
+  #       ) -- subqueries combined with OR
+  #
+  # It can be useful when merging scopes with different join tables:
+  #     agents_with_open_plage = Agent.joins(:plage_ouvertures).merge(PlageOuverture.reservable_online)
+  #     agents_with_open_rdv_collectif = Agent.joins(:rdvs).merge(Rdv.collectif)
+  #     Agent.where_id_in_subqueries([agents_with_open_plage, agents_with_open_rdv_collectif])
+  #
+  def self.where_id_in_subqueries(subqueries)
+    subqueries.map { |scope| where(id: scope) }.reduce(:or)
+  end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -172,20 +172,19 @@ class Motif < ApplicationRecord
   end
 
   def self.with_availability_for_lieux(lieu_ids)
-    individual_motif_ids = individuel.joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: lieu_ids }).ids.uniq
-    # Pour prendre en compte le filtre sur le lieu_id pour les RDV Collectif,
-    # nous ne pouvons pas passer par une requête `or` qui nécessite les mêmes jointures des deux côtés.
+    individual_motif_ids = individuel.joins(:plage_ouvertures).where(plage_ouvertures: { lieu_id: lieu_ids }).select(:id)
     collective_motif_ids = Rdv.collectif_and_available_for_reservation
-      .where(lieu_id: lieu_ids, motif: collectif).pluck(:motif_id).uniq
-    where(id: individual_motif_ids + collective_motif_ids)
+      .where(lieu_id: lieu_ids, motif: collectif).select(:motif_id)
+
+    where_id_in_subqueries([individual_motif_ids, collective_motif_ids])
   end
 
   def self.with_availability_for_agents(agent_ids)
-    individual_motif_ids = individuel.joins(:plage_ouvertures).where(plage_ouvertures: { agent_id: agent_ids }).ids.uniq
+    individual_motif_ids = individuel.joins(:plage_ouvertures).where(plage_ouvertures: { agent_id: agent_ids }).select(:id)
     collective_motif_ids = Rdv.collectif_and_available_for_reservation
-      .where(motif: collectif).joins(:agents).where(agents: { id: agent_ids }).pluck(:motif_id).uniq
+      .where(motif: collectif).joins(:agents).where(agents: { id: agent_ids }).select(:motif_id)
 
-    where(id: individual_motif_ids + collective_motif_ids)
+    where_id_in_subqueries([individual_motif_ids, collective_motif_ids])
   end
 
   private

--- a/app/policies/agent/absence_policy.rb
+++ b/app/policies/agent/absence_policy.rb
@@ -40,10 +40,7 @@ class Agent::AbsencePolicy < ApplicationPolicy
           .joins(:agent).where(agents: { service: current_agent.service })
         absences_of_orgs_i_basic_same_service = scope.where(id: absences_of_orgs_i_basic_same_service)
 
-        # wrap in subqueries so that we can OR without worrying about “structural compatibility”
-        # (i.e. the joined tables are not the same)
-        scope.where(id: absences_of_orgs_i_admin)
-          .or(scope.where(id: absences_of_orgs_i_basic_same_service))
+        scope.where_id_in_subqueries([absences_of_orgs_i_admin, absences_of_orgs_i_basic_same_service])
       end
     end
   end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -53,11 +53,7 @@ class Agent::AgentPolicy < ApplicationPolicy
         agents_of_orgs_i_basic_same_service = scope.joins(:organisations).merge(current_agent.organisations_level(:basic))
           .where(service: current_agent.service)
 
-        # wrap in subqueries so that we can OR without worrying about “structural compatibility”
-        # (i.e. the joined tables are not the same)
-        scope.where(id: agents_of_territories_i_admin)
-          .or(scope.where(id: agents_of_orgs_i_admin))
-          .or(scope.where(id: agents_of_orgs_i_basic_same_service))
+        scope.where_id_in_subqueries([agents_of_territories_i_admin, agents_of_orgs_i_admin, agents_of_orgs_i_basic_same_service])
       end
     end
   end

--- a/app/services/users/geo_search.rb
+++ b/app/services/users/geo_search.rb
@@ -82,9 +82,11 @@ class Users::GeoSearch
   end
 
   def available_motifs_arels
-    [available_motifs_from_departement_organisations_arel] +
-      [available_motifs_from_attributed_organisations_arel] +
-      [available_motifs_from_attributed_agents_arel]
+    [
+      available_motifs_from_departement_organisations_arel,
+      available_motifs_from_attributed_organisations_arel,
+      available_motifs_from_attributed_agents_arel,
+    ]
   end
 
   def available_motifs_from_departement_organisations_arel

--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -32,7 +32,7 @@ Au delà du style de syntaxe, nous essayons de suivre quelques principes. RDVS-S
 6. Pour les tests, utiliser les helpers et rspec avec parcimonie
   - Par exemple, les `let`, `subject`, etc, doivent rester proches de leur lieu d’utilisation, quitte à être répétés dans un autre `context`.
 7. Pour manipuler des dates et heures, il est recommandé d'utiliser `ActiveSupport::TimeWithZone` plutôt que des Time ou des DateTime. Plus d'explications dans [cette PR](https://github.com/betagouv/rdv-solidarites.fr/pull/2955).
-8. Lorsque l'on veut fusionner des requêtes SQL structurellement différentes, il est recommandé d'utiliser `.where_id_in_subqueries` quand c'est pertinent.
+8. Lorsque l'on veut fusionner des requêtes SQL structurellement différentes, il est recommandé d'utiliser de sous-requêtes plutôt que de passer de récupérer puis réutiliser des listes d'IDs. La méthode de helper `.where_id_in_subqueries` peut être utilisée pour construire facilement des sous-requêtes.
 
 ## Linters
 

--- a/docs/2-contributions.md
+++ b/docs/2-contributions.md
@@ -32,6 +32,7 @@ Au delà du style de syntaxe, nous essayons de suivre quelques principes. RDVS-S
 6. Pour les tests, utiliser les helpers et rspec avec parcimonie
   - Par exemple, les `let`, `subject`, etc, doivent rester proches de leur lieu d’utilisation, quitte à être répétés dans un autre `context`.
 7. Pour manipuler des dates et heures, il est recommandé d'utiliser `ActiveSupport::TimeWithZone` plutôt que des Time ou des DateTime. Plus d'explications dans [cette PR](https://github.com/betagouv/rdv-solidarites.fr/pull/2955).
+8. Lorsque l'on veut fusionner des requêtes SQL structurellement différentes, il est recommandé d'utiliser `.where_id_in_subqueries` quand c'est pertinent.
 
 ## Linters
 


### PR DESCRIPTION
Dans plusieurs endroits du code, lorsque l'on veut combiner des requêtes en base dont la structure est incompatible, on récupère une liste d'ID retournée par chaque requête, puis on passe la combinaison de ces IDs à une requête finale.

Cette méthode a deux inconvénients : 
- elle multiplie le nombre d'aller-retours entre Ruby et Postgres
- elle instancie des tableaux (parfois grands) en mémoire puis les passe à Postgres qui va devoir les parser
- on fait des opérations de dédoublonnage en mémoire en Ruby au lieu de laisse Postgres gérer l'exécution d'une sous-requête

Qu'en dîtes-vous ? :upside_down_face: 