### PR TITLE
feat(webhooks): Add follow_up attribute to motif blueprint

### DIFF
--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -3,5 +3,5 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :reservable_online, :service_id, :category, :organisation_id, :collectif
+  fields :name, :location_type, :deleted_at, :reservable_online, :service_id, :category, :organisation_id, :collectif, :follow_up
 end


### PR DESCRIPTION
J'ajoute l'attribut `follow_up` au blueprint des motifs, qu'on utilise maintenant que l'on gère les rdvs avec référents.
