### PR TITLE
Permettre de créer des plages d'ouverture qui finissent après 20h

### DIFF
--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -1,22 +1,17 @@
 # frozen_string_literal: true
 
 module PlageOuverturesHelper
-  def time_collections_for_plage_ouverture
-    time_collections_for_hours(7..22) + ["23:00"]
-  end
-
-  def time_collections_for_absence
-    time_collections_for_hours(0..23)
-  end
-
-  def time_collections_for_hours(hours_range)
-    hours_range.flat_map do |h|
-      padded_h = format("%02i", h)
-      (0..55).step(5).map do |m|
-        padded_min = format("%02i", m)
-        "#{padded_h}:#{padded_min}"
-      end
+  # Generates ["00:00", "00:05", "00:10", ... "23:50", "23:55"]
+  EVERY_5_MINUTES_OF_THE_DAY = (0..23).flat_map do |h|
+    padded_h = format("%02i", h)
+    (0..55).step(5).map do |m|
+      padded_min = format("%02i", m)
+      "#{padded_h}:#{padded_min}"
     end
+  end.freeze
+
+  def every_5_minutes_of_the_day
+    EVERY_5_MINUTES_OF_THE_DAY
   end
 
   def display_recurrence(plage_ouverture)

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -2,7 +2,7 @@
 
 module PlageOuverturesHelper
   def time_collections_for_plage_ouverture
-    time_collections_for_hours(7..19) + ["20:00"]
+    time_collections_for_hours(7..22) + ["23:00"]
   end
 
   def time_collections_for_absence

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -7,11 +7,8 @@
         = date_input(f, :end_day)
 
   .row
-    - time_collections = model.is_a?(Absence) ? time_collections_for_absence : time_collections_for_plage_ouverture
-    .col
-      = f.input :start_time, as: :select, collection: time_collections, selected: model.start_time&.strftime("%H:%M"), include_blank: false
-    .col
-      = f.input :end_time, as: :select, collection: time_collections, selected: model.end_time&.strftime("%H:%M"), include_blank: false
+    .col = f.input :start_time, as: :select, collection: every_5_minutes_of_the_day, selected: model.start_time&.strftime("%H:%M"), include_blank: false
+    .col = f.input :end_time,   as: :select, collection: every_5_minutes_of_the_day, selected: model.end_time&.strftime("%H:%M"),   include_blank: false
 
   = f.input :recurrence, as: :hidden, input_html: { value: model.recurrence ? model.recurrence.as_json.to_json : "", "data-target": "recurrence.recurrenceComputed", class: "js-recurrence-computed" }
 

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -8,10 +8,10 @@ describe PlageOuverturesHelper do
   end
 
   describe "#time_collections_for_plage_ouverture" do
-    it "goes from 7:00 to 20:00, so that it's possible to create a plage_ouverture that allows booking a rdv at 19:00" do
-      expect(time_collections_for_plage_ouverture.count).to eq(157)
+    it "goes from 7:00 to 23:00, so that it's possible to create a plage_ouverture that allows booking a rdv at 21:00" do
+      expect(time_collections_for_plage_ouverture.count).to eq(193)
       expect(time_collections_for_plage_ouverture.first).to eq("07:00")
-      expect(time_collections_for_plage_ouverture.last).to eq("20:00")
+      expect(time_collections_for_plage_ouverture.last).to eq("23:00")
     end
   end
 

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -7,27 +7,13 @@ describe PlageOuverturesHelper do
     travel_to(now)
   end
 
-  describe "#time_collections_for_plage_ouverture" do
-    it "goes from 7:00 to 23:00, so that it's possible to create a plage_ouverture that allows booking a rdv at 21:00" do
-      expect(time_collections_for_plage_ouverture.count).to eq(193)
-      expect(time_collections_for_plage_ouverture.first).to eq("07:00")
-      expect(time_collections_for_plage_ouverture.last).to eq("23:00")
-    end
-  end
-
-  describe "#time_collections_for_absence" do
-    it "return 288 entries" do
-      expect(time_collections_for_absence.count).to eq(288)
-      expect(time_collections_for_absence.first).to eq("00:00")
-      expect(time_collections_for_absence.last).to eq("23:55")
-    end
-  end
-
-  describe "#time_collections_for_hours" do
-    it "return 24 parts" do
-      start_time = 12
-      end_time = 13
-      expect(time_collections_for_hours(start_time..end_time).count).to eq(24)
+  describe "#every_5_minutes_of_the_day" do
+    it "return 288 entries for all times of the day by 5 minutes increment" do
+      expect(every_5_minutes_of_the_day.count).to eq(288)
+      expect(every_5_minutes_of_the_day.first).to eq("00:00")
+      expect(every_5_minutes_of_the_day.last).to eq("23:55")
+      expect(every_5_minutes_of_the_day[12 * 18]).to eq("18:00")
+      expect(every_5_minutes_of_the_day[(12 * 18) + 5]).to eq("18:25")
     end
   end
 


### PR DESCRIPTION
Ticket Zammad : https://zammad10.ethibox.fr/#ticket/zoom/3527

Dans ce ticket, un agent nous demande de pouvoir faire terminer une plage d'ouverture à 21h, car pour le moment on ne propose des choix que jusqu'à 20h.

Je propose donc d'étendre ces choix jusqu'à 23h pour être tranquille. Je pense que ce changement n'est pas gênant pour les agents qui n'ont pas besoin de finir si tard, tout en permettant de le faire si besoin.

Note : on pourrait aussi modifier l'affichage de l'agenda pour qu'il affiche les soirées, mais si c'est un besoin on le fera dans un autre ticket, car ça pose des questions d'UX.

Pour tester : Se connecter avec `martine@demo.rdv-solidarites.fr / 123456` et créer une plage d'ouverture : 
https://demo-rdv-solidarites-pr3152.osc-secnum-fr1.scalingo.io/admin/organisations/1/agents/1/plage_ouvertures/new

PS : L'heure max avait été précédemment modifiée dans #2507.

# Avant

![image](https://user-images.githubusercontent.com/6357692/206168045-672204b6-a8c5-458c-aec8-6f16eee7c8b8.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/206168118-66086b3b-20ec-436e-bfa1-d625a3da1140.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
