### PR TITLE
Ajouter le nom de l'organisation dans le lien de réservation en ligne

### DIFF
--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -3,8 +3,6 @@
 class Admin::Organisations::OnlineBookingsController < AgentAuthController
   before_action :set_organisation
 
-  helper_method :booking_link
-
   def show
     authorize(@organisation)
 
@@ -18,6 +16,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
   private
 
   def booking_link
-    public_link_to_org_url(organisation_id: current_organisation.id)
+    public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug)
   end
+  helper_method :booking_link
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -90,4 +90,8 @@ class Organisation < ApplicationRecord
   def domain
     new_domain_beta? ? Domain::RDV_AIDE_NUMERIQUE : Domain::RDV_SOLIDARITES
   end
+
+  def slug
+    name.parameterize[..80]
+  end
 end

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -12,10 +12,10 @@
     p Une fois qu'elle est activée, vous pouvez envoyer ce lien à vos usagers pour qu'ils prennent rendez-vous :
 
     form data={ "controller": "clipboard" }
-      .form-row
-        .col-6
-           = text_field_tag :booking_link, booking_link, readonly: true, class: "form-control", data: { "clipboard-target": "input-to-copy" }
-        .col-4
+      .d-flex
+        .flex-grow-1
+          = text_field_tag :booking_link, booking_link, readonly: true, class: "form-control", data: { "clipboard-target": "input-to-copy" }
+        .flex-grow-0
           = button_tag class: "ml-2 btn btn-primary", data: { "clipboard-target": "copy-button" }
             i.fa.fa-copy.mr-1
             | copier

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Organisation, type: :model do
-  describe "#contactable" do
+  describe ".contactable" do
     it "return nothing when no organisation" do
       expect(described_class.contactable).to be_empty
     end
@@ -22,6 +22,18 @@ describe Organisation, type: :model do
       organisation = create(:organisation, phone_number: nil, website: nil, email: "aude@pasdecalais.fr")
       create(:organisation, phone_number: nil, website: nil, email: nil)
       expect(described_class.contactable).to eq([organisation])
+    end
+  end
+
+  describe "#slug" do
+    it "separates with dashes, squishes whitespace and skips special characters" do
+      organisation = build(:organisation, name: "SDSEI Est Béarn - site de NAY ($`'&@*!:)")
+      expect(organisation.slug).to eq("sdsei-est-bearn-site-de-nay")
+    end
+
+    it "limits length to 80" do
+      organisation = build(:organisation, name: "SDSEI Pays Basque Intérieur - site de SAINT JEAN LE VIEUX mais aussi d'un autre endroit")
+      expect(organisation.slug).to eq("sdsei-pays-basque-interieur-site-de-saint-jean-le-vieux-mais-aussi-d-un-autre-end")
     end
   end
 end


### PR DESCRIPTION
Ticket Zammad : https://zammad10.ethibox.fr/#ticket/zoom/3557

Ceci est une petite amélioration conçue avec @NesserineZarouri pour répondre en partie à la demande ci-dessus. Cela permet aux agents d'avoir des liens plus agréables à manipuler, en particulier si ils sont sur plusieurs organisations. :wink: 

Note : la partie `org_slug` de la route n'est pas du tout utilisée, sa seule utilité est de justement faire des liens qui portent une information pour les humains. Il est inspiré du fonctionnement de StackOverflow, où les liens suivants sont équivalents :
- https://stackoverflow.com/questions/1302022
- https://stackoverflow.com/questions/1302022/best-way-to-generate-slugs-human-readable-ids-in-rails 

# Avant

![image](https://user-images.githubusercontent.com/6357692/206191875-aeba1ad2-141e-4147-a6fa-48e92af22849.png)


# Après

![image](https://user-images.githubusercontent.com/6357692/206191932-21d641a2-59f5-412c-8340-5a6b88350e77.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
