### PR TITLE
Fix multiple notifications aprés l'ajout d'une participation pour un rdv collectif

### DIFF
--- a/app/models/concerns/rdvs_user/creatable.rb
+++ b/app/models/concerns/rdvs_user/creatable.rb
@@ -29,15 +29,11 @@ module RdvsUser::Creatable
 
   def notify_create!(author)
     # We pass an empty array if notifications are disabled to avoid notifying other users
-    user_to_notify = user_valid_for_lifecycle_notifications? ? [user] : []
+    user_to_notify = send_lifecycle_notifications? ? [user] : []
 
     @notifier = Notifiers::RdvCreated.new(rdv, author, user_to_notify)
     @notifier.perform
     # we re-enable the webhooks that we deactivated during the notification process
     rdv.skip_webhooks = false
-  end
-
-  def user_valid_for_lifecycle_notifications?
-    send_lifecycle_notifications == true
   end
 end

--- a/app/models/concerns/rdvs_user/creatable.rb
+++ b/app/models/concerns/rdvs_user/creatable.rb
@@ -28,9 +28,16 @@ module RdvsUser::Creatable
   end
 
   def notify_create!(author)
-    @notifier = Notifiers::RdvCreated.new(rdv, author)
+    # We pass an empty array if notifications are disabled to avoid notifying other users
+    user_to_notify = user_valid_for_lifecycle_notifications? ? [user] : []
+
+    @notifier = Notifiers::RdvCreated.new(rdv, author, user_to_notify)
     @notifier.perform
     # we re-enable the webhooks that we deactivated during the notification process
     rdv.skip_webhooks = false
+  end
+
+  def user_valid_for_lifecycle_notifications?
+    send_lifecycle_notifications == true
   end
 end


### PR DESCRIPTION
Je viens de m'apercevoir de cet oubli.
C'est fix et j'ai adapté le test en conséquence. Je travaille sur un test un peu plus complet dans cette PR : https://github.com/betagouv/rdv-solidarites.fr/pull/3153 
Je modifie la PR en suivant en prenant en compte ces modifications et j'ajouterai 2 tests : un test avec des participants existant et un test sans participant pour les différentes situations (usager invité et usager connecté).