### PR TITLE
fix(api): Render not_found when user does not belong to org

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::UsersController < Api::V1::AgentAuthBaseController
-  before_action :retrieve_user, only: %i[show update invite]
+  before_action :set_organisation, only: %i[show update]
+  before_action :set_user, only: %i[show update invite]
 
   def index
     users = policy_scope(User)
@@ -41,8 +42,12 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
 
   private
 
-  def retrieve_user
-    @user = current_organisation.present? ? current_organisation.users.find(params[:id]) : User.find(params[:id])
+  def set_organisation
+    @organisation = params[:organisation_id].present? ? Organisation.find(params[:organisation_id]) : nil
+  end
+
+  def set_user
+    @user = @organisation.present? ? @organisation.users.find(params[:id]) : User.find(params[:id])
     authorize(@user)
   rescue ActiveRecord::RecordNotFound
     render_error :not_found, not_found: :user

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -556,9 +556,9 @@ describe "Users API", swagger_doc: "v1/api.json" do
         let!(:user) { create(:user, first_name: "Jean", last_name: "JACQUES", organisations: [organisation], email: "jean@jacques.fr") }
       end
 
-      it_behaves_like "an endpoint that returns 404 - not found", "l'usager·ère est lié·e à une autre organisation" do
+      it_behaves_like "an endpoint that returns 404 - not found", "l'usager·ère n'est pas lié·e à l'organisation" do
         let!(:another_org) { create(:organisation) }
-        let!(:agent) { create(:agent, basic_role_in_organisations: [organisation, another_org]) }
+        let!(:agent) { create(:agent, basic_role_in_organisations: [another_org]) }
         let!(:user) { create(:user, organisations: [another_org]) }
       end
     end


### PR DESCRIPTION
Il y avait un petit bug sur l'endpoint `api/v1/:organisation_id/users/:user_id`: Si l'agent et le `user` n'appartenaient pas à l'organisation en question, cet endpoint renvoyait quand même le `user`. Je fais en sorte de régler ça en cherchant toujours le user dans le scope de l'organisation défini par l'URL.