### PR TITLE
Petit refacto de skip_webhooks

### DIFF
--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -73,8 +73,6 @@ module Rdv::Updatable
     end
 
     @notifier&.perform
-    # we re-enable the webhooks that we deactivated during the notification process
-    self.skip_webhooks = false
   end
 
   def rdv_status_reloaded_from_cancelled?

--- a/app/models/concerns/rdvs_user/creatable.rb
+++ b/app/models/concerns/rdvs_user/creatable.rb
@@ -33,7 +33,5 @@ module RdvsUser::Creatable
 
     @notifier = Notifiers::RdvCreated.new(rdv, author, user_to_notify)
     @notifier.perform
-    # we re-enable the webhooks that we deactivated during the notification process
-    rdv.skip_webhooks = false
   end
 end

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -54,9 +54,14 @@ class Notifiers::RdvBase < ::BaseService
     # attributes or associations of the Rdv.
     @rdv.skip_webhooks = true
 
-    rdv_users_with_token_needed.each do |rdv_user|
+    tokens = rdv_users_with_token_needed.each do |rdv_user|
       @rdv_users_tokens_by_user_id[rdv_user.user_id] = rdv_user.new_raw_invitation_token
     end
+
+    # we re-enable the webhooks that we deactivated during the notification process
+    @rdv.skip_webhooks = false
+
+    tokens
   end
 
   ## Configured Mailers

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -54,13 +54,11 @@ class Notifiers::RdvBase < ::BaseService
     # attributes or associations of the Rdv.
     @rdv.skip_webhooks = true
 
-    tokens = rdv_users_with_token_needed.each do |rdv_user|
+    rdv_users_with_token_needed.each do |rdv_user|
       @rdv_users_tokens_by_user_id[rdv_user.user_id] = rdv_user.new_raw_invitation_token
     end
 
     @rdv.skip_webhooks = false
-
-    tokens
   end
 
   ## Configured Mailers

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -58,7 +58,6 @@ class Notifiers::RdvBase < ::BaseService
       @rdv_users_tokens_by_user_id[rdv_user.user_id] = rdv_user.new_raw_invitation_token
     end
 
-    # we re-enable the webhooks that we deactivated during the notification process
     @rdv.skip_webhooks = false
 
     tokens


### PR DESCRIPTION
Pour rendre notre code un peu plus lisible, on peut grouper ensemble les changements de valeur de `rdv.skip_webhooks`. Ça permet d'éviter que les notifiers aient des effets de bord, et qu'on ai un bug si on oublie de faire cet appel après un notifier.