### PR TITLE
Modification de l'explication d'inclusion connect

### DIFF
--- a/app/views/common/_inclusionconnect_button.html.slim
+++ b/app/views/common/_inclusionconnect_button.html.slim
@@ -1,7 +1,6 @@
 - if !ENV["INCLUSIONCONNECT_DISABLED"] || params[:force_inclusionconnect].present?
   .text-center.mb-3
-    p Inclusion Connect est service d'authentification qui permet à un utilisateur d'utiliser les mêmes informations d'identification (email et mot de passe) pour accéder à plusieurs applications.
-
+    p Inclusion Connect vous permet d'utiliser le même identifiant et mot de passe pour vous connecter à différents services. Simple, sécurisé, efficace !
     = link_to inclusion_connect_auth_path, class: "inclusion-connect-link", title: "utiliser inclusion connect pour s'authentifier" do
       .normal = image_tag("inclusionconnect-bouton.svg", role: "none")
     .inclusion-connect-details


### PR DESCRIPTION
Suite à l'entretien avec Sonia, PM sur le service Inclusion Connect, elle nous propose de modifier la phrase d'explication. 

Avant :
![Screenshot 2022-12-07 at 21-47-37 RDV Solidarités](https://user-images.githubusercontent.com/42057/206292308-60438b27-1f7b-44b9-9983-9181d50f684f.png)

Après :
![Screenshot 2022-12-07 at 21-47-51 RDV Solidarités](https://user-images.githubusercontent.com/42057/206292304-6e821473-be7a-4fe7-b39b-9d0f88ee84c8.png)


