### PR TITLE
Ajout des territorial access rights à l'import des CNFS

### DIFF
--- a/scripts/backfill_agent_territorial_access_rights.rb
+++ b/scripts/backfill_agent_territorial_access_rights.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# usage: rails runner scripts/backfill_agent_territorial_access_rights.rb
+Agent.joins("left outer join agent_territorial_access_rights on agents.id = agent_territorial_access_rights.agent_id")
+  .where(agent_territorial_access_rights: { id: nil })
+  .find_each do |agent|
+    AgentTerritorialAccessRight.create(agent: agent, territory: agent.organisations.first.territory)
+  end

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -1,15 +1,7 @@
 # frozen_string_literal: true
 
 describe AddConseillerNumerique do
-  before do
-    create(:territory, name: "Conseillers Numériques")
-    create(:service, :conseiller_numerique)
-    stub_request(
-      :get,
-      "https://api-adresse.data.gouv.fr/search/?postcode=75019&q=16%20quai%20de%20la%20Loire,%2075019%20Paris"
-    ).to_return(status: 200, body: file_fixture("geocode_result.json").read, headers: {})
-  end
-
+  let!(:territory) { create(:territory, name: "Conseillers Numériques") }
   let(:params) do
     {
       external_id: "exemple@conseiller-numerique.fr",
@@ -23,6 +15,14 @@ describe AddConseillerNumerique do
         address: "16 quai de la Loire, 75019 Paris",
       },
     }
+  end
+
+  before do
+    create(:service, :conseiller_numerique)
+    stub_request(
+      :get,
+      "https://api-adresse.data.gouv.fr/search/?postcode=75019&q=16%20quai%20de%20la%20Loire,%2075019%20Paris"
+    ).to_return(status: 200, body: file_fixture("geocode_result.json").read, headers: {})
   end
 
   context "when the conseiller numerique and their structure have never been imported before" do
@@ -80,6 +80,13 @@ describe AddConseillerNumerique do
           )
 
           expect(Agent.last.roles.count).to eq 1
+          expect(Agent.last.agent_territorial_access_rights.first).to have_attributes(
+            territory: territory,
+            allow_to_manage_teams: false,
+            allow_to_manage_access_rights: false,
+            allow_to_invite_agents: false,
+            allow_to_download_metrics: false
+          )
         end
       end
     end


### PR DESCRIPTION
Fix pour https://sentry.io/organizations/rdv-solidarites/issues/3793554494/?project=1811205

Une fois que la logique sera corrigée et le script de backfill lancé, on pourra ajouter une validation ou un autre mécanisme pour s'assurer que les agents ont des access rights.