### PR TITLE
Evite les erreurs lors d'une race condition de réservation en ligne de rdv collectif

### DIFF
--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -18,7 +18,7 @@ module UserRdvWizard
       @attributes = attributes.to_h.symbolize_keys
       rdv_defaults = { user_ids: [user&.id] }
       if attributes[:rdv_collectif_id].present?
-        @rdv = Rdv.collectif_and_available_for_reservation.find(attributes[:rdv_collectif_id])
+        @rdv = Rdv.collectif.reservable_online.find(attributes[:rdv_collectif_id])
       else
         @rdv = Rdv.new(
           rdv_defaults

--- a/spec/features/users/user_can_register_to_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_register_to_collective_rdv_spec.rb
@@ -153,6 +153,24 @@ RSpec.describe "Adding a user to a collective RDV" do
       expect(page).to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
     end
 
+    context "when other users sign up before we can finish booking" do
+      it "redirects to creneau search" do
+        login_as(user, scope: :user)
+        visit root_path(params)
+        motif_selector
+        lieu_selector
+        click_link("S'inscrire")
+        click_button("Continuer")
+
+        rdv.update!(max_participants_count: 2)
+        create(:rdvs_user, rdv: rdv)
+        create(:rdvs_user, rdv: rdv)
+
+        click_button("Continuer")
+        expect(page).to have_content("Ce créneau n'est plus disponible")
+      end
+    end
+
     it "display message of participation if already exist" do
       login_as(user, scope: :user)
       create(:rdvs_user, rdv: rdv, user: user)


### PR DESCRIPTION
En travaillant sur les réservations de rdv collectif par prescripteur, on a trouvé un bug qui avait lieu dans le cas d'une race condition de réservation :
- Un usager commence son inscription pour le rdv collectif, se connecte, commence le wizard mais n'a pas encore confirmé son rdv
- D'autres usagers finissent leur inscription, et le rdv n'a plus de disponibilités
- Le premier usager passe à l'étape suivante dans le wizard -> Erreur 500 parce que le scope `Rdv.collectif_and_available_for_reservation` ne renvoie plus le rdv collectif sélectionné.

Le fix est donc de ne pas filtrer par rdv avec des places disponibles dans le rdv wizard. C'est ensuite la méthode `#creneau` qui va renvoyer nil, et le controller qui va rediriger vers le début de la prise de rdv
