### PR TITLE
Éviter le message de dépréciation sur `ActiveRecord::Base.default_timezone`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem "auto_strip_attributes"
 # Frontend
 gem "slim"
 gem "chartkick", "~> 3.4.0"
-gem "groupdate", "~> 4.2"
+gem "groupdate", "~> 6.1"
 gem "rails_autolink"
 gem "active_link_to"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,8 +216,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    groupdate (4.3.0)
-      activesupport (>= 5)
+    groupdate (6.1.0)
+      activesupport (>= 5.2)
     hashdiff (1.0.1)
     hashie (5.0.0)
     hiredis (0.6.3)
@@ -636,7 +636,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot
   faker
-  groupdate (~> 4.2)
+  groupdate (~> 6.1)
   hiredis
   icalendar (~> 2.5)
   jbuilder


### PR DESCRIPTION
Depuis Rails 7, la façon de définir `default_timezone` a changé : 

    DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.default_timezone` instead.

L'appel déprécié était fait par la gem `groupdate`, dont la version datait de décembre 2019. J'ai mis à jour vers la dernière version, datant d'avril 2022. J'ai cherché "breaking" dans [le changelog](https://github.com/ankane/groupdate/blob/master/CHANGELOG.md) et je ne vois rien d'alarmant. J'ai aussi vérifié le rendu de la page `/stats` en local, et le changement de version semble bien ne rien changer.

# Avant

![image](https://user-images.githubusercontent.com/6357692/207022772-3caa1e1a-1f41-4971-a360-e22715aec10f.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/207022790-85ed30ab-139b-4eae-bbd8-81b88c7f0e0d.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
