### PR TITLE
Utiliser `pluralize` à la place de "(s)"

### DIFF
--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -36,7 +36,8 @@
   div.mr-1
     i.fa.fa-fw.fa-user.text-primary-blue>
   div
-    strong> Professionnel(s) :
+    strong
+      => "Professionnel".pluralize(rdv.agents.size)
     = agents_to_sentence(rdv.agents)
 
 - rdv.rdvs_users.select(&:prescripteur).each do |rdvs_user|

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -9,7 +9,9 @@
       span.title= "#{User.model_name.human} :"
       span.float-right= @user.full_name
     - else
-      span.title Usager(s) :
+      span.title
+        = "Usager".pluralize(rdv.users.size)
+        |  :
       span.float-right= rdv.users.map(&:full_name).sort.to_sentence
     .clear
   div.row-result

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -20,7 +20,7 @@
                 - %i[seen excused revoked noshow].each do |temporal_status|
                   = render "stats/rdv_counter_without_link", \
                     temporal_status: temporal_status, \
-                    element: "RDV", \
+                    element: "RDV".pluralize(@stats.rdvs.status(temporal_status).count), \
                     count: @stats.rdvs.status(temporal_status).count
             .col-lg-4
               .px-1
@@ -50,30 +50,34 @@
             .col-lg-4
               .px-1
                 - %i[seen excused revoked noshow].each do |temporal_status|
+                  - count = RdvsUser.where(rdv: @stats.rdvs).status(temporal_status).count
                   = render "stats/rdv_counter_without_link", \
                     temporal_status: temporal_status, \
-                    element: "Usager(s)", \
-                    count: RdvsUser.where(rdv: @stats.rdvs).status(temporal_status).count
+                    element: "Usager".pluralize(count), \
+                    count: count
             .col-lg-4
               .px-1
+                - count = RdvsUser.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_past).count
                 = render "stats/rdv_counter_without_link", \
                   temporal_status: :unknown_past, \
-                  element: "Usager(s)", \
-                  count: RdvsUser.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_past).count
+                  element: "Usager".pluralize(count), \
+                  count: count
             .col-lg-4
               .px-1
+                - count = RdvsUser.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_future).count
                 = render "stats/rdv_counter_without_link", \
-                  element: "Usager(s)", \
+                  element: "Usager".pluralize(count), \
                   temporal_status: :unknown_future, \
-                  count: RdvsUser.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_future).count
+                  count: count
           hr
           .row
             .col-lg-4
               .px-1
+                - count = RdvsUser.where(rdv: @stats.rdvs).count
                 = render "stats/rdv_counter_without_link", \
-                  element: "Usager(s)", \
+                  element: "Usager".pluralize(count), \
                   label: "Tous", \
-                  count: RdvsUser.where(rdv: @stats.rdvs).count
+                  count: count
 
       .card.mb-5
         .card-body


### PR DESCRIPTION
Nous avons des pages très visitées qui affichent un (s) alors qu'on peut facilement accorder en nombre.

# Avant (notif e-mail)

![image](https://user-images.githubusercontent.com/6357692/207028546-04cccdf1-c067-4381-9596-49a0581d3d98.png)

# Après (notif e-mail)

![image](https://user-images.githubusercontent.com/6357692/207028575-d6c4d437-7eaf-444b-989d-b0c32c1f853e.png)

# Avant (affichage du RDV à l'agent)

![image](https://user-images.githubusercontent.com/6357692/207028843-f7298ba5-63b8-4ccb-8831-358d330e5430.png)


# Après (affichage du RDV à l'agent)

![image](https://user-images.githubusercontent.com/6357692/207028861-0655334d-95d0-44d2-a5f5-85be3af3c897.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
