### PR TITLE
POC design sur les policies User pour les RDV et les Participations

### DIFF
--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -79,8 +79,12 @@ class RdvsUser < ApplicationRecord
     status.in? CANCELLED_STATUSES
   end
 
+  def cancellable?
+    !cancelled? && rdv.collectif? && !rdv.cancelled? && !rdv.in_the_past?
+  end
+
   def cancellable_by_user?
-    !cancelled? && rdv.collectif? && !rdv.cancelled? && rdv.motif.rdvs_cancellable_by_user? && rdv.starts_at > Rdv::MIN_DELAY_FOR_CANCEL.from_now
+    cancellable? && rdv.motif.rdvs_cancellable_by_user? && rdv.starts_at > Rdv::MIN_DELAY_FOR_CANCEL.from_now
   end
 
   def set_default_notifications_flags

--- a/app/policies/user/rdv_policy.rb
+++ b/app/policies/user/rdv_policy.rb
@@ -12,19 +12,15 @@ class User::RdvPolicy < ApplicationPolicy
   end
 
   def new?
-    return false if record.revoked?
-
-    (record.collectif? && record.reservable_online?) || rdv_belongs_to_user_or_relatives?
+    rdv_belongs_to_user_or_relatives? || (record.collectif? && record.reservable_online?)
   end
 
   def create?
-    return false if record.collectif?
-
-    rdv_belongs_to_user_or_relatives?
+    rdv_belongs_to_user_or_relatives? && record.creatable_by_user?
   end
 
   def show?
-    return true if record.collectif? && record.reservable_online? && rdv_belongs_to_user_or_relatives?
+    return true if record.collectif? && rdv_belongs_to_user_or_relatives?
 
     rdv_belongs_to_user_or_relatives? && (!current_user.only_invited? || current_user.invited_for_rdv?(record))
   end
@@ -35,10 +31,6 @@ class User::RdvPolicy < ApplicationPolicy
 
   def edit?
     show? && record.editable_by_user?
-  end
-
-  def can_change_participants?
-    !current_user.only_invited? && current_user.participation_for(record).not_cancelled? && !record.in_the_past?
   end
 
   alias creneaux? edit?

--- a/app/policies/user/rdvs_user_policy.rb
+++ b/app/policies/user/rdvs_user_policy.rb
@@ -8,9 +8,8 @@ class User::RdvsUserPolicy < ApplicationPolicy
   end
 
   def create?
-    return false if record.rdv.revoked?
-
-    rdvs_user_belongs_to_user_or_relatives?
+    # J'ai volontairement pas délégué not_revoked du rdv à la participation pour des raisons de clarté
+    rdvs_user_belongs_to_user_or_relatives? && record.rdv.not_revoked?
   end
 
   def cancel?

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -28,7 +28,8 @@ ul.list-group.list-group-flush
       .col
         .fa.fa-user>
         = users_to_sentence(rdv.users)
-    - if policy([:user, rdv]).can_change_participants?
+    / Comment refacto ca pour que ce soit plus clair ?
+    - if !current_user.only_invited? && current_user.participation_for(rdv).not_cancelled? && !rdv.in_the_past?
       .col-auto
         span>
         = link_to "modifier", users_rdv_participations_path(rdv)
@@ -43,6 +44,7 @@ ul.list-group.list-group-flush
       = auto_link(simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1"), html: { target: "_blank" })
   = render "/users/rdvs/file_attente", rdv: rdv
 
+  / Comment refacto ca pour que ce soit plus clair ?
   / Check for authorizations and already cancelled rdv/participation
   - unless policy([:user, rdv]).cancel? || \
       policy([:user, current_user.participation_for(rdv)]).cancel? || \


### PR DESCRIPTION
Expérience suite au dernier point tech.
Objectif : 
Réorganiser les policies (User pour les RDV et les Participation) en faisant apparaitre des conditions simples sous la forme : 
`droit_accés_utilisateur && régles_métiers`