### PR TITLE
[BUG] Les notifications ne sont pas envoyées aux usagers pour les modifs des rdv collectifs coté agent

### DIFF
--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -58,19 +58,15 @@ module Rdv::Updatable
     if rdv_cancelled?
       file_attentes.destroy_all
       @notifier = Notifiers::RdvCancelled.new(self, author)
-    end
-
-    if rdv_status_reloaded_from_cancelled?
+    elsif rdv_status_reloaded_from_cancelled?
       @notifier = Notifiers::RdvCreated.new(self, author)
-    end
-
-    if starts_at_changed? || lieu_changed?
+    elsif starts_at_changed? || lieu_changed?
       @notifier = Notifiers::RdvUpdated.new(self, author)
     end
 
     @notifier&.perform
 
-    if collectif? && previous_participations != rdvs_users
+    if collectif? && previous_participations.sort != rdvs_users.sort
       Notifiers::RdvCollectifParticipations.perform_with(self, author, previous_participations)
     end
   end

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -68,11 +68,11 @@ module Rdv::Updatable
       @notifier = Notifiers::RdvUpdated.new(self, author)
     end
 
-    if collectif?
-      @notifier = Notifiers::RdvCollectifParticipations.new(self, author, previous_participations)
-    end
-
     @notifier&.perform
+
+    if collectif? && previous_participations != rdvs_users
+      Notifiers::RdvCollectifParticipations.perform_with(self, author, previous_participations)
+    end
   end
 
   def rdv_status_reloaded_from_cancelled?

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -60,7 +60,7 @@ module Rdv::Updatable
       @notifier = Notifiers::RdvCancelled.new(self, author)
     elsif rdv_status_reloaded_from_cancelled?
       @notifier = Notifiers::RdvCreated.new(self, author)
-    elsif starts_at_changed? || lieu_changed?
+    elsif rdv_updated?
       @notifier = Notifiers::RdvUpdated.new(self, author)
     end
 
@@ -90,5 +90,9 @@ module Rdv::Updatable
 
   def starts_at_changed?
     previous_changes["starts_at"].present?
+  end
+
+  def rdv_updated?
+    starts_at_changed? || lieu_changed?
   end
 end

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe Rdv::Updatable, type: :concern do
 
   let(:agent) { create(:agent, rdv_notifications_level: "all") }
   let!(:rdv) { create(:rdv, agents: [agent]) }
+  let!(:rdv_co) { create(:rdv, :collectif, users: [user_co1, user_co2], agents: [agent]) }
+  let!(:user_co1) { create(:user) }
+  let!(:user_co2) { create(:user) }
   let(:user) { rdv.users.first }
 
   describe "#update_and_notify" do
@@ -50,17 +53,27 @@ RSpec.describe Rdv::Updatable, type: :concern do
     end
 
     describe "sends relevant notifications" do
-      it "notifies when rdv cancelled" do
+      it "notifies agent when rdv is cancelled (excused)" do
         expect(Notifiers::RdvCancelled).to receive(:new).with(rdv, agent).and_call_original
         rdv.update_and_notify(agent, status: "excused")
         perform_enqueued_jobs
         expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email])
       end
 
+      it "notifies agent and users when rdv is cancelled (revoked) for collective rdv" do
+        expect(Notifiers::RdvCancelled).to receive(:new).with(rdv_co, agent).and_call_original
+        rdv_co.update_and_notify(agent, status: "revoked")
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user_co1.email, user_co2.email])
+      end
+
       it "does not notify when status does not change" do
+        rdv.reload
         rdv.update!(status: "waiting")
         expect(Notifiers::RdvCancelled).not_to receive(:new)
         rdv.update_and_notify(agent, status: "waiting")
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
 
       it "notifies when date changes" do
@@ -70,17 +83,41 @@ RSpec.describe Rdv::Updatable, type: :concern do
         expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user.email])
       end
 
+      it "notifies when date changes for collective rdv" do
+        expect(Notifiers::RdvUpdated).to receive(:new).with(rdv_co, agent).and_call_original
+        rdv_co.update_and_notify(agent, starts_at: 2.days.from_now)
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user_co1.email, user_co2.email])
+      end
+
       it "does not notify when date does not change" do
         rdv.reload
         expect(Notifiers::RdvUpdated).not_to receive(:new)
         rdv.update_and_notify(agent, starts_at: rdv.starts_at)
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+      end
+
+      it "does not notify when date does not change for collective rdv" do
+        rdv_co.reload
+        expect(Notifiers::RdvUpdated).not_to receive(:new)
+        rdv_co.update_and_notify(agent, starts_at: rdv_co.starts_at)
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
 
       it "does not notify when other attributes change" do
         rdv.reload
-        expect(Notifiers::RdvCancelled).not_to receive(:new)
-        expect(Notifiers::RdvUpdated).not_to receive(:new)
         rdv.update_and_notify(agent, context: "some context")
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
+      end
+
+      it "does not notify when other attributes change for collective rdv" do
+        rdv_co.reload
+        rdv_co.update_and_notify(agent, context: "some context")
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
     end
 
@@ -90,6 +127,14 @@ RSpec.describe Rdv::Updatable, type: :concern do
       rdv.update_and_notify(agent, status: "unknown")
       perform_enqueued_jobs
       expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user.email])
+    end
+
+    it "call Notifiers::RdvCreated when reloaded status from cancelled status for collective rdv" do
+      rdv_co.update!(status: "revoked", cancelled_at: Time.zone.parse("12/1/2020 12:56"))
+      expect(Notifiers::RdvCreated).to receive(:new).and_call_original
+      rdv_co.update_and_notify(agent, status: "unknown")
+      perform_enqueued_jobs
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user_co1.email, user_co2.email])
     end
 
     describe "triggers webhook" do
@@ -168,6 +213,17 @@ RSpec.describe Rdv::Updatable, type: :concern do
       rdv.notify!(agent, [])
       perform_enqueued_jobs
       expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user.email])
+    end
+
+    it "calls lieu_updated_notifier with lieu changes for collective rdv" do
+      lieu = create(:lieu, availability: "enabled")
+      autre_lieu = create(:lieu, availability: "enabled")
+      rdv_co.update!(lieu: lieu)
+      rdv_co.reload
+      expect(Notifiers::RdvUpdated).to receive(:new).and_call_original
+      rdv_co.update_and_notify(agent, lieu: autre_lieu)
+      perform_enqueued_jobs
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user_co1.email, user_co2.email])
     end
   end
 


### PR DESCRIPTION
Je suis tombé sur un bug en investiguant ce ticket : https://github.com/betagouv/rdv-solidarites.fr/issues/3144
A priori le bug que j'ai trouvé n'explique pas le problème du ticket (?) mais c'est un bug critique car depuis cette refacto : https://github.com/betagouv/rdv-solidarites.fr/pull/3099 les notifications de modification et d'annulation par les agents pour les rdv collectifs ne partent plus !
De plus les tests n'allaient pas assez loin et on se contentait de vérifier l'appel à la méthode new du notifier et pas l'envoi réél de la notification.