### PR TITLE
Correctif pour les tokens envoyés dans les sms aux responsables

### DIFF
--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -50,7 +50,7 @@ module TokenInvitable
   end
 
   def invited_user
-    user_by_token || rdv_user_by_token&.user
+    user_by_token || rdv_user_by_token&.user&.user_to_notify
   end
 
   def rdv_by_token

--- a/app/services/notifiers/rdv_base.rb
+++ b/app/services/notifiers/rdv_base.rb
@@ -54,8 +54,10 @@ class Notifiers::RdvBase < ::BaseService
     # attributes or associations of the Rdv.
     @rdv.skip_webhooks = true
 
-    rdv_users_with_token_needed.each do |rdv_user|
-      @rdv_users_tokens_by_user_id[rdv_user.user_id] = rdv_user.new_raw_invitation_token
+    @rdv.rdvs_users.each do |rdv_user|
+      participant = rdv_user.user
+      user_to_notify = participant.user_to_notify
+      @rdv_users_tokens_by_user_id[user_to_notify.id] = rdv_user.new_raw_invitation_token
     end
 
     @rdv.skip_webhooks = false
@@ -75,13 +77,6 @@ class Notifiers::RdvBase < ::BaseService
 
   def users_to_notify
     @users.map(&:user_to_notify).uniq
-  end
-
-  # we generate the tokens for the rdv_users to notify linked to the users we send a notif to
-  def rdv_users_with_token_needed
-    rdvs_users_to_notify.select do |rdv_user|
-      rdv_user.user_id.in?(users_to_notify.map(&:id))
-    end
   end
 
   ## Agents notifications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,6 +236,11 @@ Rails.application.routes.draw do
   get "r/:id", to: (redirect do |path_params, req|
     query_params = format_redirect_params(req.params)
     "users/rdvs/#{path_params[:id]}#{query_params}"
+  end), as: "rdv_short_with_optional_tkn" # This is deprecated, because we always want to have a token for these links
+
+  get "r/:id/:tkn", to: (redirect do |path_params, req|
+    query_params = format_redirect_params(req.params)
+    "users/rdvs/#{path_params[:id]}#{query_params}"
   end), as: "rdv_short"
 
   # TODO: remplacer `prendre_rdv` par le root_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,11 +233,13 @@ Rails.application.routes.draw do
   ## Shorten urls for SMS
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"
 
+  # We keep this deprecated route because some users have received sms or emails with this kind of link
   get "r/:id", to: (redirect do |path_params, req|
     query_params = format_redirect_params(req.params)
     "users/rdvs/#{path_params[:id]}#{query_params}"
-  end), as: "rdv_short_with_optional_tkn" # This is deprecated, because we always want to have a token for these links
+  end), as: "rdv_short_deprecated"
 
+  # tkn est obligatoire pour s'assurer qu'il est possible de se connecter
   get "r/:id/:tkn", to: (redirect do |path_params, req|
     query_params = format_redirect_params(req.params)
     "users/rdvs/#{path_params[:id]}#{query_params}"

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe "Step 4 of the rdv wizard" do
       click_button "Créer RDV"
       expect(page).to have_content("Le rendez-vous a été créé.")
       perform_enqueued_jobs
-      expect(Receipt.last.content).to include("token")
+      rdv_url = rdv_short_url(Rdv.last, host: Domain::RDV_SOLIDARITES.dns_domain_name, tkn: RdvsUser.last.raw_invitation_token)
+      expect(Receipt.last.content).to include(rdv_url)
     end
   end
 end

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+# frozen_string_literal: true
 
 RSpec.describe "Step 4 of the rdv wizard" do
   let(:motif) { create(:motif, :by_phone) }

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -22,13 +22,16 @@ RSpec.describe "Step 4 of the rdv wizard" do
 
     before { stub_netsize_ok }
 
+    before do
+      allow(Devise.token_generator).to receive(:generate).and_return("12345")
+    end
+
     it "sends a sms with a valid link" do
       login_as(agent, scope: :agent)
       visit new_admin_organisation_rdv_wizard_step_path(params)
       click_button "Créer RDV"
-      expect(page).to have_content("Le rendez-vous a été créé.")
       perform_enqueued_jobs
-      rdv_url = rdv_short_url(Rdv.last, host: Domain::RDV_SOLIDARITES.dns_domain_name, tkn: RdvsUser.last.raw_invitation_token)
+      rdv_url = rdv_short_url(Rdv.last, host: Domain::RDV_SOLIDARITES.dns_domain_name, tkn: "12345")
       expect(Receipt.last.content).to include(rdv_url)
     end
   end

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "Step 4 of the rdv wizard" do
+  let(:motif) { create(:motif, :by_phone) }
+  let(:organisation) { motif.organisation }
+  let(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
+
+  let(:params) do
+    {
+      organisation_id: organisation.id,
+      user_ids: [user.id],
+      duration_in_min: 30,
+      motif_id: motif.id,
+      starts_at: 2.days.from_now,
+      step: 4,
+    }
+  end
+
+  context "when booking a rdv for a relative" do
+    let(:user) { create(:user, :relative, responsible: responsible) }
+    let(:responsible) { create(:user, email: nil) }
+
+    before { stub_netsize_ok }
+
+    it "sends a sms with a valid link" do
+      login_as(agent, scope: :agent)
+      visit new_admin_organisation_rdv_wizard_step_path(params)
+      click_button "Créer RDV"
+      expect(page).to have_content("Le rendez-vous a été créé.")
+      perform_enqueued_jobs
+      expect(Receipt.last.content).to include("token")
+    end
+  end
+end

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -30,9 +30,8 @@ RSpec.describe "Step 4 of the rdv wizard" do
       visit new_admin_organisation_rdv_wizard_step_path(params)
       click_button "Créer RDV"
       expect(page).to have_content("Le rendez-vous a été créé.")
-      perform_enqueued_jobs
       rdv_url = rdv_short_url(Rdv.last, host: Domain::RDV_SOLIDARITES.dns_domain_name, tkn: "12345")
-      expect(Receipt.last.content).to include(rdv_url)
+      expect_sms_enqueued(content: /#{rdv_url}/)
     end
   end
 end

--- a/spec/features/agents/rdv_wizard/step4_spec.rb
+++ b/spec/features/agents/rdv_wizard/step4_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe "Step 4 of the rdv wizard" do
     let(:user) { create(:user, :relative, responsible: responsible) }
     let(:responsible) { create(:user, email: nil) }
 
-    before { stub_netsize_ok }
-
     before do
+      stub_netsize_ok
       allow(Devise.token_generator).to receive(:generate).and_return("12345")
     end
 
@@ -30,6 +29,7 @@ RSpec.describe "Step 4 of the rdv wizard" do
       login_as(agent, scope: :agent)
       visit new_admin_organisation_rdv_wizard_step_path(params)
       click_button "Créer RDV"
+      expect(page).to have_content("Le rendez-vous a été créé.")
       perform_enqueued_jobs
       rdv_url = rdv_short_url(Rdv.last, host: Domain::RDV_SOLIDARITES.dns_domain_name, tkn: "12345")
       expect(Receipt.last.content).to include(rdv_url)

--- a/spec/models/concerns/rdvs_user/creatable_spec.rb
+++ b/spec/models/concerns/rdvs_user/creatable_spec.rb
@@ -45,8 +45,6 @@ RSpec.describe RdvsUser::Creatable, type: :concern do
         perform_enqueued_jobs
         expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email, user.email])
         expect(rdv.reload.rdvs_users).to eq([rdv_user_relative])
-        # no token because relatives
-        expect(rdv_user_relative.rdv_user_token).to eq(nil)
         expect(rdv_user1.rdv_user_token).to eq(nil)
       end
     end
@@ -61,8 +59,6 @@ RSpec.describe RdvsUser::Creatable, type: :concern do
         perform_enqueued_jobs
         expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email])
         expect(rdv.reload.rdvs_users).to eq([rdv_user_with_lifecycle_disabled])
-        # No token because no notifs
-        expect(rdv_user_with_lifecycle_disabled.rdv_user_token).to eq(nil)
       end
 
       it "for a relative" do

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -3,28 +3,19 @@
 describe Notifiers::RdvCreated, type: :service do
   subject { described_class.perform_with(rdv, user1) }
 
-  let(:user1) { build(:user) }
-  let(:user2) { build(:user) }
-  let(:agent1) { build(:agent) }
-  let(:agent2) { build(:agent) }
-  let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, agents: [agent1, agent2]) }
-  let(:rdv_user1) { create(:rdvs_user, user: user1, rdv: rdv) }
-  let(:rdv_user2) { create(:rdvs_user, user: user2, rdv: rdv) }
-  let(:rdvs_users_relation) { RdvsUser.where(id: [rdv_user1.id, rdv_user2.id]) }
-  let(:rdvs_users_array) { [rdv_user1, rdv_user2] }
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:agent1) { create(:agent) }
+  let(:agent2) { create(:agent) }
+  let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, agents: [agent1, agent2], users: [user1, user2]) }
   let(:token1) { "123456" }
   let(:token2) { "56789" }
 
   before do
     stub_netsize_ok
-
     allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(Agents::RdvMailer).to receive(:with).and_call_original
-    allow(rdv).to receive(:rdvs_users).and_return(rdvs_users_relation)
-    allow(rdvs_users_relation).to receive(:where).with(send_lifecycle_notifications: true)
-      .and_return(rdvs_users_array.select(&:send_lifecycle_notifications))
-    allow(rdv_user1).to receive(:new_raw_invitation_token).and_return(token1)
-    allow(rdv_user2).to receive(:new_raw_invitation_token).and_return(token2)
+    allow(Devise.token_generator).to receive(:generate).and_return(token1, token2)
   end
 
   context "starts in more than 2 days" do

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -17,7 +17,7 @@ describe Users::RdvSms, type: :service do
         expect(subject).to include("RDV PMI vendredi 10/12 à 13h10")
         expect(subject).to include("MDS Centre (10 rue d'ici)")
         expect(subject).to include("Infos et annulation")
-        expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/123?tkn=12345")
+        expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/123/12345")
       end
     end
 
@@ -51,7 +51,7 @@ describe Users::RdvSms, type: :service do
       expect(subject).to include("RDV modifié: PMI vendredi 10/12 à 13h10")
       expect(subject).to include("MDS Centre (10 rue d'ici)")
       expect(subject).to include("Infos et annulation")
-      expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/124?tkn=2345")
+      expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/124/2345")
     end
   end
 
@@ -127,7 +127,7 @@ describe Users::RdvSms, type: :service do
       expect(subject).to include("Rappel RDV PMI le vendredi 10/12 à 13h10")
       expect(subject).to include("MDS Centre (10 rue d'ici)")
       expect(subject).to include("Infos et annulation")
-      expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/140?tkn=7777")
+      expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/140/7777")
     end
   end
 


### PR DESCRIPTION
Les sms envoyés aux responsables n'avaient pas de token. Voir https://sentry.incubateur.net/organizations/betagouv/issues/15798/?environment=production&query=is%3Aunresolved (une cinquantaine d'occurrences par jour)

Pour la spec, j'ai pas vraiment trouvé de test qui faisait vraiment des vérifications sur les sms au niveau intégration, donc je me suis positionné à ce niveau, vu qu'on est vraiment sur du bug difficile à voir autrement qu'en intégration.

Le fix est de s'assurer qu'on génère bien un token pour le user qui est notifié, et pas le user qui participe (et de faire la vérification correspondante au moment de l'authentification).

En regardant les tests de plus près, je me suis rendu compte que c'était pas évident de tester que le bon lien était envoyé, et qu'une bonne modification à apporter pour éviter ce genre de bug à l'avenir c'est de rendre le token obligatoire dans le lien envoyé par sms. En plus ça économise quelques caractères dans le sms.

