### PR TITLE
Discard jobs on ActiveJob::DeserializationError

### DIFF
--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -3,6 +3,10 @@
 class Agents::AbsenceMailer < ApplicationMailer
   helper PlageOuverturesHelper
 
+  # Some jobs raise ActiveJob::DeserializationError because the PlageOuverture has been deleted
+  # In this case, we want to discard the job without raising an error.
+  discard_on ActiveJob::DeserializationError
+
   before_action do
     @absence = params[:absence]
   end

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -4,6 +4,10 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
   helper MotifsHelper
   helper PlageOuverturesHelper
 
+  # Some jobs raise ActiveJob::DeserializationError because the PlageOuverture has been deleted
+  # In this case, we want to discard the job without raising an error.
+  discard_on ActiveJob::DeserializationError
+
   before_action do
     @plage_ouverture = params[:plage_ouverture]
   end


### PR DESCRIPTION
Issue sentry : https://sentry.incubateur.net/organizations/betagouv/issues/15889/?environment=production&project=74&query=is%3Aunresolved

Explication du bug :
- Une plage d'ouverture est créée, un job est lancé pour envoyer une notif par mail à l'agent
- C'est le matin, donc il y a beaucoup de sms à envoyer, donc le job n'est pas traité tout de suite
- L'agent supprime la plage d'ouverture
- Le job est traité, mais la plage d'ouverture n'existe plus. Ce n'est pas un problème pour la notif mail (vu que la destruction de la plage d'ouverture envoie un mail en synchrone), mais ça nous ajoute une erreur dans Sentry.

On peut ignorer ces erreurs tant que l'envoi de mail de suppression est fait en synchrone.