### PR TITLE
Amélioration rapide de la page d'accueil de rdv-aide-numerique.fr

### DIFF
--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -1,13 +1,52 @@
-section.bg-white.py-5
-  .container
-    .row
-      .col-md-12.text-center
-        p.alert-link La prise de rendez-vous en ligne n'est pas encore ouverte au public.
-        p Vous pouvez prendre contact avec un conseiller numérique via la #{link_to("carte des Conseillers numérique France Services", "https://carte.conseiller-numerique.gouv.fr/")}.
+section.bg-primary.p-4
+  .container.mb-4
+    .d-flex.justify-content-center
+      button.btn.btn-lg.btn-outline-light type="button" data-toggle="collapse" data-target="#iframe-carto" aria-expanded="false" aria-controls="iframe-carto"
+        .fa.fa-map-location.mr-1
+        | Afficher la carte des Conseillers numériques
 
-section.bg-lightturquoise.py-5
+    .d-flex.justify-content-center
+      #iframe-carto.collapse.p-4 style="width: 100%"
+        iframe src="https://www.conseiller-numerique.gouv.fr/carte" width="100%" height=600
+
+        .d-flex.justify-content-center.mt-4
+          = link_to("https://carte.conseiller-numerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
+            .fa.fa-arrow-up-right-from-square.mr-1
+            | Ouvrir la carte dans un nouvel onglet
+
+section
+  .container
+    .row.mt-4
+      .col-lg-12
+        h2.text-center  Comment ça marche ?
+    .row.mt-5
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/location.svg", class: "img-circle mb-3", alt: "premièrement"
+          span.text-primary.mt-3 Zoomez près de chez vous
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/service.svg", class: "img-circle mb-3", alt: "deuxièmement"
+          span.text-primary.mt-3 Choisissez un acteur présent près de chez vous
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/motif.svg", class: "img-circle mb-3", alt: "troisièmement"
+          span.text-primary.mt-3 Appelez la structure au numéro indiqué
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/creneau.svg", class: "img-circle mb-3", alt: "et quatrièmement"
+          span.text-primary.mt-3 ou planifiez directement un RDV si ses disponibilités sont indiquées !
+
+section.bg-lightturquoise.p-5
   .container
     .row
-      .col-md-12.text-center
-        h3 Vous êtes conseiller numérique ?
-        = link_to("En savoir plus", presentation_agent_path, class: "btn btn-tertiary")
+      .col-md-3.align-items-center
+        = image_tag "welcome/agent.svg", class: "mx-auto d-block", alt: ""
+      .col-md-9
+        h3.mb-2.text-primary Vous êtes Conseiller numérique ?
+        p.lead Faciliter la prise de rendez-vous avec vos apprenants.
+        = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -1,18 +1,9 @@
 section.bg-primary.p-4
   .container.mb-4
     .d-flex.justify-content-center
-      button.btn.btn-lg.btn-outline-light type="button" data-toggle="collapse" data-target="#iframe-carto" aria-expanded="false" aria-controls="iframe-carto"
-        .fa.fa-map-location.mr-1
-        | Afficher la carte des Conseillers numériques
-
-    .d-flex.justify-content-center
-      #iframe-carto.collapse.p-4 style="width: 100%"
-        iframe src="https://www.conseiller-numerique.gouv.fr/carte" width="100%" height=600
-
-        .d-flex.justify-content-center.mt-4
-          = link_to("https://carte.conseiller-numerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
-            .fa.fa-arrow-up-right-from-square.mr-1
-            | Ouvrir la carte dans un nouvel onglet
+      = link_to("https://carte.conseiller-numerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
+        | Consulter la carte des Conseillers numériques
+        .fa.fa-arrow-up-right-from-square.ml-1
 
 section
   .container

--- a/app/views/search/banners/_rdv_aide_numerique.html.slim
+++ b/app/views/search/banners/_rdv_aide_numerique.html.slim
@@ -1,1 +1,3 @@
-| Trouvez de l'aide pour vous former au numérique
+' Prenez rendez-vous avec
+br
+span.text-secondary> un médiateur numérique

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ unless Rails.env.test?
     policy.font_src    :self, :data, "github.com"
     policy.object_src  :none
     policy.worker_src :blob
-    policy.child_src :blob, :self, "https://www.conseiller-numerique.gouv.fr"
+    policy.child_src :blob, :self
 
     if Rails.env.development?
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net",

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ unless Rails.env.test?
     policy.font_src    :self, :data, "github.com"
     policy.object_src  :none
     policy.worker_src :blob
-    policy.child_src :blob, :self
+    policy.child_src :blob, :self, "https://www.conseiller-numerique.gouv.fr"
 
     if Rails.env.development?
       policy.script_src :self, :unsafe_inline, "stats.data.gouv.fr", "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net",


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3188.osc-secnum-fr1.scalingo.io/

L'idée de cette PR n'est pas d'avoir la landing page parfaite, mais plutôt de dépenser une heure de boulot pour améliorer grandement la page actuelle qui est très rustique.

Note : j'ai utilisé une iframe pour afficher la carte, idéalement ce serait top si l'équipe carto pouvait proposer une page sans layout pour cet usage ! 

# Avant

![image](https://user-images.githubusercontent.com/6357692/207933920-e48108be-dbc5-40ef-ac13-362668954745.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/207934862-7fe9715f-5e7f-401c-a811-5e033ef2f8ff.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
