### PR TITLE
masque la sectorisation en cas de rdv de suivi

### DIFF
--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -18,8 +18,12 @@ class MotifForm {
       !document.querySelector("#motif_follow_up:checked")
   }
 
-  toggleSectorisation = () => {
-    const enabled = this.reservableOnlineCheckbox.checked
+  sectorisationShouldBeDisable() {
+    return !document.querySelector("#motif_follow_up:checked")
+  }
+
+  toggleSectorisation() {
+    const enabled = this.reservableOnlineCheckbox.checked && this.sectorisationShouldBeDisable();
     if (enabled == this.sectorisationEnabled) return;
 
     if (!enabled) {
@@ -34,7 +38,6 @@ class MotifForm {
     this.sectorisationEnabled = enabled
   }
 
-
   toggleOnlineSubFields() {
     const enabled = this.reservableOnlineCheckbox.checked
     document.querySelectorAll(".js-rdvs-editable").forEach(rdvEditableElement =>
@@ -47,7 +50,6 @@ class MotifForm {
     document.querySelector("#motif_rdvs_editable_by_user").checked = enabled
   }
 
-
   constructor() {
     this.secretariatCheckbox = document.querySelector('#motif_for_secretariat')
     this.reservableOnlineCheckbox = document.querySelector('#motif_reservable_online')
@@ -56,6 +58,10 @@ class MotifForm {
     const noSecretariatInputs = ["input[name=\"motif[location_type]\"]", "input[name=\"motif[follow_up]\"]"]
     document.querySelectorAll(noSecretariatInputs).forEach(input =>
       input.addEventListener('change', e => this.toggleSecretariat())
+    )
+    const noSectorisationInputs = ["input[name=\"motif[sectorisation_level]\"]", "input[name=\"motif[follow_up]\"]"]
+    document.querySelectorAll(noSectorisationInputs).forEach(input =>
+      input.addEventListener('change', e => this.toggleSectorisation())
     )
     this.reservableOnlineCheckbox.addEventListener('change', e => {
       if (document.querySelector(".js-sectorisation-card") !== null) { this.toggleSectorisation() }

--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -19,11 +19,11 @@ class MotifForm {
   }
 
   sectorisationShouldBeDisable() {
-    return !document.querySelector("#motif_follow_up:checked")
+    return !document.querySelector("#motif_follow_up:checked") && this.reservableOnlineCheckbox.checked
   }
 
   toggleSectorisation() {
-    const enabled = this.reservableOnlineCheckbox.checked && this.sectorisationShouldBeDisable();
+    const enabled = this.sectorisationShouldBeDisable();
     if (enabled == this.sectorisationEnabled) return;
 
     if (!enabled) {
@@ -59,8 +59,8 @@ class MotifForm {
     document.querySelectorAll(noSecretariatInputs).forEach(input =>
       input.addEventListener('change', e => this.toggleSecretariat())
     )
-    const noSectorisationInputs = ["input[name=\"motif[sectorisation_level]\"]", "input[name=\"motif[follow_up]\"]"]
-    document.querySelectorAll(noSectorisationInputs).forEach(input =>
+    const toggleSectorisationInputs = ["input[name=\"motif[sectorisation_level]\"]", "input[name=\"motif[follow_up]\"]"]
+    document.querySelectorAll(toggleSectorisationInputs).forEach(input =>
       input.addEventListener('change', e => this.toggleSectorisation())
     )
     this.reservableOnlineCheckbox.addEventListener('change', e => {

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -80,30 +80,31 @@
           = link_to "https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-territoire/sectorisation-geographique/" do
             span> Documentation sur la sectorisation
             i.fa.fa-external-link-alt>
-        .mb-2= label_tag do
-          = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
-          span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT, context: :hint)
-        = label_tag do
-          = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION)
-          span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION, context: :hint)
-          .text-muted.font-14.my-1.ml-3
-            - sectors_attributed_to_orga = Sector.attributed_to_organisation(current_organisation)
-            = t("motifs.form.sectorisation_level.sectors_attributed_to_orga", count: sectors_attributed_to_orga.count, sectors: sectors_attributed_to_orga.map(&:name).to_sentence.truncate(100), organisation: current_organisation.name)
-        = label_tag do
-          = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT)
-          span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT, context: :hint)
-          - if motif.service.present?
-            - attributions_group = SectorAttribution.level_agent_grouped_by_service(current_organisation).fetch(motif.service_id, {agents_count: 0, attributions: []})
+        .mb-2
+          = label_tag do
+            = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)
+            span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT, context: :hint)
+          = label_tag do
+            = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION)
+            span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_ORGANISATION, context: :hint)
             .text-muted.font-14.my-1.ml-3
-              = t( \
-                "motifs.form.sectorisation_level.sectors_attributed_to_agents", \
-                count: attributions_group[:agents_count], \
-                service: motif.service.name, \
-                sectors_count_human: t("motifs.index.sectorisation_level_organisation", count: attributions_group[:sectors_count]), \
-                sectors: attributions_group[:attributions].map { "#{_1.agent.full_name} -> #{_1.sector.name}" }.to_sentence.truncate(100) \
-              )
+              - sectors_attributed_to_orga = Sector.attributed_to_organisation(current_organisation)
+              = t("motifs.form.sectorisation_level.sectors_attributed_to_orga", count: sectors_attributed_to_orga.count, sectors: sectors_attributed_to_orga.map(&:name).to_sentence.truncate(100), organisation: current_organisation.name)
+          = label_tag do
+            = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT)
+            span.ml-1= Motif.human_attribute_value(:sectorisation_level, Motif::SECTORISATION_LEVEL_AGENT, context: :hint)
+            - if motif.service.present?
+              - attributions_group = SectorAttribution.level_agent_grouped_by_service(current_organisation).fetch(motif.service_id, {agents_count: 0, attributions: []})
+              .text-muted.font-14.my-1.ml-3
+                = t( \
+                  "motifs.form.sectorisation_level.sectors_attributed_to_agents", \
+                  count: attributions_group[:agents_count], \
+                  service: motif.service.name, \
+                  sectors_count_human: t("motifs.index.sectorisation_level_organisation", count: attributions_group[:sectors_count]), \
+                  sectors: attributions_group[:attributions].map { "#{_1.agent.full_name} -> #{_1.sector.name}" }.to_sentence.truncate(100) \
+                )
         - if current_agent.territorial_admin_in?(current_organisation.territory)
-          = link_to " Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
+          = link_to "Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
 
   .card
     .card-body

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -103,7 +103,7 @@
                 sectors: attributions_group[:attributions].map { "#{_1.agent.full_name} -> #{_1.sector.name}" }.to_sentence.truncate(100) \
               )
         - if current_agent.territorial_admin_in?(current_organisation.territory)
-          = link_to "Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
+          = link_to " Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
 
   .card
     .card-body


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3192.osc-secnum-fr1.scalingo.io/

L'objectif ici est de ne pas afficher le paramétrage de la sectorisation quand un motif est créé pour un rdv de suivi réservable en ligne.

Closes #3125

avant:

![image](https://user-images.githubusercontent.com/60173782/208139748-bb542efc-fdd3-49d8-bb95-01c65d44d0f1.png)

après :

![image](https://user-images.githubusercontent.com/60173782/208138505-692694d5-f0bd-4dba-aeca-05de11e1e331.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
