### PR TITLE
Ajoute un bouton pour recréer une zone tout de suite

### DIFF
--- a/app/controllers/admin/territories/zones_controller.rb
+++ b/app/controllers/admin/territories/zones_controller.rb
@@ -18,7 +18,7 @@ class Admin::Territories::ZonesController < Admin::Territories::BaseController
   end
 
   def new
-    zone_defaults = { level: Zone::LEVEL_CITY }
+    zone_defaults = { level: params[:default_zone_level] || Zone::LEVEL_CITY }
     @zone = Zone.new(**zone_defaults.merge(zone_params_get), sector: @sector)
     @sectors = policy_scope(Sector)
     authorize @zone
@@ -28,7 +28,11 @@ class Admin::Territories::ZonesController < Admin::Territories::BaseController
     @zone = Zone.new(**zone_params, sector: @sector)
     authorize @zone
     if @zone.save
-      redirect_to admin_territory_sector_path(current_territory, @sector), flash: { success: "#{@zone.human_attribute_value(:level)} ajoutée au secteur" }
+      if params[:commit] == I18n.t("helpers.submit.create")
+        redirect_to admin_territory_sector_path(current_territory, @sector), flash: { success: "#{@zone.human_attribute_value(:level)} ajoutée au secteur" }
+      else
+        redirect_to new_admin_territory_sector_zone_path(current_territory, @sector, default_zone_level: @zone.level), flash: { success: t(".created", zone: @zone.name) }
+      end
     else
       render :new
     end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -38,6 +38,14 @@ class Zone < ApplicationRecord
     level == LEVEL_STREET
   end
 
+  def name
+    if level_city?
+      city_name
+    else
+      street_name
+    end
+  end
+
   protected
 
   def coherent_city_code_departement

--- a/app/views/admin/territories/zones/_form.html.slim
+++ b/app/views/admin/territories/zones/_form.html.slim
@@ -51,3 +51,6 @@
       .col-6= f.input :street_ban_id, input_html: { readonly: true }, required: true
 
   = f.submit class: "btn btn-primary"
+  - if zone.new_record?
+    div ou
+    div = f.submit class: "btn btn-light", value: "Enregistrer puis créer une autre #{zone.level_street? ? 'rue' : 'commune'}"

--- a/config/locales/views/admin_territories_sectors.fr.yml
+++ b/config/locales/views/admin_territories_sectors.fr.yml
@@ -4,6 +4,11 @@ fr:
       sms_configurations:
         show:
           explain_default_provider: Si vous ne sélectionnez par de fournisseur de SMS, nous utiliserons le fournisseur de SMS mutualisé par l'ANCT.
+      zones:
+        created: Zone %{zone} créé
+        updated: Zone mis à jour
+        deleted: Zone supprimé
+        delete_error: Erreur lors de la suppression
       sectors:
         created: Secteur %{sector} créé
         updated: Secteur mis à jour

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -61,4 +61,16 @@ RSpec.describe Zone, type: :model do
       expect(zone.errors.attribute_names).to eq([:base])
     end
   end
+
+  describe "#name" do
+    it "return street name with a street level" do
+      zone = build(:zone, level: :street, street_name: "Boulevard Flandres", city_name: "Paris")
+      expect(zone.name).to eq("Boulevard Flandres")
+    end
+
+    it "return city name with a city level" do
+      zone = build(:zone, level: :city, street_name: "Boulevard Flandres", city_name: "Paris")
+      expect(zone.name).to eq("Paris")
+    end
+  end
 end

--- a/spec/requests/admin/territories/crud_zones_spec.rb
+++ b/spec/requests/admin/territories/crud_zones_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe "CRUD zone pour la sectorisation", type: :request do
+  include Rails.application.routes.url_helpers
+
+  let(:territory) { create(:territory, departement_number: "62") }
+  let(:organisation) { create(:organisation, territory: territory) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation], role_in_territories: [territory]) }
+
+  before { sign_in agent }
+
+  describe "GET new" do
+    it "return successful" do
+      sector = create(:sector, territory: territory)
+      get new_admin_territory_sector_zone_path(territory, sector)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST create" do
+    it "redirect to sector page when commit params is simple create" do
+      sector = create(:sector, territory: territory)
+      zone_attributes = attributes_for(:zone, sector: sector)
+      post admin_territory_sector_zones_path(territory, sector), params: { zone: zone_attributes, commit: I18n.t("helpers.submit.create") }
+      expect(response).to redirect_to(admin_territory_sector_path(territory, sector))
+    end
+
+    it "redirect to new zone page for city when commit params is create and new city zone" do
+      sector = create(:sector, territory: territory)
+      zone_attributes = {
+        level: "city",
+        city_code: "62040",
+        city_name: "Arques",
+      }
+      post admin_territory_sector_zones_path(territory, sector), params: { zone: zone_attributes, commit: "Créer puis créer une autre commune" }
+      expect(response).to redirect_to(new_admin_territory_sector_zone_path(territory, sector, default_zone_level: "city"))
+    end
+
+    it "redirect to new zone page for street when commit params is create and new street zone" do
+      sector = create(:sector, territory: territory)
+      zone_attributes = {
+        level: "street",
+        city_code: "62040",
+        city_name: "Arques",
+        street_ban_id: "62040_0020",
+        street_name: "Boulevard du docteur Alexandre",
+      }
+      post admin_territory_sector_zones_path(territory, sector), params: { zone: zone_attributes, commit: "Créer puis créer une autre rue" }
+      expect(response).to redirect_to(new_admin_territory_sector_zone_path(territory, sector, default_zone_level: "street"))
+    end
+  end
+end


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3212.osc-secnum-fr1.scalingo.io/

Afin de faciliter la création de commune ou de rue à la chaîne ; Des référentes nous ont demandé d'ajouter un bouton pour créer et ajouter une nouvelle zone (rue ou commune).

À la manière de ce qui existe déjà pour les secteurs.

Cette PR ajoute le bouton et les mécanismes liés à la sélection de la rue ou de la commune

Close #1672

![Screenshot 2022-12-21 at 18-07-15 RDV Solidarités](https://user-images.githubusercontent.com/42057/208963451-08d82d62-4b9c-4134-8e37-e9808befb258.png)
![Screenshot 2022-12-21 at 18-07-04 RDV Solidarités](https://user-images.githubusercontent.com/42057/208963457-5be77014-bb22-47c7-b495-929b21f8fcfa.png)


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
