### PR TITLE
Toujours montrer la page du choix de service lorsqu'il y en a plusieurs

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -64,15 +64,13 @@ class SearchContext
   def service
     @service ||= if @service_id.present?
                    Service.find(@service_id)
-                 elsif motif_name_and_type_selected?
-                   first_matching_motif.service
                  elsif services.count == 1
                    services.first
                  end
   end
 
   def services
-    unique_motifs_by_name_and_location_type.map(&:service).uniq.sort_by(&:name)
+    @services ||= matching_motifs.includes(:service).map(&:service).uniq.sort_by(&:name)
   end
 
   def requires_organisation_selection?

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -239,6 +239,32 @@ describe "User can search for rdvs" do
     end
   end
 
+  describe "when two motifs have the same name and location type on different services" do
+    let!(:territory) { create(:territory, departement_number: "92") }
+    let!(:organisation) { create(:organisation, territory: territory) }
+
+    let!(:service) { create(:service) }
+    let!(:other_service) { create(:service) }
+    let!(:motif) do
+      create(
+        :motif, :by_phone, reservable_online: true, name: "Consultation", service: service, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)]
+      )
+    end
+    let!(:other_motif) do
+      create(
+        :motif, :by_phone, reservable_online: true, name: "Consultation", service: other_service, organisation: organisation, plage_ouvertures: [create(:plage_ouverture)]
+      )
+    end
+
+    it "shows the service selection" do
+      visit root_path(departement: "92")
+
+      expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
+      expect(page).to have_content(service.name)
+      expect(page).to have_content(other_service.name)
+    end
+  end
+
   private
 
   def execute_search

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -110,8 +110,9 @@ describe SearchContext, type: :service do
       service_b = create(:service, name: "B")
       motif_a = create(:motif, service: service_a)
       motif_b = create(:motif, service: service_b)
+      matching_motifs = Motif.where(id: [motif_a.id, motif_b.id])
       search_context = described_class.new(nil, motif_name_with_location_type: [])
-      allow(search_context).to receive(:matching_motifs).and_return([motif_b, motif_a])
+      allow(search_context).to receive(:matching_motifs).and_return(matching_motifs)
       expect(search_context.services).to eq([service_a, service_b])
     end
   end
@@ -125,30 +126,34 @@ describe SearchContext, type: :service do
 
     it "returns service from selected motif" do
       motif = create(:motif)
+      matching_motifs = Motif.where(id: motif.id)
       search_context = described_class.new(nil, {})
-      allow(search_context).to receive(:matching_motifs).and_return([motif])
+      allow(search_context).to receive(:matching_motifs).and_return(matching_motifs)
       expect(search_context.service).to eq(motif.service)
     end
 
     it "returns service from same service motifs" do
       motif = create(:motif)
       autre_motif = create(:motif, service: motif.service)
+      matching_motifs = Motif.where(id: [motif.id, autre_motif.id])
       search_context = described_class.new(nil, {})
-      allow(search_context).to receive(:matching_motifs).and_return([motif, autre_motif])
+      allow(search_context).to receive(:matching_motifs).and_return(matching_motifs)
       expect(search_context.service).to eq(motif.service)
     end
 
     it "returns nil without motifs or service_id" do
       search_context = described_class.new(nil, {})
-      allow(search_context).to receive(:matching_motifs).and_return([])
+      matching_motifs = Motif.none
+      allow(search_context).to receive(:matching_motifs).and_return(matching_motifs)
       expect(search_context.service).to be_nil
     end
 
     it "returns nil with multiple service from motifs" do
       motif = create(:motif)
       autre_motif = create(:motif)
+      matching_motifs = Motif.where(id: [motif.id, autre_motif.id])
       search_context = described_class.new(nil, {})
-      allow(search_context).to receive(:matching_motifs).and_return([motif, autre_motif])
+      allow(search_context).to receive(:matching_motifs).and_return(matching_motifs)
       expect(search_context.service).to be_nil
     end
   end


### PR DESCRIPTION
Certaines organisations comme celles du 64 ont des motifs qui ont le même nom et le même type mais avec des services différents.
Dans ces cas-là il faut s'assurer qu'un choix de service soit fait côté usager,  sinon ça crée des incohérences: le motif étant retrouvé à partir du nom et du type, on se retrouver à calculer des créneaux sur deux motifs distincts d'une page à l'autre. 