### PR TITLE
Ajoute la clef et traduction pour le responsible

### DIFF
--- a/config/locales/models/attributes.fr.yml
+++ b/config/locales/models/attributes.fr.yml
@@ -18,3 +18,4 @@ fr:
     confirmed_at: Confirmation
     city_name: Nom de la commune
     city_code: Code commune INSEE
+    responsible_id: Responsable


### PR DESCRIPTION
Le département des Hautes-Seine nous a signalé qu'un label dans l'écran de fusion d'usager n'était pas traduit. Cette PR propose une correction

close #3211

Pour tester : https://demo-rdv-solidarites-pr3214.osc-secnum-fr1.scalingo.io/

Avant 
![Screenshot 2022-12-23 at 08-38-29 Fusionner deux usagers - RDV Solidarités](https://user-images.githubusercontent.com/42057/209293456-8ea190e6-f88a-4eca-83fe-faea366325c7.png)

Après

![Screenshot 2022-12-23 at 08-38-13 Fusionner deux usagers - RDV Solidarités](https://user-images.githubusercontent.com/42057/209293460-01b750bd-faaf-4a70-9c87-062681ef2e1c.png)


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
