### PR TITLE
Affiche collectif ou suivi sur la liste RDV usager

### DIFF
--- a/app/views/admin/rdvs/_short_rdv.html.slim
+++ b/app/views/admin/rdvs/_short_rdv.html.slim
@@ -3,6 +3,7 @@ li.card-body.py-2
   = rdv_status_tag(short_rdv)
   div
     = short_rdv.motif.name
+    = motif_badges(short_rdv.motif, only: %i[collectif follow_up])
     - if current_organisation.territory.enable_context_field
       div
         - if short_rdv.context.blank?


### PR DESCRIPTION
Les libellés de motif ne précisent pas toujours si c'est un motif de RDV collectif. Idem pour les motifs de suivis.

Des départements nous ont demandé d'ajouter un badge pour visualiser le type de RDV dans la liste des RDV à venir d'un usager.

close #3210

Pour tester : https://demo-rdv-solidarites-pr3215.osc-secnum-fr1.scalingo.io/

Avant :

![Screenshot 2022-12-23 at 08-55-02 Léa DUPONT - RDV Solidarités](https://user-images.githubusercontent.com/42057/209295960-9d0eef76-f7c1-4a93-b4c6-a1e71b3e36b6.png)

Après : 

![Screenshot 2022-12-23 at 08-53-51 Léa DUPONT - RDV Solidarités](https://user-images.githubusercontent.com/42057/209295968-dea9d016-00c7-443a-8219-c65a3cff16f0.png)


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
