### PR TITLE
Utilise l'action index plutôt que search pour Teams

### DIFF
--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -3,6 +3,8 @@
 class Admin::Territories::TeamsController < Admin::Territories::BaseController
   before_action :set_team, only: %i[show edit update destroy]
 
+  respond_to :html, :json
+
   def index
     @teams = policy_scope(Team).page(params[:page])
     @teams = params[:search].present? ? @teams.search_by_text(params[:search]) : @teams.order(:name)
@@ -45,16 +47,7 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
     redirect_to admin_territory_teams_path(current_territory)
   end
 
-  def search
-    teams = policy_scope(Team).limit(10)
-    @teams = search_params[:term].present? ? teams.search_by_text(search_params[:term]) : teams.order(:name)
-  end
-
   private
-
-  def search_params
-    @search_params ||= params.permit(:term)
-  end
 
   def team_params
     params.require(:team).permit(:name, agent_ids: [])

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -47,7 +47,7 @@
                 data: { \
                   "select-options": { \
                     ajax: {\
-                      url: search_admin_territory_teams_path(current_organisation.territory),
+                      url: admin_territory_teams_path(current_organisation.territory),
                       dataType: "json",
                       delay: 250, \
                     }, \

--- a/app/views/admin/territories/teams/index.json.jbuilder
+++ b/app/views/admin/territories/teams/index.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.results @teams do |team|
+  json.id team.id
+  json.text team.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,11 +109,7 @@ Rails.application.routes.draw do
           resources :agent_territorial_access_rights, only: %i[update]
           resources :webhook_endpoints, except: %i[show]
           resources :agents, only: %i[index update edit]
-          resources :teams do
-            collection do
-              get :search
-            end
-          end
+          resources :teams
           resource :user_fields, only: %i[edit update]
           resource :rdv_fields, only: %i[edit update]
           resource :motif_fields, only: %i[edit update]

--- a/spec/controllers/admin/territories/teams_controller_spec.rb
+++ b/spec/controllers/admin/territories/teams_controller_spec.rb
@@ -4,29 +4,6 @@ describe Admin::Territories::TeamsController, type: :controller do
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
 
-  describe "#index" do
-    it "assigns territory's teams" do
-      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
-      team = create(:team, territory: territory)
-      create(:team, territory: create(:territory))
-      sign_in agent
-
-      get :index, params: { territory_id: territory.id }
-      expect(assigns(:teams)).to eq([team])
-    end
-
-    it "filters territory's teams with search params" do
-      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
-      team = create(:team, territory: territory, name: "first team")
-      create(:team, territory: territory, name: "second")
-      create(:team, territory: create(:territory), name: "first group")
-      sign_in agent
-
-      get :index, params: { territory_id: territory.id, search: "first" }
-      expect(assigns(:teams)).to eq([team])
-    end
-  end
-
   describe "#new" do
     it "assigns new team" do
       agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory])
@@ -108,25 +85,6 @@ describe Admin::Territories::TeamsController, type: :controller do
       expect  do
         post :destroy, params: { territory_id: territory.id, id: team.id, team: { name: "otherName" } }
       end.to change(Team, :count).by(-1)
-    end
-  end
-
-  describe "#search" do
-    it "successful" do
-      agent = create(:agent)
-      create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_manage_teams: true)
-      sign_in agent
-      get :search, params: { territory_id: territory.id, term: "bla", format: "json" }
-      expect(response).to be_successful
-    end
-
-    it "assigns teams" do
-      agent = create(:agent)
-      create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_manage_teams: true)
-      sign_in agent
-      team = create(:team, name: "bla", territory: territory)
-      get :search, params: { territory_id: territory.id, term: "bla", format: "json" }
-      expect(assigns(:teams)).to eq([team])
     end
   end
 end

--- a/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
+++ b/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe "CRUDS teams configuration", type: :request do
+  include Rails.application.routes.url_helpers
+
+  describe "GET admin/territories/:territory_id/teams" do
+    it "returns all teams" do
+      territory = create(:territory)
+      agent = create(:agent)
+      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent, territory: territory)
+
+      sign_in agent
+
+      teams = create_list(:team, 3, territory: territory)
+
+      get admin_territory_teams_path(territory)
+
+      expect(response).to be_successful
+      expect(assigns(:teams).sort).to eq(teams.sort)
+    end
+
+    it "returns searched teams" do
+      territory = create(:territory)
+      agent = create(:agent)
+      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent, territory: territory)
+
+      sign_in agent
+
+      create(:team, territory: territory, name: "other name")
+      matching_team = create(:team, territory: territory, name: "First Groupe")
+
+      get admin_territory_teams_path(territory, search: "first")
+
+      expect(response).to be_successful
+      expect(assigns(:teams)).to eq([matching_team])
+    end
+
+    it "returns searched teams with json format" do
+      territory = create(:territory)
+      agent = create(:agent)
+      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent, territory: territory)
+
+      sign_in agent
+
+      create(:team, territory: territory, name: "other name")
+      matching_team = create(:team, territory: territory, name: "First Groupe")
+
+      get admin_territory_teams_path(territory, search: "first", format: :json)
+
+      expect(response).to be_successful
+      expect(assigns(:teams)).to eq([matching_team])
+    end
+  end
+end


### PR DESCRIPTION
Pour éviter d'avoir des comportements différents, de multiplier les actions, cette PR propose, comme évoqué dans le ticket #2201, de regrouper l'action de recherche et d'index pour les équipes.

ref #2201

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
