### PR TITLE
Fix chemin après sélection de service

### DIFF
--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -16,7 +16,7 @@ section.bg-light.p-4
 
     - context.services.each do |service|
       .card.mb-3
-        = link_to path_to_motif_selection(context.query.merge(service_id: service.id)) do
+        = link_to prendre_rdv_path(context.query.merge(service_id: service.id)) do
           .card-body
             .row
               .col-md


### PR DESCRIPTION
Je change ici l'url vers laquelle on est redirigée au moment de la sélection du service pour utiliser `prendre_rdv_path` de manière analogue à ce qu'on fait à la sélection de  motif ou de lieu.
Le helper `path_to_motif_selection` reste utilisé pour le retour en arrière.