### PR TITLE
Ajout du champ cancelled_at (et timestamps) sur rdvs_users

### DIFF
--- a/app/blueprints/rdvs_users_blueprint.rb
+++ b/app/blueprints/rdvs_users_blueprint.rb
@@ -3,7 +3,7 @@
 class RdvsUsersBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :status, :send_lifecycle_notifications, :send_reminder_notification
+  fields :status, :send_lifecycle_notifications, :send_reminder_notification, :cancelled_at
 
   association :user, blueprint: UserBlueprint
 end

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -50,7 +50,7 @@ module RdvsHelper
   end
 
   def rdv_tag(rdv)
-    if rdv.cancelled_at || current_user&.participation_for(rdv)&.cancelled?
+    if rdv.cancelled_at || current_user&.participation_for(rdv)&.cancelled_at
       tag.span("Annulé", class: "badge badge-warning")
     elsif rdv.starts_at.future?
       tag.span("À venir", class: "badge bg-info")

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -343,7 +343,7 @@ class Rdv < ApplicationRecord
       symbol_method = "#{status}?".to_sym
       next unless rdvs_users.any?(&symbol_method)
 
-      self.cancelled_at = status.in?(%w[revoked noshow]) ? Time.zone.now : nil
+      self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
       update!(status: status)
       break
     end

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -27,6 +27,7 @@ class RdvsUser < ApplicationRecord
   after_initialize :set_default_notifications_flags
   before_validation :set_default_notifications_flags
   before_create :set_status_from_rdv
+  before_save :set_cancelled_at, if: :will_save_change_to_status?
   after_save :update_counter_cache
   after_destroy :update_counter_cache
 
@@ -54,6 +55,10 @@ class RdvsUser < ApplicationRecord
     return if rdv&.status.nil? || rdv.collectif?
 
     self.status = rdv.status
+  end
+
+  def set_cancelled_at
+    self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
   end
 
   def temporal_status

--- a/db/migrate/20221226133126_add_cancelled_at_to_rdvs_user.rb
+++ b/db/migrate/20221226133126_add_cancelled_at_to_rdvs_user.rb
@@ -1,0 +1,19 @@
+class AddCancelledAtToRdvsUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :rdvs_users, :cancelled_at, :datetime, null: true
+    add_timestamps :rdvs_users, null: true
+
+    up_only do
+      execute(<<-SQL.squish
+        UPDATE rdvs_users SET
+        cancelled_at = (SELECT cancelled_at FROM rdvs WHERE rdvs_users.rdv_id = rdvs.id),
+        created_at = (SELECT created_at FROM rdvs WHERE rdvs_users.rdv_id = rdvs.id),
+        updated_at = (SELECT updated_at FROM rdvs WHERE rdvs_users.rdv_id = rdvs.id)
+      SQL
+             )
+    end
+
+    change_column_null :rdvs_users, :created_at, false
+    change_column_null :rdvs_users, :updated_at, false
+  end
+end

--- a/db/migrate/20221226133126_add_cancelled_at_to_rdvs_user.rb
+++ b/db/migrate/20221226133126_add_cancelled_at_to_rdvs_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCancelledAtToRdvsUser < ActiveRecord::Migration[7.0]
   def change
     add_column :rdvs_users, :cancelled_at, :datetime, null: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_30_143520) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_26_133126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -468,6 +468,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_30_143520) do
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
+    t.datetime "cancelled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["invitation_token"], name: "index_rdvs_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_rdvs_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_rdvs_users_on_invited_by"


### PR DESCRIPTION
Closes #3001 

On a besoin d'une date d'annulation pour suivre les annulations des rdvs coté rdv-insertion.
Désormais avec les rdv collectifs, pour des questions de logique métier il faut déplacer le champ cancelled_at sur les participations (comme on l'a fait avec les status)
Cette PR ajoute le champ cancelled_at sur les rdvs_users (participations) et les timestamps.

Je me suis aperçu que ce champ n'est pas vraiment utilisé dans rdv-solidarites et date d'il y a longtemps (+3 ans d'après le schéma) : 
- Il est utilisé dans un helper de vue pour les tags (on pourrait très bien utiliser les status des rdvs)
- Il est utilisé dans les blueprints (et on s'en sert coté rdv insertion, est ce que d'autres consommateurs d'api/webhooks s'en servent ?)

Une fois le champ ajouté sur les participations, on pourrait questionner sa présence au niveau du rdv lui même (ainsi que le champ status d'ailleurs).
