### PR TITLE
Plus de cohérence dans les titres et contenu des emails à destination des agents pour les rdv collectifs

### DIFF
--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -14,13 +14,21 @@ class Agents::RdvMailer < ApplicationMailer
 
   def rdv_created
     self.ics_payload = @rdv.payload(:create, @agent)
-    subject = t("agents.rdv_mailer.rdv_created.title", domain_name: domain.name, date: relative_date(@rdv.starts_at))
+    subject = if @rdv.collectif?
+                t("agents.rdv_mailer.rdv_created.title_participation", domain_name: domain.name, date: relative_date(@rdv.starts_at))
+              else
+                t("agents.rdv_mailer.rdv_created.title", domain_name: domain.name, date: relative_date(@rdv.starts_at))
+              end
     mail(subject: subject)
   end
 
   def rdv_cancelled
     self.ics_payload = @rdv.payload(:destroy, @agent)
-    subject = t("agents.rdv_mailer.rdv_cancelled.title", date: relative_date(@rdv.starts_at))
+    subject = if @rdv.collectif?
+                t("agents.rdv_mailer.rdv_cancelled.title_participation", domain_name: domain.name, date: relative_date(@rdv.starts_at))
+              else
+                t("agents.rdv_mailer.rdv_cancelled.title", domain_name: domain.name, date: relative_date(@rdv.starts_at))
+              end
     mail(subject: subject)
   end
 

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -17,6 +17,9 @@ class RdvsUser < ApplicationRecord
   belongs_to :user, -> { unscope(where: :deleted_at) }, inverse_of: :rdvs_users, optional: true
   has_one :prescripteur, dependent: :destroy
 
+  # Delegates
+  delegate :full_name, to: :user
+
   # Validations
   # Uniqueness validation doesn’t work with nested_attributes, see https://github.com/rails/rails/issues/4568
   # We do have on a DB constraint.

--- a/app/views/mailers/agents/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_cancelled.html.slim
@@ -7,6 +7,8 @@ div
       = t(".revoked_at_date_by_agent", date: date , author: author)
     - elsif @author.is_a? Agent
       = t(".cancelled_at_date_by_agent", date: date , author: author)
+    - elsif @author.is_a?(User) && @rdv.collectif?
+      = t(".cancelled_participation_at_date_by_user", date: date , author: author)
     - else
       = t(".cancelled_at_date_by_user", date: date , author: author)
 

--- a/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
@@ -1,7 +1,13 @@
 div
   p Bonjour,
   p
-    | Un nouveau RDV qui aura lieu #{relative_date @rdv.starts_at} vient d’être ajouté à votre agenda.
+    - date = relative_date(@rdv.starts_at)
+    - author = @author&.full_name
+    - if @rdv.collectif?
+      = t(".created_participation_at_date_by_user", date: date , author: author)
+    - else
+      = t(".created_at_date_by_user", date: date , author: author)
+
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   p.aligncenter

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -10,9 +10,9 @@
       span.float-right= @user.full_name
     - else
       span.title
-        = "Usager".pluralize(rdv.users.size)
+        = "Usager".pluralize(rdv.users_count)
         |  :
-      span.float-right= rdv.users.map(&:full_name).sort.to_sentence
+      span.float-right= rdv.rdvs_users.not_cancelled.map(&:full_name).sort.to_sentence
     .clear
   div.row-result
     span.title Motif :

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -40,13 +40,18 @@ fr:
     rdv_mailer:
       rdv_created:
         title: Nouveau RDV ajouté sur votre agenda %{domain_name} pour %{date}
+        title_participation: Nouvelle participation au RDV collectif sur votre agenda %{domain_name} pour %{date}
+        created_at_date_by_user: Un nouveau RDV qui aura lieu %{date} vient d’être ajouté à votre agenda.
+        created_participation_at_date_by_user: La participation de %{author} au RDV collectif qui aura lieu %{date} vient d’être ajoutée.
       rdv_updated:
         title: RDV du %{date} modifié
       rdv_cancelled:
         title: RDV annulé %{date}
+        title_participation: Participation au RDV collectif annulée %{date}
         revoked_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} pour raison administrative.
         cancelled_at_date_by_agent: Un RDV qui devait avoir lieu %{date} vient d’être annulé par %{author} à la demande de l’usager.
         cancelled_at_date_by_user: Un RDV qui devait avoir lieu %{date} vient d’être annulé par l’usager %{author}.
+        cancelled_participation_at_date_by_user: La participation au RDV collectif %{date} vient d’être annulé par l’usager %{author}.
     reply_transfer_mailer:
       notify_agent_of_user_reply:
         title: Message d'usager⋅e au sujet de votre RDV %{date}

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
     )
 
     perform_enqueued_jobs(queue: "mailers")
-    expect(email_sent_to(agent.email).subject).to include("Nouveau RDV ajouté sur votre agenda RDV Solidarités")
+    expect(email_sent_to(agent.email).subject).to include("Nouvelle participation au RDV collectif sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")
 


### PR DESCRIPTION
Les titres des emails et le contenu à destination des agents lors des inscriptions et annulations des participants aux rdv collectifs ne sont pas cohérents.
Il n'y a pas de changement concernant les emails à destination des usagers.
Voici les changements que cette PR met en place : 

Création Avant/Après :

![Capture d’écran 2022-12-28 à 15 40 25](https://user-images.githubusercontent.com/28594222/209829294-6d186ffb-1eff-4f83-aed2-8008662f58a0.png)
![Capture d’écran 2022-12-28 à 15 40 45](https://user-images.githubusercontent.com/28594222/209829215-5a9760e0-2fd6-41ea-8c0d-2bf03d2287f0.png)

Annulation Avant/Après :

![Capture d’écran 2022-12-28 à 15 40 07](https://user-images.githubusercontent.com/28594222/209829231-fb7d0215-edda-4da6-82b2-3ac779313bf4.png)
![Capture d’écran 2022-12-28 à 15 40 36](https://user-images.githubusercontent.com/28594222/209829236-bb53326f-d15e-49bd-8976-132b9c974dc5.png)
