### PR TITLE
Ajout du label prescripteur aux stats

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -33,6 +33,7 @@ class Stat
       agent: "Agent (#{rdvs.created_by_agent.count})",
       user: "Usager (#{rdvs.created_by_user.count})",
       file_attente: "File d'attente (#{rdvs.created_by_file_attente.count})",
+      prescripteur: "Prescripteur (#{rdvs.created_by_prescripteur.count})",
     }
     rdvs_group_by_week.transform_keys { |key| [new_keys[key[0].to_sym], key[1]] }
   end


### PR DESCRIPTION
Avant :
![Capture d’écran 2023-01-02 à 10 37 58](https://user-images.githubusercontent.com/1840367/210214718-b073a5aa-408a-4339-b3cf-aab3eb655d51.png)

Après : 
![Capture d’écran 2023-01-02 à 10 37 45](https://user-images.githubusercontent.com/1840367/210214720-7bd3335e-c2de-41bf-a7a3-918ffc22d220.png)