### PR TITLE
Ne pas utiliser les adresse mail non-officielles des cnfs

### DIFF
--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -4,7 +4,7 @@ class AddConseillerNumerique
   class ConseillerNumerique
     include ActiveModel::Model
 
-    attr_accessor :email, :first_name, :last_name, :external_id, :alternate_email
+    attr_accessor :email, :first_name, :last_name, :external_id
   end
 
   class Structure

--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -45,17 +45,13 @@ class AddConseillerNumerique
 
   def invite_agent(organisation)
     Agent.invite!(
-      {
-        email: @conseiller_numerique.email,
-        first_name: @conseiller_numerique.first_name.capitalize,
-        last_name: @conseiller_numerique.last_name,
-        external_id: @conseiller_numerique.external_id,
-        service: service,
-        password: SecureRandom.hex,
-        roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }],
-      },
-      nil,
-      { cc: @conseiller_numerique.alternate_email }
+      email: @conseiller_numerique.email,
+      first_name: @conseiller_numerique.first_name.capitalize,
+      last_name: @conseiller_numerique.last_name,
+      external_id: @conseiller_numerique.external_id,
+      service: service,
+      password: SecureRandom.hex,
+      roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }]
     ).tap do |agent|
       AgentTerritorialAccessRight.create!(agent: agent, territory: territory)
     end

--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -24,9 +24,6 @@
   <%= link_to("Activer mon compte", accept_invitation_url(@resource, invitation_token: @token, user: @user_params),  class: "btn btn-primary") %>
 </div>
 
-<p><%= t("devise.mailer.invitation_instructions_cnfs.account_info", email: @resource.email) %></p>
-<p><%= t("devise.mailer.invitation_instructions_cnfs.account_info2") %></p>
-
 <br>
 <h1><%= t("devise.mailer.invitation_instructions_cnfs.title1") %></h1>
 

--- a/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.text.erb
@@ -14,11 +14,6 @@
 Activer mon compte: <%= accept_invitation_url(@resource, invitation_token: @token, user: @user_params) %>
 
 
-<%= t("devise.mailer.invitation_instructions_cnfs.account_info", email: @resource.email) %>
-<%= t("devise.mailer.invitation_instructions_cnfs.account_info2") %>
-
-
-
 <%= t("devise.mailer.invitation_instructions_cnfs.title1") %>
 
 <%= t("devise.mailer.invitation_instructions_cnfs.paragraph1", video_link: "https://peertube.ethibox.fr/w/f5Pd9h7uuor7xDNEKQRkqV") %>

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -52,8 +52,6 @@ fr:
         use4: "✅ Importer vos rendez-vous dans vos agendas externes (Outlook, Google Agenda, etc...) "
         title1: Comment ça marche ?
         paragraph1: Pour mieux comprendre, nous vous proposons de regarder la vidéo de présentation de l’outil %{video_link}.
-        account_info: "💡 La connexion à votre compte se fait via votre adresse %{email}."
-        account_info2: "Une fois le compte activé, vous pouvez changer cette adresse dans vos paramètres."
         first_steps_info: Vous trouverez  également un guide “premiers pas” dans l’interface de l’outil.
         title2: Besoin d’aide ?
         help_info: "Vous pouvez  nous contacter sur le Mattermost dans le canal : %{mattermost}  ou bien par mail à %{support_email}"

--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -15,7 +15,6 @@ conseillers_numeriques.each do |conseiller_numerique|
   AddConseillerNumerique.process!({
     external_id: external_id,
     email: conseiller_numerique["Email @conseiller-numerique.fr"],
-    alternate_email: conseiller_numerique["Email"],
     first_name: conseiller_numerique["Prénom"],
     last_name: conseiller_numerique["Nom"],
     structure: {

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -6,7 +6,6 @@ describe AddConseillerNumerique do
     {
       external_id: "exemple@conseiller-numerique.fr",
       email: "exemple@conseiller-numerique.fr",
-      alternate_email: "exemple@ccas-paris.fr",
       first_name: "Camille",
       last_name: "Clavier",
       structure: {
@@ -26,7 +25,7 @@ describe AddConseillerNumerique do
   end
 
   context "when the conseiller numerique and their structure have never been imported before" do
-    it "creates the agent for the conseiller numerique and notifies them on both email addresses" do
+    it "creates the agent for the conseiller numerique and notifies them" do
       described_class.process!(params)
       expect(Agent.count).to eq 1
       expect(Agent.last).to have_attributes(
@@ -49,10 +48,7 @@ describe AddConseillerNumerique do
       perform_enqueued_jobs
       invitation_email = ActionMailer::Base.deliveries.last
 
-      expect(invitation_email).to have_attributes(
-        to: ["exemple@conseiller-numerique.fr"],
-        cc: ["exemple@ccas-paris.fr"]
-      )
+      expect(invitation_email).to have_attributes(to: ["exemple@conseiller-numerique.fr"])
     end
   end
 


### PR DESCRIPTION
Plusieurs CnFS nous ont reprochés d'être trop insistants dans nos mails d'invitation. Pour le moment, on désactive donc les cc qui sont envoyés à leur adresse mail non officielle (c'est donc un rollback de https://github.com/betagouv/rdv-solidarites.fr/pull/2811, en plus du rollback des relances fait dans https://github.com/betagouv/rdv-solidarites.fr/pull/3149).

Si on améliore un peu notre mail et/ou notre stratégie de relance, on pourra envisager de remettre ces adresses en cc.