### PR TITLE
Ne pas passer des rdv collectifs en annulés en cas d'annulation de l'usager

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -358,7 +358,7 @@ class Rdv < ApplicationRecord
 
   def update_status_priority_order_participations
     # Priority Order. One participation will change rdv status
-    %w[unknown seen noshow excused revoked].each do |status|
+    %w[unknown seen noshow revoked].each do |status|
       symbol_method = "#{status}?".to_sym
       next unless rdvs_users.any?(&symbol_method)
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -243,6 +243,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         fill_in(:letter2, with: "V")
 
         expect_cancel_participation.to change { participation.reload.status }.from("unknown").to("excused")
+        expect(rdv.reload.status).to eq("unknown")
 
         expect_notifications_for(user, "rdv_cancelled")
         expect_webhooks_for(user)
@@ -264,6 +265,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         fill_in(:letter2, with: "V")
 
         expect_cancel_participation.to change { participation.reload.status }.from("unknown").to("excused")
+        expect(rdv.reload.status).to eq("unknown")
 
         perform_enqueued_jobs
         expect(ActionMailer::Base.deliveries.map(&:to).flatten).to match_array([agent.email])

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -749,15 +749,6 @@ describe Rdv, type: :model do
       expect(rdv.status).to eq("noshow")
     end
 
-    it "updated as excused (fourth priority)" do
-      rdv.rdvs_users.first.update(status: "revoked")
-      rdv.rdvs_users.second.update(status: "excused")
-      rdv.rdvs_users.third.update(status: "excused")
-      rdv.rdvs_users.last.update(status: "excused")
-      rdv.update_rdv_status_from_participation
-      expect(rdv.status).to eq("excused")
-    end
-
     it "updated as revoked (last priority)" do
       rdv.rdvs_users.first.update(status: "revoked")
       rdv.rdvs_users.second.update(status: "revoked")
@@ -767,7 +758,7 @@ describe Rdv, type: :model do
       expect(rdv.status).to eq("revoked")
     end
 
-    %w[seen noshow excused].each do |status|
+    %w[seen noshow].each do |status|
       it "updated as #{status} if all participations statuses are #{status}" do
         rdv.rdvs_users.update(status: status)
         rdv.update_rdv_status_from_participation


### PR DESCRIPTION
fixes https://github.com/betagouv/rdv-solidarites.fr/issues/3227

C'est le plus petit fix possible pour corriger le bug, mais d'autres questions restent en suspens.

### Incohérence sur les RDV collectifs entre la possibilité d'être en "Absence non excusée" mais pas en "Absence excusée"

Ces deux états dépendent de l'action de l'usager, mais un seul des deux est autorisé dans l'interface.

### Logique existante pour les participations revoked

Si je comprend bien le code, il n'est pas possible de passer directement une participation en revoked. Il faut passer le rdv en revoked, ce qui fera passer la participation dans cet état aussi, et pourtant on a bien de la logique pour mettre à jour le rdv à partir de ce changement de participation.

### Duplication de la logique de la machine à état des rendez-vous et de leur participations

La machine à état (liste des états possibles et des transitions autorisées d'un état à l'autre) de l'ensemble 

### Flou sur le sens d'un rdv collectif en "Absence non excusée" ou "Absence excusée"

Pour le moment, un rdv collectif en "Absence non excusée" signifie que aucun des participants n'est venu. Est-ce que ça vaut vraiment le coup d'avoir un état pour ce cas qui devrait être exceptionnel ?

### Texte d'explications des changements d'état prévus pour les rdv individuels, mais pas les rendez-vous collectifs

J'ai l'impression que c'est une autre illustration du problème précédent : les textes d'explications dans la dropdown sont prévus pour les rdv individuels, et sont donc ambigus pour les rendez-vous collectifs. Si on arrive à clarifier le sens des états précédents (voire à les supprimer complètement)

### Proposition pour la suite

voir https://github.com/betagouv/rdv-solidarites.fr/issues/3232

