### PR TITLE
Changement de la contrainte sur la longueur des intitulés

### DIFF
--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -25,6 +25,7 @@ module Admin::RdvFormConcern
     validate :warn_rdvs_overlapping_rdv
     validate :warn_rdv_duplicate_suspected
     validate :warn_starts_in_the_past
+    validate :warn_name_too_long_for_sms
   end
 
   def check_duplicates
@@ -116,6 +117,17 @@ module Admin::RdvFormConcern
     return if rdv.starts_at >= Time.zone.now
 
     add_benign_error(I18n.t("activemodel.warnings.models.rdv.attributes.starts_at.in_the_past", distance: distance_of_time_in_words_to_now(rdv.starts_at)))
+  end
+
+  def warn_name_too_long_for_sms
+    return if ignore_benign_errors
+    return if rdv.individuel?
+
+    truncated_name = Users::RdvSms.truncated_rdv_name(rdv.name)
+
+    return if truncated_name == rdv.name
+
+    add_benign_error("L'intitulé est trop long et sera abbrévié ainsi dans les notifications sms : #{truncated_name}")
   end
 
   def rdv_agent_pairs_ending_shortly_before_grouped_by_agent

--- a/app/form_models/admin/rdv_form_concern.rb
+++ b/app/form_models/admin/rdv_form_concern.rb
@@ -127,7 +127,7 @@ module Admin::RdvFormConcern
 
     return if truncated_name == rdv.name
 
-    add_benign_error("L'intitulé est trop long et sera abbrévié ainsi dans les notifications sms : #{truncated_name}")
+    add_benign_error("L'intitulé est trop long et sera abrégé ainsi dans les notifications SMS : #{truncated_name}")
   end
 
   def rdv_agent_pairs_ending_shortly_before_grouped_by_agent

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -42,6 +42,8 @@ class Users::RdvSms < Users::BaseSms
   end
 
   def self.truncated_rdv_name(name)
+    return if name.blank?
+
     if name.length > MAX_RDV_NAME_LENGTH
       "#{name.first(MAX_RDV_NAME_LENGTH)}..."
     else

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -38,7 +38,7 @@ class Users::RdvSms < Users::BaseSms
   MAX_RDV_NAME_LENGTH = 50
 
   def truncated_rdv_name
-    self.class.truncated_rdv_name(name)
+    self.class.truncated_rdv_name(@rdv.name)
   end
 
   def self.truncated_rdv_name(name)

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -5,7 +5,7 @@ class Users::RdvSms < Users::BaseSms
 
   def rdv_title(rdv)
     if rdv.collectif? && rdv.name.present?
-      "#{rdv.motif.service.short_name} : #{rdv.name},"
+      "#{rdv.motif.service.short_name} : #{truncated_rdv_name},"
     else
       rdv.motif.service.short_name
     end
@@ -33,6 +33,20 @@ class Users::RdvSms < Users::BaseSms
                "Allez sur #{url} pour reprendre RDV."
              end
     @content = "#{base_message}\n#{footer}"
+  end
+
+  MAX_RDV_NAME_LENGTH = 50
+
+  def truncated_rdv_name
+    self.class.truncated_rdv_name(name)
+  end
+
+  def self.truncated_rdv_name(name)
+    if name.length > MAX_RDV_NAME_LENGTH
+      "#{name.first(MAX_RDV_NAME_LENGTH)}..."
+    else
+      name
+    end
   end
 
   private

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -72,7 +72,7 @@
                     }
 
             - if @rdv_form.motif.collectif?
-              = f.input :name, label: "Intitulé (max 50 caractères)", wrapper_html: { class: "mb-1" }, input_html: { maxlength: 50 }
+              = f.input :name, wrapper_html: { class: "mb-1" }
               p
                 span.font-14.font-weight-bold= "Avertissement : "
                 span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -20,7 +20,7 @@
               = datetime_input(f, :starts_at, input_html: { data: { "past-date-alert-target": "date-input" } })
             .col-md-6= f.input :duration_in_min, as: :integer
           = f.association :agents, collection: @rdv.motif.authorized_agents.includes(:service), label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input" }
-          = f.input :name, label: "Intitulé (max 50 caractères)", wrapper_html: { class: "mb-1" }, input_html: { maxlength: 50 }
+          = f.input :name, wrapper_html: { class: "mb-1" }
           p
             span.font-14.font-weight-bold= "Avertissement : "
             span.text-muted.font-14= I18n.t("activerecord.attributes.rdv/name.hint")

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Agent can create a Rdv collectif" do
+describe "Agent can create a Rdv collectif from the agenda" do
   include UsersHelper
 
   let!(:organisation) { create(:organisation) }
@@ -24,7 +24,7 @@ describe "Agent can create a Rdv collectif" do
   end
 
   it "default", js: true do
-    find(".fc-minor", match: :first).click
+    find(".fc-minor", match: :first).click # Click on the agenda
 
     select(motif.name, from: "rdv_motif_id")
     click_button("Continuer")

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -112,7 +112,7 @@ describe "Agent can organize a rdv collectif", js: true do
       select(lieu.name, from: "rdv_lieu_id")
 
       click_button "Enregistrer"
-      expect(page).to have_content("L'intitulé est trop long et sera abbrévié ainsi dans les notifications sms : Organiser ses fichiers et ses dossiers sur son ord...")
+      expect(page).to have_content("L'intitulé est trop long et sera abrégé ainsi dans les notifications SMS : Organiser ses fichiers et ses dossiers sur son ord...")
     end
   end
 end


### PR DESCRIPTION
correctif long terme pour #3233 (en plus de #3235)
On transforme l'erreur de validation en avertissement, puisqu'il y a des cas où les intitulés ont une bonne raison de faire plus de 50 caractères.

Avant :
Impossible de mettre un intitulé de plus de 50 caractères, et les rdv existants sont soit tronqués soit en erreur
<img width="1110" alt="Capture d’écran 2023-01-04 à 17 21 18" src="https://user-images.githubusercontent.com/1840367/210601231-dba719b3-1fc7-4120-a705-168b46944f6c.png">


Après :
On met un avertissement, et on laisse l'agent choisir l'intitulé

<img width="818" alt="Capture d’écran 2023-01-04 à 17 16 20" src="https://user-images.githubusercontent.com/1840367/210600341-0a892103-c68e-4b4a-a9e7-a6ad83604944.png">
