### PR TITLE
Correctif rapide pour #3233

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -63,7 +63,6 @@ class Rdv < ApplicationRecord
   validate :lieu_is_not_disabled_if_needed
   validate :starts_at_is_plausible
   validate :duration_is_plausible
-  validates :name, length: { maximum: 50 }
   validates :max_participants_count, numericality: { greater_than: 0, allow_nil: true }
 
   # Hooks


### PR DESCRIPTION
Cette PR est un correctif rapide pour #3233 pour débloquer les usagers et agents en attendant que la PR https://github.com/betagouv/rdv-solidarites.fr/pull/3234 soit prête.

Il n'y a pas de changement d'interface, puisque la validation en front est encore là, mais au moins ça évitera les erreurs.