### PR TITLE
Respecter la casse de "FranceConnect"

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@ MATOMO_APP_ID=change_me
 ## Github (SuperAdmins)
 GITHUB_APP_ID=change_me
 GITHUB_APP_SECRET=change_me
-## France Connect (Users)
+## FranceConnect (Users)
 FRANCECONNECT_APP_ID=change_me
 FRANCECONNECT_APP_SECRET=change_me
 FRANCECONNECT_HOST=change_me

--- a/app/views/common/_franceconnect_button.html.slim
+++ b/app/views/common/_franceconnect_button.html.slim
@@ -2,8 +2,8 @@
   .text-center.mb-3
     p FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne
     = link_to "/omniauth/franceconnect", class: "france-connect-link", method: :post do
-      .normal = image_tag("franceconnect-bouton.svg", alt: "S'identifier avec France connect")
-      .hover = image_tag("franceconnect-bouton-hover.svg", alt: "S'identifier avec France connect")
+      .normal = image_tag("franceconnect-bouton.svg", alt: "S'identifier avec FranceConnect")
+      .hover = image_tag("franceconnect-bouton-hover.svg", alt: "S'identifier avec FranceConnect")
     .france-connect-details= link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/"
 
   hr

--- a/spec/features/users/user_can_login_using_france_connect_spec.rb
+++ b/spec/features/users/user_can_login_using_france_connect_spec.rb
@@ -19,9 +19,9 @@ describe "User can login using FranceConnect" do
   context "visiting rdv-solidarites domain" do
     it "allows a user to create an account using the FranceConnect button" do
       visit "http://www.rdv-solidarites-test.localhost/users/sign_in"
-      expect(page).to have_link("S'identifier avec France connect")
+      expect(page).to have_link("S'identifier avec FranceConnect")
 
-      expect { click_on "S'identifier avec France connect" }.to change(User, :count).by(1)
+      expect { click_on "S'identifier avec FranceConnect" }.to change(User, :count).by(1)
 
       expect(User.last).to have_attributes(
         email: "france@monopolis.fr",
@@ -39,7 +39,7 @@ describe "User can login using FranceConnect" do
   context "visiting rdv-aide-numerique domain" do
     it "hides the FranceConnect button" do
       visit "http://www.rdv-aide-numerique-test.localhost/users/sign_in"
-      expect(page).not_to have_link("S'identifier avec France connect")
+      expect(page).not_to have_link("S'identifier avec FranceConnect")
     end
   end
 end


### PR DESCRIPTION
Ce matin j'ai demandé l'ajout du domain rdv-aide-numerique.fr à notre config FranceConnect, et j'en ai profité pour lire les guidelines : https://partenaires.franceconnect.gouv.fr/monprojet/recetter/

> Merci de faire attention à l’écriture du terme « FranceConnect » et d’accoler les deux mots France et Connect partout où « FranceConnect » est mentionné.