### PR TITLE
Ajout de la vérification de domaine pour la synchro Outlook

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -18,4 +18,6 @@ class StaticPagesController < ApplicationController
   def presentation_for_agents
     render current_domain.presentation_for_agents_template_name
   end
+
+  def microsoft_domain_verification; end
 end

--- a/app/views/static_pages/microsoft_domain_verification.json.erb
+++ b/app/views/static_pages/microsoft_domain_verification.json.erb
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "<%= ENV["AZURE_APPLICATION_CLIENT_ID"] %>"
+    }
+  ]
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,7 @@ Rails.application.routes.draw do
   %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite domaines health_check].each do |page_name|
     get page_name => "static_pages##{page_name}"
   end
+  get "/.well-known/microsoft-identity-association" => "static_pages#microsoft_domain_verification", format: :json
 
   get "/budget", to: redirect("https://pad.incubateur.net/3hxhbOuaSyapxRUg_PnA5g#ANCT-L%E2%80%99Incubateur-des-Territoires", status: 302)
 

--- a/spec/requests/domain_verification_spec.rb
+++ b/spec/requests/domain_verification_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+# frozen_string_literal: true
 
 # see https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain
 RSpec.describe "Microsoft domain verification" do

--- a/spec/requests/domain_verification_spec.rb
+++ b/spec/requests/domain_verification_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+# see https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain
+RSpec.describe "Microsoft domain verification" do
+  before do
+    ENV["AZURE_APPLICATION_CLIENT_ID"] = "public_client_id_123456"
+  end
+
+  it "shows the public app id at the correct route" do
+    get "/.well-known/microsoft-identity-association.json"
+    parsed_response = JSON.parse(response.body)
+    expect(parsed_response.dig("associatedApplications", 0, "applicationId")).to eq "public_client_id_123456"
+  end
+end


### PR DESCRIPTION
Actuellement, quand on lance une synchro Outlook, Microsoft indique que notre app est "unverified", ce qui est le cas puisqu'on n'a pas fait le processus de vérification. Cette PR permet de faire cette vérification en ajoutant le bon fichier au bon endroit

<img width="538" alt="Capture d’écran 2023-01-09 à 15 14 35" src="https://user-images.githubusercontent.com/1840367/211350215-dfccbc7e-6b65-4c37-bbce-1b93e38754ee.png">
