### PR TITLE
Correction du content type pour la vérification de publisher Azure Microsoft

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -22,5 +22,9 @@ class StaticPagesController < ApplicationController
   def microsoft_domain_verification
     # see https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain#select-a-verified-domain
     response.headers["Content-Type"] = "application/json"
+
+    render # pour avoir un response.body sur lequel calculer Content-Length
+
+    response.headers["Content-Length"] = response.body.length.to_s
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -19,5 +19,8 @@ class StaticPagesController < ApplicationController
     render current_domain.presentation_for_agents_template_name
   end
 
-  def microsoft_domain_verification; end
+  def microsoft_domain_verification
+    # see https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain#select-a-verified-domain
+    response.headers['Content-Type'] = "application/json"
+  end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -21,6 +21,6 @@ class StaticPagesController < ApplicationController
 
   def microsoft_domain_verification
     # see https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain#select-a-verified-domain
-    response.headers['Content-Type'] = "application/json"
+    response.headers["Content-Type"] = "application/json"
   end
 end

--- a/spec/requests/domain_verification_spec.rb
+++ b/spec/requests/domain_verification_spec.rb
@@ -2,8 +2,13 @@
 
 # see https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-configure-publisher-domain
 RSpec.describe "Microsoft domain verification" do
-  before do
+  around do |example|
+    previous_client_id = ENV["AZURE_APPLICATION_CLIENT_ID"]
     ENV["AZURE_APPLICATION_CLIENT_ID"] = "public_client_id_123456"
+
+    example.run
+
+    ENV["AZURE_APPLICATION_CLIENT_ID"] = previous_client_id
   end
 
   it "shows the public app id at the correct route" do


### PR DESCRIPTION
Toujours dans le contexte de la mise en prod d'outlook (https://github.com/betagouv/rdv-solidarites.fr/issues/3246), j'ai eu une erreur lors de la vérification du domaine : il faut que le header Content-Type soit exactement `application/json`, et non pas `application/json; charset=utf-8`.
J'en profite pour ajouter un lien vers la doc depuis le controller.

J'ai testé la vérification avec la review app, ça m'a permis d'apprendre qu'il faut aussi un content-length, et je l'espère d'éviter une énième PR de correctif 😬 

(ping @damienlethiec pour info)