### PR TITLE
Permet la déconnexion Outlook en cas d'erreur de suppression d'un event

### DIFF
--- a/app/jobs/outlook/mass_destroy_event_job.rb
+++ b/app/jobs/outlook/mass_destroy_event_job.rb
@@ -3,10 +3,8 @@
 module Outlook
   class MassDestroyEventJob < ApplicationJob
     def perform(agent)
-      while agent.agents_rdvs.exists_in_outlook.any?
-        agent.agents_rdvs.exists_in_outlook.each do |agents_rdv|
-          Outlook::DestroyEventJob.perform_now(agents_rdv.outlook_id, agents_rdv.agent)
-        end
+      agent.agents_rdvs.exists_in_outlook.each do |agents_rdv|
+        Outlook::DestroyEventJob.perform_now(agents_rdv.outlook_id, agents_rdv.agent)
       end
       agent.update!(microsoft_graph_token: nil, refresh_microsoft_graph_token: nil)
     end


### PR DESCRIPTION
En testant la synchro outlook, on a eu un cas où l'event avait déjà été supprimé sur outlook (potentiellement à cause d'une race condition de deux jobs qui tournaient en parallèle, mais ça pourrait aussi arriver si l'évènement a déjà été supprimé manuellement sur le calendrier outlook). Avec l'implémentation précédente, ça faisait une boucle infinie d'appel à l'api d'outlook.

Dans cette nouvelle implémentation, on se dit que ce n'est pas grave s'il y a des erreurs lors de la suppression des évènements, et on déconnecte l'utilisateur même s'il y a encore potentiellement des évènements dans son calendrier outlook.

lié à #3246 et #3115