### PR TITLE
Correctifs pour les services autre que CnFS sur le domaine RDV Aide Numérique

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -31,12 +31,4 @@ module AdminHelper
     end
     policy([:agent, mock]).send("#{action}?")
   end
-
-  def faq_url
-    if current_agent.conseiller_numerique?
-      "https://rdvs.notion.site/FAQ-CNFS-c55933f66f054aaba60fe4799851000e"
-    else
-      "https://rdv-solidarites.notion.site/F-A-Q-M-dico-social-aaf94709c0ea448b8eb9d93f548acdb9"
-    end
-  end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -11,7 +11,7 @@ Domain = Struct.new(
   :online_reservation_with_public_link,
   :can_sync_to_outlook,
   :france_connect_enabled,
-  :default,
+  :faq_url,
   keyword_init: true
 )
 
@@ -27,6 +27,7 @@ class Domain
       online_reservation_with_public_link: false,
       can_sync_to_outlook: false,
       sms_sender_name: "RdvSoli",
+      faq_url: "https://rdv-solidarites.notion.site/F-A-Q-M-dico-social-aaf94709c0ea448b8eb9d93f548acdb9",
       france_connect_enabled: true
     ),
 
@@ -40,6 +41,7 @@ class Domain
       online_reservation_with_public_link: true,
       can_sync_to_outlook: false,
       sms_sender_name: "RdvAideNum",
+      faq_url: "https://rdvs.notion.site/FAQ-CNFS-c55933f66f054aaba60fe4799851000e",
       france_connect_enabled: false
     ),
   ].freeze

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,38 +1,21 @@
 # frozen_string_literal: true
 
+Domain = Struct.new(
+  :id,
+  :name,
+  :logo_path,
+  :public_logo_path,
+  :dark_logo_path,
+  :presentation_for_agents_template_name,
+  :sms_sender_name,
+  :online_reservation_with_public_link,
+  :can_sync_to_outlook,
+  :france_connect_enabled,
+  :default,
+  keyword_init: true
+)
+
 class Domain
-  # rubocop:disable Metrics/ParameterLists
-  def initialize(
-    id:,
-    name:,
-    logo_path:,
-    public_logo_path:,
-    dark_logo_path:,
-    presentation_for_agents_template_name:,
-    sms_sender_name:,
-    online_reservation_with_public_link:,
-    can_sync_to_outlook:,
-    france_connect_enabled:,
-    default: false
-  )
-    @id = id
-    @name = name
-    @logo_path = logo_path
-    @public_logo_path = public_logo_path
-    @dark_logo_path = dark_logo_path
-    @presentation_for_agents_template_name = presentation_for_agents_template_name
-    @sms_sender_name = sms_sender_name
-    @online_reservation_with_public_link = online_reservation_with_public_link
-    @can_sync_to_outlook = can_sync_to_outlook
-    @france_connect_enabled = france_connect_enabled
-    @default = default
-  end
-  # rubocop:enable Metrics/ParameterLists
-
-  attr_reader :id, :logo_path, :public_logo_path, :dark_logo_path, :name, :presentation_for_agents_template_name,
-              :sms_sender_name, :online_reservation_with_public_link, :can_sync_to_outlook, :france_connect_enabled,
-              :default
-
   ALL = [
     RDV_SOLIDARITES = new(
       id: "RDV_SOLIDARITES",
@@ -97,6 +80,7 @@ class Domain
   def default?
     self == RDV_SOLIDARITES
   end
+  alias default default?
 
   ALL_BY_URL = ALL.index_by(&:dns_domain_name)
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -102,11 +102,9 @@ class Rdv < ApplicationRecord
   scope :with_remaining_seats, -> { where("users_count < max_participants_count OR max_participants_count IS NULL") }
   scope :for_domain, lambda { |domain|
     if domain == Domain::RDV_AIDE_NUMERIQUE
-      joins(motif: :service).where(service: { name: Service::CONSEILLER_NUMERIQUE })
-        .joins(:organisation).where(organisations: { new_domain_beta: true })
+      joins(:organisation).where(organisations: { new_domain_beta: true })
     else
-      # TODO: #rdv-aide-numerique-v1 afficher uniquement les rdv du médico-social
-      all
+      joins(:organisation).where(organisations: { new_domain_beta: false })
     end
   }
   ## -

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -71,7 +71,7 @@
         = f.input(:rdvs_editable_by_user)
         p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
 
-  - unless current_agent.conseiller_numerique?
+  - unless current_domain.online_reservation_with_public_link?
     .card.js-sectorisation-card
       .card-body
         h5.mb-2= Motif.human_attribute_name("sectorisation_level_title")

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -71,7 +71,7 @@
         = f.input(:rdvs_editable_by_user)
         p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
 
-  - unless current_domain.online_reservation_with_public_link?
+  - unless current_domain.online_reservation_with_public_link
     .card.js-sectorisation-card
       .card-body
         h5.mb-2= Motif.human_attribute_name("sectorisation_level_title")

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -56,7 +56,7 @@
             motif_option_activated(@motif, :rdvs_editable_by_user), \
             hint: Motif.human_attribute_name(:rdvs_editable_by_user_hint)
 
-          - unless current_domain.online_reservation_with_public_link?
+          - unless current_domain.online_reservation_with_public_link
             = motif_attribute_row("Sectorisation") do
               - if @motif.reservable_online?
                 div= @motif.human_attribute_value(:sectorisation_level)

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -56,7 +56,7 @@
             motif_option_activated(@motif, :rdvs_editable_by_user), \
             hint: Motif.human_attribute_name(:rdvs_editable_by_user_hint)
 
-          - unless current_agent.conseiller_numerique?
+          - unless current_domain.online_reservation_with_public_link?
             = motif_attribute_row("Sectorisation") do
               - if @motif.reservable_online?
                 div= @motif.human_attribute_value(:sectorisation_level)

--- a/app/views/admin/organisations/setup_checklists/show_conseiller_numerique.slim
+++ b/app/views/admin/organisations/setup_checklists/show_conseiller_numerique.slim
@@ -49,7 +49,7 @@
         p Si vous utilisez déjà un agenda comme Outlook ou Google Calendar, vous pouvez synchroniser votre agenda #{current_domain.name} vers votre agenda externe, pour que vos rendez-vous y soient visibles aussi.
         p
           = "Vous pouvez trouver plus d'information à ce sujet dans notre "
-          = link_to "FAQ", faq_url
+          = link_to "FAQ", current_domain.faq_url
           = "."
 
         h5 Recherche de créneaux

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -17,7 +17,7 @@
         p
           span> Vous pouvez aussi consulter les
           ruby:
-          = link_to faq_url do
+          = link_to current_domain.faq_url do
             span> Questions fréquentes
             i.fa.fa-external-link-alt
 

--- a/app/views/agents/outlook_sync/show.html.slim
+++ b/app/views/agents/outlook_sync/show.html.slim
@@ -16,6 +16,6 @@
       = image_tag("sign_in_with_microsoft.svg", alt: "S'identifier avec Microsoft")
 
   p Tous vos rendez-vous de #{current_domain.name} seront copiés automatiquement au fur et à mesure de leur création (ou modification).
-  p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", faq_url, target: :blank)}.
+  p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", current_domain.faq_url, target: :blank)}.
 
 = link_to "Retour aux méthodes de synchronisation calendrier", agents_calendar_sync_path, class: "btn btn-link float-right mt-3"

--- a/app/views/agents/webcal_sync/show.html.slim
+++ b/app/views/agents/webcal_sync/show.html.slim
@@ -6,7 +6,7 @@ p.mb-1 Allez dans votre agenda externe et ajoutez un nouveau calendrier avec cet
 =  link_to(calendar_url, calendar_url, class: "mb-1")
 
 p Tous vos rendez-vous de #{current_domain.name} seront copiés automatiquement au fur et à mesure de leur création (ou modification).
-p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", faq_url, target: :blank)}.
+p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la FAQ", current_domain.faq_url, target: :blank)}.
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 

--- a/app/views/layouts/_cnfs_online_booking_banner.html.slim
+++ b/app/views/layouts/_cnfs_online_booking_banner.html.slim
@@ -1,4 +1,4 @@
--if current_agent.conseiller_numerique? && !cookies[:disable_cnfs_online_booking_banner].present?
+-if current_domain.online_reservation_with_public_link? && !cookies[:disable_cnfs_online_booking_banner].present?
   - online_booking_path = admin_organisation_online_booking_path(current_organisation)
   .navbar.alert-info.p-2.flex-gap-1em
     div.flex-grow-1

--- a/app/views/layouts/_cnfs_online_booking_banner.html.slim
+++ b/app/views/layouts/_cnfs_online_booking_banner.html.slim
@@ -1,4 +1,4 @@
--if current_domain.online_reservation_with_public_link? && !cookies[:disable_cnfs_online_booking_banner].present?
+-if current_domain.online_reservation_with_public_link && !cookies[:disable_cnfs_online_booking_banner].present?
   - online_booking_path = admin_organisation_online_booking_path(current_organisation)
   .navbar.alert-info.p-2.flex-gap-1em
     div.flex-grow-1

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe Domain do
+  it "has domains initialized with all the required keys" do
+    Domain::ALL.each do |domain|
+      expect(domain.to_h.compact.keys).to match_array(described_class.members)
+    end
+  end
+end


### PR DESCRIPTION
Le but premier de cette PR était de faire que dans l'index des rdv côté usager, les rdv pris avec un service autre que les CNFS soient visibles (c'est utile notamment pour les Pass Numérique et les Maisons France Service).

Au passage, j'en ai profité pour passer d'autres features flags qui étaient sur le service en feature flags sur le domaine. Ce fonctionnement sur le service est du legacy d'avant qu'on ai deux domaines différents.
Avec cette PR, l'appli se comporte de manière plus cohérente pour les membres d'une même équipe.

Cette PR introduit aussi un léger changement de comportement, qui est la suite de la mise en place de RDV Aide Numérique : côté usager, on arrête d'afficher sur RDV Solidarités les rendez-vous pris sur RDV Aide Numérique (on avait laissé ça en place pour la période de transition entre les deux domaines).

### Features flags qui passent du service au domaine

- La liste des rdvs côté usager
- Le lien vers la FAQ : vu qu'on va avoir un comportement homogène au niveau du domaine, et que la FAQ CnFS est déjà formulée pour RDV Aide Numérique, c'est plus logique comme ça.
- L'affichage de la bannière de réservation en ligne côté agent : plus logique vu que la réservation en ligne est configurée aussi en fonction d'un flag sur le domaine


### Features flags qui restent sur le service plutôt que le domaine

- l'affichage de la page d'embarquement des CnFS : ça fait partie des choses qu'on va peut-être modifier bientôt
- les services des agents qui peuvent être invités : ça sera bientôt configurable au niveau du département