### PR TITLE
Recherche une équipe

### DIFF
--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -7,7 +7,7 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
 
   def index
     @teams = policy_scope(Team).page(params[:page])
-    @teams = params[:search].present? ? @teams.search_by_text(params[:search]) : @teams.order(:name)
+    @teams = params[:term].present? ? @teams.search_by_text(params[:term]) : @teams.order(:name)
   end
 
   def new

--- a/app/views/admin/territories/teams/index.html.slim
+++ b/app/views/admin/territories/teams/index.html.slim
@@ -7,9 +7,9 @@
     .text-right
       = link_to t(".create_team"), new_admin_territory_team_path(current_territory), class:"btn btn-outline-primary"
     .m-3.d-flex.justify-content-end
-      - search = params[:search].blank? ? "d-none" : ""
-      div= link_to "Réinitialiser", admin_territory_teams_path(current_territory), class: "btn btn-link #{search}"
-      = f.input :search, placeholder: "ex. Puericultrice", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+      - term = params[:term].blank? ? "d-none" : ""
+      div= link_to "Réinitialiser", admin_territory_teams_path(current_territory), class: "btn btn-link #{term}"
+      = f.input :term, placeholder: "ex. Puericultrice", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
       = f.button :submit, "Rechercher"
 
     table.table

--- a/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
+++ b/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "CRUDS teams configuration", type: :request do
       create(:team, territory: territory, name: "other name")
       matching_team = create(:team, territory: territory, name: "First Groupe")
 
-      get admin_territory_teams_path(territory, search: "first")
+      get admin_territory_teams_path(territory, term: "first")
 
       expect(response).to be_successful
       expect(assigns(:teams)).to eq([matching_team])
@@ -45,7 +45,7 @@ RSpec.describe "CRUDS teams configuration", type: :request do
       create(:team, territory: territory, name: "other name")
       matching_team = create(:team, territory: territory, name: "First Groupe")
 
-      get admin_territory_teams_path(territory, search: "first", format: :json)
+      get admin_territory_teams_path(territory, term: "first", format: :json)
 
       expect(response).to be_successful
       expect(assigns(:teams)).to eq([matching_team])


### PR DESCRIPTION
ref https://zammad10.ethibox.fr/#ticket/zoom/4079

La recherche d'équipe dans la page de liste des équipes fonctionne bien.

Dans le formulaire pour « Trouver un RDV », la liste n'est pas filtrée par la saisie.

Le problème, c'est que d'un côté, nous utilisions un paramètre `serach` alors que de l'autre, nous utilisons `term`.

`term` est plus largement utilisé dans notre application, aussi cette PR propose de remplacer le paramètre `search` dans la liste des équipes par `term`.
