### PR TITLE
Corrige une flaky spec

### DIFF
--- a/spec/jobs/outlook/update_event_job_spec.rb
+++ b/spec/jobs/outlook/update_event_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Outlook::UpdateEventJob, type: :job do
   let(:fake_agent) { create(:agent) }
   let(:agent) { create(:agent, microsoft_graph_token: "token") }
   let(:rdv) { create(:rdv, id: 20, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
-  let(:agents_rdv) { create(:agents_rdv, id: 12, rdv: rdv, agent: agent, outlook_id: "super_id") }
+  let(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "super_id") }
 
   let(:expected_body) do
     {
@@ -68,7 +68,7 @@ RSpec.describe Outlook::UpdateEventJob, type: :job do
     end
 
     it "sends the error to Sentry" do
-      expect(sentry_events.last.message).to eq("Outlook API error for AgentsRdv 12: Quelle terrible erreur")
+      expect(sentry_events.last.message).to eq("Outlook API error for AgentsRdv #{agents_rdv.id}: Quelle terrible erreur")
     end
   end
 end


### PR DESCRIPTION
![Capture d’écran 2023-01-16 à 11 19 55](https://user-images.githubusercontent.com/1840367/212655192-f7cc5ad0-d1d8-4b85-a64c-29c91e35e19c.png)

Dans le cas où l'id 12 avait déjà été affecté (ce qui peut arriver puisque les specs tournent dans un ordre aléatoire), on avait une erreur sur cette spec.
De manière générale c'est toujours plus safe d'éviter d'assigner des id dans les lets.
