### PR TITLE
Déplacer le soft delete vers des concerns

### DIFF
--- a/app/models/concerns/agent/soft_deletable.rb
+++ b/app/models/concerns/agent/soft_deletable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Agent::SoftDeletable
+  extend ActiveSupport::Concern
+
+  def soft_delete
+    raise SoftDeleteError, "agent still has attached resources" if organisations.any? || plage_ouvertures.any? || absences.any?
+
+    # skip Devise email notifications that are normally triggered when updating email
+    skip_reconfirmation!
+
+    Agent.transaction do
+      sector_attributions.destroy_all
+      update!(deleted_at: Time.zone.now, email_original: email, email: deleted_email, uid: deleted_email)
+    end
+  end
+
+  private
+
+  def deleted_email
+    "agent_#{id}@deleted.rdv-solidarites.fr"
+  end
+end

--- a/app/models/concerns/motif/soft_deletable.rb
+++ b/app/models/concerns/motif/soft_deletable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Motif::SoftDeletable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :active, lambda { |active = true|
+      active ? where(deleted_at: nil) : where.not(deleted_at: nil)
+    }
+  end
+
+  def soft_delete
+    rdvs.any? ? update!(:deleted_at, Time.zone.now) : destroy
+  end
+end

--- a/app/models/concerns/rdv/soft_deletable.rb
+++ b/app/models/concerns/rdv/soft_deletable.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Rdv::SoftDeletable
+  extend ActiveSupport::Concern
+
+  included do
+    alias_attribute :soft_deleted?, :deleted_at?
+  end
+
+  def soft_delete
+    # disable the :updated webhook because we want to manually trigger a :destroyed webhook
+    self.skip_webhooks = true
+    return false unless update(deleted_at: Time.zone.now)
+
+    generate_payload_and_send_webhook_for_destroy
+    true
+  end
+end

--- a/app/models/concerns/user/soft_deletable.rb
+++ b/app/models/concerns/user/soft_deletable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module User::SoftDeletable
+  extend ActiveSupport::Concern
+
+  def soft_delete(organisation = nil)
+    self_and_relatives.each { _1.do_soft_delete(organisation) }
+  end
+
+  def can_be_soft_deleted_from_organisation?(organisation)
+    Rdv.not_cancelled
+      .future
+      .joins(:users).where(users: self_and_relatives)
+      .where(organisation: organisation)
+      .empty?
+  end
+
+  protected
+
+  def do_soft_delete(organisation)
+    # skip Devise email notifications that are normally triggered when updating email
+    skip_reconfirmation!
+
+    if organisation.present?
+      organisations.delete(organisation)
+    else
+      self.organisations = []
+    end
+    return save! if organisations.any? # only actually mark deleted when no orgas left
+
+    update!(deleted_at: Time.zone.now, email_original: email, email: deleted_email)
+  end
+
+  def deleted_email
+    "user_#{id}@deleted.rdv-solidarites.fr"
+  end
+end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -8,6 +8,7 @@ class Motif < ApplicationRecord
 
   include PgSearch::Model
   include Motif::Category
+  include Motif::SoftDeletable
 
   pg_search_scope(:search_by_text,
                   against: :name,
@@ -62,9 +63,6 @@ class Motif < ApplicationRecord
   validate :not_at_home_if_collectif
 
   # Scopes
-  scope :active, lambda { |active = true|
-    active ? where(deleted_at: nil) : where.not(deleted_at: nil)
-  }
   scope :reservable_online, -> { where(reservable_online: true) }
   scope :not_reservable_online, -> { where(reservable_online: false) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
@@ -103,10 +101,6 @@ class Motif < ApplicationRecord
 
   def to_s
     name
-  end
-
-  def soft_delete
-    rdvs.any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
   end
 
   def authorized_agents

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,10 +167,6 @@ class User < ApplicationRecord
       .empty?
   end
 
-  def previous_rdvs_ordered_and_truncated(organisation)
-    rdvs_for_organisation(organisation).past.order(starts_at: :desc).limit(5)
-  end
-
   def rdvs_future_without_ongoing(organisation)
     rdvs_for_organisation(organisation).start_after(Time.zone.now + ONGOING_MARGIN)
   end


### PR DESCRIPTION
En travaillant sur #3254 j'ai trouvé que la classe `User` était un peu longue, et je me suis dit qu'on pouvait déplacer ce qui touche au soft delete dans un concern. Au passage, j'ai fait de même pour `Agent`, `Motif` et `Rdv`, qui sont les 3 autres modèles ayant un soft delete.


# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
