### PR TITLE
Matomo for rdv aides numériques

### DIFF
--- a/lib/tasks/matomo.rake
+++ b/lib/tasks/matomo.rake
@@ -11,8 +11,8 @@ namespace :matomo do
         Such token is available at: https://stats.data.gouv.fr/index.php?module=UsersManager&action=userSettings"
     end
 
-    # Production and Demo sites
-    id_sites = %w[123 124]
+    # Production, Demo sites et RDV Aides Numériques
+    id_sites = %w[123 124 275]
     id_sites.each do |id_site|
       token_auth = ENV["MATOMO_AUTH_TOKEN"]
       # https://developer.matomo.org/api-reference/reporting-api


### PR DESCRIPTION
Il semble que les stats ne remontent pas sur Matomo pour les pages dans le domaine RDV Aides Numériques. Je suis chaud pour qu'on me confirme cette information mais je ne trouve en tout cas pas les stats de certaines pages Aides Jeunes qui sont sur le domaine RDV Aides Numériques dans le matomo actuel.

Cette PR tente de résoudre ce problème en rajoute l'ID du domaine en question à nos domaines Matomo.

Ca vous semble une solution logique?

Une discussion avec des infos: https://mattermost.incubateur.net/betagouv/pl/xxupyziyijb95pz6ifcai3dyoa
