### PR TITLE
Inverser l'ordre des RDV dans la liste côté agent

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -16,7 +16,7 @@ class Admin::RdvsController < AgentAuthController
     @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).enabled.order(:name)
     @motifs = Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) })
     @rdvs_users_count = RdvsUser.where(rdv: @rdvs).count
-    @rdvs = @rdvs.order(starts_at: :asc).page(params[:page]).per(10)
+    @rdvs = @rdvs.order(starts_at: rdv_index_selected_order).page(params[:page]).per(10)
   end
 
   def export

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -122,7 +122,8 @@ module RdvsHelper
   end
 
   def rdv_index_selected_order
-    params[:order].presence || :desc
+    default = current_agent.secretariat? ? :asc : :desc
+    params[:order].presence || default
   end
 
   private

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -114,6 +114,17 @@ module RdvsHelper
     "#{rdv.users_count} / #{rdv.max_participants_count}"
   end
 
+  def rdv_index_order_options
+    [
+      ["Les plus récents en premier", :desc],
+      ["Les plus anciens en premier", :asc],
+    ]
+  end
+
+  def rdv_index_selected_order
+    params[:order].presence || :desc
+  end
+
   private
 
   def rdv_individuel_title_for_agent(rdv)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -100,6 +100,7 @@ class Agent < ApplicationRecord
 
   delegate :name, to: :domain, prefix: true
   delegate :dns_domain_name, to: :domain
+  delegate :secretariat?, to: :service
 
   def remember_me # Override from Devise::rememberable to enable it by default
     super.nil? ? true : super

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for(form, method: "GET", url: url_for({}), as: "") do |f|
+= simple_form_for(form, method: "GET", url: url_for({}), as: "rdv_search_form") do |f|
   - if current_agent.multiple_organisations_access?
     .row
       .col-md-6

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -59,9 +59,15 @@
 
   .row.justify-content-center.pb-3
     .col-md-8
-      .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+      .d-flex.justify-content-between.align-items-center
+        = paginate @rdvs, theme: "twitter-bootstrap-4"
+        .mb-2 = select_tag("order", options_for_select(rdv_index_order_options, rdv_index_selected_order), { class: "js-submit-on-change form-control select", form: "new_rdv_search_form" })
+
       = render(partial: "rdv", collection: @rdvs, locals: { agent: nil })
-      .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+
+      .d-flex.justify-content-between.align-items-center
+        = paginate @rdvs, theme: "twitter-bootstrap-4"
+
 - else
   .row.justify-content-center.pb-3
     .col-md-8


### PR DESCRIPTION
Edit : le fait d'inverser l'ordre des RDV semble ne pas répondre au besoin, voir https://github.com/betagouv/rdv-solidarites.fr/issues/3189#issuecomment-1396612296

------------

Closes #3189

Comme convenu lors de l'atelier informel : 
- Pour les agents du secrétariat, garder l'ordre chronologique par défaut
- Pour les autres agents, afficher dans les rdv les plus récents en premier
- Il est possible de changer l'ordre via l'interface

Pour tester : https://demo-rdv-solidarites-pr3270.osc-secnum-fr1.scalingo.io/

# Notes sur l'implémentation

Au début je me suis dit que j'allais appeler le paramètre `order_by` et lui passer des valeurs du genre `"starts_at__desc"` et `"starts_at__asc"`, pour pouvoir par la suite proposer d'ordonner les RDVs par date de dernière modif ou autre critère, et puis j'ai réalisé qu'on en avait pas besoin. Si on en a besoin dans le futur, on saura très bien comment faire. :brain: 

# Avant

![image](https://user-images.githubusercontent.com/6357692/213205213-0b80dd1a-ed55-4883-a154-043c4bc26ee7.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/213205234-df0133e8-b494-447f-9dd9-f518849b639b.png)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
