### PR TITLE
Mise à jour de la gem `mail` qui était fixée en version RC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,7 @@ gem "jsbundling-rails"
 gem "turbolinks", "~> 5"
 gem "bootsnap", require: false # Reduces boot times through caching; required in config/boot.rb
 gem "rack-cors" # CORS management
-
-# Temporarily fixed version : this RC version supports Ruby 3.1 (https://github.com/mikel/mail/commit/d9d8dcc)
-gem "mail", "2.8.0.rc1"
+gem "mail"
 
 # Ops
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0.rc1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
@@ -655,7 +655,7 @@ DEPENDENCIES
   letter_opener_web
   listen
   lograge
-  mail (= 2.8.0.rc1)
+  mail
   montrose
   omniauth-github
   omniauth-microsoft_graph


### PR DESCRIPTION
Lors de #2548 la version de la gem `mail` a été fixée en RC car c'était la seule version compatible avec Ruby 3.1.

Une version stable est sortie il y a un mois (le 3 décembre 2022), et donc on peut cesser de fixer la version et utiliser la dernière version en date ! :tada: 