### PR TITLE
Prise de rdv prescripteurs sans ouverture aux usagers

### DIFF
--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -59,9 +59,27 @@
 
   .card#reservable_online_section
     .card-body
-      h5.card-title= Motif.human_attribute_name("reservable_online_title")
-      p.text-muted.font-14= Motif.human_attribute_name("reservable_online_hint")
-      = f.input :reservable_online
+      h5.card-title= "Ouverture de la prise de RDV en ligne"
+      p.text-muted.font-14= "Vous pouvez ouvrir la prise de RDV en ligne à des gens autres que les agents de votre organisation"
+      = label_tag do
+        = f.radio_button(:reservable_online, false)
+        span.ml-1= "Restreindre aux agents de #{@motif.organisation.name}"
+        p.text-muted.font-14= "Les agents peuvent ajouter des rendez-vous à l'agenda de leurs collègues"
+
+      = label_tag do
+        = f.radio_button(:reservable_online, true)
+        span.ml-1= "Ouvrir aux prescripteurs"
+        p.text-muted.font-14
+          = "Les prescripteurs sont des agents d'une autre organisation du service public, qui orientent des usagers vers le service dont ils ont besoin."
+          br
+          = "Ils pourront prendre rendez-vous uniquement sur les plages d'ouvertures définies par les agents de #{@motif.organisation.name}"
+
+      = label_tag do
+        = f.radio_button(:reservable_online, false)
+        span.ml-1= "Ouvrir aux prescripteurs et aux usagers"
+        p.text-muted.font-14.mb-4= "Les usagers pourront directement prendre rendez-vous en ligne sur les plages d'ouverture prédéfinies"
+
+
 
       .form-row.js-rdvs-editable
         .col-md-4= f.input :min_booking_delay, collection: min_max_delay_options

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -59,7 +59,7 @@
 
   .card#reservable_online_section
     .card-body
-      h5.card-title= "Ouverture de la prise de RDV en ligne"
+      h5.card-title= "Prise de RDV en ligne"
       p.text-muted.font-14= "Vous pouvez ouvrir la prise de RDV en ligne à des gens autres que les agents de votre organisation"
       = label_tag do
         = f.radio_button(:reservable_online, false)

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -59,16 +59,16 @@
 
   .card#reservable_online_section
     .card-body
-      h5.card-title= "Prise de RDV en ligne"
-      p.text-muted.font-14= "Vous pouvez ouvrir la prise de RDV en ligne à des gens autres que les agents de votre organisation"
+      h5.card-title= "Réservation en ligne"
+      p.text-muted.font-14= "Vous pouvez ouvrir la prise de RDV en ligne à d'autres agents du service public, ou à tous les usagers."
       = label_tag do
         = f.radio_button(:reservable_online, false)
-        span.ml-1= "Restreindre aux agents de #{@motif.organisation.name}"
+        span.ml-1= "Uniquement les agents de #{@motif.organisation.name}"
         p.text-muted.font-14= "Les agents peuvent ajouter des rendez-vous à l'agenda de leurs collègues"
 
       = label_tag do
         = f.radio_button(:reservable_online, true)
-        span.ml-1= "Ouvrir aux prescripteurs"
+        span.ml-1= "Ouvert aux prescripteurs"
         p.text-muted.font-14
           = "Les prescripteurs sont des agents d'une autre organisation du service public, qui orientent des usagers vers le service dont ils ont besoin."
           br
@@ -76,7 +76,7 @@
 
       = label_tag do
         = f.radio_button(:reservable_online, false)
-        span.ml-1= "Ouvrir aux prescripteurs et aux usagers"
+        span.ml-1= "Ouvert aux prescripteurs et aux usagers"
         p.text-muted.font-14.mb-4= "Les usagers pourront directement prendre rendez-vous en ligne sur les plages d'ouverture prédéfinies"
 
 


### PR DESCRIPTION
Cette PR n'a pas vocation à être mergé : elle propose des maquettes qui pourront servir de spec pour l'ouverture à la réservation par prescripteurs dans le Var, pour travailler sur une généralisation


### Côté agent

La partie Réservation en ligne du formulaire de motif change : 

Avant :
<img width="1160" alt="Capture d’écran 2023-01-23 à 11 21 02" src="https://user-images.githubusercontent.com/1840367/214016118-4db091c3-2342-4c43-aad9-07b4da6399d6.png">

Après :
<img width="1198" alt="Capture d’écran 2023-01-23 à 11 20 37" src="https://user-images.githubusercontent.com/1840367/214016034-2440a1b7-d2f2-4072-b0d1-844d6d9acf83.png">

Au passage, on harmonise le texte pour parler de "Réservation en ligne" (puisque c'est le terme utilisé ailleurs dans l'interface) plutôt que de "Prise de rdv en ligne".

Autres pages qui ont besoin d'être modifiées pour afficher le status  : 
- index des motifs
<img width="300" alt="Capture d’écran 2023-01-23 à 11 21 17" src="https://user-images.githubusercontent.com/1840367/214016825-b981e746-b965-4543-b2d0-3813f14b81e5.png">


- page de détails d'un motif
<img width="300" alt="Capture d’écran 2023-01-23 à 11 21 24" src="https://user-images.githubusercontent.com/1840367/214016725-0b2a3cc2-b4fa-415c-8f68-41a6997e00fb.png">
Ces modifications sont assez mineures, et devraient suivre le texte du formulaire

### Côté prescripteur

On propose un lien `/prescripteurs/83` qui redirige vers `/prendre_rdv?departement=83&prescripteur=1`
Ce lien affiche une prise de rdv pour usager normale, mais après le choix de créneau, on passe directement au formulaire de prescripteur. Autrement dit, on passe de cet écran :
<img width="841" alt="Capture d’écran 2023-01-23 à 11 19 36" src="https://user-images.githubusercontent.com/1840367/214015869-ef3ea805-fdad-4af6-b9e0-33c4fdcf5034.png">
A celui-ci :
<img width="739" alt="Capture d’écran 2023-01-23 à 11 19 44" src="https://user-images.githubusercontent.com/1840367/214015876-07c3e48e-20f8-4346-b1a1-a53cacf62fb7.png">


#### Questions en suspens pour le MVP :
- Est-ce qu'il faut avoir un moyen d'utiliser la sectorisation avec la prise de rdv par prescripteurs ? D'après la référente du Var, non
- Est-ce qu'on fait ce changement de formulaire uniquement pour le Var ? Si possible, oui

#### Pour aller plus loin qu'un MVP :
ll faudra permettre de rendre cette fonctionnalité découvrable sans accompagnement de notre part. Pour faire ça, il faudra probablement trouver comment indiquer ce statut intermédiaire dans la page "Réservation en ligne".
