### PR TITLE
Fix scalingo_dump.sh

### DIFF
--- a/scripts/scalingo_dump.sh
+++ b/scripts/scalingo_dump.sh
@@ -11,7 +11,11 @@ fi
 REGION=osc-secnum-fr1
 APP="$1"-rdv-solidarites
 ADDON_ID=$(scalingo addons --region $REGION --app "$APP" | grep PostgreSQL | cut -d ' ' -f 4)
-TAR_NAME=$(scalingo backups-download --region $REGION --app "$APP" --addon "$ADDON_ID" | grep '===> ' | sed 's/===> //')
+
+# download archive file
+scalingo backups-download --region $REGION --app "$APP" --addon "$ADDON_ID"
+# get name of most recently created tar.gz file (most likely the archive)
+TAR_NAME=$(ls -t | grep tar.gz | head -n1)
 
 # untar
 tar xf "$TAR_NAME"


### PR DESCRIPTION
Ce script se base sur la sortie de la commande `scalingo backups-download` pour déterminer le nom du fichier tar.gz à extraire, mais sur ma machine cette méthode ne fonctionne jamais, et donc je dois faire les choses à moitié à la main à chaque fois.

Ce fix emploie donc une autre méthode : télécharger le tar.gz puis retrouver le fichier tar.gz le plus récent, ce qui semble plus robuste que de parser STDOUT, bien que ce ne soit toujours pas idéal.