### PR TITLE
Améliorer l'accessibilité et donc la délivrabilité de nos mails

### DIFF
--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -10,7 +10,7 @@ html
         td.logo.d-block
           = link_to root_url do
             / using <img width=...> attribute because Outlook sometimes ignores the CSS
-            = image_tag domain.public_logo_path, style: "width: 200px; margin: auto;", width: "200"
+            = image_tag domain.public_logo_path, style: "width: 200px; margin: auto;", width: "200", alt: "Le logo de #{domain.name}"
         td.container
           .content
             table.main width="100%"


### PR DESCRIPTION
Dans le cadre d'un ajustement de notre config DNS pour authentifier nos e-mails, j'ai utilisé un service qui détermine notre score "spam", et il m'indique que nos mails contiennent une image qui n'a pas de description dans `alt` : 

https://www.mail-tester.com/test-hmc4t2gxs

![image](https://user-images.githubusercontent.com/6357692/214547453-a0512c23-fd65-4298-88a7-0ca56bb70a26.png)

Cette PR ajoute donc une description de l'image, pour améliorer notre score et potentiellement diminuer notre mise en spam.

Au passage, l'accessibilité est améliorée. :+1: 