### PR TITLE
feat(webhooks): Add method to trigger webhook for subscribed resources

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,7 +4,6 @@ class Organisation < ApplicationRecord
   # Mixins
   has_paper_trail
   include WebhookDeliverable
-  include WebhookDeliverable
 
   # Attributes
   auto_strip_attributes :email, :name
@@ -27,6 +26,7 @@ class Organisation < ApplicationRecord
   # we specify dependent: :destroy because by default it will be deleted (dependent: :delete)
   # and we need to destroy to trigger the callbacks on the model
   has_many :users, through: :user_profiles, dependent: :destroy
+  has_many :referent_assignations, through: :users
   has_many :receipts, through: :rdvs
 
   accepts_nested_attributes_for :agent_roles

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -12,4 +12,19 @@ class WebhookEndpoint < ApplicationRecord
   ALL_SUBSCRIPTIONS = %w[
     rdv absence plage_ouverture user user_profile organisation motif lieu agent agent_role referent_assignation
   ].freeze
+
+  def trigger_for_all_subscribed_resources
+    subscriptions.each do |subscription|
+      if subscription == "organisation"
+        trigger_for(organisation)
+      else
+        records = organisation.send(subscription.pluralize)
+        records.each { |record| trigger_for(record) }
+      end
+    end
+  end
+
+  def trigger_for(record)
+    WebhookJob.perform_later(record.generate_webhook_payload(:created), id)
+  end
 end


### PR DESCRIPTION
Dans cette PR j'ajoute une méthode pour envoyer des webhooks sur l'url de destination pour toutes les ressources liés à l'organisation du `webhook_endpoint`.
Cette méthode nous est utile notamment lorsqu'on lie une organisation de RDV-S à RDV-U.

Pour l'instant l'idée est de l'appeler manuellement sur le `webhook_endpoint` en question.
On pourrait améliorer ça en:
* proposant de l'appeler depuis la page du `webhook_endpoint` 
* l'appelant éventuellement dans un `after_create` callback pour ceux liés à RDV-I
