### PR TITLE
Améliorer les perfs de la liste des RDVs (janvier 2023)

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -15,7 +15,6 @@ class Admin::RdvsController < AgentAuthController
     @form = Admin::RdvSearchForm.new(parsed_params)
     @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).enabled.order(:name)
     @motifs = Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) })
-    @rdvs_users_count = RdvsUser.where(rdv: @rdvs).count
     @rdvs = @rdvs.order(starts_at: :asc).page(params[:page]).per(10)
   end
 

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -10,7 +10,16 @@ class Admin::RdvsController < AgentAuthController
   def index
     set_scoped_organisations
     @rdvs = policy_scope(Rdv).search_for(@scoped_organisations, parsed_params)
-      .includes([:rdvs_users, :agents_rdvs, :organisation, :lieu, :motif, { agents: :service, users: %i[responsible organisations] }])
+      .includes(
+        [
+          :agents_rdvs, :organisation, :lieu, :motif,
+          {
+            rdvs_users: [:prescripteur, { user: :user_profiles }],
+            agents: :service,
+            users: %i[responsible organisations user_profiles],
+          },
+        ]
+      )
     @breadcrumb_page = params[:breadcrumb_page]
     @form = Admin::RdvSearchForm.new(parsed_params)
     @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).enabled.order(:name)

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -13,7 +13,7 @@ class AgentAuthController < ApplicationController
   private
 
   def pundit_user
-    AgentOrganisationContext.new(current_agent, current_organisation)
+    @pundit_user ||= AgentOrganisationContext.new(current_agent, current_organisation)
   end
   helper_method :pundit_user
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -142,8 +142,8 @@ class User < ApplicationRecord
   end
 
   def profile_for(organisation)
-    @profiles ||= user_profiles.index_by(&:organisation)
-    @profiles[organisation]
+    @profiles ||= user_profiles.index_by(&:organisation_id)
+    @profiles[organisation.id]
   end
 
   def participation_for(rdv)

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -37,7 +37,7 @@
   .card-body
     = render "rdv_search_form", form: @form
 
-  - if @rdvs.any?
+  - if @rdvs.total_count > 0
     .card-footer
       div.d-flex.justify-content-end
         - if policy([:configuration, current_territory]).allow_to_download_metrics?
@@ -50,7 +50,7 @@
         input.btn.btn-small.btn-link.d-print-none type="submit" value="Imprimer 🖨" onclick="window.print();return false;"
       = render "admin/rdvs/rdv_visibility"
 
-- if @rdvs.any?
+- if @rdvs.total_count > 0
   .mb-2
     h4>= "#{@rdvs.total_count} rendez-vous"
     .custom-control.custom-switch

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -42,7 +42,7 @@
       div.d-flex.justify-content-end
         - if policy([:configuration, current_territory]).allow_to_download_metrics?
           = link_to rdvs_users_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-small btn-link d-print-none" do
-            span> Exporter les #{@rdvs_users_count} RDVs par usager en XLS
+            span> Exporter les RDVs par usager en XLS
             i.fa.fa-download>
         = link_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-small btn-link d-print-none" do
           span> Exporter les #{@rdvs.total_count} RDVs en XLS


### PR DESCRIPTION
Une fois encore, Skylight nous indique qu'une minorité de requêtes sur la liste des RDVs est très lente (jusqu'à 55 secondes !).

![image](https://user-images.githubusercontent.com/6357692/215112109-865cbfaf-1cea-4fa7-8901-6c72e4f2cb4e.png)

# Le coupable principale : le count sur les `rdvs_users`

Nous pouvons voir que 99% du temps est passé en base, et une majorité de ce temps est passé à évaluer une requête qui compte les participations pour afficher ceci : 

![image](https://user-images.githubusercontent.com/6357692/215112594-4ce8acd6-8380-494f-915d-f1a4bc45a640.png)

Et je propose donc de ne pas faire cette requêtes, pour gagner beaucoup en perf, et afficher ceci à la place : 

![image](https://user-images.githubusercontent.com/6357692/215112705-1bab5369-7b34-4bd8-887d-3869241f848e.png)


# Les autres petites améliorations

En utilisant `rack-mini-profiler`, j'ai trouvé et corrigé les requêtes N+1, et j'ai donc complété ce que l'on passe à `includes` pour que tout soit préchargé.

Aussi, dans la vue, au lieu de faire `@rdvs.any?` (qui déclenche une requête `SELECT 1 FROM ...` pour vérifier si au moins un record existe), on peut utiliser `@rdvs.total_count`, que nous avons de toute façon déjà chargé pour afficher le nombre total de RDV.