### PR TITLE
Mise à jour de la gem launchy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,8 +261,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    launchy (2.5.0)
-      addressable (~> 2.7)
+    launchy (2.5.2)
+      addressable (~> 2.8)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
     letter_opener_web (2.0.0)
@@ -371,7 +371,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
-    public_suffix (5.0.0)
+    public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
     pundit (2.2.0)


### PR DESCRIPTION
Cette mise à jour permet de corriger le crash qui a lieu avec Ruby 3.2 lorsqu'on appelle `save_and_open_page`.

Voir : https://github.com/copiousfreetime/launchy/pull/138