### PR TITLE
Rés'in > Permettre de passer plusieurs orgas dans un lien public de résa

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,6 +21,15 @@ class SearchController < ApplicationController
     redirect_to_organisation_search(organisation)
   end
 
+  def resin
+    redirect_to prendre_rdv_path(
+      departement: "CN",
+      service_id: Service.find_by(name: Service::CONSEILLER_NUMERIQUE)&.id,
+      motif_name_with_location_type: "Accompagnement+individuel-public_office",
+      external_organisation_ids: params[:ids].split(",")
+    )
+  end
+
   private
 
   def redirect_to_organisation_search(organisation)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -25,8 +25,8 @@ class SearchController < ApplicationController
     redirect_to prendre_rdv_path(
       departement: "CN",
       service_id: Service.find_by(name: Service::CONSEILLER_NUMERIQUE)&.id,
-      motif_name_with_location_type: "Accompagnement+individuel-public_office",
-      external_organisation_ids: params[:ids].split(",")
+      motif_name_with_location_type: "Accompagnement individuel-public_office",
+      external_organisation_ids: params[:external_organisation_ids].split(",")
     )
   end
 
@@ -47,8 +47,8 @@ class SearchController < ApplicationController
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
       :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category,
-      :invitation_token, :motif_id, :public_link_organisation_id,
-      :user_selected_organisation_id, organisation_ids: [], referent_ids: []
+      :invitation_token, :motif_id, :public_link_organisation_id, :user_selected_organisation_id,
+      organisation_ids: [], referent_ids: [], external_organisation_ids: []
     )
   end
 end

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -6,7 +6,7 @@ class Users::RdvWizardStepsController < UserAuthController
     :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code, :rdv_collectif_id,
     :street_ban_id, :invitation_token, :address, :motif_search_terms, :user_selected_organisation_id,
     :public_link_organisation_id,
-    { organisation_ids: [], referent_ids: [] },
+    { organisation_ids: [], referent_ids: [], external_organisation_ids: [] },
   ].freeze
   after_action :allow_iframe
   before_action :set_step_titles

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -61,7 +61,7 @@ module UserRdvWizard
         @attributes.slice(
           :where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id, :invitation_token,
           :address, :organisation_ids, :motif_search_terms, :public_link_organisation_id, :user_selected_organisation_id,
-          :referent_ids
+          :referent_ids, :external_organisation_ids
         )
       )
     end

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -52,6 +52,7 @@ module SearchContextHelper
       address: params[:address],
       public_link_organisation_id: params[:public_link_organisation_id],
       referent_ids: params[:referent_ids],
+      external_organisation_ids: params[:external_organisation_ids],
     }
   end
 end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -16,6 +16,7 @@ class SearchContext
     @street_ban_id = query[:street_ban_id]
     @public_link_organisation_id = query[:public_link_organisation_id]
     @user_selected_organisation_id = query[:user_selected_organisation_id]
+    @external_organisation_ids = query[:external_organisation_ids]
     @fallback_organisation_ids = query[:organisation_ids]
     @motif_id = query[:motif_id]
     @motif_search_terms = query[:motif_search_terms]
@@ -184,6 +185,7 @@ class SearchContext
     motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
     motifs = motifs.where(category: @motif_category) if @motif_category.present?
     motifs = motifs.where(organisations: { id: organisation_id }) if organisation_id.present?
+    motifs = motifs.where(organisations: { external_id: @external_organisation_ids.compact }) if @external_organisation_ids.present?
     motifs = motifs.where(id: @motif_id) if @motif_id.present?
     motifs = motifs.with_availability_for_lieux([lieu.id]) if lieu.present?
     motifs = motifs.where(follow_up: follow_up?)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,9 @@ Rails.application.routes.draw do
   get "org/:organisation_id(/:org_slug)" => "search#public_link_with_internal_organisation_id", as: :public_link_to_org
   get "org/ext/:territory/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
 
+  # resin public link
+  get "resin/:external_organisation_ids" => "search#resin", as: :resin_link
+
   ##
 
   get "accueil_mds", to: redirect("presentation_agent", status: 307)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -272,7 +272,7 @@ Rails.application.routes.draw do
   get "org/ext/:territory/:organisation_external_id(/:org_slug)" => "search#public_link_with_external_organisation_id", as: :public_link_to_external_org
 
   # resin public link
-  get "resin/:external_organisation_ids" => "search#resin", as: :resin_link
+  get "resin/:external_organisation_ids" => "search#resin"
 
   ##
 

--- a/spec/features/users/user_can_open_resin_link_spec.rb
+++ b/spec/features/users/user_can_open_resin_link_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Ce test de non-régression a été ajouté pour s'assurer que le
+# lien public que nous avons fourni à Rés'In est toujours fonctionnel.
+# Ce lien est une redirection vers notre
+RSpec.describe "Rés'In specific public link" do
+  before do
+    travel_to(Time.zone.parse("2023-01-30 17:00"))
+  end
+
+  let!(:cnfs_territory) { create(:territory, departement_number: "CN") }
+  let!(:cnfs_service) { create(:service, :conseiller_numerique) }
+  let!(:orga_cnfs_lyon_a) { create(:organisation, territory: cnfs_territory, external_id: "123") }
+  let!(:orga_cnfs_lyon_b) { create(:organisation, territory: cnfs_territory, external_id: "456") }
+
+  let!(:motif_a) { create(:motif, :sectorisation_level_departement, service: cnfs_service, organisation: orga_cnfs_lyon_a, name: "Accompagnement individuel", location_type: :public_office) }
+  let!(:motif_b) { create(:motif, :sectorisation_level_departement, service: cnfs_service, organisation: orga_cnfs_lyon_b, name: "Accompagnement individuel", location_type: :public_office) }
+
+  let!(:lieu_a) { create(:lieu, name: "Antenne Voltaire Lyon", organisation: orga_cnfs_lyon_a) }
+  let!(:lieu_b) { create(:lieu, name: "Maison de la Métropole de Lyon", organisation: orga_cnfs_lyon_b) }
+
+  let!(:plage_ouverture_a) { create(:plage_ouverture, motifs: [motif_a], lieu: lieu_a) }
+  let!(:plage_ouverture_b) { create(:plage_ouverture, motifs: [motif_b], lieu: lieu_b) }
+
+  it "allows user to book a RDV" do
+    visit "/resin/123,456"
+    expect(page).to have_content("Accompagnement individuel (Sur place)")
+    expect(page).to have_content("2 lieux sont disponibles")
+    expect(page).to have_content(motif_a.name)
+    expect(page).to have_content(motif_b.name)
+
+    click_on "Prochaine disponibilité lemardi 07 février 2023 à 08h00"
+    click_on "08:00"
+    expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
+  end
+
+  context 'when a motif is not named "Accompagnement individuel"' do
+    before do
+      motif_b.update!(name: "Accompagnement individuel 2")
+    end
+
+    it "is not shown" do
+      visit "/resin/123,456"
+      expect(page).to have_content(motif_a.name)
+      expect(page).not_to have_content(motif_b.name)
+    end
+  end
+end

--- a/spec/features/users/user_can_open_resin_link_spec.rb
+++ b/spec/features/users/user_can_open_resin_link_spec.rb
@@ -2,7 +2,6 @@
 
 # Ce test de non-régression a été ajouté pour s'assurer que le
 # lien public que nous avons fourni à Rés'In est toujours fonctionnel.
-# Ce lien est une redirection vers notre
 RSpec.describe "Rés'In specific public link" do
   before do
     travel_to(Time.zone.parse("2023-01-30 17:00"))


### PR DESCRIPTION
# Contexte

Rés'In est une plateforme pilotée par l’équipe inclusion numérique de la Métropole de Lyon. Leur site propose un parcours "[Orienter un bénéficiaire](https://resin.grandlyon.com/orientation)", qui permet de trouver les services répondant à une besoin. 

La liste des structures pouvant répondre à ce besoin est déterminée lors du parcours, constitué d'une suite de questions (ex: "Je souhaite acquérir des compétences numériques" -> "Utilisation d'internet" -> "Trouver un RDV dans une structure d'accompagnement"). À la fin de ce parcours, Rés'In souhaite pouvoir proposer un lien vers RDV Aide Numérique qui affiche toutes les lieux qui ont des plages d'ouvertures ouvertes pour le motif "Accompagnement individuel".

# Réponse au besoin

Il nous a semblé raisonnable d'introduire un lien personnalisé pour Rés'In pour le moment

`/resin/:org_ids` 

plutôt qu'un lien générique vers notre système de recherche de RDV 

`/prendre_rdv?departement=CN&motif_name_with_location_type=Accompagnement+individuel-public_office&service_id=30&external_organisation_ids=:org_ids`

En effet, si à l'avenir nous avons besoin de changer l'API de notre système (`SearchContext`), ou si les besoins de Rés'In changent, nous pourrons facilement nous adapter de notre côté, sans qu'ils aient besoin de changer leur lien. En résumé, cette route custom permet de garder une API fixe et de changer l'implémentation à notre guise.

Côté implémentation, c'est assez simple : on ajoute le paramètre `external_organisation_ids` à notre `SearchContext` (qui mériterait peut-être un réfacto), et on ajoute aussi ce paramètre aux permitted params et aux listes de params que nous avons dans divers objets qui servent à générer des liens ou de redirections.

# Checklist

Avant la revue :
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
