### PR TITLE
Bugfix: mettre à jour l'expression CRON en base lorsqu'elle change dans le code

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -11,6 +11,7 @@ class CronJob < ApplicationJob
   class << self
     def schedule
       set(cron: cron_expression).perform_later unless scheduled?
+      update_cron_expression!
     end
 
     def remove
@@ -19,6 +20,10 @@ class CronJob < ApplicationJob
 
     def scheduled?
       delayed_job.present?
+    end
+
+    def update_cron_expression!
+      delayed_job.update!(cron: cron_expression)
     end
 
     def delayed_job


### PR DESCRIPTION
D'après [la doc](delayed_cron_job) de la gem `delayed_cron_job` : 

> Note that if you have a CronJob scheduled and change its `cron_expression` in its source file, you will have to remove any scheduled instances of the Job and reschedule it (e.g. with the snippet above: `rails db:migrate`). This is because the `cron_expression` is already persisted in the database (as `cron`).

Mais j'ai testé en local, et nous ne sommes pas obligés de supprimer le job de cron puis de le re-créer, nous pouvons simplement faire un `update` sur l'expression, et un callback `ActiveRecord` se chargera de mettre à jour l'heure de prochain lancement de ce job (on peut voir la définition de ce callback [ici](https://github.com/codez/delayed_cron_job/blob/c01812bd8a65fd74cd1dcfd5b3515bf63c391c5e/lib/delayed_cron_job/backend/updatable_cron.rb#L6)).

Je propose donc d'ajouter une mise à jour automatique de l'expression de cron dans notre code, car il me semble que c'est le comportement qu'on s'attend à avoir quand on déploie en prod une nouvelle expression de cron. Pour info, la méthode `schedule` est appelée lors de chaque déploiement à travers la tâche rake [`schedule_jobs`](https://github.com/betagouv/rdv-solidarites.fr/blob/28d83cc6b443058f7525d190f06beaa3f298ca39/lib/tasks/schedule_jobs.rake#L4).