### PR TITLE
fix(webhook): Trigger webhook when agent removed from org

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -68,13 +68,13 @@ class Agent < ApplicationRecord
   has_many :lieux, through: :plage_ouvertures
   has_many :motifs, through: :service
   has_many :rdvs, dependent: :destroy, through: :agents_rdvs
-  has_many :organisations, through: :roles
-  has_many :webhook_endpoints, through: :organisations
   has_many :territories, through: :territorial_roles
   has_many :organisations_of_territorial_roles, source: :organisations, through: :territories
   # we specify dependent: :destroy because by default it will be deleted (dependent: :delete)
   # and we need to destroy to trigger the callbacks on the model
   has_many :users, through: :referent_assignations, dependent: :destroy
+  has_many :organisations, through: :roles, dependent: :destroy
+  has_many :webhook_endpoints, through: :organisations
 
   # Validation
   # Note about validation and Devise:

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -22,10 +22,10 @@ class Organisation < ApplicationRecord
 
   # Through relations
   has_many :sectors, through: :sector_attributions
-  has_many :agents, through: :agent_roles
   # we specify dependent: :destroy because by default it will be deleted (dependent: :delete)
   # and we need to destroy to trigger the callbacks on the model
   has_many :users, through: :user_profiles, dependent: :destroy
+  has_many :agents, through: :agent_roles, dependent: :destroy
   has_many :referent_assignations, through: :users
   has_many :receipts, through: :rdvs
 

--- a/app/services/agent_removal.rb
+++ b/app/services/agent_removal.rb
@@ -10,7 +10,7 @@ class AgentRemoval
     return false if upcoming_rdvs?
 
     Agent.transaction do
-      @agent.organisations.delete(@organisation)
+      @agent.roles.find_by(organisation: @organisation).destroy!
       @agent.absences.where(organisation: @organisation).each(&:destroy!)
       @agent.plage_ouvertures.where(organisation: @organisation).each(&:destroy!)
       @agent.soft_delete if should_soft_delete?


### PR DESCRIPTION
J'ajoute une option `dependent: :destroy` à la relation à Agents <-> Organisations pour que les callbacks soient appelés quand un agent est retiré d'une orga et ainsi envoyer le webhook correspondant.

En faisant ça je me suis rendu compte que le service `AgentRemoval` ne prenait pas en compte les validations avant destruction, notamment [celle-ci](https://github.com/betagouv/rdv-solidarites.fr/blob/28d83cc6b443058f7525d190f06beaa3f298ca39/app/models/agent_role.rb#L42). 

Du coup j'ai adapté le service et ses tests pour prendre ça en compte, mais si c'est pas le comportement que l'on veut je peux changer (peut-être que @yaf ou @francois-ferrandis ont un avis là-dessus ?).