### PR TITLE
documente la variable d'environnement DEGRADED_SERVICE_MESSAGE_AGENTS

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,7 @@ SECRET_KEY_BASE=
 
 # Feature flags and App configuration
 DEGRADED_SERVICE_MESSAGE_USERS=
+DEGRADED_SERVICE_MESSAGE_AGENTS=
 # RDV_SOLIDARITES_VERSION is set automatically in bin/start_web_server
 SIGN_IN_AS_ALLOWED=true
 SAFE_DOMAIN_LIST=


### PR DESCRIPTION
Mise à jour du .env.sample pour documenter les variables DEGRADED_SERVICE_MESSAGE_AGENTS et DEGRADED_SERVICE_MESSAGE_USERS permettant d'afficher le bandeau en cas de problèmes.

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
