### PR TITLE
Empêcher d'exporter trop de RDVs

### DIFF
--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -39,15 +39,24 @@
 
   - if @rdvs.total_count > 0
     .card-footer
-      div.d-flex.justify-content-end
-        - if policy([:configuration, current_territory]).allow_to_download_metrics?
-          = link_to rdvs_users_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-small btn-link d-print-none" do
-            span> Exporter les RDVs par usager en XLS
+      div.d-flex.justify-content-end.align-items-center
+        - if @rdvs.total_count < 10_000
+          - if policy([:configuration, current_territory]).allow_to_download_metrics?
+            = link_to rdvs_users_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none" do
+              span> Exporter les RDVs par usager en XLS
+              i.fa.fa-download>
+          = link_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none" do
+            span> Exporter les #{@rdvs.total_count} RDVs en XLS
             i.fa.fa-download>
-        = link_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-small btn-link d-print-none" do
-          span> Exporter les #{@rdvs.total_count} RDVs en XLS
-          i.fa.fa-download>
-        input.btn.btn-small.btn-link.d-print-none type="submit" value="Imprimer 🖨" onclick="window.print();return false;"
+
+        - else
+          .btn.btn-sm.btn-link.disabled.d-print-none
+            span> Export impossible pour plus de 10 000 RDVs
+            i.fa.fa-download>
+
+        .btn.btn-sm.btn-link.d-print-none role="button" onclick="window.print();return false;"
+          span> Imprimer
+          i.fa.fa-print>
 
 = render "admin/rdvs/rdv_visibility"
 

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -48,7 +48,8 @@
           span> Exporter les #{@rdvs.total_count} RDVs en XLS
           i.fa.fa-download>
         input.btn.btn-small.btn-link.d-print-none type="submit" value="Imprimer 🖨" onclick="window.print();return false;"
-      = render "admin/rdvs/rdv_visibility"
+
+= render "admin/rdvs/rdv_visibility"
 
 - if @rdvs.total_count > 0
   .mb-2


### PR DESCRIPTION
Fixes #3069

# Contexte

Nous avons des demandes d'export qui contiennent plus de 30 000 RDVs. Lorsque ces exports sont traités, il arrive que SendInBlue nous informe qu'il ne peut pas envoyer une pièce jointe de plus de 14 Mo. Que se passe-t-il à ce moment là ? L'agent ne reçoit pas le mail, et donc iel re-demande l'export. 

Conséquences : 
- l'agent ne peut pas obtenir l'export dont il a besoin
- notre base de donnée et notre système de jobs sont ralentis

# Pourquoi cette solution

**La solution fondamentale est de questionner les besoins de chaque persona, mais ça demande beaucoup de temps.**

En attendant de faire ce travail, j pense que limiter la taille des exports à 10 000 RDVs permet d'éviter les blocages actuels, sans être non plus trop contraignant (au lieu d'avoir un export sur les 2 derniers mois, l'agent peut demander des exports de 3 x 3 semaines). C'est pas idéal, mais c'est mieux que de ne pas obtenir d'export du tout.

Qu'en pensez-vous ?

# Avant

![image](https://user-images.githubusercontent.com/6357692/217031173-2d6cbd0d-34fe-4ebc-b5f5-9baf28022f44.png)

# Après

![image](https://user-images.githubusercontent.com/6357692/217031190-775178f1-e3b8-452b-bcf9-c95d4c87bee9.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
