### PR TITLE
Affiche toutes les indisponibilités

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -9,7 +9,6 @@ class Admin::AbsencesController < AgentAuthController
 
   def index
     absences = policy_scope(Absence)
-      .where(organisation: current_organisation)
       .where(agent_id: filter_params[:agent_id])
       .includes(:organisation, :agent)
       .by_starts_at

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -16,7 +16,6 @@ class Admin::AbsencesController < AgentAuthController
 
     @organisations = policy_scope(@agent.organisations)
 
-
     @absences = params[:current_tab] == "expired" ? absences.expired : absences.not_expired
     @display_tabs = absences.expired.any? || params[:current_tab] == "expired"
   end
@@ -46,7 +45,6 @@ class Admin::AbsencesController < AgentAuthController
   end
 
   def create
-    @absence.organisation = current_organisation
     authorize(@absence)
     if @absence.save
       absence_mailer.absence_created.deliver_later if @agent.absence_notification_level == "all"
@@ -97,7 +95,7 @@ class Admin::AbsencesController < AgentAuthController
   end
 
   def absence_params
-    params.require(:absence).permit(:title, :agent_id, :first_day, :end_day, :start_time, :end_time, :recurrence)
+    params.require(:absence).permit(:title, :agent_id, :first_day, :end_day, :start_time, :end_time, :recurrence, :organisation_id)
   end
 
   def filter_params

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -98,11 +98,7 @@ class Admin::AbsencesController < AgentAuthController
   end
 
   def absence_params
-    p = params.require(:absence).permit(:title, :agent_id, :first_day, :end_day, :start_time, :end_time, :recurrence, :organisation_id)
-    if p[:organisation_id].blank?
-      p = p.merge(organisation_id: current_organisation.id)
-    end
-    p
+    params.require(:absence).permit(:title, :agent_id, :first_day, :end_day, :start_time, :end_time, :recurrence, :organisation_id)
   end
 
   def filter_params

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -51,6 +51,7 @@ class Admin::AbsencesController < AgentAuthController
       flash[:notice] = t(".busy_time_created")
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
+      @organisations = policy_scope(@agent.organisations)
       render :edit
     end
   end
@@ -62,6 +63,7 @@ class Admin::AbsencesController < AgentAuthController
       flash[:notice] = t(".busy_time_updated")
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
+      @organisations = policy_scope(@agent.organisations)
       render :edit
     end
   end
@@ -74,6 +76,7 @@ class Admin::AbsencesController < AgentAuthController
       flash[:notice] = t(".busy_time_deleted")
       redirect_to admin_organisation_agent_absences_path(@absence.organisation_id, @absence.agent_id)
     else
+      @organisations = policy_scope(@agent.organisations)
       render :edit
     end
   end
@@ -95,7 +98,11 @@ class Admin::AbsencesController < AgentAuthController
   end
 
   def absence_params
-    params.require(:absence).permit(:title, :agent_id, :first_day, :end_day, :start_time, :end_time, :recurrence, :organisation_id)
+    p = params.require(:absence).permit(:title, :agent_id, :first_day, :end_day, :start_time, :end_time, :recurrence, :organisation_id)
+    if p[:organisation_id].blank?
+      p = p.merge(organisation_id: current_organisation.id)
+    end
+    p
   end
 
   def filter_params

--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -14,6 +14,9 @@ class Admin::AbsencesController < AgentAuthController
       .by_starts_at
       .page(filter_params[:page])
 
+    @organisations = policy_scope(@agent.organisations)
+
+
     @absences = params[:current_tab] == "expired" ? absences.expired : absences.not_expired
     @display_tabs = absences.expired.any? || params[:current_tab] == "expired"
   end
@@ -34,10 +37,12 @@ class Admin::AbsencesController < AgentAuthController
     @absence = Absence.new(organisation: current_organisation, agent: @agent, **defaults)
 
     authorize(@absence)
+    @organisations = policy_scope(@agent.organisations)
   end
 
   def edit
     authorize(@absence)
+    @organisations = policy_scope(@agent.organisations)
   end
 
   def create

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -11,7 +11,7 @@ tr
       | Se répète :
       br
       = sanitize(display_recurrence(absence).join("<br/>"))
-  - if @organisations.count > 1
+  - if @agent_organisations.count > 1
     td
       span>= organisation.name
   td

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -11,8 +11,9 @@ tr
       | Se répète :
       br
       = sanitize(display_recurrence(absence).join("<br/>"))
-  td
-    span>= organisation.name
+  - if @organisations.count > 1
+    td
+      span>= organisation.name
   td
     .d-flex
       div.mr-3= link_to edit_admin_organisation_absence_path(organisation, absence),

--- a/app/views/admin/absences/_form.html.slim
+++ b/app/views/admin/absences/_form.html.slim
@@ -1,7 +1,7 @@
 = simple_form_for [:admin, absence.organisation, absence] do |f|
   = render "model_errors", model: absence
   = f.hidden_field :agent_id
-  
+
   - if @organisations.count > 1
     = f.input :organisation_id, collection: @organisations.map {[_1.name, _1.id]}, \
                 label: "Organisation", \

--- a/app/views/admin/absences/_form.html.slim
+++ b/app/views/admin/absences/_form.html.slim
@@ -9,6 +9,8 @@
                 input_html: { \
                   class: "select2-input", \
                 }
+  - else
+    = f.input :organisation_id, as: :hidden, input_html: {value: current_organisation.id}
 
   = f.input :title, hint:"Uniquement visible en interne", placeholder: t(".busy_time_example")
 

--- a/app/views/admin/absences/_form.html.slim
+++ b/app/views/admin/absences/_form.html.slim
@@ -2,8 +2,8 @@
   = render "model_errors", model: absence
   = f.hidden_field :agent_id
 
-  - if @organisations.count > 1
-    = f.input :organisation_id, collection: @organisations.map {[_1.name, _1.id]}, \
+  - if @agent_organisations.count > 1
+    = f.input :organisation_id, collection: @agent_organisations.map {[_1.name, _1.id]}, \
                 label: "Organisation", \
                 include_blank: false, \
                 input_html: { \

--- a/app/views/admin/absences/_form.html.slim
+++ b/app/views/admin/absences/_form.html.slim
@@ -1,6 +1,15 @@
 = simple_form_for [:admin, absence.organisation, absence] do |f|
   = render "model_errors", model: absence
   = f.hidden_field :agent_id
+  
+  - if @organisations.count > 1
+    = f.input :organisation_id, collection: @organisations.map {[_1.name, _1.id]}, \
+                label: "Organisation", \
+                include_blank: false, \
+                input_html: { \
+                  class: "select2-input", \
+                }
+
   = f.input :title, hint:"Uniquement visible en interne", placeholder: t(".busy_time_example")
 
   hr

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -24,7 +24,8 @@
         tr
           th Description
           th Dates
-          th Organisation
+          - if @organisations.count > 1
+            th Organisation
           th Actions
       tbody
         = render @absences

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -24,7 +24,7 @@
         tr
           th Description
           th Dates
-          - if @organisations.count > 1
+          - if @agent_organisations.count > 1
             th Organisation
           th Actions
       tbody

--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -92,7 +92,9 @@ describe Admin::AbsencesController, type: :controller do
             agent_id: agent.id,
             first_day: "12/09/2019",
             start_time: "09:00",
+            # end_time before start_time !
             end_time: "07:00",
+            organisation_id: organisation.id,
           }
         end
 


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3322.osc-secnum-fr1.scalingo.io/

Après l'affichage des organisations dans le tableau des absence (pr #3320), ici on affiches toutes les indisponibilités d'un agent sur le même tableau, quelque soit l'organisation. On permet également de choisir l'organisation pour laquelle l'indisponibilité sera créée.

# screeshot 
## tableau des indisponibilités 
 avant :
![image](https://user-images.githubusercontent.com/60173782/217037143-dccdd654-0f46-477c-9ec9-6c5ba42f5648.png)

 après : 
![image](https://user-images.githubusercontent.com/60173782/217036835-c9488503-423c-4f6d-ae18-1f0c95be279f.png)

## Création d'indisponibilité
 avant :
![image](https://user-images.githubusercontent.com/60173782/218418188-8d0e0ad2-c9ab-4896-a557-9442f1404468.png)
 

 après :

![image](https://user-images.githubusercontent.com/60173782/218418058-ebcc3ffc-1138-4e10-a0bc-cab158e8b6da.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
