### PR TITLE
Corrige une erreur dans le nom de domaine de l'e-mail de contact

### DIFF
--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -132,5 +132,5 @@
 <p>
   Pour une demande d’amélioration, une question sur l’utilisation ou tout autre sujet,
   vous pouvez nous contacter à cette adresse mail&nbsp;:
-  <a href="mailto:contact@rdv-solidarités.fr">contact@rdv-solidarités.fr</a>
+  <a href="mailto:contact@rdv-solidarités.fr">contact@rdv-solidarites.fr</a>
 </p>

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -123,7 +123,7 @@
 
         p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
 
-        strong = mail_to "contact@rdv-solidarités.fr"
+        strong = mail_to "contact@rdv-solidarites.fr"
 
         p ou par voie postale :
 


### PR DESCRIPTION
Pour info, je viens de créer et configurer une boite mail contact@rdv-solidarités.fr pour qu'elle redirige les mails reçus vers contact@rdv-solidarites.fr (et donc vers le Zammad). :wink: 

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
