### PR TITLE
Affiche les restrictions dans la page du RDV usager

### DIFF
--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -4,6 +4,11 @@ ul.list-group.list-group-flush
     = rdv_title(rdv)
     = rdv_tag(rdv)
 
+  - if rdv.motif.restriction_for_rdv
+    li.list-group-item.alert.alert-warning
+        .fa.fa-warning>
+        = rdv.motif.restriction_for_rdv
+
   - if rdv.home?
     li.list-group-item
       .fa.fa-home>

--- a/spec/features/users/user_can_see_rdv_instruction_spec.rb
+++ b/spec/features/users/user_can_see_rdv_instruction_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+describe "User can see RDV instructions" do
+  it "can see RDV inscrution on RDV page" do
+    motif = create(:motif, restriction_for_rdv: "Pensez à prendre votre carnet de santé")
+    rdv = create(:rdv, motif: motif)
+    user = rdv.users.first
+    login_as(user, scope: :user)
+    visit users_rdv_path(rdv)
+    expect(page).to have_content(motif.restriction_for_rdv)
+  end
+end


### PR DESCRIPTION
Les restrictions s'affichent lorsque l'on selectionne un motif.

Lorsque l'on arrive directement sur la page du RDV depuis une notification, ou bien que l'on suit un lien d'invitation qui a présélectionné le motif, ces instructions ne s'affichent pas.

Cette PR propose d'afficher les « restrictions » associé à un motif sur la fiche du RDV de l'usager.

![Screenshot 2023-02-09 at 16-42-28 RDV Solidarités](https://user-images.githubusercontent.com/42057/217862586-a62c0710-ded6-4248-ba01-8226b45d7785.png)


Close #3291
Close #3302

Pour tester : <`mettre ici l'url de la review app une fois déployé`>

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
