### PR TITLE
N'affiche pas les badges de suppression si non nécessaire

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -46,6 +46,7 @@ module UsersHelper
 
   def user_soft_deleted_tag(organisation, user)
     return tag.span("Supprimé", class: "badge badge-danger") if user.deleted_at
+    return if organisation.territory.visible_users_throughout_the_territory?
 
     tag.span("Supprimé de cette organisation", class: "badge badge-danger") unless user.profile_for(organisation)
   end


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3348.osc-secnum-fr1.scalingo.io/

Nous continuons d'afficher que l'usager a été supprimé de cette organisation alors que l'option de visibilité des usagers à travers tout le territoire est active. Ça n'a plus de sens. Cette PR propose de ne plus prendre en compte ce badge si l'option est activée.

Avant

![Screenshot 2023-02-13 at 13-28-36 Liste des RDV - RDV Solidarités](https://user-images.githubusercontent.com/42057/218457743-25128c77-e215-4adf-ad8c-120cfdeac6d9.png)


Après

![Screenshot 2023-02-13 at 13-28-52 Liste des RDV - RDV Solidarités](https://user-images.githubusercontent.com/42057/218457772-2c01354c-4ad3-4186-a27b-5f3a7a42101d.png)



Closes #3347


Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
