### PR TITLE
Bug Fix notifications multiples lors de l'annulation d'une participation à un rdv

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -56,10 +56,8 @@ class Admin::RdvsCollectifsController < AgentAuthController
     @rdv = Rdv.find(params[:id])
     authorize(@rdv, :update?)
 
-    previous_participations = @rdv.rdvs_users.to_a
-    if @rdv.update(update_users_params)
+    if @rdv.update_and_notify(current_agent, update_users_params)
       flash[:notice] = "Participants mis à jour"
-      Notifiers::RdvCollectifParticipations.perform_with(@rdv, current_agent, previous_participations)
       redirect_to admin_organisation_rdvs_collectifs_path(current_organisation)
     else
       render :edit

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -57,6 +57,7 @@ module Rdv::Updatable
 
   def notify!(author, previous_participations)
     if rdv_cancelled?
+      file_attentes.destroy_all
       @notifier = new_cancelled_notifier(author, previous_participations)
     elsif rdv_status_reloaded_from_cancelled?
       @notifier = Notifiers::RdvCreated.new(self, author)
@@ -72,8 +73,7 @@ module Rdv::Updatable
   end
 
   def new_cancelled_notifier(author, previous_participations)
-    file_attentes.destroy_all
-    # Only notify cancellation for NEW cancelled participations
+    # Don't notify RDV cancellation to users that had previously cancelled their individual participation
     available_users_for_notif = previous_participations.select(&:not_cancelled?).map(&:user)
     Notifiers::RdvCancelled.new(self, author, available_users_for_notif)
   end

--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -11,13 +11,14 @@ module Rdv::Updatable
   def save_and_notify(author)
     Rdv.transaction do
       self.updated_at = Time.zone.now
+      previous_participations = rdvs_users.select(&:persisted?)
 
       if status_changed?
         self.cancelled_at = status.in?(%w[excused revoked noshow]) ? Time.zone.now : nil
         change_participation_statuses(status)
+        # Reload is needed after .persisted? method call.
+        rdvs_users.reload
       end
-
-      previous_participations = rdvs_users.select(&:persisted?)
 
       if save
         notify!(author, previous_participations)
@@ -56,8 +57,7 @@ module Rdv::Updatable
 
   def notify!(author, previous_participations)
     if rdv_cancelled?
-      file_attentes.destroy_all
-      @notifier = Notifiers::RdvCancelled.new(self, author)
+      @notifier = new_cancelled_notifier(author, previous_participations)
     elsif rdv_status_reloaded_from_cancelled?
       @notifier = Notifiers::RdvCreated.new(self, author)
     elsif rdv_updated?
@@ -69,6 +69,13 @@ module Rdv::Updatable
     if collectif? && previous_participations.sort != rdvs_users.sort
       Notifiers::RdvCollectifParticipations.perform_with(self, author, previous_participations)
     end
+  end
+
+  def new_cancelled_notifier(author, previous_participations)
+    file_attentes.destroy_all
+    # Only notify cancellation for NEW cancelled participations
+    available_users_for_notif = previous_participations.select(&:not_cancelled?).map(&:user)
+    Notifiers::RdvCancelled.new(self, author, available_users_for_notif)
   end
 
   def rdv_status_reloaded_from_cancelled?

--- a/app/services/notifiers/rdv_collectif_participations.rb
+++ b/app/services/notifiers/rdv_collectif_participations.rb
@@ -10,6 +10,8 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
   end
 
   def perform
+    # This is the historical way to notify participations changes
+    # when rdv is updated by the agent with participations add/remove in the updatable concern
     return if @rdv.starts_at < Time.zone.now
 
     # FIXME: this is not ideal but it's the simplest workaround to avoid notifying the agent
@@ -33,7 +35,7 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
   end
 
   def new_participants_to_notify
-    new_participations.select(&:send_lifecycle_notifications).map(&:user)
+    new_participations.select(&:not_cancelled?).select(&:send_lifecycle_notifications).map(&:user)
   end
 
   def removed_participations
@@ -43,7 +45,8 @@ class Notifiers::RdvCollectifParticipations < ::BaseService
   end
 
   def removed_participants_to_notify
-    removed_participations.select(&:send_lifecycle_notifications).map(&:user)
+    # We do not notify already cancelled participations
+    removed_participations.select(&:not_cancelled?).select(&:send_lifecycle_notifications).map(&:user)
   end
 
   def current_participations

--- a/app/services/notifiers/rdv_created.rb
+++ b/app/services/notifiers/rdv_created.rb
@@ -12,7 +12,8 @@ class Notifiers::RdvCreated < Notifiers::RdvBase
   protected
 
   def rdvs_users_to_notify
-    @rdv.rdvs_users.where(send_lifecycle_notifications: true)
+    # Rdv_created with cancelled status is not supposed to happen
+    @rdv.rdvs_users.not_cancelled.where(send_lifecycle_notifications: true)
   end
 
   def notify_agent(agent)

--- a/app/services/notifiers/rdv_upcoming_reminder.rb
+++ b/app/services/notifiers/rdv_upcoming_reminder.rb
@@ -4,7 +4,7 @@ class Notifiers::RdvUpcomingReminder < Notifiers::RdvBase
   protected
 
   def rdvs_users_to_notify
-    @rdv.rdvs_users.not_excused.where(send_reminder_notification: true)
+    @rdv.rdvs_users.not_cancelled.where(send_reminder_notification: true)
   end
 
   def notify_user_by_mail(user)

--- a/app/services/notifiers/rdv_updated.rb
+++ b/app/services/notifiers/rdv_updated.rb
@@ -2,7 +2,7 @@
 
 class Notifiers::RdvUpdated < Notifiers::RdvBase
   def rdvs_users_to_notify
-    @rdv.rdvs_users.not_excused.where(send_lifecycle_notifications: true)
+    @rdv.rdvs_users.not_cancelled.where(send_lifecycle_notifications: true)
   end
 
   def notify_user_by_mail(user)

--- a/spec/models/concerns/rdvs_user/status_changeable_spec.rb
+++ b/spec/models/concerns/rdvs_user/status_changeable_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RdvsUser::StatusChangeable, type: :concern do
         rdv_user_with_lifecycle_disabled.change_status_and_notify(agent, "revoked")
         expect(rdv_user_with_excused_status.reload.status).to eq("revoked")
         expect(rdv_user_with_lifecycle_disabled.reload.status).to eq("revoked")
-        expect_no_notifications_for_user
+        expect_no_notifications
       end
     end
 

--- a/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
+++ b/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
@@ -32,12 +32,12 @@ describe Notifiers::RdvUpcomingReminder, type: :service do
     rdv_user1.update(status: "excused")
     rdv_user2.update(status: "revoked")
     subject
-    expect_no_notifications_for_user
+    expect_no_notifications
   end
 
   it "rdv_users_tokens_by_user_id attribute outputs the tokens" do
     allow(Devise.token_generator).to receive(:generate).and_return("t0k3n")
-    notifier = described_class.new(rdv, user1)
+    notifier = described_class.new(rdv, nil)
     notifier.perform
     expect(notifier.rdv_users_tokens_by_user_id).to eq({ user1.id => "t0k3n", user2.id => "t0k3n" })
   end

--- a/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
+++ b/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
@@ -1,37 +1,44 @@
 # frozen_string_literal: true
 
 describe Notifiers::RdvUpcomingReminder, type: :service do
-  subject { described_class.perform_with(rdv, user1) }
+  subject { described_class.perform_with(rdv, nil) }
 
-  let(:user1) { build(:user) }
-  let(:rdv) { create(:rdv, starts_at: 2.days.from_now) }
-  let(:rdv_user) { create(:rdvs_user, user: user1, rdv: rdv) }
-  let(:rdvs_users) { RdvsUser.where(id: rdv_user.id) }
+  let!(:rdv) { create(:rdv, starts_at: 2.days.from_now, users: [user1, user2]) }
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+  let!(:user3) { create(:user) }
+  let!(:rdv_user1) { rdv.rdvs_users.where(user: user1).first }
+  let!(:rdv_user2) { rdv.rdvs_users.where(user: user2).first }
 
   before do
     stub_netsize_ok
-
-    allow(Users::RdvMailer).to receive(:with).and_call_original
-    allow(Users::RdvSms).to receive(:rdv_upcoming_reminder).and_call_original
-    allow(rdv).to receive(:rdvs_users).and_return(rdvs_users)
   end
 
   it "sends an sms and an email" do
-    expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user1, token: /^[A-Z0-9]{8}$/ })
-    expect(Users::RdvSms).to receive(:rdv_upcoming_reminder).with(rdv, user1, /^[A-Z0-9]{8}$/)
     subject
+    expect_notifications_sent_for(rdv, user1, :rdv_upcoming_reminder)
+    expect_notifications_sent_for(rdv, user2, :rdv_upcoming_reminder)
+    expect_no_notifications_for(rdv, user3, :rdv_upcoming_reminder)
   end
 
   it "doesnt send email if user participation is excused" do
-    rdv_user.update(status: "excused")
-    expect(Users::RdvMailer).not_to receive(:with).with({ rdv: rdv, user: user1, token: /^[A-Z0-9]{8}$/ })
-    expect(Users::RdvSms).not_to receive(:rdv_upcoming_reminder).with(rdv, user1, /^[A-Z0-9]{8}$/)
+    rdv_user1.update(status: "excused")
     subject
+    expect_no_notifications_for_user(user1)
+    expect_notifications_sent_for(rdv, user2, :rdv_upcoming_reminder)
+  end
+
+  it "doesnt send email if user participation is revoked" do
+    rdv_user1.update(status: "excused")
+    rdv_user2.update(status: "revoked")
+    subject
+    expect_no_notifications_for_user
   end
 
   it "rdv_users_tokens_by_user_id attribute outputs the tokens" do
+    allow(Devise.token_generator).to receive(:generate).and_return("t0k3n")
     notifier = described_class.new(rdv, user1)
     notifier.perform
-    expect(notifier.rdv_users_tokens_by_user_id).to match(user1.id => /^[A-Z0-9]{8}$/)
+    expect(notifier.rdv_users_tokens_by_user_id).to eq({ user1.id => "t0k3n", user2.id => "t0k3n" })
   end
 end

--- a/spec/services/notifiers/rdv_updated_spec.rb
+++ b/spec/services/notifiers/rdv_updated_spec.rb
@@ -54,5 +54,14 @@ describe Notifiers::RdvUpdated, type: :service do
       expect_notifications_sent_for(rdv, agent2, :rdv_updated)
       expect_no_notifications_for(rdv, user1, :rdv_updated)
     end
+
+    it "doesnt send email if user participation is revoked" do
+      rdv.rdvs_users.where(user: user1).update(status: "revoked")
+      subject
+
+      expect_notifications_sent_for(rdv, user2, :rdv_updated)
+      expect_notifications_sent_for(rdv, agent2, :rdv_updated)
+      expect_no_notifications_for(rdv, user1, :rdv_updated)
+    end
   end
 end

--- a/spec/support/notifications_helper.rb
+++ b/spec/support/notifications_helper.rb
@@ -7,55 +7,72 @@ module NotificationsHelper
 
   def expect_notifications_sent_for(rdv, person, event, notif_type = nil)
     perform_enqueued_jobs
-    klass = person.class
     other_events = EVENTS.reject { |i| i == event }
 
-    expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(person.email)
-
-    if klass == User
-      expect_sms_sent_for(person, event) unless notif_type == :mail
-      expect(email_sent_to(person.email).subject).to include(email_title_for_user(rdv, event))
+    if person.instance_of?(User)
+      if notif_type == :mail
+        expect_no_sms_sent_for(person, event)
+      else
+        expect_sms_sent_for(person, event)
+      end
+      expect_email_sent_for(rdv, person, event)
       # Check for no notifications for undesirable events
       other_events.each { expect_no_notifications_for(rdv, person, _1) }
-    elsif klass == Agent
-      expect(email_sent_to(person.email).subject).to include(email_title_for_agent(rdv, person, event))
+    elsif person.instance_of?(Agent)
+      expect_email_sent_for(rdv, person, event)
       # Check for no notifications for undesirable events
       # We reject rdv_upcoming_reminder event because it is not used for agents
       other_events.reject { |i| i == :rdv_upcoming_reminder }.each { expect_no_notifications_for(rdv, person, _1) }
     end
   end
 
-  def expect_sms_sent_for(person, event)
-    perform_enqueued_jobs
-    expect(Receipt.where(user_id: person.id, channel: "sms", result: "delivered").count).to eq 1
-    expect(Receipt.where(user_id: person.id, channel: "sms", event: event).count).to eq 1
-  end
-
   def expect_no_notifications_for(rdv, person, event)
     perform_enqueued_jobs
-    klass = person.class
-    if klass == User
-      expect(Receipt.where(user_id: person.id, channel: "sms", event: event).count).to eq 0
+    expect_no_email_sent_for(rdv, person, event)
+    expect_no_sms_sent_for(person, event) if person.instance_of?(User)
+  end
+
+  def expect_no_notifications_for_user(user)
+    perform_enqueued_jobs
+    expect(ActionMailer::Base.deliveries.map(&:to).flatten).not_to include(user.email)
+    expect(Receipt.where(user_id: user.id, channel: "sms", result: "delivered").count).to eq 0
+  end
+
+  def expect_no_notifications
+    perform_enqueued_jobs
+    expect(ActionMailer::Base.deliveries.size).to eq(0)
+    expect(Receipt.count).to eq(0)
+  end
+
+  private
+
+  def expect_email_sent_for(rdv, person, event)
+    expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(person.email)
+    if person.instance_of?(User)
+      expect(email_sent_to(person.email).subject).to include(email_title_for_user(rdv, event))
+    elsif person.instance_of?(Agent)
+      expect(email_sent_to(person.email).subject).to include(email_title_for_agent(rdv, person, event))
+    end
+  end
+
+  def expect_no_email_sent_for(rdv, person, event)
+    if person.instance_of?(User)
       if ActionMailer::Base.deliveries.map(&:to).flatten.include?(person.email)
         expect(email_sent_to(person.email).subject).not_to include(email_title_for_user(rdv, event))
       end
-    elsif klass == Agent
+    elsif person.instance_of?(Agent)
       if ActionMailer::Base.deliveries.map(&:to).flatten.include?(person.email)
         expect(email_sent_to(person.email).subject).not_to include(email_title_for_agent(rdv, person, event))
       end
     end
   end
 
-  def expect_no_notifications_for_user(user = nil)
-    perform_enqueued_jobs
+  def expect_sms_sent_for(person, event)
+    expect(Receipt.where(user_id: person.id, channel: "sms", event: event).count).to eq 1
+  end
 
-    if user
-      expect(ActionMailer::Base.deliveries.map(&:to).flatten).not_to include(user.email)
-      expect(Receipt.where(user_id: user.id, channel: "sms", result: "delivered").count).to eq 0
-    else
-      expect(ActionMailer::Base.deliveries.size).to eq(0)
-      expect(Receipt.count).to eq(0)
-    end
+  def expect_no_sms_sent_for(person, event)
+    expect(Receipt.where(user_id: person.id, channel: "sms", event: event).count).to eq 0
   end
 
   def email_title_for_agent(rdv, person, event)

--- a/spec/support/notifications_helper.rb
+++ b/spec/support/notifications_helper.rb
@@ -49,10 +49,12 @@ module NotificationsHelper
   def expect_no_notifications_for_user(user = nil)
     perform_enqueued_jobs
 
-    expect(ActionMailer::Base.deliveries.size).to eq(0)
-
     if user
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).not_to include(user.email)
       expect(Receipt.where(user_id: user.id, channel: "sms", result: "delivered").count).to eq 0
+    else
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+      expect(Receipt.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
Close : https://github.com/betagouv/rdv-solidarites.fr/issues/3345
Cette PR remplace en partie https://github.com/betagouv/rdv-solidarites.fr/pull/3263 qui faisait trop de choses différentes.
Ici on se contente de : 
- Régler un premier bug de notifications d'annulations multiple (l'issue ci dessus) lorsqu'un usager annule sa participation et que le rdv est ensuite annulé par un agent, l'usager qui avait annulé sa participation reçoit un nouveau mail d'annulation.
- Régler un bug de notification de rappel pour les rdv annulés par les agents. (dans le scope de `Notifiers::RdvUpcomingReminder`) Je viens de découvrir ce bug critique en travaillant sur cette PR.
- Refacto (lisibilité et améliorations des tests) du `NotificationHelper`
- Commentaires et tests

J'ai également replacé l'appel du `Notifiers::RdvCollectifParticipations` qui se faisait dans le contrôleur des rdv collectifs par la methode `update_and_notify` du concern `Updatable` pour une meilleure cohérence du code.