### PR TITLE
Suppression du status waiting

### DIFF
--- a/app/javascript/stylesheets/components/_rdv_status.scss
+++ b/app/javascript/stylesheets/components/_rdv_status.scss
@@ -10,7 +10,6 @@ $status_colors: (
   "unknown_future": $light,
   "unknown_today": $warning,
   "unknown_past": $warning,
-  "waiting": $tertiary,
   "seen": $success,
   "revoked": $teal,
   "excused": $info,

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -8,8 +8,8 @@ class RdvsUser < ApplicationRecord
   include RdvsUser::Creatable
 
   # Attributes
-  enum status: { unknown: "unknown", waiting: "waiting", seen: "seen", excused: "excused", revoked: "revoked", noshow: "noshow" }
-  NOT_CANCELLED_STATUSES = %w[unknown waiting seen noshow].freeze
+  enum status: { unknown: "unknown", seen: "seen", excused: "excused", revoked: "revoked", noshow: "noshow" }
+  NOT_CANCELLED_STATUSES = %w[unknown seen noshow].freeze
   CANCELLED_STATUSES = %w[excused revoked].freeze
 
   # Relations
@@ -41,9 +41,9 @@ class RdvsUser < ApplicationRecord
   scope :status, lambda { |status|
     case status.to_s
     when "unknown_past"
-      past.where(status: %w[unknown waiting])
+      past.where(status: %w[unknown])
     when "unknown_future"
-      future.where(status: %w[unknown waiting])
+      future.where(status: %w[unknown])
     else
       where(status: status)
     end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -41,7 +41,6 @@ class Stat
   def rdvs_group_by_status
     res = rdvs
       .where("starts_at < ?", Time.zone.today)
-      .where.not(status: :waiting)
       .group("status")
       .group_by_week("rdvs.starts_at", format: DEFAULT_FORMAT)
       .count
@@ -67,7 +66,6 @@ class Stat
       .joins(:rdv)
       .where(rdv: rdvs)
       .where("rdvs.starts_at < ?", Time.zone.today)
-      .where.not(status: :waiting)
       .group("status")
       .group_by_week("rdvs.starts_at", format: DEFAULT_FORMAT)
       .count

--- a/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_rdv_status_dropdown.html.slim
@@ -26,11 +26,6 @@
         .dropdown-divider
         = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "revoked", remote: remote
 
-      - when "waiting"
-        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "seen", remote: remote
-        .dropdown-divider
-        = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "unknown", remote: remote
-
       - else
         = render "admin/rdvs/rdv_status_dropdown_item", rdv: rdv, agent: agent, status: "unknown", remote: remote
 

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -45,7 +45,6 @@ fr:
         file_attente: "RDV en file d'attente"
       rdv/statuses:
         unknown: État indéterminé
-        waiting: En salle d’attente
         seen: Rendez-vous honoré
         excused: Annulé (excusé)
         revoked: Annulé (par le service)
@@ -55,14 +54,12 @@ fr:
         unknown_future: Rendez-vous à venir
       rdv/statuses/action:
         unknown: Réinitialiser
-        waiting: En salle d’attente
         seen: Rendez-vous honoré
         excused: Annulé à l’initiative de l’usager
         revoked: Annulé à l’initiative du service
         noshow: Absence non excusée
       rdv/statuses/explanation:
         unknown: Pour corriger l’état du rendez-vous.
-        waiting: L’usager est présent.
         seen: L’usager s’est présenté à son rendez-vous et a été reçu.
         excused: L’usager a pu prévenir de son absence. Une notification de confirmation lui sera envoyée.
         revoked: Le rendez-vous a du être annulé par le service, par exemple pour une raison administrative. Une notification sera envoyée à l’usager.

--- a/db/migrate/20230213155047_remove_waiting_from_enum_status.rb
+++ b/db/migrate/20230213155047_remove_waiting_from_enum_status.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class RemoveWaitingFromEnumStatus < ActiveRecord::Migration[7.0]
+  def up
+    execute(<<-SQL.squish
+      UPDATE rdvs
+      SET status = 'unknown'
+      WHERE status = 'waiting'
+    SQL
+           )
+
+    execute(<<-SQL.squish
+      UPDATE rdvs_users
+      SET status = 'unknown'
+      WHERE status = 'waiting'
+    SQL
+           )
+    remove_enum_value :rdv_status, "waiting"
+  end
+
+  def down
+    # We assume migrated "waiting" statuses will not be recovered in case of rollback
+    add_enum_value :rdv_status, "waiting"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_07_142918) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_13_155047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -47,7 +47,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_142918) do
 
   create_enum :rdv_status, [
     "unknown",
-    "waiting",
     "seen",
     "excused",
     "revoked",

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -102,7 +102,7 @@ describe RdvsHelper do
       travel_to(now)
     end
 
-    %i[waiting seen excused revoked noshow].each do |rdv_status|
+    %i[seen excused revoked noshow].each do |rdv_status|
       context "with a today's RDV" do
         let(:rdv) { build(:rdv, starts_at: now) }
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
                 items: { "$ref" => "#/components/schemas/rdvs_user" },
               },
               starts_at: { type: "string" },
-              status: { type: "string", enum: %w[unknown waiting seen excused revoked noshow] },
+              status: { type: "string", enum: %w[unknown seen excused revoked noshow] },
               users: {
                 type: "array",
                 items: { "$ref" => "#/components/schemas/user" },
@@ -319,7 +319,7 @@ RSpec.configure do |config|
             properties: {
               send_lifecycle_notifications: { type: "boolean" },
               send_reminder_notification: { type: "boolean" },
-              status: { type: "string", enum: %w[unknown waiting seen excused revoked noshow] },
+              status: { type: "string", enum: %w[unknown seen excused revoked noshow] },
               user: { "$ref" => "#/components/schemas/user" },
             },
             required: %w[send_lifecycle_notifications send_reminder_notification status user],

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -116,7 +116,6 @@
             "type": "string",
             "enum": [
               "unknown",
-              "waiting",
               "seen",
               "excused",
               "revoked",
@@ -702,7 +701,6 @@
             "type": "string",
             "enum": [
               "unknown",
-              "waiting",
               "seen",
               "excused",
               "revoked",


### PR DESCRIPTION
Ici on enlève ce qu'il reste du status des rdv `waiting` et qui n'est plus utilisé.
On migre les status `waiting`encore en db vers le status par défaut : `unknown`
Cette PR fait suite à celle ci https://github.com/betagouv/rdv-solidarites.fr/pull/3263 qui couvrait trop de choses différentes.