### PR TITLE
feat(search): Filter motifs on organisation ids

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -17,7 +17,7 @@ class SearchContext
     @public_link_organisation_id = query[:public_link_organisation_id]
     @user_selected_organisation_id = query[:user_selected_organisation_id]
     @external_organisation_ids = query[:external_organisation_ids]
-    @fallback_organisation_ids = query[:organisation_ids]
+    @preselected_organisation_ids = query[:organisation_ids]
     @motif_id = query[:motif_id]
     @motif_search_terms = query[:motif_search_terms]
     # TODO: Remove "query[:motif_category] ||" after RDV-I migration OK
@@ -185,6 +185,7 @@ class SearchContext
     motifs = motifs.where(service: service) if @service_id.present?
     motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
     motifs = motifs.with_motif_category_short_name(@motif_category_short_name) if @motif_category_short_name.present?
+    motifs = motifs.where(organisation_id: @preselected_organisation_ids) if @preselected_organisation_ids.present?
     motifs = motifs.where(organisations: { id: organisation_id }) if organisation_id.present?
     motifs = motifs.where(organisations: { external_id: @external_organisation_ids.compact }) if @external_organisation_ids.present?
     motifs = motifs.where(id: @motif_id) if @motif_id.present?
@@ -220,7 +221,7 @@ class SearchContext
         # we retrieve the geolocalised matching motifs, if there are none we fallback
         # on the matching motifs for the organisations passed in the query
         filter_motifs(geo_search.available_motifs).presence || filter_motifs(
-          Motif.available_with_plages_ouvertures.where(organisation_id: @fallback_organisation_ids)
+          Motif.available_with_plages_ouvertures.where(organisation_id: @preselected_organisation_ids)
         )
       else
         filter_motifs(geo_search.available_motifs)

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -136,14 +136,14 @@ describe "User can be invited" do
     before do
       travel_to(now)
       allow(Users::GeoSearch).to receive(:new).and_return(geo_search)
+    end
 
+    it "shows the geo search available motifs to take a rdv", js: true do
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
         address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
       )
-    end
 
-    it "shows the geo search available motifs to take a rdv", js: true do
       # Motif selection
       expect(page).to have_content(motif.name)
       expect(page).to have_content(motif2.name)
@@ -180,6 +180,19 @@ describe "User can be invited" do
       expect(page).to have_content("Votre RDV")
       expect(page).to have_content(lieu.address)
       expect(page).to have_content("11h00")
+    end
+
+    context "when the organisations are preselected" do
+      it "shows the available motifs for the preselected orgs" do
+        visit prendre_rdv_path(
+          departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+          address: "16 rue de la résistance", motif_search_terms: "RSA orientation", organisation_ids: [organisation.id]
+        )
+
+        # It directly selects the first motif and goes to lieu selection
+        expect(page).to have_content(lieu.name)
+        find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
+      end
     end
   end
 

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -66,6 +66,24 @@ describe SearchContext, type: :service do
       expect(subject.send(:matching_motifs)).to eq([motif])
     end
 
+    context "when there are two available motifs from the geo search" do
+      let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
+
+      it "is the returns the two matching motifs" do
+        expect(subject.send(:matching_motifs)).to match_array([motif, motif2])
+      end
+
+      context "when one of the motif does not belong to the preselected orgs" do
+        let!(:other_org) { create(:organisation) }
+
+        before { motif2.update! organisation: other_org }
+
+        it "returns only the matching motif from the preselected orgs" do
+          expect(subject.send(:matching_motifs)).to eq([motif])
+        end
+      end
+    end
+
     context "for an invitation (old param)" do
       before do
         search_query[:invitation_token] = invitation_token
@@ -95,7 +113,7 @@ describe SearchContext, type: :service do
         before { search_query[:referent_ids] = [agent.id] }
 
         let!(:agent) { create(:agent, users: [user]) }
-        let!(:motif) { create(:motif, follow_up: true, motif_category: rsa_orientation) }
+        let!(:motif) { create(:motif, follow_up: true, motif_category: rsa_orientation, organisation: organisation) }
         let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif]) }
         let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
 
@@ -134,7 +152,7 @@ describe SearchContext, type: :service do
         before { search_query[:referent_ids] = [agent.id] }
 
         let!(:agent) { create(:agent, users: [user]) }
-        let!(:motif) { create(:motif, follow_up: true, motif_category: rsa_orientation) }
+        let!(:motif) { create(:motif, follow_up: true, motif_category: rsa_orientation, organisation: organisation) }
         let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif]) }
         let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
 


### PR DESCRIPTION
Dans cette PR j'applique dans le `SearchContext` un filtre sur les `organisation_ids` envoyés dans l'URL d'invitation.
Du coup je renomme la variable `fallback_organisation_ids` en `preselected_organisation_ids` car elle n'est plus utilisée uniquement en tant que fallback.
Ce filtre n'apparait que maintenant parce qu'avant nous n'avions pas un mécanisme de régulation côté RDV-I pour restreindre le nombre d'orgas que l'on référençait dans l'URL.

Remarque: le paramètre dans l'url reste `organisation_ids`. Je pourrais le renommer en `preselected_organisation_ids` et avoir la possibilité de passer les 2 (le temps que le nouveau nom de paramètre soit pris en compte côté RDV-I), mais je me suis dit que ça allait beaucoup de paramètres et nous allons de toutes façons séparer (encore une fois 😅 ) la logique spécifique à l'invitation du reste dans le `SearchContext`. 