### PR TITLE
Correction flaky tests causés par IDs codés en dur

### DIFF
--- a/spec/jobs/outlook/destroy_event_job_spec.rb
+++ b/spec/jobs/outlook/destroy_event_job_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Outlook::DestroyEventJob, type: :job do
-  let(:organisation) { create(:organisation, id: 10) }
+  let(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, name: "Super Motif", location_type: :phone) }
   # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
   let(:fake_agent) { create(:agent) }
   let(:agent) { create(:agent, microsoft_graph_token: "token") }
-  let(:rdv) { create(:rdv, id: 20, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
-  let!(:agents_rdv) { create(:agents_rdv, id: 12, rdv: rdv, agent: agent, outlook_id: "super_id") }
+  let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+  let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "super_id") }
 
   let(:expected_headers) do
     {

--- a/spec/jobs/outlook/mass_create_event_job_spec.rb
+++ b/spec/jobs/outlook/mass_create_event_job_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Outlook::MassCreateEventJob, type: :job do
-  let(:organisation) { create(:organisation, id: 10) }
+  let(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, name: "Super Motif", location_type: :phone) }
   # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
   let(:fake_agent) { create(:agent) }
   let(:agent) { create(:agent) }
-  let(:rdv) { create(:rdv, id: 1, motif: motif, organisation: organisation, starts_at: 1.day.from_now, agents: [fake_agent]) }
-  let(:rdv2) { create(:rdv, id: 2, motif: motif, organisation: organisation, starts_at: 2.days.from_now, agents: [fake_agent]) }
-  let(:rdv3) { create(:rdv, id: 3, motif: motif, organisation: organisation, starts_at: 1.day.ago, agents: [fake_agent]) }
-  let(:rdv4) { create(:rdv, id: 4, motif: motif, organisation: organisation, starts_at: 2.days.ago, agents: [fake_agent]) }
+  let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: 1.day.from_now, agents: [fake_agent]) }
+  let(:rdv2) { create(:rdv, motif: motif, organisation: organisation, starts_at: 2.days.from_now, agents: [fake_agent]) }
+  let(:rdv3) { create(:rdv, motif: motif, organisation: organisation, starts_at: 1.day.ago, agents: [fake_agent]) }
+  let(:rdv4) { create(:rdv, motif: motif, organisation: organisation, starts_at: 2.days.ago, agents: [fake_agent]) }
   let!(:agents_rdv) { create(:agents_rdv, agent: agent, rdv: rdv) }
   let!(:agents_rdv2) { create(:agents_rdv, agent: agent, rdv: rdv2) }
   let!(:agents_rdv3) { create(:agents_rdv, agent: agent, rdv: rdv3) }

--- a/spec/jobs/outlook/mass_destroy_event_job_spec.rb
+++ b/spec/jobs/outlook/mass_destroy_event_job_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Outlook::MassDestroyEventJob, type: :job do
-  let(:organisation) { create(:organisation, id: 10) }
+  let(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, name: "Super Motif", location_type: :phone) }
   # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
   let(:fake_agent) { create(:agent) }
   let(:agent) { create(:agent, microsoft_graph_token: "token", refresh_microsoft_graph_token: "refresh_token") }
-  let(:rdv) { create(:rdv, id: 1, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), agents: [fake_agent]) }
-  let(:rdv2) { create(:rdv, id: 2, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 13h00"), agents: [fake_agent]) }
-  let(:rdv3) { create(:rdv, id: 3, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 15h00"), agents: [fake_agent]) }
-  let(:rdv4) { create(:rdv, id: 4, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 17h00"), agents: [fake_agent]) }
+  let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), agents: [fake_agent]) }
+  let(:rdv2) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 13h00"), agents: [fake_agent]) }
+  let(:rdv3) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 15h00"), agents: [fake_agent]) }
+  let(:rdv4) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 17h00"), agents: [fake_agent]) }
   let!(:agents_rdv) { create(:agents_rdv, agent: agent, rdv: rdv, outlook_id: "abc") }
   let!(:agents_rdv2) { create(:agents_rdv, agent: agent, rdv: rdv2, outlook_id: "def") }
   let!(:agents_rdv3) { create(:agents_rdv, agent: agent, rdv: rdv3) }

--- a/spec/jobs/outlook/update_event_job_spec.rb
+++ b/spec/jobs/outlook/update_event_job_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Outlook::UpdateEventJob, type: :job do
-  let(:organisation) { create(:organisation, id: 10) }
+  let(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, name: "Super Motif", location_type: :phone) }
   # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
   let(:fake_agent) { create(:agent) }
   let(:agent) { create(:agent, microsoft_graph_token: "token") }
   let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-  let(:rdv) { create(:rdv, id: 20, motif: motif, users: [user], organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+  let(:rdv) { create(:rdv, motif: motif, users: [user], organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
   let(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "super_id") }
 
   let(:expected_body) do
@@ -17,7 +17,7 @@ RSpec.describe Outlook::UpdateEventJob, type: :job do
       subject: "Super Motif",
       body: {
         contentType: "HTML",
-        content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/10/rdvs/20",
+        content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
       },
       start: {
         dateTime: "2023-01-01T11:00:00+01:00",

--- a/spec/models/concerns/outlook/synchronizable_spec.rb
+++ b/spec/models/concerns/outlook/synchronizable_spec.rb
@@ -27,14 +27,14 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
       let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-      let(:rdv) { create(:rdv, id: 20, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
 
       let(:expected_body) do
         {
           subject: "Super Motif",
           body: {
             contentType: "HTML",
-            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
           },
           start: {
             dateTime: "2023-01-01T11:00:00+01:00",
@@ -65,7 +65,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       end
 
       it "creates the Event in Outlook" do
-        agents_rdv = create(:agents_rdv, id: 12, agent: agent, rdv: rdv)
+        agents_rdv = create(:agents_rdv, agent: agent, rdv: rdv)
 
         expect(a_request(:post,
                          "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_body)).to have_been_made.once
@@ -103,7 +103,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
       let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-      let(:rdv) { create(:rdv, id: 20, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
       let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "abc") }
 
       let(:expected_body) do
@@ -111,7 +111,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
           subject: "Super Motif",
           body: {
             contentType: "HTML",
-            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
           },
           start: {
             dateTime: "2023-01-01T11:00:00+01:00",
@@ -171,14 +171,14 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
       let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-      let(:rdv) { create(:rdv, id: 20, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
 
       let(:expected_body) do
         {
           subject: "Super Motif",
           body: {
             contentType: "HTML",
-            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
           },
           start: {
             dateTime: "2023-01-01T11:00:00+01:00",
@@ -206,7 +206,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
           subject: "Super Motif",
           body: {
             contentType: "HTML",
-            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
           },
           start: {
             dateTime: "2023-01-01T11:00:00+01:00",
@@ -240,7 +240,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       end
 
       it "creates the Outlook Event" do
-        agents_rdv = create(:agents_rdv, id: 12, agent: agent, rdv: rdv)
+        agents_rdv = create(:agents_rdv, agent: agent, rdv: rdv)
         rdv.update(duration_in_min: 40)
 
         expect(a_request(:post,
@@ -255,7 +255,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
-      let(:rdv) { create(:rdv, id: 20, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
       let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "abc") }
 
       before do
@@ -277,14 +277,14 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
       let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-      let(:rdv) { create(:rdv, id: 20, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
 
       let(:expected_body) do
         {
           subject: "Super Motif",
           body: {
             contentType: "HTML",
-            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
           },
           start: {
             dateTime: "2023-01-01T11:00:00+01:00",
@@ -315,7 +315,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       end
 
       it "does not call Outlook::DestroyEventJob" do
-        agents_rdv = create(:agents_rdv, id: 12, agent: agent, rdv: rdv)
+        agents_rdv = create(:agents_rdv, agent: agent, rdv: rdv)
         expect do
           rdv.update(cancelled_at: Time.zone.now, status: "revoked")
         end.not_to have_enqueued_job(Outlook::DestroyEventJob).with(agents_rdv.outlook_id, agent.id)
@@ -328,7 +328,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
-      let(:rdv) { create(:rdv, id: 20, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
       let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "abc") }
 
       before do
@@ -352,7 +352,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
-      let(:rdv) { create(:rdv, id: 20, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
       let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent, outlook_id: "abc") }
 
       before do
@@ -373,7 +373,7 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       # We need to create a fake agent to initialize a RDV as they have a validation on agents which prevents us to control the data in its AgentsRdv
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent) }
-      let(:rdv) { create(:rdv, id: 20, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
       let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent) }
 
       before do
@@ -396,14 +396,14 @@ RSpec.describe Outlook::Synchronizable, type: :concern do
       let(:fake_agent) { create(:agent) }
       let(:agent) { create(:agent, microsoft_graph_token: "token") }
       let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-      let(:rdv) { create(:rdv, id: 20, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+      let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
 
       let(:expected_body) do
         {
           subject: "Super Motif",
           body: {
             contentType: "HTML",
-            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+            content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
           },
           start: {
             dateTime: "2023-01-01T11:00:00+01:00",

--- a/spec/models/outlook/event_spec.rb
+++ b/spec/models/outlook/event_spec.rb
@@ -14,7 +14,7 @@ describe Outlook::Event, type: :model do
     let(:fake_agent) { create(:agent) }
     let(:agent) { create(:agent, microsoft_graph_token: "token", refresh_microsoft_graph_token: "refresh_token") }
     let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-    let(:rdv) { create(:rdv, id: 20, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
+    let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [fake_agent]) }
 
     let(:expected_headers) do
       {
@@ -42,7 +42,7 @@ describe Outlook::Event, type: :model do
         subject: "Super Motif",
         body: {
           contentType: "HTML",
-          content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/20",
+          content: "plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}",
         },
         start: {
           dateTime: "2023-01-01T11:00:00+01:00",
@@ -83,7 +83,7 @@ describe Outlook::Event, type: :model do
     end
 
     it "refreshes the Outlook::User's token when needed" do
-      create(:agents_rdv, id: 12, agent: agent, rdv: rdv)
+      create(:agents_rdv, agent: agent, rdv: rdv)
 
       expect(a_request(:post,
                        "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_body)).to have_been_made.twice


### PR DESCRIPTION
Certains tests étaient flaky car on avait utilisé des IDs codés en dur.

J''en ai corrigé la plupart, certains restent mais utilisent des IDs du genre `456_000` donc peu de risque de collision.