### PR TITLE
N'affiche plus les rdvs supprimés des utilisateurs

### DIFF
--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -13,7 +13,7 @@ class RdvsUser < ApplicationRecord
   CANCELLED_STATUSES = %w[excused revoked].freeze
 
   # Relations
-  belongs_to :rdv, -> { unscope(where: :deleted_at) }, touch: true, inverse_of: :rdvs_users, optional: true
+  belongs_to :rdv, touch: true, inverse_of: :rdvs_users, optional: true
   belongs_to :user, -> { unscope(where: :deleted_at) }, inverse_of: :rdvs_users, optional: true
   has_one :prescripteur, dependent: :destroy
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -688,6 +688,13 @@ describe Rdv, type: :model do
       expect(described_class.all).to be_empty
     end
 
+    it "hide soft_deleted rdv of one user" do
+      rdv = create(:rdv)
+      user = rdv.users.first
+      rdv.soft_delete
+      expect(user.rdvs).to be_empty
+    end
+
     it "allows finding soft_deleted rdv using `unscoped`" do
       rdv = create(:rdv)
       rdv.soft_delete


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3370.osc-secnum-fr1.scalingo.io/

Les RDVs supprimés (soft-deleted) continuaient à apparaître dans la fiche des usagers. Cette PR corrige le bug.

Closes #3284

# screeshots : 
## avant 
![image](https://user-images.githubusercontent.com/60173782/220687304-febd58af-cdb5-4374-a088-b801d57aadf6.png)

## après
![image](https://user-images.githubusercontent.com/60173782/220687609-f7553de2-f8f1-4629-9bd6-67f2a7156823.png)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
