### PR TITLE
Liste les usagers unique d'un territoire

### DIFF
--- a/app/policies/agent/user_policy.rb
+++ b/app/policies/agent/user_policy.rb
@@ -35,13 +35,8 @@ class Agent::UserPolicy < DefaultAgentPolicy
                          else
                            current_organisation&.id || current_agent.organisation_ids
                          end
-      scope
-        .joins(:organisations)
-        .where(
-          organisations: {
-            id: organisation_ids,
-          }
-        )
+
+      scope.where(id: UserProfile.where("user_profiles.organisation_id": organisation_ids).distinct.select(:user_id))
     end
   end
 

--- a/app/views/admin/users/search.json.jbuilder
+++ b/app/views/admin/users/search.json.jbuilder
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# En effet, on rencontre ce problème : Casecommons/pg_search#238
-# Le uniq est un solution qui casse parfois le décompte, mais ça paraît acceptable !
-json.results @users.uniq do |user|
+json.results @users do |user|
   json.id user.id
   json.text reverse_full_name_and_birthdate(user)
 end

--- a/spec/features/agents/users/users_spec.rb
+++ b/spec/features/agents/users/users_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe "can search users" do
+  context "when user is visible only in organisation" do
+    it "can't see user that match search query from other organsiation" do
+      territory = create(:territory, visible_users_throughout_the_territory: false)
+      organisation = create(:organisation, territory: territory)
+      other_organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      user = create(:user, first_name: "Tanguy", last_name: "Laverdure", organisations: [organisation])
+      other_organisation_user = create(:user, first_name: "Tanguy", last_name: "De retour", organisations: [other_organisation])
+
+      login_as(agent, scope: :agent)
+      visit admin_organisation_users_path(organisation, search: "Tanguy")
+
+      expect(page).to have_content(user.last_name.upcase)
+      expect(page).not_to have_content(other_organisation_user.last_name.upcase)
+    end
+
+    it "see users that match search query" do
+      territory = create(:territory, visible_users_throughout_the_territory: false)
+      organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      user = create(:user, first_name: "Tanguy", last_name: "Laverdure", organisations: [organisation])
+      other_user = create(:user, first_name: "Tanguy", last_name: "Deretour", organisations: [organisation])
+
+      login_as(agent, scope: :agent)
+      visit admin_organisation_users_path(organisation, search: "Tanguy")
+
+      expect(page).to have_content(user.last_name.upcase)
+      expect(page).to have_content(other_user.last_name.upcase)
+    end
+  end
+
+  context "when user is visible through territor" do
+    it "see all users that match search query" do
+      territory = create(:territory, visible_users_throughout_the_territory: true)
+      organisation = create(:organisation, territory: territory)
+      other_organisation = create(:organisation, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: [organisation])
+      user = create(:user, first_name: "Tanguy", last_name: "Laverdure", organisations: [organisation])
+      other_organisation_user = create(:user, first_name: "Tanguy", last_name: "Deretour", organisations: [other_organisation])
+
+      login_as(agent, scope: :agent)
+      visit admin_organisation_users_path(organisation, search: "Tanguy")
+
+      expect(page).to have_content(user.last_name.upcase)
+      expect(page).to have_content(other_organisation_user.last_name.upcase)
+    end
+
+    it "see all users in one page" do
+      territory = create(:territory, visible_users_throughout_the_territory: true)
+      organisations = create_list(:organisation, 15, territory: territory)
+      agent = create(:agent, basic_role_in_organisations: organisations)
+      create_list(:user, 8, first_name: "Tanguy", last_name: "Laverdure", organisations: organisations.sample(rand(15)))
+
+      login_as(agent, scope: :agent)
+      visit admin_organisation_users_path(organisations.first, search: "Tanguy")
+
+      expect(page).not_to have_content("Suivant")
+    end
+  end
+end


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3372.osc-secnum-fr1.scalingo.io/

Lorsque les départements activent la visibilité des usagers sur le territoire entier, il y a un bug d'affichage qui donne une drôle d'impression.

C'est lié à une multiplication des usagers lors d'une jointure sur les `user_profiles` pour filtre, dans les policies, les usagers que l'on a le droit de voir (soit en regardant sur l'organisation courante, soit en listant l'ensemble des organisations).


La solution n'est pas sans risque sur la performance, mais je n'en trouve pas de meilleure pour le moment.

Il serait sans doute intéressant de lier les usagers directement au territoire. Et peut-être d'envisager qu'un usager n'appartient qu'à un seul territoire...

Il y avait un indice du problème dans `app/views/admin/users/index.json.builder`

> En effet, on rencontre ce problème : Casecommons/pg_search#238
> Le uniq est un solution qui casse parfois le décompte, mais ça paraît acceptable !

Le `uniq` a cette endroit n'est plus nécessaire du coup.