### PR TITLE
Désactiver le log des args sensibles des jobs

### DIFF
--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -3,6 +3,9 @@
 class SmsJob < ApplicationJob
   queue_as :sms
 
+  # Pour éviter de fuiter des données personnelles dans les logs
+  self.log_arguments = false
+
   class InvalidMobilePhoneNumberError < StandardError; end
 
   def perform(sender_name:, phone_number:, content:, provider:, api_key:, receipt_params:) # rubocop:disable Metrics/ParameterLists

--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -3,6 +3,9 @@
 class TransferEmailReplyJob < ApplicationJob
   queue_as :mailers
 
+  # Pour éviter de fuiter des données personnelles dans les logs
+  self.log_arguments = false
+
   def self.reply_address_for_rdv(rdv)
     "rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"
   end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -9,6 +9,9 @@ class WebhookJob < ApplicationJob
 
   retry_on(OutgoingWebhookError, wait: :exponentially_longer, attempts: 10, queue: :webhook_retries)
 
+  # Pour éviter de fuiter des données personnelles dans les logs
+  self.log_arguments = false
+
   def perform(payload, webhook_endpoint_id)
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -9,3 +9,9 @@ Rails.application.config.filter_parameters += %i[
   address city_code post_code city_name address_details logement
   family_situation number_of_children case_number
 ]
+
+# NOTE: Le logging des paramètres a été désactivé dans
+# https://github.com/betagouv/rdv-solidarites.fr/pull/3374
+# et donc cette liste de champs n'es plus opérante.
+# Nous la laissons pour qu'elle serve de base si l'on
+# décide de logger à nouveau les params HTTP.

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -2,10 +2,4 @@
 
 Rails.application.configure do
   config.lograge.enabled = true
-  config.lograge.custom_options = lambda do |event|
-    exceptions = %w[controller action format id]
-    {
-      params: event.payload[:params].except(*exceptions),
-    }
-  end
 end


### PR DESCRIPTION
Closes #3259 

Deux choses faites dans cette PR pour éviter la fuite de données personnelles dans les logs : 
1. Désactivation du logging des args pour les jobs sensibles `(SmsJob` et `WebhookJob`).
2. Suppression d'une config lograge introduite dans #3191 qui avait pour effet de logger les paramètres de requêtes HTTP (alors que par défaut [lograge ne logge pas les paramètres](https://github.com/roidrage/lograge#what-it-doesnt-do)). J'ai réalisé qu'on avait ces fuites en cherchant le mot clé "couple" dans nos logs. Si ce manque de log nous handicape on reviendra sur la décision, mais pour le moment soyons prudents !

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
