### PR TITLE
Mettre à jour la stack Scalingo (de `scalingo-18` à `scalingo-22`)

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,6 +1,6 @@
 {
   "name": "RDV-Solidarités",
-  "stack": "scalingo-18",
+  "stack": "scalingo-22",
   "env": {
     "HOST": {
       "description": "HOST",


### PR DESCRIPTION
La stack `scalingo-18` est déprécié et sera phased out en avril (le mois prochain). Nous avons reçu un mail nous indiquant que nos apps sont sur cette stack : 

> List of impacted apps: demo-rdv-solidarites, production-rdv-solidarites, demo-rdv-solidarites-pr3181, demo-rdv-solidarites-pr3276, demo-rdv-solidarites-pr3349, demo-rdv-solidarites-pr3354, demo-rdv-solidarites-pr3356, demo-rdv-solidarites-pr3358, demo-rdv-solidarites-pr3368, demo-rdv-solidarites-pr3370, demo-rdv-solidarites-pr3373, demo-rdv-solidarites-pr3374, demo-rdv-solidarites-pr3376

Je mets donc à jour la stack dans le fichier `scalingo.json`, ce qui a pour effet de tester sur la review app. Si tout est OK nous pourrons changer la stack sur la démo puis la prod.

https://doc.scalingo.com/platform/internals/stacks/stacks#migrating-to-a-new-stack

# Checklist

Avant la revue :

- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
