### PR TITLE
Bandeau d'information pour les absences

### DIFF
--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -1,4 +1,5 @@
 - content_for(:menu_item) { "menu-absences" }
+= render "layouts/absences_change_banner"
 
 - content_for :title do
   - if @absence.agent == current_agent

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -1,6 +1,8 @@
 - content_for(:menu_item) { "menu-absences" }
 - content_for(:menu_agent_select_path_helper_name) { "admin_organisation_agent_absences_path" }
 
+= render "layouts/absences_change_banner"
+
 - content_for :title do
   - if current_agent == @agent
     = t(".your_busy_times")

--- a/app/views/admin/absences/new.html.slim
+++ b/app/views/admin/absences/new.html.slim
@@ -1,5 +1,6 @@
 - content_for(:menu_item) { "menu-absences" }
 - content_for(:menu_agent_select_path_helper_name) { "new_admin_organisation_agent_absence_path" }
+= render "layouts/absences_change_banner"
 
 - content_for :title do
   - if @absence.agent == current_agent

--- a/app/views/layouts/_absences_change_banner.html.slim
+++ b/app/views/layouts/_absences_change_banner.html.slim
@@ -7,4 +7,4 @@
         = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos indisponibilités. "
         br
         = "Si ce nouveau fonctionnement risque de vous poser problème, nous vous invitons à nous prévenir en écrivant à l'adresse "
-        = mail_to("contact@rdv-solidarites.fr", "contact@rdv-solidarites.fr.",target: "_blank")
+        = mail_to("contact@rdv-solidarites.fr", "contact@rdv-solidarites.fr.", subject: "[Retours sur les indisponibilités]")

--- a/app/views/layouts/_absences_change_banner.html.slim
+++ b/app/views/layouts/_absences_change_banner.html.slim
@@ -1,0 +1,7 @@
+.navbar.alert-warning.p-2
+  div
+    .fa.fa-exclamation-circle.alert-link>
+    span.ml-1.alert-link
+      = "Nous prévoyons de bientôt changer le fonctionnement des absences pour qu'elles s'appliquent à toutes vos organisations."
+      = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos absences."
+      = "Si ce nouveau fonctionnement risque de vous posez problème, nous vous invitons à nous prévenir en écrivant à l'adresse contact@rdv-solidarites.fr."

--- a/app/views/layouts/_absences_change_banner.html.slim
+++ b/app/views/layouts/_absences_change_banner.html.slim
@@ -6,4 +6,5 @@
         = "Nous prévoyons de bientôt changer le fonctionnement des indisponibilités pour qu'elles s'appliquent à toutes vos organisations. "
         = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos indisponibilités. "
         br
-        = "Si ce nouveau fonctionnement risque de vous poser problème, nous vous invitons à nous prévenir en écrivant à l'adresse contact@rdv-solidarites.fr."
+        = "Si ce nouveau fonctionnement risque de vous poser problème, nous vous invitons à nous prévenir en écrivant à l'adresse "
+        = mail_to("contact@rdv-solidarites.fr", "contact@rdv-solidarites.fr.",target: "_blank")

--- a/app/views/layouts/_absences_change_banner.html.slim
+++ b/app/views/layouts/_absences_change_banner.html.slim
@@ -2,6 +2,6 @@
   div
     .fa.fa-exclamation-circle.alert-link>
     span.ml-1.alert-link
-      = "Nous prévoyons de bientôt changer le fonctionnement des absences pour qu'elles s'appliquent à toutes vos organisations."
-      = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos absences."
+      = "Nous prévoyons de bientôt changer le fonctionnement des absences pour qu'elles s'appliquent à toutes vos organisations. "
+      = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos absences. "
       = "Si ce nouveau fonctionnement risque de vous posez problème, nous vous invitons à nous prévenir en écrivant à l'adresse contact@rdv-solidarites.fr."

--- a/app/views/layouts/_absences_change_banner.html.slim
+++ b/app/views/layouts/_absences_change_banner.html.slim
@@ -1,7 +1,9 @@
-.navbar.alert-warning.p-2
-  div
-    .fa.fa-exclamation-circle.alert-link>
-    span.ml-1.alert-link
-      = "Nous prévoyons de bientôt changer le fonctionnement des absences pour qu'elles s'appliquent à toutes vos organisations. "
-      = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos absences. "
-      = "Si ce nouveau fonctionnement risque de vous posez problème, nous vous invitons à nous prévenir en écrivant à l'adresse contact@rdv-solidarites.fr."
+- if @agent_organisations.count > 1
+  .navbar.alert-warning.p-2.mb-2
+    div
+      .fa.fa-exclamation-triangle.alert-link>
+      span.ml-1.alert-link
+        = "Nous prévoyons de bientôt changer le fonctionnement des indisponibilités pour qu'elles s'appliquent à toutes vos organisations. "
+        = "Cela vous permettra de ne pas avoir à les indiquer en double pour chaque organisation, et d'éviter la création de rendez-vous par erreur pendant vos indisponibilités. "
+        br
+        = "Si ce nouveau fonctionnement risque de vous poser problème, nous vous invitons à nous prévenir en écrivant à l'adresse contact@rdv-solidarites.fr."


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3380.osc-secnum-fr1.scalingo.io/

Mise en place d'un bandeau pour prévenir les utilisateurs de la modification de gestion des absences


Closes [#3378](https://github.com/betagouv/rdv-solidarites.fr/issues/3378)

# Captures

![image](https://user-images.githubusercontent.com/60173782/222702951-e60bf568-d650-48a6-9d68-9eff068e5dc5.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
