### PR TITLE
modification du comportement de suppression d'un agent

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -18,17 +18,15 @@ class Admin::AgentsController < AgentAuthController
     @agent = policy_scope(Agent).find(params[:id])
     authorize(@agent)
     removal_service = AgentRemoval.new(@agent, current_organisation)
-    if removal_service.upcoming_rdvs?
-      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent.role_in_organisation(current_organisation)), flash: { error: t(".cannot_delete_because_of_rdvs") }
-    else
-      removal_service.remove!
+
+    if removal_service.remove!
       if @agent.invitation_accepted_at.blank?
-        redirect_to admin_organisation_invitations_path(current_organisation), notice: t(".invitation_deleted")
-      elsif @agent.deleted_at?
-        redirect_to admin_organisation_agents_path(current_organisation), notice: t(".agent_deleted")
+        redirect_to admin_organisation_invitations_path(current_organisation), notice: removal_service.confirm
       else
-        redirect_to admin_organisation_agents_path(current_organisation), notice: t(".agent_removed_from_org")
+        redirect_to admin_organisation_agents_path(current_organisation), notice: removal_service.confirm
       end
+    else
+      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent.role_in_organisation(current_organisation)), flash: { error: removal_service.errors }
     end
   end
 

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -21,12 +21,12 @@ class Admin::AgentsController < AgentAuthController
 
     if removal_service.remove!
       if @agent.invitation_accepted_at.blank?
-        redirect_to admin_organisation_invitations_path(current_organisation), notice: removal_service.confirm
+        redirect_to admin_organisation_invitations_path(current_organisation), notice: removal_service.confirmation_message
       else
-        redirect_to admin_organisation_agents_path(current_organisation), notice: removal_service.confirm
+        redirect_to admin_organisation_agents_path(current_organisation), notice: removal_service.confirmation_message
       end
     else
-      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent.role_in_organisation(current_organisation)), flash: { error: removal_service.errors }
+      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent.role_in_organisation(current_organisation)), flash: { error: removal_service.error_message }
     end
   end
 

--- a/app/controllers/admin/territories/agent_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_roles_controller.rb
@@ -35,12 +35,12 @@ class Admin::Territories::AgentRolesController < Admin::Territories::BaseControl
 
     if removal_service.remove!
       if agent.organisations.count >= 1
-        redirect_to edit_admin_territory_agent_path(current_territory, agent_role.agent), notice: removal_service.confirm
+        redirect_to edit_admin_territory_agent_path(current_territory, agent_role.agent), notice: removal_service.confirmation_message
       else
-        redirect_to admin_territory_agents_path(current_territory), notice: removal_service.confirm
+        redirect_to admin_territory_agents_path(current_territory), notice: removal_service.confirmation_message
       end
     else
-      redirect_to edit_admin_territory_agent_path(current_territory, agent_role.agent), flash: { error: removal_service.errors }
+      redirect_to edit_admin_territory_agent_path(current_territory, agent_role.agent), flash: { error: removal_service.error_message }
     end
   end
 

--- a/app/controllers/admin/territories/agent_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_roles_controller.rb
@@ -34,13 +34,13 @@ class Admin::Territories::AgentRolesController < Admin::Territories::BaseControl
     removal_service = AgentRemoval.new(agent, organisation)
 
     if removal_service.remove!
-      if agent.organisations.count > 1
+      if agent.organisations.count >= 1
         redirect_to edit_admin_territory_agent_path(current_territory, agent_role.agent), notice: removal_service.confirm
       else
         redirect_to admin_territory_agents_path(current_territory), notice: removal_service.confirm
       end
     else
-      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent.role_in_organisation(current_organisation)), flash: { error: removal_service.errors }
+      redirect_to edit_admin_territory_agent_path(current_territory, agent_role.agent), flash: { error: removal_service.errors }
     end
   end
 

--- a/app/services/agent_removal.rb
+++ b/app/services/agent_removal.rb
@@ -26,7 +26,7 @@ class AgentRemoval
     (@agent.organisations - [@organisation]).empty?
   end
 
-  def errors
+  def error_message
     I18n.t("admin.territories.agent_roles.destroy.cannot_delete_because_of_rdvs") if upcoming_rdvs?
   end
 

--- a/app/services/agent_removal.rb
+++ b/app/services/agent_removal.rb
@@ -27,16 +27,16 @@ class AgentRemoval
   end
 
   def errors
-    I18n.t(".cannot_delete_because_of_rdvs") if upcoming_rdvs?
+    I18n.t("admin.territories.agent_roles.destroy.cannot_delete_because_of_rdvs") if upcoming_rdvs?
   end
 
   def confirm
     if @agent.invitation_accepted_at.blank?
-      I18n.t(".invitation_deleted")
+      I18n.t("admin.territories.agent_roles.destroy.invitation_deleted")
     elsif @agent.deleted_at?
-      I18n.t(".agent_deleted")
+      I18n.t("admin.territories.agent_roles.destroy.agent_deleted")
     else
-      I18n.t(".agent_removed_from_org")
+      I18n.t("admin.territories.agent_roles.destroy.agent_removed_from_org")
     end
   end
 

--- a/app/services/agent_removal.rb
+++ b/app/services/agent_removal.rb
@@ -30,7 +30,7 @@ class AgentRemoval
     I18n.t("admin.territories.agent_roles.destroy.cannot_delete_because_of_rdvs") if upcoming_rdvs?
   end
 
-  def confirm
+  def confirmation_message
     if @agent.invitation_accepted_at.blank?
       I18n.t("admin.territories.agent_roles.destroy.invitation_deleted")
     elsif @agent.deleted_at?

--- a/app/services/agent_removal.rb
+++ b/app/services/agent_removal.rb
@@ -25,5 +25,20 @@ class AgentRemoval
   def should_soft_delete?
     (@agent.organisations - [@organisation]).empty?
   end
+
+  def errors
+    I18n.t(".cannot_delete_because_of_rdvs") if upcoming_rdvs?
+  end
+
+  def confirm
+    if @agent.invitation_accepted_at.blank?
+      I18n.t(".invitation_deleted")
+    elsif @agent.deleted_at?
+      I18n.t(".agent_deleted")
+    else
+      I18n.t(".agent_removed_from_org")
+    end
+  end
+
   alias will_soft_delete? should_soft_delete?
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -72,15 +72,23 @@ fr:
           territory_teams_title: Créer une équipe
         edit:
           territory_teams_title: Modifier une équipe
+      agent_roles:
+        destroy:
+          cannot_delete_because_of_rdvs: Impossible de retirer cet agent car il a des RDVs à venir dans cette organisation. Veuillez les supprimer ou les réaffecter avant de retirer cet agent.
+          invitation_deleted: L’invitation a été supprimée.
+          agent_deleted: Le compte agent a été supprimé.
+          agent_removed_from_org: L’agent a été retiré de l’organisation.
 
   activerecord:
     errors:
       messages:
-        record_invalid: 'La validation a échoué : %{errors}'
+        record_invalid: "La validation a échoué : %{errors}"
         restrict_dependent_destroy:
-          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
+          has_one:
+            Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
             dépendant(e) existe
-          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
+          has_many:
+            Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
             dépendants existent
       models:
         team:

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -41,40 +41,40 @@ describe Admin::Territories::AgentRolesController, type: :controller do
   end
 
   describe "#destoy" do
-    it "redirect to territorial_agent_edit on success if agent is in another organisation" do
+    it "redirect to territorial_agent_edit on success if agent has another organisation" do
       territory = create(:territory)
+      organisation = create(:organisation, territory: territory)
+      organisation2 = create(:organisation, territory: territory)
       agent = create(:agent, role_in_territories: [territory])
+      create(:agent_territorial_access_right, territory: territory, agent: agent)
+      agent_role = create(:agent_role, organisation: organisation, agent: agent, level: "basic")
+      create(:agent_role, organisation: organisation2, agent: agent, level: "basic")
 
-      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-      agent_role = create(:agent_role, agent: agent, level: "basic")
-      agent_role2 = create(:agent_role, agent: agent, level: "basic")
-
-      puts "redirect to territorial_agent_edit on success if agent has more as one organisation"
-      puts "territory => #{territory.id}"
-      puts "agent => #{agent.id}"
-      puts "agent_role => #{agent_role.inspect}"
-      puts "agent_role2 => #{agent_role2.inspect}"
+      last_agent = create(:agent)
+      create(:agent_territorial_access_right, territory: territory, agent: last_agent)
+      create(:agent_role, organisation: organisation, agent: last_agent, level: "admin")
 
       sign_in agent
 
-
-
-      delete :destroy, params: {territory_id: territory.id, organisation_id: agent_role.organisation_id, id: agent.id }
+      delete :destroy, params: { territory_id: territory.id, id: agent_role.id }
       expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
-
-
     end
 
-    it "redirect to admin_territory_agents on success" do
+    it "redirect to territorial_agent_edit on success if it the last organisation" do
       territory = create(:territory)
+      organisation = create(:organisation, territory: territory)
       agent = create(:agent, role_in_territories: [territory])
+      create(:agent_territorial_access_right, territory: territory, agent: agent)
+      agent_role = create(:agent_role, organisation: organisation, agent: agent, level: "basic")
 
-      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-      agent_role = create(:agent_role, agent: agent, level: "basic")
+      last_agent = create(:agent)
+      create(:agent_territorial_access_right, territory: territory, agent: last_agent)
+      create(:agent_role, organisation: organisation, agent: last_agent, level: "admin")
+
       sign_in agent
 
-      delete :destroy, params: { organisation_id: agent_role.organisation_id, id: agent.id }
-      expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
+      delete :destroy, params: { territory_id: territory.id, id: agent_role.id }
+      expect(response).to redirect_to(admin_territory_agents_path(territory))
     end
 
     it "destroy agent_role" do

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -41,14 +41,39 @@ describe Admin::Territories::AgentRolesController, type: :controller do
   end
 
   describe "#destoy" do
-    it "redirect to territorial_agent_edit on success" do
+    it "redirect to territorial_agent_edit on success if agent is in another organisation" do
       territory = create(:territory)
       agent = create(:agent, role_in_territories: [territory])
+
+      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
+      agent_role = create(:agent_role, agent: agent, level: "basic")
+      agent_role2 = create(:agent_role, agent: agent, level: "basic")
+
+      puts "redirect to territorial_agent_edit on success if agent has more as one organisation"
+      puts "territory => #{territory.id}"
+      puts "agent => #{agent.id}"
+      puts "agent_role => #{agent_role.inspect}"
+      puts "agent_role2 => #{agent_role2.inspect}"
+
+      sign_in agent
+
+
+
+      delete :destroy, params: {territory_id: territory.id, organisation_id: agent_role.organisation_id, id: agent.id }
+      expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
+
+
+    end
+
+    it "redirect to admin_territory_agents on success" do
+      territory = create(:territory)
+      agent = create(:agent, role_in_territories: [territory])
+
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
       agent_role = create(:agent_role, agent: agent, level: "basic")
       sign_in agent
 
-      delete :destroy, params: { territory_id: territory.id, id: agent_role.id }
+      delete :destroy, params: { organisation_id: agent_role.organisation_id, id: agent.id }
       expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
     end
 


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3386.osc-secnum-fr1.scalingo.io/

Un problème de suppression de plages d'ouverture suite à la suppression d'un agent d'une organisation a été remonté (https://zammad10.ethibox.fr/#ticket/zoom/3958). 

Il y a deux chemins possible pour supprimer un agent d'une organisation. Si l’utilisateur passe par le panneau de configuration des agents, il est possible de retirer un agent d'une organisation sans le supprimer. L'objectif de cette PR est de modifier le comportement de cette suppression.

Closes #3237

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
