### PR TITLE
Augmenter la taille du pool de connexions Postgres pour GoodJob

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,8 +23,11 @@ default: &default
   host: <%= ENV['POSTGRES_HOST'] %>
   <% end %>
   # For details on connection pooling, see Rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  # And also GoodJob doc: https://github.com/bensheldon/good_job#database-connections
+  # For web containers, pool size is puma's default number of threads.
+  # For GoodJob container, pool size is GOOD_JOB_MAX_THREADS (5) + 3 (1 for LISTEN/NOTIFY, 2 for CRON)
+  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : ENV.fetch("RAILS_MAX_THREADS", 5).to_i %>
 
 development:
   <<: *default


### PR DESCRIPTION
Nous avons eu des timeouts lorsque récemment quand GoodJob tentait de prendre une connexion dans le pool, mais qu'il était trop petit.

En effet, jusqu'ici on a eu un pool de 5 connexion, alors que GoodJob en a besoin de :
- une par thread, donc 5
- + 1 pour le LISTEN/NOTIFY
- + 2 pour le CRON

Référence : https://github.com/bensheldon/good_job#database-connections

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
