### PR TITLE
Dédoublonnage des usagers lors de la prise de rdv par prescripteurs.

### DIFF
--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -12,7 +12,7 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
 
   def create!
     ActiveRecord::Base.transaction do
-      setup_user
+      find_or_create_user
 
       if @rdv.collectif?
         create_participation!
@@ -51,7 +51,7 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
     @participation ||= RdvsUser.new(rdv: @rdv, user: @user, prescripteur: @prescripteur)
   end
 
-  def setup_user
+  def find_or_create_user
     user_from_params = User.new(@user_attributes)
 
     @user = User.where(

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -59,6 +59,6 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
 
     @user.skip_confirmation_notification! # Désactivation du mail Devise de confirmation de compte
     @user.created_through = "prescripteur"
-    @user.user_profiles.find_or_initialize_by(organisation_id: rdv.motif.organisation_id)
+    @user.user_profiles.find_or_initialize_by(organisation_id: rdv.motif.organisation_id).save!
   end
 end

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -64,6 +64,6 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
 
     @user.skip_confirmation_notification! # Désactivation du mail Devise de confirmation de compte
     @user.created_through = "prescripteur"
-    @user.user_profiles.find_or_create_by!(organisation_id: rdv.motif.organisation_id)
+    @user.user_profiles.find_or_initialize_by(organisation_id: rdv.motif.organisation_id).save!
   end
 end

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -64,6 +64,6 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
 
     @user.skip_confirmation_notification! # Désactivation du mail Devise de confirmation de compte
     @user.created_through = "prescripteur"
-    @user.user_profiles.find_or_initialize_by(organisation_id: rdv.motif.organisation_id).save!
+    @user.user_profiles.find_or_create_by!(organisation_id: rdv.motif.organisation_id)
   end
 end

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -59,6 +59,6 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
 
     @user.skip_confirmation_notification! # Désactivation du mail Devise de confirmation de compte
     @user.created_through = "prescripteur"
-    @user.organisations << rdv.motif.organisation
+    @user.user_profiles.find_or_initialize_by(organisation_id: rdv.motif.organisation_id)
   end
 end

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -6,7 +6,7 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
   def initialize(attributes, domain)
     super(nil, attributes)
     @prescripteur = Prescripteur.new(attributes[:prescripteur]) if attributes[:prescripteur].present?
-    @user = User.new(attributes[:user]) if attributes[:user].present?
+    @user_attributes = attributes[:user]
     @domain = domain
   end
 
@@ -50,6 +50,13 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
   end
 
   def setup_user
+    user_from_params = User.new(@user_attributes)
+
+    @user = User.find_by(
+      first_name: user_from_params.first_name,
+      phone_number_formatted: user_from_params.phone_number_formatted
+    ) || user_from_params
+
     @user.skip_confirmation_notification! # Désactivation du mail Devise de confirmation de compte
     @user.created_through = "prescripteur"
     @user.organisations << rdv.motif.organisation

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -96,7 +96,17 @@ RSpec.describe "prescripteur can create RDV for a user" do
     expect(enqueued_jobs.first["arguments"][0]["phone_number"]).to eq("+33611223344")
   end
 
-  context "when a similar user already exists" do
+  def fill_address_form
+    fill_in :search_where, with: "21 rue des Ardennes, 75019 Paris"
+
+    # fake address autocomplete
+    page.execute_script("document.querySelector('#search_departement').value = '#{motif.organisation.territory.departement_number}'")
+    page.execute_script("document.querySelector('#search_submit').disabled = false")
+
+    click_on("Rechercher")
+  end
+
+  context "when a similar user already exists", js: true do
     let!(:user) do
       create(:user, first_name: "Patricia", last_name: "Duroy", phone_number: "0611223344")
     end
@@ -110,7 +120,9 @@ RSpec.describe "prescripteur can create RDV for a user" do
     end
 
     it "doesn't create a new one but adds the user to the organisation" do
-      visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur/#{organisation.territory.departement_number}"
+      visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
+
+      fill_address_form
 
       click_on "Prochaine disponibilité le", match: :first # choix du lieu
       click_on "08:00" # choix du créneau
@@ -138,7 +150,9 @@ RSpec.describe "prescripteur can create RDV for a user" do
       end
 
       it "doesn't create a duplicate profile" do
-        visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur/#{organisation.territory.departement_number}"
+        visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
+
+        fill_address_form
 
         click_on "Prochaine disponibilité le", match: :first # choix du lieu
         click_on "08:00" # choix du créneau
@@ -163,13 +177,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
     it "goes directly to prescripteur forms after creneau selection ands keeps the prescripteur param when navigating backwards", js: true do
       visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
 
-      fill_in :search_where, with: "21 rue des Ardennes, 75019 Paris"
-
-      # fake address autocomplete
-      page.execute_script("document.querySelector('#search_departement').value = '#{motif.organisation.territory.departement_number}'")
-      page.execute_script("document.querySelector('#search_submit').disabled = false")
-
-      click_on("Rechercher")
+      fill_address_form
 
       click_on "Prochaine disponibilité le", match: :first # choix du lieu
       click_on "08:00" # choix du créneau

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
       click_on "Continuer"
     end
 
-    it "doesn't create a new one" do
+    it "doesn't create a new one but adds the user to the organisation" do
       visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur/#{organisation.territory.departement_number}"
 
       click_on "Prochaine disponibilité le", match: :first # choix du lieu
@@ -122,7 +122,14 @@ RSpec.describe "prescripteur can create RDV for a user" do
       # Le format du numéro de téléphone n'est pas exactement le même que celui en base
       fill_in "Téléphone", with: "06 11 22 33 44"
 
-      expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1).and(change(User, :count).by(0))
+      expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1)
+        .and(change(User, :count).by(0))
+        .and(change(UserProfile, :count).by(1))
+
+      expect(UserProfile.last).to have_attributes(
+        user: user,
+        organisation: motif.organisation
+      )
     end
 
     context "and is already part of the organisation" do

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -67,14 +67,19 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
     created_rdv = Rdv.last
     expect(created_rdv.agents).to eq([agent])
+
     expect(created_rdv.rdvs_users.size).to eq(1)
-    expect(created_rdv.rdvs_users.first.user).to have_attributes(
+
+    created_participation = created_rdv.rdvs_users.first
+    created_user = created_participation.user
+
+    expect(created_user).to have_attributes(
       full_name: "Patricia DUROY",
       created_through: "prescripteur",
       phone_number: "0611223344",
-      organisations: [organisation]
+      organisation_ids: [organisation.id]
     )
-    expect(created_rdv.rdvs_users.first.prescripteur).to have_attributes(
+    expect(created_participation.prescripteur).to have_attributes(
       first_name: "Alex",
       last_name: "Prescripteur",
       email: "alex@prescripteur.fr",
@@ -89,6 +94,32 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
     expect(enqueued_jobs.first["job_class"]).to eq("SmsJob")
     expect(enqueued_jobs.first["arguments"][0]["phone_number"]).to eq("+33611223344")
+  end
+
+  context "when a similar user already exists" do
+    before do
+      create(:user, first_name: "Patricia", last_name: "Duroy", phone_number: "0611223344")
+    end
+
+    it "doesn't create a new one" do
+      visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur/#{organisation.territory.departement_number}"
+
+      click_on "Prochaine disponibilité le", match: :first # choix du lieu
+      click_on "08:00" # choix du créneau
+
+      fill_in "Votre prénom", with: "Alex"
+      fill_in "Votre nom", with: "Prescripteur"
+      fill_in "Votre email professionnel", with: "alex@prescripteur.fr"
+      fill_in "Votre numéro de téléphone", with: "0655443322"
+      click_on "Continuer"
+
+      fill_in "Prénom", with: "Patricia"
+      fill_in "Nom", with: "DUROY"
+      # Le format du numéro de téléphone n'est pas exactement le même que celui en base
+      fill_in "Téléphone", with: "06 11 22 33 44"
+
+      expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1).and(change(User, :count).by(0))
+    end
   end
 
   context "when using the prescripteur route" do

--- a/spec/form_models/prescripteur_rdv_wizard_spec.rb
+++ b/spec/form_models/prescripteur_rdv_wizard_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe PrescripteurRdvWizard do
+  let!(:organisation) { create(:organisation) }
+  let!(:motif) { create(:motif, organisation: organisation) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
+
+  let(:attributes) do
+    {
+      starts_at: plage_ouverture.starts_at,
+      motif_id: motif.id,
+      lieu_id: lieu.id,
+      user: {
+        first_name: "Léa",
+        last_name: "Boubakar",
+        phone_number: "06 11 22 33 44",
+      },
+      departement: "62",
+      city_code: "62100",
+    }
+  end
+
+  context "when the user already exists but with different case or accents in their name" do
+    let!(:user) do
+      create(:user, first_name: "Lea", last_name: "BOUBAKAR", phone_number: "0611223344")
+    end
+
+    it "adds the rdv to the user" do
+      wizard = described_class.new(attributes, Domain::ALL.first)
+      expect { wizard.create! }.to change(Rdv, :count).by(1)
+
+      expect(Rdv.last.users.first).to eq(user)
+    end
+  end
+
+  context "when the existing users have a different first name, last name or phone number" do
+    before do
+      create(:user, first_name: "Leo", last_name: "BOUBAKAR", phone_number: "0611223344")
+      create(:user, first_name: "Léa", last_name: "BOUBAKA", phone_number: "0611223344")
+      create(:user, first_name: "Léa", last_name: "BOUBAKAR", phone_number: "0688889999")
+    end
+
+    it "creates a new user" do
+      wizard = described_class.new(attributes, Domain::ALL.first)
+      expect { wizard.create! }.to change(User, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3404.osc-secnum-fr1.scalingo.io/prendre_rdv_prescripteur/62

Le dédoublonnage se fait maintenant avec le nom, prénom et numéro de téléphone

L'interface ne change pas, on réutilise juste l'usager s'il existe déjà.

Closes #3035 

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
