### PR TITLE
Passer le polling de l'agenda à 60 secondes (au lieu de 30)

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -43,7 +43,7 @@ class CalendarRdvSolidarites {
 
   setRefetchInterval = () => {
     if (this.refreshCalendarInterval) return
-    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 30000)
+    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 60000)
   }
 
   clearRefetchInterval = () => {


### PR DESCRIPTION
Nous avons depuis quelques jours de gros soucis de performances causés par un trop grosse charge de Postgres.

Ce changement a pour but de contribuer à baisser la charge.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
