### PR TITLE
Corriger l'heure de nettoyage des salles d'attente + cron à heure locale

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -14,33 +14,41 @@ Rails.application.configure do
   config.good_job.enable_cron = ENV["CONTAINER"] == "jobs-1"
   # To locally run GoodJob with cron enabled, run: `GOOD_JOB_ENABLE_CRON=1 bundle exec good_job start`
 
+  # Rappel des changements d'heure :
+  # - au passage à l'heure d'hiver, on passe deux fois sur l'heure entre 02:00 et 02:59
+  # - au passage à l'heure d'été, on passe de 01:59 à 03:00
+  # Il est donc dangereux de déclarer un cron entre 02:00 et 02:59.
   config.good_job.cron = {
     file_attente_job: {
-      cron: "0/10 9,10,11,12,13,14,15,16,17,18 * * *", # Every 10 minutes, from 9:00 to 18:00
+      cron: "0/10 9,10,11,12,13,14,15,16,17,18 * * * Europe/Paris", # Every 10 minutes, from 9:00 to 18:00
       class: "CronJob::FileAttenteJob",
     },
+
+    # Ces jobs doivent s'exécuter dans la matinée, pas la soirée
     reminder_job: {
-      cron: "0 3 * * *", # At 3:00 every day
+      cron: "every day at 03:00 Europe/Paris",
       class: "CronJob::ReminderJob",
     },
     update_expirations_job: {
-      cron: "0 1 * * *", # At 1:00 every day
+      cron: "every day at 03:30 Europe/Paris",
       class: "CronJob::UpdateExpirationsJob",
     },
     warm_up_occurrences_cache: {
-      cron: "0 23 * * *", # At 23:00 every day
+      cron: "every day at 04:00 Europe/Paris",
       class: "CronJob::WarmUpOccurrencesCache",
     },
+
+    # Ces jobs peuvent s'exécuter dans la soirée
     destroy_old_rdvs_job: {
-      cron: "0 2 * * *", # At 2:00 every day
+      cron: "every day at 22:00 Europe/Paris",
       class: "CronJob::DestroyOldRdvsJob",
     },
     destroy_old_plage_ouverture_job: {
-      cron: "0 1 * * *", # At 1:00 every day
+      cron: "every day at 22:30 Europe/Paris",
       class: "CronJob::DestroyOldPlageOuvertureJob",
     },
     destroy_redis_waiting_room_keys: {
-      cron: "every day at 22:00 Europe/Paris",
+      cron: "every day at 23:00 Europe/Paris",
       class: "CronJob::DestroyRedisWaitingRoomKeys",
     },
   }

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
       class: "CronJob::DestroyOldPlageOuvertureJob",
     },
     destroy_redis_waiting_room_keys: {
-      cron: "0 13 * * *", # At 3:00 every day
+      cron: "every day at 22:00 Europe/Paris",
       class: "CronJob::DestroyRedisWaitingRoomKeys",
     },
   }


### PR DESCRIPTION
Dans ma PR pour passer à GoodJob (#3338), j'ai dû m'endormir sur mon clavier et j'ai modifié la date d'exécution de `DestroyRedisWaitingRoomKeys` de 03:00 à 13:00. ([voir cette ligne](https://github.com/betagouv/rdv-solidarites.fr/pull/3338/files#diff-ac799e1c76b47172aff65443ca19a667b17de6a8d2d4b68677d1c2d4f52916c6R43))

Au passage, j'ai fait en sorte que chaque job de cron se lance à heure locale fixe car je trouve que c'est plus facile à comprendre (pas de conversion en UTC à faire quand on veut savoir à quelle heure le truc s'est lancé hier). 

J'ai pris soin à ne pas mettre d'heure entre 02:00 et 02:59 pour éviter les embrouilles avec les changements d'heure.

J'ai aussi fait en sorte que les jobs ne s'exécutent pas à la même heure, car j'ai remarqué que `UpdateExpirationsJob` et `DestroyOldPlageOuvertureJob` s'exécutaient tous deux à 1 heure du matin, et que `UpdateExpirationsJob` mettait une heure à s'exécuter, ce qui est suspect car chez moi il met une minute ou deux.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
