### PR TITLE
Ajoute des scripts de dump/load RDVS d'agent

### DIFF
--- a/scripts/dump_agent_rdv.rb
+++ b/scripts/dump_agent_rdv.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Le principe c'est de pouvoir extraire d'un environnement, d'une base de
+# donnée, une structure de donnée à partir d'un agent pour pouvoir le recharger
+# dans une nouvelle base de donnée, un nouvel environnement.
+#
+# La structure la plus simple semble être json ou yaml...
+
+if ARGV.first.blank?
+  puts "Aucun identifiant d'agent"
+  exit 0
+end
+
+begin
+  agent = Agent.find(ARGV.first)
+rescue StandardError
+  puts "Aucun agent trouvé avec l'ID #{ARGV.first}"
+  exit 0
+end
+
+rdvs = agent.rdvs
+puts rdvs.as_json(
+  include: %i[motif users lieu]
+).to_json

--- a/scripts/load_agent_rdv.rb
+++ b/scripts/load_agent_rdv.rb
@@ -11,14 +11,15 @@ EXCLUDE_KEYS = %w[id created_at updated_at old_address old_enabled enabled servi
 
 SERVICE_ID = 3
 ORGANISATION_ID = 4
-AGENT_ID = 4
+AGENT_ID = 5
 # 6971 en prod ?
 
-json_file = "agent_rdvs.json"
+if ARGV.blank?
+  puts "il faut passer le chemin vers le fichier qui contient les rendez-vous au format json en paramètre du script"
+  exit 0
+end
 
-file = File.read(json_file)
-
-rdvs = JSON.parse(file)
+rdvs = JSON.parse(File.read(ARGV[0]))
 
 rdv_params = {}
 users = []

--- a/scripts/load_agent_rdv.rb
+++ b/scripts/load_agent_rdv.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+#
+# On ne gère pas les agents du RDV, on force avec le seul agent concerné.
+#
+# L'objectif pour l'instant, c'est de récupérér un conseiller numérique
+# qui s'est installé sur la Démo au lieu de la prod...
+#
+
+EXCLUDE_KEYS = %w[id created_at updated_at old_address old_enabled enabled service_id organisation_id].freeze
+
+SERVICE_ID = 3
+ORGANISATION_ID = 4
+AGENT_ID = 4
+# 6971 en prod ?
+
+json_file = "agent_rdvs.json"
+
+file = File.read(json_file)
+
+rdvs = JSON.parse(file)
+
+rdv_params = {}
+users = []
+agents = [Agent.find(AGENT_ID)]
+
+rdvs.each do |rdv|
+  rdv.each do |key, value|
+    next if EXCLUDE_KEYS.include?(key)
+
+    case key
+    when "motif"
+      puts "--- motif"
+      motif = Motif.find_or_create_by!(value.reject { |k| EXCLUDE_KEYS.include?(k) }.merge(service_id: SERVICE_ID, organisation_id: ORGANISATION_ID))
+      puts "motif trouvé ou créer (#{motif} ##{motif.id})"
+      rdv_params[:motif_id] = motif.id
+    when "lieu"
+      puts "--- lieu"
+      l = Lieu.find_or_create_by(value.reject { |k| EXCLUDE_KEYS.include?(k) }.merge(organisation_id: ORGANISATION_ID))
+      puts "lieu trouvé ou créer (#{l.name})"
+      rdv_params[:lieu] = l
+    when "users"
+      puts "--- users"
+      value.each do |user|
+        puts "user email: #{user['email']} user.inspect: #{user.inspect}"
+        next if user["email"].present? && user["email"].match(/@deleted\.rdv-solidarites\.fr/)
+
+        u = User.find_or_create_by(user.reject { |k| EXCLUDE_KEYS.include?(k) })
+        puts "user trouvé ou créer (#{u})"
+        users << u
+      end
+    else
+      next if EXCLUDE_KEYS.include?(key)
+
+      rdv_params[key] = value
+    end
+  end
+
+  new_rdv = Rdv.new(rdv_params)
+  new_rdv.agents = agents
+  new_rdv.users = users.uniq
+  new_rdv.organisation = Organisation.find(ORGANISATION_ID)
+
+  if (existing_rdv = Rdv.find_by(new_rdv.attributes.reject { |k| EXCLUDE_KEYS.include?(k) }))
+    puts "rdv existant #{existing_rdv.inspect}"
+  elsif new_rdv.save
+    puts "creation du RDV (#{new_rdv.id})"
+  else
+    puts "Problème lors de l'enregistrement du RDV #{new_rdv} : #{new_rdv.errors.full_messages.join(',')}"
+  end
+end


### PR DESCRIPTION
Un conseiller numérique a réalisé toutes ces créations de RDV sur la plateforme de démo...

Ces scripts ont vocation à permettre de rapatrier ses informations sur la prod.

Le principe, c'est un script pour faire un `dump` des RDV dans un flux JSON depuis la démo, puis de faire un `load` de ce fichier dans la prod.

Dans le fichier, nous plaçons une liste de RDV sous la forme

```json
[
{
  "id": "23",
  "starts_at": "2023-03-07T09:00:00.000+01:00",
  "organisation_id": 295,
  "motif": {
      "id": 755,
      "name": "Atelier individuel",
      "color": "#008000",
      "created_at": "2022-04-01T12:31:56.156+02:00",    
  },
  "lieu": {
      "id": 501, 
      "name": "France Services Guémené-Sur-Scorff",  
      "organisation_id": 295, 
  },
  "users": [
    {
       "id": 3387,
       "first_name": "Marcel et Gisèle", 
       "last_name": "Le Vaillant", 
       "email": null,                     
    }
  ]
}
]
```

Cela nécessite de préparer la production avant...

Il faut que
- l'agent existe
- l'organisation existe

