### PR TITLE
Correction du crash de FileAttenteJob

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -201,6 +201,8 @@ class Rdv < ApplicationRecord
 
   def creneaux_available(date_range)
     date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
+    return [] if date_range.blank?
+
     SlotBuilder.available_slots(motif, lieu, date_range)
   end
 


### PR DESCRIPTION
Crash du job en boucle : https://sentry.incubateur.net/organizations/betagouv/issues/25617

On se trouvait dans un cas où le RDV n'était plus réservable entre aujourd'hui et son heure de fin. Je n'ai pas débuggé quel RDV exactement, mais la correctif semble raisonnable. D'ailleurs on avait déjà fait la même chose à [un autre endroit où l'on appelait la même méthode](https://github.com/betagouv/rdv-solidarites.fr/blob/27706ecba7311c2e050dc89eb6b45ad36b82e213/app/services/concerns/users/creneaux_search_concern.rb#L16).

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
