### PR TITLE
Correction d'un test qui échoue au changement d'heure

### DIFF
--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -262,7 +262,7 @@ describe "Users API", swagger_doc: "v1/api.json" do
 
         it { expect(parsed_response_body["invitation_url"]).to start_with("http://www.example.com/users/invitation/accept?invitation_token=") }
 
-        it { expect(user.reload.invitation_due_at).to eq(user.invitation_created_at + 1.day) }
+        it { expect(user.reload.invitation_due_at).to eq(user.invitation_created_at + 24.hours) }
 
         it { expect(user.reload.invited_through).to eq("external") }
       end


### PR DESCRIPTION
La durée d'une invitation est de 86 400 secondes soit 24 heures. Le test était donc incorrect les jours qui ne durent pas 24 heures.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
