### PR TITLE
Correctif pour dedoublonnage prescripteurs

### DIFF
--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -37,10 +37,9 @@ class MergeUsersService < BaseService
 
   def merge_rdvs
     @user_to_merge.rdvs.where(organisation: @organisation).each do |rdv|
-      users = rdv.users.to_a
-      users.delete(@user_to_merge)
-      users.append(@user_target) unless users.include?(@user_target)
-      rdv.users.replace(users)
+      rdv.rdvs_users.where(user: @user_to_merge).each do |rdv_user|
+        rdv_user.update!(user: @user_target)
+      end
     end
   end
 

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -38,7 +38,11 @@ class MergeUsersService < BaseService
   def merge_rdvs
     @user_to_merge.rdvs.where(organisation: @organisation).each do |rdv|
       rdv.rdvs_users.where(user: @user_to_merge).each do |rdv_user|
-        rdv_user.update!(user: @user_target)
+        if rdv.rdvs_users.where(user_id: @user_target).any?
+          rdv_user.destroy!
+        else
+          rdv_user.update!(user: @user_target)
+        end
       end
     end
   end

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -234,18 +234,18 @@ describe MergeUsersService, type: :service do
 
   context "when one of the users was created by a prescripteur" do
     let(:user1) { create(:user) }
-    let(:user2) do
-      create(:user, created_through: :prescripteur)
-    end
+    let(:user2) { create(:user, created_through: :prescripteur) }
     let(:rdv) { create(:rdv, organisation: organisation) }
+    let(:prescripteur) { create(:prescripteur) }
 
     before do
-      create(:rdvs_user, rdv: rdv, user: user2, prescripteur: create(:prescripteur))
+      create(:rdvs_user, rdv: rdv, user: user2, prescripteur: prescripteur)
     end
 
-    it "merges users" do
-      described_class.perform_with(user1, user2, attributes_to_merge, organisation)
-      expect(Prescripteur.last.user).to eq(user1)
+    it "changes the prescripteur to the target user" do
+      expect do
+        described_class.perform_with(user1, user2, attributes_to_merge, organisation)
+      end.to change { prescripteur.reload.user }.from(user2).to(user1)
     end
   end
 end

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -231,4 +231,20 @@ describe MergeUsersService, type: :service do
       expect(user_target.franceconnect_openid_sub).to eq("unechainedecharacteres")
     end
   end
+
+  context "when one of the users was created by a prescripteur" do
+    let(:user1) { create(:user) }
+    let(:user2) do
+      create(:user, created_through: :prescripteur)
+    end
+    let(:rdv) { create(:rdv, organisation: organisation) }
+
+    before do
+      create(:rdvs_user, rdv: rdv, user: user2, prescripteur: create(:prescripteur))
+    end
+
+    it "merges users" do
+      described_class.perform_with(user1, user2, attributes_to_merge, organisation)
+    end
+  end
 end

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -245,6 +245,7 @@ describe MergeUsersService, type: :service do
 
     it "merges users" do
       described_class.perform_with(user1, user2, attributes_to_merge, organisation)
+      expect(Prescripteur.last.user).to eq(user1)
     end
   end
 end


### PR DESCRIPTION
Pour tester :
- Prendre un rdv via https://demo-rdv-solidarites-pr3416.osc-secnum-fr1.scalingo.io/prendre_rdv_prescripteur/62
- Se connecter côté agent pour dédoublonner manuellement l'usager créé

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3415

Plutôt que de supprimer d'anciennes participations et d'en créer des nouvelles, on change juste le user_id. Il se peut que ça nous évite aussi des bugs sur les statuts des participations.

