### PR TITLE
Ajout d'une validation pour les organisations avec un téléphone à 4 chiffres

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -38,7 +38,7 @@ class Organisation < ApplicationRecord
   # Validation
   validates :name, presence: true, uniqueness: { scope: :territory }
   validates :external_id, uniqueness: { scope: :territory, allow_nil: true }
-  validates :phone_number, phone: { allow_blank: true }
+  validate :validate_phone_number
   validates(
     :human_id,
     format: {
@@ -93,5 +93,16 @@ class Organisation < ApplicationRecord
 
   def slug
     name.parameterize[..80]
+  end
+
+  def validate_phone_number
+    return if phone_number_is_valid?
+
+    errors.add(:phone_number, :invalid)
+  end
+
+  def phone_number_is_valid?
+    # Blank, Valid Phone, 4 digits phone (organisations only)
+    phone_number.blank? || Phonelib.parse(phone_number).valid? || phone_number.match(/^\d{4}$/)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -38,7 +38,7 @@ class Organisation < ApplicationRecord
   # Validation
   validates :name, presence: true, uniqueness: { scope: :territory }
   validates :external_id, uniqueness: { scope: :territory, allow_nil: true }
-  validate :validate_phone_number
+  validate :validate_organisation_phone_number
   validates(
     :human_id,
     format: {
@@ -95,7 +95,7 @@ class Organisation < ApplicationRecord
     name.parameterize[..80]
   end
 
-  def validate_phone_number
+  def validate_organisation_phone_number
     return if phone_number_is_valid?
 
     errors.add(:phone_number, :invalid)

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -36,4 +36,21 @@ describe Organisation, type: :model do
       expect(organisation.slug).to eq("sdsei-pays-basque-interieur-site-de-saint-jean-le-vieux-mais-aussi-d-un-autre-end")
     end
   end
+
+  describe "phone_number" do
+    it "invalid phone" do
+      organisation = build(:organisation, phone_number: "12345")
+      expect(organisation).to be_invalid
+    end
+
+    it "blank phone is valid" do
+      organisation = build(:organisation, phone_number: nil)
+      expect(organisation).to be_valid
+    end
+
+    it "4 digits phones are valid" do
+      organisation = build(:organisation, phone_number: "3949")
+      expect(organisation).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
close : https://github.com/betagouv/rdv-insertion/issues/933
Demande de rdv-insertion mais qui peut très bien être utile pour rdv-s également.
J'ai modifié uniquement le modèle `organisation` de façon à ne pas rajouter de validations erronés sur les autres modèles (`user` entre autre).


