### PR TITLE
Bugfix: les RDVs ne sont pas ordonnés proprement au sein de chaque page

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -11,12 +11,13 @@ class Admin::RdvsController < AgentAuthController
     set_scoped_organisations
     @breadcrumb_page = params[:breadcrumb_page]
 
+    order = { starts_at: :asc }
     @rdvs = policy_scope(Rdv).search_for(@scoped_organisations, parsed_params)
-      .order(starts_at: :asc).page(params[:page]).per(10)
+      .order(order).page(params[:page]).per(10)
 
     # On fait cette requête en deux temps pour éviter de faire un `order` et un `include` sur le même scope,
     # parce que ça fait un sort et beaucoup de left outer joins
-    @rdvs_in_page = Rdv.where(id: @rdvs.pluck(:id)).includes(
+    @rdvs_in_page = Rdv.where(id: @rdvs.pluck(:id)).order(order).includes(
       [
         :agents_rdvs, :organisation, :lieu, :motif,
         {


### PR DESCRIPTION
Depuis l'optimisation mise en place dans #3396, les RDVs sont ordonnés par ID au sein de chaque page, alors qu'ils devraient être ordonnés par heure de début.

Ce fix s'assure que l'ordre est bien conservé au sein de la page.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
