### PR TITLE
Expirer le cache de toutes les vues

### DIFF
--- a/app/views/admin/receipts/_receipts.html.slim
+++ b/app/views/admin/receipts/_receipts.html.slim
@@ -6,4 +6,6 @@ table.table.table-sm
       th= Receipt.human_attribute_name(:content)
       th= Receipt.human_attribute_name(:result)
   tbody
-    = render partial: "admin/receipts/receipt", collection: receipts, cached: true
+    - receipts.each do |receipt|
+      - cache(receipt, expires_in: 7.days) do
+        = render partial: "admin/receipts/receipt", locals: { receipt: receipt }

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -37,7 +37,9 @@
         tbody id="users-list"
           / En effet, on rencontre ce problème : Casecommons/pg_search#238
           / Le uniq est un solution qui casse parfois le décompte, mais ça paraît acceptable !
-          = render partial: "admin/users/user", collection: @users.includes(:responsible).uniq, cached: ->(user) { [user, current_organisation] }
+          - @users.includes(:responsible).uniq.each do |user|
+            - cache([current_organisation.id, user], expires_in: 7.days)
+              = render partial: "admin/users/user", locals: { user: user }
 
     - if @users.empty?
       .mb-4.p.text-center Aucun usager trouvé pour ces critères

--- a/app/views/admin/versions/_resource_versions_row.html.slim
+++ b/app/views/admin/versions/_resource_versions_row.html.slim
@@ -7,6 +7,6 @@
           = t("admin.versions.title")
     .collapse.hide#history-collapse
       .card-body
-        = cache [resource, resource.class.paper_trail_options[:only]] do
+        = cache([resource, resource.class.paper_trail_options[:only]], expires_in: 7.days) do
           - versions = PaperTrailAugmentedVersion.for_resource(resource)
           = render "admin/versions/versions", versions: versions.reverse


### PR DESCRIPTION
Closes #3412

Note : j'ai mis 7 jours, mais je suis preneur d'avis sur la durée idéal. :thinking: 

J'ai regardé à la main, et toutes les clés sans TTL en prod commencent par l'une de ces trois valeurs : 
- `"cache:views/admin/users/_user"`
- `"cache:views/admin/receipts/_receipt"`
- `"cache:views/admin/versions/_resource_versions_row"`

J'ai donc bien corrigé ces 3 templates ! :tada: 

Une fois la PR mergée on pourra supprimer les clés qui n'ont pas de TTL avec ce script : 

```ruby
redis = Redis.new(url: Rails.configuration.x.redis_url)

cursor, keys_in_page = redis.scan(0, match: "*", count: 1000)

deleted_count = 0

while cursor.to_i != 0
  puts "Page size: #{keys_in_page.size}\t  Cursor: [#{cursor}]"
  keys_in_page.each do |key|
    if redis.ttl(key) == -1
      redis.del(key)
      puts "DELETED #{key}"
      deleted_count += 1
    end
  end
  cursor, keys_in_page = redis.scan(cursor, match: "session:*", count: 1000)
end

puts "#{deleted_count.inspect} entrées supprimées"
```

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
