### PR TITLE
Purger les anciennes versions PaperTrail

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -48,11 +48,10 @@ class CronJob < ApplicationJob
   class DestroyOldPlageOuvertureJob < CronJob
     def perform
       po_exceptionnelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)
-      po_reccurent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
-      po_exceptionnelle_closed_since_1_year.or(po_reccurent_closed_since_1_year).each do |po|
-        po.skip_webhooks = true
-        po.destroy
-      end
+      po_recurrent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
+      ids_to_destroy = po_exceptionnelle_closed_since_1_year.or(po_recurrent_closed_since_1_year).ids
+      MotifsPlageOuverture.where(plage_ouverture_id: ids_to_destroy).delete_all
+      PlageOuverture.where(id: ids_to_destroy).delete_all
     end
   end
 

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -48,10 +48,11 @@ class CronJob < ApplicationJob
   class DestroyOldPlageOuvertureJob < CronJob
     def perform
       po_exceptionnelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)
-      po_recurrent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
-      ids_to_destroy = po_exceptionnelle_closed_since_1_year.or(po_recurrent_closed_since_1_year).ids
-      MotifsPlageOuverture.where(plage_ouverture_id: ids_to_destroy).delete_all
-      PlageOuverture.where(id: ids_to_destroy).delete_all
+      po_reccurent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
+      po_exceptionnelle_closed_since_1_year.or(po_reccurent_closed_since_1_year).each do |po|
+        po.skip_webhooks = true
+        po.destroy
+      end
     end
   end
 

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -55,6 +55,13 @@ class CronJob < ApplicationJob
     end
   end
 
+  class DestroyOldVersions < CronJob
+    def perform
+      # Versions are used in RDV exports, and RDVs are currently kept for 2 years.
+      PaperTrail::Version.where("created_at < ?", 2.years.ago).delete_all
+    end
+  end
+
   class DestroyRedisWaitingRoomKeys < CronJob
     def perform
       Rdv.reset_user_in_waiting_room!

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -48,8 +48,8 @@ class CronJob < ApplicationJob
   class DestroyOldPlageOuvertureJob < CronJob
     def perform
       po_exceptionnelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)
-      po_reccurent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
-      po_exceptionnelle_closed_since_1_year.or(po_reccurent_closed_since_1_year).each do |po|
+      po_recurrent_closed_since_1_year = PlageOuverture.where(recurrence_ends_at: ..1.year.ago)
+      po_exceptionnelle_closed_since_1_year.or(po_recurrent_closed_since_1_year).each do |po|
         po.skip_webhooks = true
         po.destroy
       end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -24,21 +24,32 @@ Rails.application.configure do
       class: "CronJob::FileAttenteJob",
     },
 
-    # Ces jobs doivent s'exécuter dans la matinée, pas la soirée
+    # Ce job doit impérativement s'exécuter exactement une fois dans la journée,
+    # il schedule les envois des notifs des RDVs ayant lieu le surlendemain.
     reminder_job: {
       cron: "every day at 03:00 Europe/Paris",
       class: "CronJob::ReminderJob",
     },
+
+    # Pré-calcul d'index : pas essentiel mais idéalement quotidien
     update_expirations_job: {
       cron: "every day at 03:30 Europe/Paris",
       class: "CronJob::UpdateExpirationsJob",
     },
+
+    # Préchauffage de cache : pas essentiel mais idéalement quotidien
     warm_up_occurrences_cache: {
       cron: "every day at 04:00 Europe/Paris",
       class: "CronJob::WarmUpOccurrencesCache",
     },
 
-    # Ces jobs peuvent s'exécuter dans la soirée
+    # Reset de la liste d'usagers en salle d'attente, à vider chaque soir
+    destroy_redis_waiting_room_keys: {
+      cron: "every day at 21:30 Europe/Paris",
+      class: "CronJob::DestroyRedisWaitingRoomKeys",
+    },
+
+    # Nettoyage de vieille données : pas essentiel mais idéalement quotidien
     destroy_old_rdvs_job: {
       cron: "every day at 22:00 Europe/Paris",
       class: "CronJob::DestroyOldRdvsJob",
@@ -47,9 +58,9 @@ Rails.application.configure do
       cron: "every day at 22:30 Europe/Paris",
       class: "CronJob::DestroyOldPlageOuvertureJob",
     },
-    destroy_redis_waiting_room_keys: {
+    destroy_old_versions: {
       cron: "every day at 23:00 Europe/Paris",
-      class: "CronJob::DestroyRedisWaitingRoomKeys",
+      class: "CronJob::DestroyOldVersions",
     },
   }
 end


### PR DESCRIPTION
Closes #3314 

J'ai choisi 2 ans d'âge car les RDVs sont gardés 2 ans et que nous utilisons les versions pour l'export des RDVs (colonne `"créé par"`). Tout cela peut changer car idéalement selon moi : 
- on devrait supprimer les RDVs avant 2 ans
- on ne devrait pas dépendre des versions PaperTrail pour un export (à débattre)


# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
