### PR TITLE
Correctif pour la navigation prescripteur

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,12 +37,18 @@ class ApplicationController < ActionController::Base
   end
 
   def sentry_user
-    user_or_agent = current_agent || current_user
+    current_person = current_agent || current_user || current_prescripteur
     {
-      id: user_or_agent&.id,
-      role: user_or_agent&.class&.name || "Guest",
-      email: user_or_agent&.email,
+      id: current_person&.id,
+      role: current_person&.class&.name || "Guest",
+      email: current_person&.email,
     }.compact
+  end
+
+  def current_prescripteur
+    return nil unless session[:autocomplete_prescripteur_attributes]
+
+    @current_prescripteur ||= Prescripteur.new(session[:autocomplete_prescripteur_attributes])
   end
 
   # By default, Sentry does not log request URL and params because they could

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -70,6 +70,11 @@ class PrescripteurRdvWizardController < ApplicationController
   private
 
   def set_rdv_wizard
+    if session[:rdv_wizard_attributes].blank?
+      flash[:error] = "Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous."
+      redirect_to prendre_rdv_path(prescripteur: 1) and return
+    end
+
     @rdv_wizard = PrescripteurRdvWizard.new(session[:rdv_wizard_attributes], current_domain)
   end
 

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -7,7 +7,8 @@ class PrescripteurRdvWizardController < ApplicationController
     @step_titles = ["Choix du rendez-vous", "Prescripteur", "Bénéficiaire", "Confirmation"]
   end
 
-  before_action :set_rdv_wizard,                  only: %i[new_prescripteur save_prescripteur new_beneficiaire create_rdv]
+  before_action :check_rdv_wizard_attributes, except: %i[start confirmation]
+  before_action :set_rdv_wizard,                  only: %i[new_prescripteur new_beneficiaire create_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
 
   def start
@@ -69,12 +70,15 @@ class PrescripteurRdvWizardController < ApplicationController
 
   private
 
-  def set_rdv_wizard
+  def check_rdv_wizard_attributes
     if session[:rdv_wizard_attributes].blank?
+      Sentry.capture_message("Prescripteur sans infos de creneau. Voir https://github.com/betagouv/rdv-solidarites.fr/issues/3420")
       flash[:error] = "Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous."
       redirect_to prendre_rdv_path(prescripteur: 1) and return
     end
+  end
 
+  def set_rdv_wizard
     @rdv_wizard = PrescripteurRdvWizard.new(session[:rdv_wizard_attributes], current_domain)
   end
 

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -7,7 +7,7 @@ class PrescripteurRdvWizardController < ApplicationController
     @step_titles = ["Choix du rendez-vous", "Prescripteur", "Bénéficiaire", "Confirmation"]
   end
 
-  before_action :set_rdv_wizard,                  only: %i[new_prescripteur new_beneficiaire create_rdv]
+  before_action :set_rdv_wizard,                  only: %i[new_prescripteur save_prescripteur new_beneficiaire create_rdv]
   before_action :redirect_if_creneau_unavailable, only: %i[new_prescripteur new_beneficiaire create_rdv]
 
   def start

--- a/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
+++ b/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
@@ -4,5 +4,8 @@ div
   p
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
+  = "Besoin de déplacer le rendez-vous ou de corriger un détail ? "
+  =< mail_to(SUPPORT_EMAIL, "Contactez-nous", target: "_blank")
+  br
   br
   = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-agent: *
 Disallow: /prendre_rdv_prescripteur/
+Disallow: /prescripteur/

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -201,6 +201,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
   context "when going directly to a prescripteur form without having selected a creneau" do
     it "redirects to the homepage with an error message" do
+      expect(Sentry).to receive(:capture_message)
       visit "http://www.rdv-solidarites-test.localhost/prescripteur/new_prescripteur"
       expect(page).to have_content("Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous.")
     end

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -198,4 +198,11 @@ RSpec.describe "prescripteur can create RDV for a user" do
       expect(page).to have_content("Vos coordonnées de prescripteur")
     end
   end
+
+  context "when going directly to a prescripteur form without having selected a creneau" do
+    it "redirects to the homepage with an error message" do
+      visit "http://www.rdv-solidarites-test.localhost/prescripteur/new_prescripteur"
+      expect(page).to have_content("Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous.")
+    end
+  end
 end

--- a/spec/mailers/previews/prescripteur_mailer_preview.rb
+++ b/spec/mailers/previews/prescripteur_mailer_preview.rb
@@ -2,6 +2,6 @@
 
 class PrescripteurMailerPreview < ActionMailer::Preview
   def rdv_created
-    PrescripteurMailer.rdv_created(Rdv.last.rdvs_users.first, Rdv.last.domain.name)
+    PrescripteurMailer.rdv_created(Rdv.last.rdvs_users.first, Rdv.last.domain.id)
   end
 end


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3445.osc-secnum-fr1.scalingo.io/


Le but de cette PR est de corriger les erreurs liées à cette issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/20566/?environment=production&project=74&query=is%3Aunresolved

En regardant de plus près les referer des différentes occurrences de l'erreur, on a plusieurs cas différents :
- des gens qui naviguent deux fois vers le formulaire de prescripteur à partir d'un même lien (probablement ou l'ouvrant dans deux onglets différents)
- parfois des gens qui naviguent directement vers les pages de formulaire prescripteur depuis une recherche google

Le fix principal de cette PR est donc de faire une redirection vers la page d'accueil quand on ne trouve pas le créneau pour lequel le prescripteur essaye de prendre rendez-vous, mais il y a aussi plusieurs petites améliorations :
- On ajoute un lien de contact dans le mail de confirmation pour permettre au prescripteur de modifier le rdv (en faisant la demande à notre service utilisateur)
- On améliore le tracking Sentry des prescripteur, pour savoir qui a eu l'erreur
- On répare le preview de maileur prescripteur
- On évite d'indexer les pages de formulaire de prescripteur dans les moteurs de recherche

Closes #3420 

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
