### PR TITLE
Correctif de la synchro initiale avec outlook

### DIFF
--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -5,7 +5,7 @@ module Outlook
     queue_as :outlook_sync
 
     def perform(agent)
-      agent.agents_rdvs.includes(:rdv).where(rdv: { starts_at: 1.month.ago.. }).find_each do |agents_rdv|
+      agent.agents_rdvs.joins(:rdv).where(rdv: { starts_at: 1.month.ago.. }).find_each do |agents_rdv|
         Outlook::SyncEventJob.perform_later_for(agents_rdv)
       end
     end

--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -6,9 +6,9 @@ module Outlook
 
     def perform(agent)
       agent.agents_rdvs.future.find_each do |agents_rdv|
-        # if agents_rdv.outlook_id.nil?
-        #   agents_rdv.update_columns(outlook_create_in_progress: true)
-        # end
+        if agents_rdv.outlook_id.nil?
+          agents_rdv.update_columns(outlook_create_in_progress: true)
+        end
         Outlook::SyncEventJob.perform_later_for(agents_rdv)
       end
     end

--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -6,6 +6,9 @@ module Outlook
 
     def perform(agent)
       agent.agents_rdvs.future.find_each do |agents_rdv|
+        # if agents_rdv.outlook_id.nil?
+        #   agents_rdv.update_columns(outlook_create_in_progress: true)
+        # end
         Outlook::SyncEventJob.perform_later_for(agents_rdv)
       end
     end

--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -6,9 +6,6 @@ module Outlook
 
     def perform(agent)
       agent.agents_rdvs.includes(:rdv).where(rdv: { starts_at: 1.month.ago.. }).find_each do |agents_rdv|
-        if agents_rdv.outlook_id.nil?
-          agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
-        end
         Outlook::SyncEventJob.perform_later_for(agents_rdv)
       end
     end

--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -5,9 +5,9 @@ module Outlook
     queue_as :outlook_sync
 
     def perform(agent)
-      agent.agents_rdvs.future.find_each do |agents_rdv|
+      agent.agents_rdvs.includes(:rdv).where(rdv: { starts_at: 1.month.ago.. }).find_each do |agents_rdv|
         if agents_rdv.outlook_id.nil?
-          agents_rdv.update_columns(outlook_create_in_progress: true)
+          agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
         end
         Outlook::SyncEventJob.perform_later_for(agents_rdv)
       end

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -5,7 +5,7 @@ module Outlook
     queue_as :outlook_sync
 
     def self.perform_later_for(agents_rdv)
-      if agents_rdv.outlook_id.nil? && agents_rdv.persisted?
+      if agents_rdv.outlook_id.nil? && !agents_rdv.destroyed?
         agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
       end
       # En cas de suppression du agents_rdv, on ne pourra pas le désérialiser au moment de l'exécution du job.

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -5,6 +5,9 @@ module Outlook
     queue_as :outlook_sync
 
     def self.perform_later_for(agents_rdv)
+      if agents_rdv.outlook_id.nil? && agents_rdv.persisted?
+        agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
+      end
       # En cas de suppression du agents_rdv, on ne pourra pas le désérialiser au moment de l'exécution du job.
       # On aura donc besoin du outlook_id et de l'agent pour supprimer l'event dans Outlook
       perform_later(agents_rdv.id, agents_rdv.outlook_id, agents_rdv.agent)

--- a/app/models/agents_rdv.rb
+++ b/app/models/agents_rdv.rb
@@ -7,8 +7,6 @@ class AgentsRdv < ApplicationRecord
   belongs_to :rdv, touch: true
   belongs_to :agent
 
-  scope :future, -> { includes(:rdv).where(rdv: { starts_at: Time.zone.now.. }) }
-
   # Validation
   # Uniqueness validation doesn’t work with nested_attributes, see https://github.com/rails/rails/issues/4568
   # We do have on a DB constraint.

--- a/app/models/concerns/outlook/event_serializer_and_listener.rb
+++ b/app/models/concerns/outlook/event_serializer_and_listener.rb
@@ -94,9 +94,6 @@ module Outlook
 
     def self.enqueue_sync_for_marked_records(agents_rdvs)
       agents_rdvs.select(&:needs_sync_to_outlook).each do |agents_rdv|
-        if agents_rdv.outlook_id.nil? && agents_rdv.persisted?
-          agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
-        end
         Outlook::SyncEventJob.perform_later_for(agents_rdv)
         agents_rdv.assign_attributes(needs_sync_to_outlook: false)
       end

--- a/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
@@ -3,6 +3,13 @@
 describe "Agent can sync his account to outlook" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent]) }
+
+  let(:client_double) { instance_double(Outlook::ApiClient) }
+
+  before do
+    allow(Outlook::ApiClient).to receive(:new).with(agent).and_return(client_double)
+  end
 
   before do
     OmniAuth.config.test_mode = true
@@ -15,16 +22,17 @@ describe "Agent can sync his account to outlook" do
     OmniAuth.config.mock_auth[:microsoft_graph] = nil
   end
 
-  before do
+  it "syncs the account" do
     login_as(agent, scope: :agent)
     visit agents_calendar_sync_outlook_sync_path
-    find(:xpath, "//a/img[@alt=\"S'identifier avec Microsoft\"]").find(:xpath, "..").click
-  end
 
-  it "syncs the account" do
-    expect(agent.reload.microsoft_graph_token).to eq("super_token")
-    expect(agent.reload.refresh_microsoft_graph_token).to eq("super_refresh_token")
-    expect(Outlook::MassCreateEventJob).to have_been_enqueued.with(agent)
-    expect(page).to have_content("Votre compte Outlook a bien été connecté")
+    expect(client_double).to receive(:create_event!).and_return("stubbed_outlook_event_id")
+    perform_enqueued_jobs do
+      find(:xpath, "//a/img[@alt=\"S'identifier avec Microsoft\"]").find(:xpath, "..").click
+
+      expect(agent.reload.microsoft_graph_token).to eq("super_token")
+      expect(agent.reload.refresh_microsoft_graph_token).to eq("super_refresh_token")
+      expect(page).to have_content("Votre compte Outlook a bien été connecté")
+    end
   end
 end

--- a/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
@@ -3,7 +3,7 @@
 describe "Agent can sync his account to outlook" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-  let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent]) }
+  let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], starts_at: 10.days.ago) }
 
   let(:client_double) { instance_double(Outlook::ApiClient) }
 

--- a/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
@@ -26,7 +26,7 @@ describe "Agent can sync his account to outlook" do
     login_as(agent, scope: :agent)
     visit agents_calendar_sync_outlook_sync_path
 
-    expect(client_double).to receive(:create_event!).and_return("stubbed_outlook_event_id")
+    expect(client_double).to receive(:create_event!)
     perform_enqueued_jobs do
       find(:xpath, "//a/img[@alt=\"S'identifier avec Microsoft\"]").find(:xpath, "..").click
 

--- a/spec/jobs/outlook/mass_create_event_job_spec.rb
+++ b/spec/jobs/outlook/mass_create_event_job_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Outlook::MassCreateEventJob do
 
   let!(:future_rdv1) { create(:rdv, organisation: organisation, starts_at: 1.day.from_now, agents: [agent]) }
   let!(:future_rdv2) { create(:rdv, organisation: organisation, starts_at: 2.days.from_now, agents: [agent]) }
-  let!(:past_rdv1) { create(:rdv, organisation: organisation, starts_at: 1.day.ago, agents: [agent]) }
-  let!(:past_rdv2) { create(:rdv, organisation: organisation, starts_at: 2.days.ago, agents: [agent]) }
+  let!(:recent_past_rdv) { create(:rdv, organisation: organisation, starts_at: 10.days.ago, agents: [agent]) }
+  let!(:distant_past_rdv) { create(:rdv, organisation: organisation, starts_at: 200.days.ago, agents: [agent]) }
 
   before { allow(Outlook::SyncEventJob).to receive(:perform_later_for) }
 
@@ -17,7 +17,7 @@ RSpec.describe Outlook::MassCreateEventJob do
     described_class.perform_now(agent)
     expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv1.agents_rdvs.first)
     expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv2.agents_rdvs.first)
-    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(past_rdv1.agents_rdvs.first)
-    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(past_rdv2.agents_rdvs.first)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(recent_past_rdv.agents_rdvs.first)
+    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(distant_past_rdv.agents_rdvs.first)
   end
 end


### PR DESCRIPTION
(Ne peut pas être testé en review app à cause de l'oaut outlook)

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3446

Le bug était causé par le fait qu'on ne settait pas le flag `outlook_create_in_progress` au moment de la création d'events dans le mass import. J'en ai profité pour déplacer ça dans le job.
