### PR TITLE
Supprime la liste des specs lentes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,7 +1,6 @@
 --color
 --order rand
 --require rails_helper
---profile 3
 --format progress
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 --format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log


### PR DESCRIPTION
Comme discuté en point tech, cette PR enlève la liste des specs lentes qui ajoute du bruit quand on lance les specs et qui ne semble pas nous donner des infos dont on se serve.