### PR TITLE
Ajouter les clés étrangères manquantes

### DIFF
--- a/.active_record_doctor
+++ b/.active_record_doctor
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+ActiveRecordDoctor.configure do
+  # Global settings affect all detectors.
+  global :ignore_tables, [
+    # Ignore internal Rails-related tables.
+    "good_jobs",
+  ]
+
+  # Detector-specific settings affect only one specific detector.
+  detector :missing_foreign_keys,
+           ignore_columns: %w[
+             agents.external_id
+             organisations.human_id
+             organisations.external_id
+             agents_rdvs.outlook_id
+             sectors.human_id
+             zones.street_ban_id
+           ]
+end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,38 @@ jobs:
           ruby-version: 3.2.2
           bundler-cache: true
       - run: bundle exec brakeman
+  active_record_doctor:
+    name: active_record_doctor
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["5432:5432"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+      - name: Run active_record_doctor:missing_foreign_keys
+        run: RAILS_ENV=test bundle exec rails active_record_doctor:missing_foreign_keys
+        env:
+          HOST: http://example.com
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
   test_unit:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ gem "icalendar", "~> 2.5"
 gem "lograge"
 
 group :development, :test do
+  gem "active_record_doctor"
   gem "byebug", platforms: %i[mri mingw x64_mingw] # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "brakeman", require: false
   gem "rubocop", "1.24.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
+    active_record_doctor (1.11.0)
+      activerecord (>= 4.2.0)
     activejob (7.0.4.3)
       activesupport (= 7.0.4.3)
       globalid (>= 0.3.6)
@@ -607,6 +609,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_link_to
+  active_record_doctor
   activerecord-postgres_enum
   administrate
   auto_strip_attributes

--- a/db/migrate/20230413163145_add_foreign_keys.rb
+++ b/db/migrate/20230413163145_add_foreign_keys.rb
@@ -1,0 +1,39 @@
+class AddForeignKeys < ActiveRecord::Migration[7.0]
+  def change
+    up_only do
+      MotifsPlageOuverture.where.not(plage_ouverture_id: PlageOuverture.all.select(:id)).delete_all
+
+      # This is much much faster that a subquery
+      user_ids = User.unscope(:where).pluck(:id).to_set
+      user_profiles_users_ids = UserProfile.distinct.pluck(:user_id).to_set
+      broken_references = user_profiles_users_ids - user_ids
+      UserProfile.where(user_id: broken_references).delete_all
+    end
+
+    add_foreign_key :agent_roles, :agents
+    add_foreign_key :agent_roles, :organisations
+    add_foreign_key :agent_teams, :teams
+    add_foreign_key :agent_teams, :agents
+    add_foreign_key :agent_territorial_roles, :agents
+    add_foreign_key :agent_territorial_roles, :territories
+    add_foreign_key :agents_rdvs, :agents
+    add_foreign_key :agents_rdvs, :rdvs
+    add_foreign_key :motif_categories_territories, :motif_categories
+    add_foreign_key :motif_categories_territories, :territories
+    add_foreign_key :motifs_plage_ouvertures, :motifs
+    add_foreign_key :motifs_plage_ouvertures, :plage_ouvertures
+    add_foreign_key :organisations, :territories
+    add_foreign_key :receipts, :rdvs
+    add_foreign_key :receipts, :users
+    add_foreign_key :referent_assignations, :users
+    add_foreign_key :referent_assignations, :agents
+    add_foreign_key :sectors, :territories
+    add_foreign_key :rdvs_users, :rdvs
+    add_foreign_key :rdvs_users, :users
+    add_foreign_key :teams, :territories
+    add_foreign_key :sector_attributions, :sectors
+    add_foreign_key :user_profiles, :organisations
+    add_foreign_key :user_profiles, :users
+    add_foreign_key :zones, :sectors
+  end
+end

--- a/db/migrate/20230413163145_add_foreign_keys.rb
+++ b/db/migrate/20230413163145_add_foreign_keys.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 class AddForeignKeys < ActiveRecord::Migration[7.0]
+  # rubocop:disable Metrics/MethodLength
   def change
     up_only do
       MotifsPlageOuverture.where.not(plage_ouverture_id: PlageOuverture.all.select(:id)).delete_all
@@ -36,4 +39,5 @@ class AddForeignKeys < ActiveRecord::Migration[7.0]
     add_foreign_key :user_profiles, :users
     add_foreign_key :zones, :sectors
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_27_152334) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_13_163145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -727,15 +727,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_152334) do
 
   add_foreign_key "absences", "agents"
   add_foreign_key "absences", "organisations"
+  add_foreign_key "agent_roles", "agents"
+  add_foreign_key "agent_roles", "organisations"
+  add_foreign_key "agent_teams", "agents"
+  add_foreign_key "agent_teams", "teams"
   add_foreign_key "agent_territorial_access_rights", "agents"
   add_foreign_key "agent_territorial_access_rights", "territories"
+  add_foreign_key "agent_territorial_roles", "agents"
+  add_foreign_key "agent_territorial_roles", "territories"
   add_foreign_key "agents", "services"
+  add_foreign_key "agents_rdvs", "agents"
+  add_foreign_key "agents_rdvs", "rdvs"
   add_foreign_key "file_attentes", "rdvs"
   add_foreign_key "file_attentes", "users"
   add_foreign_key "lieux", "organisations"
+  add_foreign_key "motif_categories_territories", "motif_categories"
+  add_foreign_key "motif_categories_territories", "territories"
   add_foreign_key "motifs", "motif_categories"
   add_foreign_key "motifs", "organisations"
   add_foreign_key "motifs", "services"
+  add_foreign_key "motifs_plage_ouvertures", "motifs"
+  add_foreign_key "motifs_plage_ouvertures", "plage_ouvertures"
+  add_foreign_key "organisations", "territories"
   add_foreign_key "plage_ouvertures", "agents"
   add_foreign_key "plage_ouvertures", "lieux"
   add_foreign_key "plage_ouvertures", "organisations"
@@ -743,8 +756,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_152334) do
   add_foreign_key "rdvs", "lieux"
   add_foreign_key "rdvs", "motifs"
   add_foreign_key "rdvs", "organisations"
+  add_foreign_key "rdvs_users", "rdvs"
+  add_foreign_key "rdvs_users", "users"
+  add_foreign_key "receipts", "rdvs"
+  add_foreign_key "receipts", "users"
+  add_foreign_key "referent_assignations", "agents"
+  add_foreign_key "referent_assignations", "users"
   add_foreign_key "sector_attributions", "agents"
   add_foreign_key "sector_attributions", "organisations"
+  add_foreign_key "sector_attributions", "sectors"
+  add_foreign_key "sectors", "territories"
+  add_foreign_key "teams", "territories"
+  add_foreign_key "user_profiles", "organisations"
+  add_foreign_key "user_profiles", "users"
   add_foreign_key "users", "users", column: "responsible_id"
   add_foreign_key "webhook_endpoints", "organisations"
+  add_foreign_key "zones", "sectors"
 end

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -258,8 +258,7 @@ RSpec.describe Outlook::EventSerializerAndListener, database_cleaner_strategy: :
 
     context "agent not synced with outlook" do
       let(:agent) { create(:agent, microsoft_graph_token: nil) }
-      let(:rdv) { create(:rdv, motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30) }
-      let!(:agents_rdv) { create(:agents_rdv, rdv: rdv, agent: agent) }
+      let(:rdv) { create(:rdv, agents: [agent], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30) }
 
       it "does not call Outlook::DestroyEventJob" do
         expect do


### PR DESCRIPTION
Closes #3317

Voir la doc de la gem ici : 
https://github.com/gregnavis/active_record_doctor#detecting-missing-foreign-key-constraints

J'ai configuré pour ignorer les faux positifs (des colonnes qui finissent par "_id" mais ne sont pas des références internes).

Dans la migration je supprime dans 2 tables des références mortes que nous avions (dieu merci il n'y en avait que sur 2 tables).

Pour éviter de retomber dans la même situation, j'ai ajouté un job dans la CI, il échouera si la commande `RAILS_ENV=test bundle exec rails active_record_doctor:missing_foreign_keys` ne retourne pas 0 (la valeur de succès en bash).

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
