### PR TITLE
Corrige le bug du menu Planning sur les RDV collectifs

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -33,6 +33,7 @@ module AgentsHelper
       "menu-agendas" => "planning",
       "menu-plages-ouvertures" => "planning",
       "menu-absences" => "planning",
+      "menu-rdvs-collectifs-list" => "planning",
       "menu-agents" => "settings",
       "menu-invitations" => "settings",
       "menu-lieux" => "settings",


### PR DESCRIPTION
Pour tester : <`mettre ici l'url de la review app une fois déployé`>

Permet de régler le bug du menu "Planning" qui se ferme lorsque que l'on accède à la page des RDV collectifs

## captures d'écran
avant : 
![image](https://user-images.githubusercontent.com/60173782/232501246-d23b26e8-0354-4042-8448-d0b51a777334.png)


après : 
![image](https://user-images.githubusercontent.com/60173782/232501008-3babdf34-ed5e-42cb-9105-24471bb5ec89.png)


Closes #3442

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
