### PR TITLE
Correctif du flash de confirmation dans le rdv wizard 

### DIFF
--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -34,7 +34,7 @@ class Admin::RdvWizardStepsController < AgentAuthController
     end
 
     if @rdv_wizard.save
-      redirect_to @rdv_wizard.success_path, notice: I18n.t("admin.rdvs.message.success.create")
+      redirect_to @rdv_wizard.success_path, @rdv_wizard.success_flash
     else
       render current_step
     end

--- a/app/form_models/admin/rdv_wizard_form/step4.rb
+++ b/app/form_models/admin/rdv_wizard_form/step4.rb
@@ -18,4 +18,8 @@ class Admin::RdvWizardForm::Step4
       date: starts_at.to_date
     )
   end
+
+  def success_flash
+    { notice: I18n.t("admin.rdvs.message.success.create") }
+  end
 end

--- a/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
+++ b/app/form_models/concerns/admin/rdv_wizard_form_concern.rb
@@ -75,4 +75,8 @@ module Admin::RdvWizardFormConcern
   def path_for_step(target_step_number)
     new_admin_organisation_rdv_wizard_step_path(organisation, to_query.merge(step: target_step_number))
   end
+
+  def success_flash
+    {}
+  end
 end

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -53,6 +53,7 @@ describe "Agent can create a Rdv with wizard" do
     sleep(1) # wait for modal to hide completely
     fill_in :rdv_context, with: "RDV très spécial"
     click_button("Continuer")
+    expect(page).not_to have_content("Le rendez-vous a été créé")
   end
 
   def step3(lieu_availability)


### PR DESCRIPTION
Avant : 
On faisait croire que le rdv était confirmé alors que ce n'était pas le cas : 
<img width="1182" alt="Capture d’écran 2023-04-18 à 10 45 21" src="https://user-images.githubusercontent.com/1840367/232723808-97d93527-b5a1-425e-bf41-27c5020c90cc.png">

Après : 
Pas de faux messages de confirmation
<img width="1185" alt="Capture d’écran 2023-04-18 à 10 45 07" src="https://user-images.githubusercontent.com/1840367/232723835-9c277b81-c189-4459-bd59-dbd6b1053ca8.png">


Le bug avait été introduit dans https://github.com/betagouv/rdv-solidarites.fr/pull/2818

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3443


# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
