### PR TITLE
Ajout du nombre d'agents qui utilisent la synchro outlook aux stats

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -179,6 +179,14 @@
             h2.card-title Agents actifs par mois
           p Nombre d'agents ayant participé à au moins un rdv chaque mois
           = column_chart active_agents_stats_path(territory: @territory)
+
+      .card.mb-5
+        .card-header
+          = self_anchor "outlook_sync"
+            h2.card-title Synchronisation Outlook
+        .card-body
+          p #{@agents.where.not(microsoft_graph_token: nil).count} agents utilisent la synchronisation d'agenda avec Outlook
+
       .card.mb-5
         .card-header
           = "#{@territories.count} structures utilisent RDV-Solidarités"


### PR DESCRIPTION
une manière simple de suivre l'évolution de l'utilisation de notre focus du sprint : 

<img width="1186" alt="Capture d’écran 2023-04-18 à 16 01 54" src="https://user-images.githubusercontent.com/1840367/232836848-683c421c-4043-482f-8f28-b37fd365e936.png">
