### PR TITLE
Fournir à Sentry les métadonnées des jobs

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -4,6 +4,14 @@ module DefaultJobBehaviour
   extend ActiveSupport::Concern
 
   included do
+    # Include job metadata to Sentry context
+    around_perform do |_job, block|
+      Sentry.with_scope do |scope|
+        scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
+        block.call
+      end
+    end
+
     # This retry_on means:
     # "retry 20 times with an exponential backoff, then mark job as discarded"
     #
@@ -11,13 +19,6 @@ module DefaultJobBehaviour
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
     retry_on(StandardError, wait: :exponentially_longer, attempts: 20)
-
-    around_perform do |_job, block|
-      Sentry.with_scope do |scope|
-        scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
-        block.call
-      end
-    end
 
     # Makes sure every failed attempt is logged to Sentry
     # (see: https://github.com/bensheldon/good_job#retries)

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -4,7 +4,7 @@ module DefaultJobBehaviour
   extend ActiveSupport::Concern
 
   included do
-    # Include job metadata to Sentry context
+    # Include job metadata in Sentry context
     around_perform do |_job, block|
       Sentry.with_scope do |scope|
         scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -12,6 +12,13 @@ module DefaultJobBehaviour
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
     retry_on(StandardError, wait: :exponentially_longer, attempts: 20)
 
+    around_perform do |_job, block|
+      Sentry.with_scope do |scope|
+        scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
+        block.call
+      end
+    end
+
     # Makes sure every failed attempt is logged to Sentry
     # (see: https://github.com/bensheldon/good_job#retries)
     around_perform do |_job, block|

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -16,7 +16,7 @@ describe ApplicationJob, type: :job do
 
     stub_sentry_events
 
-    it "reports the job context to Sentry" do
+    it "reports job metadata to Sentry" do
       job_class.perform_later(123, _some_kw_arg: 456)
       enqueued_job_id = enqueued_jobs.last["job_id"]
       expect { perform_enqueued_jobs }.to change(sentry_events, :size).by(1)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: false
+
+describe ApplicationJob, type: :job do
+  describe "sentry logging on error" do
+    let(:job_class) do
+      stub_const "MyJob", Class.new(described_class)
+      MyJob.class_eval do
+        queue_as :custom_queue
+
+        def perform(_some_positional_arg, _some_kw_arg:)
+          raise "Something unexpected happened"
+        end
+      end
+      MyJob
+    end
+
+    stub_sentry_events
+
+    it "reports the job context to Sentry" do
+      job_class.perform_later(123, _some_kw_arg: 456)
+      enqueued_job_id = enqueued_jobs.last["job_id"]
+      expect { perform_enqueued_jobs }.to change(sentry_events, :size).by(1)
+      expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
+      expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
+      expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { :_some_kw_arg => 456 }])
+    end
+  end
+end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 describe ApplicationJob, type: :job do
-  describe "sentry logging on error" do
+  describe "error logging" do
     let(:job_class) do
       stub_const "MyJob", Class.new(described_class)
       MyJob.class_eval do
@@ -20,9 +20,13 @@ describe ApplicationJob, type: :job do
       job_class.perform_later(123, _some_kw_arg: 456)
       enqueued_job_id = enqueued_jobs.last["job_id"]
       expect { perform_enqueued_jobs }.to change(sentry_events, :size).by(1)
+
       expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
       expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
       expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { :_some_kw_arg => 456 }])
+
+      expect(sentry_events.last.exception.values.first.value).to match("Something unexpected happened (RuntimeError)")
+      expect(sentry_events.last.exception.values.first.type).to eq("RuntimeError")
     end
   end
 end


### PR DESCRIPTION
Actuellement, lorsque nous remontons des erreurs de job à Sentry, nous n'avons pas les métadonnées du job. Avec cette PR nous aurons l'ID du job, sa queue et ses arguments. :tada: 

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
