### PR TITLE
Ne pas logger les premiers échecs de jobs dans Sentry

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -22,11 +22,15 @@ module DefaultJobBehaviour
 
     # Makes sure every failed attempt is logged to Sentry
     # (see: https://github.com/bensheldon/good_job#retries)
-    around_perform do |_job, block|
+    around_perform do |job, block|
       block.call
     rescue StandardError => e
-      Sentry.capture_exception(e)
+      Sentry.capture_exception(e) if job.log_failure_to_sentry?
       raise # will be caught by the retry mechanism
     end
+  end
+
+  def log_failure_to_sentry?
+    true
   end
 end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -3,6 +3,10 @@
 class CronJob < ApplicationJob
   queue_as :cron
 
+  def log_failure_to_sentry?
+    true
+  end
+
   class FileAttenteJob < CronJob
     def perform
       FileAttente.send_notifications

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -3,10 +3,6 @@
 class CronJob < ApplicationJob
   queue_as :cron
 
-  def log_failure_to_sentry?
-    true
-  end
-
   class FileAttenteJob < CronJob
     def perform
       FileAttente.send_notifications

--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -13,4 +13,10 @@ class SmsJob < ApplicationJob
 
     SmsSender.perform_with(sender_name, phone_number, content, provider, api_key, receipt_params)
   end
+
+  # Don't log first failures to Sentry, to prevent noise
+  # on temporary unavailability of an external service.
+  def log_failure_to_sentry?
+    executions > 2
+  end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -39,10 +39,8 @@ class WebhookJob < ApplicationJob
     request.run
   end
 
-  # Don't log first failures to Sentry, to prevent noise
-  # on temporary unavailability of an external service.
   def log_failure_to_sentry?
-    executions > 2
+    executions >= 10 # only log last attempt to Sentry, to prevent noise
   end
 
   # La réponse de la Drôme est en JSON

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -39,6 +39,12 @@ class WebhookJob < ApplicationJob
     request.run
   end
 
+  # Don't log first failures to Sentry, to prevent noise
+  # on temporary unavailability of an external service.
+  def log_failure_to_sentry?
+    executions > 2
+  end
+
   # La réponse de la Drôme est en JSON
   # mais leur serveur nous renvoie des erreurs
   # quand il n'arrive pas à faire son boulot.

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -4,10 +4,11 @@ class OutgoingWebhookError < StandardError; end
 
 class WebhookJob < ApplicationJob
   TIMEOUT = 10
+  MAX_ATTEMPTS = 10
 
   queue_as :webhook
 
-  retry_on(OutgoingWebhookError, wait: :exponentially_longer, attempts: 10, queue: :webhook_retries)
+  retry_on(OutgoingWebhookError, wait: :exponentially_longer, attempts: MAX_ATTEMPTS, queue: :webhook_retries)
 
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
@@ -40,7 +41,7 @@ class WebhookJob < ApplicationJob
   end
 
   def log_failure_to_sentry?
-    executions >= 10 # only log last attempt to Sentry, to prevent noise
+    executions >= MAX_ATTEMPTS # only log last attempt to Sentry, to prevent noise
   end
 
   # La réponse de la Drôme est en JSON

--- a/app/mailers/custom_mailer_delivery_job.rb
+++ b/app/mailers/custom_mailer_delivery_job.rb
@@ -14,4 +14,10 @@ class CustomMailerDeliveryJob < ActionMailer::MailDeliveryJob
       retry_job
     end
   end
+
+  # Don't log first failures to Sentry, to prevent noise
+  # on temporary unavailability of an external service.
+  def log_failure_to_sentry?
+    executions > 2
+  end
 end

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -18,7 +18,7 @@ describe SmsJob do
 
       specify do
         expect(SmsSender).to receive(:perform_with)
-        expect { subject.perform }.not_to raise_error
+        expect { subject }.not_to raise_error
       end
     end
 
@@ -26,7 +26,7 @@ describe SmsJob do
       let(:phone_number) { "0130303030" }
 
       specify do
-        expect { subject.perform }.to raise_error(SmsJob::InvalidMobilePhoneNumberError)
+        expect { subject }.to raise_error(SmsJob::InvalidMobilePhoneNumberError)
       end
     end
   end

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -1,31 +1,65 @@
 # frozen_string_literal: true
 
 describe SmsJob do
-  subject do
-    described_class.new.perform(
-      sender_name: "RdvSoli",
-      phone_number: phone_number,
-      content: "test",
-      provider: "netsize",
-      api_key: "fake_key",
-      receipt_params: {}
-    )
-  end
+  describe "phone number validation" do
+    subject(:perform) do
+      described_class.new.perform(
+        sender_name: "RdvSoli",
+        phone_number: phone_number,
+        content: "test",
+        provider: "netsize",
+        api_key: "fake_key",
+        receipt_params: {}
+      )
+    end
 
-  context "phone_number is mobile" do
-    let(:phone_number) { "0612345678" }
+    context "phone_number is mobile" do
+      let(:phone_number) { "0612345678" }
 
-    specify do
-      expect(SmsSender).to receive(:perform_with)
-      expect { subject }.not_to raise_error
+      specify do
+        expect(SmsSender).to receive(:perform_with)
+        expect { subject.perform }.not_to raise_error
+      end
+    end
+
+    context "phone_number is landline" do
+      let(:phone_number) { "0130303030" }
+
+      specify do
+        expect { subject.perform }.to raise_error(SmsJob::InvalidMobilePhoneNumberError)
+      end
     end
   end
 
-  context "phone_number is landline" do
-    let(:phone_number) { "0130303030" }
+  describe "error logging" do
+    stub_sentry_events
 
-    specify do
-      expect { subject }.to raise_error(SmsJob::InvalidMobilePhoneNumberError)
+    it "only sends error to Sentry after 3rd error" do
+      described_class.perform_later(
+        sender_name: "RdvSoli",
+        phone_number: "0123456789",
+        content: "test",
+        provider: "netsize",
+        api_key: "fake_key",
+        receipt_params: {}
+      )
+
+      expect(enqueued_jobs.first["executions"]).to eq(0)
+
+      # first execution, error is not logged
+      perform_enqueued_jobs
+      expect(enqueued_jobs.first["executions"]).to eq(1)
+      expect(sentry_events).to be_empty
+
+      # second execution, error is not logged
+      perform_enqueued_jobs
+      expect(enqueued_jobs.first["executions"]).to eq(2)
+      expect(sentry_events).to be_empty
+
+      # third execution, error is logged
+      perform_enqueued_jobs
+      expect(enqueued_jobs.first["executions"]).to eq(3)
+      expect(sentry_events.last.exception.values.last.type).to eq("SmsJob::InvalidMobilePhoneNumberError")
     end
   end
 end


### PR DESCRIPTION
Closes #3428

J'ai choisi de n'appliquer ce comportement que sur les jobs les plus bruyants, car il me paraît dangereux de passer sous silence par défaut les échecs de tous les types de jobs, notamment les jobs rarements appelés (`MassDestroyEventJob`, `TriggerWebhookJob`) ou les jobs de cron, qui s'exécutent une fois par jour.

À discuter bien sûr ! :slightly_smiling_face: 

Note : le diff des specs est plus facile à comprendre quand on ignore le whitespace

![image](https://user-images.githubusercontent.com/6357692/233998986-3628f250-ff46-4f4a-ba54-6f9301ae16d6.png)


# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
