### PR TITLE
Supression des tables `agents_users` et `delayed_jobs`

### DIFF
--- a/db/migrate/20230425084138_remove_unused_tables.rb
+++ b/db/migrate/20230425084138_remove_unused_tables.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveUnusedTables < ActiveRecord::Migration[7.0]
+  def change
+    # rubocop:disable Rails/ReversibleMigration
+    drop_table :agents_users
+    drop_table :delayed_jobs
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_163145) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_084138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -227,29 +227,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_163145) do
     t.index ["agent_id", "rdv_id"], name: "index_agents_rdvs_on_agent_id_and_rdv_id", unique: true
     t.index ["agent_id"], name: "index_agents_rdvs_on_agent_id"
     t.index ["rdv_id"], name: "index_agents_rdvs_on_rdv_id"
-  end
-
-  create_table "agents_users", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "agent_id", null: false
-    t.index ["agent_id"], name: "index_agents_users_on_agent_id"
-    t.index ["user_id"], name: "index_agents_users_on_user_id"
-  end
-
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer "priority", default: 0, null: false
-    t.integer "attempts", default: 0, null: false
-    t.text "handler", null: false
-    t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
-    t.string "locked_by"
-    t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string "cron"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "file_attentes", force: :cascade do |t|


### PR DESCRIPTION
La table `agents_users` est un reliquat de #605 qui mettait en place les référents. C'est désormais la table `referent_assignations` qui porte cette jointure, et donc `agents_users` est à supprimer.

Quant à la table `delayed_jobs`, elle contient les jobs qui étaient en retry lors du passage à GoodJob dans #3338, et j'avais regardé, c'était que des vieux jobs du genre numéro invalide ou webhook en 500. 

Note : il existe aussi un certain nombre de colonnes qui contiennent le terme "old", et qui pourraient être supprimées, mais je pense que ça peut être fait dans une autre PR, car ça demande peut-être un tout petit peu de réflexion.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
