### PR TITLE
Correction de flaky spec : clic sur un nom ambigu

### DIFF
--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -11,9 +11,9 @@ module Select2SpecHelper
   def add_user(user)
     find("span", text: "Ajouter un usager", match: :first).click
     within(".select2-search--dropdown") do
-      fill_in(class: "select2-search__field", with: user.first_name)
+      fill_in(class: "select2-search__field", with: "#{user.last_name} #{user.first_name}")
     end
-    find("li", text: user.last_name).click
+    find("li", text: "#{user.last_name} #{user.first_name}").click
 
     # This is to make sure we wait for the user to be added before doing the next action
     expect(page).to have_content("#{user.first_name} #{user.last_name}")


### PR DESCRIPTION
Dans cet exemple d'échec de flaky spec : 
https://github.com/betagouv/rdv-solidarites.fr/actions/runs/4818192711/jobs/8579848917

Nous voyons :

> expected to find text "Théodore LE GALL" in "[...]participants\nMelchior LE GALL\nAlcibiade MARTIN\nLieu[...]"

Nous avions donc dans notre test 2 usagers portant le même nom de famille (`"LE GALL"`). Voilà ce qu'il se passait : 

```ruby
add_user(user1) # Melchior LE GALL

... # Le select2 affiche alors à ce moment une liste incluant Melchior LE GALL

add_user(user2) # Théodore LE GALL
  fill_in(class: "select2-search__field", with: user.first_name) # on lance une recherche avec "Théodore"
  find("li", text: user.last_name).click # on clique sur Melchior CAR LA REQUÊTE AJAX CI-DESSUS N'EST PAS TERMINÉE

# On a donc sélectionné 2 fois Melchior, car on a pas attendu les résultats de la recherche de Théodore
```

## Pour reproduire

Dans `full_lifecycle_spec.rb`, définir le même nom pour les deux usagers : 

```ruby
  let!(:user1) { create(:user, first_name: "Jordan", last_name: "LE GALL", organisations: [organisation]) }
  let!(:user2) { create(:user, first_name: "Laurent", last_name: "LE GALL", organisations: [organisation]) }
```

La spec échoue alors.

Je ne pense pas qu'il soit nécessaire d'ajouter une spec de "non régression" pour un cas aussi spécifique, et surtout que c'est une flaky spec et pas un bug.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
