### PR TITLE
Ne pas ouvrir InclusionConnect dans un nouvel onglet

### DIFF
--- a/app/views/common/_inclusionconnect_button.html.slim
+++ b/app/views/common/_inclusionconnect_button.html.slim
@@ -2,7 +2,7 @@
   .text-center.mb-3
     p Inclusion Connect vous permet d'utiliser le même identifiant et mot de passe pour vous connecter à différents services. Simple, sécurisé, efficace !
     - image_path = image_path("logo-inclusion-connect-bg.svg")
-    a.btn-inclusion-connect href=inclusion_connect_auth_path target="_blank" style="background-image: url(#{image_path})"
+    a.btn-inclusion-connect href=inclusion_connect_auth_path style="background-image: url(#{image_path})"
       = image_tag("logo-inclusion-connect-one-line.svg", alt: "Se connecter avec Inclusion Connect", height: 14)
 
   hr


### PR DESCRIPTION
J'avais ajouté `target="_blank"` dans #3336 sans réfléchir parce que c'était l'exemple donné dans [la doc](https://betagouv.github.io/itou-theme/content-ic.html).

J'ai trouvé ça étrange à l'usage et après [confirmation](https://mattermost.incubateur.net/betagouv/pl/x7hkc7ai638m9mzsowgportcfe) j'ai retiré cet attribut.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
