### PR TITLE
Bugfix: Section "Restrictions" affichée même quand vide

### DIFF
--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -4,10 +4,10 @@ ul.list-group.list-group-flush
     = rdv_title(rdv)
     = rdv_tag(rdv)
 
-  - if rdv.motif.restriction_for_rdv
+  - if rdv.motif.restriction_for_rdv.present?
     li.list-group-item.alert.alert-warning
-        .fa.fa-warning>
-        = rdv.motif.restriction_for_rdv
+      .fa.fa-warning>
+      = rdv.motif.restriction_for_rdv
 
   - if rdv.home?
     li.list-group-item


### PR DESCRIPTION
Bug découvert lors d'une démo à @ousmanedev : j'ai créé un motif et son champ `restriction_for_rdv` semble avoir pour valeur par défaut `""`.

je corrige donc ici la condition d'affichage de ce champ sur le récapitulatif du RDV.

## Avant

![image](https://user-images.githubusercontent.com/6357692/235934352-f39e47f9-8ef8-4aec-b8ac-da999944e33c.png)

## Après

![image](https://user-images.githubusercontent.com/6357692/235934368-235715f8-f739-4fd0-8ade-1f9995d56621.png)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
