### PR TITLE
[3467] Make links in Motifs restriction text (Motif#restriction_for_rdv) clickable

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -105,4 +105,12 @@ module MotifsHelper
       ).in_range(Time.zone.now..).count
     end
   end
+
+  def restriction_for_rdv_to_html(motif)
+    auto_link(simple_format(motif.restriction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
+  end
+
+  def instruction_for_rdv_to_html(motif)
+    auto_link(simple_format(motif.instruction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
+  end
 end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -5,6 +5,7 @@ class Users::RdvMailer < ApplicationMailer
   helper UsersHelper
   helper RdvsHelper
   helper DateHelper
+  helper MotifsHelper
 
   before_action do
     @rdv = params[:rdv]

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -73,11 +73,11 @@
 
         = motif_attribute_row \
           Motif.human_attribute_name(:restriction_for_rdv_short), \
-          @motif.restriction_for_rdv, \
+          simple_format(@motif.restriction_for_rdv), \
           hint: Motif.human_attribute_name(:restriction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:instruction_for_rdv_short), \
-          @motif.instruction_for_rdv, \
+          simple_format(@motif.instruction_for_rdv), \
           hint: Motif.human_attribute_name(:instruction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:custom_cancel_warning_message), \

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -73,11 +73,11 @@
 
         = motif_attribute_row \
           Motif.human_attribute_name(:restriction_for_rdv_short), \
-          simple_format(@motif.restriction_for_rdv), \
+          restriction_for_rdv_to_html(@motif), \
           hint: Motif.human_attribute_name(:restriction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:instruction_for_rdv_short), \
-          simple_format(@motif.instruction_for_rdv), \
+          instruction_for_rdv_to_html(@motif), \
           hint: Motif.human_attribute_name(:instruction_for_rdv_hint)
         = motif_attribute_row \
           Motif.human_attribute_name(:custom_cancel_warning_message), \

--- a/app/views/common/_creneaux.html.slim
+++ b/app/views/common/_creneaux.html.slim
@@ -34,7 +34,7 @@ div id="creneaux-lieu-#{lieu.id}"
                         small= creneau.agent.short_name
 
                     =  render "/common/modal", id: "js-rdv-restriction-motif#{creneau.starts_at.to_i}" , title: "À lire avant de prendre un rendez-vous", confirm_path: new_users_rdv_wizard_step_path(@query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)) do
-                      = ActionController::Base.helpers.auto_link(simple_format(creneau.motif.restriction_for_rdv), html: { target: "_blank"})
+                      = restriction_for_rdv_to_html(creneau.motif)
             - elsif date >= (Time.now + max_public_booking_delay.seconds).to_date
               p.text-center.text-muted
                 | Date fermée à la reservation

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -52,4 +52,4 @@
   - if rdv.motif.instruction_for_rdv.present? && for_role == :user
     .div.row-result.no-border
       span.title Informations supplémentaires :
-      = auto_link(simple_format(rdv.motif.instruction_for_rdv), html: { target: "_blank" })
+      = instruction_for_rdv_to_html(rdv.motif)

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -40,7 +40,8 @@ main.container
               li.list-group-item
                 i.fa.fa-exclamation-triangle>
                 strong Informations supplémentaires :
-                = auto_link(simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1"), html: { target: "_blank" })
+                .pl-3.pt-1
+                  = instruction_for_rdv_to_html(rdv.motif)
             li.list-group-item
               = "Besoin de déplacer le rendez-vous ou de corriger un détail ? "
               =< mail_to(SUPPORT_EMAIL, "Contactez-nous", target: "_blank")

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -37,4 +37,4 @@ section.bg-light.p-4
              = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
                = render "motif_selection_card", motif: motif
              = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
-               = ActionController::Base.helpers.auto_link(simple_format(motif.restriction_for_rdv), html: { target: "_blank"})
+               = restriction_for_rdv_to_html(motif)

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -35,7 +35,8 @@
         li.list-group-item
           i.fa.fa-exclamation-triangle>
           strong Informations supplémentaires :
-          = auto_link(simple_format(@rdv.motif.instruction_for_rdv, class:"pl-3 pt-1"), html: { target: "_blank" })
+          .pl-3.pt-1
+            = instruction_for_rdv_to_html(@rdv.motif)
 
       li.list-group-item
         i.fa.fa-users>

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -7,7 +7,7 @@ ul.list-group.list-group-flush
   - if rdv.motif.restriction_for_rdv.present?
     li.list-group-item.alert.alert-warning
       .fa.fa-warning>
-      = rdv.motif.restriction_for_rdv
+      = auto_link(simple_format(rdv.motif.restriction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
 
   - if rdv.home?
     li.list-group-item

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -7,7 +7,7 @@ ul.list-group.list-group-flush
   - if rdv.motif.restriction_for_rdv.present?
     li.list-group-item.alert.alert-warning
       .fa.fa-warning>
-      = auto_link(simple_format(rdv.motif.restriction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
+      = restriction_for_rdv_to_html(rdv.motif)
 
   - if rdv.home?
     li.list-group-item
@@ -45,7 +45,8 @@ ul.list-group.list-group-flush
     li.list-group-item
       i.fa.fa-exclamation-triangle>
       strong Informations supplémentaires :
-      = auto_link(simple_format(rdv.motif.instruction_for_rdv, class:"pl-3 pt-1"), html: { target: "_blank" })
+      .pl-3.pt-1
+        = instruction_for_rdv_to_html(rdv.motif)
   = render "/users/rdvs/file_attente", rdv: rdv
 
   / Check for authorizations and already cancelled rdv/participation


### PR DESCRIPTION
# Rendre cliquables, les liens dans les instructions avant la prise de RDVs

## Description
- En ce qui concerne les instructions après la prise des RDVs, les liens y sont déjà cliquables. Pas de changement à faire.
- En ce qui concerne les mails envoyés aux usagers, ils ne contiennent pas les instructions pré-RDV. Il n'y a donc pas de changement à faire.
- Le seul fichier impacté est: `app/views/users/rdvs/_rdv.html.slim`

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3467

## Avant
Lien (https://google.fr) non cliquable
<img width="566" alt="Screenshot 2023-05-03 at 16 52 16" src="https://user-images.githubusercontent.com/11911945/235953574-42906c62-8f00-44fa-a5d2-1e19fb946060.png">

## Après
Lien (https://google.fr) cliquable
<img width="557" alt="after" src="https://user-images.githubusercontent.com/11911945/235964377-b5b05a56-2b3a-4695-80fb-c2914b6b2e77.png">

