### PR TITLE
Ajout de validation sur le formulaire de prescripteur

### DIFF
--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -33,7 +33,7 @@ class PrescripteurRdvWizardController < ApplicationController
 
     @prescripteur.validate
     # On veut valider uniquement les attributs qui sont sur le formulaire, pas l'association avec le RdvUser
-    valid_prescripteur_form = prescripteur_attributes.keys.none? { |key| @prescripteur.errors[key] }
+    valid_prescripteur_form = prescripteur_attributes.keys.none? { |key| @prescripteur.errors[key].present? }
 
     if valid_prescripteur_form
       session[:autocomplete_prescripteur_attributes] = prescripteur_attributes
@@ -42,6 +42,7 @@ class PrescripteurRdvWizardController < ApplicationController
 
       redirect_to prescripteur_new_beneficiaire_path
     else
+      flash[:error] = "Veuillez compléter tous les champs obligatoires"
       @step_title = @step_titles[1]
 
       render :new_prescripteur

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -29,11 +29,23 @@ class PrescripteurRdvWizardController < ApplicationController
   def save_prescripteur
     prescripteur_attributes = params[:prescripteur].permit(:first_name, :last_name, :email, :phone_number)
 
-    session[:autocomplete_prescripteur_attributes] = prescripteur_attributes
+    @prescripteur = Prescripteur.new(prescripteur_attributes)
 
-    session[:rdv_wizard_attributes][:prescripteur] = prescripteur_attributes
+    @prescripteur.validate
+    # On veut valider uniquement les attributs qui sont sur le formulaire, pas l'association avec le RdvUser
+    valid_prescripteur_form = prescripteur_attributes.keys.none? { |key| @prescripteur.errors[key] }
 
-    redirect_to prescripteur_new_beneficiaire_path
+    if valid_prescripteur_form
+      session[:autocomplete_prescripteur_attributes] = prescripteur_attributes
+
+      session[:rdv_wizard_attributes][:prescripteur] = prescripteur_attributes
+
+      redirect_to prescripteur_new_beneficiaire_path
+    else
+      @step_title = @step_titles[1]
+
+      render :new_prescripteur
+    end
   end
 
   def new_beneficiaire

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -26,7 +26,7 @@ class PrescripteurRdvWizardController < ApplicationController
     @prescripteur = Prescripteur.new(session[:autocomplete_prescripteur_attributes])
   end
 
-  def save_prescripteur
+  def store_prescripteur_in_session
     prescripteur_attributes = params[:prescripteur].permit(:first_name, :last_name, :email, :phone_number)
 
     @prescripteur = Prescripteur.new(prescripteur_attributes)

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -72,7 +72,7 @@ class Users::ParticipationsController < UserAuthController
       raise Pundit::NotAuthorizedError
     end
 
-    new_participation.create_and_notify(current_user)
+    new_participation.create_and_notify!(current_user)
     set_user_name_initials_verified
     flash[:notice] = "Participation confirmée"
     redirect_to users_rdv_path(@rdv, invitation_token: new_participation.rdv_user_token)

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -44,7 +44,7 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
   end
 
   def create_participation!
-    participation.create_and_notify(@prescripteur)
+    participation.create_and_notify!(@prescripteur)
   end
 
   def participation

--- a/app/models/concerns/rdvs_user/creatable.rb
+++ b/app/models/concerns/rdvs_user/creatable.rb
@@ -3,15 +3,11 @@
 module RdvsUser::Creatable
   extend ActiveSupport::Concern
 
-  def create_and_notify(author)
+  def create_and_notify!(author)
     RdvsUser.transaction do
       empty_rdv_from_relatives
-      if save
-        notify_create!(author)
-        true
-      else
-        false
-      end
+      save!
+      notify_create!(author)
     end
   end
 

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -11,7 +11,7 @@ main.container
             = "Ces informations permettront à l'agent qui assure le rendez-vous de savoir qui l'a planifié, "
             = "et de vous contacter s'il y a une erreur sur le type de rendez-vous."
 
-          = simple_form_for @prescripteur, url: prescripteur_save_prescripteur_path do |f|
+          = simple_form_for @prescripteur, url: prescripteur_store_prescripteur_in_session_path do |f|
             .form-group
               .row
                 .col-6

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,7 +223,7 @@ Rails.application.routes.draw do
   scope path: "prescripteur", as: "prescripteur", controller: "prescripteur_rdv_wizard" do
     get "start"
     get "new_prescripteur"
-    post "save_prescripteur"
+    post "store_prescripteur_in_session"
     get "new_beneficiaire"
     post "create_rdv"
     get "confirmation"

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -106,6 +106,24 @@ RSpec.describe "prescripteur can create RDV for a user" do
     click_on("Rechercher")
   end
 
+  context "when the prescripteur info isn't filled in" do
+    it "doesn't shows error messages and doesn't allow continuing" do
+      visit "http://www.rdv-aide-numerique-test.localhost/org/#{organisation.id}"
+
+      click_on "Prochaine disponibilité le" # choix du lieu
+      click_on "08:00" # choix du créneau
+      click_on "Je suis un prescripteur qui oriente un bénéficiaire" # page de login
+
+      fill_in "Votre prénom", with: "Alex"
+      fill_in "Votre nom", with: "  "
+      fill_in "Votre email professionnel", with: "alex@prescripteur.fr"
+      fill_in "Votre numéro de téléphone", with: "0611223344"
+      click_on "Continuer"
+
+      expect(page).to have_content("Vos coordonnées de prescripteur")
+    end
+  end
+
   context "when a similar user already exists", js: true do
     let!(:user) do
       create(:user, first_name: "Patricia", last_name: "Duroy", phone_number: "0611223344")

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -121,6 +121,8 @@ RSpec.describe "prescripteur can create RDV for a user" do
       click_on "Continuer"
 
       expect(page).to have_content("Vos coordonnées de prescripteur")
+      expect(page).to have_content("Nom d’usage doit être rempli(e)")
+      expect(page).to have_content("Veuillez compléter tous les champs obligatoires")
     end
   end
 

--- a/spec/models/concerns/rdvs_user/creatable_spec.rb
+++ b/spec/models/concerns/rdvs_user/creatable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RdvsUser::Creatable, type: :concern do
       it "sends a webhook" do
         rdv.reload
         expect(WebhookJob).to receive(:perform_later)
-        rdv_user1.create_and_notify(user)
+        rdv_user1.create_and_notify!(user)
       end
     end
 
@@ -32,7 +32,7 @@ RSpec.describe RdvsUser::Creatable, type: :concern do
       let(:rdv_user_relative) { build(:rdvs_user, rdv: rdv, user: relative) }
 
       it "for self (user)" do
-        rdv_user1.create_and_notify(user)
+        rdv_user1.create_and_notify!(user)
         expect_notifications_sent_for(rdv, user, :rdv_created)
         expect_notifications_sent_for(rdv, agent, :rdv_created)
         expect(rdv.reload.rdvs_users).to eq([rdv_user1])
@@ -41,7 +41,7 @@ RSpec.describe RdvsUser::Creatable, type: :concern do
 
       it "for a relative with existing participations" do
         rdv_user1.save!
-        rdv_user_relative.create_and_notify(user)
+        rdv_user_relative.create_and_notify!(user)
         expect_notifications_sent_for(rdv, user, :rdv_created)
         expect_notifications_sent_for(rdv, agent, :rdv_created)
         expect(rdv.reload.rdvs_users).to eq([rdv_user_relative])
@@ -55,14 +55,14 @@ RSpec.describe RdvsUser::Creatable, type: :concern do
       let(:rdv_user_relative) { build(:rdvs_user, rdv: rdv, user: relative, send_lifecycle_notifications: false) }
 
       it "for self (user)" do
-        rdv_user_with_lifecycle_disabled.create_and_notify(user3)
+        rdv_user_with_lifecycle_disabled.create_and_notify!(user3)
         expect_no_notifications_for(rdv, user, :rdv_created)
         expect_notifications_sent_for(rdv, agent, :rdv_created)
         expect(rdv.reload.rdvs_users).to eq([rdv_user_with_lifecycle_disabled])
       end
 
       it "for a relative" do
-        rdv_user_relative.create_and_notify(user)
+        rdv_user_relative.create_and_notify!(user)
         expect_no_notifications_for(rdv, user, :rdv_created)
         expect_notifications_sent_for(rdv, agent, :rdv_created)
         expect(rdv.reload.rdvs_users).to eq([rdv_user_relative])


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3498.osc-secnum-fr1.scalingo.io/

Avant : le formulaire prescripteur ne mettait pas de message d'erreur si on met un nom de famille vide

Après : 
<img width="1338" alt="Screenshot 2023-05-05 at 10 02 10" src="https://user-images.githubusercontent.com/1840367/236410462-57d08a83-ba23-4c48-992a-6dcd190ca3dd.png">

Le fix ajoute principalement une validation back-end à un formulaire qui n'avait que des validations front.

Au passage, sur le dernier commit, j'ai fait en sorte que la méthode `#create_and_notify` lève explicitement une erreur si la participation n'est pas persistée. Au début je pensais que ça pouvait éviter d'autres erreurs sur le formulaire de prescripteur, mais en regardant de plus près, ça ne change rien à ce cas. Je suis quand même tenté de laisser ces modifs pour être plus défensif sur la création de participations.

Closes #3497

Après avoir mergé, ça pourra être bien de manuellement corriger les participations sans prescripteurs

# Checklist

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
