### PR TITLE
Modification de l'attribut new_domain_beta => verticale

### DIFF
--- a/app/blueprints/organisation_blueprint.rb
+++ b/app/blueprints/organisation_blueprint.rb
@@ -3,5 +3,5 @@
 class OrganisationBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :phone_number, :email
+  fields :name, :phone_number, :email, :verticale
 end

--- a/app/controllers/api/v1/organisations_controller.rb
+++ b/app/controllers/api/v1/organisations_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::OrganisationsController < Api::V1::AgentAuthBaseController
   end
 
   def organisation_params
-    params.permit(:name, :phone_number, :email)
+    params.permit(:name, :phone_number, :email, :verticale)
   end
 
   def organisations_relevant_to_sector

--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -19,7 +19,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     phone_number: Field::String,
     human_id: Field::String,
     territory: Field::BelongsTo,
-    new_domain_beta: Field::Boolean,
+    verticale: EnumField,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -45,7 +45,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     motifs
     lieux
     human_id
-    new_domain_beta
+    verticale
     created_at
     updated_at
   ].freeze
@@ -57,7 +57,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
     name
     horaires
     phone_number
-    new_domain_beta
+    verticale
     human_id
     territory
   ].freeze

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -224,7 +224,7 @@ class Agent < ApplicationRecord
   delegate :conseiller_numerique?, to: :service
 
   def domain
-    @domain ||= if organisations.where(new_domain_beta: true).any?
+    @domain ||= if organisations.where(verticale: :rdv_aide_numerique).any?
                   Domain::RDV_AIDE_NUMERIQUE
                 else
                   Domain::RDV_SOLIDARITES

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,6 +7,7 @@ class Organisation < ApplicationRecord
 
   # Attributes
   auto_strip_attributes :email, :name
+  enum verticale: { rdv_insertion: "rdv_insertion", rdv_solidarites: "rdv_solidarites", rdv_aide_numerique: "rdv_aide_numerique" }
 
   # Relations
   belongs_to :territory
@@ -88,7 +89,7 @@ class Organisation < ApplicationRecord
   end
 
   def domain
-    new_domain_beta? ? Domain::RDV_AIDE_NUMERIQUE : Domain::RDV_SOLIDARITES
+    rdv_aide_numerique? ? Domain::RDV_AIDE_NUMERIQUE : Domain::RDV_SOLIDARITES
   end
 
   def slug

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -105,9 +105,9 @@ class Rdv < ApplicationRecord
   scope :with_remaining_seats, -> { where("users_count < max_participants_count OR max_participants_count IS NULL") }
   scope :for_domain, lambda { |domain|
     if domain == Domain::RDV_AIDE_NUMERIQUE
-      joins(:organisation).where(organisations: { new_domain_beta: true })
+      joins(:organisation).where(organisations: { verticale: :rdv_aide_numerique })
     else
-      joins(:organisation).where(organisations: { new_domain_beta: false })
+      joins(:organisation).where.not(organisations: { verticale: :rdv_aide_numerique })
     end
   }
   ## -

--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -67,7 +67,7 @@ class AddConseillerNumerique
       external_id: @structure.external_id,
       name: next_available_organisation_name,
       territory: territory,
-      new_domain_beta: true
+      verticale: :rdv_aide_numerique
     )
     create_motifs(organisation)
     create_lieu(organisation)

--- a/app/views/layouts/_domain_change_banner.html.slim
+++ b/app/views/layouts/_domain_change_banner.html.slim
@@ -1,4 +1,4 @@
-- if organisation.present? && organisation.domain != current_domain && organisation.new_domain_beta
+- if organisation.present? && organisation.domain != current_domain && organisation.rdv_aide_numerique?
   .navbar.alert-warning.p-2
     div
       .fa.fa-exclamation-circle.alert-link>

--- a/db/migrate/20230504120852_add_verticale_to_organisations.rb
+++ b/db/migrate/20230504120852_add_verticale_to_organisations.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddVerticaleToOrganisations < ActiveRecord::Migration[7.0]
+  def up
+    create_enum :verticale, %i[rdv_insertion rdv_solidarites rdv_aide_numerique]
+
+    add_column :organisations, :verticale, :verticale, default: :rdv_solidarites, null: false
+
+    execute(<<-SQL.squish
+      UPDATE organisations
+      SET verticale = 'rdv_aide_numerique'
+      WHERE new_domain_beta = TRUE
+    SQL
+           )
+
+    remove_column :organisations, :new_domain_beta
+
+    # Migrating rdv_insertion organisations will be done on demo and prod manually :
+    # Organisation.where(id: [rdv_insertion_orgs_ids]).each { |org| org.verticale = :rdv_insertion; org.save }
+  end
+
+  def down
+    add_column :organisations, :new_domain_beta, :boolean, default: false, null: false,
+                                                           comment: "en mettant ce boolean a true, on active l'utilisation du nouveau domaine pour les conseillers numeriques de cette organisation"
+
+    execute(<<-SQL.squish
+      UPDATE organisations
+      SET new_domain_beta = (verticale = 'rdv_aide_numerique')
+    SQL
+           )
+
+    remove_column :organisations, :verticale
+    drop_enum :verticale
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_25_084138) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_04_120852) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,6 +95,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_084138) do
   create_enum :user_invited_through, [
     "devise_email",
     "external",
+  ], force: :cascade
+
+  create_enum :verticale, [
+    "rdv_insertion",
+    "rdv_solidarites",
+    "rdv_aide_numerique",
   ], force: :cascade
 
   create_table "absences", force: :cascade do |t|
@@ -389,7 +395,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_084138) do
     t.string "email"
     t.bigint "territory_id", null: false
     t.string "external_id", comment: "The organisation's unique and immutable id in the system managing them and adding them to our application"
-    t.boolean "new_domain_beta", default: false, null: false, comment: "en mettant ce boolean a true, on active l'utilisation du nouveau domaine pour les conseillers numeriques de cette organisation"
+    t.enum "verticale", default: "rdv_solidarites", null: false, enum_type: "verticale"
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["human_id", "territory_id"], name: "index_organisations_on_human_id_and_territory_id", unique: true, where: "((human_id)::text <> ''::text)"
     t.index ["name", "territory_id"], name: "index_organisations_on_name_and_territory_id", unique: true

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -15,7 +15,7 @@ org_cnfs = Organisation.create!(
   human_id: "mediatheque-paris-nord",
   territory: territory_cnfs,
   external_id: "666",
-  new_domain_beta: true
+  verticale: :rdv_aide_numerique
 )
 
 # MOTIFS Conseiller Numérique

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -26,19 +26,22 @@ org_drome1 = Organisation.create!(
   name: "Plateforme mutualisée d'orientation",
   phone_number: "0475796991",
   human_id: "plateforme-mutualisee-orientation-drome",
-  territory: territory_drome
+  territory: territory_drome,
+  verticale: :rdv_insertion
 )
 org_drome2 = Organisation.create!(
   name: "PLIE Valence",
   phone_number: "0101010102",
   human_id: "plie-valence",
-  territory: territory_drome
+  territory: territory_drome,
+  verticale: :rdv_insertion
 )
 org_yonne = Organisation.create!(
   name: "UT Avallon",
   phone_number: "0303030303",
   human_id: "ut-avallon",
-  territory: territory_yonne
+  territory: territory_yonne,
+  verticale: :rdv_insertion
 )
 
 # Service

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -91,8 +91,8 @@ describe "Admin can configure the organisation" do
     expect(current_email.subject).to eq "Vous avez été invité sur RDV Solidarités"
   end
 
-  context "when the organisation is not using the default domain" do
-    let!(:organisation) { create(:organisation, new_domain_beta: true) }
+  context "when the organisation is using rdv_aide_numerique verticale" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
 
     it "allows inviting agents on the correct domain" do
       click_link "Agents"
@@ -103,6 +103,20 @@ describe "Admin can configure the organisation" do
       open_email("jean@paul.com")
       expect(current_email.subject).to eq "Vous avez été invité sur RDV Aide Numérique"
       expect(current_email.body).to include "rejoindre RDV Aide Numérique"
+    end
+  end
+
+  context "when the organisation is using rdv_insertion verticale" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_insertion) }
+
+    it "allows inviting agents on the correct domain" do
+      click_link "Agents"
+      click_link "Inviter un agent", match: :first
+      fill_in "Email", with: "jean@paul.com"
+      click_button "Envoyer une invitation"
+
+      open_email("jean@paul.com")
+      expect(current_email.subject).to eq "Vous avez été invité sur RDV Solidarités"
     end
   end
 

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -27,7 +27,7 @@ describe "User resets his password spec" do
   describe "using the user's domain" do
     context "when the user only has RDVs for motif Conseiller Numérique" do
       let(:user) do
-        organisation = create(:organisation, new_domain_beta: true)
+        organisation = create(:organisation, verticale: :rdv_aide_numerique)
         motif_numerique = create(:motif, service: create(:service, :conseiller_numerique))
         create(:user, rdvs: create_list(:rdv, 2, organisation: organisation, motif: motif_numerique))
       end

--- a/spec/mailers/agents/absence_mailer_spec.rb
+++ b/spec/mailers/agents/absence_mailer_spec.rb
@@ -24,8 +24,8 @@ describe Agents::AbsenceMailer, type: :mailer do
       end
 
       describe "using the agent domain's branding" do
-        context "when agent belongs to an organisation with new_domain_beta=false" do
-          before { agent.organisations.first.update!(new_domain_beta: false) }
+        context "when agent belongs to an organisation with rdv_solidarites verticale" do
+          before { agent.organisations.first.update!(verticale: :rdv_solidarites) }
 
           it "works" do
             mail = described_class.with(absence: absence).send("absence_#{action}")
@@ -36,12 +36,20 @@ describe Agents::AbsenceMailer, type: :mailer do
           end
         end
 
-        context "when agent belongs to an organisation with new_domain_beta=true" do
-          before { agent.organisations.first.update!(new_domain_beta: false) }
+        context "when agent belongs to an organisation with rdv_insertion verticale" do
+          before { agent.organisations.first.update!(verticale: :rdv_insertion) }
 
-          before do
-            allow(agent).to receive(:domain).and_return(Domain::RDV_AIDE_NUMERIQUE)
+          it "works" do
+            mail = described_class.with(absence: absence).send("absence_#{action}")
+            expect(mail.subject).to start_with("RDV Solidarités - Indisponibilité")
+            expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
+            expect(mail.html_part.body.to_s).to include("Voir sur RDV Solidarités") unless action == :destroyed
+            expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/))
           end
+        end
+
+        context "when agent belongs to an organisation with rdv_aide_numerique verticale" do
+          before { agent.organisations.first.update!(verticale: :rdv_aide_numerique) }
 
           it "works" do
             mail = described_class.with(absence: absence).send("absence_#{action}")

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -20,7 +20,16 @@ describe CustomDeviseMailer, "#domain" do
   end
 
   context "when user only has RDV Solidarités rdvs" do
-    let!(:organisation) { create(:organisation, new_domain_beta: false) }
+    let!(:organisation) { create(:organisation, verticale: :rdv_solidarites) }
+    let(:user) { create(:user, rdvs: create_list(:rdv, 2, organisation: organisation)) }
+
+    it "uses RDV_SOLIDARITES" do
+      expect_to_use_domain(Domain::RDV_SOLIDARITES)
+    end
+  end
+
+  context "when user only has RDV Insertion rdvs" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_insertion) }
     let(:user) { create(:user, rdvs: create_list(:rdv, 2, organisation: organisation)) }
 
     it "uses RDV_SOLIDARITES" do
@@ -29,7 +38,7 @@ describe CustomDeviseMailer, "#domain" do
   end
 
   context "when user only has RDV Aide Numérique rdvs" do
-    let!(:organisation) { create(:organisation, new_domain_beta: true) }
+    let!(:organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
     let(:user) { create(:user, rdvs: create_list(:rdv, 2, organisation: organisation)) }
 
     it "uses RDV_AIDE_NUMERIQUE" do
@@ -37,15 +46,45 @@ describe CustomDeviseMailer, "#domain" do
     end
   end
 
-  context "when user has mixed RDV domains (and organisation is in beta program)" do
-    let!(:old_domain_organisation) { create(:organisation, new_domain_beta: false) }
-    let!(:new_domain_organisation) { create(:organisation, new_domain_beta: true) }
+  context "when user has mixed RDV domains and most recent is rdv_aide_numerique" do
+    let!(:old_domain_organisation) { create(:organisation, verticale: :rdv_solidarites) }
+    let!(:old_domain_organisation2) { create(:organisation, verticale: :rdv_insertion) }
+    let!(:new_domain_organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
     let!(:recent_rdv) { build(:rdv, organisation: new_domain_organisation, created_at: 2.days.ago) }
     let!(:old_rdv) { build(:rdv, organisation: old_domain_organisation, created_at: 3.months.ago) }
-    let!(:user) { create(:user, rdvs: [recent_rdv, old_rdv]) }
+    let!(:old_rdv2) { build(:rdv, organisation: old_domain_organisation2, created_at: 4.months.ago) }
+    let!(:user) { create(:user, rdvs: [recent_rdv, old_rdv, old_rdv2]) }
 
     it "uses the domain of the most recently created rdv" do
       expect_to_use_domain(Domain::RDV_AIDE_NUMERIQUE)
+    end
+  end
+
+  context "when user has mixed RDV domains and most recent is rdv_solidarites" do
+    let!(:old_domain_organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
+    let!(:old_domain_organisation2) { create(:organisation, verticale: :rdv_insertion) }
+    let!(:new_domain_organisation) { create(:organisation, verticale: :rdv_solidarites) }
+    let!(:recent_rdv) { build(:rdv, organisation: new_domain_organisation, created_at: 2.days.ago) }
+    let!(:old_rdv) { build(:rdv, organisation: old_domain_organisation, created_at: 3.months.ago) }
+    let!(:old_rdv2) { build(:rdv, organisation: old_domain_organisation2, created_at: 4.months.ago) }
+    let!(:user) { create(:user, rdvs: [recent_rdv, old_rdv, old_rdv2]) }
+
+    it "uses the domain of the most recently created rdv" do
+      expect_to_use_domain(Domain::RDV_SOLIDARITES)
+    end
+  end
+
+  context "when user has mixed RDV domains and most recent is rdv_insertion" do
+    let!(:old_domain_organisation) { create(:organisation, verticale: :rdv_solidarites) }
+    let!(:old_domain_organisation2) { create(:organisation, verticale: :rdv_aide_numerique) }
+    let!(:new_domain_organisation) { create(:organisation, verticale: :rdv_insertion) }
+    let!(:recent_rdv) { build(:rdv, organisation: new_domain_organisation, created_at: 2.days.ago) }
+    let!(:old_rdv) { build(:rdv, organisation: old_domain_organisation, created_at: 3.months.ago) }
+    let!(:old_rdv2) { build(:rdv, organisation: old_domain_organisation2, created_at: 4.months.ago) }
+    let!(:user) { create(:user, rdvs: [recent_rdv, old_rdv, old_rdv2]) }
+
+    it "uses the domain of the most recently created rdv" do
+      expect_to_use_domain(Domain::RDV_SOLIDARITES)
     end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -154,8 +154,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
         create(:motif, service: create(:service), organisation: organisation)
       end
 
-      context "when the organisation uses the default domain name" do
-        let(:organisation) { create(:organisation, new_domain_beta: false) }
+      context "when the organisation uses the rdv_solidarites verticale" do
+        let(:organisation) { create(:organisation, verticale: :rdv_solidarites) }
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
@@ -166,8 +166,20 @@ RSpec.describe Users::RdvMailer, type: :mailer do
         end
       end
 
-      context "when the organisation is part of the beta" do
-        let(:organisation) { create(:organisation, new_domain_beta: true) }
+      context "when the organisation uses the rdv_insertion verticale" do
+        let(:organisation) { create(:organisation, verticale: :rdv_insertion) }
+
+        it "works" do
+          mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
+          expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+          expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
+          expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost))
+          expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Solidarités))
+        end
+      end
+
+      context "when the organisation uses the rdv_aide_numerique verticale" do
+        let(:organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)

--- a/spec/requests/api/v1/public_links_request_spec.rb
+++ b/spec/requests/api/v1/public_links_request_spec.rb
@@ -16,13 +16,13 @@ describe "Public links API", swagger_doc: "v1/api.json" do
 
       response 200, "Retourne les liens publics de recherche" do
         let!(:terr) { create(:territory, departement_number: "CN") }
-        let!(:organisation_a) { create(:organisation, new_domain_beta: true, external_id: "ext_id_A", territory: terr) }
-        let!(:organisation_b) { create(:organisation, new_domain_beta: true, external_id: "ext_id_B", territory: terr) }
-        let!(:organisation_c) { create(:organisation, new_domain_beta: true, external_id: "ext_id_C", territory: terr) }
-        let!(:organisation_d) { create(:organisation, new_domain_beta: true, external_id: "ext_id_D", territory: terr) }
-        let!(:organisation_e) { create(:organisation, new_domain_beta: true, external_id: "ext_id_E", territory: terr) }
-        let!(:organisation_f) { create(:organisation, new_domain_beta: true, external_id: "ext_id_F", territory: create(:territory)) }
-        let!(:organisation_g) { create(:organisation, new_domain_beta: true, external_id: nil,        territory: terr) }
+        let!(:organisation_a) { create(:organisation, verticale: :rdv_aide_numerique, external_id: "ext_id_A", territory: terr) }
+        let!(:organisation_b) { create(:organisation, verticale: :rdv_aide_numerique, external_id: "ext_id_B", territory: terr) }
+        let!(:organisation_c) { create(:organisation, verticale: :rdv_aide_numerique, external_id: "ext_id_C", territory: terr) }
+        let!(:organisation_d) { create(:organisation, verticale: :rdv_aide_numerique, external_id: "ext_id_D", territory: terr) }
+        let!(:organisation_e) { create(:organisation, verticale: :rdv_aide_numerique, external_id: "ext_id_E", territory: terr) }
+        let!(:organisation_f) { create(:organisation, verticale: :rdv_aide_numerique, external_id: "ext_id_F", territory: create(:territory)) }
+        let!(:organisation_g) { create(:organisation, verticale: :rdv_aide_numerique, external_id: nil,        territory: terr) }
 
         let(:territory) { terr.departement_number }
 


### PR DESCRIPTION
Closes #3495 

Plutôt que d'ajouter un nouvel attribut au model `Organisation` pour le flag des organisations de rdv-insertion, il a été décidé de modifier l'attribut existant `new_domain_beta`  qui permettait de distinguer (boolean) les organisations rdv_aide_numerique des organisations rdv_solidarites.
Le nouvel attribut se nomme `verticale` pour correspondre à notre vocabulaire métier. 
C'est un enum qui peut prendre plusieurs valeurs : `rdv_solidarites` (par défaut), `rdv_aide_numerique` et enfin `rdv_insertion`.
Pour le moment seul les 2 premiers ont un impact au niveau du domaine, de l'expéditeur des mails... (mais ca pourrait être le cas dans le futur pour rdv_insertion également)
La 3eme valeur `rdv_insertion` va permettre d'afficher quelques éléments d'UX spécifiques à rdv-insertion, en remplacement de la présence des catégories de motifs. (PR en suivant)
 