### PR TITLE
Correctif pour la suppression d'agents

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -127,7 +127,9 @@ class Agent < ApplicationRecord
   end
 
   def soft_delete
-    raise SoftDeleteError, "agent still has attached resources" if roles.reject(&:destroyed?).any? || plage_ouvertures.reject(&:destroyed?).any? || absences.reject(&:destroyed?).any?
+    still_has_attached_resources = roles.any? { |r| !r.destroyed? } || plage_ouvertures.any? { |r| !r.destroyed? } || absences.any? { |r| !r.destroyed? }
+
+    raise SoftDeleteError, "agent still has attached resources" if still_has_attached_resources
 
     sector_attributions.destroy_all
     update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email, uid: deleted_email)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -127,7 +127,7 @@ class Agent < ApplicationRecord
   end
 
   def soft_delete
-    raise SoftDeleteError, "agent still has attached resources" if organisations.any? || plage_ouvertures.any? || absences.any?
+    raise SoftDeleteError, "agent still has attached resources" if roles.reject(&:destroyed?).any? || plage_ouvertures.reject(&:destroyed?).any? || absences.reject(&:destroyed?).any?
 
     sector_attributions.destroy_all
     update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email, uid: deleted_email)

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -127,7 +127,7 @@ class Agent < ApplicationRecord
   end
 
   def soft_delete
-    still_has_attached_resources = roles.any? { |r| !r.destroyed? } || plage_ouvertures.any? { |r| !r.destroyed? } || absences.any? { |r| !r.destroyed? }
+    still_has_attached_resources = organisations.any? || plage_ouvertures.any? { |r| !r.destroyed? } || absences.any? { |r| !r.destroyed? }
 
     raise SoftDeleteError, "agent still has attached resources" if still_has_attached_resources
 

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -10,13 +10,13 @@ describe AgentRemoval, type: :service do
     let!(:absences) { create_list(:absence, 2, agent: agent) }
 
     it "succeeds destroy absences and plages ouvertures, and soft delete" do
-      expect(agent).to receive(:soft_delete)
       result = described_class.new(agent, organisation).remove!
       expect(result).to eq true
       agent.reload
       expect(agent.organisations).to be_empty
       expect(agent.absences).to be_empty
       expect(agent.plage_ouvertures).to be_empty
+      expect(agent.deleted_at).not_to be_nil
     end
   end
 


### PR DESCRIPTION
On avait des objets AR qui étaient encore présent en mémoire, alors qu'ils sont supprimés en DB. Il suffisait d'enlever le stub pour voir le bug 😢 


Closes #3501


