### PR TITLE
Permet le transfert des mails aux agents pour les rdv soft deleted

### DIFF
--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -42,7 +42,7 @@ class TransferEmailReplyJob < ApplicationJob
   end
 
   def rdv
-    Rdv.find_by(uuid: uuid) if uuid
+    Rdv.unscoped.find_by(uuid: uuid) if uuid
   end
 
   def user

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe TransferEmailReplyJob do
     end
   end
 
+  context "when the rdv has been soft deleted" do
+    before { rdv.soft_delete }
+
+    it "sends a notification email to the agent, containing the user reply" do
+      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      transferred_email = ActionMailer::Base.deliveries.last
+      expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
+      expect(transferred_email[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+      expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
+      expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
+      expect(transferred_email.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))
+    end
+  end
+
   context "when an e-mail address does not match our pattern" do
     let(:sendinblue_payload) do
       sendinblue_valid_payload.tap { |hash| hash[:Headers][:To] = "nimportequoi@reply.rdv-solidarites.fr" }


### PR DESCRIPTION
Ce ticket zammad aurait pu être évité si on avait réussi à transférer le mail à l'agent : https://zammad10.ethibox.fr/#ticket/zoom/5376

Il n'a pas pu être transféré correctement, puisque le rendez-vous était soft deleted

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3505

