### PR TITLE
Renommer l'association `User#agents` en `User#referents`

### DIFF
--- a/app/controllers/admin/referent_assignations_controller.rb
+++ b/app/controllers/admin/referent_assignations_controller.rb
@@ -4,7 +4,7 @@ class Admin::ReferentAssignationsController < AgentAuthController
   def index
     @user = policy_scope(User).find(index_params[:user_id])
     authorize(@user, :update?)
-    @referents = policy_scope(@user.agents).distinct.order(:last_name)
+    @referents = policy_scope(@user.referents).distinct.order(:last_name)
     @agents = policy_scope(Agent).merge(current_organisation.agents)
     @agents = @agents.search_by_text(index_params[:search]) if index_params[:search].present?
     @agents = @agents.page(params[:page])
@@ -12,13 +12,13 @@ class Admin::ReferentAssignationsController < AgentAuthController
 
   def create
     find_agent_and_user_save_and_redirect_with(params) do |user, agent|
-      user.agents << agent
+      user.referents << agent
     end
   end
 
   def destroy
     find_agent_and_user_save_and_redirect_with(params) do |user, agent|
-      user.agents.delete(agent)
+      user.referents.delete(agent)
     end
   end
 

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -95,7 +95,7 @@ class Agent < ApplicationRecord
     motif.for_secretariat ? joins(:service).where(service: motif.service).or(secretariat) : where(service: motif.service)
   }
   scope :available_referents_for, lambda { |user|
-    where.not(id: [user.agents.map(&:id)])
+    where.not(id: [user.referents.map(&:id)])
   }
   scope :in_orgs, lambda { |organisations|
     joins(:roles).where(agent_roles: { organisations: organisations })

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   # we specify dependent: :destroy because by default user_profiles and referent_assignations
   # will be deleted (dependent: :delete) and we need to destroy to trigger the callbacks on both models
   has_many :organisations, through: :user_profiles, dependent: :destroy
-  has_many :agents, through: :referent_assignations, dependent: :destroy
+  has_many :referents, through: :referent_assignations, dependent: :destroy, class_name: "Agent"
   has_many :webhook_endpoints, through: :organisations
   has_many :rdvs, through: :rdvs_users
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,7 @@ class User < ApplicationRecord
   # we specify dependent: :destroy because by default user_profiles and referent_assignations
   # will be deleted (dependent: :delete) and we need to destroy to trigger the callbacks on both models
   has_many :organisations, through: :user_profiles, dependent: :destroy
-  has_many :referents, through: :referent_assignations, dependent: :destroy, class_name: "Agent"
+  has_many :referents, through: :referent_assignations, source: :agent, dependent: :destroy, class_name: "Agent"
   has_many :webhook_endpoints, through: :organisations
   has_many :rdvs, through: :rdvs_users
 

--- a/app/services/concerns/users/creneaux_search_concern.rb
+++ b/app/services/concerns/users/creneaux_search_concern.rb
@@ -34,7 +34,7 @@ module Users::CreneauxSearchConcern
   end
 
   def retrieve_attributed_agents
-    return @user.agents if motif.follow_up?
+    return @user.referents if motif.follow_up?
     return geo_attributed_agents if @geo_search.present? && motif.sectorisation_level_agent?
 
     []

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -56,8 +56,8 @@ class MergeUsersService < BaseService
 
   def merge_file_attentes
     @user_to_merge.file_attentes
-                  .joins(:rdv).where(rdvs: { organisation: @organisation })
-                  .each do |file_attente_to_merge|
+      .joins(:rdv).where(rdvs: { organisation: @organisation })
+      .each do |file_attente_to_merge|
       file_attente_target = @user_target.file_attentes.find_by(rdv: file_attente_to_merge.rdv)
       if file_attente_target
         file_attente_to_merge.destroy

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -74,6 +74,6 @@ class MergeUsersService < BaseService
       @user_target.referents.to_a +
         @user_to_merge.referents.merge(@organisation.agents).to_a
     ).uniq
-    @user_target.update!(agents: agents)
+    @user_target.update!(referents: agents)
   end
 end

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -14,7 +14,7 @@ class MergeUsersService < BaseService
       merge_rdvs
       merge_relatives
       merge_file_attentes
-      merge_agents
+      merge_referents
       @user_to_merge.reload.soft_delete(@organisation) # ! reload refreshes associations to delete
     end
   end
@@ -56,23 +56,23 @@ class MergeUsersService < BaseService
 
   def merge_file_attentes
     @user_to_merge.file_attentes
-      .joins(:rdv).where(rdvs: { organisation: @organisation })
-      .each do |file_attente_to_merge|
-        file_attente_target = @user_target.file_attentes.find_by(rdv: file_attente_to_merge.rdv)
-        if file_attente_target
-          file_attente_to_merge.destroy
-        else
-          file_attente_to_merge.update!(user: @user_target)
-        end
+                  .joins(:rdv).where(rdvs: { organisation: @organisation })
+                  .each do |file_attente_to_merge|
+      file_attente_target = @user_target.file_attentes.find_by(rdv: file_attente_to_merge.rdv)
+      if file_attente_target
+        file_attente_to_merge.destroy
+      else
+        file_attente_to_merge.update!(user: @user_target)
       end
+    end
   end
 
-  def merge_agents
-    return unless @user_to_merge.agents.merge(@organisation.agents).any?
+  def merge_referents
+    return unless @user_to_merge.referents.merge(@organisation.agents).any?
 
     agents = (
-      @user_target.agents.to_a +
-      @user_to_merge.agents.merge(@organisation.agents).to_a
+      @user_target.referents.to_a +
+        @user_to_merge.referents.merge(@organisation.agents).to_a
     ).uniq
     @user_target.update!(agents: agents)
   end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -233,7 +233,7 @@ class SearchContext
   def retrieve_referents
     return [] if @referent_ids.blank? || @current_user.nil?
 
-    @current_user.agents.where(id: @referent_ids)
+    @current_user.referents.where(id: @referent_ids)
   end
 
   def matching_motifs

--- a/app/views/admin/merge_users/_user_agents.html.slim
+++ b/app/views/admin/merge_users/_user_agents.html.slim
@@ -1,5 +1,5 @@
-- agents = user&.agents&.merge(current_organisation.agents)
-- if agents.present?
-  = agents.map(&:full_name).to_sentence
+- referents = user&.referents&.merge(current_organisation.agents)
+- if referents.present?
+  = referents.map(&:full_name).to_sentence
 - else
   i.text-muted Aucun agent responsable

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -83,10 +83,10 @@
         .card-header Agents référents du responsable
         .card-body
           ul.list-unstyled.mb-2
-            - @user.responsible.agents.includes([:service]).each do |agent|
+            - @user.responsible.referents.includes([:service]).each do |agent|
               li.mb-2
               | #{agent.full_name_and_service}
-            - if @user.responsible.agents.empty?
+            - if @user.responsible.referents.empty?
               li.mb-2
                 .font-italic Aucun référent
 

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -35,8 +35,8 @@
             .text-center.mt-2
   .col-md-6
     h1.text-dark.mb-3 Vos référents
-    - if current_user.agents.any?
-      - current_user.agents.each do |agent|
+    - if current_user.referents.any?
+      - current_user.referents.each do |agent|
         .card
           .card-body
             = agent.full_name_and_service

--- a/spec/controllers/admin/referent_assignations_controller_spec.rb
+++ b/spec/controllers/admin/referent_assignations_controller_spec.rb
@@ -46,7 +46,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
 
       post :create, params: { organisation_id: organisation.id, user_id: user.id, agent_id: new_referent.id }
 
-      expect(user.reload.agents).to include(new_referent)
+      expect(user.reload.referents).to include(new_referent)
       expect(response).to redirect_to(admin_organisation_user_referent_assignations_path(organisation, user))
     end
 
@@ -81,7 +81,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
 
       post :destroy, params: { organisation_id: organisation.id, user_id: user.id, id: referent.id }
 
-      expect(user.reload.agents).not_to include(referent)
+      expect(user.reload.referents).not_to include(referent)
       expect(response).to redirect_to(admin_organisation_user_referent_assignations_path(organisation, user))
     end
 

--- a/spec/controllers/admin/referent_assignations_controller_spec.rb
+++ b/spec/controllers/admin/referent_assignations_controller_spec.rb
@@ -4,7 +4,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
   describe "#index" do
     it "assigns available agents and respond success" do
       organisation = create(:organisation)
-      user = create(:user, agents: [], organisations: [organisation])
+      user = create(:user, referents: [], organisations: [organisation])
       service = create(:service)
       agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       lea = create(:agent, basic_role_in_organisations: [organisation], service: service)
@@ -20,7 +20,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
 
     it "assigns matching search agent" do
       organisation = create(:organisation)
-      user = create(:user, agents: [], organisations: [organisation])
+      user = create(:user, referents: [], organisations: [organisation])
       service = create(:service)
       connected_agent = create(:agent, basic_role_in_organisations: [organisation], service: service, first_name: "Marc", last_name: "Dubois")
       agent = create(:agent, basic_role_in_organisations: [organisation], service: service, first_name: "Martine", last_name: "Durant")
@@ -38,7 +38,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
   describe "#create" do
     it "add given agent to referents and redirect to user show" do
       organisation = create(:organisation)
-      user = create(:user, agents: [], organisations: [organisation])
+      user = create(:user, referents: [], organisations: [organisation])
       service = create(:service)
       agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       new_referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
@@ -52,7 +52,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
 
     it "return errors and redirect to index" do
       organisation = create(:organisation)
-      user = create(:user, agents: [], organisations: [organisation])
+      user = create(:user, referents: [], organisations: [organisation])
       service = create(:service)
       agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       new_referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
@@ -75,7 +75,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
       service = create(:service)
       referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      user = create(:user, agents: [referent], organisations: [organisation])
+      user = create(:user, referents: [referent], organisations: [organisation])
 
       sign_in agent
 
@@ -90,7 +90,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
       service = create(:service)
       referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      user = create(:user, agents: [referent], organisations: [organisation])
+      user = create(:user, referents: [referent], organisations: [organisation])
 
       sign_in agent
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe Admin::UsersController, type: :controller do
     end
 
     it "assigns user where I am referent" do
-      user_with_referent = create(:user, agents: [agent], organisations: [organisation])
-      create(:user, agents: [], organisations: [organisation])
+      user_with_referent = create(:user, referents: [agent], organisations: [organisation])
+      create(:user, referents: [], organisations: [organisation])
       get :index, params: { organisation_id: organisation.id, agent_id: agent.id }
       expect(assigns(:users)).to eq([user_with_referent])
     end

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -57,7 +57,7 @@ describe "agents page", js: true do
   it "admin organisation user path is accessible" do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
-    user = create(:user, email: "testuser@test.net", agents: [], organisations: [organisation])
+    user = create(:user, email: "testuser@test.net", referents: [], organisations: [organisation])
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
     login_as agent
 

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -136,8 +136,8 @@ describe "Agent can create a Rdv with wizard" do
 
       before do
         # Creating a duplicate RDV with same attributes but different user / agent
-        create(:rdv, organisation: organisation, users: [create(:user)], agents: [create(:agent)], motif: motif,
-                     lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
+        create(:rdv, organisation: organisation, users: [create(:user)], referents: [create(:agent)], motif: motif,
+               lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
       end
 
       # There was a bug that caused the Rdv payload's "users" to

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -137,7 +137,7 @@ describe "Agent can create a Rdv with wizard" do
       before do
         # Creating a duplicate RDV with same attributes but different user / agent
         create(:rdv, organisation: organisation, users: [create(:user)], referents: [create(:agent)], motif: motif,
-               lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
+                     lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
       end
 
       # There was a bug that caused the Rdv payload's "users" to

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -137,7 +137,7 @@ describe "Agent can create a Rdv with wizard" do
       before do
         # Creating a duplicate RDV with same attributes but different user / agent
         create(:rdv, organisation: organisation, users: [create(:user)], agents: [create(:agent)], motif: motif,
-               lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
+                     lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
       end
 
       # There was a bug that caused the Rdv payload's "users" to

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -136,8 +136,8 @@ describe "Agent can create a Rdv with wizard" do
 
       before do
         # Creating a duplicate RDV with same attributes but different user / agent
-        create(:rdv, organisation: organisation, users: [create(:user)], referents: [create(:agent)], motif: motif,
-                     lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
+        create(:rdv, organisation: organisation, users: [create(:user)], agents: [create(:agent)], motif: motif,
+               lieu: lieu, starts_at: Time.zone.parse("2019-10-11 14:15:00"), duration_in_min: 35, skip_webhooks: true)
       end
 
       # There was a bug that caused the Rdv payload's "users" to

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -104,7 +104,7 @@ describe "User can search for rdvs" do
   end
 
   describe "follow up rdvs" do
-    let!(:user) { create(:user, agents: [agent]) }
+    let!(:user) { create(:user, referents: [agent]) }
     let!(:agent) { create(:agent) }
     let!(:agent2) { create(:agent) }
     let!(:organisation) { create(:organisation, territory: create(:territory, departement_number: "92")) }
@@ -228,7 +228,7 @@ describe "User can search for rdvs" do
     end
 
     context "when the agent has no PO" do
-      let!(:user) { create(:user, agents: [agent3]) }
+      let!(:user) { create(:user, referents: [agent3]) }
       let!(:agent3) { create(:agent) }
 
       it "shows an error message" do

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -51,14 +51,14 @@ describe Agent, type: :model do
 
   describe "#available_referents_for" do
     it "returns empty array without agents" do
-      user = build(:user, agents: [])
+      user = build(:user, referents: [])
       expect(described_class.available_referents_for(user)).to eq([])
     end
 
     it "returns agent that not already referents array without agents" do
       agent = create(:agent)
       already_referent = create(:agent)
-      user = create(:user, agents: [already_referent])
+      user = create(:user, referents: [already_referent])
       expect(described_class.available_referents_for(user)).to eq([agent])
     end
   end

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Search", type: :request do
     context "with connected user" do
       let(:organisation) { create(:organisation) }
       let(:agent) { create(:agent, organisations: [organisation]) }
-      let(:user) { create(:user, organisations: [organisation], agents: [agent]) }
+      let(:user) { create(:user, organisations: [organisation], referents: [agent]) }
 
       before do
         login_as(user)

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -139,7 +139,7 @@ describe MergeUsersService, type: :service do
 
     it "appends agents" do
       subject
-      expect(user_target.agents).to contain_exactly(agent1, agent2)
+      expect(user_target.referents).to contain_exactly(agent1, agent2)
     end
   end
 
@@ -151,7 +151,7 @@ describe MergeUsersService, type: :service do
 
     it "does not do anything" do
       subject
-      expect(user_target.agents).to contain_exactly(agent1, agent2)
+      expect(user_target.referents).to contain_exactly(agent1, agent2)
     end
   end
 
@@ -162,7 +162,7 @@ describe MergeUsersService, type: :service do
 
     it "sets agent" do
       subject
-      expect(user_target.agents).to contain_exactly(agent)
+      expect(user_target.referents).to contain_exactly(agent)
     end
   end
 
@@ -173,7 +173,7 @@ describe MergeUsersService, type: :service do
 
     it "does not do anything" do
       subject
-      expect(user_target.agents).to contain_exactly(agent)
+      expect(user_target.referents).to contain_exactly(agent)
     end
   end
 
@@ -186,8 +186,8 @@ describe MergeUsersService, type: :service do
 
     it "does not move the agent from the other orga anything" do
       subject
-      expect(user_target.reload.agents).to contain_exactly(agent1)
-      expect(user_to_merge.reload.agents).to contain_exactly(agent2)
+      expect(user_target.reload.referents).to contain_exactly(agent1)
+      expect(user_to_merge.reload.referents).to contain_exactly(agent2)
     end
   end
 

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -133,9 +133,9 @@ describe MergeUsersService, type: :service do
 
   context "with different agents from same orga attached" do
     let!(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:user_target) { create(:user, agents: [agent1], organisations: [organisation]) }
+    let(:user_target) { create(:user, referents: [agent1], organisations: [organisation]) }
     let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:user_to_merge) { create(:user, agents: [agent2], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, referents: [agent2], organisations: [organisation]) }
 
     it "appends agents" do
       subject
@@ -146,8 +146,8 @@ describe MergeUsersService, type: :service do
   context "with same agents" do
     let!(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:user_target) { create(:user, agents: [agent1, agent2], organisations: [organisation]) }
-    let(:user_to_merge) { create(:user, agents: [agent1, agent2], organisations: [organisation]) }
+    let(:user_target) { create(:user, referents: [agent1, agent2], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, referents: [agent1, agent2], organisations: [organisation]) }
 
     it "does not do anything" do
       subject
@@ -157,8 +157,8 @@ describe MergeUsersService, type: :service do
 
   context "target user doesn't have any agents yet" do
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:user_target) { create(:user, agents: [], organisations: [organisation]) }
-    let(:user_to_merge) { create(:user, agents: [agent], organisations: [organisation]) }
+    let(:user_target) { create(:user, referents: [], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, referents: [agent], organisations: [organisation]) }
 
     it "sets agent" do
       subject
@@ -168,8 +168,8 @@ describe MergeUsersService, type: :service do
 
   context "merged user doesn't have any agents yet" do
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:user_target) { create(:user, agents: [agent], organisations: [organisation]) }
-    let(:user_to_merge) { create(:user, agents: [], organisations: [organisation]) }
+    let(:user_target) { create(:user, referents: [agent], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, referents: [], organisations: [organisation]) }
 
     it "does not do anything" do
       subject
@@ -181,8 +181,8 @@ describe MergeUsersService, type: :service do
     let!(:organisation2) { create(:organisation) }
     let!(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
     let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation2]) }
-    let(:user_target) { create(:user, agents: [agent1], organisations: [organisation]) }
-    let(:user_to_merge) { create(:user, agents: [agent2], organisations: [organisation, organisation2]) }
+    let(:user_target) { create(:user, referents: [agent1], organisations: [organisation]) }
+    let(:user_to_merge) { create(:user, referents: [agent2], organisations: [organisation, organisation2]) }
 
     it "does not move the agent from the other orga anything" do
       subject

--- a/spec/services/users/creneaux_search_spec.rb
+++ b/spec/services/users/creneaux_search_spec.rb
@@ -20,14 +20,14 @@ describe Users::CreneauxSearch, type: :service do
   it "call with referent as filter when follow_up motif" do
     motif = create(:motif, follow_up: true, organisation: organisation)
     agent = create(:agent, basic_role_in_organisations: [organisation])
-    user = create(:user, organisations: [organisation], agents: [agent])
+    user = create(:user, organisations: [organisation], referents: [agent])
     expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [agent])
     described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
   end
 
   it "call without referents when user without referents" do
     motif = create(:motif, follow_up: true, organisation: organisation)
-    user = create(:user, agents: [])
+    user = create(:user, referents: [])
     expect(SlotBuilder).to receive(:available_slots).with(motif, lieu, date_range, [])
     described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
   end
@@ -110,7 +110,7 @@ describe Users::CreneauxSearch, type: :service do
       subject { described_class.new(user: user, motif: motif, lieu: lieu) }
 
       let!(:agent) { create(:agent) }
-      let!(:user) { create(:user, agents: [agent]) }
+      let!(:user) { create(:user, referents: [agent]) }
       let!(:motif) { create(:motif, collectif: true, organisation: organisation, follow_up: true) }
       let!(:rdv) { create(:rdv, :future, motif: motif, lieu: lieu, agents: [agent]) }
       let!(:rdv2) { create(:rdv, :future, motif: motif, lieu: lieu, agents: [build(:agent)]) }

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -54,7 +54,7 @@ describe Users::RdvSms, type: :service do
     context "with a follow_up rdv" do
       it "contains referent name" do
         agent = create(:agent, first_name: "James", last_name: "Bond")
-        user = create(:user, agents: [agent])
+        user = create(:user, referents: [agent])
         motif = create(:motif, follow_up: true)
         rdv = create(:rdv, motif: motif, users: [user], agents: [agent])
         token = "12345"


### PR DESCRIPTION
Lors de mon travail sur #3429, j'ai remarqué que le nommage de l'association `User#agents` pouvait être amélioré. Le terme `User#referents` permet de mieux coller au vocabulaire métier, et ça rend le code plus compréhensible.

Je vous laisse constater l'effet de clarification, je trouve par exemple que l'usage fait dans la méthode `retrieve_attributed_agents` devient plus clair car les deux concepts manipulés ("référent d'un usager" et "agent attribué par sectorisation") ont maintenant un nom différent.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
