### PR TITLE
[#3525] Crash de la fusion usager lorsque l'usager source a pour responsable l'usager cible

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,8 @@ class User < ApplicationRecord
   # HACK : add sign_in_count and current_sign_in_at to accessor to bypass recording IPs from Trackable Devise's module
   attr_accessor :current_sign_in_ip, :last_sign_in_ip, :sign_in_count, :current_sign_in_at
 
+  alias_attribute :soft_deleted?, :deleted_at?
+
   # Relations
   has_many :user_profiles, dependent: :restrict_with_error
   has_many :rdvs_users, dependent: :destroy

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -26,6 +26,10 @@ class MergeUsersService < BaseService
       @user_target.send("#{attribute}=", @user_to_merge.send(attribute))
     end
 
+    # On évite ici que l'usager cible soit responsable de lui-même.
+    # On arrive dans ce cas lorsque l'usager source a pour responsable l'usager cible.
+    @user_target.responsible = nil if @user_target.responsible == @user_target
+
     # Si le user_target s'est déjà connecté avec FranceConnect,
     # les attributs ne sont pas écrasés lors de la fusion
     if @user_to_merge.logged_once_with_franceconnect?

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -248,4 +248,29 @@ describe MergeUsersService, type: :service do
       end.to change { prescripteur.reload.user }.from(user2).to(user1)
     end
   end
+
+  context "when target user is responsible for user to merge" do
+    context "when target user has no responsible of her own" do
+      let!(:user_target) { create(:user) }
+      let!(:user_to_merge) { create(:user, responsible: user_target) }
+
+      it "leaves no responsible in the resulting user" do
+        described_class.perform_with(user_target, user_to_merge, [:responsible_id], organisation)
+        expect(user_to_merge).to be_soft_deleted
+        expect(user_target.responsible).to be_nil
+      end
+    end
+
+    context "when target user has a responsible user of her own" do
+      let!(:responsible_of_target_user) { create(:user) }
+      let!(:user_target) { create(:user, responsible: responsible_of_target_user) }
+      let!(:user_to_merge) { create(:user, responsible: user_target) }
+
+      it "keeps the responsible" do
+        described_class.perform_with(user_target, user_to_merge, [], organisation)
+        expect(user_to_merge).to be_soft_deleted
+        expect(user_target.responsible).to eq(responsible_of_target_user)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #3525

Toutes les infos sont dans l'issue.

Les tests sont un peu dur à comprendre, je suis preneur de suggestions pour clarifier ça ! :zany_face: 

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
