### PR TITLE
Ajouter instruction_for_rdv au motif_blueprint

### DIFF
--- a/app/blueprints/motif_blueprint.rb
+++ b/app/blueprints/motif_blueprint.rb
@@ -3,6 +3,6 @@
 class MotifBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up
+  fields :name, :location_type, :deleted_at, :bookable_publicly, :service_id, :organisation_id, :collectif, :follow_up, :instruction_for_rdv
   association :motif_category, blueprint: MotifCategoryBlueprint
 end


### PR DESCRIPTION
Côté rdv-insertion, nous souhaitons désormais récupérer le champ `instruction_for_rdv` des motifs rdv-solidarités afin de les afficher sur les sms/mails/courriers de convocation que nous générons ([PR #995 côté rdv-i](https://github.com/betagouv/rdv-insertion/pull/995)) . En effet, lorsqu'un message de convocation est généré, le bénéficiaire RSA n'a pas pu voir cette instruction au moment de la prise de RDV, il faut donc lui afficher ailleurs.