### PR TITLE
[#3534] Utiliser des adresses e-mail de support différentes selon le domaine

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,9 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
   include DomainDetection
+
   protect_from_forgery
+
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?
   before_action :set_sentry_context

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
+  include DomainDetection
   protect_from_forgery
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_user_location!, if: :storable_location?
@@ -26,11 +27,6 @@ class ApplicationController < ActionController::Base
   end
 
   protected
-
-  def current_domain
-    @current_domain ||= Domain.find_matching(URI.parse(request.url).host)
-  end
-  helper_method :current_domain
 
   def set_sentry_context
     Sentry.set_user(sentry_user)

--- a/app/controllers/concerns/domain_detection.rb
+++ b/app/controllers/concerns/domain_detection.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DomainDetection
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_domain
+  end
+
+  def current_domain
+    @current_domain ||= Domain.find_matching(URI.parse(request.url).host)
+  end
+end

--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -10,7 +10,7 @@ class InclusionConnectController < ApplicationController
 
   def callback
     if params[:state] != session[:ic_state]
-      flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse <support@rdv-solidarites.fr> si le problème persiste."
+      flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse <#{current_domain.support_email}> si le problème persiste."
       redirect_to new_agent_session_path and return
     end
 
@@ -21,7 +21,7 @@ class InclusionConnectController < ApplicationController
       session[:connected_with_inclusionconnect] = true
       redirect_to root_path
     else
-      flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse <support@rdv-solidarites.fr> si le problème persiste."
+      flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse #{current_domain.support_email} si le problème persiste."
       Sentry.capture_message("Failed to authentify agent with inclusionConnect")
       redirect_to new_agent_session_path
     end

--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -21,7 +21,7 @@ class InclusionConnectController < ApplicationController
       session[:connected_with_inclusionconnect] = true
       redirect_to root_path
     else
-      flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse #{current_domain.support_email} si le problème persiste."
+      flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse <#{current_domain.support_email}> si le problème persiste."
       Sentry.capture_message("Failed to authentify agent with inclusionConnect")
       redirect_to new_agent_session_path
     end

--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -8,6 +8,8 @@
 # you're free to overwrite the RESTful controller actions.
 module SuperAdmins
   class ApplicationController < Administrate::ApplicationController
+    include DomainDetection
+
     helper all_helpers_from_path "app/helpers"
 
     if ENV["ADMIN_BASIC_AUTH_PASSWORD"].present?

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -235,7 +235,7 @@ class CalendarRdvSolidarites {
   }
 
   handleAjaxError = () => {
-    alert("Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-solidarites.fr.");
+    alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à ${ENV.SUPPORT_EMAIL}.`);
   }
 }
 

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -235,7 +235,7 @@ class CalendarRdvSolidarites {
   }
 
   handleAjaxError = () => {
-    alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à ${ENV.SUPPORT_EMAIL}.`);
+    alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à ${ENV.CURRENT_DOMAIN_SUPPORT_EMAIL}.`);
   }
 }
 

--- a/app/mailers/admins/organisation_mailer.rb
+++ b/app/mailers/admins/organisation_mailer.rb
@@ -4,7 +4,7 @@ class Admins::OrganisationMailer < ApplicationMailer
   def organisation_created(agent, organisation)
     @agent = agent
     @organisation = organisation
-    mail(to: SUPPORT_EMAIL, subject: "Nouvelle organisation créée - #{@organisation.departement_number} - #{@organisation.name}")
+    mail(to: domain.support_email, subject: "Nouvelle organisation créée - #{@organisation.departement_number} - #{@organisation.name}")
   end
 
   def domain

--- a/app/mailers/agents/reply_transfer_mailer.rb
+++ b/app/mailers/agents/reply_transfer_mailer.rb
@@ -27,7 +27,7 @@ class Agents::ReplyTransferMailer < ApplicationMailer
     @reply_body = reply_body
     @attachment_names = source_mail.attachments.map(&:filename).join(", ")
 
-    mail(to: SUPPORT_EMAIL, subject: t(".title"))
+    mail(to: domain.support_email, subject: t(".title"))
   end
 
   private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,4 +9,11 @@ class ApplicationMailer < ActionMailer::Base
   append_view_path Rails.root.join("app/views/mailers")
 
   self.delivery_job = CustomMailerDeliveryJob
+
+  # Cet email est utilisé comme adresse de "Reply-To" pour les e-mails
+  # qui contiennent des ICS. Lorsque l'événement ICS est acceptée par le
+  # client mail / calendrier, ce client mail envoie un accusé de réception
+  # à cette adresse (ex: "Accepted: RDV Consultation médicale ").
+  # Puisque c'est une adresse technique, c'est OK qu'elle soit en rdv-solidarites.fr.
+  SECRETARIAT_EMAIL = "secretariat-auto@rdv-solidarites.fr"
 end

--- a/app/mailers/concerns/common_mailer.rb
+++ b/app/mailers/concerns/common_mailer.rb
@@ -25,6 +25,6 @@ module CommonMailer
   end
 
   def default_from
-    SUPPORT_EMAIL
+    domain.support_email
   end
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -28,7 +28,7 @@ class CustomDeviseMailer < Devise::Mailer
   def reply_to(record)
     return unless record.is_a? Agent
 
-    record.invited_by&.email || SUPPORT_EMAIL
+    record.invited_by&.email || default_from
   end
 
   def domain

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -7,12 +7,12 @@ class CustomDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application
-  default template_path: "devise/mailer"
+  default template_path: "devise/mailer",
+          reply_to: proc { inviter_or_default }
 
   def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}
-    opts[:reply_to] = reply_to(record)
     if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
       opts[:subject] = "📧 Invitation sur RDV Aide Numérique"
       opts[:cc] = record.cnfs_secondary_email if record.cnfs_secondary_email.present?
@@ -25,10 +25,10 @@ class CustomDeviseMailer < Devise::Mailer
 
   private
 
-  def reply_to(record)
-    return unless record.is_a? Agent
+  def inviter_or_default
+    return unless resource.is_a? Agent
 
-    record.invited_by&.email || default_from
+    resource.invited_by&.email || default_from
   end
 
   def domain

--- a/app/models/concerns/ical_helpers/ics.rb
+++ b/app/models/concerns/ical_helpers/ics.rb
@@ -61,7 +61,7 @@ module IcalHelpers
       event.rrule = payload[:recurrence]
       event.sequence = payload[:sequence]
       event.description = payload[:description]
-      event.organizer = "mailto:#{SECRETARIAT_EMAIL}"
+      event.organizer = "mailto:#{ApplicationMailer::SECRETARIAT_EMAIL}"
     end
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -116,7 +116,6 @@ class Domain
   def default?
     self == RDV_SOLIDARITES
   end
-
   alias default default?
 
   ALL_BY_HOST_NAME = ALL.index_by(&:host_name)

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -15,6 +15,7 @@ Domain = Struct.new(
   :france_connect_enabled,
   :faq_url,
   :documentation_url,
+  :support_email,
   keyword_init: true
 )
 
@@ -34,7 +35,8 @@ class Domain
       sms_sender_name: "RdvSoli",
       documentation_url: "https://rdvs.notion.site/RDV-Solidarit-s-94176a1507814d19aeaaf6e678ffcbed",
       faq_url: "https://rdv-solidarites.notion.site/F-A-Q-M-dico-social-aaf94709c0ea448b8eb9d93f548acdb9",
-      france_connect_enabled: true
+      france_connect_enabled: true,
+      support_email: "support@rdv-solidarites.fr"
     ),
 
     RDV_AIDE_NUMERIQUE = new(
@@ -51,7 +53,8 @@ class Domain
       sms_sender_name: "RdvAideNum",
       documentation_url: "https://rdvs.notion.site/RDV-Aide-Num-rique-cd6f04a9d90a444a800d81f77428eaf4",
       faq_url: "https://rdvs.notion.site/FAQ-CNFS-c55933f66f054aaba60fe4799851000e",
-      france_connect_enabled: false
+      france_connect_enabled: false,
+      support_email: "support@rdv-aide-numerique.fr"
     ),
 
     RDV_MAIRIE = new(
@@ -68,7 +71,8 @@ class Domain
       sms_sender_name: "Rdvmairie",
       documentation_url: "https://rdvs.notion.site/RDV-Mairie-b831caa05dd7416bb489f06f7468903a",
       faq_url: "https://rdvs.notion.site/FAQ-RDV-Mairie-6baf4af187a14e42beafe56b7005d199",
-      france_connect_enabled: false
+      france_connect_enabled: false,
+      support_email: "support@rdv-mairie.fr"
     ),
   ].freeze
 
@@ -112,6 +116,7 @@ class Domain
   def default?
     self == RDV_SOLIDARITES
   end
+
   alias default default?
 
   ALL_BY_URL = ALL.index_by(&:dns_domain_name)

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -21,7 +21,7 @@
           span> Contacter l'équipe technique
           i.fa.fa-question-circle
       .card-body
-        = mail_to SUPPORT_EMAIL,
+        = mail_to current_domain.support_email,
           subject: "[Problème Agent]",
           body: t(".contact-email-body"), class: "btn btn-primary" do
           span>

--- a/app/views/common/_env.html.erb
+++ b/app/views/common/_env.html.erb
@@ -1,6 +1,7 @@
 <script>
   var ENV = {
     MATOMO_APP_ID: "<%= ENV["MATOMO_APP_ID"] %>",
+    SUPPORT_EMAIL: "<%= current_domain.support_email %>",
     ENV: "<%= Rails.env %>",
   };
 </script>

--- a/app/views/common/_env.html.erb
+++ b/app/views/common/_env.html.erb
@@ -1,7 +1,7 @@
 <script>
   var ENV = {
     MATOMO_APP_ID: "<%= ENV["MATOMO_APP_ID"] %>",
-    SUPPORT_EMAIL: "<%= current_domain.support_email %>",
+    CURRENT_DOMAIN_SUPPORT_EMAIL: "<%= current_domain.support_email %>",
     ENV: "<%= Rails.env %>",
   };
 </script>

--- a/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
+++ b/app/views/devise/mailer/invitation_instructions_cnfs.html.erb
@@ -129,8 +129,9 @@
 
 <h2>Besoin d’un contact avec notre équipe ?</h2>
 
+<% support_email = Domain::RDV_AIDE_NUMERIQUE.support_email %>
 <p>
   Pour une demande d’amélioration, une question sur l’utilisation ou tout autre sujet,
   vous pouvez nous contacter à cette adresse mail&nbsp;:
-  <a href="mailto:contact@rdv-solidarités.fr">contact@rdv-solidarites.fr</a>
+  <a href="mailto:<%= support_email %>"><%= support_email %></a>
 </p>

--- a/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
+++ b/app/views/mailers/prescripteur_mailer/rdv_created.html.slim
@@ -5,7 +5,7 @@ div
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 
   = "Besoin de déplacer le rendez-vous ou de corriger un détail ? "
-  =< mail_to(SUPPORT_EMAIL, "Contactez-nous", target: "_blank")
+  =< mail_to(domain.support_email, "Contactez-nous", target: "_blank")
   br
   br
   = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -44,9 +44,9 @@ main.container
                   = instruction_for_rdv_to_html(rdv.motif)
             li.list-group-item
               = "Besoin de déplacer le rendez-vous ou de corriger un détail ? "
-              =< mail_to(SUPPORT_EMAIL, "Contactez-nous", target: "_blank")
+              =< mail_to(current_domain.support_email, "Contactez-nous", target: "_blank")
             li.list-group-item
               = "Vous pouvez aussi "
-              = mail_to(SUPPORT_EMAIL, "nous écrire",target: "_blank")
+              = mail_to(current_domain.support_email, "nous écrire",target: "_blank")
               = " pour nous donner votre avis sur la prise de rendez-vous."
           .mt-4.text-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)

--- a/app/views/search/_nothing_to_show.html.slim
+++ b/app/views/search/_nothing_to_show.html.slim
@@ -10,7 +10,7 @@
           = render "users/rdvs/prendre_rdv_button"
     - elsif context.invitation?
       .font-weight-bold Un problème semble s'être produit pour votre invitation. Toutes nos excuses pour cela.
-      = mail_to SUPPORT_EMAIL,
+      = mail_to current_domain.support_email,
         subject: "[Problème Invitation]",
         class: "btn btn-primary" do
         span>

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -15,7 +15,7 @@
   .row#tech-support
     .col-md-6
       h3.mt-4
-        = mail_to SUPPORT_EMAIL,
+        = mail_to current_domain.support_email,
           subject: "[Problème Usager]",
           body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "btn btn-primary" do
           span>

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -123,7 +123,7 @@
 
         p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
 
-        strong = mail_to "contact@rdv-solidarites.fr"
+        strong = mail_to current_domain.support_email
 
         p ou par voie postale :
 

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -100,7 +100,7 @@ section.bg-lightturquoise.py-5
         | .
       p.m-auto
         | Des questions ?
-        =< link_to("Contactez-nous", "mailto:#{SUPPORT_EMAIL}", target: "_blank")
+        =< link_to("Contactez-nous", "mailto:#{current_domain.support_email}", target: "_blank")
         | .
 
 section.bg-white.py-5

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,7 +1,3 @@
 # frozen_string_literal: true
 
-# L'adresse support@rdv-solidarites.fr est utilisée comme adresse de support
-# à la fois sur le domaine RDV Solidarité et le domaine RDV Aide Numérique.
-# En revanche on adapte le nom affiché pour que ce soit dans l'inbox du destinataire.
-SUPPORT_EMAIL = "support@rdv-solidarites.fr"
 SECRETARIAT_EMAIL = "secretariat-auto@rdv-solidarites.fr"

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-SECRETARIAT_EMAIL = "secretariat-auto@rdv-solidarites.fr"

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -43,6 +43,12 @@ describe InclusionConnectController, type: :controller do
       expect(flash[:error]).to eq("Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse <support@rdv-solidarites.fr> si le problème persiste.")
     end
 
+    it "uses the current domain's support email address in the error message" do
+      request.host = "www.rdv-mairie-test.localhost"
+      get :callback, params: { state: "zefjzelkf", session_state: "zfjzerklfjz", code: "klzefklzejlf" }
+      expect(flash[:error]).to include("support@rdv-mairie.fr")
+    end
+
     it "returns an error if token request error" do
       stub_const("InclusionConnect::IC_CLIENT_ID", "truc")
       stub_const("InclusionConnect::IC_CLIENT_SECRET", "truc secret")

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -28,8 +28,7 @@ describe "User resets his password spec" do
     context "when the most recent RDV is in an organisation with verticale rdv_aide_numerique" do
       let!(:user) { create(:user) }
       let(:organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
-      let(:motif_social) { create(:motif, service: create(:service, :social)) } # Le motif n'a pas d'importance
-      let!(:rdvs) { create_list(:rdv, 2, organisation: organisation, motif: motif_social, users: [user]) }
+      let!(:rdvs) { create_list(:rdv, 2, organisation: organisation, users: [user]) }
 
       it "uses the rdv-aide-numerique domain" do
         # Le domaine visité n'a pas d'importance. Voir la doc de User#domain.

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -31,13 +31,13 @@ describe "User resets his password spec" do
       let(:motif_numerique) { create(:motif, service: create(:service, :conseiller_numerique)) }
       let!(:rdvs) { create_list(:rdv, 2, organisation: organisation, motif: motif_numerique, users: [user]) }
 
-      it "uses the default domain" do
+      it "uses the rdv-aide-numerique domain" do
         # Le domaine visité n'a pas d'importance. Voir la doc de User#domain.
         visit new_user_password_url(host: Domain::RDV_SOLIDARITES.dns_domain_name)
         fill_in "user_email", with: user.email
         click_on "Envoyer"
         open_email(user.email)
-        expect(current_email.base.email[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-solidarites.fr>))
+        expect(current_email.base.email[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-aide-numerique.fr>))
         expect(current_email.html_part.body.to_s).to include('<a href="http://www.rdv-aide-numerique-test.localhost/users/password/edit?reset_password_token=')
       end
     end

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -23,13 +23,13 @@ describe "User resets his password spec" do
   end
 
   # Ce test constitue un test d'intégration du cas normal.
-  # Les tests unitaires des variations sont fait dans une spec de mailer.
+  # Les tests unitaires des variations sont fait dans une spec de CustomDeviseMailer.
   describe "using the user's domain" do
-    context "when the user only has RDVs for motif Conseiller Numérique" do
+    context "when the most recent RDV is in an organisation with verticale rdv_aide_numerique" do
       let!(:user) { create(:user) }
       let(:organisation) { create(:organisation, verticale: :rdv_aide_numerique) }
-      let(:motif_numerique) { create(:motif, service: create(:service, :conseiller_numerique)) }
-      let!(:rdvs) { create_list(:rdv, 2, organisation: organisation, motif: motif_numerique, users: [user]) }
+      let(:motif_social) { create(:motif, service: create(:service, :social)) } # Le motif n'a pas d'importance
+      let!(:rdvs) { create_list(:rdv, 2, organisation: organisation, motif: motif_social, users: [user]) }
 
       it "uses the rdv-aide-numerique domain" do
         # Le domaine visité n'a pas d'importance. Voir la doc de User#domain.

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -5,10 +5,7 @@ describe CustomDeviseMailer, "#domain" do
 
   def expect_to_use_domain(domain)
     expect(sent_email.body).to include(domain.dns_domain_name)
-    # L'adresse support@rdv-solidarites.fr est utilisée comme adresse de support
-    # à la fois sur le domaine RDV Solidarité et le domaine RDV Aide Numérique.
-    # En revanche on adapte le nom affiché pour que ce soit dans l'inbox du destinataire.
-    expect(sent_email[:from].unparsed_value).to match(%("#{domain.name}" <support@rdv-solidarites.fr>))
+    expect(sent_email[:from].unparsed_value).to match(%("#{domain.name}" <#{domain.support_email}>))
   end
 
   context "when user has no RDV" do

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -189,6 +189,18 @@ RSpec.describe Users::RdvMailer, type: :mailer do
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Aide Numérique))
         end
       end
+
+      context "when the organisation uses the rdv_mairie verticale" do
+        let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+
+        it "works" do
+          mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
+          expect(mail[:from].to_s).to eq(%(RDV Mairie <support@rdv-mairie.fr>))
+          expect(mail.html_part.body.to_s).to include(%(src="/logo_mairie.png))
+          expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-mairie-test.localhost))
+          expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Mairie))
+        end
+      end
     end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-solidarites.fr>))
+          expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-aide-numerique.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-aide-numerique-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Aide Numérique))

--- a/spec/models/concerns/ical_helpers/ics_spec.rb
+++ b/spec/models/concerns/ical_helpers/ics_spec.rb
@@ -32,6 +32,7 @@ describe IcalHelpers::Ics do
         expect(subject).to include("DESCRIPTION:Infos et annulation:")
         expect(subject).to include("LOCATION:10 rue de la Ferronerie 44100 Nantes")
         expect(subject).to include("RRULE:FREQ=WEEKLY")
+        expect(subject).to include("ORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr")
         expect(subject).to include("END:VEVENT")
       end
     end

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -50,7 +50,7 @@ describe AddConseillerNumerique do
       perform_enqueued_jobs
       invitation_email = ActionMailer::Base.deliveries.last
 
-      expect(invitation_email).to have_attributes(to: ["exemple@conseiller-numerique.fr"])
+      expect(invitation_email).to have_attributes(to: ["exemple@conseiller-numerique.fr"], reply_to: ["support@rdv-aide-numerique.fr"])
     end
   end
 


### PR DESCRIPTION
Closes #3534

La majorité des changements consistent à remplacer une valeur en dur par une variable `domain.support_email`.

Concernant l'adresse secretariat-auto@rdv-solidarites.fr, j'ai ajouté un commentaire d'explication sur sa raison d'être. Je pense qu'il n'est pas nécessaire de la décliner à tous nos domaines car c'est une adresse technique, les agents ne la voient pas ou peu.

Il y avait un usage de `SUPPORT_EMAIL` dans `SmsSender`, pour l'envoi de SMS avec le fournisseur "Contact Experience". Ce fournisseur n'est plus utilisé, j'ai supprimé les méthodes des fournisseurs obsolètes.

## Pour tester

https://demo-rdv-solidarites-pr3537.osc-secnum-fr1.scalingo.io/
Vous pouvez définir la variable d'env `REVIEW_APP_DOMAIN` à `RDV_AIDE_NUMERIQUE` ou `RDV_MAIRIE` puis redémarrer la review app pour tester les variations.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
