### PR TITLE
Revert "Adapter le code spécifique rdv-insertion en utilisant le nouvel attribut `verticale`"

### DIFF
--- a/app/javascript/components/motif-form.js
+++ b/app/javascript/components/motif-form.js
@@ -39,21 +39,30 @@ class MotifForm {
   }
 
   toggleOnlineSubFields() {
-    const enabled = !this.bookableByAgentsButton.checked || this.isbookableByAgentsAndInvitation
+    const enabled = !this.bookableByAgentsButton.checked
     document.querySelectorAll(".js-rdvs-editable").forEach(rdvEditableElement =>
       rdvEditableElement.classList.toggle('hidden', !enabled)
     )
   }
 
   toggleRdvsEditable() {
-    const enabled = !this.bookableByAgentsButton.checked || this.isbookableByAgentsAndInvitation
+    const enabled = !this.bookableByAgentsButton.checked
     document.querySelector("#motif_rdvs_editable_by_user").checked = enabled
+  }
+
+  toggleRdvInsertionNotifsDivs = () => {
+    // Specifique RDV-I temporaire
+    const selectedValue = this.motifCategorySelect?.value;
+    const hiddenDivs = document.getElementsByClassName('rdv-insertion-notif-hint');
+
+    Array.from(hiddenDivs).forEach(div => {
+      div.style.display = (selectedValue != "" && selectedValue != undefined) ? 'block' : 'none';
+    });
   }
 
   constructor() {
     this.secretariatCheckbox = document.querySelector('#motif_for_secretariat')
     this.bookableByAgentsButton = document.querySelector('#motif_bookable_by_agents')
-    this.isbookableByAgentsAndInvitation = document.getElementById("bookable_by_agents_and_invitations") ? true : false
     if (!this.secretariatCheckbox || !this.bookableByAgentsButton) return;
 
     const noSecretariatInputs = ["input[name=\"motif[location_type]\"]", "input[name=\"motif[follow_up]\"]"]
@@ -76,6 +85,14 @@ class MotifForm {
     this.toggleSecretariat()
     if (document.querySelector(".js-sectorisation-card") !== null) { this.toggleSectorisation() }
     this.toggleOnlineSubFields()
+
+    // Specifique RDV-I temporaire
+    document.addEventListener('turbolinks:load', this.toggleRdvInsertionNotifsDivs);
+
+    this.motifCategorySelect = document.getElementById('motif_motif_category_id')
+    if (this.motifCategorySelect) {
+      this.motifCategorySelect.addEventListener('change', this.toggleRdvInsertionNotifsDivs)
+    }
   }
 
 }

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -212,7 +212,12 @@ class Motif < ApplicationRecord
   end
 
   def bookable_outside_of_organisation?
-    bookable_by != "agents" || organisation.rdv_insertion?
+    bookable_by != "agents"
+  end
+
+  # Temporary method for rdv-insertion motifs
+  def motif_category_for_rdv_insertion?
+    motif_category.present?
   end
 
   private

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -67,7 +67,6 @@ class SearchContext
   end
 
   def invitation?
-    # Token validity is already handle in TokenInvitable module, prepend_before_action method handle_invitation_token
     @invitation_token.present?
   end
 
@@ -200,8 +199,6 @@ class SearchContext
     motifs = available_motifs
     motifs = if @prescripteur
                motifs.where(bookable_by: %i[agents_and_prescripteurs everyone])
-             elsif invitation?
-               motifs
              else
                motifs.where(bookable_by: :everyone)
              end

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -78,15 +78,8 @@
         .col-md-12
           = label_tag do
             = f.radio_button(:bookable_by, :agents)
-            - if current_organisation.rdv_insertion?
-              span.ml-1#bookable_by_agents_and_invitations= "Agents de l'organisation #{@motif.organisation.name} et usagers avec une invitation"
-            - else
-              span.ml-1= presenter.bookable_by_label(:agents)
-            p.text-muted.font-14
-              = "Les agents peuvent ajouter des rendez-vous à l'agenda de leurs collègues"
-              - if current_organisation.rdv_insertion?
-                br
-                span.text-muted= "Les usagers avec une invitation (RDV-Insertion) pourront prendre rendez-vous"
+            span.ml-1= presenter.bookable_by_label(:agents)
+            p.text-muted.font-14= "Les agents peuvent ajouter des rendez-vous à l'agenda de leurs collègues"
 
       - if presenter.show_bookable_by_prescripteur?
         .form-row
@@ -158,9 +151,8 @@
           span.ml-1= Motif.human_attribute_value(:visibility_type, value)
           p
             span.text-muted.font-14= Motif.human_attribute_value(:visibility_type, value, context: :hint)
-            - if current_organisation.rdv_insertion?
-              br
-              span.text-muted.font-14= Motif.human_attribute_value(:visibility_type, value, context: :hint_rdv_insertion)
+            br
+            span.text-muted.font-14.rdv-insertion-notif-hint= Motif.human_attribute_value(:visibility_type, value, context: :hint_rdv_insertion)
 
   .card
     .card-body

--- a/app/views/admin/motifs/_visibility.html.slim
+++ b/app/views/admin/motifs/_visibility.html.slim
@@ -6,6 +6,6 @@ h6.mb-2
     = motif.human_attribute_value(:visibility_type)
     p.mb-0
       span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint)
-      - if current_organisation.rdv_insertion?
+      - if motif.motif_category_for_rdv_insertion?
         br
         span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -38,10 +38,7 @@
 
         - presenter = Admin::PrescripteurExperimentMotifPresenter.new(@motif)
 
-        - if current_organisation.rdv_insertion?
-          .mb-2= motif_attribute_row(Motif.human_attribute_name(:bookable_by_title), "Agents de l'organisation #{current_organisation.name} et usagers avec une invitation")
-        - else
-          .mb-2= motif_attribute_row(Motif.human_attribute_name(:bookable_by_title), presenter.bookable_by_label)
+        .mb-2= motif_attribute_row(Motif.human_attribute_name(:bookable_by_title), presenter.bookable_by_label)
         - if @motif.bookable_outside_of_organisation?
           = motif_attribute_row(Motif.human_attribute_name(:min_public_booking_delay_short),
               @motif.bookable_outside_of_organisation? &&  min_max_delay_int_to_human(@motif.min_public_booking_delay),
@@ -69,7 +66,7 @@
           div= @motif.human_attribute_value(:visibility_type)
           div.text-muted
             = @motif.human_attribute_value(:visibility_type, context: :hint)
-            - if current_organisation.rdv_insertion?
+            - if @motif.motif_category_for_rdv_insertion?
               br
               span= @motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
         hr

--- a/app/views/admin/rdv_wizard_steps/_rdv_user_form.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_rdv_user_form.html.slim
@@ -24,8 +24,8 @@ div id=element_id
     - if rdvs_user.user.user_to_notify.email.present? || rdvs_user.user.user_to_notify.phone_number.present?
       h6= t("admin.rdvs_users.notifications_overrides")
       = form.input :send_lifecycle_notifications, wrapper: false
-      - if current_organisation.rdv_insertion?
+      - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
         span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)
       = form.input :send_reminder_notification, wrapper: false
-      - if current_organisation.rdv_insertion?
+      - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
         span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)

--- a/app/views/admin/rdvs_users/_form.html.slim
+++ b/app/views/admin/rdvs_users/_form.html.slim
@@ -15,8 +15,8 @@ div id=element_id
     - if rdvs_user.user.user_to_notify.email.present? || rdvs_user.user.user_to_notify.phone_number.present?
       h6= t("admin.rdvs_users.notifications_overrides")
       = form.input :send_lifecycle_notifications, wrapper: false
-      - if current_organisation.rdv_insertion?
+      - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
         span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)
       = form.input :send_reminder_notification, wrapper: false
-      - if current_organisation.rdv_insertion?
+      - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
         span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_checkbox)

--- a/app/views/admin/rdvs_users/_notifications_lifecycle.html.slim
+++ b/app/views/admin/rdvs_users/_notifications_lifecycle.html.slim
@@ -5,20 +5,20 @@
     span.mr-1
       i.fa.fa-times-circle.text-danger.mr-2
       strong = t("admin.rdvs_users.notifications_summary.none")
-    - if current_organisation.rdv_insertion?
+    - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
       br
       span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
   - elsif !rdvs_user.send_lifecycle_notifications
     span.mr-1
       i.fa.fa-times-circle.text-danger.mr-2
       strong = t("admin.rdvs_users.notifications_summary.lifecycle_off")
-    - if current_organisation.rdv_insertion?
+    - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
       br
       span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
   - elsif !rdvs_user.send_reminder_notification
     span.mr-1
       i.fa.fa-times-circle.text-danger.mr-2
       strong = t("admin.rdvs_users.notifications_summary.reminder_off")
-    - if current_organisation.rdv_insertion?
+    - if rdvs_user.rdv.motif.motif_category_for_rdv_insertion?
       br
       span.text-muted.font-14= rdvs_user.rdv.motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -58,6 +58,7 @@ fr:
         visible_and_notified: Le RDV sera visible dans la liste des RDVs côté usager, l'usager sera notifié par SMS et/ou email
         visible_and_not_notified: Le RDV sera visible dans la liste des RDVs côté usager, l'usager ne recevra aucune notification (ni SMS ni email)
         invisible: Le RDV sera invisible dans la liste des RDVs côté usager, l'usager ne recevra aucune notification (ni SMS ni email)
+      # Temporary hint for motif categories condition
       motif/visibility_types/hint_rdv_insertion:
         visible_and_notified: ""
         visible_and_not_notified: "Toutefois des notifications peuvent être envoyées d'une application externe (ex : RDV-Insertion)"

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -251,17 +251,5 @@ describe SearchContext, type: :service do
       create(:plage_ouverture, motifs: [motif], lieu: lieu)
       expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([motif])
     end
-
-    it "returns motif when user is invited (even if bookable_by agents only)" do
-      # This test will be obsolete when the invitation behavior will be integrated in Rdv-s (https://github.com/betagouv/rdv-solidarites.fr/issues/3438)
-      lieu = create(:lieu)
-      search_query[:invitation_token] = invitation_token
-      search_query[:motif_category_short_name] = "rsa_orientation"
-      search_query[:lieu_id] = lieu.id
-      search_context = described_class.new(nil, search_query)
-      motif = create(:motif, bookable_by: :agents, motif_category: rsa_orientation, organisation: organisation)
-      create(:plage_ouverture, motifs: [motif], lieu: lieu)
-      expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([motif])
-    end
   end
 end


### PR DESCRIPTION
Reverts betagouv/rdv-solidarites.fr#3508

Je propose qu'on revert la PR qui permettait d'ouvrir les motifs reservés aux agents aux utilisateurs ayant une invitation. 

### Explications 

On a pas assez anticipé tous les cas de figure avant qu'on la déploie, notamment le suivant  : 
Les motifs de convocations sont sur la même catégorie que les motifs d'invitations **et** les agents ont des plages d'ouvertures sur ces motifs pour pouvoir placer ces rdvs, ce qui fait qu'ils apparaissent dans la liste des motifs disponibles aux utilisateurs invités.

### Travaux à suivre 🔨 

Nous comptons retravailler le principe de convocation sur rdv-insertion, et donc on peut réfléchir à contourner ce problème, mais je ne pense pas que ce soit la bonne solution à ce problème.
Est-ce qu'il serait envisageable de rajouter un enum `bookable_by` qui serait égal à `agents_and_invited_users` à la manière de ce qui est fait avec les prescripteurs ?
La raison derrière cela est qu'avec le travail qu'a fait Romain, pour les organisations rdv-insertion, il n'est pas possible pour les agents de configurer des motifs qui ne sont visibles que par eux. 
On pourrait se dire qu'il y a moyen de contourner en disant aux agents de ne pas assigner de catégorie de motif à ces motifs mais je ne pense pas que ce soit la meilleure idée: les catégories pourraient être utilisées pour autre chose que l'invitation (comme ici avec les convocations) et cette logique n'est pas explicite dans l'interface.