### PR TITLE
[#3481] La suppression d'un agent rend inaccessible l'index des rdv des usagers qui ont eu des rdv avec lui

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -189,7 +189,7 @@ class Agent < ApplicationRecord
   end
 
   def update_unknown_past_rdv_count!
-    update_column(:unknown_past_rdv_count, rdvs.status(:unknown_past).count)
+    update_column(:unknown_past_rdv_count, rdvs.status(:unknown_past).count) if persisted?
   end
 
   # This method is called when calling #current_agent on a controller action that is automatically generated

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -18,8 +18,9 @@
         p.card-text
           i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
           = rdv_starts_at_and_duration(rdv, :time_only)
-          |&nbsp;
-          = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
+          - if rdv.agents.first
+            |&nbsp;
+            = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
       = render "admin/rdvs/rdv_details", rdv: rdv
 
     .col-md-6.col-sm-12

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -133,4 +133,17 @@ describe "Agent can see RDV details correctly" do
       expect(page).to have_content("3/X(Pas de limite de places)")
     end
   end
+
+  # Ce test a été ajouté suite à un crash de l'affichage de la page RDV
+  # lorsque l'agent du RDV avait été hard deleted depuis le SuperAdmin.
+  context "when agent has been hard deleted" do
+    let(:rdv) { create(:rdv, organisation: organisation) }
+    let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+    it "does not display the link to the agenda" do
+      rdv.agents.first.destroy!
+      visit admin_organisation_rdv_path(organisation, rdv)
+      expect(page).not_to have_content("voir dans l'agenda")
+    end
+  end
 end


### PR DESCRIPTION
Closes #3481

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
