### PR TITLE
Ajout de doc d'usage et de récupération des erreurs au script d'import de cnfs

### DIFF
--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Usage:
+# - télécharger le fichier de tous les cnfs depuis https://coop.conseiller-numerique.gouv.fr/accueil
+# - mettre le fichier export_cnfs.csv dans tmp
+# - exécuter: scalingo --app=production-rdv-solidarites --region=osc-secnum-fr1 run --file=tmp/export-cnfs.csv "rails runner scripts/import_conseillers_numeriques.rb"
+
 require "csv"
 
 conseillers_numeriques = CSV.read("/tmp/uploads/export-cnfs.csv", headers: true, col_sep: ";", liberal_parsing: true)
@@ -24,4 +29,6 @@ conseillers_numeriques.each do |conseiller_numerique|
       address: conseiller_numerique["Adresse de la structure"],
     },
   }.with_indifferent_access)
+rescue StandardError => e
+  Sentry.capture_exception(e)
 end


### PR DESCRIPTION
Afin de simplifier l'utilisation de ce script, et le rendre plus accessible au reste de l'équipe, j'ai ajouté un peu de doc, et un rescue qui permettra de limiter les opérations manuelles (habituellement j'avais besoin de modifier le csv puis relancer tout l'import à chaque échec)