### PR TITLE
Bugfix vigie : crash lors de l'assignation double d'un agent référent

### DIFF
--- a/app/controllers/admin/referent_assignations_controller.rb
+++ b/app/controllers/admin/referent_assignations_controller.rb
@@ -12,13 +12,13 @@ class Admin::ReferentAssignationsController < AgentAuthController
 
   def create
     find_agent_and_user_save_and_redirect_with(params) do |user, agent|
-      user.referent_agents << agent
+      user.referent_assignations.find_or_create_by!(agent: agent)
     end
   end
 
   def destroy
     find_agent_and_user_save_and_redirect_with(params) do |user, agent|
-      user.referent_agents.delete(agent)
+      user.referent_assignations.find_by(agent: agent)&.destroy
     end
   end
 

--- a/spec/controllers/admin/referent_assignations_controller_spec.rb
+++ b/spec/controllers/admin/referent_assignations_controller_spec.rb
@@ -51,6 +51,15 @@ describe Admin::ReferentAssignationsController, type: :controller do
       expect(response).to redirect_to(admin_organisation_user_referent_assignations_path(organisation, user))
     end
 
+    it "is idempotent" do
+      sign_in agent
+
+      post :create, params: { organisation_id: organisation.id, user_id: user.id, agent_id: new_referent.id }
+
+      # Calling the action with same params does not raise error
+      post :create, params: { organisation_id: organisation.id, user_id: user.id, agent_id: new_referent.id }
+    end
+
     it "return errors and redirect to index" do
       sign_in agent
 
@@ -79,6 +88,15 @@ describe Admin::ReferentAssignationsController, type: :controller do
 
       expect(user.reload.referent_agents).not_to include(referent)
       expect(response).to redirect_to(admin_organisation_user_referent_assignations_path(organisation, user))
+    end
+
+    it "is idempotent" do
+      sign_in agent
+
+      post :destroy, params: { organisation_id: organisation.id, user_id: user.id, id: referent.id }
+
+      # Calling the action with same params does not raise error
+      post :destroy, params: { organisation_id: organisation.id, user_id: user.id, id: referent.id }
     end
 
     it "return errors and redirect to user's show" do

--- a/spec/controllers/admin/referent_assignations_controller_spec.rb
+++ b/spec/controllers/admin/referent_assignations_controller_spec.rb
@@ -36,12 +36,13 @@ describe Admin::ReferentAssignationsController, type: :controller do
   end
 
   describe "#create" do
+    let!(:organisation) { create(:organisation) }
+    let!(:user) { create(:user, referent_agents: [], organisations: [organisation]) }
+    let!(:service) { create(:service) }
+    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+    let!(:new_referent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+
     it "add given agent to referents and redirect to user show" do
-      organisation = create(:organisation)
-      user = create(:user, referent_agents: [], organisations: [organisation])
-      service = create(:service)
-      agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      new_referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       sign_in agent
 
       post :create, params: { organisation_id: organisation.id, user_id: user.id, agent_id: new_referent.id }
@@ -51,11 +52,6 @@ describe Admin::ReferentAssignationsController, type: :controller do
     end
 
     it "return errors and redirect to index" do
-      organisation = create(:organisation)
-      user = create(:user, referent_agents: [], organisations: [organisation])
-      service = create(:service)
-      agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      new_referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
       sign_in agent
 
       allow_any_instance_of(User).to receive(:save).and_return(false)
@@ -70,13 +66,13 @@ describe Admin::ReferentAssignationsController, type: :controller do
   end
 
   describe "#delete" do
-    it "remove given agent from user's referents" do
-      organisation = create(:organisation)
-      service = create(:service)
-      referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      user = create(:user, referent_agents: [referent], organisations: [organisation])
+    let!(:organisation) { create(:organisation) }
+    let!(:service) { create(:service) }
+    let!(:referent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+    let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+    let!(:user) { create(:user, referent_agents: [referent], organisations: [organisation]) }
 
+    it "remove given agent from user's referents" do
       sign_in agent
 
       post :destroy, params: { organisation_id: organisation.id, user_id: user.id, id: referent.id }
@@ -86,12 +82,6 @@ describe Admin::ReferentAssignationsController, type: :controller do
     end
 
     it "return errors and redirect to user's show" do
-      organisation = create(:organisation)
-      service = create(:service)
-      referent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      agent = create(:agent, basic_role_in_organisations: [organisation], service: service)
-      user = create(:user, referent_agents: [referent], organisations: [organisation])
-
       sign_in agent
 
       allow_any_instance_of(User).to receive(:save).and_return(false)


### PR DESCRIPTION
Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/18832

Pour reproduire : 
- Se connecter avec martine@demo.rdv-solidarites.fr / 123456
- Visiter le profil usager de Patricia DUROY
- Dans la section "Agents référents", cliquer "Modifier"
- Double cliquer vite sur le bouton "Ajouter" d'un des agents de la liste

On voit que l'app crash car on demande deux fois d'ajouter le référent.

J'ai donc fait en sorte que l'action d'ajout soit idempotente.

Note : l'issue Sentry regroupe deux erreurs. L'une avait lieu lors de l fusion usager et a été corrigée dans #3526, et la second erreur est celle corrigée ici. Il me semble important de corriger l'erreur plutôt que de l'ignorer, pour éviter d'avoir à faire face à l'ambiguïté des remontes Sentry (groupées ensembles par erreur ici).

# Checklist

Avant la revue :+
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
