### PR TITLE
Allègement de la requête de motifs du geosearch

### DIFF
--- a/app/services/users/geo_search.rb
+++ b/app/services/users/geo_search.rb
@@ -116,11 +116,13 @@ class Users::GeoSearch
   end
 
   def individual_motifs
-    @individual_motifs ||= Motif.active.individuel.joins(:plage_ouvertures).distinct
+    @individual_motifs ||= Motif.active.where.not(bookable_by: :agents).individuel.joins(:plage_ouvertures)
+      .joins(organisation: :territory).where(territories: { departement_number: @departement }).distinct
   end
 
   def collective_motifs
-    @collective_motifs ||= Motif.active.collectif
+    @collective_motifs ||= Motif.active.where.not(bookable_by: :agents).collectif
+      .joins(organisation: :territory).where(territories: { departement_number: @departement })
       .joins(:rdvs).merge(Rdv.collectif_and_available_for_reservation).distinct
   end
 


### PR DESCRIPTION
Dans l'espoir de limiter l'utilisation mémoire et cpu de la base, cette PR propose de scoper un peu plus la requête qui est faite à la base du GeoSearch.

Avec les méthodes `individual_and_collectifs_motifs_ids` et `available_motifs_base`, on va chercher une liste d'ids, et ensuite s'en servir comme paramètres de requête pour aller chercher les motifs qui correspondent aux contraintes de sectorisation de la recherche en cours (https://github.com/betagouv/rdv-solidarites.fr/pull/3511).

Actuellement, on ne scope quasiment pas cette liste d'id, et on se retrouve à passer plusieurs milliers d'ids en paramètre. On peut de manière simple scoper cette liste d'id avec le département et en excluant les motifs non ouverts à la réservation en ligne. On passe ainsi de plusieurs milliers d'id à quelques dizaines.

En faisant des explain analyze sur un dump de prod, on passe de
```
Planning Time: 41.627 ms
Execution Time: 0.509 ms
```
à
```
Planning Time: 2.312 ms
Execution Time: 1.663 ms
```

Je ne suis pas sûr de comment vérifier que l'usage mémoire est plus faible, mais mon a priori est que ça diminue aussi.

Je n'ai pas réussi à faire un explain analyze de la requête avec toutes les ids sur la console db de prod, mais pour info la nouvelle requête donne ça :

```
 Nested Loop  (cost=6.09..86.78 rows=1 width=254) (actual time=16.336..16.346 rows=0 loops=1)
   Join Filter: (motifs.motif_category_id = motif_category.id)
   ->  Nested Loop  (cost=5.94..84.60 rows=1 width=254) (actual time=16.335..16.342 rows=0 loops=1)
         Join Filter: ((((motifs.sectorisation_level)::text = 'departement'::text) AND (organisations.id = ANY ('{312,3359,3699,3823,3824,2419}'::bigint[]))) OR (((motifs.sectorisation_level)::text = 'organisation'::text) AND (organisations.id = 2419)))
         ->  Nested Loop Semi Join  (cost=5.66..83.27 rows=1 width=254) (actual time=16.335..16.340 rows=0 loops=1)
               ->  Index Scan using index_motifs_on_organisation_id on motifs  (cost=0.29..4.39 rows=1 width=254) (actual time=0.129..0.291 rows=7 loops=1)
                     Index Cond: (organisation_id = 2419)
                     Filter: ((bookable_by = 'everyone'::bookable_by) AND (id = ANY ('{16650,14940,14647,14943,9941,13841,16114,14646,15409,15473,15474,15477,16411}'::bigint[])))
                     Rows Removed by Filter: 7
               ->  Nested Loop  (cost=5.37..78.86 rows=1 width=16) (actual time=2.291..2.291 rows=0 loops=7)
                     ->  Nested Loop  (cost=4.96..78.40 rows=1 width=24) (actual time=1.860..2.016 rows=20 loops=7)
                           ->  Index Scan using index_motif_categories_on_short_name on motif_categories motif_category_1  (cost=0.15..2.17 rows=1 width=8) (actual time=0.012..0.013 rows=1 loops=7)
                                 Index Cond: ((short_name)::text = 'rsa_cer_signature'::text)
                           ->  Nested Loop  (cost=4.81..76.23 rows=1 width=32) (actual time=1.846..2.000 rows=20 loops=7)
                                 Join Filter: ((((motifs_1.sectorisation_level)::text = 'departement'::text) AND (organisations_1.id = ANY ('{312,3359,3699,3823,3824,2419}'::bigint[]))) OR (((motifs_1.sectorisation_level)::text = 'organisation'::text) AND (organisations_1.id = 2419)))
                                 ->  Hash Join  (cost=4.53..74.89 rows=1 width=52) (actual time=1.827..1.947 rows=20 loops=7)
                                       Hash Cond: (motifs_plage_ouvertures.motif_id = motifs_1.id)
                                       ->  Index Scan using index_motifs_plage_ouvertures_on_motif_id on motifs_plage_ouvertures  (cost=0.42..70.60 rows=69 width=16) (actual time=1.543..1.893 rows=63 loops=7)
                                             Index Cond: (motif_id = motifs.id)
                                       ->  Hash  (cost=4.09..4.09 rows=1 width=36) (actual time=0.041..0.042 rows=1 loops=4)
                                             Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                             ->  Bitmap Heap Scan on motifs motifs_1  (cost=3.06..4.09 rows=1 width=36) (actual time=0.033..0.034 rows=1 loops=4)
                                                   Recheck Cond: ((organisation_id = 2419) AND (motif_category_id = motif_category_1.id))
                                                   Filter: ((NOT collectif) AND (bookable_by = 'everyone'::bookable_by) AND (id = ANY ('{16650,14940,14647,14943,9941,13841,16114,14646,15409,15473,15474,15477,16411}'::bigint[])))
                                                   Heap Blocks: exact=4
                                                   ->  BitmapAnd  (cost=3.06..3.06 rows=1 width=0) (actual time=0.024..0.024 rows=0 loops=4)
                                                         ->  Bitmap Index Scan on index_motifs_on_organisation_id  (cost=0.00..1.31 rows=3 width=0) (actual time=0.009..0.009 rows=14 loops=4)
                                                               Index Cond: (organisation_id = 2419)
                                                         ->  Bitmap Index Scan on index_motifs_on_motif_category_id  (cost=0.00..1.50 rows=29 width=0) (actual time=0.012..0.012 rows=4 loops=4)
                                                               Index Cond: (motif_category_id = motif_category_1.id)
                                 ->  Index Only Scan using organisations_pkey on organisations organisations_1  (cost=0.28..1.31 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=141)
                                       Index Cond: (id = 2419)
                                       Heap Fetches: 141
                     ->  Index Scan using plage_ouvertures_pkey on plage_ouvertures  (cost=0.42..0.46 rows=1 width=8) (actual time=0.013..0.013 rows=0 loops=141)
                           Index Cond: (id = motifs_plage_ouvertures.plage_ouverture_id)
                           Filter: (lieu_id = 1472)
                           Rows Removed by Filter: 1
         ->  Index Only Scan using organisations_pkey on organisations  (cost=0.28..1.31 rows=1 width=8) (never executed)
               Index Cond: (id = 2419)
               Heap Fetches: 0
   ->  Index Scan using index_motif_categories_on_short_name on motif_categories motif_category  (cost=0.15..2.17 rows=1 width=8) (never executed)
         Index Cond: ((short_name)::text = 'rsa_cer_signature'::text)
          Planning Time: 5.935 ms
          Execution Time: 16.627 ms
```


