### PR TITLE
[Vigie] Supprimer l'association entre les organisations et les absences

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,7 +18,6 @@ class Organisation < ApplicationRecord
   belongs_to :territory
   has_many :lieux, dependent: :destroy
   has_many :motifs, dependent: :destroy
-  has_many :absences, dependent: :destroy
   has_many :rdvs, dependent: :destroy
   has_many :webhook_endpoints, dependent: :destroy
   has_many :sector_attributions, dependent: :destroy


### PR DESCRIPTION
# [Vigie] Supprimer l'association entre les organisations et les absences

Erreur Sentry: https://sentry.incubateur.net/organizations/betagouv/issues/41949/?referrer=webhooks_plugin

## Contexte
Cette PR vient en complément de https://github.com/betagouv/rdv-solidarites.fr/pull/3379, qui a consisté à supprimer le lien entre les modèles `Absence` et `Organisation`.

## Problème
L'association fût bien supprimée au niveau de `Absence` [ici](https://github.com/betagouv/rdv-solidarites.fr/pull/3379/files#diff-9f7d0629c294ae22a14c7f9250929f83a0a164272c665c6774e416394b9b1f5fL19), mais pas au niveau de `Organisation`.

Bien que La colonne `Absences#organisation_id` fût supprimée ; nous avons au niveau de `Organisation`:
```ruby
 # app/models/organisation.rb

has_many :absences, dependent: :destroy
```

Dû fait de cette association, `organisation#destroy` enclenche une suppression des `organisation.absences` ; ce qui provoque une erreur en DB, vu qu'il n'existe plus de lien (`Absences#organisation_id`) entre `Organisation` et `Absence`

## Solution
Supprimer l'association `has_many :absences` du modèle `Organisation`.