### PR TITLE
Ajout de la Somme à l'expérimentation avec les prescripteur

### DIFF
--- a/app/presenters/admin/prescripteur_experiment_motif_presenter.rb
+++ b/app/presenters/admin/prescripteur_experiment_motif_presenter.rb
@@ -20,7 +20,7 @@ class Admin::PrescripteurExperimentMotifPresenter < SimpleDelegator
   end
 
   def show_bookable_by_prescripteur?
-    organisation.territory.departement_number.in?["80", "83"] || Rails.env.development?
+    organisation.territory.departement_number.in?(%w[80 83]) || Rails.env.development?
   end
 
   def min_public_booking_delay_hint


### PR DESCRIPTION
Suite à des discussions avec Matis, la Somme (80) souhaite utiliser la fonction prescripteurs pour ses CCAS

On pourrait prendre un peu plus de temps à un moment pour voir si le flag dans app/views/users/sessions/new.html.slim est encore pertinent, mais ce n'est pas la priorité cet été (on est sur RDV Mairie).
