### PR TITLE
[Vigie] Inclure des infos sur la session dans les logs Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,7 @@ class ApplicationController < ActionController::Base
     Sentry.configure_scope do |scope|
       scope.set_context("params", params.to_unsafe_h)
       scope.set_context("url", { "request.original_url" => request.original_url })
+      scope.set_context("session", { "key" => "session:#{session.id}" })
     end
   end
 


### PR DESCRIPTION
## Vigie: Inclure le Session Key dans les logs Sentry

Afin de faire une investigation plus profonde d'un bug, nous avons parfois besoin d'inspecter le contenu de la session de l'utilisateur.

Cette PR, nous permet d'avoir la clé Redis de la session dans Sentry.