### PR TITLE
Utiliser une sous-requête plutôt que de passer les IDs

### DIFF
--- a/app/policies/user/rdv_policy.rb
+++ b/app/policies/user/rdv_policy.rb
@@ -58,7 +58,9 @@ class User::RdvPolicy < ApplicationPolicy
         )
         .visible
 
-      scope.where(id: my_rdvs).or(scope.where(id: scope.collectif.bookable_publicly)).distinct
+      bookable_rdv_collectifs = scope.where(id: scope.collectif.bookable_publicly)
+
+      scope.where(id: my_rdvs).or(bookable_rdv_collectifs).distinct
     end
   end
 end


### PR DESCRIPTION
En bossant sur le DSFR côté usagers, j'ai remarqué que mes logs crachaient des milliers d'IDs : 

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/b06d170f-56df-42fb-aef3-5cdd8d3de4a1)

Il est inutile que l'app récupère ces IDs pour ensuite les passer à une autre requête, j'ai donc fait en sorte d'utiliser une sous-requête.

Le premier commit fait ce changement, le second est une simple introduction de variable pour améliorer la lisibilité.

Note au passage : je pense que l'ajout des RDVs collectifs à ce scope était une erreur car il serait préférable dé définir deux scopes : les RDVs que je peux voir car ce sont les miens, et les RDVs auxquels je peux m'inscrire. C'est un sujet pour une autre PR.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
