### PR TITLE
Utiliser la durée de rdv recommandée par l'ANTS

### DIFF
--- a/app/controllers/super_admins/mairie_comptes_controller.rb
+++ b/app/controllers/super_admins/mairie_comptes_controller.rb
@@ -55,7 +55,7 @@ module SuperAdmins
       Motif.create!(
         name: "Passeport / Carte d'identité",
         color: "#99CC99",
-        default_duration_in_min: 30,
+        default_duration_in_min: 15,
         location_type: :public_office,
         organisation: organisation,
         service: service,


### PR DESCRIPTION
Quand on a fait la démo, des gens ont remarqué que la durée par défaut recommandée par l'ANTS est de 15 mn pour les rdv pour les passeports et/ou cartes d'identité