### PR TITLE
Correctif du texte du footer

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -114,7 +114,7 @@ class Domain
   end
 
   def default?
-    self == RDV_SOLIDARITES
+    self == RDV_MAIRIE
   end
   alias default default?
 

--- a/app/views/common/_footer_users.html.slim
+++ b/app/views/common/_footer_users.html.slim
@@ -6,14 +6,14 @@
         ul.list-unstyled
           li.mb-2
             - if current_domain.default?
-              span> Un service fourni par
+              span> #{current_domain.name} est fourni par
               = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
               = " et un consortium de départements"
             - else
               span
-              = "#{current_domain.name} est géré par #{Domain::RDV_SOLIDARITES.name}, un service fourni par "
+              = "#{current_domain.name} est géré par #{Domain::RDV_MAIRIE.name}, un service fourni par "
               = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
-              = "."
+              = ". "
               = link_to "En savoir plus", domaines_path
           li.mb-2
             = link_to image_tag("logos/logo-incub-territoire.svg", size: "80x70", alt:"incubateur.anct.gouv.fr"), "https://incubateur.anct.gouv.fr/", title: "Aller sur le site de l'incubateur des territoires"


### PR DESCRIPTION
Pour tester : https://demo-rdv-solidarites-pr3593.osc-secnum-fr1.scalingo.io/

Suite à la recette de ce matin avec Mehdi

Avant : 
<img width="285" alt="Screenshot 2023-06-06 at 16 13 21" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/1aff486a-51a7-493a-b402-8dbfe34ea77c">
<img width="284" alt="Screenshot 2023-06-06 at 16 13 34" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/55012d62-2db1-4a09-890c-27ed215abae1">


Après : 
<img width="284" alt="Screenshot 2023-06-06 at 16 05 59" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/76e380c2-ca15-4bbd-8252-0620621a68d5">
(Le logo n'est pas le bon, mais c'est corrigé par https://github.com/betagouv/rdv-solidarites.fr/pull/3591)
<img width="289" alt="Screenshot 2023-06-06 at 16 06 04" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/07dcc950-4844-4f02-92c0-85bdf894d5a1">

 
