### PR TITLE
Ajout d'un texte d'exemple pour la vérification de nom de famille

### DIFF
--- a/app/views/users/user_name_initials_verification/new.html.slim
+++ b/app/views/users/user_name_initials_verification/new.html.slim
@@ -8,6 +8,7 @@
           .card-body
             = render "form", user: current_user
           .car-footer.text-center
+            p Par exemple :
             p.fw-lighter.fs-6 = t(".examples.first")
             p.fw-lighter.fs-6 = t(".examples.second")
             p.fw-lighter.fs-6 = t(".examples.third")

--- a/config/locales/views/user_name_initials_verification.yml
+++ b/config/locales/views/user_name_initials_verification.yml
@@ -4,6 +4,6 @@ fr:
       new:
         title: Entrez les 3 premières lettres de votre nom de famille
         examples:
-          first: "Sophie Dupont: DUP"
-          second: "Jean De La Fontaine: DEL"
-          third: "Edwige Xi: XI"
+          first: "Sophie Dupont : DUP"
+          second: "Jean De La Fontaine : DEL"
+          third: "Edwige Xi : XI"


### PR DESCRIPTION
Suite à la review de ce matin avec Mehdi, on veut clarifier qu'il s'agit d'exemples

Avant : 

<img width="729" alt="Screenshot 2023-06-06 at 16 51 37" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/23d4673c-a8bd-4f45-9945-01c9cc2c975d">


Après : 


<img width="711" alt="Screenshot 2023-06-06 at 16 53 10" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/ec305898-5293-4ef6-bb34-2b3ce6cf48a4">