### PR TITLE
Présélectionner le lieu si il y en a qu'un dans les plages d'ouvertures

### DIFF
--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -4,11 +4,12 @@
     = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
       = f.input :title, hint: "Uniquement visible en interne", placeholder: "Ex: Permanence PMI exceptionnelle"
+      - lieux = policy_scope(Lieu).enabled.ordered_by_name
       = f.association :lieu, \
-        collection: policy_scope(Lieu).enabled.ordered_by_name, \
+        collection: lieux, \
         label_method: :full_name, \
         include_blank: true, \
-        selected: (policy_scope(Lieu).size == 1 ? policy_scope(Lieu).first.id : nil)
+        selected: (lieux.size == 1 ? lieux.first.id : nil)
       = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes
 
       hr

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -4,7 +4,11 @@
     = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
       = f.input :title, hint: "Uniquement visible en interne", placeholder: "Ex: Permanence PMI exceptionnelle"
-      = f.association :lieu, collection: policy_scope(Lieu).enabled.ordered_by_name, label_method: :full_name, include_blank: true
+      = f.association :lieu, \
+        collection: policy_scope(Lieu).enabled.ordered_by_name, \
+        label_method: :full_name, \
+        include_blank: true, \
+        selected: (policy_scope(Lieu).size == 1 ? policy_scope(Lieu).first.id : nil)
       = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes
 
       hr


### PR DESCRIPTION
Suite à la recette de ce matin, cette PR corrige le point suivant : 
Dans la page de création d’une plage d’ouverture, s’il y a un seul lieu disponible, le présélectionner
