### PR TITLE
Simplification du parcours utilisateur d'embarquement pour RDV Mairie

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -1,4 +1,3 @@
-- brevo_form_url = "https://dc1a8bc9.sibforms.com/serve/MUIEANp1tYksaTME-VN6GRNuj1e3mX-DVmz1ZDOs2UNo-PTUJOMNHxcCPt_xlRx7vqHn5FnPi_tgoMWoDG3JVaWilm6-Hm-el0hYT3ll6CfItVTv16lTR_7NfqipkZ3gYPlWnl_CWvfcv8QgR08kTZOqInhCapvx6CPvta5a3FwQNFz6ylu1kPOV5ZUGt6G9tYaUuQKinolFSjtC"
 - team_meeting_url = "https://meet.brevo.com/-1918"
 .fr-py-12w[style="background-color:  #F4F6FE"]
   .fr-container.fr-grid-row.fr-grid-row--center

--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -10,8 +10,7 @@
         span[style="color: #000091"] rendez-vous en ligne
       b Une solution publique de gestion et de prise de rendez-vous pour les mairies
       ul.fr-pt-4w.fr-btns-group.fr-btns-group--inline.fr-btns-group--center
-        li= link_to("Utiliser RDV Service Public", brevo_form_url, class: "fr-btn ")
-        li= link_to("Prendre RDV avec l’équipe", team_meeting_url, class: ["fr-btn fr-btn--secondary"])
+        li= link_to("Prendre RDV avec l’équipe", team_meeting_url, class: "fr-btn ")
 
 .fr-py-12w
   .fr-container
@@ -73,13 +72,8 @@
       .fr-col-md-5
         h2 Comment l’utiliser ?
         p
-          | Pour utiliser notre solution dans votre mairie, vous devez remplir le formulaire en cliquant sur le bouton ci-dessous :
-        = link_to("Utiliser RDV Service Public", brevo_form_url, class: "fr-btn fr-mb-4w")
-        p
-          | Une fois le formulaire envoyé, vous recevrez dans un délais maximum de 48h une invitation sur l’adresse mail indiquée dans la formulaire pour rejoindre votre espace.
-        p
           | Notre équipe est à votre entière disposition pour organiser un temps de formation avec les agents de votre mairie. Vous pouvez planifier un rendez-vous :
-        = link_to("Prendre RDV avec l’équipe", team_meeting_url, class: ["fr-btn fr-btn--secondary fr-mb-4w"])
+        = link_to("Prendre RDV avec l’équipe", team_meeting_url, class: ["fr-btn fr-mb-4w"])
 
       .fr-col-md-5
         = dsfr_image_tag "rdv_mairie/image_3.svg", "Un personnage devant un formulaire et une icône de message", class: "fr-ratio-3x4"


### PR DESCRIPTION
Pour les mairies pilotes, on veut les inciter uniquement à prendre rendez-vous avec nous, pour avoir le maximum de feedback.

On fait donc de la prise de RDV le CTA principal.

Avant :
<img width="1270" alt="Screenshot 2023-06-08 at 10 15 23" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/45543d25-e4b2-45fe-823f-35596f4e45e9">


Après : 
<img width="1266" alt="Screenshot 2023-06-08 at 10 15 16" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/293755ca-2935-43fb-8da2-51c3103e49cd">