### PR TITLE
Corrige les liens de réservation en ligne pour les mairies

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,7 @@ class SearchController < ApplicationController
 
   def search_rdv
     @context = SearchContext.new(current_user, search_params.to_h)
-    if current_domain == Domain::RDV_MAIRIE
+    if current_domain == Domain::RDV_MAIRIE && request.path == "/"
       render "dsfr/rdv_mairie/homepage", layout: "application_dsfr"
     end
   end

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -9,7 +9,7 @@ describe "Agents can try the user-facing online booking pages" do
     motif.plage_ouvertures << create(:plage_ouverture, organisation: organisation, agent: agent)
   end
 
-  it "shows the online booking forms, until" do
+  it "shows the online booking forms, until the creneau selection" do
     login_as(agent, scope: :agent)
     visit public_link_to_org_path(organisation_id: organisation.id)
     expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
@@ -17,5 +17,11 @@ describe "Agents can try the user-facing online booking pages" do
     expect(page).to have_content("Sélectionnez un lieu de RDV :")
     click_link("Prochaine disponibilité")
     expect(page).to have_content("Sélectionnez un créneau :")
+  end
+
+  it "works on the RDV_MAIRIE domain" do
+    login_as(agent, scope: :agent)
+    visit "http://www.rdv-mairie-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
+    expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
   end
 end


### PR DESCRIPTION
En testant, je me suis rendu compte que les liens directs pour la réservation chez une mairie étaient cassés. Ce petit correctif moyennement joli répare ça pour le premier onboarding de tout à l'heure.