### PR TITLE
Ajout d'un enum pour le niveau de role d'un agent (et renommage de l'attribut)

### DIFF
--- a/app/blueprints/agent_role_blueprint.rb
+++ b/app/blueprints/agent_role_blueprint.rb
@@ -3,7 +3,8 @@
 class AgentRoleBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :level
+  # TODO: remove :level field after rdv-i migration
+  fields :level, :access_level
   association :organisation, blueprint: OrganisationBlueprint
   association :agent, blueprint: AgentBlueprint
 end

--- a/app/controllers/admin/agent_roles_controller.rb
+++ b/app/controllers/admin/agent_roles_controller.rb
@@ -19,7 +19,7 @@ class Admin::AgentRolesController < AgentAuthController
   private
 
   def agent_role_params
-    params.require(:agent_role).permit(:level)
+    params.require(:agent_role).permit(:access_level)
   end
 
   def set_agent_role

--- a/app/controllers/admin/invitations_devise_controller.rb
+++ b/app/controllers/admin/invitations_devise_controller.rb
@@ -6,7 +6,7 @@ class Admin::InvitationsDeviseController < Devise::InvitationsController
     authorize(resource)
 
     @services = services.order(:name)
-    @roles = current_agent.conseiller_numerique? ? [AgentRole::LEVEL_BASIC] : AgentRole::LEVELS
+    @roles = current_agent.conseiller_numerique? ? [AgentRole::ACCESS_LEVEL_BASIC] : AgentRole::ACCESS_LEVELS
 
     render :new, layout: "application_agent"
   end
@@ -79,7 +79,7 @@ class Admin::InvitationsDeviseController < Devise::InvitationsController
     params[:roles_attributes]["0"][:organisation] = current_organisation
 
     if current_agent.conseiller_numerique?
-      params[:roles_attributes]["0"][:level] = AgentRole::LEVEL_BASIC
+      params[:roles_attributes]["0"][:access_level] = AgentRole::ACCESS_LEVEL_BASIC
     end
 
     # The omniauth uid _is_ the email, always. Note: this may be better suited in a hook in Agent.rb

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -44,7 +44,7 @@ class Admin::OrganisationsController < AgentAuthController
 
   def create
     @organisation = Organisation.new(
-      agent_roles_attributes: [{ agent: current_agent, level: AgentRole::LEVEL_ADMIN }],
+      agent_roles_attributes: [{ agent: current_agent, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
       **new_organisation_params
     )
     authorize(@organisation)

--- a/app/controllers/admin/territories/agent_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_roles_controller.rb
@@ -47,6 +47,6 @@ class Admin::Territories::AgentRolesController < Admin::Territories::BaseControl
   private
 
   def agent_role_params
-    params.require(:agent_role).permit(:level, :organisation_id, :agent_id)
+    params.require(:agent_role).permit(:access_level, :organisation_id, :agent_id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,7 +70,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     if resource_class == Agent
       devise_parameter_sanitizer.permit(:invite, keys: [:email, :service_id, { organisation_ids: [] },
-                                                        { agent_territorial_access_rights_attributes: :territory_id }, { roles_attributes: %i[level organisation_id] },])
+                                                        { agent_territorial_access_rights_attributes: :territory_id }, { roles_attributes: %i[access_level organisation_id] },])
       devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name])
       devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name service_id])
     elsif resource_class == User

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -5,7 +5,7 @@ class OrganisationsController < ApplicationController
 
   def new
     @organisation = Organisation.new(territory: Territory.new)
-    @organisation.agent_roles.build(level: AgentRole::LEVEL_ADMIN)
+    @organisation.agent_roles.build(access_level: AgentRole::ACCESS_LEVEL_ADMIN)
     @organisation.agent_roles.first.build_agent
   end
 
@@ -30,7 +30,7 @@ class OrganisationsController < ApplicationController
     params.require(:organisation)
       .permit(
         :name,
-        agent_roles_attributes: [:level, { agent_attributes: %i[email service_id] }],
+        agent_roles_attributes: [:access_level, { agent_attributes: %i[email service_id] }],
         territory_attributes: [:departement_number]
       )
   end

--- a/app/controllers/super_admins/mairie_comptes_controller.rb
+++ b/app/controllers/super_admins/mairie_comptes_controller.rb
@@ -46,7 +46,7 @@ module SuperAdmins
         last_name: resource_params[:agent_last_name],
         service: service,
         password: SecureRandom.hex,
-        roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }],
+        roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
         invited_by: current_super_admin
       )
     end

--- a/app/controllers/super_admins/migrations_controller.rb
+++ b/app/controllers/super_admins/migrations_controller.rb
@@ -63,7 +63,7 @@ module SuperAdmins
         end
 
         old_role = AgentRole.find_by(agent_id: agent.id, organisation_id: params[:old_organisation_id])
-        AgentRole.create!(agent_id: agent.id, organisation: new_organisation, level: old_role.level)
+        AgentRole.create!(agent_id: agent.id, organisation: new_organisation, access_level: old_role.access_level)
         old_role.delete
       end
       # rubocop:enable Rails/SkipsModelValidations

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -161,11 +161,11 @@ class Agent < ApplicationRecord
   end
 
   def admin_orgs
-    organisations.merge(roles.where(level: AgentRole::LEVEL_ADMIN))
+    organisations.merge(roles.where(access_level: AgentRole::ACCESS_LEVEL_ADMIN))
   end
 
   def basic_orgs
-    organisations.merge(roles.where(level: AgentRole::LEVEL_BASIC))
+    organisations.merge(roles.where(access_level: AgentRole::ACCESS_LEVEL_BASIC))
   end
 
   def multiple_organisations_access?

--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -6,10 +6,14 @@ class AgentRole < ApplicationRecord
   has_paper_trail
 
   # Attributes
-  # TODO: make it an enum
-  LEVEL_BASIC = "basic"
-  LEVEL_ADMIN = "admin"
-  LEVELS = [LEVEL_BASIC, LEVEL_ADMIN].freeze
+  ACCESS_LEVEL_BASIC = "basic"
+  ACCESS_LEVEL_ADMIN = "admin"
+  ACCESS_LEVELS = [ACCESS_LEVEL_BASIC, ACCESS_LEVEL_ADMIN].freeze
+
+  enum access_level: {
+    basic: "basic", # Basic Role
+    admin: "admin", # Admin Role
+  }
 
   # Relations
   belongs_to :agent
@@ -21,7 +25,6 @@ class AgentRole < ApplicationRecord
   accepts_nested_attributes_for :agent
 
   # Validation
-  validates :level, inclusion: { in: LEVELS }
   validate :organisation_cannot_change
   validate :organisation_have_at_least_one_admin
   # Customize the uniqueness error message. This class needs to be declared before the validates :agent, uniqueness: line.
@@ -42,17 +45,13 @@ class AgentRole < ApplicationRecord
   before_destroy :organisation_have_at_least_one_admin_before_destroy
 
   # Scopes
-  scope :level_basic, -> { where(level: LEVEL_BASIC) }
-  scope :level_admin, -> { where(level: LEVEL_ADMIN) }
+  scope :access_level_basic, -> { where(access_level: :basic) }
+  scope :access_level_admin, -> { where(access_level: :admin) }
 
   ## -
 
-  def basic?
-    level == LEVEL_BASIC
-  end
-
-  def admin?
-    level == LEVEL_ADMIN
+  def level # TODO: For API compatibility only, change in rdv-insertion and remove this method
+    access_level
   end
 
   def can_access_others_planning?
@@ -68,7 +67,7 @@ class AgentRole < ApplicationRecord
   end
 
   def organisation_have_at_least_one_admin
-    return if new_record? || level == LEVEL_ADMIN || organisation.agent_roles.where.not(id: id).any?(&:admin?)
+    return if new_record? || admin? || organisation.agent_roles.where.not(id: id).any?(&:admin?)
 
     errors.add(:base, "Il doit toujours y avoir au moins un agent Admin par organisation")
   end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -14,7 +14,7 @@ class Agent::AgentPolicy < ApplicationPolicy
   def admin_in_record_organisation?
     (
       record.roles.map(&:organisation_id) &
-      current_agent.roles.level_admin.pluck(:organisation_id)
+      current_agent.roles.access_level_admin.pluck(:organisation_id)
     ).any?
   end
 

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -6,7 +6,7 @@ class Agent::OrganisationPolicy < DefaultAgentPolicy
   end
 
   def admin_in_record_organisation?
-    current_agent.roles.level_admin.pluck(:organisation_id).include?(record.id)
+    current_agent.roles.access_level_admin.pluck(:organisation_id).include?(record.id)
   end
 
   def new?

--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -56,7 +56,7 @@ class AddConseillerNumerique
       external_id: @conseiller_numerique.external_id,
       service: service,
       password: SecureRandom.hex,
-      roles_attributes: [{ organisation: organisation, level: AgentRole::LEVEL_ADMIN }]
+      roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
     ).tap do |agent|
       AgentTerritorialAccessRight.create!(agent: agent, territory: territory)
     end

--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -20,9 +20,9 @@
             = ff.input :service_id, collection: [@agent_role.agent.service], as: :select, label: "Service", hint: "Vous ne pouvez pas changer un agent de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer et recréer le compte de l'agent", disabled: true
 
           = f.input :organisation, as: :hidden
-          = f.input :level, \
-            collection: AgentRole::LEVELS, \
-            label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
+          = f.input :access_level, \
+            collection: AgentRole::ACCESS_LEVELS, \
+            label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
             hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
             as: :radio_buttons
 

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -15,7 +15,7 @@ tr id="agent_#{agent.id}"
   td
     = agent.service&.name
   td.text-nowrap
-    span>= agent_role.human_attribute_value(:level)
+    span>= agent_role.human_attribute_value(:access_level)
     - if agent_role.admin?
       i.fa.fa-user-cog
   td

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -19,7 +19,7 @@
           th= Agent.human_attribute_name(:name)
           th= Agent.human_attribute_name(:email)
           th= Agent.human_attribute_name(:service)
-          th= AgentRole.human_attribute_name(:level)
+          th= AgentRole.human_attribute_name(:access_level)
           th Actions
       tbody
         = render partial: "agent", collection: @agents

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -19,7 +19,7 @@
           th= Agent.human_attribute_name(:name)
           th= Agent.human_attribute_name(:email)
           th= Agent.human_attribute_name(:service)
-          th= AgentRole.human_attribute_name(:level)
+          th= AgentRole.human_attribute_name(:access_level)
           th Actions
       tbody
         = render partial: "admin/agents/agent", collection: @invited_agents

--- a/app/views/admin/invitations_devise/new.html.slim
+++ b/app/views/admin/invitations_devise/new.html.slim
@@ -12,9 +12,9 @@
           = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}
           = f.association :service, collection: @services, include_blank: false, hint: "Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents."
           = f.simple_fields_for :roles do |ff|
-            = ff.input :level, \
+            = ff.input :access_level, \
               collection: @roles, \
-              label_method: -> { AgentRole.human_attribute_value(:level, _1, context: :explanation).html_safe }, \
+              label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
               hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
               as: :radio_buttons
           .text-right

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -79,7 +79,7 @@
                 .card-body
                   = f.input :organisation_id, as: :hidden, input_html: { value: organisation.id }
                   = f.input :agent_id, as: :hidden, input_html: { value: @agent.id }
-                  = f.input :level, as: :radio_buttons, collection: AgentRole::LEVELS, label_method: -> { AgentRole.human_attribute_value(:level, _1) }, checked: role&.level || "none"
+                  = f.input :access_level, as: :radio_buttons, collection: AgentRole::ACCESS_LEVELS, label_method: -> { AgentRole.human_attribute_value(:access_level, _1) }, checked: role&.access_level || "none"
                 .card-footer
                   .row
                     .col.text-left
@@ -92,7 +92,7 @@
       - if policy([:configuration, current_territory]).allow_to_invite_agents? && available_other_organisations.any?
         = simple_form_for AgentRole.new, url: admin_territory_agent_roles_path(current_territory) do |f|
           = f.input :agent_id, as: :hidden, input_html: { value: @agent.id }
-          = f.input :level, as: :hidden, input_html: { value: AgentRole::LEVEL_BASIC }
+          = f.input :access_level, as: :hidden, input_html: { value: AgentRole::ACCESS_LEVEL_BASIC }
           = f.input :organisation_id, collection: available_other_organisations, include_blank: "-- sélectionner une organisation --",
                   required: false,
                   label: false

--- a/app/views/organisations/new.html.slim
+++ b/app/views/organisations/new.html.slim
@@ -22,7 +22,7 @@ section.py-5.bg-lightturquoise.text-primary
                   input_html: { class: "form-control-lg" }, \
                   wrapper_html: { class: "mb-1 mb-lg-0" }
           = f.simple_fields_for :agent_roles do |ff|
-            = ff.input :level, as: :hidden
+            = ff.input :access_level, as: :hidden
             = ff.simple_fields_for :agent do |fff|
               .form-row.mb-2
                 .col-lg-12= fff.input :email, label: t(".your_email"), placeholder: t(".example_email_organisation"), input_html: { class: "form-control-lg" }, wrapper_html: { class: "mb-1 mb-lg-0" }

--- a/config/locales/models/agent_role.fr.yml
+++ b/config/locales/models/agent_role.fr.yml
@@ -4,12 +4,12 @@ fr:
       agent_role: Rôle agent
     attributes:
       agent_role:
-        level: Niveau de permissions
-      agent_role/levels:
+        access_level: Niveau de permissions
+      agent_role/access_levels:
         none: Inaccessible
         basic: Agent
         admin: Admin
-      agent_role/levels/explanation:
+      agent_role/access_levels/explanation:
         basic: "<i class='far fa-user'></i> Agent<br><ul><li>Peut consulter et modifier son agenda et celui des agents de son service</li><li>Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation</li></ul>"
         admin: <i class='fa fa-user-cog'></i> Admin<br><ul><li>Peut consulter et modifier l'agenda de tous les agents de l'organisation</li><li>Peut créer, modifier et supprimer des lieux, des motifs et des agents</li><li>Peut accéder aux statistiques de l'organisation</li></ul>
     warnings:

--- a/db/migrate/20230612092945_add_agent_role_level_enum.rb
+++ b/db/migrate/20230612092945_add_agent_role_level_enum.rb
@@ -1,0 +1,29 @@
+class AddAgentRoleLevelEnum < ActiveRecord::Migration[7.0]
+  def up
+    create_enum :access_level, %i[admin basic]
+    add_column :agent_roles, :access_level, :access_level, default: :basic, null: false
+    add_index :agent_roles, :access_level
+
+    execute(<<-SQL.squish
+      UPDATE agent_roles
+      SET access_level = level::access_level
+    SQL
+           )
+
+    remove_column :agent_roles, :level, :string
+  end
+
+  def down
+    add_column :agent_roles, :level, :string, default: :basic, null: false
+
+    execute(<<-SQL.squish
+      UPDATE agent_roles
+      SET level = access_level
+    SQL
+           )
+
+    remove_index :agent_roles, :access_level
+    remove_column :agent_roles, :access_level, :string
+    drop_enum :access_level
+  end
+end

--- a/db/migrate/20230612092945_add_agent_role_level_enum.rb
+++ b/db/migrate/20230612092945_add_agent_role_level_enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAgentRoleLevelEnum < ActiveRecord::Migration[7.0]
   def up
     create_enum :access_level, %i[admin basic]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_07_081934) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_12_092945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "unaccent"
   enable_extension "uuid-ossp"
+
+  create_enum :access_level, [
+    "admin",
+    "basic",
+  ], force: :cascade
 
   create_enum :agents_absence_notification_level, [
     "all",
@@ -134,9 +139,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_07_081934) do
   create_table "agent_roles", force: :cascade do |t|
     t.bigint "agent_id", null: false
     t.bigint "organisation_id", null: false
-    t.string "level", default: "basic", null: false
+    t.enum "access_level", default: "basic", null: false, enum_type: "access_level"
+    t.index ["access_level"], name: "index_agent_roles_on_access_level"
     t.index ["agent_id"], name: "index_agent_roles_on_agent_id"
-    t.index ["level"], name: "index_agent_roles_on_level"
     t.index ["organisation_id", "agent_id"], name: "index_agent_roles_on_organisation_id_and_agent_id", unique: true
     t.index ["organisation_id"], name: "index_agent_roles_on_organisation_id"
   end

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -59,7 +59,7 @@ agent_cnfs = Agent.new(
   password: "123456",
   service_id: service_cnfs.id,
   invitation_accepted_at: 1.day.ago,
-  roles_attributes: [{ organisation: org_cnfs, level: AgentRole::LEVEL_ADMIN }],
+  roles_attributes: [{ organisation: org_cnfs, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
   agent_territorial_access_rights_attributes: [{
     territory: territory_cnfs,
     allow_to_manage_teams: false,

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -365,7 +365,7 @@ agent_org_paris_nord_pmi_martine = Agent.new(
   password: "123456",
   service_id: service_pmi.id,
   invitation_accepted_at: 10.days.ago,
-  roles_attributes: [{ organisation: org_paris_nord, level: AgentRole::LEVEL_ADMIN }],
+  roles_attributes: [{ organisation: org_paris_nord, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
   agent_territorial_access_rights_attributes: [{
     territory: territory75,
     allow_to_manage_teams: true,
@@ -386,7 +386,7 @@ agent_org_paris_nord_pmi_marco = Agent.new(
   password: "123456",
   service_id: service_pmi.id,
   invitation_accepted_at: 10.days.ago,
-  roles_attributes: [{ organisation: org_paris_nord, level: AgentRole::LEVEL_BASIC }],
+  roles_attributes: [{ organisation: org_paris_nord, access_level: AgentRole::ACCESS_LEVEL_BASIC }],
   agent_territorial_access_rights_attributes: [{
     territory: territory75,
     allow_to_manage_teams: false,
@@ -406,7 +406,7 @@ agent_org_paris_nord_social_polo = Agent.new(
   password: "123456",
   service_id: service_social.id,
   invitation_accepted_at: 10.days.ago,
-  roles_attributes: [{ organisation: org_paris_nord, level: AgentRole::LEVEL_BASIC }],
+  roles_attributes: [{ organisation: org_paris_nord, access_level: AgentRole::ACCESS_LEVEL_BASIC }],
   agent_territorial_access_rights_attributes: [{
     territory: territory75,
     allow_to_manage_teams: false,
@@ -426,7 +426,7 @@ org_arques_pmi_maya = Agent.new(
   password: "123456",
   service_id: service_pmi.id,
   invitation_accepted_at: 10.days.ago,
-  roles_attributes: Organisation.where(territory: territory62).pluck(:id).map { { organisation_id: _1, level: AgentRole::LEVEL_ADMIN } },
+  roles_attributes: Organisation.where(territory: territory62).pluck(:id).map { { organisation_id: _1, access_level: AgentRole::ACCESS_LEVEL_ADMIN } },
   agent_territorial_access_rights_attributes: [{
     territory: territory62,
     allow_to_manage_teams: true,
@@ -446,7 +446,7 @@ agent_org_bapaume_pmi_bruno = Agent.new(
   password: "123456",
   service_id: service_pmi.id,
   invitation_accepted_at: 10.days.ago,
-  roles_attributes: [{ organisation: org_bapaume, level: AgentRole::LEVEL_ADMIN }],
+  roles_attributes: [{ organisation: org_bapaume, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
   agent_territorial_access_rights_attributes: [{
     territory: territory62,
     allow_to_manage_teams: false,
@@ -467,7 +467,7 @@ agent_org_bapaume_pmi_gina = Agent.new(
   password: "123456",
   service_id: service_pmi.id,
   invitation_accepted_at: 10.days.ago,
-  roles_attributes: [{ organisation: org_bapaume, level: AgentRole::LEVEL_ADMIN }],
+  roles_attributes: [{ organisation: org_bapaume, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
   agent_territorial_access_rights_attributes: [{
     territory: territory62,
     allow_to_manage_teams: false,

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -119,9 +119,9 @@ agent_orgs_rdv_insertion = Agent.new(
   service_id: service_rsa.id,
   invitation_accepted_at: 10.days.ago,
   roles_attributes: [
-    { organisation: org_drome1, level: AgentRole::LEVEL_ADMIN },
-    { organisation: org_drome2, level: AgentRole::LEVEL_ADMIN },
-    { organisation: org_yonne, level: AgentRole::LEVEL_ADMIN },
+    { organisation: org_drome1, access_level: AgentRole::ACCESS_LEVEL_ADMIN },
+    { organisation: org_drome2, access_level: AgentRole::ACCESS_LEVEL_ADMIN },
+    { organisation: org_yonne, access_level: AgentRole::ACCESS_LEVEL_ADMIN },
   ],
   agent_territorial_access_rights_attributes: [
     { territory: territory_drome, allow_to_manage_teams: true },

--- a/db/seeds/rdv_mairie.rb
+++ b/db/seeds/rdv_mairie.rb
@@ -42,7 +42,7 @@ agent_mairie_de_sannois = Agent.new(
   service_id: service_titres.id,
   invitation_accepted_at: 10.days.ago,
   roles_attributes: [
-    { organisation: org_mairie_de_sannois, level: AgentRole::LEVEL_ADMIN },
+    { organisation: org_mairie_de_sannois, access_level: AgentRole::ACCESS_LEVEL_ADMIN },
   ],
   agent_territorial_access_rights_attributes: [
     { territory: territory_val_doise, allow_to_manage_teams: true },

--- a/spec/controllers/admin/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/agent_roles_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::AgentRolesController, type: :controller do
 
   describe "POST #update" do
     subject do
-      post :update, params: { organisation_id: organisation.id, id: agent_role.id, agent_role: { level: "admin" } }
+      post :update, params: { organisation_id: organisation.id, id: agent_role.id, agent_role: { access_level: "admin" } }
       agent_role.reload
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Admin::AgentRolesController, type: :controller do
     end
 
     it "changes role" do
-      expect { subject }.to change(agent_role, :level).from(AgentRole::LEVEL_BASIC).to(AgentRole::LEVEL_ADMIN)
+      expect { subject }.to change(agent_role, :access_level).from(AgentRole::ACCESS_LEVEL_BASIC).to(AgentRole::ACCESS_LEVEL_ADMIN)
     end
   end
 end

--- a/spec/controllers/admin/invitations_devise_controller_spec.rb
+++ b/spec/controllers/admin/invitations_devise_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
               },
             },
           },
@@ -83,7 +83,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
               },
             },
           },
@@ -105,7 +105,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
                 organisation_id: organisation2.id,
               },
             },
@@ -128,7 +128,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "admin",
+                access_level: "admin",
               },
             },
           },
@@ -141,7 +141,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
 
       it "creates a new basic agent instead of an admin" do
         expect { subject }.to change(Agent, :count).by(1)
-        expect(AgentRole.last).to have_attributes(level: AgentRole::LEVEL_BASIC)
+        expect(AgentRole.last).to have_attributes(access_level: AgentRole::ACCESS_LEVEL_BASIC)
       end
 
       context "when the agent already exists" do
@@ -156,14 +156,14 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             agent: {
               email: agent2.email,
               service_id: agent2.service_id,
-              roles_attributes: { "0" => { level: "basic" } },
+              roles_attributes: { "0" => { access_level: "basic" } },
             },
           }
         end
 
         it "invites the agent" do
           expect { subject }.to change { organisation.agents.count }.by(1)
-          expect(AgentRole.last).to have_attributes(level: AgentRole::LEVEL_BASIC)
+          expect(AgentRole.last).to have_attributes(access_level: AgentRole::ACCESS_LEVEL_BASIC)
         end
       end
     end
@@ -177,7 +177,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
               },
             },
           },
@@ -209,7 +209,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
               },
             },
           },
@@ -240,7 +240,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
               },
             },
           },
@@ -304,7 +304,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
             service_id: service_id,
             roles_attributes: {
               "0" => {
-                level: "basic",
+                access_level: "basic",
               },
             },
           },
@@ -323,7 +323,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
                    agent: {
                      email: "hacker@renard.com",
                      service_id: service_id,
-                     roles_attributes: { "0" => { level: "basic" } },
+                     roles_attributes: { "0" => { access_level: "basic" } },
                    }, }
         expect do
           post :create, params: params
@@ -338,7 +338,7 @@ RSpec.describe Admin::InvitationsDeviseController, type: :controller do
                    agent: {
                      email: "hacker@renard.com",
                      service_id: service_id,
-                     roles_attributes: { "0" => { level: "basic" } },
+                     roles_attributes: { "0" => { access_level: "basic" } },
                    }, }
         expect do
           post :create, params: params

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -6,10 +6,10 @@ describe Admin::Territories::AgentRolesController, type: :controller do
       territory = create(:territory)
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-      agent_role = create(:agent_role, agent: agent, level: "basic")
+      agent_role = create(:agent_role, agent: agent, access_level: "basic")
       sign_in agent
 
-      post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { level: "admin" } }
+      post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { access_level: "admin" } }
       expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
     end
 
@@ -17,12 +17,12 @@ describe Admin::Territories::AgentRolesController, type: :controller do
       territory = create(:territory)
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-      agent_role = create(:agent_role, agent: agent, level: "basic")
+      agent_role = create(:agent_role, agent: agent, access_level: "basic")
       sign_in agent
 
       expect do
-        post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { level: "admin" } }
-      end.to change { agent_role.reload.level }.from(AgentRole::LEVEL_BASIC).to(AgentRole::LEVEL_ADMIN)
+        post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { access_level: "admin" } }
+      end.to change { agent_role.reload.access_level }.from(AgentRole::ACCESS_LEVEL_BASIC).to(AgentRole::ACCESS_LEVEL_ADMIN)
     end
   end
 
@@ -35,7 +35,7 @@ describe Admin::Territories::AgentRolesController, type: :controller do
       other_agent = create(:agent, organisations: [])
       sign_in agent
 
-      post :create, params: { territory_id: territory.id, agent_role: { level: "admin", agent_id: other_agent.id, organisation_id: organisation.id } }
+      post :create, params: { territory_id: territory.id, agent_role: { access_level: "admin", agent_id: other_agent.id, organisation_id: organisation.id } }
       expect(response).to redirect_to(edit_admin_territory_agent_path(territory, other_agent))
     end
   end
@@ -47,12 +47,12 @@ describe Admin::Territories::AgentRolesController, type: :controller do
       organisation2 = create(:organisation, territory: territory)
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, territory: territory, agent: agent)
-      agent_role = create(:agent_role, organisation: organisation, agent: agent, level: "basic")
-      create(:agent_role, organisation: organisation2, agent: agent, level: "basic")
+      agent_role = create(:agent_role, organisation: organisation, agent: agent, access_level: "basic")
+      create(:agent_role, organisation: organisation2, agent: agent, access_level: "basic")
 
       last_agent = create(:agent)
       create(:agent_territorial_access_right, territory: territory, agent: last_agent)
-      create(:agent_role, organisation: organisation, agent: last_agent, level: "admin")
+      create(:agent_role, organisation: organisation, agent: last_agent, access_level: "admin")
 
       sign_in agent
 
@@ -65,11 +65,11 @@ describe Admin::Territories::AgentRolesController, type: :controller do
       organisation = create(:organisation, territory: territory)
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, territory: territory, agent: agent)
-      agent_role = create(:agent_role, organisation: organisation, agent: agent, level: "basic")
+      agent_role = create(:agent_role, organisation: organisation, agent: agent, access_level: "basic")
 
       last_agent = create(:agent)
       create(:agent_territorial_access_right, territory: territory, agent: last_agent)
-      create(:agent_role, organisation: organisation, agent: last_agent, level: "admin")
+      create(:agent_role, organisation: organisation, agent: last_agent, access_level: "admin")
 
       sign_in agent
 
@@ -82,12 +82,12 @@ describe Admin::Territories::AgentRolesController, type: :controller do
       organisation = create(:organisation, territory: territory)
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, territory: territory, agent: agent)
-      agent_role = create(:agent_role, organisation: organisation, agent: agent, level: "basic")
+      agent_role = create(:agent_role, organisation: organisation, agent: agent, access_level: "basic")
 
       # Il doit toujours y avoir un dernier admin dans une organisation pour le moment
       last_agent = create(:agent)
       create(:agent_territorial_access_right, territory: territory, agent: last_agent)
-      create(:agent_role, organisation: organisation, agent: last_agent, level: "admin")
+      create(:agent_role, organisation: organisation, agent: last_agent, access_level: "admin")
 
       sign_in agent
 

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -11,7 +11,7 @@ describe OrganisationsController, type: :controller do
             departement_number: "56",
           },
           agent_roles_attributes: [{
-            level: "admin",
+            access_level: "admin",
             agent_attributes: {
               email: "me@myself.hi",
               service_id: service.id,
@@ -41,7 +41,7 @@ describe OrganisationsController, type: :controller do
             departement_number: "56",
           },
           agent_roles_attributes: [{
-            level: "admin",
+            access_level: "admin",
             agent_attributes: {
               email: "me@myself.hi",
               service_id: "unknow", # this is the error

--- a/spec/factories/agent_role.rb
+++ b/spec/factories/agent_role.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
   factory :agent_role do
     agent
     organisation
-    level { AgentRole::LEVEL_BASIC }
+    access_level { AgentRole::ACCESS_LEVEL_BASIC }
 
     trait :admin do
-      level { AgentRole::LEVEL_ADMIN }
+      access_level { AgentRole::ACCESS_LEVEL_ADMIN }
     end
   end
 end

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -68,7 +68,7 @@ describe "Admin can configure the organisation" do
 
     click_link "PATRICK Tony"
     expect_page_title("Modifier le rôle de l'agent Tony PATRICK")
-    choose :agent_role_level_admin
+    choose :agent_role_access_level_admin
     click_button("Enregistrer")
 
     expect_page_title("Agents de Organisation n°1")

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -4,21 +4,21 @@ describe AgentRole, type: :model do
   describe "#can_access_others_planning?" do
     subject { agent_role.can_access_others_planning? }
 
-    context "admin level" do
+    context "admin access_level" do
       let(:agent_role) { build(:agent_role, :admin) }
 
       it { is_expected.to be_truthy }
     end
 
-    context "basic level, but agent is secretaire" do
+    context "basic access_level, but agent is secretaire" do
       let(:agent) { build(:agent, :secretaire) }
       let(:agent_role) { build(:agent_role, agent: agent) }
 
       it { is_expected.to be_truthy }
     end
 
-    context "basic level" do
-      let(:agent_role) { build(:agent_role, level: AgentRole::LEVEL_BASIC) }
+    context "basic access_level" do
+      let(:agent_role) { build(:agent_role, access_level: AgentRole::ACCESS_LEVEL_BASIC) }
 
       it { is_expected.to be_falsy }
     end
@@ -26,8 +26,8 @@ describe AgentRole, type: :model do
 
   describe "#organisation_cannot_change validation" do
     let!(:organisation) { create(:organisation) }
-    let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-    let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) } # needed to avoid validation error for orga without admin
+    let!(:agent_role1) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
+    let!(:agent_role2) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) } # needed to avoid validation error for orga without admin
     let!(:other_orga) { create(:organisation) }
 
     it "does not allow change" do
@@ -37,35 +37,35 @@ describe AgentRole, type: :model do
     end
 
     it "allows for another kind of update" do
-      result = agent_role1.update(level: AgentRole::LEVEL_BASIC)
+      result = agent_role1.update(access_level: AgentRole::ACCESS_LEVEL_BASIC)
       expect(result).to be_truthy
-      expect(agent_role1.reload.level).to eq(AgentRole::LEVEL_BASIC)
+      expect(agent_role1.reload.access_level).to eq(AgentRole::ACCESS_LEVEL_BASIC)
     end
   end
 
   describe "#organisations_have_at_least_one_admin validation" do
     context "there is another admin" do
       let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
+      let!(:agent_role1) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
+      let!(:agent_role2) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
 
       it "allows downgrading one agent" do
-        result = agent_role1.update(level: AgentRole::LEVEL_BASIC)
+        result = agent_role1.update(access_level: AgentRole::ACCESS_LEVEL_BASIC)
         expect(result).to be_truthy
-        expect(agent_role1.reload.level).to eq(AgentRole::LEVEL_BASIC)
+        expect(agent_role1.reload.access_level).to eq(AgentRole::ACCESS_LEVEL_BASIC)
       end
     end
 
     context "there are no other admins" do
       let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_BASIC, organisation: organisation) }
+      let!(:agent_role1) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
+      let!(:agent_role2) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_BASIC, organisation: organisation) }
 
       it "forbids downgrading admin" do
-        result = agent_role1.update(level: AgentRole::LEVEL_BASIC)
+        result = agent_role1.update(access_level: AgentRole::ACCESS_LEVEL_BASIC)
         expect(result).to be_falsey
         expect(agent_role1.errors).not_to be_empty
-        expect(agent_role1.reload.level).to eq(AgentRole::LEVEL_ADMIN)
+        expect(agent_role1.reload.access_level).to eq(AgentRole::ACCESS_LEVEL_ADMIN)
       end
     end
   end
@@ -73,8 +73,8 @@ describe AgentRole, type: :model do
   describe "#organisation_have_at_least_one_admin_before_destroy" do
     context "there is another admin" do
       let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
+      let!(:agent_role1) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
+      let!(:agent_role2) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
 
       it "allows destroying one agent" do
         agent_role1.destroy
@@ -84,8 +84,8 @@ describe AgentRole, type: :model do
 
     context "there are no other admins" do
       let!(:organisation) { create(:organisation) }
-      let!(:agent_role1) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
-      let!(:agent_role2) { create(:agent_role, level: AgentRole::LEVEL_BASIC, organisation: organisation) }
+      let!(:agent_role1) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
+      let!(:agent_role2) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_BASIC, organisation: organisation) }
 
       it "forbids destroying admin" do
         agent_role1.destroy

--- a/spec/policies/agent/agent_role_policy_spec.rb
+++ b/spec/policies/agent/agent_role_policy_spec.rb
@@ -9,14 +9,14 @@ describe Agent::AgentRolePolicy, type: :policy do
   describe "#update?" do
     context "regular agent, own agent_role" do
       let!(:agent) { create(:agent) }
-      let!(:agent_role) { create(:agent_role, level: AgentRole::LEVEL_BASIC, agent: agent, organisation: organisation) }
+      let!(:agent_role) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_BASIC, agent: agent, organisation: organisation) }
 
       permissions(:update?) { it { is_expected.not_to permit(pundit_context, agent_role) } }
     end
 
     context "admin agent, own agent_role" do
       let!(:agent) { create(:agent) }
-      let!(:agent_role) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, agent: agent, organisation: organisation) }
+      let!(:agent_role) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, agent: agent, organisation: organisation) }
 
       permissions(:update?) { it { is_expected.to permit(pundit_context, agent_role) } }
     end
@@ -24,7 +24,7 @@ describe Agent::AgentRolePolicy, type: :policy do
     context "admin agent, other agent's agent_role" do
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
       let!(:other_agent) { create(:agent) }
-      let!(:agent_role) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, agent: other_agent, organisation: organisation) }
+      let!(:agent_role) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, agent: other_agent, organisation: organisation) }
 
       permissions(:update?) { it { is_expected.to permit(pundit_context, agent_role) } }
     end
@@ -33,7 +33,7 @@ describe Agent::AgentRolePolicy, type: :policy do
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
       let!(:other_organisation) { create(:organisation) }
       let!(:other_agent) { create(:agent) }
-      let!(:agent_role) { create(:agent_role, level: AgentRole::LEVEL_ADMIN, agent: other_agent, organisation: other_organisation) }
+      let!(:agent_role) { create(:agent_role, access_level: AgentRole::ACCESS_LEVEL_ADMIN, agent: other_agent, organisation: other_organisation) }
 
       permissions(:update?) { it { is_expected.not_to permit(pundit_context, agent_role) } }
     end

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -162,12 +162,12 @@ describe "Absence authentified API", swagger_doc: "v1/api.json" do
 
         it_behaves_like "an endpoint that returns 403 - forbidden", "l'agent·e est dans un service différent" do
           let!(:agent) { create(:agent, service: create(:service)) }
-          let!(:agent_role) { create(:agent_role, agent: agent, level: AgentRole::LEVEL_BASIC, organisation: organisation) }
+          let!(:agent_role) { create(:agent_role, agent: agent, access_level: AgentRole::ACCESS_LEVEL_BASIC, organisation: organisation) }
         end
 
         response 200, "Possible si l'agent est admin", document: false do
           let!(:agent) { create(:agent, service: create(:service)) }
-          let!(:agent_role) { create(:agent_role, agent: agent, level: AgentRole::LEVEL_ADMIN, organisation: organisation) }
+          let!(:agent_role) { create(:agent_role, agent: agent, access_level: AgentRole::ACCESS_LEVEL_ADMIN, organisation: organisation) }
 
           let(:created_absence) { Absence.find(parsed_response_body["absence"]["id"]) }
 

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -43,7 +43,7 @@ describe AddConseillerNumerique do
       )
 
       expect(Agent.last.roles.last).to have_attributes(
-        level: "admin",
+        access_level: "admin",
         organisation_id: Organisation.last.id
       )
 


### PR DESCRIPTION
Afin de préparer l'ajout d'un nouveau rôle ("Intervenant") ici https://github.com/betagouv/rdv-solidarites.fr/issues/3560 je réalise dans cette PR les modifications suivantes :
- Je renomme l'attribut `level` du model `AgentRole` : 
En effet le mot clé `level` est utilisé dans plusieurs models et contexte différents dans le code (Sectorisation, Zone, Motifs, Notifications...) et ce n'est pas facile de retrouver toutes les occurrences de niveau d'accès des agents qui se confondent avec d'autres models et rendent le code moins lisible.
Pour rendre le code plus lisible j'ai renommé cet attribut en `access_level`
- J'en ai également profité pour modifier le type de champ PostGresql de cet attribut en un enum (TODO ligne 9 du model `AgentRole`)