### PR TITLE
Correction du protocole de connexion à clever technologies

### DIFF
--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -137,7 +137,7 @@ class SmsSender < BaseService
   #
   def send_with_clever_technologies
     response = Typhoeus::Request.new(
-      "http://webservicesmultimedias.clever-is.fr/api/pushs",
+      "https://webservicesmultimedias.clever-is.fr/api/pushs",
       method: :post,
       headers: { "Content-Type": "application/json; charset=UTF-8", Authorization: "Basic #{Base64.encode64(@api_key).chomp}" },
       timeout: 5,


### PR DESCRIPTION
Dans le cadre de la préparation à l'audit de sécurité, on a aperçu cette faille. J'ai testé manuellement et l'envoi de sms marche correctement en https.
Je vais contacter le dsi du 77 pour faire une rotation du mot de passe basic auth.