### PR TITLE
Nettoyage suite au renommage d'attribut `AgentRole` effectif coté rdv-i

### DIFF
--- a/app/blueprints/agent_role_blueprint.rb
+++ b/app/blueprints/agent_role_blueprint.rb
@@ -3,8 +3,7 @@
 class AgentRoleBlueprint < Blueprinter::Base
   identifier :id
 
-  # TODO: remove :level field after rdv-i migration
-  fields :level, :access_level
+  fields :access_level
   association :organisation, blueprint: OrganisationBlueprint
   association :agent, blueprint: AgentBlueprint
 end

--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -50,10 +50,6 @@ class AgentRole < ApplicationRecord
 
   ## -
 
-  def level # TODO: For API compatibility only, change in rdv-insertion and remove this method
-    access_level
-  end
-
   def can_access_others_planning?
     admin? || agent.service.secretariat?
   end

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -161,7 +161,7 @@
             span.text-muted.font-14= Motif.human_attribute_value(:visibility_type, value, context: :hint)
             - if current_organisation.rdv_insertion?
               br
-              span.text-muted.font-14.rdv-insertion-notif-hint= Motif.human_attribute_value(:visibility_type, value, context: :hint_rdv_insertion)
+              span.text-muted.font-14= Motif.human_attribute_value(:visibility_type, value, context: :hint_rdv_insertion)
 
   .card
     .card-body


### PR DESCRIPTION
Je termine la migration commencé ici :
https://github.com/betagouv/rdv-solidarites.fr/pull/3609
Les changements sont effectifs dans rdv-insertion ici :
https://github.com/betagouv/rdv-insertion/pull/1120
J'ai aussi enlevé une classe inutile (un oubli d'une précédente pr)