### PR TITLE
Refacto du traitement des token d'invitations

### DIFF
--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -15,7 +15,7 @@ module TokenInvitable
   private
 
   def store_invitation_in_session_and_redirect
-    invitation = Invitation.new(invitation_token: params[:invitation_token])
+    invitation = Invitation.new(current_url_params)
     return redirect_with_error(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
     return redirect_with_error(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)
 
@@ -37,7 +37,7 @@ module TokenInvitable
     return delete_invitation_from_session_and_redirect(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
     return delete_invitation_from_session_and_redirect(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)
     return delete_invitation_from_session_and_redirect(t("devise.invitations.session_expired")) if invitation.expired?
-    return if current_user.present? # no need to sign in if a user is already connected
+    return if current_user.present? # no need to sign in if the user is already connected
 
     user = invitation.user
     user.only_invited!(rdv: invitation.rdv)

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -1,68 +1,64 @@
 # frozen_string_literal: true
 
 # This concern allows to sign in users when a valid invitation token is passed through url params.
-# The user will be identified through the token. If the token is linked to a RdvsUser, it will also be
-# linked to a rdv.
+# If valid the invitation token and params will be stored in the session. The user will then be signed in through the invitation in session.
+# If the token is linked to a RdvsUser, it will also be linked to a rdv.
 module TokenInvitable
   extend ActiveSupport::Concern
 
   included do
-    prepend_before_action :handle_invitation_token, if: -> { invitation_token.present? }
+    # :store_invitation_in_session_and_redirect is called first, :sign_in_with_session_token after it
+    prepend_before_action :sign_in_with_session_token, if: -> { session[:invitation].present? }
+    prepend_before_action :store_invitation_in_session_and_redirect, if: -> { params[:invitation_token].present? }
   end
 
   private
 
-  def handle_invitation_token
-    store_token_in_session
+  def store_invitation_in_session_and_redirect
+    invitation = Invitation.new(invitation_token: params[:invitation_token])
+    return redirect_with_error(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
+    return redirect_with_error(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)
 
-    return delete_token_from_session_and_redirect(t("devise.invitations.invitation_token_invalid")) \
-      if invited_user.blank? && current_user.blank? # we don't check the token if a user is logged in already
+    session[:invitation] = current_url_params.merge(expires_at: 10.minutes.from_now)
 
-    return delete_token_from_session_and_redirect(t("devise.invitations.current_user_mismatch")) \
-      if current_user_mismatch?
-
-    return if invited_user.blank? || current_user.present?
-
-    invited_user.only_invited!(rdv: rdv_user_by_token&.rdv)
-    sign_in(invited_user, store: false)
+    redirect_to current_path_without_token
   end
 
-  def invitation_token
-    invitation_token_param || session[:invitation_token]
+  def current_path_without_token
+    new_params = current_url_params.except(:invitation_token)
+    new_params.any? ? "#{request.path}?#{new_params.to_query}" : request.path
   end
 
-  def invitation_token_param
-    params[:invitation_token]
+  def current_url_params
+    Rack::Utils.parse_nested_query(request.query_string).deep_symbolize_keys
   end
 
-  def store_token_in_session
-    session[:invitation_token] = invitation_token_param if invitation_token_param.present?
+  def sign_in_with_session_token
+    return delete_invitation_from_session_and_redirect(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
+    return delete_invitation_from_session_and_redirect(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)
+    return delete_invitation_from_session_and_redirect(t("devise.invitations.session_expired")) if invitation.expired?
+    return if current_user.present? # no need to sign in if a user is already connected
+
+    user = invitation.user
+    user.only_invited!(rdv: invitation.rdv)
+    sign_in(user, store: false)
   end
 
-  def current_user_mismatch?
-    invited_user.present? && current_user.present? && current_user != invited_user
+  def current_user_mismatch?(invited_user)
+    current_user.present? && current_user != invited_user
   end
 
-  def delete_token_from_session_and_redirect(error_msg)
-    session.delete(:invitation_token)
+  def delete_invitation_from_session_and_redirect(error_msg)
+    session.delete(:invitation)
+    redirect_with_error(error_msg)
+  end
+
+  def redirect_with_error(error_msg)
     flash[:error] = error_msg
     redirect_to root_path
   end
 
-  def invited_user
-    user_by_token || rdv_user_by_token&.user&.user_to_notify
-  end
-
-  def rdv_by_token
-    rdv_user_by_token&.rdv
-  end
-
-  def user_by_token
-    # find_by_invitation_token is a method added by the devise_invitable gem
-    @user_by_token ||= User.find_by_invitation_token(session[:invitation_token], true)
-  end
-
-  def rdv_user_by_token
-    @rdv_user_by_token ||= RdvsUser.find_by_invitation_token(session[:invitation_token], true)
+  def invitation
+    @invitation ||= (session[:invitation].present? ? Invitation.new(session[:invitation]) : nil)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,7 @@ class SearchController < ApplicationController
   after_action :allow_iframe
 
   def search_rdv
-    @context = SearchContext.new(current_user, search_params.to_h)
+    @context = SearchContext.new(user: current_user, query: search_query, through_invitation: invitation?)
     if current_domain == Domain::RDV_MAIRIE && request.path == "/"
       render "dsfr/rdv_mairie/homepage", layout: "application_dsfr"
     end
@@ -65,11 +65,19 @@ class SearchController < ApplicationController
     end
   end
 
+  def search_query
+    search_params.to_h.deep_symbolize_keys.merge(invitation? ? invitation.params : {})
+  end
+
+  def invitation?
+    invitation.present? && invitation.to_take_rdv?
+  end
+
   def search_params
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
       :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category_short_name,
-      :invitation_token, :motif_id, :public_link_organisation_id, :user_selected_organisation_id, :prescripteur,
+      :motif_id, :public_link_organisation_id, :user_selected_organisation_id, :prescripteur,
       organisation_ids: [], referent_ids: [], external_organisation_ids: []
     )
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,7 @@ class SearchController < ApplicationController
   after_action :allow_iframe
 
   def search_rdv
-    @context = SearchContext.new(user: current_user, query: search_query, through_invitation: invitation?)
+    @context = SearchContext.new(user: current_user, query_params: query_params, through_invitation: invitation?)
     if current_domain == Domain::RDV_MAIRIE && request.path == "/"
       render "dsfr/rdv_mairie/homepage", layout: "application_dsfr"
     end
@@ -65,8 +65,8 @@ class SearchController < ApplicationController
     end
   end
 
-  def search_query
-    search_params.to_h.deep_symbolize_keys.merge(invitation? ? invitation.params : {})
+  def query_params
+    search_params.to_h.deep_symbolize_keys.merge(invitation? ? invitation.query_params : {})
   end
 
   def invitation?

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -34,7 +34,7 @@ class UserAuthController < ApplicationController
   end
 
   def should_verify_user_name_initials?
-    return false if current_user.through_sign_in_form?
+    return false unless current_user.only_invited?
     return false if cookies.encrypted[user_name_initials_cookie_name] == true
 
     true

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -4,7 +4,7 @@ class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
     :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code, :rdv_collectif_id,
-    :street_ban_id, :invitation_token, :address, :motif_search_terms, :user_selected_organisation_id,
+    :street_ban_id, :address, :motif_search_terms, :user_selected_organisation_id,
     :public_link_organisation_id,
     { organisation_ids: [], referent_ids: [], external_organisation_ids: [] },
   ].freeze

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -45,7 +45,7 @@ class Users::RdvsController < UserAuthController
         address: (new_rdv_extra_params[:address] || new_rdv_extra_params[:where]),
         city_code: new_rdv_extra_params[:city_code], street_ban_id: new_rdv_extra_params[:street_ban_id],
         service: motif.service.id, motif_name_with_location_type: motif.name_with_location_type,
-        departement: new_rdv_extra_params[:departement], organisation_ids:  new_rdv_extra_params[:organisation_ids], invitation_token: invitation_token,
+        departement: new_rdv_extra_params[:departement], organisation_ids:  new_rdv_extra_params[:organisation_ids],
       }
       redirect_to prendre_rdv_path(query), flash: { error: t(".creneau_unavailable") }
     end

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -112,7 +112,7 @@ class Users::RdvsController < UserAuthController
   end
 
   def set_can_see_rdv_motif
-    @can_see_rdv_motif = current_user.through_sign_in_form?
+    @can_see_rdv_motif = !current_user.only_invited?
   end
 
   def redirect_if_creneau_not_available

--- a/app/controllers/users/user_name_initials_verification_controller.rb
+++ b/app/controllers/users/user_name_initials_verification_controller.rb
@@ -25,7 +25,7 @@ class Users::UserNameInitialsVerificationController < UserAuthController
 
   def after_success_redirect_path
     return session.delete(:return_to_after_verification) if session[:return_to_after_verification]
-    return users_rdv_path(rdv_by_token) if rdv_by_token
+    return users_rdv_path(invitation.rdv) if invitation&.rdv
 
     root_path
   end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -59,7 +59,7 @@ module UserRdvWizard
         motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: rdv.users&.map(&:id), rdv_collectif_id: rdv.id,
       }.merge(
         @attributes.slice(
-          :where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id, :invitation_token,
+          :where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id,
           :address, :organisation_ids, :motif_search_terms, :public_link_organisation_id, :user_selected_organisation_id,
           :referent_ids, :external_organisation_ids
         )

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -15,7 +15,7 @@ class Invitation
     @attributes[:invitation_token]
   end
 
-  def params
+  def query_params
     @attributes.except(:invitation_token, :expires_at)
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,52 @@
+class Invitation
+  attr_reader :attributes
+
+  def initialize(attributes)
+    @attributes = attributes.deep_symbolize_keys
+  end
+
+  def expires_at
+    @attributes[:expires_at]
+  end
+
+  def token
+    @attributes[:invitation_token]
+  end
+
+  def params
+    @attributes.except(:invitation_token, :expires_at)
+  end
+
+  def user
+    user_by_invitation_token || rdvs_user_by_invitation_token&.user&.user_to_notify
+  end
+
+  def rdv
+    rdvs_user_by_invitation_token&.rdv
+  end
+
+  def token_valid?
+    user.present?
+  end
+
+  def to_take_rdv?
+    user_by_invitation_token.present?
+  end
+
+  def to_edit_rdv?
+    rdvs_user_by_invitation_token.present?
+  end
+
+  def expired?
+    expires_at.blank? || expires_at < Time.zone.now
+  end
+
+  def user_by_invitation_token
+    # find_by_invitation_token is a method added by the devise_invitable gem
+    @user_by_invitation_token ||= token.present? ? User.find_by_invitation_token(token, true) : nil
+  end
+
+  def rdvs_user_by_invitation_token
+    @rdvs_user_by_invitation_token ||= token.present? ? RdvsUser.find_by_invitation_token(token, true) : nil
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Invitation
   attr_reader :attributes
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -227,10 +227,6 @@ class User < ApplicationRecord
     rdv.id == @invitation_rdv&.id
   end
 
-  def through_sign_in_form?
-    !only_invited?
-  end
-
   def domain
     if rdvs.any?
       rdvs.order(created_at: :desc).first.domain

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -2,32 +2,32 @@
 
 # rubocop:disable Metrics/ClassLength
 class SearchContext
-  attr_reader :errors, :query, :address, :city_code, :street_ban_id, :latitude, :longitude,
+  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude,
               :motif_name_with_location_type, :prescripteur, :through_invitation
   alias invitation? through_invitation
 
   # rubocop:disable Metrics/MethodLength
-  def initialize(user:, query: {}, through_invitation: false)
+  def initialize(user:, query_params: {}, through_invitation: false)
     @user = user
-    @query = query
-    @latitude = query[:latitude]
-    @longitude = query[:longitude]
-    @address = query[:address]
-    @city_code = query[:city_code]
-    @street_ban_id = query[:street_ban_id]
-    @public_link_organisation_id = query[:public_link_organisation_id]
-    @user_selected_organisation_id = query[:user_selected_organisation_id]
-    @external_organisation_ids = query[:external_organisation_ids]
-    @preselected_organisation_ids = query[:organisation_ids]
-    @motif_id = query[:motif_id]
-    @motif_search_terms = query[:motif_search_terms]
-    @motif_category_short_name = query[:motif_category_short_name]
-    @motif_name_with_location_type = query[:motif_name_with_location_type]
-    @service_id = query[:service_id]
-    @lieu_id = query[:lieu_id]
-    @start_date = query[:date]
-    @referent_ids = query[:referent_ids]
-    @prescripteur = query[:prescripteur]
+    @query_params = query_params
+    @latitude = query_params[:latitude]
+    @longitude = query_params[:longitude]
+    @address = query_params[:address]
+    @city_code = query_params[:city_code]
+    @street_ban_id = query_params[:street_ban_id]
+    @public_link_organisation_id = query_params[:public_link_organisation_id]
+    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
+    @external_organisation_ids = query_params[:external_organisation_ids]
+    @preselected_organisation_ids = query_params[:organisation_ids]
+    @motif_id = query_params[:motif_id]
+    @motif_search_terms = query_params[:motif_search_terms]
+    @motif_category_short_name = query_params[:motif_category_short_name]
+    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
+    @service_id = query_params[:service_id]
+    @lieu_id = query_params[:lieu_id]
+    @start_date = query_params[:date]
+    @referent_ids = query_params[:referent_ids]
+    @prescripteur = query_params[:prescripteur]
     @through_invitation = through_invitation
   end
   # rubocop:enable Metrics/MethodLength
@@ -57,9 +57,9 @@ class SearchContext
   def wizard_after_creneau_selection_path(params)
     url_helpers = Rails.application.routes.url_helpers
     if @prescripteur
-      url_helpers.prescripteur_start_path(query.merge(params))
+      url_helpers.prescripteur_start_path(query_params.merge(params))
     else
-      url_helpers.new_users_rdv_wizard_step_path(query.merge(params))
+      url_helpers.new_users_rdv_wizard_step_path(query_params.merge(params))
     end
   end
 
@@ -68,7 +68,7 @@ class SearchContext
   end
 
   def departement
-    @departement ||= (@query[:departement] || public_link_organisation&.departement_number)
+    @departement ||= (@query_params[:departement] || public_link_organisation&.departement_number)
   end
 
   def service
@@ -239,7 +239,7 @@ class SearchContext
     @matching_motifs ||= \
       if invitation?
         # we retrieve the geolocalised matching motifs, if there are none we fallback
-        # on the matching motifs for the organisations passed in the query
+        # on the matching motifs for the organisations passed in the query_params
         filter_motifs(geo_search.available_motifs).presence || filter_motifs(
           Motif.available_for_booking.where(organisation_id: @preselected_organisation_ids)
         )

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,30 +1,15 @@
 section.bg-light.p-4
   .container
-    - if context.invitation?
-      .card
-        .card-body
-          h2.py-1.my-1
-            i.fa.fa-info-circle>
-            = motif_name_and_location_type(context.first_matching_motif)
-            - if context.lieu.present?
-              .card-subtitle.my-2
-                i.fa.fa-map-marker-alt>
-                = context.lieu.address
-            - elsif context.user_selected_organisation.present?
-              .card-subtitle.my-2
-                i.fa.fa-building-columns>
-                = context.user_selected_organisation.name
-    - else
-      .card.card-hoverable
-        .card-body
-          = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
-            .row
-              .col-auto.align-self-center
-                i.fa.fa-chevron-left
-              .col
-                h2.pb-1.mb-1
-                  = motif_name_and_location_type(context.first_matching_motif)
-                = context.service.name
+    .card.card-hoverable
+      .card-body
+        = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
+          .row
+            .col-auto.align-self-center
+              i.fa.fa-chevron-left
+            .col
+              h2.pb-1.mb-1
+                = motif_name_and_location_type(context.first_matching_motif)
+              = context.service.name
       - if context.lieu.present?
         .card.card-hoverable
           .card-body

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -40,6 +40,6 @@ section.bg-light.p-4
           - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
             = render "rdv_collectif", rdv: rdv
         - elsif context.unique_motifs_by_name_and_location_type.present?
-          = render "creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query: context.query, context: context
+          = render "creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
         - else
           .alert.alert-warning= "Le motif <b>#{context.first_matching_motif.name}</b> n'est plus disponible à la réservation à <b>#{context.lieu.name}</b>".html_safe

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -3,7 +3,7 @@ div id="creneaux-lieu-#{lieu&.id}"
     - previous_from_date = date_range.begin - 7.days
     - if date_range.begin > Time.zone.today
       .col-12.col-md-auto.mb-2.mb-md-0.d-flex.align-items-center.justify-content-center
-        = link_to prendre_rdv_path(query.merge(date: previous_from_date)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "Semaine précédente" } do
+        = link_to prendre_rdv_path(query_params.merge(date: previous_from_date)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "Semaine précédente" } do
           i.fa.fa-chevron-left
           span.d-md-none.ml-1<
             | sem. précédente
@@ -35,7 +35,7 @@ div id="creneaux-lieu-#{lieu&.id}"
 
         - if next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center
-            = link_to prendre_rdv_path(query.merge(date: next_availability.starts_at)), class: "btn btn-light", data: { disable_with: "..." } do
+            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at)), class: "btn btn-light", data: { disable_with: "..." } do
               .d-flex.align-items-center
                 div
                   | Prochaine disponibilité le
@@ -45,7 +45,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                   i.fa.fa-chevron-right
     - if params[:date].blank? || (params[:date].to_date + 6.days) < (Time.now + max_public_booking_delay.seconds).to_date
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
-        = link_to prendre_rdv_path(query.merge(date: date_range.end + 1.day)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "semaine suivante"} do
+        = link_to prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "semaine suivante"} do
           span.d-md-none.mr-1
             | sem. prochaine
           i.fa.fa-chevron-right

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -12,7 +12,7 @@ section.bg-light.p-4
               .card-subtitle= lieu.address
               .card-subtitle= context.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
-              = link_to prendre_rdv_path(context.query.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+              = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
                 .row
                   .col
                     = t(".next_availability")

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -4,19 +4,14 @@ section.bg-light.p-4
     = render "nothing_to_show", context: context
   - else
     .container
-      - if context.invitation?
-        .card
-          .card-body
-            h2.pb-1.mb-1 = context.service.name
-      - else
-        .card
-          .card-body
-            = link_to path_to_service_selection(params), class: "d-block stretched-link" do
-              .row
-                .col-auto.align-self-center
-                  i.fa.fa-chevron-left
-                .col
-                  h2.pb-1.mb-1 = context.service.name
+      .card
+        .card-body
+          = link_to path_to_service_selection(params), class: "d-block stretched-link" do
+            .row
+              .col-auto.align-self-center
+                i.fa.fa-chevron-left
+              .col
+                h2.pb-1.mb-1 = context.service.name
     .container
        h2.font-weight-bold Sélectionnez le motif de votre RDV :
        - unless context.invitation?

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -26,10 +26,10 @@ section.bg-light.p-4
        - context.unique_motifs_by_name_and_location_type.each do |motif|
          .card.mb-3
            - if motif.restriction_for_rdv.blank?
-             = link_to(prendre_rdv_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+             = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do
                = render "motif_selection_card", motif: motif
            - else
              = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
                = render "motif_selection_card", motif: motif
-             = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query.merge(motif_name_with_location_type: motif.name_with_location_type)) do
+             = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type)) do
                = restriction_for_rdv_to_html(motif)

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -10,7 +10,7 @@ section.bg-light.p-4
               h3.card-title.mb-3.mt-0.text-success.font-weight-bold= organisation.name
               = render "organisation_card_subtitles", organisation: organisation
             .col-md.align-self-center.pt-3.pt-md-0.position-static
-              = link_to prendre_rdv_path(context.query.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+              = link_to prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
                 .row
                   .col
                     | Prochaine disponibilité le

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -21,6 +21,6 @@
     - if current_user&.participation_for(rdv)&.not_cancelled?
       .text-muted Vous êtes déjà inscrit pour cet atelier.
     - else
-      = link_to new_users_rdv_wizard_step_path(@context.query.merge(rdv_collectif_id: rdv.id)), class: "d-flex card-text mb-2" do
+      = link_to new_users_rdv_wizard_step_path(@context.query_params.merge(rdv_collectif_id: rdv.id)), class: "d-flex card-text mb-2" do
         i.fa.fa-fw.fa-user-plus>
         | &nbsp;S'inscrire

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -1,17 +1,10 @@
-- if context.invitation?
-  .card
-    .card-body
-      h2.py-1.my-1
-        i.fa.fa-info-circle>
-        = motif_name_and_location_type(context.first_matching_motif)
-- else
-  .card.card-hoverable
-    .card-body
-      = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
-        .row
-          .col-auto.align-self-center
-            i.fa.fa-chevron-left
-          .col
-            h2.pb-1.mb-1
-              = motif_name_and_location_type(context.first_matching_motif)
-            = context.service.name
+.card.card-hoverable
+  .card-body
+    = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
+      .row
+        .col-auto.align-self-center
+          i.fa.fa-chevron-left
+        .col
+          h2.pb-1.mb-1
+            = motif_name_and_location_type(context.first_matching_motif)
+          = context.service.name

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -16,7 +16,7 @@ section.bg-light.p-4
 
     - context.services.each do |service|
       .card.mb-3
-        = link_to prendre_rdv_path(context.query.merge(service_id: service.id)) do
+        = link_to prendre_rdv_path(context.query_params.merge(service_id: service.id)) do
           .card-body
             .row
               .col-md

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -26,6 +26,7 @@ fr:
       no_invitations_remaining: "Aucune invitation restante."
       invitation_removed: "Votre invitation a été annulée."
       current_user_mismatch: "L’utilisateur connecté ne correspond pas à l’utilisateur invité. Déconnectez-vous et réessayez."
+      session_expired: "La session a expiré"
       organisation_mismatch: "L’utilisateur concerné n’appartient pas à cette organisation."
       new:
         header: "Envoyer une invitation"

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -25,7 +25,7 @@ describe TokenInvitable, type: :controller do
     let!(:params) { { invitation_token: token, motif_category_short_name: "rsa_orientation" } }
 
     before do
-      allow(Invitation).to receive(:new).with(invitation_token: token).and_return(invitation)
+      allow(Invitation).to receive(:new).with(params).and_return(invitation)
       allow(invitation).to receive(:user).and_return(user)
     end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -115,8 +115,7 @@ RSpec.describe SearchController, type: :controller do
 
         it "lists the available motifs that match the search terms" do
           get :search_rdv, params: {
-            address: address, departement: departement_number, city_code: city_code,
-            invitation_token: invitation_token, motif_search_terms: "RSA orientation",
+            address: address, departement: departement_number, city_code: city_code, motif_search_terms: "RSA orientation",
           }
           expect(subject).to include("RSA orientation 1")
           expect(subject).to include("RSA orientation 2")
@@ -130,12 +129,16 @@ RSpec.describe SearchController, type: :controller do
           instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif2.id]))
         end
 
+        before do
+          request.session["invitation"] = {
+            address: address, departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+            expires_at: 1.hour.from_now,
+          }
+        end
+
         context "when there are matching motifs for the geo search available_motifs" do
           it "lists the available motifs" do
-            get :search_rdv, params: {
-              address: address, departement: departement_number, city_code: city_code,
-              invitation_token: invitation_token,
-            }
+            get :search_rdv
             expect(subject).to include("RSA orientation 2")
             expect(subject).not_to include("RSA orientation 1")
             expect(subject).not_to include("RSA orientation 3")
@@ -146,8 +149,7 @@ RSpec.describe SearchController, type: :controller do
         context "when there are no matching motifs for the geo search available_motifs after filtering" do
           it "lists the matching motifs linked to the orgas passed in the url" do
             get :search_rdv, params: {
-              organisation_ids: [organisation.id], address: address, departement: departement_number, city_code: city_code,
-              invitation_token: invitation_token, motif_category_short_name: "rsa_orientation",
+              organisation_ids: [organisation.id], motif_category_short_name: "rsa_orientation",
             }
             expect(subject).to include("RSA orientation 1")
             expect(subject).not_to include("RSA orientation 2")
@@ -157,8 +159,7 @@ RSpec.describe SearchController, type: :controller do
 
           it "reveals a problem when no motifs are available" do
             get :search_rdv, params: {
-              organisation_ids: [other_org.id], address: address, departement: departement_number, city_code: city_code,
-              invitation_token: invitation_token, motif_search_terms: "something random",
+              organisation_ids: [other_org.id], motif_search_terms: "something random",
             }
             expect(subject).to include("Un problème semble s'être produit pour votre invitation. Toutes nos excuses pour cela.")
             expect(subject).to include("support@rdv-solidarites.fr")

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -43,8 +43,10 @@ describe Users::RdvWizardStepsController, type: :controller do
           user.raw_invitation_token
         end
 
+        before { request.session[:invitation] = { invitation_token:, expires_at: 10.hours.from_now } }
+
         it "return success" do
-          get :new, params: { step: 2, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at, invitation_token: invitation_token }
+          get :new, params: { step: 2, motif_id: motif.id, lieu_id: lieu.id, starts_at: starts_at }
           expect(response).to have_http_status(:success)
           expect(assigns(:rdv).users).to eq([user])
           expect(response).to render_template("users/rdv_wizard_steps/step2")

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Users::RdvsController, type: :controller do
         motif_id: motif.id,
         starts_at: starts_at,
         organisation_ids: [organisation.id],
-        invitation_token: "44444",
       }
     end
 
@@ -75,8 +74,7 @@ RSpec.describe Users::RdvsController, type: :controller do
         expect(Rdv.count).to eq(0)
         expect(response).to redirect_to prendre_rdv_path(
           departement: "12", service: motif.service_id, motif_name_with_location_type: motif.name_with_location_type,
-          address: "1 rue de la, ville 12345", organisation_ids: [organisation.id], invitation_token: "44444",
-          city_code: "12100"
+          address: "1 rue de la, ville 12345", organisation_ids: [organisation.id], city_code: "12100"
         )
         expect(flash[:error]).to eq "Ce créneau n’est plus disponible. Veuillez en sélectionner un autre."
       end
@@ -296,8 +294,12 @@ RSpec.describe Users::RdvsController, type: :controller do
           user.raw_invitation_token
         end
 
+        before do
+          request.session[:invitation] = { invitation_token:, expires_at: 1.hour.from_now }
+        end
+
         it "redirects to the identity verification form" do
-          get :show, params: { id: rdv.id, invitation_token: invitation_token }
+          get :show, params: { id: rdv.id }
 
           expect(response).to redirect_to(new_users_user_name_initials_verification_path)
         end
@@ -360,8 +362,12 @@ RSpec.describe Users::RdvsController, type: :controller do
           user.raw_invitation_token
         end
 
+        before do
+          request.session[:invitation] = { invitation_token: invitation_token, expires_at: 1.hour.from_now }
+        end
+
         it "is not authorized" do
-          get :index, params: { invitation_token: invitation_token }
+          get :index
 
           expect(response).to redirect_to(root_path)
           expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.")

--- a/spec/controllers/users/user_name_initials_verification_controller_spec.rb
+++ b/spec/controllers/users/user_name_initials_verification_controller_spec.rb
@@ -67,10 +67,16 @@ describe Users::UserNameInitialsVerificationController, type: :controller do
 
         context "when a rdv can be found through the invitation token" do
           let!(:rdv) { create(:rdv) }
-          let!(:rdv_user) { create(:rdvs_user, rdv: rdv) }
+          let!(:invitation) { instance_double(Invitation) }
 
           before do
-            allow(RdvsUser).to receive(:find_by_invitation_token).and_return(rdv_user)
+            request.session[:invitation] = { invitation_token: "some-token" }
+            allow(Invitation).to receive(:new).and_return(invitation)
+            allow(invitation).to receive(:token_valid?).and_return(true)
+            allow(invitation).to receive(:expired?).and_return(false)
+            allow(invitation).to receive(:token_valid?).and_return(true)
+            allow(invitation).to receive(:user).and_return(user)
+            allow(invitation).to receive(:rdv).and_return(rdv)
           end
 
           it "redirects to the rdv path" do

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -165,8 +165,7 @@ describe "public pages", js: true do
             latitude: 48.859,
             longitude: 2.347,
             address: "Paris 75001",
-            service_id: motif.service_id,
-            invitation_token: invitation_token
+            service_id: motif.service_id
           )
           visit path
           expect(page).to have_content("Sélectionnez le motif de votre RDV")
@@ -182,8 +181,7 @@ describe "public pages", js: true do
             departement: 75,
             latitude: 48.859,
             longitude: 2.347,
-            street_ban_id: nil,
-            invitation_token: invitation_token
+            street_ban_id: nil
           )
           visit path
           expect(page).to have_content("Sélectionnez un lieu de RDV")
@@ -201,8 +199,7 @@ describe "public pages", js: true do
             longitude: 2.347,
             street_ban_id: nil,
             lieu_id: lieu.id,
-            date: Time.zone.now,
-            invitation_token: invitation_token
+            date: Time.zone.now
           )
 
           visit path

--- a/spec/features/allocation_for_search_context_spec.rb
+++ b/spec/features/allocation_for_search_context_spec.rb
@@ -21,7 +21,7 @@ describe "Allocation For Search Context" do
 
     params = { address: address, departement: departement_number, city_code: city_code, lieu_id: lieu.id, motif_name_with_location_type: "#{motif.name}-#{motif.location_type}" }
 
-    search_context = SearchContext.new(user: nil, query: params)
+    search_context = SearchContext.new(user: nil, query_params: params)
 
     before = GC.stat[:total_allocated_objects]
     search_context.unique_motifs_by_name_and_location_type

--- a/spec/features/allocation_for_search_context_spec.rb
+++ b/spec/features/allocation_for_search_context_spec.rb
@@ -21,7 +21,7 @@ describe "Allocation For Search Context" do
 
     params = { address: address, departement: departement_number, city_code: city_code, lieu_id: lieu.id, motif_name_with_location_type: "#{motif.name}-#{motif.location_type}" }
 
-    search_context = SearchContext.new(nil, params)
+    search_context = SearchContext.new(user: nil, query: params)
 
     before = GC.stat[:total_allocated_objects]
     search_context.unique_motifs_by_name_and_location_type

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -215,7 +215,7 @@ describe "User can be invited" do
       it "does not show the motifs that can be booked through invitation only" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation",
+          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
         )
 
         expect(page).to have_content(motif2.name)

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -203,7 +203,7 @@ describe "User can be invited" do
     end
   end
 
-  describe "when no motifs found through geo search" do
+  describe "when no motifs are found through geo search" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.none) }
     let!(:second_motif) do
       create(:motif, name: "RSA orientation telephone", bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation2, service: agent.service)
@@ -230,6 +230,26 @@ describe "User can be invited" do
       expect(page).to have_content(motif.name)
       expect(page).to have_content(second_motif.name)
       expect(page).to have_content(collectif_motif.name)
+    end
+  end
+
+  describe "invitation attributes cannot be modified" do
+    it "priorize the session invitation attributes to the url attributes" do
+      visit prendre_rdv_path(
+        departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+        address: "16 rue de la résistance", lieu_id: lieu.id
+      )
+
+      expect(page).to have_content(lieu.name)
+      expect(page).not_to have_content(lieu2.name)
+
+      visit prendre_rdv_path(
+        departement: departement_number, city_code: city_code,
+        address: "16 rue de la résistance", lieu_id: lieu2.id
+      )
+
+      expect(page).to have_content(lieu.name)
+      expect(page).not_to have_content(lieu2.name)
     end
   end
 end

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -208,7 +208,7 @@ describe "User can be invited" do
       end
     end
 
-    context "when this is not an invitation is not to take rdv" do
+    context "when this is not an invitation to take rdv" do
       let!(:rdvs_user) { create(:rdvs_user, user: user) }
       let!(:invitation_token) { rdvs_user.new_raw_invitation_token }
 

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -26,7 +26,10 @@ describe "User can be invited" do
   let!(:city_code) { "26000" }
   let!(:territory26) { create(:territory, departement_number: departement_number) }
   let!(:organisation) { create(:organisation, territory: territory26) }
-  let!(:motif) { create(:motif, name: "RSA orientation sur site", bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation, service: agent.service) }
+  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation") }
+  let!(:motif) do
+    create(:motif, name: "RSA orientation sur site", bookable_by: "agents_and_prescripteurs_and_invited_users", organisation:, service: agent.service, motif_category:)
+  end
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:lieu2) { create(:lieu, organisation: organisation) }
   let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now - 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
@@ -47,7 +50,7 @@ describe "User can be invited" do
     it "shows the available lieux to take a rdv", js: true do
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
+        address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
       )
 
       # Lieu selection
@@ -117,15 +120,16 @@ describe "User can be invited" do
           name: "RSA orientation sur site",
           max_public_booking_delay: 7.days,
           bookable_by: "agents_and_prescripteurs_and_invited_users",
-          organisation: organisation,
-          service: agent.service
+          organisation:,
+          service: agent.service,
+          motif_category:
         )
       end
 
       it "does not show the lieux" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
+          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
         )
 
         expect(page).not_to have_content(lieu.name)
@@ -137,7 +141,9 @@ describe "User can be invited" do
 
   describe "in motifs selection page" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
-    let!(:motif2) { create(:motif, name: "RSA orientation telephone", bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation2, service: agent.service) }
+    let!(:motif2) do
+      create(:motif, name: "RSA orientation telephone", bookable_by: "everyone", organisation: organisation2, service: agent.service, motif_category:)
+    end
     let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
 
     before do
@@ -148,7 +154,7 @@ describe "User can be invited" do
     it "shows the geo search available motifs to take a rdv", js: true do
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_search_terms: "RSA orientation"
+        address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
       )
 
       # Motif selection
@@ -199,6 +205,21 @@ describe "User can be invited" do
         # It directly selects the first motif and goes to lieu selection
         expect(page).to have_content(lieu.name)
         find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
+      end
+    end
+
+    context "when this is not an invitation is not to take rdv" do
+      let!(:rdvs_user) { create(:rdvs_user, user: user) }
+      let!(:invitation_token) { rdvs_user.new_raw_invitation_token }
+
+      it "does not show the motifs that can be booked through invitation only" do
+        visit prendre_rdv_path(
+          departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation",
+        )
+
+        expect(page).to have_content(motif2.name)
+        expect(page).not_to have_content(motif.name)
       end
     end
   end

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe "Adding a user to a collective RDV" do
       expect_confirm_participation.to change { rdv.reload.users.count }.from(0).to(1)
 
       expect(page).not_to have_content("modifier") # can_change_participants?
-      expect(::Addressable::URI.parse(current_url).query_values).to match("invitation_token" => /^[A-Z0-9]{8}$/)
 
       expect_notifications_sent_for(rdv, invited_user, :rdv_created)
       expect_webhooks_for(invited_user)

--- a/spec/services/search_context_spec.rb
+++ b/spec/services/search_context_spec.rb
@@ -4,10 +4,6 @@ describe SearchContext, type: :service do
   subject { described_class.new(user: user, query: search_query) }
 
   let!(:user) { create(:user, organisations: [organisation]) }
-  let!(:invitation_token) do
-    user.invite! { |u| u.skip_invitation = true }
-    user.raw_invitation_token
-  end
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:rsa_orientation) { create(:motif_category, name: "RSA orientation sur site", short_name: "rsa_orientation") }


### PR DESCRIPTION
## Contexte 

Grâce à ce qui a été fait dans #3568, on peut maintenant faire en sorte que des motifs soient réservables uniquement par des utilisateurs invités. Cependant, il est encore facile pour un utilisateur de prendre rdv sur un motif réservé aux utilisateurs invités:
* En utilisant le token qu'il a reçu dans la notification sms/mail lui permettant de consulter/modifier son rdv
* En retrouvant dans l'historique de son navigateur l'url contenant le token avec laquelle il a pris rdv 

Cette PR répond à ces 2 problématiques. En plus de ça, on fait également en sorte que les paramètres fixés dans l'url d'invitation ne soient pas modifiables par l'utilisateur.

## 🔧  Implémentation 

### Dans `TokenInvitable`

On change tout d'abord le fonctionnement du concern `TokenInvitable`, en faisant 2 actions distinctes : 
* S'il y a un token dans l'url et qu'il est valide, on persiste ce token en session **ainsi que les paramètres passés dans l'url**, puis on redirige vers cette url en enlevant le token d'invitation pour qu'il ne soit pas visible par l'utilisateur. On met également une durée d'expiration de 10 minutes à cette session
* S'il y a une invitation en session, qu'elle est valide et qu'elle n'est pas expirée, on sign in le user sur la page (en le marquant comme invité seulement)

Pour faire ça on introduit une classe `Invitation` qui gère la logique liée à cette dernière. 

### Dans le `SearchController` 

Lorsqu'on a une invitation en session et que c'est une invitation à prendre rdv (= le token est lié au `user` et pas au `rdvs_user` qui lui sert à consulter/modifier le rdv), on merge les paramètres de l'invitation aux paramètres de l'url: ça permet de ne pas rendre modifiable les paramètres de l'invitation. On passe également un nouveau paramètre au `SearchContext` pour dire qu'on est dans le cas d'une invitation.

## ➕ Avantages de cette implémentation 

En faisant ainsi, on a plus besoin d'une table d'invitation à part entière, et on n'a plus besoin d'intégrer une logique de validité aux invitations. En effet, on peut toujours réutiliser le même token puisqu'il n'est pas affiché à l'utilisateur. La logique de validité est gérée au niveau de rdv-insertion. 
On devra juste ajouter une nouvelle colonne pour ce token dans la table `users` car aujourd'hui la colonne est la même pour les invitations à prendre rdv et les invitations à créer un compte via devise.

## ➖ Inconvénients 

Ce mécanisme marche bien pour nous puisque l'utilisateur reçoit un lien vers rdv-insertion qui le redirige vers rdv-solidarités. Si l'utilisateur est amené un jour à être invité directement par rdv-solidarités, il recevrait un lien rdv-solidarités avec son token, il pourrait donc aisément modifier les paramètres de son invitation et réutiliser son token pour accéder à des motifs réservés aux invitations. 
Aussi, même via rdv-insertion le token peut être visible en regarder les requêtes faites via la console, mais on considère ce "risque" comme étant minime.

