### PR TITLE
Supprimer les jobs une semaine après leur exécution (à la place de 2 semaines)

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -4,6 +4,7 @@ Rails.application.configure do
   config.active_job.default_priority = 0
 
   config.good_job.preserve_job_records = true
+  config.cleanup_preserved_jobs_before_seconds_ago = 604_800 # 1 semaine
   config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) }
   config.good_job.execution_mode = :external
   config.good_job.queues = '*'


### PR DESCRIPTION
Voir https://github.com/bensheldon/good_job#configuration-options

En ce moment on a environ 380k jobs réussis stockés sur la table good job. J'ai l'impression que ça cause des problèmes de performance, puisque la page de dashboard de good job met beaucoup de temps à charger (et fait parfois des timeouts quand on cherche un job spécifique).
Actuellement, on utilise la valeur par défaut de ce paramètre de config, qui est de 2 semaines. Je pense qu'on peut se débrouiller avec 1 semaine dans la plupart des cas, et que ça va alléger cette table.

On va avoir beaucoup de suppression au moment où on merge cette PR, donc je vais plutôt faire ça en fin de journée.