### PR TITLE
Ouverture du lien alternatif pour prescripteur dans tous les département

### DIFF
--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -17,7 +17,8 @@
         = link_to new_registration_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)) do
           b Je m'inscris
 
-    hr
-      .text-center.text-muted
-        = link_to prescripteur_start_path(@rdv_wizard.to_query) do
-          b Je suis un prescripteur qui oriente un bénéficiaire
+    - if @rdv_wizard
+      hr
+        .text-center.text-muted
+          = link_to prescripteur_start_path(@rdv_wizard.to_query) do
+            b Je suis un prescripteur qui oriente un bénéficiaire

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -17,13 +17,7 @@
         = link_to new_registration_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)) do
           b Je m'inscris
 
-    / On évite généralement d'avoir de la logique spécifique au domain, mais ici il s'agit d'un feature flag temporaire,
-    / puisqu'on compte bientôt ouvrir cette fonctionnalité à tous les domaines
-    / On a aussi un feature flag pour l'expérimentation dans le Var en démo
-    - demo_var = @rdv_wizard&.motif&.organisation&.territory&.departement_number == "83" && current_domain.host_name.include?("demo")
-    - if @rdv_wizard && (current_domain == Domain::RDV_AIDE_NUMERIQUE || demo_var)
-      hr
-        .text-center
-          p.text-muted
-            = link_to prescripteur_start_path(@rdv_wizard.to_query) do
-              b Je suis un prescripteur qui oriente un bénéficiaire
+    hr
+      .text-center.text-muted
+        = link_to prescripteur_start_path(@rdv_wizard.to_query) do
+          b Je suis un prescripteur qui oriente un bénéficiaire


### PR DESCRIPTION
Après discussion avec Mehdi, suite à l'ouverture de la fonctionnalité prescripteur dans la Somme, on veut rendre le lien "Je suis un prescripteur qui oriente un bénéficiaire" utilisable pour tous les départements.

C'est utile pour les prescripteurs qui ont "perdu" le lien de prescription, et maintenant qu'on a un peu de recul sur la fonctionnalité, on est en confiance pour avoir ce lien dans tous les départements.
<img width="839" alt="Screenshot 2023-06-19 at 17 36 17" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/897415ca-ddb6-401d-b28b-0e475c9ae8c8">

