### PR TITLE
[SuperAdmin Mairies] Fix bugs on search

### DIFF
--- a/app/dashboards/mairie_compte_dashboard.rb
+++ b/app/dashboards/mairie_compte_dashboard.rb
@@ -12,10 +12,10 @@ class MairieCompteDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
-    address: PlacesField,
-    agent_email: Field::String,
-    agent_first_name: Field::String,
-    agent_last_name: Field::String,
+    address: PlacesField.with_options(searchable: true),
+    agent_email: Field::String.with_options(searchable: false),
+    agent_first_name: Field::String.with_options(searchable: false),
+    agent_last_name: Field::String.with_options(searchable: false),
   }.freeze
 
   # COLLECTION_ATTRIBUTES


### PR DESCRIPTION
## SuperAdmin Mairies
- Fix bugs on search: Only allow search on name and address field. Mairie is basically a `Lieu`.
