### PR TITLE
Enlever le tag `inactif` de l'index des agents pour les agents intervenants

### DIFF
--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -5,7 +5,7 @@ tr id="agent_#{agent.id}"
     - if agent.complete?
       - if policy([:agent, agent_role]).edit?
         = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
-        - if agent.inactive?
+        - if agent.inactive? && !agent.all_roles_intervenant?
           = tag.span("Inactif", class: "badge badge-warning")
       - else
         span.mr-2= agent.reverse_full_name


### PR DESCRIPTION
C'est un oubli dans ma dernière PR de mise en place des intervenants.
Ce tag n'a pas lieu d'être dans l'ux pour les agents intervenants car ils ne se connectent pas.

avant :
![Capture d’écran 2023-06-21 à 14 37 41](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/9700d1da-1835-40d1-ad13-5cfc005ac0c1)

après : 

![Capture d’écran 2023-06-21 à 14 37 32](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/7c5989fb-ae86-44d2-a677-c06eb8451443)

