### PR TITLE
Correctif pour le branchement des mairies proches d'une autre mairie sur le moteur de recherche de l'ANTS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -212,9 +212,6 @@ Style/HashSyntax:
 Style/DateTime:
   Enabled: true
 
-Style/MultilineBlockChain:
-  Enabled: false
-
 Naming/BlockForwarding:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -212,6 +212,9 @@ Style/HashSyntax:
 Style/DateTime:
   Enabled: true
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 Naming/BlockForwarding:
   Enabled: false
 

--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -10,7 +10,7 @@ class Api::Ants::EditorController < Api::Ants::BaseController
   def available_time_slots
     # On ne peut pas utiliser params[:meeting_point_ids] car l'ants passe une liste de paramètres sans crochets.
     # Autrement dit, ils utilisent la syntaxe meeting_point_ids=1&meeting_point_ids=2 pour envoyer un tableau d'ids
-    meeting_point_ids = extract_meeting_point_ids_without_square_brackets(request.query_string)
+    meeting_point_ids = request.query_string.scan(/meeting_point_ids=(\d+)/).flatten
 
     render json: lieux.where(id: meeting_point_ids).to_h { |lieu| [lieu.id, time_slots(lieu, params[:reason])] }
   end
@@ -20,14 +20,6 @@ class Api::Ants::EditorController < Api::Ants::BaseController
   CNI_AND_PASSPORT_MOTIF_CATEGORY_NAME = "Carte d'identité et passeport disponible sur le site de l'ANTS"
 
   private
-
-  def extract_meeting_point_ids_without_square_brackets(query_string)
-    query_string.split("&").select do |query_string_segment|
-      query_string_segment.start_with?("meeting_point_ids=")
-    end.map do |query_string_segment|
-      query_string_segment.split("=").last
-    end
-  end
 
   def lieux
     Lieu.joins(:organisation).where(organisations: { verticale: :rdv_mairie })

--- a/spec/features/users/user_can_search_rdv_on_rdv_mairie_spec.rb
+++ b/spec/features/users/user_can_search_rdv_on_rdv_mairie_spec.rb
@@ -39,7 +39,7 @@ describe "User can search rdv on rdv mairie" do
     expect(lieux_ids).to eq([lieu.id.to_s])
 
     visit api_ants_availableTimeSlots_url(
-      meeting_point_ids: lieux_ids,
+      meeting_point_ids: lieux_ids.first,
       start_date: Date.yesterday,
       end_date: Date.tomorrow,
       reason: "PASSPORT"
@@ -78,33 +78,5 @@ describe "User can search rdv on rdv mairie" do
     click_link("Confirmer mon RDV")
     expect(page).to have_content("Votre rendez vous a été confirmé.")
     expect(user.reload.ants_pre_demande_number).to eq(ants_pre_demande_number)
-  end
-
-  context "with multiple mairies" do
-    let!(:organisation2) { create(:organisation, :with_contact, territory: territory95, verticale: :rdv_mairie) }
-    let!(:lieu2) { create(:lieu, organisation: organisation2, name: "Mairie de Romainville", address: "Place de la mairie, Romainville, 93230") }
-    let!(:motif2) { create(:motif, name: "Passeport", organisation: organisation2, restriction_for_rdv: nil, service: service, motif_category: passport_motif_category) }
-
-    before do
-      create(:plage_ouverture, :no_recurrence, first_day: now, motifs: [motif2], lieu: lieu2, organisation: organisation2, start_time: Tod::TimeOfDay(9), end_time: Tod::TimeOfDay.new(10))
-    end
-
-    it "shows the creneaux for each mairie" do
-      visit api_ants_availableTimeSlots_url(
-        meeting_point_ids: [lieu2.id],
-        start_date: Date.yesterday,
-        end_date: Date.tomorrow,
-        reason: "PASSPORT"
-      )
-
-      time = Time.zone.now.change(hour: 9, min: 0o0)
-
-      expect(json_response).to eq(lieu2.id.to_s => [
-                                    {
-                                      "datetime" => time.strftime("%Y-%m-%dT%H:%MZ"),
-                                      "callback_url" => creneaux_url(starts_at: time.strftime("%Y-%m-%d %H:%M"), lieu_id: lieu2.id, motif_id: motif2.id),
-                                    },
-                                  ])
-    end
   end
 end

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -25,7 +25,7 @@ describe "ANTS API: availableTimeSlots" do
 
   it "returns a list of slots" do
     # L'ANTS nous envoie la requête en utilisant la syntaxe meeting_point_ids=1&meeting_point_ids=2 pour envoyer un tableau d'ids
-    # donc on encode la querystring d'une manière similaire ici pour reproduire ce comportement
+    # sans crochets donc on encode la querystring d'une manière similaire ici pour reproduire ce comportement
     get "/api/ants/availableTimeSlots?meeting_point_ids=#{lieu1.id}&meeting_point_ids=#{lieu2.id}&start_date=2022-11-01&end_date=2022-11-02&documents_number=1&reason=CNI"
 
     expect(JSON.parse(response.body)).to eq(

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -7,10 +7,12 @@ describe "ANTS API: availableTimeSlots" do
     create(:lieu, organisation: organisation)
   end
   let(:lieu2) do
-    create(:lieu, organisation: organisation)
+    create(:lieu, organisation: organisation2)
   end
   let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+  let(:organisation2) { create(:organisation, verticale: :rdv_mairie) }
   let(:motif) { create(:motif, organisation: organisation, default_duration_in_min: 30, motif_category: cni_motif_category) }
+  let(:motif2) { create(:motif, organisation: organisation2, default_duration_in_min: 30, motif_category: cni_motif_category) }
   let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }
 
   before do
@@ -20,7 +22,7 @@ describe "ANTS API: availableTimeSlots" do
                              organisation: organisation, motifs: [motif])
     create(:plage_ouverture, lieu: lieu2, first_day: Date.new(2022, 11, 2),
                              start_time: Tod::TimeOfDay(12), end_time: Tod::TimeOfDay(13),
-                             organisation: organisation, motifs: [motif])
+                             organisation: organisation2, motifs: [motif2])
   end
 
   it "returns a list of slots" do
@@ -43,11 +45,11 @@ describe "ANTS API: availableTimeSlots" do
         lieu2.id.to_s => [
           {
             datetime: "2022-11-02T12:00Z",
-            callback_url: creneaux_url(starts_at: "2022-11-02 12:00", lieu_id: lieu2.id, motif_id: motif.id),
+            callback_url: creneaux_url(starts_at: "2022-11-02 12:00", lieu_id: lieu2.id, motif_id: motif2.id),
           },
           {
             datetime: "2022-11-02T12:30Z",
-            callback_url: creneaux_url(starts_at: "2022-11-02 12:30", lieu_id: lieu2.id, motif_id: motif.id),
+            callback_url: creneaux_url(starts_at: "2022-11-02 12:30", lieu_id: lieu2.id, motif_id: motif2.id),
           },
         ],
       }.with_indifferent_access

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -24,13 +24,9 @@ describe "ANTS API: availableTimeSlots" do
   end
 
   it "returns a list of slots" do
-    get "/api/ants/availableTimeSlots", params: {
-      meeting_point_ids: [lieu1.id, lieu2.id],
-      start_date: "2022-11-01",
-      end_date: "2022-11-02",
-      reason: "CNI",
-      documents_number: 1,
-    }
+    # L'ANTS nous envoie la requête en utilisant la syntaxe meeting_point_ids=1&meeting_point_ids=2 pour envoyer un tableau d'ids
+    # donc on encode la querystring d'une manière similaire ici pour reproduire ce comportement
+    get "/api/ants/availableTimeSlots?meeting_point_ids=#{lieu1.id}&meeting_point_ids=#{lieu2.id}&start_date=2022-11-01&end_date=2022-11-02&documents_number=1&reason=CNI"
 
     expect(JSON.parse(response.body)).to eq(
       {


### PR DESCRIPTION
On a remarqué que la mairie de Parçay Meslay n'apparaissait pas dans le motuer de recherche de l'ANTS, alors que les autres y sont et qu'ils ont des disponibilités.

Après un échange de mail avec l'équipe technique de l'ants, ils nous on donné cette réponse :
> Le bug arrive quand on vous envoie plusieurs valeurs de meeting_point_ids, vous ne prendez en considération que le dernier.

> Exemple de requête multi-valeurs:
curl --location --request GET 'https://rdv.anct.gouv.fr/api/ants/availableTimeSlots?meeting_point_ids=11&start_date=2023-06-23&end_date=2023-09-23&meeting_point_ids=3&documents_number=1&reason=CNI' \

Ils n'utilisent pas de crochets `[]` pour passer un tableau de valeurs, et donc quand rails parse la query string, on obtenait `params[:meeting_point_ids] == 3`.

Le fix est donc de parser à la main la query string pour ce paramètre précis, et d'expliquer pourquoi on fait ça.
