### PR TITLE
Amélioration UX sélection automatique des options quand il y en a qu'une dans tous les formulaires

### DIFF
--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -19,7 +19,11 @@ class Select2Inputs {
     document.querySelectorAll(this.selector).forEach(this.initInput)
   }
 
-  initInput = (elt) => $(elt).select2(this.getInputOptions(elt))
+  initInput = (elt) => {
+    const options = this.getInputOptions(elt)
+    $(elt).select2(options)
+    this.autoSelectOption(elt, options)
+  }
 
   getInputOptions = elt => {
     let options = {}
@@ -27,7 +31,6 @@ class Select2Inputs {
       options = JSON.parse(elt.dataset.selectOptions)
     if (options.disableSearch)
       options.minimumResultsForSearch = Infinity // cf https://select2.org/searching
-
     // Make sure select2 works correctly inside a modal
     // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
     let modal = $(elt).closest(".modal")[0]
@@ -51,6 +54,24 @@ class Select2Inputs {
   destroyInputs = () => {
     if ($(this.selector).first().data('select2') != undefined)
       $(this.selector).select2('destroy')
+  }
+
+  autoSelectOption = (elt, options) => {
+    // This code checks if a select element (represented by the `elt` variable) has only one option.
+    // return all options if it is ajax
+    const isAjax = elt.dataset.selectOptions?.includes("ajax");
+    if (isAjax) return options;
+
+    // Get all options and remove blank values if exists (placeholders)
+    const optionsList = $(elt).find("option").filter(function() {
+      return $(this).val() !== "";
+    });
+    if (optionsList.length === 1) {
+      // if one option is already selected, return
+      if ($(elt).val() === optionsList.val()) return;
+      // Otherwise, set the value of the select element to the value of its only option and trigger a change event on it.
+      $(elt).val(optionsList.val()).trigger('change');
+    }
   }
 }
 

--- a/app/javascript/components/service-filter-for-motifs-selects.js
+++ b/app/javascript/components/service-filter-for-motifs-selects.js
@@ -47,6 +47,16 @@ class ServiceFilterForMotifsSelects {
     const filteredOptionsWithBlank = [{id: "", text: ""}].concat(filteredOptionsWithSelected)
     $(this.motifSelect).html("") // otherwise it doesn't clear previous options
     $(this.motifSelect).select2({ data: filteredOptionsWithBlank })
+
+    if (filteredOptionsWithSelected.length == 1 && filteredOptionsWithSelected[0].children.length == 1) {
+      this.autoselectFirstMotif();
+    }
+  }
+
+  autoselectFirstMotif = () => {
+    const options = this.motifSelect.querySelectorAll("option")
+    options[1].selected = true
+    $(this.motifSelect).trigger("change")
   }
 
   getFilteredGroupedOptions = (serviceName) =>

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -7,7 +7,13 @@
       h5.card-title Configuration générale
       .form-row
         .col-md-6
-          = f.association :service, collection: Service.all_for_territory(current_territory)
+          = f.association :service, collection: Service.all_for_territory(current_territory), input_html: { \
+            class: "select2-input", \
+            data: { \
+              placeholder: "Sélectionnez un service", \
+              "select-options": { disableSearch: true }, \
+            }, \
+          }
         .col-md-6
           = f.input :name
       .form-row

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -4,12 +4,17 @@
     = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
       = f.input :title, hint: "Uniquement visible en interne", placeholder: "Ex: Permanence PMI exceptionnelle"
-      - lieux = policy_scope(Lieu).enabled.ordered_by_name
-      = f.association :lieu, \
-        collection: lieux, \
-        label_method: :full_name, \
-        include_blank: true, \
-        selected: plage_ouverture.lieu_id || (lieux.size == 1 ? lieux.first.id : nil)
+      = f.association :lieu,
+        collection: policy_scope(Lieu).enabled.ordered_by_name,
+        label_method: :full_name,
+        input_html: { \
+            class: "select2-input", \
+            data: { \
+              placeholder: "Sélectionnez un lieu", \
+              "select-options": { disableSearch: true }, \
+              "allow-clear": true, \
+            }, \
+          }
       = f.association :motifs, collection: plage_ouverture.available_motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes
 
       hr

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -33,6 +33,38 @@ describe "Agent can create a Rdv with creneau search" do
     end
   end
 
+  context "when there is only one option for lieu, service and motif selector" do
+    let!(:motif) { create(:motif, service: agent.service, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], agent: agent, organisation: organisation) }
+
+    it "automatically select the option" do
+      visit admin_organisation_agent_searches_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      expect(page).to have_select("lieu_ids", selected: plage_ouverture.lieu_name)
+      expect(page).to have_select("motif_id", selected: "Motif 1 (Sur place)")
+      expect(page).to have_select("service_id", selected: agent.service.name)
+    end
+  end
+
+  context "when there is more than one option for lieux, services and motifs selector" do
+    let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+    let!(:lieu) { create(:lieu, organisation: organisation) }
+    let!(:motif) { create(:motif, service: agent.service, organisation: organisation) }
+    let!(:motif2) { create(:motif, service: agent.service, organisation: organisation) }
+    let!(:another_service) { create(:service) }
+    let!(:another_agent) { create(:agent, service: another_service, basic_role_in_organisations: [organisation]) }
+    let!(:another_lieu) { create(:lieu, organisation: organisation) }
+    let!(:another_motif) { create(:motif, service: another_service, organisation: organisation) }
+
+    it "doesnt automatically select options" do
+      visit admin_organisation_agent_searches_path(organisation)
+      expect(page).to have_content("Trouver un RDV")
+      expect(page).to have_select("lieu_ids", selected: [])
+      expect(page).to have_select("motif_id", selected: "")
+      expect(page).to have_select("service_id", selected: "")
+    end
+  end
+
   context "when there are multiple plages from different agents in the same lieu" do
     before { travel_to(Date.new(2023, 5, 2)) }
 

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -33,7 +33,7 @@ describe "Agent can create a Rdv with creneau search" do
     end
   end
 
-  context "when there is only one option for lieu, service and motif selector" do
+  context "when there is only one option for lieu, service and motif selector", js: true do
     let!(:motif) { create(:motif, service: agent.service, organisation: organisation) }
     let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], agent: agent, organisation: organisation) }
 
@@ -46,7 +46,7 @@ describe "Agent can create a Rdv with creneau search" do
     end
   end
 
-  context "when there is more than one option for lieux, services and motifs selector" do
+  context "when there is more than one option for lieux, services and motifs selector", js: true do
     let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
     let!(:motif) { create(:motif, service: agent.service, organisation: organisation) }


### PR DESCRIPTION
Fait suite à un travail entamé ici : https://github.com/betagouv/rdv-solidarites.fr/pull/3601

On en a discuté avec Victor et il s'avère qu'il y a bcp de formulaire qui auraient nécessité des modifications de ce type pour sélectionner automatiquement l'élément comme ici : 

```ruby
      - lieux = policy_scope(Lieu).enabled.ordered_by_name
      = f.association :lieu, \
        collection: lieux, \
        label_method: :full_name, \
        label: false, \
        include_blank: true, \
        required: false, \
        selected: (lieux.size == 1 ? lieux.first.id : nil), \
```

Ce n'est pas la solution idéale, l'objectif est de trouver une solution globale pour que le comportement par défaut soit de sélectionner automatiquement l'élément d'une collection d'un formulaire quand cette collection n'en contient qu'un seul.

J'ai commencé à travailler sur un helper `simple_form` mais cela m'a posé pas mal de difficultés et d'effets de bords.
Le code devient trop spécifique et complexe.

J'ai donc préféré modifier le fonctionnement de nos champs `select2-input` pour prendre en compte le nouveau comportement. J'ai également du modifié le fichier js du sélectionneur de service qui filtre les motifs pour l'adapter de la même façon.

Avant :

![Capture d’écran 2023-06-27 à 12 42 39](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/5156758b-fca4-4593-8452-deeb3abee848)

Après :

![Capture d’écran 2023-06-27 à 12 42 50](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/88854775-dcdd-49fa-a93a-a00d9ea7c0c3)
