### PR TITLE
Suppression d'une vérification inutile dans inclusion_connect

### DIFF
--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -24,7 +24,7 @@ module InclusionConnect
       return false if token.blank?
 
       user_info = get_user_info(token)
-      return false if user_info.blank? || (user_info["email_verified"] == false)
+      return false if user_info.blank?
 
       get_and_update_agent(user_info)
     end

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -23,7 +23,7 @@ describe InclusionConnectController, type: :controller do
           "Authorization" => "Bearer zekfjzeklfjl",
           "User-Agent" => "Typhoeus - https://github.com/typhoeus/typhoeus",
         }
-      ).to_return(status: 200, body: { email_verified: true, given_name: "Bob", family_name: "Eponge", email: "bob@demo.rdv-solidarites.fr" }.to_json, headers: {})
+      ).to_return(status: 200, body: { given_name: "Bob", family_name: "Eponge", email: "bob@demo.rdv-solidarites.fr" }.to_json, headers: {})
 
       state = "A STATE"
       session[:ic_state] = state
@@ -100,31 +100,6 @@ describe InclusionConnectController, type: :controller do
           "User-Agent" => "Typhoeus - https://github.com/typhoeus/typhoeus",
         }
       ).to_return(status: 500, body: "", headers: {})
-
-      session[:ic_state] = "a state"
-      get :callback, params: { state: "a state", session_state: "a state", code: "klzefklzejlf" }
-
-      expect(response).to redirect_to(new_agent_session_path)
-      expect(flash[:error]).to eq("Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse <support@rdv-solidarites.fr> si le problème persiste.")
-
-      # HTTP request is sent to Sentry as breadcrumbs
-      expect(sentry_events.last.breadcrumbs.compact.map(&:message).uniq).to eq(["HTTP request", "HTTP response"])
-    end
-
-    it "returns an error if userinfo's email checked is false" do
-      stub_const("InclusionConnect::IC_CLIENT_ID", "truc")
-      stub_const("InclusionConnect::IC_CLIENT_SECRET", "truc secret")
-      stub_const("InclusionConnect::IC_BASE_URL", base_url)
-
-      stub_token_request.to_return(status: 200, body: { access_token: "zekfjzeklfjl", expires_in: "", scopes: "openid" }.to_json, headers: {})
-
-      stub_request(:get, "#{base_url}/userinfo?schema=openid").with(
-        headers: {
-          "Expect" => "",
-          "Authorization" => "Bearer zekfjzeklfjl",
-          "User-Agent" => "Typhoeus - https://github.com/typhoeus/typhoeus",
-        }
-      ).to_return(status: 200, body: { email_verified: false, given_name: "Bob", family_name: "Eponge", email: "bob@demo.rdv-solidarites.fr" }.to_json, headers: {})
 
       session[:ic_state] = "a state"
       get :callback, params: { state: "a state", session_state: "a state", code: "klzefklzejlf" }


### PR DESCRIPTION
Closes #3635

Fin Juillet Inclusion Connect change de version et cette condition (qui à priori ne servait à rien) pose problème car `email_verified` ne sera plus renvoyé par l'api.
J'ai enlevé la condition et les tests associés.