### PR TITLE
Afficher la modal des instructions du rdv après la sélection du lieu

### DIFF
--- a/app/views/common/_creneaux.html.slim
+++ b/app/views/common/_creneaux.html.slim
@@ -1,3 +1,8 @@
+/ Je pense que ce fichier n'est pas utilisé
+/ (il n'y a pas de lien vers lui dans les autres fichiers)
+/ Il faudrait le supprimer si c'est le cas
+/ Le fichier utilisée pour cet usage semble être app/views/search/_creneaux.html.slim
+
 div id="creneaux-lieu-#{lieu.id}"
   .row
     - previous_from_date = date_range.begin - 7.days

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -10,17 +10,17 @@ section.bg-light.p-4
               h2.pb-1.mb-1
                 = motif_name_and_location_type(context.first_matching_motif)
               = context.service.name
-      - if context.lieu.present?
-        .card.card-hoverable
-          .card-body
-            = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
-              .row
-                .col-auto.align-self-center
-                  i.fa.fa-chevron-left
-                .col
-                  h2.pb-1.mb-1.card-title= context.lieu.name
-                  .card-subtitle= context.lieu.address
-      - elsif context.user_selected_organisation.present?
+    - if context.lieu.present?
+      .card.card-hoverable
+        .card-body
+          = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+            .row
+              .col-auto.align-self-center
+                i.fa.fa-chevron-left
+              .col
+                h2.pb-1.mb-1.card-title= context.lieu.name
+                .card-subtitle= context.lieu.address
+    - elsif context.user_selected_organisation.present?
         .card.card-hoverable
           .card-body
             = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -12,11 +12,24 @@ section.bg-light.p-4
               .card-subtitle= lieu.address
               .card-subtitle= context.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static
-              = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
-                .row
-                  .col
-                    = t(".next_availability")
-                    br
-                    strong= l(next_availability.starts_at, format: :human)
-                  .col-auto.align-self-center
-                      i.fa.fa-chevron-right
+              - motif = next_availability.motif
+              - if motif.restriction_for_rdv.blank?
+                = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+                  .row
+                    .col
+                      = t(".next_availability")
+                      br
+                      strong= l(next_availability.starts_at, format: :human)
+                    .col-auto.align-self-center
+                        i.fa.fa-chevron-right
+              - else
+                = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" } do
+                  .row
+                    .col
+                      = t(".next_availability")
+                      br
+                      strong= l(next_availability.starts_at, format: :human)
+                    .col-auto.align-self-center
+                        i.fa.fa-chevron-right
+                = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)) do
+                  = restriction_for_rdv_to_html(motif)

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -13,23 +13,17 @@ section.bg-light.p-4
               .col
                 h2.pb-1.mb-1 = context.service.name
     .container
-       h2.font-weight-bold Sélectionnez le motif de votre RDV :
-       - unless context.invitation?
-         .card
-           .m-2
+      h2.font-weight-bold Sélectionnez le motif de votre RDV :
+      - unless context.invitation?
+        .card
+          .m-2
             | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
             span>
             = link_to users_rdvs_path do
               i.far.fa-calendar
               span>
               | vos rendez-vous
-       - context.unique_motifs_by_name_and_location_type.each do |motif|
-         .card.mb-3
-           - if motif.restriction_for_rdv.blank?
-             = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do
-               = render "motif_selection_card", motif: motif
-           - else
-             = link_to("#", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" }) do
-               = render "motif_selection_card", motif: motif
-             = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type)) do
-               = restriction_for_rdv_to_html(motif)
+      - context.unique_motifs_by_name_and_location_type.each do |motif|
+        .card.mb-3
+          = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+            = render "motif_selection_card", motif: motif

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -13,8 +13,6 @@ FactoryBot.define do
     min_public_booking_delay { 30.minutes.seconds }
     max_public_booking_delay { 6.months.seconds }
     color { "##{SecureRandom.hex(3)}" }
-    instruction_for_rdv { "Intruction pour le RDV" }
-    restriction_for_rdv { "Consigne pour le RDV" }
     bookable_by { :everyone }
     location_type { :public_office }
     visibility_type { Motif::VISIBLE_AND_NOTIFIED }

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -152,6 +152,8 @@ describe "User can be invited" do
     end
 
     it "shows the geo search available motifs to take a rdv", js: true do
+      motif.update(restriction_for_rdv: "Consigne pour le RDV")
+
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
         address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
@@ -162,14 +164,14 @@ describe "User can be invited" do
       expect(page).to have_content(motif2.name)
       find(".card-title", text: /#{motif.name}/).click
 
+      # Lieu selection
+      expect(page).to have_content(lieu.name)
+      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
+
       # Restriction Page
       expect(page).to have_content("À lire avant de prendre un rendez-vous")
       expect(page).to have_content(motif.restriction_for_rdv)
       click_link("Accepter")
-
-      # Lieu selection
-      expect(page).to have_content(lieu.name)
-      find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
 
       # Creneau selection
       expect(page).to have_content(lieu.name)

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -40,14 +40,16 @@ RSpec.describe "Adding a user to a collective RDV" do
   def select_motif
     expect(page).to have_content("Sélectionnez le motif de votre RDV :")
     click_link(motif.name)
-    # Restriction modal
-    expect(page).to have_content(motif.restriction_for_rdv)
-    click_link("Accepter", match: :first)
   end
 
   def select_lieu
     expect(page).to have_content("Sélectionnez un lieu de RDV :")
     click_link("Prochaine disponibilité")
+  end
+
+  def accept_restriction_modal
+    expect(page).to have_content(motif.restriction_for_rdv)
+    click_link("Accepter", match: :first)
   end
 
   def expect_cancel_participation
@@ -81,12 +83,14 @@ RSpec.describe "Adding a user to a collective RDV" do
     end.at_least_once)
   end
 
-  context "Nominal cases" do
+  context "Nominal cases", js: true do
     it "with a signed in user" do
+      motif.update!(restriction_for_rdv: "Test restriction")
       login_as(logged_user, scope: :user)
       visit root_path(params)
       select_motif
       select_lieu
+      accept_restriction_modal
 
       # Testing participation (with back buttons)
       expect do
@@ -95,7 +99,6 @@ RSpec.describe "Adding a user to a collective RDV" do
         click_link("S'inscrire")
         click_button("Continuer")
         click_link("Revenir en arrière")
-        click_button("Continuer")
         click_button("Continuer")
         stub_request(:post, "https://example.com/")
         click_on("Confirmer ma participation")
@@ -347,7 +350,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         expect_webhooks_for(user)
       end
 
-      it "display rdv with cancelled tag when participation is excused or rdv is revoked", js: true do
+      it "display rdv with cancelled tag when participation is excused or rdv is revoked" do
         login_as(user, scope: :user)
         visit root_path(params)
 
@@ -375,7 +378,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         expect_no_notifications_for(rdv, user, :rdv_created)
       end
 
-      it "can cancel collective rdv participation, with mail notifications only", js: true do
+      it "can cancel collective rdv participation, with mail notifications only" do
         login_as(user, scope: :user)
         visit root_path(params)
 
@@ -393,7 +396,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         expect_webhooks_for(user)
       end
 
-      it "can cancel collective rdv participation, without notifications", js: true do
+      it "can cancel collective rdv participation, without notifications" do
         login_as(user, scope: :user)
         visit root_path(params)
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -47,11 +47,6 @@ RSpec.describe "Adding a user to a collective RDV" do
     click_link("Prochaine disponibilité")
   end
 
-  def accept_restriction_modal
-    expect(page).to have_content(motif.restriction_for_rdv)
-    click_link("Accepter", match: :first)
-  end
-
   def expect_cancel_participation
     expect do
       expect(page).to have_content("À venir")
@@ -90,7 +85,11 @@ RSpec.describe "Adding a user to a collective RDV" do
       visit root_path(params)
       select_motif
       select_lieu
-      accept_restriction_modal
+
+      # Restriction for rdv modal
+      expect(page).to have_content("À lire avant de prendre un rendez-vous")
+      expect(page).to have_content(motif.restriction_for_rdv)
+      click_link("Accepter")
 
       # Testing participation (with back buttons)
       expect do

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -116,7 +116,7 @@ describe "User can search for rdvs" do
       create(
         :motif,
         name: "RSA Suivi", follow_up: true,
-        organisation: organisation, service: service
+        organisation: organisation, service: service, restriction_for_rdv: "Instructions pour le RDV"
       )
     end
 
@@ -177,7 +177,7 @@ describe "User can search for rdvs" do
 
     before { login_as(user, scope: :user) }
 
-    it "shows only the follow up motifs related to the agent" do
+    it "shows only the follow up motifs related to the agent", js: true do
       visit root_path(referent_ids: [agent.id], departement: "92", service_id: service.id)
 
       ### Motif selection
@@ -188,10 +188,10 @@ describe "User can search for rdvs" do
       expect(page).not_to have_content(motif3.name)
 
       find(".card-title", text: /#{motif1.name}/).click
-      click_link("Accepter")
 
       expect(page).to have_content(lieu.name)
       find(".card-title", text: /#{lieu.name}/).ancestor(".card").find("a.stretched-link").click
+      click_link("Accepter")
 
       ### Creneau selection
       expect(page).to have_content(agent.last_name.upcase)


### PR DESCRIPTION
Closes #3424

Il semblerait que l'on ai un fichier `app/views/common/_creneaux.html.slim` qui ne sert à rien et porte à confusion.
Celui qui est utilisé est `app/views/search/_creneaux.html.slim`
J'aimerai avoir votre avis, en fonction je le supprimerai.

Je fix également un bug graphique lié à une mauvaise indentation dans `app/views/search/_creneau_selection.html.slim`

Avant : 
![Capture d’écran 2023-06-28 à 17 23 41](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/21196dd5-3256-48fb-a7cd-31180c095496)

Après : 
![Capture d’écran 2023-06-28 à 17 23 59](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/ca8dc5b7-3341-44f5-a60c-6a271aaa9663)
