### PR TITLE
Ajout de profile dans le scope Inclusion Connect

### DIFF
--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -11,7 +11,7 @@ module InclusionConnect
         response_type: "code",
         client_id: IC_CLIENT_ID,
         redirect_uri: inclusion_connect_callback_url,
-        scope: "openid email",
+        scope: "openid email profile",
         state: ic_state,
         nonce: Digest::SHA1.hexdigest("Something to check when it come back ?"),
         from: "community",


### PR DESCRIPTION
Ajout nécessaire pour la future version d'Inclusion Connect pour pouvoir récupérer les infos du profil IC
["given_name"] et ["family_name"].
Avant la mise à jour on pouvait récupérer ces informations sans avoir le bon scope...
Le système à jour est moins permissif et on a besoin de ce scope.
