### PR TITLE
Changement du nom de domaine de démo pour les mairies

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -95,7 +95,7 @@ class Domain
         {
           RDV_SOLIDARITES => "demo.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "demo.rdv-aide-numerique.fr",
-          RDV_MAIRIE => "demo.rdv-mairie.fr",
+          RDV_MAIRIE => "demo.rdv.anct.gouv.fr",
         }.fetch(self)
       else
         {


### PR DESCRIPTION
fixes  #3651

Le record CNAME a bien été ajouté, il n'y a plus qu'à changer l'url canonique.