### PR TITLE
Changement de contenu du message d'invitation sur la fiche usager

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -30,7 +30,7 @@
         - if @user.invited_through == "external" && @user.invitation_accepted_at.nil?
           .row.bg-info.text-white.p-2.mb-3
             .col-md-8
-              | Cet usager a reçu une invitation via un partenaire de #{current_domain.name}, mais il ne l’a pas encore acceptée.
+              | Cet usager a reçu une invitation via un partenaire de #{current_domain.name} (ex : RDV-Insertion).
 
         - if @user.logged_once_with_franceconnect?
           .row.bg-info.text-white.p-2.mb-3 Cet usager s'est déjà connecté via FranceConnect.


### PR DESCRIPTION
Juste un changement textuel permettant d'enlever l'ancien message qu'on affiche quand la personne a été invitée à prendre RDV-I et qu'elle n'a pas créé de compte.

Fixes https://github.com/betagouv/rdv-insertion/issues/1108
