### PR TITLE
[Rdv Mairie] Afficher les champs Nom naissance et date de naissance pour les infos usager

### DIFF
--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -38,7 +38,6 @@
       .form-row
         .col-md-6= f.input :first_name, **input_opts[:relative]
         .col-md-6= f.input :last_name, **input_opts[:relative]
-      - unless current_domain == Domain::RDV_MAIRIE
         = date_input(f, :birth_date, **input_opts[:relative])
       - if current_territory.enable_notes_field?
         = f.input :notes, **input_opts[:relative].deep_merge(input_html: { rows: 6 })

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -11,10 +11,9 @@
   .col-md-6= f.input :first_name, **input_opts.deep_merge(frozen_fields_opts)
   .col-md-6= f.input :last_name, **input_opts
 
-- unless current_domain == Domain::RDV_MAIRIE
-  .form-row
-    .col-md-6= f.input :birth_name, **input_opts.deep_merge(frozen_fields_opts)
-    .col-md-6= date_input(f, :birth_date, **input_opts.deep_merge(frozen_fields_opts))
+.form-row
+  .col-md-6= f.input :birth_name, **input_opts.deep_merge(frozen_fields_opts)
+  .col-md-6= date_input(f, :birth_date, **input_opts.deep_merge(frozen_fields_opts))
 
 = f.input :phone_number, as: :tel, **input_opts
 

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -8,7 +8,7 @@
     .col-md-6= f.input :first_name, placeholder: "Prénom", disabled: user.logged_once_with_franceconnect?
     .col-md-6= f.input :last_name, placeholder: "Nom"
   .form-row
-    - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
+    - unless current_user.only_invited?
       .col-md-6= f.input :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
       .col-md-6= date_input(f, :birth_date, disabled: user.logged_once_with_franceconnect?)
   - if current_domain == Domain::RDV_MAIRIE


### PR DESCRIPTION
## Contexte
Closes #3677 

> En gros j'ai discuté avec une mairie et elle aimerait avoir accés à d'autres données sur la fiche usager comme par exemple le nom de jeune fille car tu n'as que le nom d'usage (du côté médico social tu n'as pas du tout les mêmes données concernant la fiche usager); C'est envisageable ou pas à ton avis? 

Dans cette PR, nous affichons les champs Nom de naissance et Date de naissance qui étaient cachés pour la verticale Rdv Mairie.
