### PR TITLE
fix(search): always join organisation table for matching motifs 

### DIFF
--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -206,7 +206,7 @@ class SearchContext
     motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
     motifs = motifs.with_motif_category_short_name(@motif_category_short_name) if @motif_category_short_name.present?
     motifs = motifs.where(organisation_id: @preselected_organisation_ids) if @preselected_organisation_ids.present?
-    motifs = motifs.where(organisations: { id: organisation_id }) if organisation_id.present?
+    motifs = motifs.where(organisation_id: organisation_id) if organisation_id.present?
     motifs = motifs.where(organisations: { external_id: @external_organisation_ids.compact }) if @external_organisation_ids.present?
     motifs = motifs.where(id: @motif_id) if @motif_id.present?
     motifs = motifs.with_availability_for_lieux([lieu.id]) if lieu.present?
@@ -241,7 +241,7 @@ class SearchContext
         # we retrieve the geolocalised matching motifs, if there are none we fallback
         # on the matching motifs for the organisations passed in the query_params
         filter_motifs(geo_search.available_motifs).presence || filter_motifs(
-          Motif.available_for_booking.where(organisation_id: @preselected_organisation_ids)
+          Motif.available_for_booking.where(organisation_id: @preselected_organisation_ids).joins(:organisation)
         )
       else
         filter_motifs(geo_search.available_motifs)


### PR DESCRIPTION
La méthode `filter_motifs` du `SearchContext` filtre des motifs sur des attributs d'organisations associées aux motifs.
Elle prend en entrée une collection de motifs où les organisations sont déjà loadées [ici](https://github.com/betagouv/rdv-solidarites.fr/blob/32cf82dec8988457f2de8f8b67f7cf7265fd3733/app/services/users/geo_search.rb#L115).
 
Cependant, depuis [ce changement](https://github.com/betagouv/rdv-solidarites.fr/commit/86248632a162534e76a81ac62bdae741f4c92963), les organisations ne sont plus préloadées dans le cas d'une invitation où on fallback sur les organisations préselectionnées.
Ça engendrait cette erreur: https://sentry.incubateur.net/organizations/betagouv/issues/48338/?project=74&query=is%3Aunresolved&referrer=issue-stream

Je remédie à ça ici et j'en profite pour simplifier une requête sur l'`organisation_id` dans la méthode `filter_motifs`.