### PR TITLE
Changement de wording pour les invitations

### DIFF
--- a/app/views/search/banners/_rdv_solidarites.html.slim
+++ b/app/views/search/banners/_rdv_solidarites.html.slim
@@ -1,8 +1,6 @@
-- if context.invitation?
-  | J'organise mon rendez-vous
-- else
-  | Prenez&nbsp;
-  span rendez-vous en ligne
+| Prenez&nbsp;
+span rendez-vous en ligne
+- if !context.invitation?
   br
     | avec votre département&nbsp;
     - if context.departement.present?

--- a/app/views/search/banners/_rdv_solidarites.html.slim
+++ b/app/views/search/banners/_rdv_solidarites.html.slim
@@ -1,11 +1,10 @@
 - if context.invitation?
-  | Vous avez été invité(e) à prendre&nbsp;
-  span rendez-vous
+  | J'organise mon rendez-vous
 - else
   | Prenez&nbsp;
   span rendez-vous en ligne
-br
-  | avec votre département&nbsp;
-  - if context.departement.present?
-    | le&nbsp;
-    span #{context.departement}
+  br
+    | avec votre département&nbsp;
+    - if context.departement.present?
+      | le&nbsp;
+      span #{context.departement}

--- a/app/views/search/banners/_rdv_solidarites.html.slim
+++ b/app/views/search/banners/_rdv_solidarites.html.slim
@@ -1,6 +1,6 @@
 | Prenez&nbsp;
 span rendez-vous en ligne
-- if !context.invitation?
+- unless context.invitation?
   br
     | avec votre département&nbsp;
     - if context.departement.present?


### PR DESCRIPTION
Dans cette PR, je change légerement le wording de la landing page des invitations. La raison : certaines invitations sont désormais parfois envoyées par des associations non liées aux départements  (d'où les changements des lignes 7-11). J'en profite pour changer un peu le wording de la ligne 2, ce qui permet de gagner beaucoup d'espace (ce qui n'est pas négligeable sur mobile) + enlève le `(e)` (cf screenshots : avant/après)

![Capture d'écran landing invitation](https://github.com/betagouv/rdv-solidarites.fr/assets/46218316/500b9a14-8533-4332-b19b-e7e4d022bdbf)
![Screenshot 2023-07-26 at 18-27-16 RDV Solidarités](https://github.com/betagouv/rdv-solidarites.fr/assets/46218316/35191c78-04c1-464a-9fe9-dc0fcc8a62f7)
