### PR TITLE
Fix features tests sur la CI, mise à jour capybara et selenium-webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -214,8 +214,6 @@ group :test do
   gem "capybara-email"
   # Automatically create snapshots when Cucumber steps fail with Capybara and Rails
   gem "capybara-screenshot"
-  # Easy download and use of browser drivers.
-  gem "webdrivers"
   # Strategies for cleaning databases. Can be used to ensure a clean slate for testing.
   gem "database_cleaner"
   # Library for stubbing HTTP requests in Ruby.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.38.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -136,7 +136,6 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     chartkick (5.0.1)
-    childprocess (4.1.0)
     choice (0.2.0)
     coderay (1.1.3)
     coercible (1.0.0)
@@ -290,7 +289,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     montrose (0.13.0)
       activesupport (>= 5.2, < 7.1)
@@ -306,7 +305,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.2)
+    nokogiri (1.15.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -370,7 +369,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (5.6.5)
       nio4r (~> 2.0)
     pundit (2.2.0)
@@ -443,13 +442,13 @@ GEM
     redis-session-store (0.11.4)
       actionpack (>= 3, < 8)
       redis (>= 3, < 5)
-    regexp_parser (2.6.2)
+    regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -511,8 +510,7 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
-    selenium-webdriver (4.6.1)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,10 +592,6 @@ GEM
     wannabe_bool (0.7.1)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webfinger (1.2.0)
       activesupport
       httpclient (>= 2.4)
@@ -705,7 +701,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   typhoeus
   wannabe_bool
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/db/seeds/rdv_mairie.rb
+++ b/db/seeds/rdv_mairie.rb
@@ -42,7 +42,7 @@ agent_mairie_de_sannois = Agent.new(
   uid: "alain.mairie@rdv-mairie-demo.fr",
   first_name: "Alain",
   last_name: "Mairie",
-  password: "123456",
+  password: "lapinlapin",
   service_id: service_titres.id,
   invitation_accepted_at: 10.days.ago,
   roles_attributes: [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,14 +17,13 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require "axe-rspec"
-require "webdrivers/chromedriver"
 require "capybara/rspec"
 require "capybara/email/rspec"
-require "webdrivers"
 require "capybara-screenshot/rspec"
 require "pundit/rspec"
 require "webmock/rspec"
 require "simplecov"
+require "selenium-webdriver"
 
 SimpleCov.minimum_coverage 80
 SimpleCov.start

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -7,33 +7,24 @@ WebMock.disable_net_connect!(allow: [
                                "chromedriver.storage.googleapis.com", # Autorise Chromedrive storage pour l'execution de la CI
                              ])
 
-Capybara.register_driver :chrome_headless do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless")
-  options.add_argument("--no-sandbox")
-  options.add_argument("--disable-dev-shm-usage")
-  options.add_argument("--window-size=1400,1400")
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-end
-
-Capybara.javascript_driver = :chrome_headless
-
 Capybara.register_driver :selenium do |app|
-  # these args seem to reduce test flakyness
-  args = %w[headless no-sandbox disable-gpu window-size=1500,1000]
   chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
   binary = chrome_bin if chrome_bin
+  browser_options = Selenium::WebDriver::Chrome::Options.new(
+    # these args seem to reduce test flakyness
+    args: %w[headless no-sandbox disable-gpu disable-dev-shm-usage window-size=1500,1000],
+    "goog:loggingPrefs": { browser: "ALL" },
+    binary: binary
+  )
+
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    capabilities: [Selenium::WebDriver::Chrome::Options.new(
-      args: args,
-      binary: binary,
-      "goog:loggingPrefs": { browser: "ALL" }
-    )]
+    options: browser_options
   )
 end
+
+Capybara.javascript_driver = :selenium
 
 Capybara.configure do |config|
   port = 9887 + ENV["TEST_ENV_NUMBER"].to_i


### PR DESCRIPTION
Fix des problèmes de features tests sur la CI
Merci à Amine qui a eu le même soucis et l'a résolu ici : https://github.com/betagouv/rdv-insertion/pull/1229
J'ai mis à jour `selenium-webdrivers` et `capybara`. J'ai enlevé la gem `webdrivers` qui posait problème.
J'ai également nettoyé la configuration de Capybara pour l'adapter aux modifications.
J'aimerai avoir un 2eme avis à ce sujet, je pense que ce que j'ai enlevé était redondant (et en cours de dépréciation notamment pour l'argument `:capabilities`)