### PR TITLE
Extraction du formulaire de changement de mot de passe des agents

### DIFF
--- a/app/controllers/agents/mot_de_passes_controller.rb
+++ b/app/controllers/agents/mot_de_passes_controller.rb
@@ -15,6 +15,7 @@ class Agents::MotDePassesController < AgentAuthController
   def update
     authorize current_agent
     if current_agent.update_with_password(agent_params)
+      bypass_sign_in(current_agent) # Pour des raisons mystérieuses, Devise déconnecte l'agent après un changement de mot de passe
       flash[:notice] = "Votre mot de passe a été changé"
       redirect_to edit_agent_registration_path
     else

--- a/app/controllers/agents/mot_de_passes_controller.rb
+++ b/app/controllers/agents/mot_de_passes_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Contrairement au Agents::PasswordsController qui gère les reset de mot de passe via les mécanismes custom de devise
+# et qui ne nécessite pas que l'agent soit connecté,
+# ce controller gère la modification de mot de passe pour un agent connecté, sans utiliser Devise.
+class Agents::MotDePassesController < AgentAuthController
+  include Admin::AuthenticatedControllerConcern
+
+  layout "registration"
+
+  def edit
+    authorize current_agent
+  end
+
+  def update
+    authorize current_agent
+    if current_agent.update_with_password(agent_params)
+      flash[:notice] = "Votre mot de passe a été changé"
+      redirect_to edit_agent_registration_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def pundit_user
+    AgentContext.new(current_agent)
+  end
+
+  def agent_params
+    params.require(:agent).permit(:password, :password_confirmation, :current_password)
+  end
+end

--- a/app/models/concerns/agent/custom_devise_token_auth_user_omniauth_callbacks.rb
+++ b/app/models/concerns/agent/custom_devise_token_auth_user_omniauth_callbacks.rb
@@ -28,11 +28,13 @@ module Agent::CustomDeviseTokenAuthUserOmniauthCallbacks
   protected
 
   def password_required?
-    false if all_roles_intervenant?
+    return false if all_roles_intervenant?
+    super
   end
 
   def email_required?
-    false if all_roles_intervenant?
+    return false if all_roles_intervenant?
+    super
   end
 
   def uid_and_provider_defined?

--- a/app/models/concerns/agent/custom_devise_token_auth_user_omniauth_callbacks.rb
+++ b/app/models/concerns/agent/custom_devise_token_auth_user_omniauth_callbacks.rb
@@ -29,7 +29,7 @@ module Agent::CustomDeviseTokenAuthUserOmniauthCallbacks
 
   def password_required?
     return false if all_roles_intervenant?
-    super
+    super # Cette méthode est aussi implémentée par Devise::Models::Validatable, et utilisée pour vérifier les confirmations de mot de passe
   end
 
   def email_required?

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -21,6 +21,7 @@ class Agent::AgentPolicy < ApplicationPolicy
   alias show? current_agent_or_admin_in_record_organisation?
   alias new? current_agent_or_admin_in_record_organisation?
   alias create? current_agent_or_admin_in_record_organisation?
+  alias edit? current_agent_or_admin_in_record_organisation?
   alias update? current_agent_or_admin_in_record_organisation?
   alias invite? current_agent_or_admin_in_record_organisation?
   alias rdvs? current_agent_or_admin_in_record_organisation?

--- a/app/views/agents/mot_de_passes/edit.html.slim
+++ b/app/views/agents/mot_de_passes/edit.html.slim
@@ -7,6 +7,6 @@
   .form-text.text-muted.mb-2
     | Si possible, nous vous recommandons d'utiliser un gestionnaire de mots de passe.
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "off"
-  .text-right= f.submit "Modifier", class: "btn btn-primary"
-  .text-left
-  = link_to("Retour à votre compte", edit_agent_registration_path, class: "mb-2")
+  .d-flex.justify-content-between
+    = link_to("Retour à votre compte", edit_agent_registration_path, class: "mb-2")
+    = f.submit "Modifier", class: "btn btn-primary"

--- a/app/views/agents/mot_de_passes/edit.html.slim
+++ b/app/views/agents/mot_de_passes/edit.html.slim
@@ -8,3 +8,5 @@
     | Si possible, nous vous recommandons d'utiliser un gestionnaire de mots de passe.
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "off"
   .text-right= f.submit "Modifier", class: "btn btn-primary"
+  .text-left
+  = link_to("Retour à votre compte", edit_agent_registration_path, class: "mb-2")

--- a/app/views/agents/mot_de_passes/edit.html.slim
+++ b/app/views/agents/mot_de_passes/edit.html.slim
@@ -1,0 +1,10 @@
+- content_for :title, "Changement de mot de passe"
+
+= simple_form_for(current_agent, url: agent_mot_de_passes_path, html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: current_agent
+  = f.input :password, label: "Nouveau mot de passe", placeholder: "Votre nouveau mot de passe (au moins #{Devise.password_length.first} caractères)", autocomplete: "new-password"
+  = f.input :password_confirmation, label: "Confirmation du mot de passe", placeholder: "Votre nouveau mot de passe (au moins #{Devise.password_length.first} caractères)", autocomplete: "new-password"
+  .form-text.text-muted.mb-2
+    | Si possible, nous vous recommandons d'utiliser un gestionnaire de mots de passe.
+  = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "off"
+  .text-right= f.submit "Modifier", class: "btn btn-primary"

--- a/app/views/agents/mot_de_passes/edit.html.slim
+++ b/app/views/agents/mot_de_passes/edit.html.slim
@@ -9,4 +9,4 @@
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "off"
   .d-flex.justify-content-between
     = link_to("Retour à votre compte", edit_agent_registration_path, class: "mb-2")
-    = f.submit "Modifier", class: "btn btn-primary"
+    = f.submit "Enregistrer", class: "btn btn-primary"

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -14,9 +14,6 @@
   = f.input :last_name, placeholder: "Nom"
   = f.association :service, collection: [resource.service], hint: "Vous ne pouvez pas changer de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer votre compte et vous faire réinviter, ou bien vous créer un deuxième compte avec une autre adresse email.", disabled: true
 
-  /= f.input :password, label: "Nouveau mot de passe", placeholder: "Votre nouveau mot de passe (au moins #{Devise.password_length.first} caractères)"
-  /.form-text.text-muted.mb-2
-  /  | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "off"
   .form-text.text-muted.mb-2
     | Renseignez votre mot de passe actuel pour tout changement.

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -7,13 +7,16 @@
     .form-text.text-muted
       | En attente de confirmation pour #{resource.unconfirmed_email}
 
+  = f.input :password, disabled: true, input_html: { value: "**********" }
+  = link_to("Changer de mot de passe", edit_agent_mot_de_passes_path, class: "mb-2")
+
   = f.input :first_name, placeholder: "Prénom"
   = f.input :last_name, placeholder: "Nom"
   = f.association :service, collection: [resource.service], hint: "Vous ne pouvez pas changer de service, cela créerait des incohérences. Si vous voulez vraiment réaliser cette opération, il faut supprimer votre compte et vous faire réinviter, ou bien vous créer un deuxième compte avec une autre adresse email.", disabled: true
 
-  = f.input :password, label: "Nouveau mot de passe", placeholder: "Votre nouveau mot de passe (au moins #{Devise.password_length.first} caractères)"
-  .form-text.text-muted.mb-2
-    | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
+  /= f.input :password, label: "Nouveau mot de passe", placeholder: "Votre nouveau mot de passe (au moins #{Devise.password_length.first} caractères)"
+  /.form-text.text-muted.mb-2
+  /  | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
   = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "off"
   .form-text.text-muted.mb-2
     | Renseignez votre mot de passe actuel pour tout changement.

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -36,15 +36,15 @@ nav
             class=("show" if menu_top_level_item == "account")
           ]
             li.my-2
-              = link_to "Mon compte", edit_agent_registration_path
+              = link_to "Votre compte", edit_agent_registration_path
             li.my-2
-              = link_to "Mes organisations", admin_organisations_path
+              = link_to "Vos organisations", admin_organisations_path
             li.my-2
-              = active_link_to "Mes statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
+              = active_link_to "Vos statistiques", admin_organisation_agent_stats_path(current_organisation, current_agent)
             li.my-2
               = link_to destroy_agent_session_path, method: :delete do
                 i.fa.fa-sign-out
-                span Me déconnecter
+                span Se déconnecter
 
         - if show_checklist?(current_organisation, current_agent)
           li.side-nav-item.mb-4.pl-3.pr-2

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -28,15 +28,15 @@ html lang="fr"
                 .d-flex.flex-row.justify-content-center
                   ul.list-unstyled.text-left.text-white
                     li
-                      h5= link_to "Mon compte", edit_agent_registration_path
+                      h5= link_to "Votre compte", edit_agent_registration_path
                     li
                       h5= link_to t("agents.preferences.show.title"), agents_preferences_path
                     li
                       h5= link_to "Synchronisation d'agenda", agents_calendar_sync_path
                     li
-                      h5= link_to "Mes organisations", admin_organisations_path
+                      h5= link_to "Vos organisations", admin_organisations_path
                     li
-                      h5= link_to "Me déconnecter", destroy_agent_session_path, method: :delete
+                      h5= link_to "Se déconnecter", destroy_agent_session_path, method: :delete
               - else
                 h4.mb-3 Prenez RDV en ligne avec votre département !
 

--- a/config/locales/models/agent.fr.yml
+++ b/config/locales/models/agent.fr.yml
@@ -36,12 +36,21 @@ fr:
       models:
         agent:
           attributes:
+            current_password:
+              invalid: "Le mot de passe actuel n'est pas valide"
+              format: "%{message}"
             password:
               format: "%{message}"
               too_common: "Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés et ne permet donc pas d'assurer la sécurité de votre compte. Veuillez en choisir un autre."
               too_short:
                 other: "Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins %{count} caractères"
+            password_confirmation:
+              format: "%{message}"
+              confirmation: "Le nouveau mot de passe et la confirmation ne concordent pas"
         agent/roles/agent:
           attributes:
             password:
               format: "%{message}"
+            password_confirmation:
+              format: "%{message}"
+              confirmation: "Le nouveau mot de passe et la confirmation ne concordent pas"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,10 @@ Rails.application.routes.draw do
     get "agents/edit" => "agents/registrations#edit", as: "edit_agent_registration"
     put "agents" => "agents/registrations#update", as: "agent_registration"
     delete "agents" => "agents/registrations#destroy", as: "delete_agent_registration"
+
+    get "agents/mot_de_passe/edit" => "agents/mot_de_passes#edit", as: "edit_agent_mot_de_passes"
+    put "agents/mot_de_passe" => "agents/mot_de_passes#update", as: "agent_mot_de_passes"
+
     namespace :agents do
       resource :preferences, only: %i[show update] do
         post :disable_cnfs_online_booking_banner

--- a/spec/features/agents/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/agent_can_reset_his_password_spec.rb
@@ -24,7 +24,7 @@ describe "Agent resets his password spec" do
     fill_in "password", with: "correct horse battery staple"
     expect { click_on "Enregistrer" }.to change { agent.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
-    expect(page).to have_link("Mes organisations")
+    expect(page).to have_link("Vos organisations")
   end
 
   it "works when using the user's password reset form" do
@@ -41,6 +41,6 @@ describe "Agent resets his password spec" do
     fill_in "password", with: "correct horse battery staple"
     expect { click_on "Enregistrer" }.to change { agent.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
-    expect(page).to have_link("Mes organisations")
+    expect(page).to have_link("Vos organisations")
   end
 end

--- a/spec/features/agents/agent_can_see_stats_spec.rb
+++ b/spec/features/agents/agent_can_see_stats_spec.rb
@@ -35,7 +35,7 @@ describe "Agent can see stats" do
     end
 
     it "displays correct stats for agent1" do
-      click_link "Mes statistiques"
+      click_link "Vos statistiques"
       expect(page).to have_content("Statistiques #{agent1.full_name}")
       # rdv3 & rdv4
       expect(page).to have_content("À venir\n2")
@@ -58,7 +58,7 @@ describe "Agent can see stats" do
     end
 
     it "displays correct stats for agent2" do
-      click_link "Mes statistiques"
+      click_link "Vos statistiques"
       expect(page).to have_content("Statistiques #{agent2.full_name}")
       # rdv2, rdv5 & rdv6
       expect(page).to have_content("RDV créés (3)")

--- a/spec/features/agents/change_password_spec.rb
+++ b/spec/features/agents/change_password_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe "Agents can change their passwords" do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], password: "lapinlapin") }
+  let!(:admin_agent) { create(:agent, admin_role_in_organisations: [organisation]) } # Organisation needs at least one admin
+
+  before do
+    login_as(agent, scope: :agent)
+    visit edit_agent_registration_path
+    click_link "Changer de mot de passe"
+  end
+
+  it "checks for password confirmation, length and complexity" do
+    fill_in "Nouveau mot de passe", with: "unmotdepasse"
+    fill_in "Confirmation du mot de passe", with: "unautremotdepasse"
+    fill_in "Mot de passe actuel", with: "lapinlapin"
+
+    expect { click_button "Enregistrer" }.not_to change { agent.reload.encrypted_password }
+
+    expect(page).to have_content "Le nouveau mot de passe et la confirmation ne concordent pas"
+
+    fill_in "Nouveau mot de passe", with: "tropcourt"
+    fill_in "Confirmation du mot de passe", with: "tropcourt"
+    fill_in "Mot de passe actuel", with: "lapinlapin"
+
+    expect { click_button "Enregistrer" }.not_to change { agent.reload.encrypted_password }
+
+    expect(page).to have_content "Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins 10 caractères"
+
+    fill_in "Nouveau mot de passe", with: "1234567890"
+    fill_in "Confirmation du mot de passe", with: "1234567890"
+    fill_in "Mot de passe actuel", with: "lapinlapin"
+
+    expect { click_button "Enregistrer" }.not_to change { agent.reload.encrypted_password }
+
+    expect(page).to have_content "Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés et ne permet donc pas d'assurer la sécurité de votre compte. Veuillez en choisir un autre."
+
+    fill_in "Nouveau mot de passe", with: "correcthorsebattery"
+    fill_in "Confirmation du mot de passe", with: "correcthorsebattery"
+    fill_in "Mot de passe actuel", with: "lapinlapin"
+
+    expect { click_button "Enregistrer" }.to change { agent.reload.encrypted_password }
+
+    expect(page).to have_content "Votre mot de passe a été changé"
+    expect(page).to have_current_path(edit_agent_registration_path)
+  end
+end

--- a/spec/features/agents/change_password_spec.rb
+++ b/spec/features/agents/change_password_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Agents can change their passwords" do
 
     expect { click_button "Enregistrer" }.not_to change { agent.reload.encrypted_password }
 
-    expect(page).to have_content "Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés et ne permet donc pas d'assurer la sécurité de votre compte. Veuillez en choisir un autre."
+    expect(page).to have_content "Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés et ne permet donc pas d'assurer la sécurité de votre compte."
 
     fill_in "Nouveau mot de passe", with: "correcthorsebattery"
     fill_in "Confirmation du mot de passe", with: "correcthorsebattery"


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-solidarites.fr/pull/3694, dans le contexte de https://github.com/betagouv/rdv-solidarites.fr/issues/3624

Le formulaire de compte de l'agent est difficile à comprendre parce qu'il peut permettre deux choses différentes : changer les infos du compte (nom et prénom par exemple), et/ou changer le mot de passe. Ces deux comportements dépendent des champs qu'on remplit dans le formulaire "Votre compte", et en plus ils ne sont pas forcément très liés.

Pour gagner en clarté (et préparer la suite de ce ticket où on voudra encourager les agents avec des mots de passes faibles à les changer), on sépare donc ce formulaire en deux : un pour le compte, un pour le mot de passe.

Après un peu de recherche sur ce qui était possible avec Devise, j'étais un peu déçu : Devise nous fait déjà implémenter un `Agents::PasswordsController`, qui aurait été l'endroit parfait pour la logique de ce formulaire, mais les `edit` et `update` de ce controller correspondent à une **réinitialisation** de mot de passe, et pas un changement de mot de passe. Ce controller est donc fait pour être utilisé quand l'agent n'est pas connecté.

J'ai donc préféré créer un autre controller pas trop couplé à Devise, et marquer la différence en le nommant en français `Agents::MotDePassesController`. Je suis pas sûr que ça soit le choix le plus élégant au monde, donc je suis très preneur de suggestions sur ce point là.

### Avant

<img width="1278" alt="Screenshot 2023-07-27 at 16 22 26" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/2475e494-2c71-4921-a4f6-838c771c4894">


### Après 

<img width="1285" alt="Screenshot 2023-07-27 at 16 23 09" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/1f791315-9c8c-420e-ada9-bf23341785d8">
<img width="1418" alt="Screenshot 2023-07-27 at 16 21 07" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/792003a3-9e9d-48ea-8b92-09c2f2b3856d">

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
