### PR TITLE
Aider les agents à obtenir un export sans contacter le support

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -42,7 +42,7 @@ class Admin::RdvsController < AgentAuthController
       organisation_ids: @scoped_organisations.ids,
       options: parsed_params
     )
-    flash[:notice] = I18n.t("layouts.flash.confirm_export_queued", agent_email: current_agent.email)
+    flash[:notice] = t("layouts.flash.confirm_export_queued_html", agent_email: current_agent.email, support_email: current_domain.support_email)
     redirect_to admin_organisation_rdvs_path(organisation_id: current_organisation.id)
   end
 
@@ -55,7 +55,7 @@ class Admin::RdvsController < AgentAuthController
       organisation_ids: @scoped_organisations.ids,
       options: parsed_params
     )
-    flash[:notice] = I18n.t("layouts.flash.confirm_export_queued", agent_email: current_agent.email)
+    flash[:notice] = t("layouts.flash.confirm_export_queued_html", agent_email: current_agent.email, support_email: current_domain.support_email)
     redirect_to admin_organisation_rdvs_path(organisation_id: current_organisation.id)
   end
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -277,8 +277,7 @@ fr:
       update: Enregistrer
   layouts:
     flash:
-      confirm_export_queued: Votre export est en cours de création, il sera envoyé à %{agent_email} dès qu'il sera prêt. L'opération peut prendre plusieurs minutes. N'hésitez pas à contacter le support (support@rdv-solidarites.fr), si vous ne recevez rien d'ici 1h.
-  number:
+      confirm_export_queued_html: "Votre export est en cours de création : il sera envoyé à %{agent_email} dès qu'il sera prêt.<br />Il est possible que votre boîte mail ne permette pas qu'on lui envoie des fichiers trop lourds. Si vous ne recevez pas l'export dans les minutes qui viennent, essayez d'exporter moins de rendez-vous à la fois en les filtrant sur une période plus courte.<br />Pour plus d'aide, vous pouvez aussi nous contacter à l'adresse %{support_email}."
     currency:
       format:
         delimiter: " "


### PR DESCRIPTION
Cette PR est un sparadrap en attendant d'avoir une meilleure solution pour https://github.com/betagouv/rdv-solidarites.fr/issues/3701. On indique aux admins comment obtenir un export s'ils ne reçoivent rien, pour éviter qu'ils contactent le support.