### PR TITLE
fix(inclusionConnect): prevent agent from having nil values

### DIFF
--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -68,7 +68,9 @@ module InclusionConnect
       agent.update!(
         first_name: user_info["given_name"],
         last_name: user_info["family_name"],
-        confirmed_at: Time.zone.now
+        confirmed_at: Time.zone.now,
+        last_sign_in_at: Time.zone.now,
+        invitation_accepted_at: agent.invitation_accepted_at || Time.zone.now
       )
       agent
     end

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -34,6 +34,8 @@ describe InclusionConnectController, type: :controller do
       expect(agent.first_name).to eq("Bob")
       expect(agent.last_name).to eq("Eponge")
       expect(agent.confirmed_at).to be_within(10.seconds).of(now)
+      expect(agent.invitation_accepted_at).to be_within(10.seconds).of(now)
+      expect(agent.last_sign_in_at).to be_within(10.seconds).of(now)
     end
 
     it "returns an error if state doesn't match" do


### PR DESCRIPTION
Cette PR permet de mettre à jour les champs last_sign_in_at et invitation_accepted_at (s'il était nil) lors d'une connection via inclusion_connect.

Pour info je n'ai pas trouvé de tests spécifiques au service `InclusionConnect`, il semblerait qu'ils étaient présent sur le controller directement donc pour être cohérent je les ai rajouté ici. 
Dites moi si vous préférez que l'on extrait cette suite de tests pour la mettre sur le service directement.

Closes #3563 
