### PR TITLE
Fix name error event in sentry for outlook

### DIFF
--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -91,7 +91,7 @@ module Outlook
       refresh_token_response = JSON.parse(refresh_token_query.response_body)
 
       if refresh_token_response["error"].present?
-        Sentry.capture_message("Error refreshing Microsoft Graph Token for #{email}: #{refresh_token_response['error_description']}")
+        Sentry.capture_message("Error refreshing Microsoft Graph Token for #{@agent.email}: #{refresh_token_response['error_description']}")
       elsif refresh_token_response["access_token"].present?
         @agent.update!(microsoft_graph_token: refresh_token_response["access_token"])
       end


### PR DESCRIPTION
Remontée Sentry en erreur à cause d'un problème de nommage de variable dans l'api outlook.
Cela ne régle pas le problème pour lequel on recoit des remontées sentry mais ca sera déjà plus clair.

https://sentry.incubateur.net/organizations/betagouv/issues/56340/?project=74&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h

https://sentry.incubateur.net/organizations/betagouv/issues/56165/?project=74&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h