### PR TITLE
[Fix CI errors] Improve our factories

### DIFF
--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -5,8 +5,10 @@ describe "Agents can try the user-facing online booking pages" do
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 
   before do
+    first_day = Date.parse("2023/08/01")
+    travel_to(first_day.beginning_of_day)
     motif = create(:motif, organisation: organisation, service: agent.service)
-    motif.plage_ouvertures << create(:plage_ouverture, organisation: organisation, agent: agent)
+    motif.plage_ouvertures << create(:plage_ouverture, first_day: first_day, organisation: organisation, agent: agent)
   end
 
   it "shows the online booking forms, until the creneau selection" do

--- a/spec/form_models/prescripteur_rdv_wizard_spec.rb
+++ b/spec/form_models/prescripteur_rdv_wizard_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe PrescripteurRdvWizard do
-  let!(:organisation) { create(:organisation) }
-  let!(:motif) { create(:motif, organisation: organisation) }
-  let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
+  let(:organisation) { create(:organisation) }
+  let(:motif) { create(:motif, organisation: organisation) }
+  let(:lieu) { create(:lieu, organisation: organisation) }
+  let(:first_day) { Date.parse("2023/08/01") }
+  let(:plage_ouverture) { create(:plage_ouverture, first_day: first_day, motifs: [motif], lieu: lieu, organisation: organisation) }
 
   let(:attributes) do
     {
@@ -20,6 +21,8 @@ RSpec.describe PrescripteurRdvWizard do
       city_code: "62100",
     }
   end
+
+  before { travel_to(first_day.beginning_of_day) }
 
   context "when the user already exists but with different case or accents in their name" do
     let!(:user) do


### PR DESCRIPTION
## Erreur de CI dû au fait que la date de début de plage d'ouverture est un jour férié

Nous avons une erreur de CI sur certains tests, parce que le calcul de créneaux retourne: `[]`.

Après investigations, la recherche de créneaux échoue parce que la valeur `first_day` de la plage d'ouverture (dans `spec/factories/plage_ouverture.rb`) est fixée au `15/08/2023` jour d'assomption qui est donc férié.

En effet, la logique que suit permet de fixer comme first_day, la date en début de semaine additionnée d'un nombre variable de jours.
```
FactoryBot.define do
  sequence(:first_day) { |n| Time.zone.today.next_week(:monday) + n.days }
end
```

Pour régler le souci, nous choisissons une date fixe pour la plage d'ouverture dans `spec/form_models/prescripteur_rdv_wizard_spec.rb`
