### PR TITLE
Mise en place du tunnel de création et de modification des intervenants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,6 +125,7 @@ RSpec/AnyInstance:
     - spec/controllers/admin/referent_assignations_controller_spec.rb
     - spec/controllers/users/rdvs_controller_spec.rb
     - spec/features/users/user_can_be_invited_spec.rb
+    - spec/features/agents/admin_can_configure_the_organisation_spec.rb
 
 RSpec/DescribedClass:
   Exclude:

--- a/app/controllers/admin/agent_intervenants_controller.rb
+++ b/app/controllers/admin/agent_intervenants_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Admin::AgentIntervenantsController < AgentAuthController
+  before_action :set_services, only: %i[new create]
+
+  def new
+    @agent_intervenant = Agent.new(
+      roles_attributes: [
+        { organisation: current_organisation, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
+      ]
+    )
+    authorize(@agent_intervenant)
+  end
+
+  def create
+    @agent_intervenant = Agent.new(
+      roles_attributes: [
+        { organisation: current_organisation, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
+      ]
+    )
+    @agent_intervenant.assign_attributes(agent_intervenant_params)
+    authorize(@agent_intervenant)
+    if @agent_intervenant.save
+      redirect_to admin_organisation_agents_path(current_organisation), notice: "Intervenant créé avec succès."
+    else
+      render :new
+    end
+  end
+
+  def update
+    # Edit for intervenant is done in the role edit page for UX reasons
+    @agent_intervenant = Agent.find(params[:id])
+    authorize(@agent_intervenant)
+    if @agent_intervenant.update(agent_intervenant_params)
+      redirect_to admin_organisation_agents_path(current_organisation), notice: "Intervenant modifié avec succès."
+    else
+      redirect_to edit_admin_organisation_agent_role_path(current_organisation, @agent_intervenant.roles.first), flash: { error: @agent_intervenant.errors.full_messages.uniq.to_sentence }
+    end
+  end
+
+  protected
+
+  def set_services
+    @services = services.order(:name)
+  end
+
+  def services
+    Agent::ServicePolicy::AdminScope.new(pundit_user, Service).resolve
+  end
+
+  def pundit_user
+    AgentOrganisationContext.new(current_agent, current_organisation)
+  end
+
+  def current_organisation
+    Organisation.find(params[:organisation_id])
+  end
+
+  def agent_intervenant_params
+    params.require(:agent).permit(:last_name, :service_id)
+  end
+end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -79,14 +79,18 @@ module AgentsHelper
   end
 
   def access_levels_collection
-    # For CDAD Expe
-    if  current_organisation.territory_id == 59 ||
-        Rails.env.development? ||
-        ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO" ||
-        ENV["IS_REVIEW_APP"] == "true"
+    if activate_intervenants_feature?
       AgentRole::ACCESS_LEVELS_WITH_INTERVENANT
     else
       AgentRole::ACCESS_LEVELS
     end
+  end
+
+  def activate_intervenants_feature?
+    # For CDAD Expe
+    current_organisation.territory_id == 59 ||
+      Rails.env.development? ||
+      Rails.env.test? ||
+      ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
   end
 end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -18,11 +18,15 @@ class Agent::AgentPolicy < ApplicationPolicy
     ).any?
   end
 
+  def update?
+    # Cannot update other agents unless they are intervenants
+    current_agent? || (admin_in_record_organisation? && record.is_an_intervenant?)
+  end
+
   alias show? current_agent_or_admin_in_record_organisation?
   alias new? current_agent_or_admin_in_record_organisation?
   alias create? current_agent_or_admin_in_record_organisation?
   alias edit? current_agent_or_admin_in_record_organisation?
-  alias update? current_agent_or_admin_in_record_organisation?
   alias invite? current_agent_or_admin_in_record_organisation?
   alias rdvs? current_agent_or_admin_in_record_organisation?
   alias reinvite? current_agent_or_admin_in_record_organisation?

--- a/app/views/admin/agent_intervenants/_form.html.slim
+++ b/app/views/admin/agent_intervenants/_form.html.slim
@@ -1,0 +1,9 @@
+.row.justify-content-center
+  .col-md-8
+    .card
+      .card-body
+        = simple_form_for [:admin, current_organisation,  agent_intervenant], url: admin_organisation_agent_intervenant_path(current_organisation, agent_intervenant), html: { method: :put } do |f|
+          = render "model_errors", model: agent_intervenant
+          = f.input :last_name, label: "Désignation", placeholder: "Avocat #1", input_html: { autocomplete: "off"}
+          .text-right
+            = f.button :submit, "Modifier l'intervenant"

--- a/app/views/admin/agent_intervenants/new.html.slim
+++ b/app/views/admin/agent_intervenants/new.html.slim
@@ -1,0 +1,15 @@
+- content_for(:menu_item) { "menu-agents" }
+
+- content_for :title do
+  | Créer un intervenant pour #{current_organisation.name}
+
+.row.justify-content-center
+  .col-md-6
+    .card
+      .card-body
+        = simple_form_for [:admin, current_organisation,  @agent_intervenant], url: admin_organisation_agent_intervenants_path(current_organisation, @agent_intervenant), html: { method: :post } do |f|
+          = render "model_errors", model: @agent_intervenant
+          = f.input :last_name, label: "Désignation", placeholder: "Avocat #1", input_html: { autocomplete: "off"}
+          = f.association :service, collection: @services, include_blank: false, hint: "Attention, le service d'un intervenant est définitif, il ne pourra pas changer de service par la suite."
+          .text-right
+            = f.button :submit, "Créer l'intervenant"

--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -1,7 +1,10 @@
 - content_for(:menu_item) { "menu-agents" }
 
 - content_for :title do
-  | Modifier le rôle de l'agent #{@agent_role.agent.full_name}
+  - if @agent_role.agent.is_an_intervenant?
+    | Modifier l'intervenant #{@agent_role.agent.full_name}
+  - else
+    | Modifier le rôle de l'agent #{@agent_role.agent.full_name}
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
@@ -9,6 +12,9 @@
       = link_to "Vos agents", admin_organisation_agents_path(current_organisation)
     li.breadcrumb-item.active
       = @agent_role.agent.full_name
+
+- if @agent_role.agent.is_an_intervenant?
+  = render "admin/agent_intervenants/form", agent_intervenant: @agent_role.agent
 
 .row.justify-content-center
   .col-md-8

--- a/app/views/admin/agents/_intervenant.html.slim
+++ b/app/views/admin/agents/_intervenant.html.slim
@@ -2,16 +2,11 @@
 
 tr id="agent_#{agent.id}"
   td
-    - if agent.complete?
-      - if policy([:agent, agent_role]).edit?
-        = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
-        - if agent.inactive?
-          = tag.span("Inactif", class: "badge badge-warning")
-      - else
-        span.mr-2= agent.reverse_full_name
-      = me_tag(agent)
-  td.word-break-all
-    = agent.email
+    - if policy([:agent, agent_role]).edit?
+      = link_to agent.reverse_full_name, edit_admin_organisation_agent_role_path(current_organisation, agent_role), class: "mr-2"
+    - else
+      span.mr-2= agent.reverse_full_name
+    = me_tag(agent)
   td
     = agent.service&.name
   td.text-nowrap
@@ -20,10 +15,6 @@ tr id="agent_#{agent.id}"
       i.fa.fa-user-cog
   td
     .d-flex
-      - if policy([:agent, agent_role]).create? && !agent.invitation_accepted?
-        div.mr-3= link_to t("devise.invitations.reinvite"),
-                reinvite_admin_organisation_invitation_path(current_organisation, agent),
-                method: :post
       - if policy([:agent, agent_role]).edit?
         div.mr-3= link_to edit_admin_organisation_agent_role_path(current_organisation, agent_role), title: t("helpers.edit") do
           i.fa.fa-edit

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -1,6 +1,7 @@
 - content_for(:menu_item) { "menu-agents" }
 
-- content_for(:title, "Agents de #{current_organisation.name}")
+- content_for(:title, "Agents de #{current_organisation.name}") unless activate_intervenants_feature?
+- content_for(:title, "Agents et intervenants de #{current_organisation.name}") if activate_intervenants_feature?
 
 - if current_agent_can?(:create, Agent)
   - content_for :breadcrumb do
@@ -38,3 +39,31 @@
           = link_to "Voir les #{@invited_agents_count} invitations en attente", admin_organisation_invitations_path(current_organisation), class: "btn btn-link"
         - else
           .m-2 Aucune invitation en attente
+
+- if activate_intervenants_feature?
+  = simple_form_for "", url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
+    .container-fluid.bg-white.rounded
+      .m-3.d-flex.justify-content-end
+        - search = params[:intervenant_term].blank? && "d-none"
+        div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
+        = f.input :intervenant_term, placeholder: "Désignation", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:intervenant_term] }, required: false
+        = f.button :submit, t("helpers.search")
+      table.table
+        thead
+          tr
+            th= "Désignation"
+            th= Agent.human_attribute_name(:service)
+            th= AgentRole.human_attribute_name(:access_level)
+            th Actions
+        tbody
+          = render partial: "intervenant", collection: @intervenants, as: :agent
+      - if current_agent_can?(:create, Agent)
+        .m-3.d-flex.justify-content-center
+          = link_to "Créer un intervenant", new_admin_organisation_agent_intervenant_path(current_organisation), class:"btn btn-primary"
+      - if @intervenants.empty?
+        .mb-4.p.text-center Aucun intervenant trouvé
+      - elsif @intervenants.total_pages > 1
+        .m-3
+          .d-flex.justify-content-center
+            = paginate @intervenants, theme: "twitter-bootstrap-4", param_name: :intervenants_page
+          .text-center= page_entries_info @intervenants

--- a/app/views/admin/agents/index.json.jbuilder
+++ b/app/views/admin/agents/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.results @agents do |agent|
+json.results @agents_and_intervenants do |agent|
   json.id agent.id
   json.text agent.reverse_full_name
 end

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -25,5 +25,5 @@
 - elsif model.errors.any?
   .alert.alert-danger.fade.show
     ul.m-0
-      - errors_full_messages(model).each do |msg|
+      - errors_full_messages(model).uniq.each do |msg|
         li= msg

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,7 @@ Rails.application.routes.draw do
           put :toggle_displays, on: :member
         end
         resources :agent_roles, only: %i[edit update]
+        resources :agent_intervenants, only: %i[new create update]
         resources :agents, only: %i[index destroy] do
           resources :absences, only: %i[index new]
           resources :plage_ouvertures, only: %i[index new]

--- a/spec/controllers/admin/agent_intervenants_controller_spec.rb
+++ b/spec/controllers/admin/agent_intervenants_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::AgentIntervenantsController, type: :controller do
+  render_views
+
+  let!(:organisation) { create(:organisation) }
+  let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:agent_intervenant) { create(:agent, :intervenant, organisations: [organisation]) }
+  let(:service) { create(:service) }
+
+  before do
+    sign_in agent
+  end
+
+  describe "GET #new" do
+    it "returns a success response" do
+      get :new, params: { organisation_id: organisation.id }
+      expect(response).to be_successful
+      expect(assigns(:agent_intervenant)).to be_a_new(Agent)
+    end
+  end
+
+  describe "POST #create" do
+    let(:valid_params) do
+      {
+        last_name: "Intervenant",
+        service_id: service.id,
+      }
+    end
+
+    it "creates a new agent intervenant" do
+      expect do
+        post :create, params: { organisation_id: organisation.id, agent: valid_params }
+      end.to change(Agent, :count).by(1)
+
+      expect(response).to redirect_to(admin_organisation_agents_path(organisation))
+      expect(flash[:notice]).to eq("Intervenant créé avec succès.")
+    end
+
+    it "renders new on failure" do
+      post :create, params: { organisation_id: organisation.id, agent: { last_name: "" } }
+      expect(unescaped_response_body).to include("Désignation doit être remplie")
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "PUT #update" do
+    let(:valid_update_params) do
+      {
+        last_name: "UpdatedName",
+      }
+    end
+
+    it "updates the requested agent intervenant" do
+      put :update, params: { organisation_id: organisation.id, id: agent_intervenant.id, agent: valid_update_params }
+      agent_intervenant.reload
+
+      expect(agent_intervenant.last_name).to eq("UpdatedName")
+      expect(response).to redirect_to(admin_organisation_agents_path(organisation))
+      expect(flash[:notice]).to eq("Intervenant modifié avec succès.")
+    end
+
+    it "renders edit on failure" do
+      put :update, params: { organisation_id: organisation.id, id: agent_intervenant.id, agent: { last_name: "" } }
+      expect(response).to redirect_to(edit_admin_organisation_agent_role_path(organisation, agent_intervenant.roles.first))
+      expect(flash[:error]).to eq("Désignation doit être remplie")
+    end
+  end
+end

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -56,9 +56,13 @@ FactoryBot.define do
       service { Service.find_by(name: Service::CONSEILLER_NUMERIQUE) || build(:service, :conseiller_numerique) }
     end
     trait :intervenant do
-      before(:create) do |agent|
-        agent.email = nil
-        agent.uid = nil
+      email { nil }
+      uid { nil }
+      first_name { nil }
+      invitation_token { nil }
+      invitation_created_at { nil }
+      invitation_accepted_at { nil }
+      after(:build) do |agent|
         if agent.organisations.any?
           agent.roles.first.update(access_level: AgentRole::ACCESS_LEVEL_INTERVENANT)
         else

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -17,6 +17,7 @@ describe "Admin can configure the organisation" do
   around { |example| perform_enqueued_jobs { example.run } }
 
   before do
+    allow_any_instance_of(AgentsHelper).to receive(:activate_intervenants_feature?).and_return(false)
     login_as(agent_admin, scope: :agent)
     visit authenticated_agent_root_path
   end

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+describe "Agent can CRUD intervenants" do
+  let(:organisation) { create(:organisation) }
+  let!(:service) { create(:service, name: "CDAD") }
+  let!(:agent_admin) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }
+  let!(:agent_intervenant1) { create(:agent, :intervenant, last_name: "intervenant1", organisations: [organisation]) }
+  let!(:agent_intervenant2) { create(:agent, :intervenant, last_name: "intervenant2", organisations: [organisation]) }
+
+  before do
+    login_as(agent_admin, scope: :agent)
+    visit authenticated_agent_root_path
+  end
+
+  it "Change intervenant to admin (update agent_role)", js: true do
+    visit admin_organisation_agents_path(organisation)
+    expect_page_title("Agents et intervenants de Organisation n°1")
+
+    click_link "INTERVENANT1"
+    expect_page_title("Modifier l'intervenant INTERVENANT1")
+    choose :agent_role_access_level_admin
+    fill_in "Email", with: "ancien_intervenant1@invitation.com"
+    click_button("Enregistrer")
+
+    expect_page_title("Invitations en cours pour Organisation n°1")
+    expect(page).to have_content("ancien_intervenant1@invitation.com")
+    # last_name and first_name are reset when an intervenant is changed to agent
+    expect(page).to have_no_content("INTERVENANT1")
+  end
+
+  it "Create intervenant" do
+    visit admin_organisation_agents_path(organisation)
+    expect_page_title("Agents et intervenants de Organisation n°1")
+    click_link "Créer un intervenant"
+    expect_page_title("Créer un intervenant pour Organisation n°1")
+    fill_in "Désignation", with: "Avocat 1"
+    click_button("Créer l'intervenant")
+    expect_page_title("Agents et intervenants de Organisation n°1")
+    expect(page).to have_content("AVOCAT 1")
+  end
+
+  it "Update intervenant last_name" do
+    visit admin_organisation_agents_path(organisation)
+    expect_page_title("Agents et intervenants de Organisation n°1")
+    click_link "INTERVENANT1"
+    expect_page_title("Modifier l'intervenant INTERVENANT1")
+    fill_in "Désignation", with: "Nouveau nom"
+    click_button("Modifier l'intervenant")
+    expect_page_title("Agents et intervenants de Organisation n°1")
+    expect(page).to have_content("NOUVEAU NOM")
+  end
+
+  it "Delete intervenant" do
+    visit admin_organisation_agents_path(organisation)
+    expect_page_title("Agents et intervenants de Organisation n°1")
+    click_link "INTERVENANT1"
+    expect_page_title("Modifier l'intervenant INTERVENANT1")
+    click_link("Supprimer le compte")
+    expect_page_title("Agents et intervenants de Organisation n°1")
+    expect(page).to have_no_content("INTERVENANT1")
+  end
+
+  it "See intervenant and agents in the dropdown", js: true do
+    find("span", text: agent_admin.reverse_full_name, match: :first).click
+    expect(page).to have_content(agent_admin.reverse_full_name)
+    expect(page).to have_content("INTERVENANT1")
+    expect(page).to have_content("INTERVENANT2")
+  end
+end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -134,4 +134,53 @@ describe Agent, type: :model do
       expect(agent.multiple_organisations_access?).to eq(false)
     end
   end
+
+  describe "last_name and first_name validations" do
+    context "when agent is an intervenant" do
+      let!(:organisation) { create(:organisation) }
+      let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let(:agent_intervenant) { build(:agent, :intervenant, organisations: [organisation]) }
+
+      it "validates presence of last_name only on create" do
+        agent_intervenant.last_name = nil
+        agent_intervenant.first_name = nil
+        agent_intervenant.valid?
+        expect(agent_intervenant.errors[:base]).to include("Désignation doit être remplie")
+      end
+
+      it "validates presence of last_name only on update" do
+        agent_intervenant.last_name = "jesuisintervenant"
+        agent_intervenant.save
+        agent_intervenant.last_name = nil
+        agent_intervenant.first_name = nil
+        agent_intervenant.valid?
+        expect(agent_intervenant.errors[:base]).to include("Désignation doit être remplie")
+      end
+    end
+
+    context "when agent is not an intervenant" do
+      let!(:organisation) { create(:organisation) }
+      let!(:agent_admin) { build(:agent, admin_role_in_organisations: [organisation]) }
+
+      it "does not validates presence of last_name and first_name on create" do
+        # On Agent creation first_name and last_name are leave blank for invited agent to fill them later
+        agent_admin.last_name = nil
+        agent_admin.first_name = nil
+        agent_admin.valid?
+        expect(agent_admin.email).not_to be_nil
+        expect(agent_admin.errors).to be_empty
+      end
+
+      it "validates presence of last_name and first_name on update" do
+        agent_admin.last_name = "ancien last name"
+        agent_admin.first_name = "ancien first name"
+        agent_admin.save
+        agent_admin.last_name = nil
+        agent_admin.first_name = nil
+        agent_admin.valid?
+        expect(agent_admin.errors[:last_name]).to include("doit être rempli(e)")
+        expect(agent_admin.errors[:first_name]).to include("doit être rempli(e)")
+      end
+    end
+  end
 end

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -5,40 +5,43 @@ describe Agent::AgentPolicy, type: :policy do
 
   let(:pundit_context) { AgentContext.new(agent) }
   let!(:organisation) { create(:organisation) }
+  let!(:organisation2) { create(:organisation) }
 
-  describe "#show?" do
-    context "regular agent, self" do
-      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  %i[show? new? create? edit? invite? rdvs? reinvite? versions?].each do |action|
+    describe "##{action}" do
+      context "regular agent, self" do
+        let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
-      permissions(:show?) { it { is_expected.to permit(pundit_context, agent) } }
-    end
+        permissions(action) { it { is_expected.to permit(pundit_context, agent) } }
+      end
 
-    context "regular agent, other agent same orga" do
-      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      context "regular agent, other agent same orga" do
+        let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+        let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
-      permissions(:show?) { it { is_expected.not_to permit(pundit_context, other_agent) } }
-    end
+        permissions(action) { it { is_expected.not_to permit(pundit_context, other_agent) } }
+      end
 
-    context "admin agent, other agent same orga" do
-      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      context "admin agent, other agent same orga" do
+        let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+        let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
-      permissions(:show?) { it { is_expected.to permit(pundit_context, other_agent.reload) } }
-    end
+        permissions(action) { it { is_expected.to permit(pundit_context, other_agent.reload) } }
+      end
 
-    context "admin agent, other agent different orga" do
-      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let!(:other_agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
+      context "admin agent, other agent different orga" do
+        let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+        let!(:other_agent) { create(:agent, basic_role_in_organisations: [create(:organisation)]) }
 
-      permissions(:show?) { it { is_expected.not_to permit(pundit_context, other_agent) } }
-    end
+        permissions(action) { it { is_expected.not_to permit(pundit_context, other_agent) } }
+      end
 
-    context "regular agent, other agent is admin in same orga" do
-      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-      let!(:other_agent) { create(:agent, admin_role_in_organisations: [create(:organisation)]) }
+      context "regular agent, other agent is admin in same orga" do
+        let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+        let!(:other_agent) { create(:agent, admin_role_in_organisations: [create(:organisation)]) }
 
-      permissions(:show?) { it { is_expected.not_to permit(pundit_context, other_agent) } }
+        permissions(action) { it { is_expected.not_to permit(pundit_context, other_agent) } }
+      end
     end
   end
 
@@ -61,6 +64,57 @@ describe Agent::AgentPolicy, type: :policy do
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 
       permissions(:destroy?) { it { is_expected.not_to permit(pundit_context, agent) } }
+    end
+  end
+
+  describe "#update?" do
+    context "regular agent, other agent same org" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      permissions(:update?) { it { is_expected.not_to permit(pundit_context, other_agent) } }
+    end
+
+    context "admin agent, other agent same org" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      permissions(:update?) { it { is_expected.not_to permit(pundit_context, other_agent.reload) } }
+    end
+
+    context "admin agent, other agent other org" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation2]) }
+
+      permissions(:update?) { it { is_expected.not_to permit(pundit_context, other_agent.reload) } }
+    end
+
+    context "basic agent, intervenant same org" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:intervenant) { create(:agent, :intervenant, organisations: [organisation]) }
+
+      permissions(:update?) { it { is_expected.not_to permit(pundit_context, intervenant) } }
+    end
+
+    context "admin agent, intervenant same org" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:intervenant) { create(:agent, :intervenant, organisations: [organisation]) }
+
+      permissions(:update?) { it { is_expected.to permit(pundit_context, intervenant) } }
+    end
+
+    context "basic agent, intervenant other org" do
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:intervenant) { create(:agent, :intervenant, organisations: [organisation2]) }
+
+      permissions(:update?) { it { is_expected.not_to permit(pundit_context, intervenant) } }
+    end
+
+    context "admin agent, intervenant other org" do
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:intervenant) { create(:agent, :intervenant, organisations: [organisation2]) }
+
+      permissions(:update?) { it { is_expected.not_to permit(pundit_context, intervenant) } }
     end
   end
 end


### PR DESCRIPTION
close : https://github.com/betagouv/rdv-solidarites.fr/issues/3688

### Démo : 

https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/06d9916e-9af5-454d-bc8f-7360507b2c5c

### Techniquement
Rien d'extraordinaire. Tout est assez classique.
Petites précisions : 
- L'index de `Admin::AgentsController` est utilisé pour la dropdown des plannings avec le json.builder dédié.
Je l'ai modifié pour prendre en compte les 2 tableaux d'agents et d'intervenants maintenant que l'index des agents (html) affiche 2 tableaux distincts. (voir la vidéo)
- L'edit des intervenants se fait sur la même page que la modification des agent_roles pour une meilleure UX (vu avec Téo)
C'est pour cette raison que l'update de l'agent_intervenant renvoi vers l'edit agent_roles en cas de problème avec le record. Il y a peut être moyen de faire plus propre ?
- J'ai fait le choix de remplacer "Nom d'usage" en ce qui concerne les intervenants par "Désignation". Cela créé un peu de code spécifique, notamment au niveau de la gestion d'erreur dans le model mais cela me parait plus cohérent de parler de désignation pour des comptes d'intervenants génériques. (Avocat 1....)
- J'ai ajouté pas mal de tests et un feature test dédié pour le crud des intervenants.