### PR TITLE
Bug sur la modal de restriction des rdvs avec plusieurs lieux

### DIFF
--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -23,7 +23,7 @@ section.bg-light.p-4
                     .col-auto.align-self-center
                         i.fa.fa-chevron-right
               - else
-                = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{motif.id}" } do
+                = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{lieu.id}" } do
                   .row
                     .col
                       = t(".next_availability")
@@ -31,5 +31,5 @@ section.bg-light.p-4
                       strong= l(next_availability.starts_at, format: :human)
                     .col-auto.align-self-center
                         i.fa.fa-chevron-right
-                = render "/common/modal", id: "js-rdv-restriction-motif#{motif.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)) do
+                = render "/common/modal", id: "js-rdv-restriction-motif#{lieu.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)) do
                   = restriction_for_rdv_to_html(motif)


### PR DESCRIPTION
@SalmaBennani nous a remonté un bug en ce qui concerne la sélection d'un lieu lorsqu'un usager veut prendre rdv (sur des rdv dont le motif a un message de restriction).
Il s'agit d'un bug dans la modal dont l'id se basait sur le motif.
Ce bug a été implémenté avec le changement d'emplacement pour la modal du message de restriction [ici](https://github.com/betagouv/rdv-solidarites.fr/pull/3661)
Il y avait donc une seule et même modal pour tout les lieux et c'était le premier lieux qui était selectionné méme quand l'usager voulait s'inscrire dans un autre lieux.
Ce petit fix régle le problème.
