### PR TITLE
Mise en place d'un timeout pour les jobs

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -31,6 +31,7 @@ module DefaultJobBehaviour
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
     retry_on(StandardError, wait: :exponentially_longer, attempts: 20)
+    retry_on(JobTimeoutError, wait: :exponentially_longer, attempts: 20)
 
     # Makes sure every failed attempt is logged to Sentry
     # (see: https://github.com/bensheldon/good_job#retries)

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -2,27 +2,25 @@
 
 module DefaultJobBehaviour
   extend ActiveSupport::Concern
-  JobTimeoutError = Class.new(StandardError)
 
   included do
     # Include job metadata in Sentry context
-    around_perform do |_job, block|
+    around_perform do |job, block|
       Sentry.with_scope do |scope|
         scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
-        block.call
+
+        timeout_value = queue_name == "exports" ? 1.hour : 30.seconds
+        Timeout.timeout(timeout_value) do
+          block.call
+        end
+
+      rescue StandardError => e
+        Sentry.capture_exception(e) if job.log_failure_to_sentry?(e)
+        raise # will be caught by the retry mechanism
       end
     end
 
     # https://github.com/bensheldon/good_job#timeouts
-    around_perform do |_job, block|
-      timeout_value = queue_name == "exports" ? 1.hour : 30.seconds
-      Timeout.timeout(timeout_value, JobTimeoutError) do
-        block.call
-      end
-    rescue JobTimeoutError => e
-      Sentry.capture_exception(e)
-      raise
-    end
 
     # This retry_on means:
     # "retry 20 times with an exponential backoff, then mark job as discarded"
@@ -31,16 +29,9 @@ module DefaultJobBehaviour
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
     retry_on(StandardError, wait: :exponentially_longer, attempts: 20)
-    retry_on(JobTimeoutError, wait: :exponentially_longer, attempts: 20)
 
     # Makes sure every failed attempt is logged to Sentry
     # (see: https://github.com/bensheldon/good_job#retries)
-    around_perform do |job, block|
-      block.call
-    rescue StandardError => e
-      Sentry.capture_exception(e) if job.log_failure_to_sentry?(e)
-      raise # will be caught by the retry mechanism
-    end
   end
 
   def log_failure_to_sentry?(_exception)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -50,7 +50,7 @@ describe ApplicationJob, type: :job do
     end
 
     it "reports job timeout to Sentry for custom_queue" do
-      allow(Timeout).to receive(:timeout).with(30.seconds, DefaultJobBehaviour::JobTimeoutError).and_raise(DefaultJobBehaviour::JobTimeoutError, "execution expired")
+      allow(Timeout).to receive(:timeout).with(30.seconds).and_raise(Timeout::Error)
 
       timeout_job_class.perform_later
       enqueued_job_id = enqueued_jobs.last["job_id"]
@@ -58,12 +58,12 @@ describe ApplicationJob, type: :job do
 
       expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
       expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
-      expect(sentry_events.last.exception.values.first.value).to match("execution expired (DefaultJobBehaviour::JobTimeoutError)")
-      expect(sentry_events.last.exception.values.first.type).to eq("DefaultJobBehaviour::JobTimeoutError")
+      expect(sentry_events.last.exception.values.first.value).to match("Timeout::Error (Timeout::Error)")
+      expect(sentry_events.last.exception.values.first.type).to eq("Timeout::Error")
     end
 
     it "reports exports job timeout to Sentry for exports queue" do
-      allow(Timeout).to receive(:timeout).with(1.hour, DefaultJobBehaviour::JobTimeoutError).and_raise(DefaultJobBehaviour::JobTimeoutError, "execution expired")
+      allow(Timeout).to receive(:timeout).with(1.hour).and_raise(Timeout::Error)
 
       exports_timeout_job_class.perform_later
       enqueued_job_id = enqueued_jobs.last["job_id"]
@@ -71,8 +71,8 @@ describe ApplicationJob, type: :job do
 
       expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
       expect(sentry_events.last.contexts[:job][:queue_name]).to eq("exports")
-      expect(sentry_events.last.exception.values.first.value).to match("execution expired (DefaultJobBehaviour::JobTimeoutError)")
-      expect(sentry_events.last.exception.values.first.type).to eq("DefaultJobBehaviour::JobTimeoutError")
+      expect(sentry_events.last.exception.values.first.value).to match("Timeout::Error (Timeout::Error)")
+      expect(sentry_events.last.exception.values.first.type).to eq("Timeout::Error")
     end
   end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -14,6 +14,26 @@ describe ApplicationJob, type: :job do
       MyJob
     end
 
+    let(:timeout_job_class) do
+      stub_const "TimeoutJob", Class.new(described_class)
+      TimeoutJob.class_eval do
+        queue_as :custom_queue
+
+        def perform; end
+      end
+      TimeoutJob
+    end
+
+    let(:exports_timeout_job_class) do
+      stub_const "ExportsTimeoutJob", Class.new(described_class)
+      ExportsTimeoutJob.class_eval do
+        queue_as :exports
+
+        def perform; end
+      end
+      ExportsTimeoutJob
+    end
+
     stub_sentry_events
 
     it "reports job metadata to Sentry" do
@@ -23,10 +43,36 @@ describe ApplicationJob, type: :job do
 
       expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
       expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
-      expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { :_some_kw_arg => 456 }])
+      expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { _some_kw_arg: 456 }])
 
       expect(sentry_events.last.exception.values.first.value).to match("Something unexpected happened (RuntimeError)")
       expect(sentry_events.last.exception.values.first.type).to eq("RuntimeError")
+    end
+
+    it "reports job timeout to Sentry for custom_queue" do
+      allow(Timeout).to receive(:timeout).with(30.seconds, DefaultJobBehaviour::JobTimeoutError).and_raise(DefaultJobBehaviour::JobTimeoutError, "execution expired")
+
+      timeout_job_class.perform_later
+      enqueued_job_id = enqueued_jobs.last["job_id"]
+      expect { perform_enqueued_jobs }.to change(sentry_events, :size).by(1)
+
+      expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
+      expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
+      expect(sentry_events.last.exception.values.first.value).to match("execution expired (DefaultJobBehaviour::JobTimeoutError)")
+      expect(sentry_events.last.exception.values.first.type).to eq("DefaultJobBehaviour::JobTimeoutError")
+    end
+
+    it "reports exports job timeout to Sentry for exports queue" do
+      allow(Timeout).to receive(:timeout).with(1.hour, DefaultJobBehaviour::JobTimeoutError).and_raise(DefaultJobBehaviour::JobTimeoutError, "execution expired")
+
+      exports_timeout_job_class.perform_later
+      enqueued_job_id = enqueued_jobs.last["job_id"]
+      expect { perform_enqueued_jobs }.to change(sentry_events, :size).by(1)
+
+      expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
+      expect(sentry_events.last.contexts[:job][:queue_name]).to eq("exports")
+      expect(sentry_events.last.exception.values.first.value).to match("execution expired (DefaultJobBehaviour::JobTimeoutError)")
+      expect(sentry_events.last.exception.values.first.type).to eq("DefaultJobBehaviour::JobTimeoutError")
     end
   end
 end


### PR DESCRIPTION
En lien avec https://github.com/betagouv/rdv-solidarites.fr/issues/3724
Implémentation d'un timeout pour nos jobs.
En cas de dépassement de :
+ de 1 heure pour les queues 'exports'
+ de 30 secondes pour toutes les autres queues

On arrête le job
On log l'erreur dans sentry
On retry sur le même principe que pour les autres erreurs (à des intervalles exponentielle 20 fois)