### PR TITLE
Mettre une heure de timeout pour les cronjobs

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -9,7 +9,7 @@ module DefaultJobBehaviour
       Sentry.with_scope do |scope|
         scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
 
-        timeout_value = queue_name == "exports" ? 1.hour : 30.seconds
+        timeout_value = queue_name.in?(%w[exports cron]) ? 1.hour : 30.seconds
         Timeout.timeout(timeout_value) do
           block.call
         end


### PR DESCRIPTION
Suite à la mise en place de timeout pour nos jobs nous avons remarqué que les jobs de la queue "cron" peuvent prendre plusieurs minutes. On a décidé pour rapidement traiter le "problème" de mettre en place la même politique de timeout que pour les exports pour les jobs cron qui tournent la nuit (1 heure de timeout)
