### PR TITLE
Changement de css pour les cellules des rdv courts (<= 30 minutes)

### DIFF
--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -161,7 +161,7 @@
   align-items: center;
   padding-left: 0.6rem;
   &.fc-event-small{
-    line-height: 0.75rem;
+    line-height: 0.6rem;
     padding: 0;
   }
   .fc-time, .fc-title{


### PR DESCRIPTION
Pour répondre à ce besoin : https://github.com/betagouv/rdv-solidarites.fr/issues/3727
Je met en place un petit changement de css pour les rdvs <= à 30 minutes.
Il s'agit d'une modification semble t'il mineure. **Je n'ai pas eu besoin de toucher à la taille de la police déjà petite.**
Du code spécifique existait déjà pour mettre en place du css pour les rdvs dont la durée est de moins de 30 minutes avec la classe `fc-event-small`
Je me suis basé la dessus, c'est bon à savoir on pourra réutiliser ce code pour les rdvs <= à 15 minutes si on souhaite des ajustements plus précis.

Inconvénient : j'ai l'impression que la police sort légèrement en hauteur de la box de couleur

Avant : 
![Capture d’écran 2023-08-16 à 11 08 28](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/4a7ef470-e0ea-4ee9-a789-16ce0b80fee3)

Après : 
![Capture d’écran 2023-08-16 à 11 08 06](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/bea192fd-3d76-45dd-b886-47716c32745b)
