### PR TITLE
Suppression automatique des comptes usagers inactifs

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -53,11 +53,9 @@ class CronJob < ApplicationJob
     def perform(date_limit)
       old_users_without_rdvs = User.where("users.created_at < ?", date_limit).left_outer_joins(:rdvs_users).where(rdvs_users: { id: nil })
 
-      old_users_without_rdvs_or_relative_having_rdvs = old_users_without_rdvs.joins("left outer join users as relatives on users.id = relatives.responsible_id")
-        .joins("left outer join rdvs_users as rdvs_relatives on rdvs_relatives.user_id = relatives.id")
-        .where(rdvs_relatives: { id: nil })
+      old_users_without_rdvs_or_relatives = old_users_without_rdvs.joins("left outer join users as relatives on users.id = relatives.responsible_id").where(relatives: { id: nil })
 
-      old_users_without_rdvs_or_relative_having_rdvs.find_each do |user|
+      old_users_without_rdvs_or_relatives.find_each do |user|
         user.user_profiles.destroy_all
         user.skip_webhooks = true
         user.destroy

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -36,11 +36,25 @@ class CronJob < ApplicationJob
     end
   end
 
-  class DestroyOldRdvsJob < CronJob
+  class DestroyOldRdvsAndInactiveUsersJob < CronJob
     def perform
-      Rdv.unscoped.where(starts_at: ..2.years.ago).each do |rdv|
+      two_years_ago = 2.years.ago
+      Rdv.unscoped.where(starts_at: ..two_years_ago).each do |rdv|
         rdv.skip_webhooks = true
         rdv.destroy
+      end
+      # La suppression d'utilisateurs inactifs a besoin que les vieux rdv soient supprimés
+      # On utilise la même date limite pour éviter une race condition liée au temps d'exécution du premier job
+      DestroyInactiveUsers.perform_later(two_years_ago)
+    end
+  end
+
+  class DestroyInactiveUsers < CronJob
+    def perform(date_limit)
+      User.where("users.created_at < ?", date_limit).left_outer_joins(:rdvs_users).where(rdvs_users: { id: nil }).find_each do |user|
+        user.user_profiles.destroy_all
+        user.skip_webhooks = true
+        user.destroy
       end
     end
   end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -51,7 +51,13 @@ class CronJob < ApplicationJob
 
   class DestroyInactiveUsers < CronJob
     def perform(date_limit)
-      User.where("users.created_at < ?", date_limit).left_outer_joins(:rdvs_users).where(rdvs_users: { id: nil }).find_each do |user|
+      old_users_without_rdvs = User.where("users.created_at < ?", date_limit).left_outer_joins(:rdvs_users).where(rdvs_users: { id: nil })
+
+      old_users_without_rdvs_or_relative_having_rdvs = old_users_without_rdvs.joins("left outer join users as relatives on users.id = relatives.responsible_id")
+        .joins("left outer join rdvs_users as rdvs_relatives on rdvs_relatives.user_id = relatives.id")
+        .where(rdvs_relatives: { id: nil })
+
+      old_users_without_rdvs_or_relative_having_rdvs.find_each do |user|
         user.user_profiles.destroy_all
         user.skip_webhooks = true
         user.destroy

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -50,10 +50,9 @@ Rails.application.configure do
       class: "CronJob::DestroyRedisWaitingRoomKeys",
     },
 
-    # Nettoyage de vieille données : pas essentiel mais idéalement quotidien
-    destroy_old_rdvs_job: {
+    destroy_old_rdvs_and_inactive_users_job: {
       cron: "every day at 22:00 Europe/Paris",
-      class: "CronJob::DestroyOldRdvsJob",
+      class: "CronJob::DestroyOldRdvsAndInactiveUsersJob",
     },
     destroy_old_plage_ouverture_job: {
       cron: "every day at 22:30 Europe/Paris",

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -456,5 +456,6 @@ Voici les suppressions automatiques mises en place :
 - Suppression des RDVs de plus de 2 ans
 - Suppression des plages d'ouverture de plus de 1 an
 - Suppression des logs PaperTrail (auditing) de plus de 2 ans
+- Suppression des usagers inactifs (pas de rdv dans les 2 dernières années, et compte créé depuis plus de 2 ans)
 
-Note : **Aucune suppression automatique de profil usager ou agent inactif après un certain laps de temps.**
+Note : **Aucune suppression automatique de profil agent inactif après un certain laps de temps.**

--- a/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_users_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_users_job_spec.rb
@@ -1,22 +1,27 @@
 # frozen_string_literal: true
 
-describe CronJob::DestroyOldRdvsJob do
-  it "only destroys Rdvs that are more than 2 years old" do
+describe CronJob::DestroyOldRdvsAndInactiveUsersJob do
+  it "only destroys Rdvs that are more than 2 years old and inactive users created 2 more than years ago" do
     rdv_occurring_25_months_ago = travel_to(25.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
     rdv_occurring_23_months_ago = travel_to(23.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
     rdv_occurring_11_months_ago = travel_to(11.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
 
+    user_without_rdv_created_23_months_ago = travel_to(23.months.ago) { create(:user) }
+
     described_class.new.perform
+    perform_enqueued_jobs # to perform the DestroyInactiveUsers job
 
     expect(Rdv.all).to include(rdv_occurring_23_months_ago, rdv_occurring_11_months_ago)
     expect(Rdv.all).not_to include(rdv_occurring_25_months_ago)
+
+    expect(User.all).to match_array([user_without_rdv_created_23_months_ago, rdv_occurring_11_months_ago.users.first, rdv_occurring_23_months_ago.users.first])
   end
 
   it "does not call any webhook" do
     travel_to(25.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
     expect do
       described_class.new.perform
-    end.not_to have_enqueued_job
+    end.not_to have_enqueued_job(WebhookJob)
   end
 
   it "actually deletes RDVs that were soft_deleted" do

--- a/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_users_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_users_job_spec.rb
@@ -14,6 +14,11 @@ describe CronJob::DestroyOldRdvsAndInactiveUsersJob do
     relative = create(:user, responsible: user_created_25_months_ago_with_a_relative_that_has_a_rdv)
     create(:rdv, users: [relative])
 
+    other_relative = create(:user, responsible: user_created_25_months_ago_with_a_relative_that_has_a_rdv)
+
+    user_created_25_months_ago_with_a_relative_without_a_rdv, = travel_to(25.months.ago) { create(:user) }
+    relative_without_rdv = create(:user, responsible: user_created_25_months_ago_with_a_relative_without_a_rdv)
+
     described_class.new.perform
     perform_enqueued_jobs # to perform the DestroyInactiveUsers job
 
@@ -24,6 +29,9 @@ describe CronJob::DestroyOldRdvsAndInactiveUsersJob do
                                       user_without_rdv_created_23_months_ago,
                                       user_created_25_months_ago_with_a_relative_that_has_a_rdv,
                                       relative,
+                                      other_relative,
+                                      user_created_25_months_ago_with_a_relative_without_a_rdv,
+                                      relative_without_rdv,
                                       rdv_occurring_11_months_ago.users.first,
                                       rdv_occurring_23_months_ago.users.first,
                                     ])

--- a/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_users_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_users_job_spec.rb
@@ -8,13 +8,27 @@ describe CronJob::DestroyOldRdvsAndInactiveUsersJob do
 
     user_without_rdv_created_23_months_ago = travel_to(23.months.ago) { create(:user) }
 
+    user_without_rdv_created_25_months_ago = travel_to(25.months.ago) { create(:user) }
+
+    user_created_25_months_ago_with_a_relative_that_has_a_rdv = travel_to(25.months.ago) { create(:user) }
+    relative = create(:user, responsible: user_created_25_months_ago_with_a_relative_that_has_a_rdv)
+    create(:rdv, users: [relative])
+
     described_class.new.perform
     perform_enqueued_jobs # to perform the DestroyInactiveUsers job
 
     expect(Rdv.all).to include(rdv_occurring_23_months_ago, rdv_occurring_11_months_ago)
     expect(Rdv.all).not_to include(rdv_occurring_25_months_ago)
 
-    expect(User.all).to match_array([user_without_rdv_created_23_months_ago, rdv_occurring_11_months_ago.users.first, rdv_occurring_23_months_ago.users.first])
+    expect(User.all).to match_array([
+                                      user_without_rdv_created_23_months_ago,
+                                      user_created_25_months_ago_with_a_relative_that_has_a_rdv,
+                                      relative,
+                                      rdv_occurring_11_months_ago.users.first,
+                                      rdv_occurring_23_months_ago.users.first,
+                                    ])
+
+    expect(User.all).not_to include(user_without_rdv_created_25_months_ago)
   end
 
   it "does not call any webhook" do


### PR DESCRIPTION
Cette PR est une première étape pour https://github.com/betagouv/rdv-solidarites.fr/issues/3623

Pour être cohérent avec ce qui est déjà fait pour les rdvs, j'ai désactivé les webhooks : c'est pas une suppression au niveau métier, mais pour des raisons rgpd, donc c'est pas nécessaire de renvoyer les infos aux systèmes externes (au contraire, on veut supprimer les données, pas les propager encore plus). Et on compte sur les systèmes externes auxquels on envoie les données pour qu'ils suppriment les vieilles données.