### PR TITLE
Problèmes de comptes usagers RDV_MAIRIE (confirmation et récupération de mot de passe)

### DIFF
--- a/app/models/concerns/user/devise_invitable_with_domain.rb
+++ b/app/models/concerns/user/devise_invitable_with_domain.rb
@@ -15,7 +15,7 @@ module User::DeviseInvitableWithDomain
   def sign_up_domain=(domain)
     return if email.blank?
 
-    REDIS_FOR_SIGN_UP_DOMAIN.set(redis_key_for_sign_up_domain, domain.id, ex: 12.hours.in_seconds)
+    REDIS_FOR_SIGN_UP_DOMAIN.set(redis_key_for_sign_up_domain, domain.id, ex: 6.months.in_seconds)
   end
 
   private


### PR DESCRIPTION
Suite à cette remontée de bug : https://zammad10.ethibox.fr/#ticket/zoom/7006
Lors d'une vérification dans brevo, nous avons constaté qu'un utilisateur de "rdv-mairie" recevait des emails de confirmation et de réinitialisation de mot de passe en provenance de "rdv-solidarites".

Ceci est dû à un problème de stockage du domaine pour les nouveaux utilisateurs dans Redis. (A revoir ?)
Actuellement, cette clé dans Redis est configurée pour expirer au bout de 12 heures. Par conséquent, après 12 heures tout les emails envoyés par devise le seront en provenance du domaine par défaut (rdv-solidarites). C'est valable pour la confirmation de son compte et aussi pour la réinitialisation de mot de passe.
Le problème ne se pose plus si l'usager a eu/pris un rdv car c'est le domaine du rdv qu'il a pris qui est pris en compte dans ce cas pour déterminer son domaine et non plus la clé Redis en question.

En guise de solution temporaire, nous avons réglé l'expiration de cette clé Redis à 6 mois.
