### PR TITLE
[Vigie] Fix NoMethodError in invitation mail for Agents

### DIFF
--- a/app/views/agents/mailer/invitation_instructions.html.erb
+++ b/app/views/agents/mailer/invitation_instructions.html.erb
@@ -1,4 +1,4 @@
-<% inviter_email = @resource.invited_by&.email || "contact@rdv-solidarites.fr" %>
+<% inviter_email = @resource.invited_by&.email || domain.support_email %>
 <% inviter_name = @resource.invited_by&.full_name || "Équipe de #{domain.name}" %>
 
 <p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>


### PR DESCRIPTION
## Fix NoMethodError in invitation mail for Agents

[Sentry Error](https://sentry.incubateur.net/organizations/betagouv/issues/41669/events/7770539650594b778f9d543c5beb51f3/?project=74)

When onboarding a Mairie from the SuperAdmin, agent.invited_by is sometimes set to nil.
This results in an error when sending the email.

For the fix, whenever agent.invited_by.nil? , we use `contact@rdv-solidarites.fr` infos as a backup

Pour tester : <`mettre ici l'url de la review app une fois déployé`>

Décrire le pourquoi des modifications

Closes #issue_number

# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
