### PR TITLE
ne pas envoyer de webhooks pour les user profiles lors de la suppression d'usagers inactifs

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -60,6 +60,7 @@ class CronJob < ApplicationJob
           profile.skip_webhooks = true
           profile.destroy
         end
+        user.reload
         user.skip_webhooks = true
         user.destroy
       end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -56,7 +56,10 @@ class CronJob < ApplicationJob
       old_users_without_rdvs_or_relatives = old_users_without_rdvs.joins("left outer join users as relatives on users.id = relatives.responsible_id").where(relatives: { id: nil })
 
       old_users_without_rdvs_or_relatives.find_each do |user|
-        user.user_profiles.destroy_all
+        user.user_profiles.each do |profile|
+          profile.skip_webhooks = true
+          profile.destroy
+        end
         user.skip_webhooks = true
         user.destroy
       end


### PR DESCRIPTION
En faisant le test en prod, je me suis rendu compte que les webhooks partaient pour les user_profiles. Je pense pas que ça soit très grave, mais pour être cohérent avec les autre suppression je pense qu'il veut mieux ne pas les envoyer.