### PR TITLE
Add Sentry Crumb for ANTS API Requests details

### DIFF
--- a/app/controllers/api/ants/base_controller.rb
+++ b/app/controllers/api/ants/base_controller.rb
@@ -5,6 +5,7 @@ class Api::Ants::BaseController < ActionController::Base
   respond_to :json
 
   before_action :check_authentication_token!
+  before_action :add_sentry_crumb
 
   private
 
@@ -23,5 +24,19 @@ class Api::Ants::BaseController < ActionController::Base
 
   def authentication_token
     request.headers.fetch("X-HUB-RDV-AUTH-TOKEN", "")
+  end
+
+  def add_sentry_crumb
+    Sentry.add_breadcrumb(
+      Sentry::Breadcrumb.new(
+        message: "ANTS API Request details",
+        data: {
+          method: request.method,
+          url: request.url,
+          headers: request.headers,
+          params: params,
+        }
+      )
+    )
   end
 end

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -2,6 +2,7 @@
 
 describe "ANTS API: availableTimeSlots" do
   include_context "rdv_mairie_api_authentication"
+  stub_sentry_events
 
   let(:lieu1) do
     create(:lieu, organisation: organisation)
@@ -78,6 +79,25 @@ describe "ANTS API: availableTimeSlots" do
           ],
         }.with_indifferent_access
       )
+    end
+  end
+
+  context "Responds with an Error" do
+    before do
+      # Delete motifs and motifs category to create an error
+      organisation.motifs.destroy_all
+      MotifCategory.destroy_all
+    end
+
+    it "adds crumb with request details to Sentry" do
+      expect do
+        get "/api/ants/availableTimeSlots?meeting_point_ids=#{lieu1.id}&meeting_point_ids=#{lieu2.id}&start_date=2022-11-01&end_date=2022-11-02&documents_number=1&reason=CNI"
+      end.to raise_error(NoMethodError)
+
+      crumb = sentry_events.last.breadcrumbs.compact.first
+      expect(crumb.message).to eq("ANTS API Request details")
+      expect(crumb.data[:params]).to match(hash_including({ "start_date" => "2022-11-01", "end_date" => "2022-11-02", "documents_number" => "1", "reason" => "CNI", "controller" => "api/ants/editor",
+                                                            "action" => "available_time_slots", }))
     end
   end
 end


### PR DESCRIPTION
Nous constatons des erreurs récurrentes sur les requêtes émises par l'ANTS.
Exemple: [Erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/51016/events/447eae925d944a04a1a27100b894451c/?project=74)

Afin de mieux comprendre et d'investiguer plus sereinement les erreurs, cette PR permet d'ajouter aux logs sentry, les détails important des requêtes: Query Params, Headers, URL ....

# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
