### PR TITLE
Petite correction du terme utilisé dans l'interface pour désigner les agents

### DIFF
--- a/app/views/admin/agent_roles/edit.html.slim
+++ b/app/views/admin/agent_roles/edit.html.slim
@@ -6,7 +6,7 @@
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
-      = link_to "Vos agents", admin_organisation_agents_path(current_organisation)
+      = link_to "Agents", admin_organisation_agents_path(current_organisation)
     li.breadcrumb-item.active
       = @agent_role.agent.full_name
 

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -24,7 +24,7 @@
           .flex-shrink-0.mr-1.font-weight-bold Description :
           span= @plage_ouverture.title
         div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Professionnel :
+          .flex-shrink-0.mr-1.font-weight-bold Agent :
           span= @plage_ouverture.agent.full_name
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Lieu :

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -37,7 +37,7 @@
     i.fa.fa-fw.fa-user.text-primary-blue>
   div
     strong
-      => "Professionnel".pluralize(rdv.agents.size)
+      => "Agent".pluralize(rdv.agents.size)
     = agents_to_sentence(rdv.agents)
 
 - rdv.rdvs_users.select(&:prescripteur).each do |rdvs_user|

--- a/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
+++ b/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
@@ -5,7 +5,7 @@
     span.float-right= @absence.title
     .clear
   div.row-result
-    span.title Professionnel :
+    span.title Agent :
     span.float-right= @absence.agent.full_name
     .clear
   div.row-result

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -5,7 +5,7 @@
     span.float-right= plage_ouverture.title
     .clear
   div.row-result
-    span.title Professionnel :
+    span.title Agent :
     span.float-right= plage_ouverture.agent.full_name
     .clear
   div.row-result


### PR DESCRIPTION
Juste un petit détail que j'ai remarqué en travaillant sur une autre pr :  il y a plusieurs endroits où on utilise le terme "professionnel" à la place d'agent dans l'interface du back office.
Pour rendre l'appli plus claire, on veut toujours utiliser le même terme pour la même chose.