### PR TITLE
Correctif d'erreurs aléatoires sur le build

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,5 +102,6 @@ RSpec.configure do |config|
     ActionMailer::Base.deliveries.clear
     FactoryBot.rewind_sequences
     Rails.cache.clear
+    Warden.test_reset!
   end
 end


### PR DESCRIPTION
Pour reproduire l'erreur : `bundle exec rspec spec/features/agents/rdv_details_spec.rb:49 spec/features/anybody/anybody_can_see_legal_pages_spec.rb:6 --order=defined --format=doc`

(J'ai repéré ça en voyant le build d'une autre pr sur laquelle je bosse échouer. Le nom du user dans l'erreur m'a permis de comprendre quel fichier leakait des données dans les suivants, et j'ai pu ensuite trouver le bon test en reprenant le seed du build qui échouait)

Il nous manquait l'appel à Warden qui déconnecte les utilisateurs après avoir fait un login_as (même si l'agent ne semble plus exister en base)