### PR TITLE
Suppression des comptes agents inactifs

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -81,7 +81,7 @@ class CronJob < ApplicationJob
         .where("account_deletion_warning_sent_at IS NULL OR account_deletion_warning_sent_at < ?", date_limit)
 
       inactive_agents_without_recent_warning.find_each do |agent|
-        Agents::AccountDeletionMailer.with(agent).upcoming_deletion_warning.deliver_later
+        Agents::AccountDeletionMailer.with(agent: agent).upcoming_deletion_warning.deliver_later
         # Cet update doit réussir même si l'agent n'est pas valide, et ne nécessite pas les callbacks (comme les webhooks), d'où le update_columns
         agent.update_columns(account_deletion_warning_sent_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
       end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -36,7 +36,7 @@ class CronJob < ApplicationJob
     end
   end
 
-  class DestroyOldRdvsAndInactiveUsersJob < CronJob
+  class DestroyOldRdvsAndInactiveAccountsJob < CronJob
     def perform
       two_years_ago = 2.years.ago
       Rdv.unscoped.where(starts_at: ..two_years_ago).each do |rdv|

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -69,7 +69,7 @@ class CronJob < ApplicationJob
     protected
 
     def inactive_agents(date_limit)
-      agents_without_rdvs = Agent.left_outer_joins(:rdvs_agents).where(rdvs_agents: { id: nil })
+      agents_without_rdvs = Agent.left_outer_joins(:agents_rdvs).where(agents_rdvs: { id: nil })
 
       agents_without_rdvs.where("created_at < ?", date_limit).where("last_sign_in_at IS NULL OR last_sign_in_at < ?", date_limit)
     end
@@ -81,7 +81,7 @@ class CronJob < ApplicationJob
         .where("account_deletion_warning_sent_at IS NULL OR account_deletion_warning_sent_at < ?", date_limit)
 
       inactive_agents_without_recent_warning.find_each do |agent|
-        Agents::AccountDeletionMailer.with(agent).deliver_later
+        Agents::AccountDeletionMailer.with(agent).upcoming_deletion_warning.deliver_later
         # Cet update doit réussir même si l'agent n'est pas valide, et ne nécessite pas les callbacks (comme les webhooks), d'où le update_columns
         agent.update_columns(account_deletion_warning_sent_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
       end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -63,6 +63,17 @@ class CronJob < ApplicationJob
     end
   end
 
+  class DestroyInactiveAgents < CronJob
+    def perform
+      old_agents = Agent.where("created_at < ?", 2.years.ago).where("last_sign_in_at < ? OR last_sign_in_at IS NULL", 2.years.ago)
+
+      inactive_agents = old_agents.left_outer_joins(:rdvs_agents).where(rdvs_agents: { id: nil })
+
+      inactive_agents.find_each do |agent|
+      end
+    end
+  end
+
   class DestroyOldPlageOuvertureJob < CronJob
     def perform
       po_exceptionnelle_closed_since_1_year = PlageOuverture.where(recurrence: nil).where(first_day: ..1.year.ago)

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -64,6 +64,19 @@ class CronJob < ApplicationJob
     end
   end
 
+  class InactiveAgentsJob < CronJob
+
+    protected
+
+    def inactive_agents(date_limit)
+
+    end
+  end
+
+  class WarnInactiveAgentsOfAccountDeletion < CronJob
+
+  end
+
   class DestroyInactiveAgents < CronJob
     def perform(date_limit)
       old_agents = Agent.where("created_at < ?", date_limit).where("last_sign_in_at < ? OR last_sign_in_at IS NULL", date_limit)

--- a/app/mailers/agents/account_deletion_mailer.rb
+++ b/app/mailers/agents/account_deletion_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Agents::AccountDeletionMailer < ApplicationMailer
+  before_action do
+    @agent = params[:agent]
+  end
+
+  default to: -> { @agent.email }
+
+  def upcoming_deletion_warning
+    mail(subject: "Votre compte sur #{domain.name} sera supprimé dans 1 mois", domain_name: domain.name)
+  end
+
+  private
+
+  def domain
+    @agent.domain
+  end
+end

--- a/app/views/mailers/agents/account_deletion_mailer/upcoming_deletion_warning.html.slim
+++ b/app/views/mailers/agents/account_deletion_mailer/upcoming_deletion_warning.html.slim
@@ -1,10 +1,12 @@
 p = t("mailers.common.hello")
 
 p
-  | Votre compte sur #{domain.name} est inactif et sans action de votre part, il sera supprimé automatiquement dans un mois.
+  | Votre compte sur #{domain.name} est inactif depuis au moins 2 ans.
+p
+  | Sans action de votre part, il sera supprimé automatiquement dans 30 jours.
 
 p
-  | Si vous voulez conserver votre compte, il vous suffit de vous connecter sur #{domain.name} via ce lien :
+  | Si vous souhaitez conserver votre compte, il vous suffit de vous connecter sur #{domain.name} via ce lien :
 
 .btn-wrapper= link_to "Connexion", new_agent_session_url, class:"btn btn-primary"
 

--- a/app/views/mailers/agents/account_deletion_mailer/upcoming_deletion_warning.html.slim
+++ b/app/views/mailers/agents/account_deletion_mailer/upcoming_deletion_warning.html.slim
@@ -1,0 +1,14 @@
+p = t("mailers.common.hello")
+
+p
+  | Votre compte sur #{domain.name} est inactif et sans action de votre part, il sera supprimé automatiquement dans un mois.
+
+p
+  | Si vous voulez conserver votre compte, il vous suffit de vous connecter sur #{domain.name} via ce lien :
+
+.btn-wrapper= link_to "Connexion", new_agent_session_url, class:"btn btn-primary"
+
+p
+  | Sinon, aucune action n'est nécessaire de votre part.
+
+= t("mailers.common.farewell_html", domain_name: domain.name)

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
     destroy_old_rdvs_and_inactive_users_job: {
       cron: "every day at 22:00 Europe/Paris",
-      class: "CronJob::DestroyOldRdvsAndInactiveUsersJob",
+      class: "CronJob::DestroyOldRdvsAndInactiveAccountsJob",
     },
     destroy_old_plage_ouverture_job: {
       cron: "every day at 22:30 Europe/Paris",

--- a/db/migrate/20230823144508_add_agents_account_deletion_warning_sent_at.rb
+++ b/db/migrate/20230823144508_add_agents_account_deletion_warning_sent_at.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAgentsAccountDeletionWarningSentAt < ActiveRecord::Migration[7.0]
   def change
     add_column :agents, :account_deletion_warning_sent_at, :datetime

--- a/db/migrate/20230823144508_add_agents_account_deletion_warning_sent_at.rb
+++ b/db/migrate/20230823144508_add_agents_account_deletion_warning_sent_at.rb
@@ -1,0 +1,6 @@
+class AddAgentsAccountDeletionWarningSentAt < ActiveRecord::Migration[7.0]
+  def change
+    add_column :agents, :account_deletion_warning_sent_at, :datetime
+    add_index :agents, :account_deletion_warning_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_20_102741) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_23_144508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -225,6 +225,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_102741) do
     t.text "refresh_microsoft_graph_token"
     t.string "cnfs_secondary_email"
     t.boolean "outlook_disconnect_in_progress", default: false, null: false
+    t.datetime "account_deletion_warning_sent_at"
+    t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true
     t.index ["email"], name: "index_agents_on_email", unique: true, where: "(email IS NOT NULL)"

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -456,6 +456,6 @@ Voici les suppressions automatiques mises en place :
 - Suppression des RDVs de plus de 2 ans
 - Suppression des plages d'ouverture de plus de 1 an
 - Suppression des logs PaperTrail (auditing) de plus de 2 ans
-- Suppression des usagers inactifs (pas de rdv dans les 2 dernières années, et compte créé depuis plus de 2 ans)
+- Suppression des usagers inactifs pendant au moins 2 ans (pas de rdv dans les 2 dernières années, et compte créé depuis plus de 2 ans)
+- Suppression des agents inactifs pendant au moins 2 ans (pas de rdv dans les 2 dernières années, et compte créé depuis plus de 2 ans, pas de connexion depuis 2 ans)
 
-Note : **Aucune suppression automatique de profil agent inactif après un certain laps de temps.**

--- a/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
@@ -2,27 +2,30 @@
 
 describe CronJob::DestroyInactiveAgents do
   it "warns and deletes old agents" do
-    agent_created_25_months_ago_without_warning = travel_to(25.months.ago) { create(:agent) }
-
-    agent_created_25_months_ago_with_warning = travel_to(25.months.ago) { create(:agent) }
-    agent_created_25_months_ago_with_warning.update!(account_deletion_warning_sent_at: 33.days.ago)
-
+    # agents that will not be modified
     agent_created_12_months_ago_with_warning = travel_to(12.months.ago) { create(:agent, account_deletion_warning_sent_at: Time.zone.now) }
     agent_created_12_months_ago_without_warning = travel_to(12.months.ago) { create(:agent) }
 
+    # agents that will be warned, but not deleted
+    agent_created_25_months_ago_without_warning = travel_to(25.months.ago) { create(:agent) }
+
+    # agents that will be deleted
+    agent_created_25_months_ago_with_warning = travel_to(25.months.ago) { create(:agent) }
+    agent_created_25_months_ago_with_warning.update!(account_deletion_warning_sent_at: 33.days.ago)
+
     two_years_ago = 2.years.ago
     CronJob::WarnInactiveAgentsOfAccountDeletion.new.perform(two_years_ago)
-    described_class.new.perform(two_years_ago)
 
     perform_enqueued_jobs
     expect(ActionMailer::Base.deliveries.map(&:to).flatten).to eq([agent_created_25_months_ago_without_warning.email])
+    expect(agent_created_25_months_ago_without_warning.reload.account_deletion_warning_sent_at).to be_present
+
+    described_class.new.perform(two_years_ago)
 
     expect(Agent.all).to match_array([
                                        agent_created_25_months_ago_without_warning,
                                        agent_created_12_months_ago_without_warning,
                                        agent_created_12_months_ago_with_warning,
                                      ])
-
-    expect(agent_created_25_months_ago_without_warning.reload.account_deletion_warning_sent_at).to be_present
   end
 end

--- a/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe CronJob do
+describe CronJob::DestroyInactiveAgents do
   it "warns and deletes old agents" do
     agent_created_25_months_ago_without_warning = travel_to(25.months.ago) { create(:agent) }
 
@@ -12,7 +12,7 @@ describe CronJob do
 
     two_years_ago = 2.years.ago
     CronJob::WarnInactiveAgentsOfAccountDeletion.new.perform(two_years_ago)
-    CronJob::DestroyInactiveAgents.new.perform(two_years_ago)
+    described_class.new.perform(two_years_ago)
 
     perform_enqueued_jobs
     expect(ActionMailer::Base.deliveries.map(&:to).flatten).to eq([agent_created_25_months_ago_without_warning.email])

--- a/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_accounts_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_accounts_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe CronJob::DestroyOldRdvsAndInactiveUsersJob do
+describe CronJob::DestroyOldRdvsAndInactiveAccountsJob do
   it "only destroys Rdvs that are more than 2 years old and inactive users created 2 more than years ago" do
     rdv_occurring_25_months_ago = travel_to(25.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }
     rdv_occurring_23_months_ago = travel_to(23.months.ago) { create(:rdv, starts_at: Time.zone.today.change(hour: 16)) }

--- a/spec/jobs/cron_job/inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/inactive_agents_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe CronJob::DestroyInactiveAgents do
+describe CronJob do
   it "deletes old agents" do
     agent_created_25_months_ago_without_warning = travel_to(25.months.ago) { create(:agent) }
 

--- a/spec/jobs/cron_job/inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/inactive_agents_spec.rb
@@ -7,11 +7,18 @@ describe CronJob do
     agent_created_25_months_ago_with_warning = travel_to(25.months.ago) { create(:agent) }
     agent_created_25_months_ago_with_warning.update!(account_deletion_warning_sent_at: 33.days.ago)
 
+    agent_created_12_months_ago_with_warning = travel_to(12.months.ago) { create(:agent, account_deletion_warning_sent_at: Time.zone.now) }
+    agent_created_12_months_ago_without_warning = travel_to(12.months.ago) { create(:agent) }
+
     two_years_ago = 2.years.ago
     CronJob::WarnInactiveAgentsOfAccountDeletion.new.perform(two_years_ago)
     CronJob::DestroyInactiveAgents.new.perform(two_years_ago)
 
-    expect(Agent.all).to eq [agent_created_25_months_ago_without_warning]
+    expect(Agent.all).to match_array([
+                                       agent_created_25_months_ago_without_warning,
+                                       agent_created_12_months_ago_without_warning,
+                                       agent_created_12_months_ago_with_warning,
+                                     ])
 
     expect(agent_created_25_months_ago_without_warning.reload.account_deletion_warning_sent_at).to be_present
   end

--- a/spec/jobs/cron_job/inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/inactive_agents_spec.rb
@@ -1,4 +1,18 @@
 # frozen_string_literal: true
 
-describe "warning and destroying inactive agents" do
+describe CronJob::DestroyInactiveAgents do
+  it "deletes old agents" do
+    agent_created_25_months_ago_without_warning = travel_to(25.months.ago) { create(:agent) }
+
+    agent_created_25_months_ago_with_warning = travel_to(25.months.ago) { create(:agent) }
+    agent_created_25_months_ago_with_warning.update!(account_deletion_warning_sent_at: 33.days.ago)
+
+    two_years_ago = 2.years.ago
+    CronJob::WarnInactiveAgentsOfAccountDeletion.new.perform(two_years_ago)
+    CronJob::DestroyInactiveAgents.new.perform(two_years_ago)
+
+    expect(Agent.all).to eq [agent_created_25_months_ago_without_warning]
+
+    expect(agent_created_25_months_ago_without_warning.reload.account_deletion_warning_sent_at).to be_present
+  end
 end

--- a/spec/jobs/cron_job/inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/inactive_agents_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+describe "warning and destroying inactive agents" do
+end

--- a/spec/mailers/previews/agents/account_deletion_mailer_preview.rb
+++ b/spec/mailers/previews/agents/account_deletion_mailer_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Agents::AccountDeletionMailerPreview < ActionMailer::Preview
+  def upcoming_deletion_warning
+    Agents::AccountDeletionMailer.with(agent: Agent.last).upcoming_deletion_warning
+  end
+end


### PR DESCRIPTION
closes #3623 

La définition qu'on prend d'un agent inactif est :
- n'a pas de rdv (tous les rdv de plus de 2 ans sont supprimés automatiquement)
- ne s'est pas connecté depuis au moins 2 ans (ou ne s'est jamais connecté et son compte a été créé depuis au moins 2 ans)

30 jours avant de supprimer le compte d'un agent, on lui enverra ce mail :

<img width="642" alt="Screenshot 2023-08-29 at 13 59 56" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/a5d7e8c8-bbb4-4d96-80d6-2664a3fabdcd">

On s'assurera toujours que l'agent a au moins 30 jours entre l'avertissement et la suppression du compte, ce qui veut dire que quand on mettra cette PR en prod on enverra une vague de mail pour tous les agents qui sont inactifs depuis 2 ans ou plus, et 30 jours plus tard on fera les premières suppressions.

Ce mécanisme fait aussi que s'il y a un dysfonctionnement et qu'on prend du retard à envoyer les mails d'avertissement, on laissera quand même aux agents le temps de se connecter s'ils souhaitent conserver leur compte.
Ça nous oblige à ajouter une colonne à la table agents, mais je pense que ça vaut le coup.
