### PR TITLE
Permet aux CnFS d'inviter des agents avec n'importe quel niveau de permission

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -30,7 +30,7 @@ class Admin::AgentsController < AgentAuthController
       agent_params: create_agent_params,
       current_agent: current_agent,
       organisation: current_organisation,
-      access_level: access_level
+      access_level: params[:agent][:agent_role][:access_level]
     )
 
     @agent = create_agent.call
@@ -91,7 +91,7 @@ class Admin::AgentsController < AgentAuthController
 
   def render_new
     @services = services.order(:name)
-    @roles = current_agent.conseiller_numerique? ? [AgentRole::ACCESS_LEVEL_BASIC] : access_levels_collection
+    @roles = access_levels_collection
     @agent_role = AgentRole.new
 
     render :new, layout: "application_agent"
@@ -100,7 +100,7 @@ class Admin::AgentsController < AgentAuthController
   def render_edit
     @agent_role = @agent.roles.find { |r| r.organisation == current_organisation }
     @agent_removal_presenter = AgentRemovalPresenter.new(@agent, current_organisation)
-    @roles = current_agent.conseiller_numerique? ? [AgentRole::ACCESS_LEVEL_BASIC] : access_levels_collection
+    @roles = access_levels_collection
 
     render :edit
   end
@@ -136,14 +136,6 @@ class Admin::AgentsController < AgentAuthController
       Rails.env.test? ||
       ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO" ||
       ENV["IS_REVIEW_APP"] == "true"
-  end
-
-  def access_level
-    if @current_agent.conseiller_numerique?
-      AgentRole::ACCESS_LEVEL_BASIC
-    else
-      params[:agent][:agent_role][:access_level]
-    end
   end
 
   def create_agent_params

--- a/app/views/admin/territories/invitations_devise/new.html.slim
+++ b/app/views/admin/territories/invitations_devise/new.html.slim
@@ -4,10 +4,7 @@
   = simple_form_for [:admin, resource], as: resource_name, url: admin_agent_territory_invitation_path(current_territory, resource), html: { method: :post } do |f|
     = render "devise/shared/error_messages", resource: resource
     = f.input :email, placeholder: t(".email_placeholder"), input_html: { autocomplete: "off"}
-    - if current_agent.conseiller_numerique?
-      = f.input :service_id, as: :hidden, input_html: {value: Service.secretariat.first.id}
-    - else
-      = f.association :service, collection: @services, include_blank: false, hint: t(".services_hint")
+    = f.association :service, collection: @services, include_blank: false, hint: t(".services_hint")
 
     = f.association :organisations, as: :check_boxes, collection: current_agent.organisations.where(territory: current_territory), label: t(".organisations"), include_hidden: false
 


### PR DESCRIPTION
Dans le cadre de https://github.com/betagouv/rdv-solidarites.fr/issues/2312, on avait interdit aux cnfs de créer des comptes avec des niveaux de permission qui permettraient de créer des rdv pour éviter de trop grandes dépenses en sms.

Avec un peu plus de recul, on se rend compte que ce problème était largement surévalué.
On préfère simplifier le code, et uniformiser le comportement de l'appli.

Si des cnfs veulent inviter des collègues, et que ça leur permet d'utiliser l'appli efficacement, tant mieux.

Cette PR sera encore plus utile quand on aura pu merger https://github.com/betagouv/rdv-solidarites.fr/pull/3798