### PR TITLE
Bugfix: un motifs n'est jamais supprimé, toujours soft deleted

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -124,7 +124,7 @@ class Motif < ApplicationRecord
   end
 
   def soft_delete
-    Rdv.unscoped.where(motif: self).any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
+    rdvs.unscope(where: :deleted_at).any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
   end
 
   def authorized_agents

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -124,7 +124,7 @@ class Motif < ApplicationRecord
   end
 
   def soft_delete
-    rdvs.unscoped.any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
+    Rdv.unscoped.where(motif: self).any? ? update_attribute(:deleted_at, Time.zone.now) : destroy
   end
 
   def authorized_agents

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -17,12 +17,6 @@ FactoryBot.define do
     location_type { :public_office }
     visibility_type { Motif::VISIBLE_AND_NOTIFIED }
 
-    trait :with_rdvs do
-      after(:create) do |motif|
-        create_list(:rdv, 5, motif: motif, organisation: motif.organisation)
-      end
-    end
-
     trait :at_home do
       location_type { :home }
     end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 describe Motif, type: :model do
-  let(:motif_with_rdv) { create(:motif, :with_rdvs, organisation: organisation) }
   let(:secretariat) { create(:service, :secretariat) }
   let(:motif) { create(:motif, organisation: organisation) }
   let!(:organisation) { create(:organisation) }
@@ -39,8 +38,12 @@ describe Motif, type: :model do
     it "doesn't delete the motif with rdvs" do
       now = Time.zone.parse("2020-03-23 15h45")
       travel_to(now)
-      motif.soft_delete
+      motif = create(:motif)
+      motif_with_rdv = create(:rdv).motif
+
       motif_with_rdv.soft_delete
+      motif.soft_delete
+
       expect(described_class.all).to eq [motif_with_rdv]
       expect(motif_with_rdv.reload.deleted_at).to eq(now)
     end


### PR DESCRIPTION
Je suis tombé sur ce bug lors du travail sur le soft delete (#3580) : normalement, un motif est censé être supprimé si il n'est lié à aucun RDV, et soft deleted si il est lié à au moins un RDV. Mais en réalité, à cause de ce bug, il est toujours soft deleted.

Le bug était dû à l'usage de `rdvs.unscoped` depuis une méthode d'instance de `Motif`. En effet, `unscoped` a pour effet de supprimer la condition `WHERE rdvs.motif_id = ?`, et donc c'est équivalent à `Rdv.all`.

Le truc drôle, c'est qu'il y avait un test pour cette fonctionnalité, mais l'usage de `let` étant lazy, on testait le soft delete du motif sans RDV dans un état où la base était vierge de tout RDV ! Peut-être un argument en la faveur du chargement des seeds avant tous les tests unitaires, pour tester sur une base non vide (plus réaliste).

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
