### PR TITLE
Ne plus soft delete les usager⋅es

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -106,8 +106,8 @@ class Admin::UsersController < AgentAuthController
 
   def destroy
     authorize(@user)
-    if @user.can_be_soft_deleted_from_organisation?(current_organisation)
-      @user.soft_delete(current_organisation)
+    if @user.can_be_removed_from_organisation?(current_organisation)
+      @user.remove_from_organisation!(current_organisation)
       flash[:notice] = "L’usager a été supprimé."
     else
       flash[:error] = I18n.t("users.can_not_delete_because_has_future_rdvs")

--- a/app/controllers/api/v1/user_profiles_controller.rb
+++ b/app/controllers/api/v1/user_profiles_controller.rb
@@ -17,8 +17,8 @@ class Api::V1::UserProfilesController < Api::V1::AgentAuthBaseController
     organisation = user_profile.organisation
     user = user_profile.user
 
-    if user.can_be_soft_deleted_from_organisation?(organisation)
-      user.soft_delete(organisation)
+    if user.can_be_removed_from_organisation?(organisation)
+      user.remove_from_organisation!(organisation)
       head :no_content
     else
       render_error :unprocessable_entity, {

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def destroy
     authorize([:user, resource])
-    resource.soft_delete
+    resource.destroy!
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     set_flash_message! :notice, :destroyed
     yield resource if block_given?

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -41,7 +41,7 @@ class Users::RelativesController < UserAuthController
 
   def destroy
     authorize(@user)
-    flash[:notice] = "Votre proche a été supprimé." if @user.soft_delete
+    flash[:notice] = "Votre proche a été supprimé." if @user.destroy
     redirect_to users_informations_path
   end
 

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -27,7 +27,6 @@ class UserDashboard < Administrate::BaseDashboard
     birth_date: Field::DateTime,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    deleted_at: Field::DateTime,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -61,7 +60,6 @@ class UserDashboard < Administrate::BaseDashboard
     number_of_children
     created_at
     updated_at
-    deleted_at
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -80,7 +78,6 @@ class UserDashboard < Administrate::BaseDashboard
     affiliation_number
     family_situation
     number_of_children
-    deleted_at
   ].freeze
 
   def display_resource(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -44,8 +44,7 @@ module UsersHelper
     user.logged_once_with_franceconnect? ? tag.span("FranceConnect", class: "badge badge-info") : nil
   end
 
-  def user_soft_deleted_tag(organisation, user)
-    return tag.span("Supprimé", class: "badge badge-danger") if user.deleted_at
+  def user_not_in_org_tag(organisation, user)
     return if organisation.territory.visible_users_throughout_the_territory?
 
     tag.span("Supprimé de cette organisation", class: "badge badge-danger") unless user.profile_for(organisation)
@@ -99,11 +98,11 @@ module UsersHelper
     user.notes.present? ? simple_format(user.notes) : nil
   end
 
-  def user_soft_delete_confirm_message(user)
+  def user_destroy_confirm_message(user)
     relatives = user.relatives.merge(current_organisation.users)
     [
       "Confirmez-vous la suppression de cet usager ?",
-      (I18n.t("users.soft_delete_confirm_message.relatives", count: relatives.size) if relatives.any?),
+      (I18n.t("users.destroy_confirm_message.relatives", count: relatives.size) if relatives.any?),
     ].select(&:present?).join("\n\n")
   end
 
@@ -125,14 +124,14 @@ module UsersHelper
   end
 
   def user_to_link(user)
-    if !user.deleted_at && user.organisations.include?(current_organisation)
+    if user.organisations.include?(current_organisation)
       link_to admin_organisation_user_path(current_organisation, user) do
         tag.span(user.full_name) + relative_tag(user)
       end
     else
       tag.span(user.full_name) +
         relative_tag(user) +
-        user_soft_deleted_tag(current_organisation, user)
+        user_not_in_org_tag(current_organisation, user)
     end
   end
 

--- a/app/models/concerns/ants/appointment_serializer_and_listener.rb
+++ b/app/models/concerns/ants/appointment_serializer_and_listener.rb
@@ -16,7 +16,7 @@ module Ants
         Ants::AppointmentSerializerAndListener.mark_for_sync(user.rdvs) if user.saved_change_to_ants_pre_demande_number?
       end
       RdvsUser.before_commit do |rdv_user|
-        Ants::AppointmentSerializerAndListener.mark_for_sync([rdv_user.rdv], obsolete_application_id: rdv_user.user.ants_pre_demande_number)
+        Ants::AppointmentSerializerAndListener.mark_for_sync([rdv_user.rdv], obsolete_application_id: rdv_user.user.ants_pre_demande_number) if rdv_user.user.present?
       end
       Lieu.before_commit do |lieu|
         Ants::AppointmentSerializerAndListener.mark_for_sync(lieu.rdvs) if lieu.saved_change_to_name?

--- a/app/models/rdvs_user.rb
+++ b/app/models/rdvs_user.rb
@@ -15,7 +15,7 @@ class RdvsUser < ApplicationRecord
 
   # Relations
   belongs_to :rdv, touch: true, inverse_of: :rdvs_users, optional: true
-  belongs_to :user, -> { unscope(where: :deleted_at) }, inverse_of: :rdvs_users, optional: true
+  belongs_to :user, inverse_of: :rdvs_users, optional: true
   has_one :prescripteur, dependent: :destroy
 
   # Delegates

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -14,4 +14,8 @@ class Receipt < ApplicationRecord
 
   # Scopes
   scope :most_recent_first, -> { order(created_at: :desc) }
+
+  def anonymize!
+    update!(sms_phone_number: nil, email_address: nil)
+  end
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -6,8 +6,8 @@ class Receipt < ApplicationRecord
   enum channel: { sms: "sms", mail: "mail", webhook: "webhook" }, _prefix: :channel
 
   # Relations
-  belongs_to :rdv  # We could reference a RdvsUser directly (aka a “Participation”) but this would not work for responsible users of relatives.
-  belongs_to :user # Moreover, if we remove a user for a Rdv (deleting the RdvsUser), we still want to keep the receipt.
+  belongs_to :rdv, optional: true  # We could reference a RdvsUser directly (aka a “Participation”) but this would not work for responsible users of relatives.
+  belongs_to :user, optional: true # Moreover, if we remove a user for a Rdv (deleting the RdvsUser), we still want to keep the receipt.
 
   has_one :organisation, through: :rdv
   has_one :territory, through: :organisation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,8 +117,6 @@ class User < ApplicationRecord
   end
 
   def remove_from_organisation!(organisation)
-    raise "we need an org" unless organisation
-
     self_and_relatives.each { _1.remove_from_org!(organisation) }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,8 @@ class User < ApplicationRecord
   belongs_to :responsible, class_name: "User", optional: true
   has_many :relatives, foreign_key: "responsible_id", class_name: "User", inverse_of: :responsible, dependent: :nullify
   has_many :file_attentes, dependent: :destroy
+
+  before_destroy :anonymize_receipts # this needs to be before `dependent: :nullify`, see https://github.com/rails/rails/issues/5205
   has_many :receipts, dependent: :nullify
 
   # Through relations
@@ -259,6 +261,10 @@ class User < ApplicationRecord
 
   def set_email_to_null_if_blank
     self.email = nil if email.blank?
+  end
+
+  def anonymize_receipts
+    receipts.each(&:anonymize!)
   end
 
   def birth_date_validity

--- a/app/policies/agent/user_policy.rb
+++ b/app/policies/agent/user_policy.rb
@@ -2,7 +2,7 @@
 
 class Agent::UserPolicy < DefaultAgentPolicy
   def show?
-    same_org? && not_deleted?
+    same_org?
   end
 
   def create?
@@ -13,25 +13,25 @@ class Agent::UserPolicy < DefaultAgentPolicy
   end
 
   def invite?
-    same_org? && not_deleted?
+    same_org?
   end
 
   alias invite_get? invite?
 
   def rdv_invitation_token?
-    same_org? && not_deleted?
+    same_org?
   end
 
   def update?
-    same_org? && not_deleted?
+    same_org?
   end
 
   def destroy?
-    same_org? && not_deleted?
+    same_org?
   end
 
   def versions?
-    admin_and_same_org? && not_deleted?
+    admin_and_same_org?
   end
 
   class Scope < Scope
@@ -47,10 +47,6 @@ class Agent::UserPolicy < DefaultAgentPolicy
   end
 
   protected
-
-  def not_deleted?
-    @record.deleted_at.nil?
-  end
 
   def same_org?
     # we cannot use @record.organisation_ids for Users because it uses a

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -16,7 +16,7 @@ class MergeUsersService < BaseService
       merge_relatives
       merge_file_attentes
       merge_referent_agents
-      @user_to_merge.reload.soft_delete(@organisation) # ! reload refreshes associations to delete
+      @user_to_merge.reload.remove_from_organisation!(@organisation) # ! reload refreshes associations to delete
     end
   end
 

--- a/app/views/admin/users/_identity.html.slim
+++ b/app/views/admin/users/_identity.html.slim
@@ -7,4 +7,4 @@
 - else
   = t(".identity_html", user: admin_link_to_if_permitted(current_organisation, user))
 
-= user_soft_deleted_tag(current_organisation, user)
+= user_not_in_org_tag(current_organisation, user)

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -52,8 +52,8 @@
 
         .row.mt-3
           .col.text-left
-            - if @user.can_be_soft_deleted_from_organisation?(current_organisation)
-              = link_to "Supprimer", admin_organisation_user_path(current_organisation, @user), method: :delete, class: "btn btn-outline-danger", data: { confirm: user_soft_delete_confirm_message(@user)}
+            - if @user.can_be_removed_from_organisation?(current_organisation)
+              = link_to "Supprimer", admin_organisation_user_path(current_organisation, @user), method: :delete, class: "btn btn-outline-danger", data: { confirm: user_destroy_confirm_message(@user)}
             - else
               = link_to "Supprimer", "#", class: "btn btn-outline-danger", onclick: "alert(this.dataset.message)", data: { message: I18n.t("users.can_not_delete_because_has_future_rdvs") }
           .col.text-right

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -7,7 +7,6 @@ fr:
       send_instructions: "Vous allez recevoir les instructions nécessaires à la confirmation de votre compte dans quelques minutes."
       send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez bientôt recevoir un e-mail contenant les instructions de confirmation de votre compte."
     failure:
-      deleted_account: "Votre compte a été supprimé !"
       invited: "Vous avez une invitation en attente. Acceptez-la pour terminer votre inscription."
       already_authenticated: "Votre connexion est déjà active"
       inactive: "Votre compte n'est pas encore activé."

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -1,7 +1,7 @@
 fr:
   users:
     can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.
-    soft_delete_confirm_message:
+    destroy_confirm_message:
       relatives:
         one: ⚠️ Cet usager a un proche qui sera aussi supprimé
         other: ⚠️ Cet usager a %{count} proches qui seront aussi supprimés

--- a/db/migrate/20230905145446_remove_deleted_at_from_users.rb
+++ b/db/migrate/20230905145446_remove_deleted_at_from_users.rb
@@ -2,6 +2,15 @@
 
 class RemoveDeletedAtFromUsers < ActiveRecord::Migration[7.0]
   def change
+    reversible do |direction|
+      direction.up do
+        User.where.not(deleted_at: nil).each do
+          user.skip_webhooks = true
+          user.destroy
+        end
+      end
+    end
+
     remove_column :users, :deleted_at, :datetime
   end
 end

--- a/db/migrate/20230905145446_remove_deleted_at_from_users.rb
+++ b/db/migrate/20230905145446_remove_deleted_at_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveDeletedAtFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_23_144508) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_145446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -656,7 +656,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_23_144508) do
     t.integer "family_situation"
     t.integer "number_of_children"
     t.bigint "responsible_id"
-    t.datetime "deleted_at"
     t.string "birth_name"
     t.string "email_original"
     t.string "phone_number_formatted"

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -12,23 +12,19 @@ RSpec.describe Admin::UsersController, type: :controller do
   end
 
   describe "DELETE destroy" do
-    it "removes user from organisation" do
+    it "removes user from organisation but keeps her in other organisation" do
+      other_organisation = create(:organisation)
+      user.organisations << other_organisation
       expect do
         delete :destroy, params: { organisation_id: organisation.id, id: user.id }
         user.reload
-      end.to change(user, :organisation_ids).from([organisation.id]).to([])
+      end.to change(user, :organisation_ids).from([organisation.id, other_organisation.id]).to([other_organisation.id])
     end
 
-    it "appaers to destroy user" do
+    it "destroys the user" do
       expect do
         delete :destroy, params: { organisation_id: organisation.id, id: user.id }
-      end.to change(User, :count)
-    end
-
-    it "not really destroy user" do
-      expect do
-        delete :destroy, params: { organisation_id: organisation.id, id: user.id }
-      end.not_to change { User.unscoped.count }
+      end.to change(User.unscope(:where), :count)
     end
   end
 

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -128,20 +128,20 @@ RSpec.describe Users::RelativesController, type: :controller do
   end
 
   describe "DELETE #destroy" do
-    subject { delete :destroy, params: { id: relative.id } }
+    subject(:make_request) { delete :destroy, params: { id: relative.id } }
 
     let(:now) { Time.zone.parse("21/07/2019 08:22") }
 
     before { travel_to(now) }
 
-    it "soft deletes the relative" do
-      expect do
-        subject
-      end.to change { relative.reload.deleted_at }.from(nil).to(now)
+    it "destroys the relative" do
+      expect(relative.reload).to be_persisted
+      make_request
+      expect { relative.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "redirects to user edit" do
-      subject
+      make_request
       expect(response).to redirect_to(users_informations_path)
     end
   end

--- a/spec/factories/receipt.rb
+++ b/spec/factories/receipt.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     event { :rdv_created }
     channel { :sms }
     result { :processed }
+    sms_phone_number { user.phone_number }
+    email_address { user.email }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
   end

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -25,29 +25,4 @@ describe "Agent can list RDVs" do
       expect(page).not_to have_content(agent_from_other_service.rdvs.last.motif.name)
     end
   end
-
-  context "when a RDV user is soft deleted" do
-    let!(:active_user) { create(:user) }
-    let!(:deleted_user) { create(:user) }
-
-    before do
-      create(:rdv, organisation: organisation, agents: [current_agent], users: [active_user])
-      create(:rdv, organisation: organisation, agents: [current_agent], users: [deleted_user])
-
-      deleted_user.soft_delete
-    end
-
-    it "displays deleted users without a link to their profile" do
-      visit admin_organisation_rdvs_url(organisation, current_agent)
-
-      # Active user has a link to her profile
-      path_to_active_user_profile = admin_organisation_user_path(organisation_id: organisation.id, id: active_user.id)
-      expect(page).to have_link(active_user.full_name, href: path_to_active_user_profile)
-
-      # Deleted user has a link to her profile
-      path_to_deleted_user_profile = admin_organisation_user_path(organisation_id: organisation.id, id: deleted_user.id)
-      expect(page).to have_content("#{deleted_user}Supprimé")
-      expect(page.body).not_to include(path_to_deleted_user_profile)
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,6 +76,14 @@ describe User, type: :model do
         user.remove_from_organisation!(organisation)
         expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      it "anonymizes its receipts" do
+        organisation = create(:organisation)
+        user = create(:user, organisations: [organisation])
+        rdv = create(:rdv, users: [user], organisation: organisation)
+        receipt = create(:receipt, rdv: rdv, user: user)
+        expect { user.reload.remove_from_organisation!(organisation) }.to change { [receipt.reload.sms_phone_number, receipt.email_address] }.to([nil, nil])
+      end
     end
 
     context "belongs to 2 organisations" do

--- a/spec/requests/api/v1/user_profiles_request_spec.rb
+++ b/spec/requests/api/v1/user_profiles_request_spec.rb
@@ -99,7 +99,7 @@ describe "User Profile authentified API", swagger_doc: "v1/api.json" do
       response 204, "détruit l'utilisateur s'il n'appartient qu'à une organisation" do
         run_test!
 
-        it { expect(user.reload.deleted_at).not_to be_nil }
+        it { expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound) }
       end
 
       response 204, "ne détruit pas l'utilisateur s'il n'appartient à plusieurs organisations" do
@@ -108,7 +108,7 @@ describe "User Profile authentified API", swagger_doc: "v1/api.json" do
 
         run_test!
 
-        it { expect(user.reload.deleted_at).to be_nil }
+        it { expect(user.reload).not_to be_destroyed }
       end
 
       it_behaves_like "an endpoint that returns 403 - forbidden", "l'agent n'appartient pas à l'organisation" do

--- a/spec/services/duplicate_users_finder_service_spec.rb
+++ b/spec/services/duplicate_users_finder_service_spec.rb
@@ -41,36 +41,18 @@ describe DuplicateUsersFinderService, type: :service do
         let!(:duplicated_user) { create(:user, email: "lapin@beta.fr") }
 
         it { is_expected.to include(OpenStruct.new(severity: :error, attributes: [:email], user: duplicated_user)) }
-
-        context "but soft deleted" do
-          before { duplicated_user.soft_delete }
-
-          it { is_expected.to be_empty }
-        end
       end
 
       context "same main first_name, last_name, birth_date" do
         let!(:duplicated_user) { create(:user, first_name: "Mathieu", last_name: "Lapin", birth_date: "21/10/2000") }
 
         it { is_expected.to include(OpenStruct.new(severity: :warning, attributes: %i[first_name last_name birth_date], user: duplicated_user)) }
-
-        context "but soft deleted" do
-          before { duplicated_user.soft_delete }
-
-          it { is_expected.to be_empty }
-        end
       end
 
       context "same phone_number" do
         let!(:duplicated_user) { create(:user, phone_number: "0658032518") }
 
         it { is_expected.to include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user)) }
-
-        context "but soft deleted" do
-          before { duplicated_user.soft_delete }
-
-          it { is_expected.to be_empty }
-        end
       end
 
       context "multiple account" do
@@ -80,22 +62,6 @@ describe DuplicateUsersFinderService, type: :service do
 
         it { is_expected.to include(OpenStruct.new(severity: :warning, attributes: %i[first_name last_name birth_date], user: duplicated_user1)) }
         it { is_expected.to include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user2)) }
-
-        context "but first soft deleted" do
-          before { duplicated_user1.soft_delete }
-
-          it { is_expected.not_to include(OpenStruct.new(severity: :warning, attributes: %i[first_name last_name birth_date], user: duplicated_user1)) }
-          it { is_expected.to include(OpenStruct.new(severity: :warning, attributes: [:phone_number], user: duplicated_user2)) }
-        end
-
-        context "but both soft deleted" do
-          before do
-            duplicated_user1.soft_delete
-            duplicated_user2.soft_delete
-          end
-
-          it { is_expected.to be_empty }
-        end
       end
     end
   end

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -20,7 +20,7 @@ describe MergeUsersService, type: :service do
       expect(user_target.first_name).to eq("Francis")
       expect(user_target.last_name).to eq("PAUL")
       expect(user_target.email).to eq("jean@paul.fr")
-      expect(user_to_merge.reload.deleted_at).to be_within(3.seconds).of(Time.zone.now)
+      expect { user_to_merge.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -38,7 +38,7 @@ describe MergeUsersService, type: :service do
       expect(rdv2.reload.users).to contain_exactly(user_target)
       expect(rdv3.reload.users).to contain_exactly(user_target)
       expect(rdv4.reload.users).to contain_exactly(user_target)
-      expect(user_to_merge.deleted_at).not_to be_nil
+      expect { user_to_merge.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -55,7 +55,7 @@ describe MergeUsersService, type: :service do
       expect(rdv1.reload.users).to contain_exactly(user_target)
       expect(rdv2.reload.users).to contain_exactly(user_target)
       expect(rdv3.reload.users).to contain_exactly(user_to_merge)
-      expect(user_to_merge.deleted_at).to be_nil
+      expect(user_to_merge.reload).not_to be_destroyed
     end
   end
 


### PR DESCRIPTION
Comme décidé dans #3580, nous souhaitons nous débarrasser des soft deletes qui créent des bugs et nous empêchent d'avoir des données cohérentes.

Toutes les infos sur les raisons et le contexte sont dans l'issue.



# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
