### PR TITLE
Correctif sur l'affichage de la sectorisation dans l'index des motifs

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -14,7 +14,7 @@ class Admin::MotifsController < AgentAuthController
 
     @sectors_attributed_to_organisation_count = Sector.attributed_to_organisation(current_organisation).count
     @sectorisation_level_agent_counts_by_service = SectorAttribution.level_agent_grouped_by_service(current_organisation)
-    @display_sectorisation_level = current_organisation.motifs.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?
+    @display_sectorisation_level = current_organisation.motifs.active.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?
   end
 
   def new

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -8,7 +8,7 @@ tr
     = motif_badges(motif, only: %i[bookable_by_everyone bookable_by_invited_users])
   - if @display_sectorisation_level
     td
-      - if motif.bookable_outside_of_organisation?
+      - if !motif.bookable_outside_of_organisation?
         | &nbsp;
       - elsif motif.sectorisation_level_departement?
         | Tout le #{current_organisation.departement_number}

--- a/spec/features/agents/sectorisation/motifs_spec.rb
+++ b/spec/features/agents/sectorisation/motifs_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Sectorisation display for motifs" do
 
     it "doesn't display the sectorisation level in the motif index" do
       visit admin_organisation_motifs_path(organisation)
+      expect(page).not_to have_content("Sectorisation")
       expect(page).not_to have_content("Tout le 26")
     end
   end

--- a/spec/features/agents/sectorisation/motifs_spec.rb
+++ b/spec/features/agents/sectorisation/motifs_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "Sectorisation display for motifs" do
+  let(:territory) { create(:territory, departement_number: "26") }
+  let(:organisation) { create(:organisation, territory: territory) }
+  let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+  before { login_as(agent, scope: :agent) }
+
+  context "when the organisation doesn't use sectorisation" do
+    let!(:motif) { create(:motif, :sectorisation_level_departement, organisation: organisation, bookable_by: :everyone) }
+
+    it "doesn't display the sectorisation level in the motif index" do
+      visit admin_organisation_motifs_path(organisation)
+      expect(page).not_to have_content("Tout le 26")
+    end
+  end
+
+  context "when the organisation uses sectorisation" do
+    let!(:motif_with_sectorisation) { create(:motif, :sectorisation_level_organisation, organisation: organisation, bookable_by: :everyone) }
+    let!(:motif_without_sectorisation) { create(:motif, :sectorisation_level_departement, organisation: organisation, bookable_by: :everyone) }
+
+    it "doesn't display the sectorisation level in the motif index" do
+      visit admin_organisation_motifs_path(organisation)
+      expect(page).to have_content("aucun secteur")
+      expect(page).to have_content("Tout le 26")
+    end
+  end
+end


### PR DESCRIPTION
Lors d'une réunion avec les référentes de la Drôme, elles nous ont fait remarquer qu'il y a un bug d'affichage qui fait que les niveaux de sectorisation ne sont plus affichés dans l'index des motifs si un motif est ouvert au public (ce qui est toujours le cas pour les motifs qui utilisent la sectorisation), et mais qu'il est affiché pour les motifs qui ne le sont pas.

Il y avait effectivement eu un contresens sur la dernière modification de `app/views/admin/motifs/_motif.html.slim:11`.
Cette PR ajoute une spec et un correctif.