### PR TITLE
Correctif pour les validations de nom et prénom sur les agents

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -35,7 +35,7 @@ class Admin::AgentsController < AgentAuthController
 
     @agent = create_agent.call
 
-    if @agent.errors.none? # Si on relance des validations en appelant #valid?, on va déclencher les validations sur first_name et last_name
+    if @agent.valid?
       flash[:notice] = create_agent.confirmation_message
       flash[:error] = create_agent.warning_message
       redirect_to_index_path_for(@agent)

--- a/app/controllers/admin/territories/invitations_devise_controller.rb
+++ b/app/controllers/admin/territories/invitations_devise_controller.rb
@@ -8,6 +8,8 @@ class Admin::Territories::InvitationsDeviseController < Devise::InvitationsContr
     render :new, layout: "application_configuration"
   end
 
+  # Dette technique : ce controller pourrait sans doute reprendre la logique et le service object
+  # utilisés dans Admin::AgentsController
   def create
     agent = Agent.find_by(email: invite_params[:email].downcase)
     if agent.nil?
@@ -59,7 +61,8 @@ class Admin::Territories::InvitationsDeviseController < Devise::InvitationsContr
   def invite_params
     super.merge(
       # the omniauth uid _is_ the email, always. note: this may be better suited in a hook in agent.rb
-      uid: params[:email]
+      uid: params[:email],
+      allow_blank_name: true
     )
   end
 end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -17,6 +17,7 @@ class OrganisationsController < ApplicationController
       # callbacks:
       agent_role.agent.skip_confirmation!
       agent_role.agent.skip_invitation = true
+      agent_role.agent.allow_blank_name = true
       agent_role.agent.define_singleton_method(:password_required?) { false }
       agent_role.agent.define_singleton_method(:postpone_email_change?) { false }
       # forces devise_token_auth sync_uid to run

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -81,8 +81,8 @@ class Agent < ApplicationRecord
   # Note about validation and Devise:
   # * Invitable#invite! creates the Agent without validation, but validates manually in advance (because we set validate_on_invite to true)
   # * it validates :email (the invite_key) specifically with Devise.email_regexp.
-  validates :first_name, presence: true, on: :update, unless: -> { is_an_intervenant? }
-  validates :last_name, presence: true, on: :update
+  validates :first_name, presence: true, unless: -> { is_an_intervenant? || invitation_accepted_at.nil? }
+  validates :last_name, presence: true, if: -> { invitation_accepted_at.present? }
   validate :service_cannot_be_changed
 
   # Hooks

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -82,7 +82,7 @@ class Agent < ApplicationRecord
   # * Invitable#invite! creates the Agent without validation, but validates manually in advance (because we set validate_on_invite to true)
   # * it validates :email (the invite_key) specifically with Devise.email_regexp.
   validates :first_name, presence: true, unless: -> { is_an_intervenant? || invitation_accepted_at.nil? }
-  validates :last_name, presence: true, if: -> { invitation_accepted_at.present? }
+  validates :last_name, presence: true, if: -> { is_an_intervenant? || invitation_accepted_at.present? }
   validate :service_cannot_be_changed
 
   # Hooks

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -77,12 +77,14 @@ class Agent < ApplicationRecord
   has_many :organisations, through: :roles, dependent: :destroy
   has_many :webhook_endpoints, through: :organisations
 
+  attr_accessor :allow_blank_name
+
   # Validation
   # Note about validation and Devise:
   # * Invitable#invite! creates the Agent without validation, but validates manually in advance (because we set validate_on_invite to true)
   # * it validates :email (the invite_key) specifically with Devise.email_regexp.
-  validates :first_name, presence: true, unless: -> { is_an_intervenant? || invitation_accepted_at.nil? }
-  validates :last_name, presence: true, if: -> { is_an_intervenant? || invitation_accepted_at.present? }
+  validates :first_name, presence: true, unless: -> { allow_blank_name || is_an_intervenant? }
+  validates :last_name, presence: true, unless: -> { allow_blank_name }
   validate :service_cannot_be_changed
 
   # Hooks

--- a/app/services/admin_creates_agent.rb
+++ b/app/services/admin_creates_agent.rb
@@ -19,7 +19,7 @@ class AdminCreatesAgent
       elsif @access_level == "intervenant"
         @agent = Agent.create(agent_and_role_params)
       else
-        @agent = Agent.invite!(agent_and_role_params, @current_agent)
+        @agent = Agent.invite!(agent_and_role_params.merge(allow_blank_name: true), @current_agent)
       end
 
       if @agent.errors.none? # Si on relance des validations en appelant #valid?, on va déclencher les validations sur first_name et last_name
@@ -63,6 +63,7 @@ class AdminCreatesAgent
 
   def add_agent_to_organisation
     @agent.update(
+      allow_blank_name: true,
       roles_attributes: [
         organisation: @organisation,
         access_level: @access_level,

--- a/app/services/admin_creates_agent.rb
+++ b/app/services/admin_creates_agent.rb
@@ -22,7 +22,7 @@ class AdminCreatesAgent
         @agent = Agent.invite!(agent_and_role_params.merge(allow_blank_name: true), @current_agent)
       end
 
-      if @agent.errors.none? # Si on relance des validations en appelant #valid?, on va déclencher les validations sur first_name et last_name
+      if @agent.valid?
         AgentTerritorialAccessRight.find_or_create_by!(agent: @agent, territory: @organisation.territory)
       end
     end

--- a/spec/controllers/admin/invitations_controller_spec.rb
+++ b/spec/controllers/admin/invitations_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::InvitationsController, type: :controller do
 
     context "some invitations exist" do
       let!(:agent1) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let!(:agent_invitee) { create(:agent, :invitation_not_accepted, first_name: nil, last_name: nil, basic_role_in_organisations: [organisation]) }
+      let!(:agent_invitee) { create(:agent, :invitation_not_accepted, first_name: nil, last_name: nil, allow_blank_name: true, basic_role_in_organisations: [organisation]) }
 
       it "returns a success response" do
         get :index, params: { organisation_id: organisation.id }
@@ -33,7 +33,7 @@ RSpec.describe Admin::InvitationsController, type: :controller do
   end
 
   describe "POST #reinvite" do
-    let(:agent_invitee) { create(:agent, invited_by: agent, confirmed_at: nil, first_name: nil, last_name: nil, basic_role_in_organisations: [organisation]) }
+    let(:agent_invitee) { create(:agent, invited_by: agent, confirmed_at: nil, first_name: nil, last_name: nil, allow_blank_name: true, basic_role_in_organisations: [organisation]) }
 
     it "returns a success response" do
       post :reinvite, params: { organisation_id: organisation.id, id: agent_invitee.to_param }

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -9,7 +9,7 @@ describe InclusionConnectController, type: :controller do
     it "update first_name and last_name of agent" do
       now = Time.zone.parse("2022-08-22 11h34")
       travel_to(now)
-      agent = create(:agent, :invitation_not_accepted, first_name: nil, last_name: nil, email: "bob@demo.rdv-solidarites.fr")
+      agent = create(:agent, :invitation_not_accepted, first_name: nil, last_name: nil, allow_blank_name: true, email: "bob@demo.rdv-solidarites.fr")
 
       stub_const("InclusionConnect::IC_CLIENT_ID", "truc")
       stub_const("InclusionConnect::IC_CLIENT_SECRET", "truc secret")

--- a/spec/features/agents/agents/create_agents_spec.rb
+++ b/spec/features/agents/agents/create_agents_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Agent can create another agent" do
       click_link("Ajouter un agent", match: :first)
       fill_in("Email", with: "bob@test.com")
       click_button("Envoyer une invitation")
+      expect(Agent.count).to eq(2)
 
       expect(page).to have_content("Invitations en cours")
       expect(organisation2.reload.agents.count).to eq 2

--- a/spec/features/agents/agents/create_agents_spec.rb
+++ b/spec/features/agents/agents/create_agents_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Agent can incite another agent" do
+RSpec.describe "Agent can create another agent" do
   let(:territory) { create(:territory) }
   let(:organisation1) { create(:organisation, territory: territory) }
   let(:organisation2) { create(:organisation, territory: territory) }
@@ -9,7 +9,7 @@ RSpec.describe "Agent can incite another agent" do
   before { login_as(agent, scope: :agent) }
 
   context "in two different organisations" do
-    it "allows inviting the agent" do
+    specify do
       visit admin_organisation_agents_path(organisation1)
       click_link("Ajouter un agent", match: :first)
       fill_in("Email", with: "bob@test.com")

--- a/spec/features/agents/agents/invite_agents_spec.rb
+++ b/spec/features/agents/agents/invite_agents_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe "Agent can incite another agent" do
+
+  context "in two different organisations" do
+
+  end
+
+end

--- a/spec/features/agents/agents/invite_agents_spec.rb
+++ b/spec/features/agents/agents/invite_agents_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe "Agent can incite another agent" do
+  let(:territory) { create(:territory) }
 
   context "in two different organisations" do
-
   end
-
 end

--- a/spec/features/agents/agents/invite_agents_spec.rb
+++ b/spec/features/agents/agents/invite_agents_spec.rb
@@ -2,7 +2,26 @@
 
 RSpec.describe "Agent can incite another agent" do
   let(:territory) { create(:territory) }
+  let(:organisation1) { create(:organisation, territory: territory) }
+  let(:organisation2) { create(:organisation, territory: territory) }
+  let(:agent) { create(:agent, admin_role_in_organisations: [organisation1, organisation2]) }
+
+  before { login_as(agent, scope: :agent) }
 
   context "in two different organisations" do
+    it "allows inviting the agent" do
+      visit admin_organisation_agents_path(organisation1)
+      click_link("Ajouter un agent", match: :first)
+      fill_in("Email", with: "bob@test.com")
+      click_button("Envoyer une invitation")
+
+      visit admin_organisation_agents_path(organisation2)
+      click_link("Ajouter un agent", match: :first)
+      fill_in("Email", with: "bob@test.com")
+      click_button("Envoyer une invitation")
+
+      expect(page).to have_content("Invitations en cours")
+      expect(organisation2.reload.agents.count).to eq 2
+    end
   end
 end

--- a/spec/features/agents/agents/invite_agents_spec.rb
+++ b/spec/features/agents/agents/invite_agents_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Agent can incite another agent" do
       click_link("Ajouter un agent", match: :first)
       fill_in("Email", with: "bob@test.com")
       click_button("Envoyer une invitation")
+      expect(Agent.count).to eq(2)
 
       visit admin_organisation_agents_path(organisation2)
       click_link("Ajouter un agent", match: :first)

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -135,51 +135,43 @@ describe Agent, type: :model do
     end
   end
 
-  describe "last_name and first_name validations" do
-    context "when agent is an intervenant" do
+  describe "last_name validation" do
+    let!(:agent) { build(:agent) }
+
+    it "can be bypassed when needed" do
+      expect(agent).to be_valid
+      agent.last_name = nil
+      expect(agent).not_to be_valid
+
+      agent.errors.clear
+
+      agent.allow_blank_name = true
+      expect(agent).to be_valid
+    end
+  end
+
+  describe "first_name validation" do
+    let!(:agent) { build(:agent) }
+
+    it "can be bypassed when needed" do
+      expect(agent).to be_valid
+      agent.first_name = nil
+      expect(agent).not_to be_valid
+
+      agent.errors.clear
+
+      agent.allow_blank_name = true
+      expect(agent).to be_valid
+    end
+
+    context "for an intervenant" do
       let!(:organisation) { create(:organisation) }
       let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation]) }
       let(:agent_intervenant) { build(:agent, :intervenant, organisations: [organisation]) }
 
-      it "validates presence of last_name only on create" do
-        agent_intervenant.last_name = nil
+      it "is never needed" do
         agent_intervenant.first_name = nil
-        agent_intervenant.valid?
-        expect(agent_intervenant.errors.full_messages.uniq.to_sentence).to eq("Nom d’usage doit être rempli(e)")
-      end
-
-      it "validates presence of last_name only on update" do
-        agent_intervenant.last_name = "jesuisintervenant"
-        agent_intervenant.save
-        agent_intervenant.last_name = nil
-        agent_intervenant.first_name = nil
-        agent_intervenant.valid?
-        expect(agent_intervenant.errors.full_messages.uniq.to_sentence).to eq("Nom d’usage doit être rempli(e)")
-      end
-    end
-
-    context "when agent is not an intervenant" do
-      let!(:organisation) { create(:organisation) }
-      let!(:agent_admin) { build(:agent, admin_role_in_organisations: [organisation]) }
-
-      it "does not validates presence of last_name and first_name on create" do
-        # On Agent creation first_name and last_name are leave blank for invited agent to fill them later
-        agent_admin.last_name = nil
-        agent_admin.first_name = nil
-        agent_admin.valid?
-        expect(agent_admin.email).not_to be_nil
-        expect(agent_admin.errors).to be_empty
-      end
-
-      it "validates presence of last_name and first_name on update" do
-        agent_admin.last_name = "ancien last name"
-        agent_admin.first_name = "ancien first name"
-        agent_admin.save
-        agent_admin.last_name = nil
-        agent_admin.first_name = nil
-        agent_admin.valid?
-        expect(agent_admin.errors[:last_name]).to include("doit être rempli(e)")
-        expect(agent_admin.errors[:first_name]).to include("doit être rempli(e)")
+        expect(agent_intervenant).to be_valid
       end
     end
   end


### PR DESCRIPTION
Dans https://github.com/betagouv/rdv-solidarites.fr/pull/3748, on a introduit des changements aux validations sur le prénom et nom.

Ça a introduit un bug qui fait qu'on ne peut pas inviter un agent dans une deuxième organisation avant qu'il n'ai accepté l'invitation (remonté par l'équipe RDV Insertion, voir ce message sur mattermost : https://mattermost.incubateur.net/betagouv/pl/k3n1h5rd9id7mghusrt5mnaozy)

On reste obligés d'avoir des validations contextuelles (similaire au `validates :last_name, presence: true, on: :update` qu'on avait avant), puisqu'on a deux cas similaires avec des règles différentes sur la présence du prénom :
- un agent basique qui vient d'être invité mais qui n'a pas encore activé son compte n'a pas de prénom. On veut pouvoir l'inviter dans d'autres organisations.

Pour rendre ces validations explicites, on ajoute un flag explicite `allow_blank_name` dans les cas où on autorise ça (invitation d'un nouvel agent non intervenant).

Je suis aussi tombé sur deux controllers qui semblent pas ou peu utilisés, et j'ai préféré faire un correctif minimal pour résoudre le bug le plus vite, plutôt que de me lancer dans un remboursement de dette technique/produit sur des sujets pas forcément prioritaires.