### PR TITLE
Modification du niveau de notification par défaut des Agent à `others` au lieu de `soon`

### DIFF
--- a/db/migrate/20230912082341_update_rdv_notifications_level_default.rb
+++ b/db/migrate/20230912082341_update_rdv_notifications_level_default.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UpdateRdvNotificationsLevelDefault < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :agents, :rdv_notifications_level, from: "soon", to: "others"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_23_144508) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_082341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -208,7 +208,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_23_144508) do
     t.string "uid", default: ""
     t.text "tokens"
     t.boolean "allow_password_change", default: false
-    t.enum "rdv_notifications_level", default: "soon", enum_type: "agents_rdv_notifications_level"
+    t.enum "rdv_notifications_level", default: "others", enum_type: "agents_rdv_notifications_level"
     t.integer "unknown_past_rdv_count", default: 0
     t.boolean "display_saturdays", default: false
     t.boolean "display_cancelled_rdv", default: true

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -16,19 +16,19 @@ describe Notifiers::RdvCancelled, type: :service do
     rdv.update!(status: new_status)
   end
 
-  context "cancellation by agent" do
+  context "cancellation by agent (default notification level : others)" do
     let!(:author) { agent1 }
     let!(:new_status) { :revoked }
 
     context "starts in more than 2 days" do
       let(:starts_at) { 3.days.from_now }
 
-      it "only notifies the user" do
+      it "notifies the users and the other agents (not the author)" do
         subject
         expect_notifications_sent_for(rdv, user1, :rdv_cancelled)
         expect_notifications_sent_for(rdv, user2, :rdv_cancelled)
+        expect_notifications_sent_for(rdv, agent2, :rdv_cancelled)
         expect_no_notifications_for(rdv, agent1, :rdv_cancelled)
-        expect_no_notifications_for(rdv, agent2, :rdv_cancelled)
       end
 
       it "rdv_users_tokens_by_user_id attribute outputs the tokens" do
@@ -47,6 +47,72 @@ describe Notifiers::RdvCancelled, type: :service do
         expect_notifications_sent_for(rdv, user1, :rdv_cancelled)
         expect_notifications_sent_for(rdv, user2, :rdv_cancelled)
         expect_notifications_sent_for(rdv, agent2, :rdv_cancelled)
+        expect_no_notifications_for(rdv, agent1, :rdv_cancelled)
+      end
+    end
+  end
+
+  context "cancellation by agent ('all' notification level)" do
+    let!(:author) { agent1 }
+    let!(:new_status) { :revoked }
+
+    before do
+      agent1.update!(rdv_notifications_level: "all")
+    end
+
+    context "starts in more than 2 days" do
+      let(:starts_at) { 3.days.from_now }
+
+      it "notifies the author (agent)" do
+        subject
+        expect_notifications_sent_for(rdv, agent1, :rdv_cancelled)
+      end
+    end
+  end
+
+  context "cancellation by agent ('soon' notification level)" do
+    let!(:author) { agent2 }
+    let!(:new_status) { :revoked }
+
+    before do
+      agent1.update!(rdv_notifications_level: "soon")
+    end
+
+    context "starts in more than 2 days" do
+      let(:starts_at) { 3.days.from_now }
+
+      it "does not notify other agent with 'soon' notif level" do
+        subject
+        expect_no_notifications_for(rdv, agent1, :rdv_cancelled)
+      end
+    end
+
+    context "starts today or tomorrow" do
+      let(:starts_at) { 1.day.from_now }
+
+      it "notify others agents with 'soon' notif level" do
+        subject
+        expect_notifications_sent_for(rdv, agent1, :rdv_cancelled)
+      end
+    end
+  end
+
+  context "cancellation by agent ('none' notification level)" do
+    let!(:author) { agent2 }
+    let!(:new_status) { :revoked }
+
+    before do
+      agent1.update!(rdv_notifications_level: "none")
+    end
+
+    context "starts in more than 2 days" do
+      let(:starts_at) { 3.days.from_now }
+
+      it "notifies the users only (not the agent author or agent with none notif level)" do
+        subject
+        expect_notifications_sent_for(rdv, user1, :rdv_cancelled)
+        expect_notifications_sent_for(rdv, user2, :rdv_cancelled)
+        expect_no_notifications_for(rdv, agent2, :rdv_cancelled)
         expect_no_notifications_for(rdv, agent1, :rdv_cancelled)
       end
     end


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/1277

Modification du niveau de notification par défaut **pour les nouveaux agents** qui seront désormais notifiés de toutes les actions faites par les usagers ou d'autres agents sur les rdv.
Auparavant le niveau par défaut était : `soon` qui notifie les événements uniquement si ceux la ont lieu moins de 24h avant le rdv.
C'est une demande de rdv-insertion, c'est plus logique et plus compréhensible pour les nouveaux agents (qui peuvent très bien modifier le niveau de notif de leur profile si ils le souhaitent).
