### PR TITLE
Reload sms provider to be able to send waiting sms from 62 and 92

### DIFF
--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -7,12 +7,12 @@ class SmsSender < BaseService
 
   attr_reader :phone_number, :content, :provider, :api_key
 
-  def initialize(sender_name, phone_number, content, provider, api_key, receipt_params) # rubocop:disable Metrics/ParameterLists
+  def initialize(sender_name, phone_number, content, _provider, _api_key, receipt_params) # rubocop:disable Metrics/ParameterLists
     @sender_name = sender_name
     @phone_number = phone_number
     @content = formatted_content(content)
-    @provider = provider
-    @api_key = api_key
+    @provider = receipt_params[:rdv]&.organisation&.territory&.sms_provider
+    @api_key = receipt_params[:rdv]&.organisation&.territory&.sms_configuration
     @receipt_params = receipt_params
   end
 

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -7,12 +7,13 @@ class SmsSender < BaseService
 
   attr_reader :phone_number, :content, :provider, :api_key
 
-  def initialize(sender_name, phone_number, content, _provider, _api_key, receipt_params) # rubocop:disable Metrics/ParameterLists
+  def initialize(sender_name, phone_number, content, provider, api_key, receipt_params) # rubocop:disable Metrics/ParameterLists
     @sender_name = sender_name
     @phone_number = phone_number
     @content = formatted_content(content)
-    @provider = receipt_params[:rdv]&.organisation&.territory&.sms_provider
-    @api_key = receipt_params[:rdv]&.organisation&.territory&.sms_configuration
+    # Temporary hack to use netsize for sfr_mail2sms
+    @provider = provider.to_sym == :sfr_mail2sms ? :netsize : provider
+    @api_key = provider.to_sym == :sfr_mail2sms ? Territory.find_by(sms_provider: :netsize)&.sms_configuration : api_key
     @receipt_params = receipt_params
   end
 

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 describe SmsSender, type: :service do
+  let(:rdv) { create(:rdv) }
+  let(:user) { create(:user) }
+  let(:receipt_params) { { event: "rdv_created", rdv: rdv, user: user } }
+
   describe "#content" do
     subject { test_sms.content }
 
-    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, nil, nil, nil) }
+    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, nil, nil, receipt_params) }
 
     context "remove accents and weird chars" do
       let(:content) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }
@@ -40,12 +44,9 @@ describe SmsSender, type: :service do
   end
 
   describe "receipt creation" do
-    let(:rdv) { create(:rdv) }
-    let(:user) { create(:user) }
-
     before do
       stub_netsize_ok
-      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", { event: "rdv_created", rdv: rdv, user: user })
+      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", receipt_params)
     end
 
     it do

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -8,7 +8,7 @@ describe SmsSender, type: :service do
   describe "#content" do
     subject { test_sms.content }
 
-    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, nil, nil, receipt_params) }
+    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, "netsize", nil, receipt_params) }
 
     context "remove accents and weird chars" do
       let(:content) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }


### PR DESCRIPTION
utiliser les receipt params (fix temporaire) pour utiliser netsize au lieu de sfr pour les départements 62 et 92