### PR TITLE
Réactivation de SFR Mail2SMS suite aux problèmes du 12 septembre

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -232,8 +232,3 @@ RSpec/ScatteredSetup:
 RSpec/FilePath:
   CustomTransform:
     SfrMail2SmsMailer: sfr_mail_2_sms_mailer
-
-# Temp Build Fix for SFRMail2SmsMailer
-Lint/UnreachableCode:
-  Exclude:
-    - "app/services/sms_sender.rb"

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -11,9 +11,8 @@ class SmsSender < BaseService
     @sender_name = sender_name
     @phone_number = phone_number
     @content = formatted_content(content)
-    # Temporary hack to use netsize for sfr_mail2sms
-    @provider = provider.to_sym == :sfr_mail2sms ? :netsize : provider
-    @api_key = provider.to_sym == :sfr_mail2sms ? Territory.find_by(sms_provider: :netsize)&.sms_configuration : api_key
+    @provider = provider
+    @api_key = api_key
     @receipt_params = receipt_params
   end
 
@@ -124,7 +123,6 @@ class SmsSender < BaseService
   # - le département des Hautes-Seine (92)
   #
   def send_with_sfr_mail2sms
-    raise "Disabling this until sfr works again"
     Admins::SfrMail2SmsMailer.send_sms(@api_key, @phone_number, @content).deliver_now
 
     save_receipt(result: :processed)

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 describe SmsSender, type: :service do
+  let(:rdv) { create(:rdv) }
+  let(:user) { create(:user) }
+  let(:receipt_params) { { event: "rdv_created", rdv: rdv, user: user } }
+
   describe "#content" do
     subject { test_sms.content }
 
-    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, nil, nil, nil) }
+    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, "netsize", nil, receipt_params) }
 
     context "remove accents and weird chars" do
       let(:content) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }
@@ -40,12 +44,9 @@ describe SmsSender, type: :service do
   end
 
   describe "receipt creation" do
-    let(:rdv) { create(:rdv) }
-    let(:user) { create(:user) }
-
     before do
       stub_netsize_ok
-      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", { event: "rdv_created", rdv: rdv, user: user })
+      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", receipt_params)
     end
 
     it do

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
 describe SmsSender, type: :service do
-  let(:rdv) { create(:rdv) }
-  let(:user) { create(:user) }
-  let(:receipt_params) { { event: "rdv_created", rdv: rdv, user: user } }
-
   describe "#content" do
     subject { test_sms.content }
 
-    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, "netsize", nil, receipt_params) }
+    let(:test_sms) { described_class.new("RdvSoli", "0612345678", content, nil, nil, nil) }
 
     context "remove accents and weird chars" do
       let(:content) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }
@@ -44,9 +40,12 @@ describe SmsSender, type: :service do
   end
 
   describe "receipt creation" do
+    let(:rdv) { create(:rdv) }
+    let(:user) { create(:user) }
+
     before do
       stub_netsize_ok
-      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", receipt_params)
+      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", { event: "rdv_created", rdv: rdv, user: user })
     end
 
     it do


### PR DESCRIPTION
Rollback du code mis en place le 12/09/2023.
On réactive le mail2SMS
