### PR TITLE
Ajout de la possibilité de définir des agents admins de territoires dans le super_admin

### DIFF
--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -16,6 +16,7 @@ class AgentDashboard < Administrate::BaseDashboard
     last_name: Field::String,
     organisations: Field::HasMany,
     roles: Field::HasMany,
+    territories: Field::HasMany,
     service: Field::BelongsTo,
     invitation_sent_at: Field::DateTime,
     deleted_at: Field::DateTime,
@@ -44,6 +45,7 @@ class AgentDashboard < Administrate::BaseDashboard
     last_name
     organisations
     roles
+    territories
     service
     invitation_sent_at
     created_at
@@ -60,6 +62,7 @@ class AgentDashboard < Administrate::BaseDashboard
     last_name
     organisations
     service
+    territories
     deleted_at
   ].freeze
 

--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -17,6 +17,7 @@ class AgentDashboard < Administrate::BaseDashboard
     organisations: Field::HasMany,
     roles: Field::HasMany,
     territories: Field::HasMany,
+    territorial_roles: Field::HasMany,
     service: Field::BelongsTo,
     invitation_sent_at: Field::DateTime,
     deleted_at: Field::DateTime,
@@ -45,7 +46,7 @@ class AgentDashboard < Administrate::BaseDashboard
     last_name
     organisations
     roles
-    territories
+    territorial_roles
     service
     invitation_sent_at
     created_at

--- a/app/dashboards/agent_territorial_role_dashboard.rb
+++ b/app/dashboards/agent_territorial_role_dashboard.rb
@@ -2,7 +2,7 @@
 
 require "administrate/base_dashboard"
 
-class TerritoryDashboard < Administrate::BaseDashboard
+class AgentTerritorialRoleDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -11,12 +11,8 @@ class TerritoryDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    departement_number: Field::String,
-    name: Field::String,
-    admin_agents: Field::HasMany,
-    roles: Field::HasMany,
-    created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    territory: Field::BelongsTo,
+    agent: Field::BelongsTo,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -26,31 +22,24 @@ class TerritoryDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     id
-    departement_number
-    name
+    territory
+    agent
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    name
-    roles
-    departement_number
-    created_at
-    updated_at
+    territory
+    agent
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = %i[
-    name
-    admin_agents
-    departement_number
-  ].freeze
+  FORM_ATTRIBUTES = %i[].freeze
 
-  def display_resource(territory)
-    "Territory ##{territory.id} - #{territory.name} (#{territory.departement_number})"
+  def display_resource(territorial_role)
+    "Territory ##{territorial_role.id} - #{territorial_role.territory.name} (#{territorial_role.territory.departement_number})"
   end
 end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -26,7 +26,7 @@ class Territory < ApplicationRecord
 
   # Through relations
   has_many :organisations_agents, -> { distinct }, through: :organisations, source: :agents
-  has_many :admin_agents, through: :roles
+  has_many :admin_agents, through: :roles, source: :agent
   has_many :zones, through: :sectors
   has_many :rdvs, through: :organisations
   has_many :receipts, through: :rdvs

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -261,6 +261,10 @@ fr:
     label:
       agent:
         territories:  "Admin de Territoires"
+        territorial_roles: "Admin de Territoires"
+      territory:
+        roles: "Admins du Territoire"
+        admin_agents: "Admins du Territoire"
     add: Ajouter
     back: Retour
     clone: Dupliquer

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -258,6 +258,9 @@ fr:
         one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
         other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
+    label:
+      agent:
+        territories:  "Admin de Territoires"
     add: Ajouter
     back: Retour
     clone: Dupliquer

--- a/config/locales/models/agent.fr.yml
+++ b/config/locales/models/agent.fr.yml
@@ -7,6 +7,7 @@ fr:
         role: Rôle
         rdvs: Rendez-vous
         service: Service
+        territories: Admin de Territoires
         rdv_notifications_level: Notifications de RDV
         display_saturdays: Affichage des samedis sur le calendrier
         display_cancelled_rdv: Affichage des rendez-vous annulés

--- a/config/locales/models/territory.fr.yml
+++ b/config/locales/models/territory.fr.yml
@@ -1,7 +1,7 @@
 fr:
   activerecord:
     models:
-      territory: Territory
+      territory: Territoire
     attributes:
       territory:
         base: "" # weird hack for nested base error


### PR DESCRIPTION
close : https://github.com/betagouv/rdv-solidarites.fr/issues/3747

On ajoute ici la possibilité de définir des admins de territoires dans le `super_admin` via le formulaire agent.
J'ai ajouté les traductions correspondantes pour que ce soit clair dans l'interface que l'action porte sur les admin de territoires.

Une petite subtilité de la gem `administrate` qui utilise la traduction `helpers.label` pour les index et les show (raison pour laquelle tous les labels de nos pages show et index ne sont pas traduits dans le `super_admin`) et les traductions habituelles `activerecord` pour les autres pages qui contiennent des formulaires (new, edit...)

PI, cette PR n'a pas pour but de clarifier les différences entre les tables `agent_territorial_roles` et `agent_territorial_access_rights`. C'est l'objet de cette issue : https://github.com/betagouv/rdv-solidarites.fr/issues/3588

![Capture d’écran 2023-09-15 à 11 25 54](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/dadd8500-905c-4564-a17e-94ecb1cb4a3f)
![Capture d’écran 2023-09-15 à 11 26 05](https://github.com/betagouv/rdv-solidarites.fr/assets/28594222/dc0138d8-c3b6-4d2d-9590-e69d8e00cf09)