### PR TITLE
Correction de l'affichage de la sectorisation pour les motifs de suivi

### DIFF
--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -8,7 +8,7 @@ tr
     = motif_badges(motif, only: %i[bookable_by_everyone bookable_by_invited_users])
   - if @display_sectorisation_level
     td
-      - if !motif.bookable_outside_of_organisation?
+      - if !motif.bookable_outside_of_organisation? || motif.follow_up?
         | &nbsp;
       - elsif motif.sectorisation_level_departement?
         | Tout le #{current_organisation.departement_number}

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -53,7 +53,7 @@
             motif_option_activated(@motif, :rdvs_editable_by_user), \
             hint: Motif.human_attribute_name(:rdvs_editable_by_user_hint)
 
-          - unless current_domain.online_reservation_with_public_link
+          - if !current_domain.online_reservation_with_public_link && !@motif.follow_up?
             = motif_attribute_row("Sectorisation") do
               - if @motif.bookable_by_everyone_or_bookable_by_invited_users?
                 div= @motif.human_attribute_value(:sectorisation_level)

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -22,10 +22,10 @@ fr:
         for_secretariat_label: Le RDV pourra être effectué par le service secrétariat
         for_secretariat_short: RDV Secrétariat
         for_secretariat_hint: Les membres du service Secrétariat pourront poser des RDV dans leur agenda et configurer les plages d'ouverture avec ce motif
-        follow_up: Ce motif est réservé aux usagers bénéficiant d'un accompagnement
+        follow_up: Ce motif est réservé uniquement aux usagers bénéficiant d'un accompagnement
         follow_up_short: RDV de suivi
         follow_up_warning: Ne cochez cette case que si vous savez ce que vous faîtes
-        follow_up_hint: Ce motif est réservé aux usagers bénéficiant d'un accompagnement
+        follow_up_hint: Ce motif est réservé uniquement aux usagers bénéficiant d'un accompagnement
         default_duration_in_min: Durée par défaut en minutes
         default_duration_in_min_short: Durée par défaut
         default_duration: Durée par défaut


### PR DESCRIPTION
Dans la continuité de https://github.com/betagouv/rdv-solidarites.fr/issues/3125, puisque la sectorisation n'a pas de sens pour les motifs de suivi, il ne faut pas qu'on affiche les infos de sectorisation dans l'index des motifs et le résumé d'un motif pour un motif de suivi.

Le cas ne s'était pas présenté jusqu'à aujourd'hui, mais la Drôme est en train d'ouvrir de la réservation en ligne avec de la sectorisation sur certains motifs et du suivi sur d'autres.

On contracte ici un petit peu de dette technique, puisqu'on a du fonctionnement commun entre des conditions à trois endroits :
- `app/views/admin/motifs/show.html.slim`
- `app/views/admin/motifs/_motif.html.slim`
- `app/javascript/components/motif-form.js`

et que je fais cette pr sans test vu le niveau de risque faible et le besoin d'évacuer rapidement ce sujet.
Je pense que cette dette technique est raisonnable, vu qu'on a aussi une dette d'interface utilisateur plus large sur la possibilité de consolider les infos de restrictions sur le motifs (secto, réservation par les usagers, suivi).

## Avant

<img width="1157" alt="Screenshot 2023-09-15 at 12 22 35" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/2af61a5d-58aa-4ad7-9e44-c2db595b0b8a">

<img width="1083" alt="Screenshot 2023-09-15 at 12 21 55" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/e8024f44-c84a-4766-81e5-25a8a390c57f">


## Après 

<img width="1182" alt="Screenshot 2023-09-15 at 12 27 14" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/0b0a42c0-1384-4303-8558-ccf5bd863431">


L'info "Sectorisation" ne s'affiche plus

<img width="1079" alt="Screenshot 2023-09-15 at 12 21 32" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/05bc2d6c-3546-4a8c-936b-185a78ed1301">
Le texte "Tout le 75" a bien disparu de la dernière ligne

