### PR TITLE
Bugfix: le nom de naissance est affiché même si il est identique au nom de famille

### DIFF
--- a/app/models/concerns/full_name_concern.rb
+++ b/app/models/concerns/full_name_concern.rb
@@ -9,7 +9,7 @@ module FullNameConcern
   def full_name
     names = [first_name,
              last_name&.upcase,
-             ("(#{birth_name})" if defined?(birth_name) && birth_name.present?),]
+             ("(#{birth_name})" if show_birth_name?),]
 
     names.compact.join(" ")
   end
@@ -17,7 +17,7 @@ module FullNameConcern
   # Curie (Skłodowska) Marie
   def reverse_full_name
     names = [last_name&.upcase,
-             ("(#{birth_name})" if defined?(birth_name) && birth_name.present?),
+             ("(#{birth_name})" if show_birth_name?),
              first_name,]
 
     names.compact.join(" ")
@@ -30,5 +30,11 @@ module FullNameConcern
     else
       last_name
     end
+  end
+
+  private
+
+  def show_birth_name?
+    defined?(birth_name) && birth_name.present? && birth_name&.upcase != last_name&.upcase
   end
 end

--- a/spec/models/concerns/full_name_concern_spec.rb
+++ b/spec/models/concerns/full_name_concern_spec.rb
@@ -18,6 +18,12 @@ describe FullNameConcern do
 
       it { is_expected.to eq "Pierre CURIE" }
     end
+
+    context "when birth name is the same" do
+      let(:person) { build :user, first_name: "Pierre", last_name: "Curie", birth_name: "curie" }
+
+      it { is_expected.to eq "Pierre CURIE" }
+    end
   end
 
   describe "reverse_full_name" do
@@ -31,6 +37,12 @@ describe FullNameConcern do
 
     context "without birth_name" do
       let(:person) { pierre }
+
+      it { is_expected.to eq "CURIE Pierre" }
+    end
+
+    context "when birth name is the same" do
+      let(:person) { build :user, first_name: "Pierre", last_name: "Curie", birth_name: "curie" }
 
       it { is_expected.to eq "CURIE Pierre" }
     end


### PR DESCRIPTION
Dans le cas où le nom de naissance saisi est le même que le nom de famille, il est inutile d'afficher le nom de naissance entre parenthèses.

Une autre option serait d'interdire de saisir le même nom de famille et nom de naissance, mais ça impliquerait une gêne potentielle pour l'agent, et poserait la question des données existantes. Je suis donc allé au plus simple.

# Avant

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/ea72b645-ed8f-4fad-8fc9-11bdd88ddf6d)

# Après

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/707486f0-9cd9-41eb-b9f9-967b0fe0b575)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
