### PR TITLE
feat(webhooks): Send webhooks for AgentsRdv

### DIFF
--- a/app/blueprints/agents_rdv_blueprint.rb
+++ b/app/blueprints/agents_rdv_blueprint.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AgentsRdvBlueprint < Blueprinter::Base
+  identifier :id
+
+  association :agent, blueprint: AgentBlueprint
+  association :rdv, blueprint: RdvBlueprint
+end

--- a/app/models/agents_rdv.rb
+++ b/app/models/agents_rdv.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class AgentsRdv < ApplicationRecord
+  # Mixins
   include Outlook::EventSerializerAndListener
+  include WebhookDeliverable
 
   # Relations
   belongs_to :rdv, touch: true
   belongs_to :agent
+
+  # Delegates
+  delegate :organisation, to: :rdv
+  delegate :webhook_endpoints, to: :organisation
 
   # Validation
   # Uniqueness validation doesn’t work with nested_attributes, see https://github.com/rails/rails/issues/4568

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -33,6 +33,7 @@ class Organisation < ApplicationRecord
   has_many :agents, through: :agent_roles, dependent: :destroy
   has_many :referent_assignations, through: :users
   has_many :receipts, through: :rdvs
+  has_many :agents_rdvs, through: :rdvs
 
   accepts_nested_attributes_for :agent_roles
   accepts_nested_attributes_for :territory

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -12,6 +12,7 @@ class WebhookEndpoint < ApplicationRecord
 
   ALL_SUBSCRIPTIONS = %w[
     rdv absence plage_ouverture user user_profile organisation motif lieu agent agent_role referent_assignation
+    agents_rdv
   ].freeze
 
   def trigger_for_all_subscribed_resources


### PR DESCRIPTION
Jusqu'à présent nous ne liions pas les agents aux rdvs sur RDVI, or nous allons en avoir besoin.
Je fais donc en sorte ici que l'on envoie des webhooks à la création/modification/suppression d'`agents_rdvs`.

## Migration

Une fois cette PR déployée, il va falloir qu'on s'envoie les webhooks de tous les `agents_rdvs` liés à des rdvs RDVI. Ça devrait à priori concerner au moins 91 849 records: 

<img width="853" alt="image" src="https://github.com/betagouv/rdv-solidarites.fr/assets/7602809/99fbeb3c-4a13-4cdf-a1a3-cca23ba9510c">

Il faudra donc se concerter pour trouver la meilleur stratégie pour faire cette migration.