### PR TITLE
Script pour merger 2 agents d'une meme orga

### DIFF
--- a/scripts/merge_two_agents.rb
+++ b/scripts/merge_two_agents.rb
@@ -38,8 +38,8 @@ Agent.transaction do
   source.absences.update!(agent_id: dest.id)
 
   puts "---Merging Roles---"
-  source_role = source.roles.take
-  destination_role = dest.roles.take
+  source_role = source.roles.first
+  destination_role = dest.roles.first
 
   destination_role.destroy!
   source_role.update!(agent_id: dest.id)


### PR DESCRIPTION
Ce script permet de merger ensemble 2 agents d'une même organisation.
Cela permet de régler le souci des agents créés en double dans la même organisation, qui nous été remonté.

Le script effectue une migration des données de l'agent source vers l'agent destination, et au final supprime l'agent source.

Pour raison de simplicité, le script est pour le moment fonctionnel uniquement avec 2 agents appartenant à la même organisation et n'appartenant qu'à cette seule organisation.

Les données modifiées proviennent des tables suivantes:

```ruby
absences
agent_roles
agent_teams
agent_territorial_access_rights
agent_territorial_roles
agents_rdvs
plage_ouvertures
referent_assignations
sector_attributions
```

Closes https://github.com/betagouv/rdv-solidarites.fr/issues/3793

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort
