### PR TITLE
Désactiver les notifications pour les intervenants

### DIFF
--- a/app/services/admin_creates_agent.rb
+++ b/app/services/admin_creates_agent.rb
@@ -17,7 +17,13 @@ class AdminCreatesAgent
         add_agent_to_organisation
         check_agent_service
       elsif @access_level == "intervenant"
-        @agent = Agent.create(agent_and_role_params)
+        @agent = Agent.create(
+          agent_and_role_params.merge(
+            rdv_notifications_level: "none",
+            plage_ouverture_notification_level: "none",
+            absence_notification_level: "none"
+          )
+        )
       else
         @agent = Agent.invite!(agent_and_role_params.merge(allow_blank_name: true), @current_agent)
       end

--- a/app/services/admin_updates_agent.rb
+++ b/app/services/admin_updates_agent.rb
@@ -34,6 +34,7 @@ class AdminUpdatesAgent
 
   def turn_intervenant_into_agent_with_account
     assign_agent_and_role_attributes
+    set_agent_notifications_levels_to_default
     if @agent.save
       @agent.confirm
       @agent.invite!(@inviting_agent)
@@ -60,6 +61,7 @@ class AdminUpdatesAgent
     end
 
     reset_agent_email_and_password
+    set_agent_notifications_levels_to_none
     reset_agent_invitation_fields
     @agent.assign_attributes(first_name: nil)
     @agent.assign_attributes(roles_attributes: {
@@ -69,6 +71,18 @@ class AdminUpdatesAgent
     if @agent.save
       @confirmation_message = I18n.t("activerecord.notice.models.agent_role.updated")
     end
+  end
+
+  def set_agent_notifications_levels_to_none
+    @agent.rdv_notifications_level = "none"
+    @agent.plage_ouverture_notification_level = "none"
+    @agent.absence_notification_level = "none"
+  end
+
+  def set_agent_notifications_levels_to_default
+    @agent.rdv_notifications_level = "others"
+    @agent.plage_ouverture_notification_level = "all"
+    @agent.absence_notification_level = "all"
   end
 
   def reset_agent_email_and_password

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -21,6 +21,11 @@ describe "Agent can CRUD intervenants" do
     click_button("Ajouter l'intervenant")
     expect_page_title("Agents de Organisation n°1")
     expect(page).to have_content("AVOCAT 1")
+    expect(Agent.last).to have_attributes(
+      plage_ouverture_notification_level: "none",
+      rdv_notifications_level: "none",
+      absence_notification_level: "none"
+    )
 
     # Change their last name
     click_link "INTERVENANT1"
@@ -50,7 +55,10 @@ describe "Agent can CRUD intervenants" do
 
     expect(Agent.last).to have_attributes(
       email: "ancien_intervenant1@invitation.com",
-      uid: "ancien_intervenant1@invitation.com"
+      uid: "ancien_intervenant1@invitation.com",
+      plage_ouverture_notification_level: "all",
+      rdv_notifications_level: "others",
+      absence_notification_level: "all"
     )
 
     expect_page_title("Invitations en cours pour Organisation n°1")
@@ -86,7 +94,10 @@ describe "Agent can CRUD intervenants" do
       invitation_created_at: nil,
       invitation_sent_at: nil,
       invited_by_id: nil,
-      invited_by_type: nil
+      invited_by_type: nil,
+      plage_ouverture_notification_level: "none",
+      rdv_notifications_level: "none",
+      absence_notification_level: "none"
     )
 
     # On vérifie que nos factories correspondent à la réalité


### PR DESCRIPTION
Suite à cette remontée sentry : https://sentry.incubateur.net/organizations/betagouv/issues/60610/?project=74&referrer=webhooks_plugin
Nous avons des erreurs d'envoi smtp (email null) pour les intervenants.

Cette PR fix ce problème en utilisant le système de notification existant.
On désactive les notifs lorsque l'on créé un intervenant ou que l'on passe un agent en intervenant.

Une fois la PR merge je ferai les changements à la main pour les intervenants existants en demo et en prod.
