### PR TITLE
Enlever la possibilité de supprimer une Orga depuis le SuperAdmin

### DIFF
--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -8,6 +8,8 @@
 # you're free to overwrite the RESTful controller actions.
 module SuperAdmins
   class ApplicationController < Administrate::ApplicationController
+    PROTECTED_RESOURCES = %w[organisation].freeze
+
     include DomainDetection
 
     helper all_helpers_from_path "app/helpers"
@@ -36,6 +38,20 @@ module SuperAdmins
 
     def sign_in_as_allowed?
       ENV.fetch("SIGN_IN_AS_ALLOWED", false)
+    end
+
+    # We override this method, so we don't show the "Supprimer" button for Protected resources
+    def existing_action?(resource, action_name)
+      return false if action_name.to_s == "destroy" && PROTECTED_RESOURCES.include?(resource.to_s)
+
+      super
+    end
+
+    # We override this method, so DELETE requests for Protected resources are not allowed
+    def valid_action?(action_name, resource = resource_class)
+      return false if action_name.to_s == "destroy" && PROTECTED_RESOURCES.include?(resource.to_s)
+
+      super
     end
   end
 end


### PR DESCRIPTION
Hier lors du Standup, Romain a soulevé combien il était simple de supprimer une Organisation par mégarde depuis le SuperAdmin.

Cette PR retire cette possibilité en faisant du `override` sur quelques méthodes provenant de la gem [Administrate](https://github.dev/thoughtbot/administrate).

Pour l'instant, nous limitons la restriction aux Organisations et cela pourrait facilement s'étendre à d'autres ressources en ajoutant le nom de la ressource dans la constante: `PROTECTED_RESOURCES`.

## Avant
<img width="1286" alt="Screenshot 2023-09-21 at 15 49 20" src="https://github.com/betagouv/rdv-solidarites.fr/assets/11911945/5e5542c5-b2b2-461e-8ec4-1245c4e296c5">
<img width="1297" alt="Screenshot 2023-09-21 at 16 34 42" src="https://github.com/betagouv/rdv-solidarites.fr/assets/11911945/5d77c925-eeb6-488e-97a9-943f1a92d6b0">


## Après
<img width="1270" alt="Screenshot 2023-09-21 at 16 34 14" src="https://github.com/betagouv/rdv-solidarites.fr/assets/11911945/b435a04a-63d6-4c4e-9657-e6beeaa276d2">
<img width="1281" alt="Screenshot 2023-09-21 at 16 34 24" src="https://github.com/betagouv/rdv-solidarites.fr/assets/11911945/1f510ab4-467e-40fe-b279-78238d712f4a">


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
