### PR TITLE
Utiliser un timeout au niveau HTTP

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -29,7 +29,7 @@ class WebhookJob < ApplicationJob
 
     request.on_failure do |response|
       if response.timed_out?
-        raise OutgoingWebhookError, "Error: HTTP Timeout, URL: #{webhook_endpoint.target_url}"
+        raise OutgoingWebhookError, "HTTP Timeout, URL: #{webhook_endpoint.target_url}"
       elsif !WebhookJob.false_negative_from_drome?(response.body)
         raise OutgoingWebhookError, "HTTP #{response.code}, URL: #{webhook_endpoint.target_url}"
       end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -28,7 +28,7 @@ class WebhookJob < ApplicationJob
     )
 
     request.on_complete do |response|
-      if !response.success? && !WebhookJob.false_negative_from_drome?(response.body)
+      if !response.success? && !response.timed_out? && !WebhookJob.false_negative_from_drome?(response.body)
         message = "Webhook-Failure (#{response.body.force_encoding('UTF-8')[0...1000]}):\n"
         message += "  url: #{webhook_endpoint.target_url}\n"
         message += "  org: #{webhook_endpoint.organisation.name}\n"

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+DEFAULT_TYPHOEUS_TIMEOUT = 15
+class Typhoeus::Errors::TimeoutError < Typhoeus::Errors::TyphoeusError; end
+
+# Typhoeus ne lève pas d'exception en cas de timeout, donc on fait
+# en sorte de mettre un timeout par défaut et de lever l'exception.
+Typhoeus.before do |request|
+  request.options[:timeout] ||= DEFAULT_TYPHOEUS_TIMEOUT
+  # Les timeouts sont parfois gérés de façon adaptée au niveau de l'appel.
+  # Nous ajoutons ce callback `on_failure` pour avoir une levée d'exception par défaut.
+  if request.on_failure.blank?
+    request.on_failure do |response|
+      if response.timed_out?
+        raise Typhoeus::Errors::TimeoutError, "Timed out calling #{response.request.url}"
+      end
+    end
+  end
+  true # Si le block de callback retourne une valeur falsy, la requête est annulée.
+end
+
 Typhoeus.before do |request|
   filter_secrets_from_body = lambda do |body|
     body.to_s.gsub(InclusionConnect::IC_CLIENT_SECRET || "", "filtered")

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -37,6 +37,14 @@ describe WebhookJob, type: :job do
       perform_enqueued_jobs
       expect(enqueued_jobs.first["priority"]).to eq(-20)
     end
+
+    it "retries on timeout" do
+      stub_request(:post, "https://example.com/rdv-s-endpoint").to_timeout
+      described_class.perform_later(payload, webhook_endpoint.id)
+
+      perform_enqueued_jobs
+      expect(enqueued_jobs.first["executions"]).to eq(1)
+    end
   end
 
   describe ".false_negative_from_drome?" do

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -87,6 +87,20 @@ describe Outlook::ApiClient do
         expect(sentry_events).to be_empty
       end
     end
+
+    context "when the request times out" do
+      before do
+        stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events").to_timeout
+      end
+
+      stub_sentry_events
+
+      it "raises an exception" do
+        expect do
+          described_class.new(agent).create_event!(expected_body)
+        end.to raise_error(Typhoeus::Errors::TimeoutError)
+      end
+    end
   end
 
   describe "when the token needs to be refreshed" do


### PR DESCRIPTION
Suite au [post-mortem du 12 septembre 2023](https://pad.incubateur.net/KB2I5pdMSGag6VaBxL8mfQ#), nous avons décidé de mettre un timeout à toutes nos requêtes HTTP pour éviter d'avoir des jobs qui tournent trop longtemps et congestionnent nos queues.

J'ai donc ici ajouté dans `config/initializers/typhoeus.rb` un timeout par défaut à toutes nos requêtes Typhoeus. Aussi, désormais, si aucun callback `on_failure` n'est défini au niveau de la requête, c'est un callback par défaut qui s'exécute et lève une exception en cas de timeout.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
