### PR TITLE
[Update Doc de Vigie] Inclure la responsabilité de surveiller GoodJob

### DIFF
--- a/docs/5-role-de-vigie.md
+++ b/docs/5-role-de-vigie.md
@@ -5,7 +5,7 @@ La vigie est un.e dev qui surveille la prod et qui traite les petites demandes a
 C'est un rôle qui tourne toutes les 2 semaines dans l'équipe technique.
 
 
-Un des deux buts de la vigie est de surveiller que tout se passe bien en prod pour que le reste de l'équipe tech puisse se concentrer sur son travail en toute sérénité. Ielle n'a pas forcément vocation à résoudre tous les bugs qui peuvent arriver, mais de surveiller la prod, notamment via Sentry.
+Un des deux buts de la vigie est de surveiller que tout se passe bien en prod pour que le reste de l'équipe tech puisse se concentrer sur son travail en toute sérénité. Ielle n'a pas forcément vocation à résoudre tous les bugs qui peuvent arriver, mais de surveiller la prod, notamment via Sentry, et GoodJob.
 
 L'autre but est de traiter les petites demandes (tout ce qui nécessite moins d'une journée de dev, ou les sujets où on sait clairement quelle est la petite amélioration à faire mais qu'on n'a jamais le temps de traiter). En traitant ces demandes rapidement à partir du moment où elles apparaissent, on limite la quantité de "petits sujets flottants" qui nous distraient.
 
@@ -33,3 +33,7 @@ Ces erreurs sont normalement ignorées au niveau du client Sentry (dans l'appli 
 Ce qui nous intéresse, ce sont les erreur ActiveRecord::NotFound qui sont liée à un vrai bug et pas juste un lien obsolète. On peut donc trier sur la base de la présence du header http referer : les liens obsolètes qui sont partagés par mail ou conservés dans les favoris n'auront pas de valeur pour ce header, alors que les vraies erreurs, comme un lien cassé sur l'appli, auront notre nom de domaine dans le referer. On a ajouté la recherche sauvegardée "RecordNotFound with internal referer" dans Sentry pour chercher ce type d'erreurs.
 
 Les erreurs liées à des liens obsolètes peuvent être ignorées avec des règles du type "Ignore until this occurs again 100 times per week". Le nombre exact d'occurrences par semaine est à trouver au cas par cas. Il vaut mieux commencer avec un nombre assez bas, et augmenter au fur et à mesure, ce qui nous permettra de voir s'il y a soudainement un pic d'erreurs de ce type (ce qui pourrait révéler un vrai bug, et pas juste un bruit de fond d'erreurs liées à des liens obsolètes).
+
+## GoodJob
+
+Il faudra surveiller le [Dashboard de GoodJob](https://www.rdv-solidarites.fr/super_admins/good_job/jobs), notamment les jobs qui finissent dans la section ["Abandonnés"](https://www.rdv-solidarites.fr/super_admins/good_job/jobs?locale=fr&state=discarded)


### PR DESCRIPTION
A la suite du Post-mortem de l'incident du 12/09/2023, nous avons décidé d'étendre les responsabilités de la Vigie à la surveillance des jobs depuis le dashboard de GoodJob.

Pour plus d'infos : [Le doc du post-mortem du 12/09/2023](https://pad.incubateur.net/KB2I5pdMSGag6VaBxL8mfQ#)
