### PR TITLE
Bugfix: logger l'environnement Rack lors de l'échec Omniauth

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -27,7 +27,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       data: {
         error: env["omniauth.error"],
         error_type: env["omniauth.error.type"],
-        full_env: env.to_json, # for testing in review app
+        full_env: env.select { |_key, value| value.is_a?(String) },
       }
     )
     Sentry.add_breadcrumb(crumb)


### PR DESCRIPTION
La première tentative appelait `request.env.to_json`, mais il y avait probablement des self-reference dans le hash, donc on obtient `stack level too deep (SystemStackError)` :

https://sentry.incubateur.net/organizations/betagouv/issues/66850/?project=74&referrer=webhooks_plugin

Je pense qu'on peut logger les valeurs qui sont des strings et voir si ça suffit.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
