### PR TITLE
Définir un timeout différent par type de job

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -12,8 +12,7 @@ module DefaultJobBehaviour
       Sentry.with_scope do |scope|
         scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
 
-        timeout_value = queue_name.in?(%w[exports cron]) ? 1.hour : 30.seconds
-        Timeout.timeout(timeout_value) do
+        Timeout.timeout(hard_timeout) do
           block.call
         end
 
@@ -39,5 +38,9 @@ module DefaultJobBehaviour
 
   def log_failure_to_sentry?(_exception)
     true
+  end
+
+  def hard_timeout
+    30.seconds
   end
 end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -3,6 +3,12 @@
 class CronJob < ApplicationJob
   queue_as :cron
 
+  private
+
+  def hard_timeout
+    1.hour
+  end
+
   class FileAttenteJob < CronJob
     def perform
       FileAttente.send_notifications

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -17,4 +17,10 @@ class ExportJob < ApplicationJob
     # It is thus only used as a control flow mechanism, and should not e sent to Sentry.
     !exception.is_a?(GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError)
   end
+
+  private
+
+  def hard_timeout
+    1.hour
+  end
 end

--- a/app/jobs/outlook/mass_destroy_event_job.rb
+++ b/app/jobs/outlook/mass_destroy_event_job.rb
@@ -17,5 +17,11 @@ module Outlook
       end
       agent.update!(microsoft_graph_token: nil, refresh_microsoft_graph_token: nil, outlook_disconnect_in_progress: false)
     end
+
+    private
+
+    def hard_timeout
+      20.minutes
+    end
   end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -25,20 +25,16 @@ describe ApplicationJob, type: :job do
     end
 
     let(:exports_timeout_job_class) do
-      stub_const "ExportsTimeoutJob", Class.new(described_class)
+      stub_const "ExportsTimeoutJob", Class.new(ExportJob)
       ExportsTimeoutJob.class_eval do
-        queue_as :exports
-
         def perform; end
       end
       ExportsTimeoutJob
     end
 
     let(:cron_timeout_job_class) do
-      stub_const "CronTimeoutJob", Class.new(described_class)
+      stub_const "CronTimeoutJob", Class.new(CronJob)
       CronTimeoutJob.class_eval do
-        queue_as :cron
-
         def perform; end
       end
       CronTimeoutJob


### PR DESCRIPTION
On avait un timeout de 30 secondes par défaut. Or, le job de suppression en masse d'événements Outlook a besoin de plus de 30 secondes.

https://sentry.incubateur.net/organizations/betagouv/issues/66829/?referrer=webhooks_plugin

Je fais donc en sorte de pouvoir définir des timeouts spécifiques par classe de job.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
