### PR TITLE
Stabiliser le fingerprinting des erreurs omniauth

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -32,7 +32,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
         strategy: strategy,
         error: error,
         error_type: error_type,
-        full_env: env.select { |_key, value| value.is_a?(String) },
+        full_env: env.transform_values { |value| value.is_a?(String) ? value : value.inspect },
       }
     )
     Sentry.add_breadcrumb(crumb)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -25,7 +25,8 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     crumb = Sentry::Breadcrumb.new(
       message: "Omniauth env values",
       data: {
-        error: env["omniauth.error"],
+        strategy: env["omniauth.error"],
+        error: env["omniauth.error.strategy"].class,
         error_type: env["omniauth.error.type"],
         full_env: env.select { |_key, value| value.is_a?(String) },
       }
@@ -34,7 +35,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
     Sentry.capture_message(
       "Omniauth failed : #{env['omniauth.error']}",
-      fingerprint: [env["omniauth.error.strategy"], env["omniauth.error.type"]]
+      fingerprint: [env["omniauth.error.strategy"].class, env["omniauth.error.type"]]
     )
 
     OmniauthCallbacksController.action(:failure).call(env)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -22,21 +22,22 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   )
 
   on_failure do |env|
+    strategy = env["omniauth.error.strategy"].class.name
+    error_type = env["omniauth.error.type"]
+    error = env["omniauth.error"]
+
     crumb = Sentry::Breadcrumb.new(
       message: "Omniauth env values",
       data: {
-        strategy: env["omniauth.error"],
-        error: env["omniauth.error.strategy"].class,
-        error_type: env["omniauth.error.type"],
+        strategy: strategy,
+        error: error,
+        error_type: error_type,
         full_env: env.select { |_key, value| value.is_a?(String) },
       }
     )
     Sentry.add_breadcrumb(crumb)
 
-    Sentry.capture_message(
-      "Omniauth failed : #{env['omniauth.error']}",
-      fingerprint: [env["omniauth.error.strategy"].class, env["omniauth.error.type"]]
-    )
+    Sentry.capture_message("Omniauth failed: #{error}", fingerprint: [strategy, error_type])
 
     OmniauthCallbacksController.action(:failure).call(env)
   end


### PR DESCRIPTION
Un fingerprint avait été conçu pour grouper les erreurs par provider **et** type d'erreur. Mais en fait la clé `omniauth.error.strategy` contient une instance d'une stratégie, dont l'`inspect` change donc à chaque fois.

```json
{
  "fingerprint": [
    "#<OmniAuth::Strategies::Franceconnect:0x00007fed4f158da0>",
    "csrf_detected"
  ]
}
```

Avec cette nouvelle version, on aura : 

```json
{
  "fingerprint": [
    "OmniAuth::Strategies::Franceconnect",
    "csrf_detected"
  ]
}
```

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
