### PR TITLE
Donner un peu de temps à TriggerWebhookJob

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -36,6 +36,8 @@ module DefaultJobBehaviour
     # (see: https://github.com/bensheldon/good_job#retries)
   end
 
+  private
+
   def log_failure_to_sentry?(_exception)
     true
   end

--- a/app/jobs/trigger_webhook_job.rb
+++ b/app/jobs/trigger_webhook_job.rb
@@ -9,4 +9,10 @@ class TriggerWebhookJob < ApplicationJob
     @webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
     @webhook_endpoint.trigger_for_all_subscribed_resources
   end
+
+  private
+
+  def hard_timeout
+    10.minutes
+  end
 end

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -15,12 +15,14 @@ class WebhookEndpoint < ApplicationRecord
   ].freeze
 
   def trigger_for_all_subscribed_resources
-    subscriptions.each do |subscription|
-      if subscription == "organisation"
-        trigger_for(organisation)
-      else
-        records = organisation.send(subscription.pluralize)
-        records.find_each { |record| trigger_for(record) }
+    transaction do
+      subscriptions.each do |subscription|
+        if subscription == "organisation"
+          trigger_for(organisation)
+        else
+          records = organisation.send(subscription.pluralize)
+          records.find_each { |record| trigger_for(record) }
+        end
       end
     end
   end


### PR DESCRIPTION
On a des levées de `Timeout.timeout` sur ce job donc visiblement il a besoin de plus de temps.

Le contexte aujourd'hui : pluie de notifs Sentry.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
