### PR TITLE
Correctif pour les stats par organisation

### DIFF
--- a/app/controllers/admin/organisations/stats_controller.rb
+++ b/app/controllers/admin/organisations/stats_controller.rb
@@ -5,7 +5,7 @@ class Admin::Organisations::StatsController < AgentAuthController
 
   def index
     @stats = Stat.new(
-      rdvs: policy_scope(Rdv).where(organisation: current_organisation),
+      rdvs: rdv_scope,
       agents: policy_scope(Agent)
         .joins(:organisations).where(organisations: { id: current_organisation.id }),
       users: policy_scope(User)
@@ -14,7 +14,7 @@ class Admin::Organisations::StatsController < AgentAuthController
 
   def rdvs
     skip_authorization
-    stats = Stat.new(rdvs: policy_scope(Rdv))
+    stats = Stat.new(rdvs: rdv_scope)
     stats = if params[:by_service].present?
               stats.rdvs_group_by_service
             elsif params[:by_location_type].present?
@@ -28,5 +28,11 @@ class Admin::Organisations::StatsController < AgentAuthController
   def users
     skip_authorization
     render json: Stat.new(users: policy_scope(User)).users_group_by_week
+  end
+
+  private
+
+  def rdv_scope
+    policy_scope(Rdv).where(organisation: current_organisation)
   end
 end

--- a/spec/controllers/admin/organisations/stats_controller_spec.rb
+++ b/spec/controllers/admin/organisations/stats_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::Organisations::StatsController do
+  describe "#rdvs" do
+    it "returns rdvs of the current organisation only" do
+      organisation = create(:organisation)
+      other_organisation = create(:organisation)
+      agent = create(:agent, admin_role_in_organisations: [organisation, other_organisation])
+
+      create(:rdv, organisation: organisation)
+      create(:rdv, organisation: other_organisation)
+      sign_in agent
+      get :rdvs, params: { organisation_id: organisation.id, agent_id: agent.id, format: :json }
+
+      expect(response).to be_successful
+
+      expect(JSON.parse(response.body)).to eq(
+        [
+          { "data" => [["24/09/2023", 1]], "name" => "Agent (1)" },
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
remarqué par la référente de la Drôme (voir le ticket zammad https://zammad10.ethibox.fr/#ticket/zoom/7833)

Les stats par organisation étaient pour tous les rdvs visibles par l'agent, et non pas ceux de l'organisation