### PR TITLE
Ajout d'un endpoint de calcul de créneaux pour les invitations

### DIFF
--- a/app/controllers/api/rdvi/organisations_controller.rb
+++ b/app/controllers/api/rdvi/organisations_controller.rb
@@ -4,14 +4,8 @@ class Api::Rdvi::OrganisationsController < Api::V1::AgentAuthBaseController
   before_action :set_organisation
 
   def available_creneaux_count
-    # render json: { available_creneaux_count: 0 }
-    # return
-
     total_creneaux = calculate_total_creneaux
     render json: { available_creneaux_count: total_creneaux }
-
-    # Quid de l'affichage dynamique dans rdvi si ils créent de nouveaux créneaux entre temps ? webhooks ?
-    # Pas de cache possible car recalcul si nvx rdv collectif ou plage d'ouverture créée entre temps
   end
 
   private
@@ -56,8 +50,7 @@ class Api::Rdvi::OrganisationsController < Api::V1::AgentAuthBaseController
   end
 
   def calculate_collective_creneaux(motif, date_range)
-    rdvs = Rdv.collectif_and_available_for_reservation.where(motif: motif, starts_at: date_range)
-    rdvs.sum(&:remaining_seats)
+    Rdv.collectif_and_available_for_reservation.where(motif: motif, starts_at: date_range).sum(&:remaining_seats)
   end
 
   def calculate_individual_creneaux(motif, date_range)

--- a/app/controllers/api/rdvi/organisations_controller.rb
+++ b/app/controllers/api/rdvi/organisations_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class Api::Rdvi::OrganisationsController < Api::V1::AgentAuthBaseController
+  before_action :set_organisation
+
+  def available_creneaux_count
+    # render json: { available_creneaux_count: 0 }
+    # return
+
+    total_creneaux = calculate_total_creneaux
+    render json: { available_creneaux_count: total_creneaux }
+
+    # Quid de l'affichage dynamique dans rdvi si ils créent de nouveaux créneaux entre temps ? webhooks ?
+    # Pas de cache possible car recalcul si nvx rdv collectif ou plage d'ouverture créée entre temps
+  end
+
+  private
+
+  def set_organisation
+    @organisation = Organisation.find(params[:id])
+    authorize @organisation
+  end
+
+  def calculate_total_creneaux
+    sc = initialize_search_context
+
+    motifs = sc.unique_motifs_by_name_and_location_type
+    date_range = compute_date_range
+
+    total_creneaux = 0
+    motifs.each do |motif|
+      total_creneaux += if motif.collectif?
+                          calculate_collective_creneaux(motif, date_range)
+                        else
+                          calculate_individual_creneaux(motif, date_range)
+                        end
+    end
+
+    total_creneaux
+  end
+
+  def initialize_search_context
+    SearchContext.new(
+      user: nil,
+      query_params: {
+        motif_category_short_name: params[:motif_category_short_name],
+        organisation_ids: [params[:id]],
+      },
+      through_invitation: true
+    )
+  end
+
+  def compute_date_range
+    max_delay = params[:max_delay].to_i
+    Time.zone.today..(Time.zone.today + max_delay.days)
+  end
+
+  def calculate_collective_creneaux(motif, date_range)
+    rdvs = Rdv.collectif_and_available_for_reservation.where(motif: motif, starts_at: date_range)
+    rdvs.sum(&:remaining_seats)
+  end
+
+  def calculate_individual_creneaux(motif, date_range)
+    total_creneaux = 0
+    motif.lieux.each do |lieu|
+      creneau_search = Users::CreneauxSearch.new(
+        user: nil,
+        motif: motif,
+        lieu: lieu,
+        date_range: date_range,
+        geo_search: nil
+      )
+      total_creneaux += creneau_search.creneaux.count
+    end
+    total_creneaux
+  end
+end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -44,9 +44,9 @@ class Motif < ApplicationRecord
   has_many :motifs_plage_ouvertures, dependent: :delete_all
 
   # Through relations
-  has_many :lieux, through: :plage_ouvertures
   has_many :webhook_endpoints, through: :organisation
   has_many :plage_ouvertures, -> { distinct }, through: :motifs_plage_ouvertures
+  has_many :lieux, through: :plage_ouvertures
 
   # Delegates
   delegate :service_social?, to: :service

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -295,6 +295,12 @@ class Rdv < ApplicationRecord
     Time.zone.now + motif.max_public_booking_delay
   end
 
+  def remaining_seats
+    return 0 unless max_participants_count
+
+    max_participants_count - users_count
+  end
+
   def remaining_seats?
     return true unless max_participants_count
 

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -9,6 +9,9 @@ class Agent::OrganisationPolicy < DefaultAgentPolicy
     current_agent.roles.access_level_admin.pluck(:organisation_id).include?(record.id)
   end
 
+  # Droit à faire valider/vérifier
+  alias available_creneaux_count? admin_in_record_organisation?
+
   def new?
     current_agent.territorial_admin_in?(record.territory)
   end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -27,6 +27,12 @@ namespace :api do
     get "availableTimeSlots", to: "editor#available_time_slots"
     get "searchApplicationIds", to: "editor#search_application_ids"
   end
+
+  namespace :rdvi do
+    resources :organisations, only: [] do
+      get 'available_creneaux_count', to: 'organisations#available_creneaux_count', on: :member
+    end
+  end
 end
 
 # This one has been published before versioning the public API and unification with auth API:


### PR DESCRIPTION
WIP
En lien avec https://github.com/betagouv/rdv-insertion/issues/1237

Ajout d'un endpoint pour le calcul des créneaux disponibles (individuels et collectifs) pour des invitations avec les paramêtres suivants : 
L'organisation (obligatoire)
Le délai max pour le calcul des créneaux dispos (obligatoire)
Un nom de catégorie de motif (Optionnel)