### PR TITLE
Ajout d'un timeout aux appels synchrones de l'api ANTS

### DIFF
--- a/app/models/concerns/user/ants.rb
+++ b/app/models/concerns/user/ants.rb
@@ -13,7 +13,7 @@ module User::Ants
   end
 
   def self.find_appointment(application_id)
-    AntsApi::Appointment.first(application_id: application_id, timeout: 2)
+    AntsApi::Appointment.first(application_id: application_id, timeout: 4)
   rescue AntsApi::Appointment::ApiRequestError, Typhoeus::Errors::TimeoutError => e
     # Si l'api de l'ANTS renvoie une erreur ou un timeout, on ne veut pas bloquer la prise de rendez-vous
     # pour l'usager, donc on considère le numéro comme valide.

--- a/app/models/concerns/user/ants.rb
+++ b/app/models/concerns/user/ants.rb
@@ -13,8 +13,10 @@ module User::Ants
   end
 
   def self.find_appointment(application_id)
-    AntsApi::Appointment.first(application_id: application_id)
-  rescue AntsApi::Appointment::ApiRequestError => e
+    AntsApi::Appointment.first(application_id: application_id, timeout: 2)
+  rescue AntsApi::Appointment::ApiRequestError, Typhoeus::Errors::TimeoutError => e
+    # Si l'api de l'ANTS renvoie une erreur ou un timeout, on ne veut pas bloquer la prise de rendez-vous
+    # pour l'usager, donc on considère le numéro comme valide.
     Sentry.capture_exception(e)
     nil
   end

--- a/app/services/ants_api/appointment.rb
+++ b/app/services/ants_api/appointment.rb
@@ -57,8 +57,8 @@ module AntsApi
         Appointment.new(application_id: application_id, **appointment_data.symbolize_keys) if appointment_data
       end
 
-      def first(application_id:)
-        appointment_data = load_appointments(application_id).first
+      def first(application_id:, timeout: nil)
+        appointment_data = load_appointments(application_id, timeout: timeout).first
         Appointment.new(application_id: application_id, **appointment_data.symbolize_keys) if appointment_data
       end
 
@@ -80,12 +80,13 @@ module AntsApi
 
       private
 
-      def load_appointments(application_id)
+      def load_appointments(application_id, timeout: nil)
         response_body = request do
           Typhoeus.get(
             "#{ENV['ANTS_RDV_API_URL']}/status",
             params: { application_ids: application_id },
-            headers: headers
+            headers: headers,
+            timeout: timeout
           )
         end
 

--- a/spec/controllers/admin/organisations/stats_controller_spec.rb
+++ b/spec/controllers/admin/organisations/stats_controller_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Admin::Organisations::StatsController do
   describe "#rdvs" do
     it "returns rdvs of the current organisation only" do
+      travel_to(Time.zone.parse("2023-09-24"))
       organisation = create(:organisation)
       other_organisation = create(:organisation)
       agent = create(:agent, admin_role_in_organisations: [organisation, other_organisation])


### PR DESCRIPTION
suite au pic d'erreur de timeout depuis hier : https://sentry.incubateur.net/organizations/betagouv/issues/67365/?environment=production&project=74&query=is%3Aunresolved&referrer=issue-stream

Pour éviter de bloquer les utilisateurs qui veulent prendre rendez-vous, on ajoute un timeout et on considère que le numéro de pré-demande est valide.
Cela introduit un léger risque de doublons de rendez-vous, mais on considère que c'est tolérable plutôt que de bloquer la prise de rendez-vous pour tout le monde.