### PR TITLE
Raccourcissement du timeout ants

### DIFF
--- a/app/models/concerns/user/ants.rb
+++ b/app/models/concerns/user/ants.rb
@@ -13,7 +13,7 @@ module User::Ants
   end
 
   def self.find_appointment(application_id)
-    AntsApi::Appointment.first(application_id: application_id, timeout: 4)
+    AntsApi::Appointment.first(application_id: application_id, timeout: 1)
   rescue AntsApi::Appointment::ApiRequestError, Typhoeus::Errors::TimeoutError => e
     # Si l'api de l'ANTS renvoie une erreur ou un timeout, on ne veut pas bloquer la prise de rendez-vous
     # pour l'usager, donc on considère le numéro comme valide.


### PR DESCRIPTION
Ils ont confirmés qu'ils ont un soucis de leur côté, on raccourcit le timeout en attendant qu'ils le réparent.