### PR TITLE
Ajout d'un index sur `rdvs.uuid`

### DIFF
--- a/db/migrate/20231002124541_add_index_to_rdvs_uuid.rb
+++ b/db/migrate/20231002124541_add_index_to_rdvs_uuid.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToRdvsUuid < ActiveRecord::Migration[7.0]
+  def change
+    add_index :rdvs, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_12_082341) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_02_124541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -487,6 +487,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_082341) do
     t.index ["status"], name: "index_rdvs_on_status"
     t.index ["updated_at"], name: "index_rdvs_on_updated_at"
     t.index ["users_count"], name: "index_rdvs_on_users_count"
+    t.index ["uuid"], name: "index_rdvs_on_uuid"
   end
 
   create_table "rdvs_users", force: :cascade do |t|


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/67442/?project=74&referrer=webhooks_plugin

Nous avons eu un timeout de la requête

```ruby
Rdv.unscoped.find_by(uuid: uuid) if uuid
```

ce qui m'a fait remarquer qu'il n'y a pas d'index sur cette colonne ! :fearful: 

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
