### PR TITLE
Changer l'ordre d'affichage des RDVs

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -11,7 +11,7 @@ class Admin::RdvsController < AgentAuthController
     set_scoped_organisations
     @breadcrumb_page = params[:breadcrumb_page]
 
-    order = { starts_at: :asc }
+    order = { starts_at: :desc }
     @rdvs = policy_scope(Rdv).search_for(@scoped_organisations, parsed_params)
       .order(order).page(params[:page]).per(10)
 


### PR DESCRIPTION
Discuté avec @mekaidmekaid : on sait qu'il y a un ensemble de quick wins à faire sur la page de liste des RDVs (avoir des onglets "RDVs à venir", "RDVs du jour", "RDVs passés", etc...). Ceci étant dit, les référent⋅es ont affirmé qu'un ordre de RDV antichronologique serait plus utile que l'ordre chronologique, **même si cela implique de voir des RDVs futurs en premier**.

# Avant

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/34289df0-8543-49bd-9d55-77ef3799ab0a)

# Après

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/9fa483f4-8978-4d00-995a-655a09065078)


# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
