### PR TITLE
Spike : utiliser le thème bootstrap DSFR

### DIFF
--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -8,6 +8,8 @@
 @import "~select2/dist/css/select2";
 @import "~select2-bootstrap4-theme/dist/select2-bootstrap4.min";
 
+@import "dsfr-connect/dist/bootstrap-v5";
+
 // Plugins
 @import '@fullcalendar/core/main';
 @import '@fullcalendar/daygrid/main';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartkick": "^5.0.1",
     "custom-event-polyfill": "^1.0.7",
+    "dsfr-connect": "^1.0.5",
     "holderjs": "^2.9.6",
     "jquery": "^3.4.0",
     "jquery-datetimepicker": "^2.5.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,6 +506,11 @@ date-fns@>=2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
+dsfr-connect@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/dsfr-connect/-/dsfr-connect-1.0.5.tgz#919bb398f992b4bfe8e5de0df806197ae5a9a2e8"
+  integrity sha512-TmM+TR5lkvRsT4KrPuTCn8Bdd8VU66DYc3KpsjgAAruKE7QKKtnVDToltD4YzoRvL/k5JLiEp50BEZnv1Vc3yA==
+
 electron-to-chromium@^1.4.118:
   version "1.4.132"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.132.tgz#b64599eb018221e52e2e4129de103b03a413c55d"


### PR DESCRIPTION
Nous commençons à implémenter des maquettes côté agent, et plusieurs possibilités s'offrent à nous : 

1. Continuer d'utiliser le design système actuel : composants bootstrap et quelques arrangements
2. Installer le [thème bootstrap "DSFR" créé par Thomas Ramé](https://dsfr-connect.rame.fr/main/) pour beta
3. Charger la librairie CSS DSFR officielle en plus de notre CSS actuel : risque de conflits

# Look actuel

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/9c8b5607-e172-41d8-b4ce-01abb014386d)

# Avec thème bootstrap DSFR

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/6f795d30-06d9-49e0-b163-58cbd4b89fa7)

# En important à la fois bootstrap et le DSFR

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/6e6316ad-3aec-44b1-932c-f3b55cc75d37)


# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
