### PR TITLE
Eviter la création de doublons usager

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -21,8 +21,8 @@ class Agents::UsersController < AgentAuthController
     results_count = users_from_organisation.count
 
     users_from_territory = if results_count < MAX_RESULTS
-                             user_scope.joins(:territories).where(territories: { id: current_agent.agent_territorial_access_rights.pluck(:territory_id) })
-                               .where.not(id: users_from_organisation.ids)
+                             user_scope.joins(:territories).where(territories: { id: current_agent.agent_territorial_access_rights.select(:territory_id) })
+                               .where.not(id: users_from_organisation.select(:id))
                                .limit(MAX_RESULTS - results_count)
                            else
                              []

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -21,7 +21,7 @@ class Agents::UsersController < AgentAuthController
     results_count = users_from_organisation.count
 
     users_from_territory = if results_count < MAX_RESULTS
-                             user_scope.joins(:territories).where(territories: current_agent.territories)
+                             user_scope.joins(:territories).where(territories: { id: current_agent.agent_territorial_access_rights.pluck(:territory_id) })
                                .where.not(id: users_from_organisation.ids)
                                .limit(MAX_RESULTS - results_count)
                            else

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -12,7 +12,7 @@ class Agents::UsersController < AgentAuthController
       return head :forbidden
     end
 
-    user_scope = UserSearchParser.new(params[:term]).scope.where.not(id: params[:exclude_ids])
+    user_scope = User.where.not(id: params[:exclude_ids]).search_by_text(params[:term])
 
     users_from_organisation = user_scope.joins(:user_profiles).where(user_profiles: { organisation_id: params[:organisation_id] }).limit(MAX_RESULTS)
 
@@ -43,57 +43,6 @@ class Agents::UsersController < AgentAuthController
     end
 
     render json: { results: results }
-  end
-
-  class UserSearchParser
-    def initialize(prompt)
-      @prompt = prompt.squish
-    end
-
-    def scope
-      @terms = @prompt.split.map { Term.new(_1) }
-      scope = User.all
-      scope = User.search_by_text(text_search) if text_search
-      scope = scope.where(birth_date: date_terms.last.date) if date_terms.any?
-      scope
-    end
-
-    private
-
-    def text_search
-      text_terms = @terms.select(&:text?)
-      return unless text_terms.any?
-
-      text_terms.map(&:str).join(" ")
-    end
-
-    def date_terms
-      @terms.select(&:date?)
-    end
-
-    class Term
-      def initialize(str)
-        @str = str
-      end
-
-      attr_reader :str
-
-      def date
-        return unless @str =~ %r{[0-3][0-9]/[0-1][0-9]/[0-9]{4}}
-
-        Date.strptime(@str, "%d/%m/%Y")
-      rescue Date::Error
-        nil
-      end
-
-      def date?
-        !date.nil?
-      end
-
-      def text?
-        !date?
-      end
-    end
   end
 
   private

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -18,7 +18,34 @@ class Agents::UsersController < AgentAuthController
                            else
                              []
                            end
+    if users_from_organisation.none? && users_from_territory.none?
+      render json: { results: [] }
+    else
 
-    @users = users_from_organisation + users_from_territory
+      render json: {
+        results: [
+          {
+            text: nil,
+            children: users_from_organisation.map do |user|
+              {
+                id: user.id,
+                text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+              }
+            end,
+          },
+          users_from_territory.first && {
+            text: "Usagers des autres organisations",
+            children: users_from_territory.map do |user|
+              {
+                id: user.id,
+                text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+              }
+            end,
+
+          },
+        ].compact,
+
+      }
+    end
   end
 end

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -7,6 +7,13 @@ class Agents::UsersController < AgentAuthController
 
   def search
     skip_authorization # On scope les usagers par organisation puis par territoire via de la logique métier plutôt qu'une policy Pundit
+    # Dans cette recherche, on autorise un périmètre plus grand que la policy de base, puisqu'on est en train d'ajouter un usager à l'organisation en créant un rdv
+
+    # On veut quand même vérifier que l'organisation demandée fait partie des organisations de l'agent
+    if current_agent.organisations.find_by(id: params[:organisation_id]).nil?
+      return head :forbidden
+    end
+
     user_scope = User.where.not(id: params[:exclude_ids]).search_by_text(params[:term])
 
     users_from_organisation = user_scope.joins(:user_profiles).where(user_profiles: { organisation_id: params[:organisation_id] }).limit(MAX_RESULTS)
@@ -14,38 +21,38 @@ class Agents::UsersController < AgentAuthController
     results_count = users_from_organisation.count
 
     users_from_territory = if results_count < MAX_RESULTS
-                             user_scope.joins(:territories).where(territories: current_agent.territories).limit(MAX_RESULTS - results_count).where.not(id: users_from_organisation.ids)
+                             user_scope.joins(:territories).where(territories: current_agent.territories)
+                               .where.not(id: users_from_organisation.ids)
+                               .limit(MAX_RESULTS - results_count)
                            else
                              []
                            end
-    if users_from_organisation.none? && users_from_territory.none?
-      render json: { results: [] }
-    else
 
-      render json: {
-        results: [
-          {
-            text: nil,
-            children: users_from_organisation.map do |user|
-              {
-                id: user.id,
-                text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
-              }
-            end,
-          },
-          users_from_territory.first && {
-            text: "Usagers des autres organisations",
-            children: users_from_territory.map do |user|
-              {
-                id: user.id,
-                text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
-              }
-            end,
+    results = []
 
-          },
-        ].compact,
-
+    if users_from_organisation.any?
+      results << {
+        text: nil,
+        children: users_from_organisation.map { |user| serialize(user) },
       }
     end
+
+    if users_from_territory.any?
+      results << {
+        text: "Usagers des autres organisations",
+        children: users_from_territory.map { |user| serialize(user) },
+      }
+    end
+
+    render json: { results: results }
+  end
+
+  private
+
+  def serialize(user)
+    {
+      id: user.id,
+      text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+    }
   end
 end

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Agents::UsersController < AgentAuthController
   respond_to :json
 

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Agents::UsersController < AgentAuthController
+  respond_to :json
+
+  MAX_RESULTS = 4
+
+  def search
+    skip_authorization # On scope les usagers par organisation puis par territoire via de la logique métier plutôt qu'une policy Pundit
+    user_scope = User.where.not(id: params[:exclude_ids]).search_by_text(params[:term])
+
+    users_from_organisation = user_scope.joins(:user_profiles).where(user_profiles: { organisation_id: params[:organisation_id] }).limit(MAX_RESULTS)
+
+    results_count = users_from_organisation.count
+
+    users_from_territory = if results_count < MAX_RESULTS
+                             user_scope.joins(:territories).where(territories: current_agent.territories).limit(MAX_RESULTS - results_count).where.not(id: users_from_organisation.ids)
+                           else
+                             []
+                           end
+
+    @users = users_from_organisation + users_from_territory
+  end
+end

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -9,7 +9,7 @@ class Agents::UsersController < AgentAuthController
     skip_authorization # On scope les usagers par organisation puis par territoire via de la logique métier plutôt qu'une policy Pundit
     # Dans cette recherche, on autorise un périmètre plus grand que la policy de base, puisqu'on est en train d'ajouter un usager à l'organisation en créant un rdv
 
-    # On veut quand même vérifier que l'organisation demandée fait partie des organisations de l'agent
+    # On vérifie quand même que l'organisation demandée fait partie des organisations de l'agent
     if current_agent.organisations.find_by(id: params[:organisation_id]).nil?
       return head :forbidden
     end
@@ -33,14 +33,14 @@ class Agents::UsersController < AgentAuthController
     if users_from_organisation.any?
       results << {
         text: nil,
-        children: users_from_organisation.map { |user| serialize(user) },
+        children: serialize(users_from_organisation),
       }
     end
 
     if users_from_territory.any?
       results << {
         text: "Usagers des autres organisations",
-        children: users_from_territory.map { |user| serialize(user) },
+        children: serialize(users_from_territory),
       }
     end
 
@@ -49,10 +49,12 @@ class Agents::UsersController < AgentAuthController
 
   private
 
-  def serialize(user)
-    {
-      id: user.id,
-      text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
-    }
+  def serialize(users)
+    users.map do |user|
+      {
+        id: user.id,
+        text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+      }
+    end
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -58,7 +58,7 @@ module UsersHelper
   end
 
   def self.reverse_full_name_and_notification_coordinates(user)
-    [user.reverse_full_name, user.humanized_phone_number, user.email, user.birth_date && I18n.l(user.birth_date)].compact.join(" - ")
+    [user.reverse_full_name, user.birth_date && I18n.l(user.birth_date), user.humanized_phone_number, user.email].compact.join(" - ")
   end
 
   def birth_date_and_age_if_exist(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -58,7 +58,7 @@ module UsersHelper
   end
 
   def self.reverse_full_name_and_notification_coordinates(user)
-    [user.reverse_full_name, user.humanized_phone_number, user.email].compact.join(" - ")
+    [user.reverse_full_name, user.humanized_phone_number, user.email, user.birth_date && I18n.l(user.birth_date)].compact.join(" - ")
   end
 
   def birth_date_and_age_if_exist(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -57,6 +57,10 @@ module UsersHelper
     user.reverse_full_name + birth_date_and_age_if_exist(user)
   end
 
+  def reverse_full_name_and_notification_coordinates(user)
+    [user.reverse_full_name, user.humanized_phone_number, user.email].compact.join(" - ")
+  end
+
   def birth_date_and_age_if_exist(user)
     return " - #{birth_date_and_age(user)}" if user.birth_date
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -57,7 +57,7 @@ module UsersHelper
     user.reverse_full_name + birth_date_and_age_if_exist(user)
   end
 
-  def reverse_full_name_and_notification_coordinates(user)
+  def self.reverse_full_name_and_notification_coordinates(user)
     [user.reverse_full_name, user.humanized_phone_number, user.email].compact.join(" - ")
   end
 

--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -16,5 +16,6 @@
 }
 
 .select2-container--bootstrap4 .select2-results__group {
+  padding-top: 18px;
   font-size: initial;
 }

--- a/app/lib/phone_number_validation.rb
+++ b/app/lib/phone_number_validation.rb
@@ -54,5 +54,9 @@ module PhoneNumberValidation
       format_phone_number
       super
     end
+
+    def humanized_phone_number
+      Phonelib.parse(phone_number_formatted).national
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,7 @@ class User < ApplicationRecord
   # we specify dependent: :destroy because by default user_profiles and referent_assignations
   # will be deleted (dependent: :delete) and we need to destroy to trigger the callbacks on both models
   has_many :organisations, through: :user_profiles, dependent: :destroy
+  has_many :territories, through: :organisations
   has_many :referent_agents, through: :referent_assignations, source: :agent, dependent: :destroy, class_name: "Agent"
   has_many :webhook_endpoints, through: :organisations
   has_many :rdvs, through: :participations

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -21,7 +21,7 @@ ruby:
           div
             i.fa.fa-user
             | &nbsp;
-            = reverse_full_name_and_birthdate(user)
+            = reverse_full_name_and_notification_coordinates(user)
             = relative_tag(user)
           ruby:
             remove_path_params = @rdv_wizard.to_query.deep_dup.merge(step: 2)
@@ -41,25 +41,27 @@ ruby:
       = link_to ".collapse-add-user-selection", data: { toggle: "collapse" }
         i.fa.fa-plus-circle
         span.ml-1= t("helpers.add")
-    .mt-2.collapse.collapse-add-user-selection.no-transition class=(show_add_user ? "show" : "")
-      = select_tag :status,
-      options_for_select([]),
-      include_blank: "Sélectionner un usager",
-      required: false,
-      class: "select2-input js-new-rdv-users-select",
-      data: { \
-        width: "auto", \
-        "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.users.map(&:id)), dataType: "json", delay: 250 }}, \
-      }
+    .pl-2.mt-2.collapse.collapse-add-user-selection.no-transition class=(show_add_user ? "show" : "")
+      = label_tag :user_search, "Rechercher un usager", {class: "form-control-label string optional"}
+      div.form-row.grid-align-center
+        .flex-grow-1.pr-4
+          = select_tag :status,
+          options_for_select([]),
+          required: false,
+          class: "select2-input js-new-rdv-users-select",
+          data: { \
+            width: :style,
+            "select-options": { ajax: { url: search_agents_users_path(exclude_ids: @rdv.users.map(&:id), organisation_id: @rdv.organisation_id), dataType: "json", delay: 250}, placeholder: "Nom, prénom, téléphone, ou email" }, \
+          }
 
-      span.small.text-muted
-        | L'usager n'existe pas ?&nbsp;
-        = link_to \
-          "Créer un usager", \
-          new_admin_organisation_user_path( \
-              current_organisation, modal: true, return_location: modals_return_location, role: default_service_selection_from(@rdv.motif.service) \
-              ), \
-          data: { modal: true }
+        span.small.text-muted
+          | L'usager n'existe pas ?&nbsp;
+          = link_to \
+            "Créer un usager", \
+            new_admin_organisation_user_path( \
+                current_organisation, modal: true, return_location: modals_return_location, role: default_service_selection_from(@rdv.motif.service) \
+                ), \
+            data: { modal: true }
 
     - if current_organisation.territory.enable_context_field
       .mt-3= f.input :context, as: :text, label: Rdv.human_attribute_name(:context), input_html: { rows: 4 }

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -21,7 +21,7 @@ ruby:
           div
             i.fa.fa-user
             | &nbsp;
-            = reverse_full_name_and_notification_coordinates(user)
+            = UsersHelper.reverse_full_name_and_notification_coordinates(user)
             = relative_tag(user)
           ruby:
             remove_path_params = @rdv_wizard.to_query.deep_dup.merge(step: 2)

--- a/app/views/agents/users/search.json.jbuilder
+++ b/app/views/agents/users/search.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+json.results @users do |user|
+  json.id user.id
+  json.text reverse_full_name_and_notification_coordinates(user)
+end

--- a/app/views/agents/users/search.json.jbuilder
+++ b/app/views/agents/users/search.json.jbuilder
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-json.results @users do |user|
-  json.id user.id
-  json.text reverse_full_name_and_notification_coordinates(user)
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,12 @@ Rails.application.routes.draw do
         resource :webcal_sync, only: %i[show update], controller: :webcal_sync
         resource :outlook_sync, only: %i[show destroy], controller: :outlook_sync
       end
+
+      resources :users, only: [] do
+        collection do
+          get "search"
+        end
+      end
     end
     get "omniauth/microsoft_graph/callback" => "omniauth_callbacks#microsoft_graph"
   end

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -332,6 +332,30 @@ user_org_paris_nord_jean.skip_confirmation!
 user_org_paris_nord_jean.save!
 user_org_paris_nord_jean.profile_for(org_paris_nord).update!(logement: 2)
 
+user_org_arques = User.new(
+  first_name: "Francis",
+  last_name: "Factice",
+  password: "lapinlapin",
+  phone_number: "0611223344",
+  organisation_ids: [org_arques.id],
+  created_through: "user_sign_up"
+)
+
+user_org_arques.skip_confirmation!
+user_org_arques.save!
+
+user_org_bapaume = User.new(
+  first_name: "François",
+  last_name: "Factice",
+  password: "lapinlapin",
+  email: "francois@factice.cool",
+  organisation_ids: [org_bapaume.id],
+  created_through: "user_sign_up"
+)
+
+user_org_bapaume.skip_confirmation!
+user_org_bapaume.save!
+
 # Insert a lot of users and add them to the paris_nord organisation
 # rubocop:disable Rails/SkipsModelValidations
 now = Time.zone.now

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -4,7 +4,7 @@ describe "Agent can create a Rdv with wizard" do
   let(:territory) { create(:territory, enable_context_field: true) }
   let(:organisation) { create(:organisation, territory: territory) }
   let(:service) { create(:service) }
-  let!(:agent) { create(:agent, first_name: "Alain", last_name: "DIALO", service: service, basic_role_in_organisations: [organisation], territories: [territory]) }
+  let!(:agent) { create(:agent, first_name: "Alain", last_name: "DIALO", service: service, basic_role_in_organisations: [organisation]) }
   let!(:agent2) { create(:agent, first_name: "Robert", last_name: "Martin", service: service, basic_role_in_organisations: [organisation]) }
   let!(:motif) { create(:motif, :collectif, :at_public_office, service: service, organisation: organisation, name: "Super Motif") }
   let!(:lieu) { create(:lieu, organisation: organisation) }
@@ -116,6 +116,8 @@ describe "Agent can create a Rdv with wizard" do
     end
 
     describe "with a user from outside the organisation" do
+      before { create(:agent_territorial_access_right, agent: agent, territory: territory) }
+
       let(:other_organisation) { create(:organisation, territory: territory) }
 
       let!(:user_from_other_organisation) { create(:user, organisations: [other_organisation]) }

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -131,7 +131,7 @@ describe "Agent can create a Rdv with wizard" do
         step4
 
         expect(user_from_other_organisation.rdvs.count).to eq(1)
-        expect(user_from_other_organisation.reload.organisations).to include(organisation)
+        expect(user_from_other_organisation.reload.organisations).to match_array([organisation, other_organisation])
       end
     end
 

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Step 2 of the rdv wizard" do
   let(:other_organisation) { create(:organisation, territory: territory) }
   let(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
 
-  before { create(:agent_territorial_role, agent: agent, territory: territory) }
+  before { create(:agent_territorial_access_right, agent: agent, territory: territory) }
 
   it "allows searching for users", js: true do
     login_as(agent, scope: :agent)

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -50,25 +50,4 @@ RSpec.describe "Step 2 of the rdv wizard" do
 
     expect(page).to have_content("Aucun résultat")
   end
-
-  it "allows searching by birth date", js: true do
-    user.update!(birth_date: Date.new(1990, 4, 2))
-
-    login_as(agent, scope: :agent)
-    visit new_admin_organisation_rdv_wizard_step_path(params)
-
-    # Click on the search field
-    find(".collapse-add-user-selection .select2-selection").click
-
-    find(".select2-search__field").send_keys("Franc")
-    expect(page).to have_content("FICTIF François")
-
-    find(".select2-search__field").send_keys(" 22/11/2002")
-    expect(page).not_to have_content("FICTIF François")
-
-    11.times { find(".select2-search__field").send_keys(:backspace) } # erase " 02/04/1990"
-
-    find(".select2-search__field").send_keys(" 02/04/1990")
-    expect(page).to have_content("FICTIF François")
-  end
 end

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Step 2 of the rdv wizard" do
   let(:motif) { create(:motif, :by_phone, organisation: organisation) }
   let(:params) do

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Step 2 of the rdv wizard" do
       step: 2,
     }
   end
-  let!(:user) { create(:user, organisations: [organisation], first_name: "François", last_name: "Fictif", phone_number_formatted: "+33611223344", email: nil) }
+  let!(:user) { create(:user, organisations: [organisation], first_name: "François", last_name: "Fictif", phone_number: "06.11.223344", email: nil, birth_date: Date.new(1990, 1, 1)) }
   let!(:user_from_other_organisation) { create(:user, organisations: [other_organisation], first_name: "Francis", last_name: "Factice", phone_number_formatted: nil, email: "francis@factice.cool") }
   let(:territory) { create(:territory) }
   let(:organisation) { create(:organisation, territory: territory) }
@@ -27,7 +27,7 @@ RSpec.describe "Step 2 of the rdv wizard" do
 
     find(".select2-search__field").send_keys("Franc")
 
-    expect(page).to have_content("FICTIF François")
+    expect(page).to have_content("FICTIF François - 06 11 22 33 44 - 01/01/1990")
     expect(page).to have_content("Usagers des autres organisations")
     expect(page).to have_content("FACTICE Francis")
 

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -50,4 +50,25 @@ RSpec.describe "Step 2 of the rdv wizard" do
 
     expect(page).to have_content("Aucun résultat")
   end
+
+  it "allows searching by birth date", js: true do
+    user.update!(birth_date: Date.new(1990, 4, 2))
+
+    login_as(agent, scope: :agent)
+    visit new_admin_organisation_rdv_wizard_step_path(params)
+
+    # Click on the search field
+    find(".collapse-add-user-selection .select2-selection").click
+
+    find(".select2-search__field").send_keys("Franc")
+    expect(page).to have_content("FICTIF François")
+
+    find(".select2-search__field").send_keys(" 22/11/2002")
+    expect(page).not_to have_content("FICTIF François")
+
+    11.times { find(".select2-search__field").send_keys(:backspace) } # erase " 02/04/1990"
+
+    find(".select2-search__field").send_keys(" 02/04/1990")
+    expect(page).to have_content("FICTIF François")
+  end
 end

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Step 2 of the rdv wizard" do
 
     find(".select2-search__field").send_keys("Franc")
 
-    expect(page).to have_content("FICTIF François - 06 11 22 33 44 - 01/01/1990")
+    expect(page).to have_content("FICTIF François - 01/01/1990 - 06 11 22 33 44")
     expect(page).to have_content("Usagers des autres organisations")
     expect(page).to have_content("FACTICE Francis")
 

--- a/spec/features/agents/rdv_wizard/step2_spec.rb
+++ b/spec/features/agents/rdv_wizard/step2_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe "Step 2 of the rdv wizard" do
+  let(:motif) { create(:motif, :by_phone, organisation: organisation) }
+  let(:params) do
+    {
+      organisation_id: organisation.id,
+      duration_in_min: 30,
+      motif_id: motif.id,
+      starts_at: 2.days.from_now,
+      step: 2,
+    }
+  end
+  let!(:user) { create(:user, organisations: [organisation], first_name: "François", last_name: "Fictif", phone_number_formatted: "+33611223344", email: nil) }
+  let!(:user_from_other_organisation) { create(:user, organisations: [other_organisation], first_name: "Francis", last_name: "Factice", phone_number_formatted: nil, email: "francis@factice.cool") }
+  let(:territory) { create(:territory) }
+  let(:organisation) { create(:organisation, territory: territory) }
+  let(:other_organisation) { create(:organisation, territory: territory) }
+  let(:agent) { create(:agent, service: motif.service, basic_role_in_organisations: [organisation]) }
+
+  before { create(:agent_territorial_role, agent: agent, territory: territory) }
+
+  it "allows searching for users", js: true do
+    login_as(agent, scope: :agent)
+    visit new_admin_organisation_rdv_wizard_step_path(params)
+
+    # Click on the search field
+    find(".collapse-add-user-selection .select2-selection").click
+
+    find(".select2-search__field").send_keys("Franc")
+
+    expect(page).to have_content("FICTIF François")
+    expect(page).to have_content("Usagers des autres organisations")
+    expect(page).to have_content("FACTICE Francis")
+
+    find(".select2-search__field").send_keys("o") # Search is "Franco"
+
+    expect(page).to have_content("FICTIF François")
+    expect(page).not_to have_content("Usagers des autres organisations")
+    expect(page).not_to have_content("FACTICE Francis")
+
+    find(".select2-search__field").send_keys(:backspace)
+
+    find(".select2-search__field").send_keys("i") # Search is "Franci"
+
+    expect(page).not_to have_content("FICTIF François")
+    expect(page).to have_content("Usagers des autres organisations")
+    expect(page).to have_content("FACTICE Francis")
+
+    find(".select2-search__field").send_keys(:backspace)
+    find(".select2-search__field").send_keys("k")
+
+    expect(page).to have_content("Aucun résultat")
+  end
+end

--- a/spec/requests/agents/users_spec.rb
+++ b/spec/requests/agents/users_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe "Agents::UsersController" do
+  describe "#search" do
+    describe "when passing an organisation_id the agent doesn't belong to" do
+      let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let(:organisation) { create(:organisation) }
+      let(:other_organisation) { create(:organisation) }
+
+      it "returns a 403 error and an empty body" do
+        sign_in agent
+        get search_agents_users_path(organisation_id: other_organisation, exclude_ids: [])
+        expect(response.status).to eq 403
+        expect(response.body).to be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/agents/users_spec.rb
+++ b/spec/requests/agents/users_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 RSpec.describe "Agents::UsersController" do
   describe "#search" do
     describe "when passing an organisation_id the agent doesn't belong to" do

--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -2,7 +2,10 @@ module Select2SpecHelper
   def select_user(user)
     find(".collapse-add-user-selection .select2-selection").click
     find(".select2-search__field").send_keys(user.last_name[0..2])
-    find(".select2-results li.select2-results__option", text: user.reverse_full_name).click
+
+    result_selector = ".select2-results li.select2-results__option li"
+
+    find(result_selector, text: user.reverse_full_name).click
     expect(page).to have_selector("a[title='Modifier']")
   end
 

--- a/spec/support/select2_spec_helper.rb
+++ b/spec/support/select2_spec_helper.rb
@@ -2,10 +2,7 @@ module Select2SpecHelper
   def select_user(user)
     find(".collapse-add-user-selection .select2-selection").click
     find(".select2-search__field").send_keys(user.last_name[0..2])
-
-    result_selector = ".select2-results li.select2-results__option li"
-
-    find(result_selector, text: user.reverse_full_name).click
+    find(".select2-results li.select2-results__option li", text: user.reverse_full_name).click
     expect(page).to have_selector("a[title='Modifier']")
   end
 


### PR DESCRIPTION
L'objectif de cette PR est d'éviter la création de doublons usager par les agents lors de la prise de rendez-vous.

Aujourd'hui, on essaye d'éviter les doublons en avertissant l'agent d'un doublon potentiel lorsqu'il a fini de remplir la fiche usager lors de la création du rdv (voir le screenshot en début de l'issue).

Dans cette PR, on cherche à éviter que l'agent ai besoin de revenir en arrière après avoir rempli une fiche, et on étend le périmètre de la recherche d'usager à tout le territoire (puisque de toutes façons la recherche de doublon lors de la création de l'usager se fait à l'échelle de toute la base).

On améliore aussi l'UX de la recherche sur deux points :
- On rend explicite que cette recherche peut se faire par numéro de téléphone et email, en changeant le placeholder, et l'affichage des résultats de recherche.
- On déplace le cta de création d'un nouvel usager pour éviter qu'il soit caché par le dropdown de recherche, notamment dans le cas où on ne trouve aucun usager.

Closes #3653 

## Avant / Après

### Recherche

<img width="1180" alt="Screenshot 2023-10-13 at 12 40 37" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/78c7479d-d793-4d9c-93fc-253c26501f4e">
<img width="1182" alt="Screenshot 2023-10-13 at 12 40 23" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/74b24b1b-41b2-4160-8fc1-165ee40fd7ba">


### Résultats

<img width="1183" alt="Screenshot 2023-10-13 at 12 39 45" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/c1682230-ae30-41df-b284-36581a8cbf3f">
<img width="1185" alt="Screenshot 2023-10-13 at 12 40 02" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/2042030d-88ce-4d9a-9254-4408cdedb32b">

