### PR TITLE
Bugfix : mauvaises couleurs des plages d'ouverture

### DIFF
--- a/app/views/admin/agents/absences/index.json.jbuilder
+++ b/app/views/admin/agents/absences/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params], expires_in: 8.hours do
+json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
   json.array! @absence_occurrences do |absence, occurrence|
     json.title absence.title
     json.start occurrence.starts_at.as_json

--- a/app/views/admin/agents/absences/index.json.jbuilder
+++ b/app/views/admin/agents/absences/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
+json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params, @organisation.id], expires_in: 8.hours do
   json.array! @absence_occurrences do |absence, occurrence|
     json.title absence.title
     json.start occurrence.starts_at.as_json

--- a/app/views/admin/agents/absences/index.json.jbuilder
+++ b/app/views/admin/agents/absences/index.json.jbuilder
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
-  json.array! @absence_occurrences do |absence, occurrence|
-    json.title absence.title
-    json.start occurrence.starts_at.as_json
-    json.end occurrence.ends_at.as_json
-    json.backgroundColor "rgba(127, 140, 141, 0.7)"
+json.array! @absence_occurrences do |absence, occurrence|
+  json.title absence.title
+  json.start occurrence.starts_at.as_json
+  json.end occurrence.ends_at.as_json
+  json.backgroundColor "rgba(127, 140, 141, 0.7)"
 
-    # url pour éditer l'absence
-    json.url edit_admin_organisation_absence_path(@organisation, absence)
-  end
+  # url pour éditer l'absence
+  json.url edit_admin_organisation_absence_path(@organisation, absence)
 end

--- a/app/views/admin/agents/absences/index.json.jbuilder
+++ b/app/views/admin/agents/absences/index.json.jbuilder
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-json.array! @absence_occurrences do |absence, occurrence|
-  json.title absence.title
-  json.start occurrence.starts_at.as_json
-  json.end occurrence.ends_at.as_json
-  json.backgroundColor "rgba(127, 140, 141, 0.7)"
+json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
+  json.array! @absence_occurrences do |absence, occurrence|
+    json.title absence.title
+    json.start occurrence.starts_at.as_json
+    json.end occurrence.ends_at.as_json
+    json.backgroundColor "rgba(127, 140, 141, 0.7)"
 
-  # url pour éditer l'absence
-  json.url edit_admin_organisation_absence_path(@organisation, absence)
+    # url pour éditer l'absence
+    json.url edit_admin_organisation_absence_path(@organisation, absence)
+  end
 end

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params], expires_in: 8.hours do
+json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
   json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
     json.title plage_ouverture.title
     json.start occurrence.starts_at.as_json

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
+json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params, @organisation.id], expires_in: 8.hours do
   json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
     json.title plage_ouverture.title
     json.start occurrence.starts_at.as_json

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
-json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
-  json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
-    json.title plage_ouverture.title
-    json.start occurrence.starts_at.as_json
-    json.end occurrence.ends_at.as_json
-    if plage_ouverture.organisation == @organisation
-      json.backgroundColor "#6fceff80"
-    else
-      json.backgroundColor "grey"
-    end
-    json.textColor "#313131"
-    json.rendering "background" if params[:in_background]
+json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
+  json.title plage_ouverture.title
+  json.start occurrence.starts_at.as_json
+  json.end occurrence.ends_at.as_json
+  if plage_ouverture.organisation == @organisation
+    json.backgroundColor "#6fceff80"
+  else
+    json.backgroundColor "grey"
+  end
+  json.textColor "#313131"
+  json.rendering "background" if params[:in_background]
 
-    json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
-    json.extendedProps do
-      json.organisationName plage_ouverture.organisation.name
-      json.location plage_ouverture.lieu_address
-      json.lieu plage_ouverture.lieu_name
-    end
+  json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
+  json.extendedProps do
+    json.organisationName plage_ouverture.organisation.name
+    json.location plage_ouverture.lieu_address
+    json.lieu plage_ouverture.lieu_name
   end
 end

--- a/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
+++ b/app/views/admin/agents/plage_ouvertures/index.json.jbuilder
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
-  json.title plage_ouverture.title
-  json.start occurrence.starts_at.as_json
-  json.end occurrence.ends_at.as_json
-  if plage_ouverture.organisation == @organisation
-    json.backgroundColor "#6fceff80"
-  else
-    json.backgroundColor "grey"
-  end
-  json.textColor "#313131"
-  json.rendering "background" if params[:in_background]
+json.cache! [@plage_ouverture_occurrences, :all_occurrences_for, date_range_params, @organisation], expires_in: 8.hours do
+  json.array! @plage_ouverture_occurrences do |plage_ouverture, occurrence|
+    json.title plage_ouverture.title
+    json.start occurrence.starts_at.as_json
+    json.end occurrence.ends_at.as_json
+    if plage_ouverture.organisation == @organisation
+      json.backgroundColor "#6fceff80"
+    else
+      json.backgroundColor "grey"
+    end
+    json.textColor "#313131"
+    json.rendering "background" if params[:in_background]
 
-  json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
-  json.extendedProps do
-    json.organisationName plage_ouverture.organisation.name
-    json.location plage_ouverture.lieu_address
-    json.lieu plage_ouverture.lieu_name
+    json.url admin_organisation_plage_ouverture_path(@organisation, plage_ouverture)
+    json.extendedProps do
+      json.organisationName plage_ouverture.organisation.name
+      json.location plage_ouverture.lieu_address
+      json.lieu plage_ouverture.lieu_name
+    end
   end
 end


### PR DESCRIPTION
En explorant le sujet "agenda multi orga", nous avons repéré ce bug.

### Comportement attendu

Les plages d'ouvertures de l'orga courante est en bleu, celles des autres orgas sont en gris.

### Comportement observé

La couleur des plages d'ouvertures ne change pas lorsqu'on change d'orga.

### Explications et solution

La clé de cache ne contient pas l'organisation courante.

Plusieurs solutions possibles : 
1.  ajouter `@organisation.id` dans la clé de cache
2. ne plus utiliser de cache sur les plages d'ouvertures en JSON

J'ai opté pour la 1, car je pense que ce cache est utile avec tout le polling qu'on fait et la basse fréquence d'invalidation.

Chaud d'avoir vos avis ! :wink: 

PS : l'attribut `url` des données renvoyées est aussi impacté par ce bug, car il dépend lui aussi de l'orga.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
