### PR TITLE
Aider à la cohérence des noms de motifs entre les orgas (autocomplétion à la saisie)

### DIFF
--- a/app/helpers/creneaux_helper.rb
+++ b/app/helpers/creneaux_helper.rb
@@ -32,6 +32,8 @@ module CreneauxHelper
   end
 
   def build_agent_creneaux_search_form(organisation, params)
+    raise "et voilà" if params.fetch(:user_ids, []).compact_blank.present?
+
     AgentCreneauxSearchForm.new(
       organisation_id: organisation.id,
       service_id: params[:service_id],

--- a/app/helpers/creneaux_helper.rb
+++ b/app/helpers/creneaux_helper.rb
@@ -32,8 +32,6 @@ module CreneauxHelper
   end
 
   def build_agent_creneaux_search_form(organisation, params)
-    raise "et voilà" if params.fetch(:user_ids, []).compact_blank.present?
-
     AgentCreneauxSearchForm.new(
       organisation_id: organisation.id,
       service_id: params[:service_id],

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -15,6 +15,8 @@
             }, \
           }
         .col-md-6
+          / Nous voulons que l'autocomplete ne propose que les noms des motifs en base,
+          / pas celles de l'historique de saisie du navigateur, d'où le autocomplete="off".
           = f.input :name, input_html: { list: "motif_names", autocomplete: "off" }
           datalist#motif_names
             - Motif.where(organisation_id: current_agent.organisations).map(&:name).uniq.each do |org_name|

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -15,7 +15,10 @@
             }, \
           }
         .col-md-6
-          = f.input :name
+          = f.input :name, input_html: { list: "motif_names", autocomplete: "off" }
+          datalist#motif_names
+            - Motif.where(organisation_id: current_agent.organisations).map(&:name).uniq.each do |org_name|
+              option= org_name
       .form-row
         .col-md-4= f.input :default_duration_in_min
         .col-md-4= f.input :color, as: "color"


### PR DESCRIPTION
Fiche notion de l'opportunité : https://www.notion.so/rdvs/Partage-de-motifs-inter-orga-ca4a0ffcd9144da6b825adea46921345

Testable sur la review app ici : https://demo-rdv-solidarites-pr3835.osc-secnum-fr1.scalingo.io/

Le nom du motif est utilisé côté usager pour chercher des créneaux à travers plusieurs orgas (c'est la paramètre `motif_name_with_location_type`). En effet, dans plusieurs départements, les motifs sont dupliqués d'une orga à l'autre. Il est donc essentiel que les noms des motifs soient les mêmes à travers toutes orgas d'un même département.

Certaines référentes nous disent utiliser le copier / coller pour s'assurer que les motifs ont bien le même nom à travers toutes les orgas qu'elles configurent.

On peut imaginer qu'un autocomplete dans le champ du nom du motif permette une saisie plus rapide et sans faute.

Ça tombe bien, il existe une fonctionnalité native dans les navigateurs qui permet d'avoir de l'autocomplétion sur les champs texte ! Il fonctionne sur un match insensible à la casse, mais sensible aux accents, donc pas parfait mais peut-être déjà une amélioration. Il serait possible d'avoir recours à une lib JS d'autocomplétion, mais c'est beaucoup plus coûteux à implémenter et maintenir.

[Screencast from 2023-10-16 11-01-49.webm](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/4a2e7ed0-1987-4a7d-be80-cf4399c56123)

# Checklist

Avant la revue :
- [x] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
