### PR TITLE
Rétablir la cohérence entre la DB de prod et schema.rb

### DIFF
--- a/db/migrate/20231017125305_reunite_prod_schema.rb
+++ b/db/migrate/20231017125305_reunite_prod_schema.rb
@@ -4,13 +4,13 @@ class ReuniteProdSchema < ActiveRecord::Migration[7.0]
   def up
     enable_extension "pg_stat_statements"
 
-    change_column :absences, :created_at, :datetime, precision: 6, null: false
-    change_column :absences, :updated_at, :datetime, precision: 6, null: false
+    change_column :absences, :created_at, :datetime, precision: 6
+    change_column :absences, :updated_at, :datetime, precision: 6
     change_column :absences, :recurrence_ends_at, :datetime, precision: 6
     change_column :agents, :reset_password_sent_at, :datetime, precision: 6
     change_column :agents, :remember_created_at, :datetime, precision: 6
-    change_column :agents, :created_at, :datetime, precision: 6, null: false
-    change_column :agents, :updated_at, :datetime, precision: 6, null: false
+    change_column :agents, :created_at, :datetime, precision: 6
+    change_column :agents, :updated_at, :datetime, precision: 6
     change_column :agents, :confirmed_at, :datetime, precision: 6
     change_column :agents, :confirmation_sent_at, :datetime, precision: 6
     change_column :agents, :invitation_created_at, :datetime, precision: 6
@@ -20,28 +20,28 @@ class ReuniteProdSchema < ActiveRecord::Migration[7.0]
     change_column :agents, :current_sign_in_at, :datetime, precision: 6
     change_column :agents, :last_sign_in_at, :datetime, precision: 6
     change_column :file_attentes, :last_creneau_sent_at, :datetime, precision: 6
-    change_column :lieux, :created_at, :datetime, precision: 6, null: false
-    change_column :lieux, :updated_at, :datetime, precision: 6, null: false
-    change_column :motifs, :created_at, :datetime, precision: 6, null: false
-    change_column :motifs, :updated_at, :datetime, precision: 6, null: false
+    change_column :lieux, :created_at, :datetime, precision: 6
+    change_column :lieux, :updated_at, :datetime, precision: 6
+    change_column :motifs, :created_at, :datetime, precision: 6
+    change_column :motifs, :updated_at, :datetime, precision: 6
     change_column :motifs, :deleted_at, :datetime, precision: 6
-    change_column :organisations, :created_at, :datetime, precision: 6, null: false
-    change_column :organisations, :updated_at, :datetime, precision: 6, null: false
-    change_column :plage_ouvertures, :created_at, :datetime, precision: 6, null: false
-    change_column :plage_ouvertures, :updated_at, :datetime, precision: 6, null: false
+    change_column :organisations, :created_at, :datetime, precision: 6
+    change_column :organisations, :updated_at, :datetime, precision: 6
+    change_column :plage_ouvertures, :created_at, :datetime, precision: 6
+    change_column :plage_ouvertures, :updated_at, :datetime, precision: 6
     change_column :plage_ouvertures, :recurrence_ends_at, :datetime, precision: 6
-    change_column :rdvs, :starts_at, :datetime, precision: 6, null: false
-    change_column :rdvs, :created_at, :datetime, precision: 6, null: false
-    change_column :rdvs, :updated_at, :datetime, precision: 6, null: false
+    change_column :rdvs, :starts_at, :datetime, precision: 6
+    change_column :rdvs, :created_at, :datetime, precision: 6
+    change_column :rdvs, :updated_at, :datetime, precision: 6
     change_column :rdvs, :cancelled_at, :datetime, precision: 6
-    change_column :rdvs, :ends_at, :datetime, precision: 6, null: false
+    change_column :rdvs, :ends_at, :datetime, precision: 6
     change_column :rdvs_users, :invitation_created_at, :datetime, precision: 6
     change_column :rdvs_users, :invitation_sent_at, :datetime, precision: 6
     change_column :rdvs_users, :invitation_accepted_at, :datetime, precision: 6
-    change_column :super_admins, :created_at, :datetime, precision: 6, null: false
-    change_column :super_admins, :updated_at, :datetime, precision: 6, null: false
-    change_column :users, :created_at, :datetime, precision: 6, null: false
-    change_column :users, :updated_at, :datetime, precision: 6, null: false
+    change_column :super_admins, :created_at, :datetime, precision: 6
+    change_column :super_admins, :updated_at, :datetime, precision: 6
+    change_column :users, :created_at, :datetime, precision: 6
+    change_column :users, :updated_at, :datetime, precision: 6
     change_column :users, :reset_password_sent_at, :datetime, precision: 6
     change_column :users, :remember_created_at, :datetime, precision: 6
     change_column :users, :confirmed_at, :datetime, precision: 6
@@ -57,13 +57,13 @@ class ReuniteProdSchema < ActiveRecord::Migration[7.0]
   def down
     disable_extension "pg_stat_statements"
 
-    change_column :absences, :created_at, :datetime, precision: nil, null: false
-    change_column :absences, :updated_at, :datetime, precision: nil, null: false
+    change_column :absences, :created_at, :datetime, precision: nil
+    change_column :absences, :updated_at, :datetime, precision: nil
     change_column :absences, :recurrence_ends_at, :datetime, precision: nil
     change_column :agents, :reset_password_sent_at, :datetime, precision: nil
     change_column :agents, :remember_created_at, :datetime, precision: nil
-    change_column :agents, :created_at, :datetime, precision: nil, null: false
-    change_column :agents, :updated_at, :datetime, precision: nil, null: false
+    change_column :agents, :created_at, :datetime, precision: nil
+    change_column :agents, :updated_at, :datetime, precision: nil
     change_column :agents, :confirmed_at, :datetime, precision: nil
     change_column :agents, :confirmation_sent_at, :datetime, precision: nil
     change_column :agents, :invitation_created_at, :datetime, precision: nil
@@ -73,28 +73,28 @@ class ReuniteProdSchema < ActiveRecord::Migration[7.0]
     change_column :agents, :current_sign_in_at, :datetime, precision: nil
     change_column :agents, :last_sign_in_at, :datetime, precision: nil
     change_column :file_attentes, :last_creneau_sent_at, :datetime, precision: nil
-    change_column :lieux, :created_at, :datetime, precision: nil, null: false
-    change_column :lieux, :updated_at, :datetime, precision: nil, null: false
-    change_column :motifs, :created_at, :datetime, precision: nil, null: false
-    change_column :motifs, :updated_at, :datetime, precision: nil, null: false
+    change_column :lieux, :created_at, :datetime, precision: nil
+    change_column :lieux, :updated_at, :datetime, precision: nil
+    change_column :motifs, :created_at, :datetime, precision: nil
+    change_column :motifs, :updated_at, :datetime, precision: nil
     change_column :motifs, :deleted_at, :datetime, precision: nil
-    change_column :organisations, :created_at, :datetime, precision: nil, null: false
-    change_column :organisations, :updated_at, :datetime, precision: nil, null: false
-    change_column :plage_ouvertures, :created_at, :datetime, precision: nil, null: false
-    change_column :plage_ouvertures, :updated_at, :datetime, precision: nil, null: false
+    change_column :organisations, :created_at, :datetime, precision: nil
+    change_column :organisations, :updated_at, :datetime, precision: nil
+    change_column :plage_ouvertures, :created_at, :datetime, precision: nil
+    change_column :plage_ouvertures, :updated_at, :datetime, precision: nil
     change_column :plage_ouvertures, :recurrence_ends_at, :datetime, precision: nil
-    change_column :rdvs, :starts_at, :datetime, precision: nil, null: false
-    change_column :rdvs, :created_at, :datetime, precision: nil, null: false
-    change_column :rdvs, :updated_at, :datetime, precision: nil, null: false
+    change_column :rdvs, :starts_at, :datetime, precision: nil
+    change_column :rdvs, :created_at, :datetime, precision: nil
+    change_column :rdvs, :updated_at, :datetime, precision: nil
     change_column :rdvs, :cancelled_at, :datetime, precision: nil
-    change_column :rdvs, :ends_at, :datetime, precision: nil, null: false
+    change_column :rdvs, :ends_at, :datetime, precision: nil
     change_column :rdvs_users, :invitation_created_at, :datetime, precision: nil
     change_column :rdvs_users, :invitation_sent_at, :datetime, precision: nil
     change_column :rdvs_users, :invitation_accepted_at, :datetime, precision: nil
-    change_column :super_admins, :created_at, :datetime, precision: nil, null: false
-    change_column :super_admins, :updated_at, :datetime, precision: nil, null: false
-    change_column :users, :created_at, :datetime, precision: nil, null: false
-    change_column :users, :updated_at, :datetime, precision: nil, null: false
+    change_column :super_admins, :created_at, :datetime, precision: nil
+    change_column :super_admins, :updated_at, :datetime, precision: nil
+    change_column :users, :created_at, :datetime, precision: nil
+    change_column :users, :updated_at, :datetime, precision: nil
     change_column :users, :reset_password_sent_at, :datetime, precision: nil
     change_column :users, :remember_created_at, :datetime, precision: nil
     change_column :users, :confirmed_at, :datetime, precision: nil

--- a/db/migrate/20231017125305_reunite_prod_schema.rb
+++ b/db/migrate/20231017125305_reunite_prod_schema.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+class ReuniteProdSchema < ActiveRecord::Migration[7.0]
+  def up
+    enable_extension "pg_stat_statements"
+
+    change_column :absences, :created_at, :datetime, precision: 6, null: false
+    change_column :absences, :updated_at, :datetime, precision: 6, null: false
+    change_column :absences, :recurrence_ends_at, :datetime, precision: 6
+    change_column :agents, :reset_password_sent_at, :datetime, precision: 6
+    change_column :agents, :remember_created_at, :datetime, precision: 6
+    change_column :agents, :created_at, :datetime, precision: 6, null: false
+    change_column :agents, :updated_at, :datetime, precision: 6, null: false
+    change_column :agents, :confirmed_at, :datetime, precision: 6
+    change_column :agents, :confirmation_sent_at, :datetime, precision: 6
+    change_column :agents, :invitation_created_at, :datetime, precision: 6
+    change_column :agents, :invitation_sent_at, :datetime, precision: 6
+    change_column :agents, :invitation_accepted_at, :datetime, precision: 6
+    change_column :agents, :deleted_at, :datetime, precision: 6
+    change_column :agents, :current_sign_in_at, :datetime, precision: 6
+    change_column :agents, :last_sign_in_at, :datetime, precision: 6
+    change_column :file_attentes, :last_creneau_sent_at, :datetime, precision: 6
+    change_column :lieux, :created_at, :datetime, precision: 6, null: false
+    change_column :lieux, :updated_at, :datetime, precision: 6, null: false
+    change_column :motifs, :created_at, :datetime, precision: 6, null: false
+    change_column :motifs, :updated_at, :datetime, precision: 6, null: false
+    change_column :motifs, :deleted_at, :datetime, precision: 6
+    change_column :organisations, :created_at, :datetime, precision: 6, null: false
+    change_column :organisations, :updated_at, :datetime, precision: 6, null: false
+    change_column :plage_ouvertures, :created_at, :datetime, precision: 6, null: false
+    change_column :plage_ouvertures, :updated_at, :datetime, precision: 6, null: false
+    change_column :plage_ouvertures, :recurrence_ends_at, :datetime, precision: 6
+    change_column :rdvs, :starts_at, :datetime, precision: 6, null: false
+    change_column :rdvs, :created_at, :datetime, precision: 6, null: false
+    change_column :rdvs, :updated_at, :datetime, precision: 6, null: false
+    change_column :rdvs, :cancelled_at, :datetime, precision: 6
+    change_column :rdvs, :ends_at, :datetime, precision: 6, null: false
+    change_column :rdvs_users, :invitation_created_at, :datetime, precision: 6
+    change_column :rdvs_users, :invitation_sent_at, :datetime, precision: 6
+    change_column :rdvs_users, :invitation_accepted_at, :datetime, precision: 6
+    change_column :super_admins, :created_at, :datetime, precision: 6, null: false
+    change_column :super_admins, :updated_at, :datetime, precision: 6, null: false
+    change_column :users, :created_at, :datetime, precision: 6, null: false
+    change_column :users, :updated_at, :datetime, precision: 6, null: false
+    change_column :users, :reset_password_sent_at, :datetime, precision: 6
+    change_column :users, :remember_created_at, :datetime, precision: 6
+    change_column :users, :confirmed_at, :datetime, precision: 6
+    change_column :users, :confirmation_sent_at, :datetime, precision: 6
+    change_column :users, :invitation_created_at, :datetime, precision: 6
+    change_column :users, :invitation_sent_at, :datetime, precision: 6
+    change_column :users, :invitation_accepted_at, :datetime, precision: 6
+    change_column :users, :deleted_at, :datetime, precision: 6
+    change_column :users, :last_sign_in_at, :datetime, precision: 6
+    change_column :versions, :created_at, :datetime, precision: 6
+  end
+
+  def down
+    disable_extension "pg_stat_statements"
+
+    change_column :absences, :created_at, :datetime, precision: nil, null: false
+    change_column :absences, :updated_at, :datetime, precision: nil, null: false
+    change_column :absences, :recurrence_ends_at, :datetime, precision: nil
+    change_column :agents, :reset_password_sent_at, :datetime, precision: nil
+    change_column :agents, :remember_created_at, :datetime, precision: nil
+    change_column :agents, :created_at, :datetime, precision: nil, null: false
+    change_column :agents, :updated_at, :datetime, precision: nil, null: false
+    change_column :agents, :confirmed_at, :datetime, precision: nil
+    change_column :agents, :confirmation_sent_at, :datetime, precision: nil
+    change_column :agents, :invitation_created_at, :datetime, precision: nil
+    change_column :agents, :invitation_sent_at, :datetime, precision: nil
+    change_column :agents, :invitation_accepted_at, :datetime, precision: nil
+    change_column :agents, :deleted_at, :datetime, precision: nil
+    change_column :agents, :current_sign_in_at, :datetime, precision: nil
+    change_column :agents, :last_sign_in_at, :datetime, precision: nil
+    change_column :file_attentes, :last_creneau_sent_at, :datetime, precision: nil
+    change_column :lieux, :created_at, :datetime, precision: nil, null: false
+    change_column :lieux, :updated_at, :datetime, precision: nil, null: false
+    change_column :motifs, :created_at, :datetime, precision: nil, null: false
+    change_column :motifs, :updated_at, :datetime, precision: nil, null: false
+    change_column :motifs, :deleted_at, :datetime, precision: nil
+    change_column :organisations, :created_at, :datetime, precision: nil, null: false
+    change_column :organisations, :updated_at, :datetime, precision: nil, null: false
+    change_column :plage_ouvertures, :created_at, :datetime, precision: nil, null: false
+    change_column :plage_ouvertures, :updated_at, :datetime, precision: nil, null: false
+    change_column :plage_ouvertures, :recurrence_ends_at, :datetime, precision: nil
+    change_column :rdvs, :starts_at, :datetime, precision: nil, null: false
+    change_column :rdvs, :created_at, :datetime, precision: nil, null: false
+    change_column :rdvs, :updated_at, :datetime, precision: nil, null: false
+    change_column :rdvs, :cancelled_at, :datetime, precision: nil
+    change_column :rdvs, :ends_at, :datetime, precision: nil, null: false
+    change_column :rdvs_users, :invitation_created_at, :datetime, precision: nil
+    change_column :rdvs_users, :invitation_sent_at, :datetime, precision: nil
+    change_column :rdvs_users, :invitation_accepted_at, :datetime, precision: nil
+    change_column :super_admins, :created_at, :datetime, precision: nil, null: false
+    change_column :super_admins, :updated_at, :datetime, precision: nil, null: false
+    change_column :users, :created_at, :datetime, precision: nil, null: false
+    change_column :users, :updated_at, :datetime, precision: nil, null: false
+    change_column :users, :reset_password_sent_at, :datetime, precision: nil
+    change_column :users, :remember_created_at, :datetime, precision: nil
+    change_column :users, :confirmed_at, :datetime, precision: nil
+    change_column :users, :confirmation_sent_at, :datetime, precision: nil
+    change_column :users, :invitation_created_at, :datetime, precision: nil
+    change_column :users, :invitation_sent_at, :datetime, precision: nil
+    change_column :users, :invitation_accepted_at, :datetime, precision: nil
+    change_column :users, :deleted_at, :datetime, precision: nil
+    change_column :users, :last_sign_in_at, :datetime, precision: nil
+    change_column :versions, :created_at, :datetime, precision: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_16_075305) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_17_125305) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -214,8 +215,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_075305) do
     t.boolean "display_cancelled_rdv", default: true
     t.enum "plage_ouverture_notification_level", default: "all", enum_type: "agents_plage_ouverture_notification_level"
     t.enum "absence_notification_level", default: "all", enum_type: "agents_absence_notification_level"
-    t.string "external_id", comment: "The agent's unique and immutable id in the system managing them and adding them to our application"
-    t.string "calendar_uid", comment: "the uid used for the url of the agent's ics calendar"
+    t.string "external_id"
+    t.string "calendar_uid"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
@@ -412,7 +413,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_16_075305) do
     t.string "website"
     t.string "email"
     t.bigint "territory_id", null: false
-    t.string "external_id", comment: "The organisation's unique and immutable id in the system managing them and adding them to our application"
+    t.string "external_id"
     t.enum "verticale", default: "rdv_solidarites", null: false, enum_type: "verticale"
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["human_id", "territory_id"], name: "index_organisations_on_human_id_and_territory_id", unique: true, where: "((human_id)::text <> ''::text)"


### PR DESCRIPTION
Problème : le `schema.rb` ne reflète pas l'état de la db de production.

Liste des différences entre la db de prod et nos db de dev / test / review app :

## 1. L'extension `pg_stat_statements` est activée en prod

Il est probable que ce soit Scalingo qui ait activé cette extension sur toutes ses bases PG pour offrir la fonctionnalité de stats de requêtes (qui nous est d'ailleurs fort utile parfois).

## 2. 48 colonnes de type `datetime` ont une précision de `nil` en prod mais de  `6` ailleurs

Depuis Rails 7.0, la précision par défaut des colonnes `datetime` est passée de `nil` à `6`. Cette PR définit donc la précision à 6 pour tous nos champs en prod, afin que nous adhérions au standard de Rails, et que nous n'ayons plus à nous poser la question à l'avenir.

## 3. La base de prod ne contient aucun commentaire alors qu'il y en a 3 

Visiblement les commentaires Postgres ne sont pas gardés en prod, et vu l'usage plus que sporadique que nous en avons, nous pouvons décider de virer les 3 qu'il reste.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
