### PR TITLE
Bloquer les requêtes HTTP en dev

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -11,7 +11,7 @@ class WebhookJob < ApplicationJob
   self.log_arguments = false
 
   def perform(payload, webhook_endpoint_id)
-    return if Rails.env.development? # On évite le risque d'appeler des URL de prod en local
+    return if Rails.env.development? # On évite le risque d'appeler des URL de prod en local (PR #3841)
 
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -11,9 +11,9 @@ class WebhookJob < ApplicationJob
   self.log_arguments = false
 
   def perform(payload, webhook_endpoint_id)
-    return if Rails.env.development? # On évite le risque d'appeler des URL de prod en local (PR #3841)
-
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
+
+    return if Rails.env.development? && !webhook_endpoint.target_url =~ /localhost/
 
     request = Typhoeus::Request.new(
       webhook_endpoint.target_url,

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -11,6 +11,8 @@ class WebhookJob < ApplicationJob
   self.log_arguments = false
 
   def perform(payload, webhook_endpoint_id)
+    return if Rails.env.development? # On évite le risque d'appeler des URL de prod en local
+
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 
     request = Typhoeus::Request.new(

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -26,7 +26,7 @@ end
 Typhoeus.before do |request|
   if Rails.env.development? && ENV["ALLOW_HTTP_REQUEST_IN_DEV"] != "true"
     Rails.logger.info("Blocked HTTP request to #{request.url} because this is dev env")
-    false
+    false # Un callback Typhoeus interrompt la requête si un callback `before` retourne `nil` ou `false`
   else
     true
   end

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -24,6 +24,15 @@ Typhoeus.before do |request|
 end
 
 Typhoeus.before do |request|
+  if Rails.env.development? && ENV["ALLOW_HTTP_REQUEST_IN_DEV"] != "true"
+    Rails.logger.info("Blocked HTTP request to #{request.url} because this is dev env")
+    false
+  else
+    true
+  end
+end
+
+Typhoeus.before do |request|
   filter_secrets_from_body = lambda do |body|
     body.to_s.gsub(InclusionConnect::IC_CLIENT_SECRET || "", "filtered")
   end

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -24,15 +24,6 @@ Typhoeus.before do |request|
 end
 
 Typhoeus.before do |request|
-  if Rails.env.development? && ENV["ALLOW_HTTP_REQUEST_IN_DEV"] != "true"
-    Rails.logger.info("Blocked HTTP request to #{request.url} because this is dev env")
-    false # Un callback Typhoeus interrompt la requête si un callback `before` retourne `nil` ou `false`
-  else
-    true
-  end
-end
-
-Typhoeus.before do |request|
   filter_secrets_from_body = lambda do |body|
     body.to_s.gsub(InclusionConnect::IC_CLIENT_SECRET || "", "filtered")
   end


### PR DESCRIPTION
Problématique : lorsqu'on copie une base d'une instance vers notre db de dev, les webhooks restent activés. Le risque est donc d'appeler les URLs des webhooks accidentellement en lançant le worker de jobs par exemple.

Je propose que l'on désactive par défaut les appels HTTP en dev, du moins ceux que l'on fait avec Typhoeus (webhooks, synchro Outlook). On fait 2 appels GET avec Faraday, ils sont inoffensifs.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
