### PR TITLE
Correction du crash des exports

### DIFF
--- a/app/jobs/rdvs_export_page_job.rb
+++ b/app/jobs/rdvs_export_page_job.rb
@@ -2,7 +2,7 @@
 
 class RdvsExportPageJob < ExportJob
   def perform(rdv_ids, page_index, redis_key)
-    rows = RdvExporter.rows_from_rdvs(Rdv.where(id: rdv_ids)).order(starts_at: :desc)
+    rows = RdvExporter.rows_from_rdvs(Rdv.where(id: rdv_ids).order(starts_at: :desc))
 
     redis_connection = Redis.new(url: Rails.configuration.x.redis_url)
     redis_connection.hset(redis_key, page_index, rows.to_json)


### PR DESCRIPTION
L'erreur est simple, et d'ailleurs elle avait été évitée côté export `RdvsUsersExportPageJob`.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
