### PR TITLE
Restore "Refacto `SearchContext` et mise en place de l'api de calcul de créneaux pour RDVI"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ Metrics/BlockLength:
     - "config/initializers/*"
     - "config/environments/*"
     - "config/routes.rb"
+    - "config/routes/api.rb"
 
 Metrics/CyclomaticComplexity:
   Max: 8 # default is 7
@@ -152,6 +153,7 @@ RSpec/MultipleDescribes:
 RSpec/VariableName:
   Exclude:
     - "spec/requests/api/v1/**/*"
+    - "spec/requests/api/rdvinsertion/**/*"
     - "spec/support/api_spec_shared_examples.rb"
 
 RSpec/MultipleExpectations:

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
+  INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
+
+  def creneau_availability
+    render json: { creneau_availability: creneau_available? }
+  rescue StandardError => e
+    render json: { error: e.message }, status: :internal_server_error
+  end
+
+  private
+
+  def user
+    @user ||= Invitation.new(invitation_link_hash).user
+  end
+
+  def creneau_available?
+    invitation_search_context.matching_motifs.any? do |motif|
+      if motif.phone?
+        creneaux_available_for_motif?(motif)
+      else
+        motif.lieux.any? { |lieu| creneaux_available_for_motif?(motif, lieu) }
+      end
+    end
+  end
+
+  def creneaux_available_for_motif?(motif, lieu = nil)
+    Users::CreneauxSearch.new(
+      user: user,
+      motif: motif,
+      lieu: lieu,
+      geo_search: invitation_search_context.geo_search
+    ).creneaux.any?
+  end
+
+  def invitation_search_context
+    @invitation_search_context ||= InvitationSearchContext.new(
+      user: user,
+      query_params: invitation_link_hash
+    )
+  end
+
+  def invitation_link_hash
+    @invitation_link_hash ||= invitation_link_params.to_h.deep_symbolize_keys
+  end
+
+  def invitation_link_params
+    params.permit(INVITATION_LINK_PARAMS)
+  end
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,11 @@ class SearchController < ApplicationController
   after_action :allow_iframe
 
   def search_rdv
-    @context = SearchContext.new(user: current_user, query_params: query_params, through_invitation: invitation?)
+    @context = if invitation?
+                 WebInvitationSearchContext.new(user: current_user, query_params: query_params)
+               else
+                 WebSearchContext.new(user: current_user, query_params: query_params)
+               end
     if current_domain == Domain::RDV_MAIRIE && request.path == "/"
       render "dsfr/rdv_mairie/homepage", layout: "application_dsfr"
     end
@@ -78,7 +82,7 @@ class SearchController < ApplicationController
   def search_params
     params.permit(
       :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
-      :service_id, :lieu_id, :date, :motif_search_terms, :motif_name_with_location_type, :motif_category_short_name,
+      :service_id, :lieu_id, :date, :motif_name_with_location_type, :motif_category_short_name,
       :motif_id, :public_link_organisation_id, :user_selected_organisation_id, :prescripteur,
       organisation_ids: [], referent_ids: [], external_organisation_ids: []
     )

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -4,7 +4,7 @@ class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
     :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code, :rdv_collectif_id,
-    :street_ban_id, :address, :motif_search_terms, :user_selected_organisation_id,
+    :street_ban_id, :address, :user_selected_organisation_id,
     :public_link_organisation_id, :duration,
     { organisation_ids: [], referent_ids: [], external_organisation_ids: [] },
   ].freeze

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -44,6 +44,7 @@ class Users::RdvsController < UserAuthController
       set_user_name_initials_verified
       redirect_to users_rdv_path(@rdv, invitation_token: notifier.rdv_users_tokens_by_user_id[current_user.id]), notice: t(".rdv_confirmed")
     else
+      # TODO: cette liste de paramètres devrait ressembler a SearchController#search_params, mais sans certains paramètres de choix du wizard de créneaux
       query = {
         address: (new_rdv_extra_params[:address] || new_rdv_extra_params[:where]),
         city_code: new_rdv_extra_params[:city_code], street_ban_id: new_rdv_extra_params[:street_ban_id],

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -63,7 +63,7 @@ module UserRdvWizard
       }.merge(
         @attributes.slice(
           :where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id,
-          :address, :organisation_ids, :motif_search_terms, :public_link_organisation_id, :user_selected_organisation_id,
+          :address, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
           :referent_ids, :external_organisation_ids, :duration
         )
       )

--- a/app/lib/lapin/range.rb
+++ b/app/lib/lapin/range.rb
@@ -4,6 +4,7 @@ module Lapin
   module Range
     class << self
       def reduce_range_to_delay(motif, date_range)
+        return motif.booking_delay_range if date_range.nil?
         return nil unless motif.booking_delay_range.overlaps?(date_range)
 
         start_range = [motif.start_booking_delay, date_range.begin].max

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -44,9 +44,14 @@ class Motif < ApplicationRecord
   has_many :motifs_plage_ouvertures, dependent: :delete_all
 
   # Through relations
-  has_many :lieux, through: :plage_ouvertures
   has_many :webhook_endpoints, through: :organisation
   has_many :plage_ouvertures, -> { distinct }, through: :motifs_plage_ouvertures
+  has_many :lieux_through_po, through: :plage_ouvertures, source: :lieu
+  has_many :lieux_through_rdvs, through: :rdvs, source: :lieu
+
+  def lieux
+    collectif? ? lieux_through_rdvs : lieux_through_po
+  end
 
   # Delegates
   delegate :service_social?, to: :service

--- a/app/policies/agent/organisation_policy.rb
+++ b/app/policies/agent/organisation_policy.rb
@@ -9,6 +9,8 @@ class Agent::OrganisationPolicy < DefaultAgentPolicy
     current_agent.roles.access_level_admin.pluck(:organisation_id).include?(record.id)
   end
 
+  alias creneau_availability? link_to_organisation?
+
   def new?
     current_agent.territorial_admin_in?(record.territory)
   end

--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module Users::CreneauxWizardConcern
+  extend ActiveSupport::Concern
+
+  # *** Method that outputs the next step for the user to complete its rdv journey ***
+  # *** It is used in #to_partial_path to render the matching partial view ***
+  def current_step
+    if departement.blank?
+      :address_selection
+    elsif !service_selected?
+      :service_selection
+    elsif !motif_name_and_type_selected?
+      :motif_selection
+    elsif requires_lieu_selection?
+      :lieu_selection
+    elsif requires_organisation_selection?
+      :organisation_selection
+    else
+      :creneau_selection
+    end
+  end
+
+  def start_date
+    query_params[:date]&.to_date || super
+  end
+
+  def to_partial_path
+    "search/#{current_step}"
+  end
+
+  def wizard_after_creneau_selection_path(params)
+    url_helpers = Rails.application.routes.url_helpers
+    if @prescripteur
+      url_helpers.prescripteur_start_path(query_params.merge(params))
+    else
+      url_helpers.new_users_rdv_wizard_step_path(query_params.merge(params))
+    end
+  end
+
+  def user_selected_organisation
+    @user_selected_organisation ||= \
+      @user_selected_organisation_id.present? ? Organisation.find(@user_selected_organisation_id) : nil
+  end
+
+  def unique_motifs_by_name_and_location_type
+    @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq { [_1.name, _1.location_type] }
+  end
+
+  # next availability by organisation for motifs without lieu
+  def next_availability_by_motifs_organisations
+    @next_availability_by_motifs_organisations ||= matching_motifs.to_h do |motif|
+      [motif.organisation, creneaux_search_for(nil, date_range, motif).next_availability]
+    end.compact
+  end
+
+  def service
+    @service ||= if @service_id.present?
+                   Service.find(@service_id)
+                 elsif services.count == 1
+                   services.first
+                 end
+  end
+
+  def services
+    @services ||= matching_motifs.includes(:service).map(&:service).uniq.sort_by(&:name)
+  end
+
+  def lieux
+    @lieux ||= \
+      Lieu
+        .with_open_slots_for_motifs(matching_motifs)
+        .includes(:organisation)
+        .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
+  end
+
+  def next_availability_by_lieux
+    @next_availability_by_lieux ||= lieux.index_with do |lieu|
+      creneaux_search_for(
+        lieu, date_range, matching_motifs.where(organisation: lieu.organisation).first
+      ).next_availability
+    end.compact
+  end
+
+  def shown_lieux
+    next_availability_by_lieux.keys
+  end
+
+  def next_availability
+    @next_availability ||= creneaux.empty? ? creneaux_search.next_availability : nil
+  end
+
+  def max_public_booking_delay
+    matching_motifs.maximum("max_public_booking_delay")
+  end
+
+  private
+
+  def requires_organisation_selection?
+    !first_matching_motif.requires_lieu? && user_selected_organisation.nil? && public_link_organisation.nil?
+  end
+
+  def motif_name_and_type_selected?
+    unique_motifs_by_name_and_location_type.length == 1
+  end
+
+  def service_selected?
+    service.present?
+  end
+
+  def requires_lieu_selection?
+    first_matching_motif.requires_lieu? && lieu.nil?
+  end
+end

--- a/app/services/invitation_search_context.rb
+++ b/app/services/invitation_search_context.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class InvitationSearchContext < SearchContext
+  attr_reader :departement, :city_code, :street_ban_id
+
+  INVITATION_PARAMS = %i[city_code departement street_ban_id motif_category_short_name lieu_id].freeze + [
+    organisation_ids: [], referent_ids: [],
+  ].freeze
+
+  def initialize(user:, query_params: {})
+    super
+    INVITATION_PARAMS.each do |param_name|
+      if param_name.is_a?(Hash)
+        param_name.each_key do |key|
+          instance_variable_set("@#{key}", query_params[key])
+        end
+      else
+        instance_variable_set("@#{param_name}", query_params[param_name])
+      end
+    end
+  end
+
+  def filter_motifs(available_motifs)
+    motifs = super
+    motifs = motifs.bookable_by_everyone_or_bookable_by_invited_users
+    motifs = motifs.with_motif_category_short_name(@motif_category_short_name) if @motif_category_short_name.present?
+    motifs = motifs.where(organisation_id: @organisation_ids) if @organisation_ids.present?
+    motifs
+  end
+
+  # We use matching_motifs in API so we need to keep it public
+  def matching_motifs
+    # we retrieve the geolocalised matching motifs, if there are none we fallback
+    # on the matching motifs for the organisations passed in the query_params
+    @matching_motifs ||=
+      filter_motifs(geo_search.available_motifs).presence || filter_motifs(
+        Motif.available_for_booking.where(organisation_id: @organisation_ids).joins(:organisation)
+      )
+  end
+
+  private
+
+  attr_reader :referent_ids, :lieu_id
+end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -1,169 +1,21 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class SearchContext
-  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude,
-              :motif_name_with_location_type, :prescripteur, :through_invitation
-  alias invitation? through_invitation
-
-  # rubocop:disable Metrics/MethodLength
-  def initialize(user:, query_params: {}, through_invitation: false)
+  def initialize(user:, query_params: {})
     @user = user
     @query_params = query_params
-    @latitude = query_params[:latitude]
-    @longitude = query_params[:longitude]
-    @address = query_params[:address]
-    @city_code = query_params[:city_code]
-    @street_ban_id = query_params[:street_ban_id]
-    @public_link_organisation_id = query_params[:public_link_organisation_id]
-    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
-    @external_organisation_ids = query_params[:external_organisation_ids]
-    @preselected_organisation_ids = query_params[:organisation_ids]
-    @motif_id = query_params[:motif_id]
-    @motif_search_terms = query_params[:motif_search_terms]
-    @motif_category_short_name = query_params[:motif_category_short_name]
-    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
-    @service_id = query_params[:service_id]
-    @lieu_id = query_params[:lieu_id]
-    @start_date = query_params[:date]
-    @referent_ids = query_params[:referent_ids]
-    @prescripteur = query_params[:prescripteur]
-    @through_invitation = through_invitation
-  end
-  # rubocop:enable Metrics/MethodLength
-
-  # *** Method that outputs the next step for the user to complete its rdv journey ***
-  # *** It is used in #to_partial_path to render the matching partial view ***
-  def current_step
-    if departement.blank?
-      :address_selection
-    elsif !service_selected?
-      :service_selection
-    elsif !motif_name_and_type_selected?
-      :motif_selection
-    elsif requires_lieu_selection?
-      :lieu_selection
-    elsif requires_organisation_selection?
-      :organisation_selection
-    else
-      :creneau_selection
-    end
-  end
-
-  def to_partial_path
-    "search/#{current_step}"
-  end
-
-  def wizard_after_creneau_selection_path(params)
-    url_helpers = Rails.application.routes.url_helpers
-    if @prescripteur
-      url_helpers.prescripteur_start_path(query_params.merge(params))
-    else
-      url_helpers.new_users_rdv_wizard_step_path(query_params.merge(params))
-    end
   end
 
   def geo_search
-    Users::GeoSearch.new(departement: departement, city_code: @city_code, street_ban_id: @street_ban_id)
-  end
-
-  def departement
-    @departement ||= (@query_params[:departement] || public_link_organisation&.departement_number)
-  end
-
-  def service
-    @service ||= if @service_id.present?
-                   Service.find(@service_id)
-                 elsif services.count == 1
-                   services.first
-                 end
-  end
-
-  def services
-    @services ||= matching_motifs.includes(:service).map(&:service).uniq.sort_by(&:name)
-  end
-
-  def requires_organisation_selection?
-    !first_matching_motif.requires_lieu? && user_selected_organisation.nil? && public_link_organisation.nil?
-  end
-
-  def user_selected_organisation
-    @user_selected_organisation ||= \
-      @user_selected_organisation_id.present? ? Organisation.find(@user_selected_organisation_id) : nil
-  end
-
-  def public_link_organisation
-    @public_link_organisation ||= \
-      @public_link_organisation_id.present? ? Organisation.find(@public_link_organisation_id) : nil
-  end
-
-  def organisation_id
-    @public_link_organisation_id || @user_selected_organisation_id
-  end
-
-  # next availability by organisation for motifs without lieu
-  def next_availability_by_motifs_organisations
-    @next_availability_by_motifs_organisations ||= matching_motifs.to_h do |motif|
-      [motif.organisation, creneaux_search_for(nil, date_range, motif).next_availability]
-    end.compact
-  end
-
-  def unique_motifs_by_name_and_location_type
-    @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq { [_1.name, _1.location_type] }
-  end
-
-  def first_matching_motif
-    return unless motif_name_and_type_selected?
-
-    matching_motifs.first
-  end
-
-  def motif_name_and_type_selected?
-    unique_motifs_by_name_and_location_type.length == 1
-  end
-
-  def service_selected?
-    service.present?
-  end
-
-  def requires_lieu_selection?
-    first_matching_motif.requires_lieu? && lieu.nil?
+    Users::GeoSearch.new(departement: departement, city_code: city_code, street_ban_id: street_ban_id)
   end
 
   def lieu
-    @lieu ||= @lieu_id.blank? ? nil : Lieu.find(@lieu_id)
-  end
-
-  def lieux
-    @lieux ||= \
-      Lieu
-        .with_open_slots_for_motifs(matching_motifs)
-        .includes(:organisation)
-        .sort_by { |lieu| lieu.distance(@latitude.to_f, @longitude.to_f) }
-  end
-
-  def next_availability_by_lieux
-    @next_availability_by_lieux ||= lieux.index_with do |lieu|
-      creneaux_search_for(
-        lieu, date_range, matching_motifs.where(organisation: lieu.organisation).first
-      ).next_availability
-    end.compact
-  end
-
-  def shown_lieux
-    next_availability_by_lieux.keys
+    @lieu ||= lieu_id.blank? ? nil : Lieu.find(lieu_id)
   end
 
   def start_date
-    @start_date&.to_date || Time.zone.today
-  end
-
-  def date_range
-    start_date..(start_date + 6.days)
-  end
-
-  def max_public_booking_delay
-    matching_motifs.maximum("max_public_booking_delay")
+    Time.zone.today
   end
 
   def creneaux
@@ -179,8 +31,8 @@ class SearchContext
     creneaux_search_for(lieu, date_range, first_matching_motif)
   end
 
-  def next_availability
-    @next_availability ||= creneaux.empty? ? creneaux_search.next_availability : nil
+  def first_matching_motif
+    matching_motifs.first
   end
 
   def referent_agents
@@ -188,36 +40,46 @@ class SearchContext
   end
 
   def follow_up?
-    @referent_ids.present?
+    referent_ids.present?
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def date_range
+    start_date..(start_date + 6.days)
+  end
+
   def filter_motifs(available_motifs)
     motifs = available_motifs
-    motifs = if @prescripteur
-               motifs.where(bookable_by: %i[agents_and_prescripteurs agents_and_prescripteurs_and_invited_users everyone])
-             elsif invitation?
-               motifs.bookable_by_everyone_or_bookable_by_invited_users
-             else
-               motifs.bookable_by_everyone
-             end
-    motifs = motifs.search_by_name_with_location_type(@motif_name_with_location_type) if @motif_name_with_location_type.present?
-    motifs = motifs.where(service: service) if @service_id.present?
-    motifs = motifs.search_by_text(@motif_search_terms) if @motif_search_terms.present?
-    motifs = motifs.with_motif_category_short_name(@motif_category_short_name) if @motif_category_short_name.present?
-    motifs = motifs.where(organisation_id: @preselected_organisation_ids) if @preselected_organisation_ids.present?
-    motifs = motifs.where(organisation_id: organisation_id) if organisation_id.present?
-    motifs = motifs.where(organisations: { external_id: @external_organisation_ids.compact }) if @external_organisation_ids.present?
-    motifs = motifs.where(id: @motif_id) if @motif_id.present?
-    motifs = motifs.with_availability_for_lieux([lieu.id]) if lieu.present?
     motifs = motifs.where(follow_up: follow_up?)
+    motifs = motifs.with_availability_for_lieux([lieu.id]) if lieu.present?
     motifs = motifs.with_availability_for_agents(referent_agents.map(&:id)) if follow_up?
-
     motifs
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   private
+
+  def referent_ids
+    raise NoMethodError
+  end
+
+  def matching_motifs
+    raise NoMethodError
+  end
+
+  def departement
+    raise NoMethodError
+  end
+
+  def city_code
+    raise NoMethodError
+  end
+
+  def street_ban_id
+    raise NoMethodError
+  end
+
+  def lieu_id
+    raise NoMethodError
+  end
 
   def creneaux_search_for(lieu, date_range, motif)
     Users::CreneauxSearch.new(
@@ -234,18 +96,4 @@ class SearchContext
 
     @user.referent_agents.where(id: @referent_ids)
   end
-
-  def matching_motifs
-    @matching_motifs ||= \
-      if invitation?
-        # we retrieve the geolocalised matching motifs, if there are none we fallback
-        # on the matching motifs for the organisations passed in the query_params
-        filter_motifs(geo_search.available_motifs).presence || filter_motifs(
-          Motif.available_for_booking.where(organisation_id: @preselected_organisation_ids).joins(:organisation)
-        )
-      else
-        filter_motifs(geo_search.available_motifs)
-      end
-  end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/web_invitation_search_context.rb
+++ b/app/services/web_invitation_search_context.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class WebInvitationSearchContext < InvitationSearchContext
+  include Users::CreneauxWizardConcern
+  attr_reader :errors, :query_params, :address, :latitude, :longitude
+
+  def initialize(user:, query_params: {})
+    super
+    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
+    @motif_id = query_params[:motif_id]
+    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
+    @service_id = query_params[:service_id]
+    @address = query_params[:address]
+    @latitude = query_params[:latitude]
+    @longitude = query_params[:longitude]
+  end
+
+  # dupliqué de WebSearchContext
+  def filter_motifs(available_motifs)
+    motifs = super
+    motifs = motifs.search_by_name_with_location_type(@motif_name_with_location_type) if @motif_name_with_location_type.present?
+    motifs = motifs.where(service_id: @service_id) if @service_id.present?
+    motifs = motifs.where(organisation_id: organisation_id) if organisation_id.present?
+    motifs = motifs.where(id: @motif_id) if @motif_id.present?
+    motifs
+  end
+
+  def invitation?
+    true
+  end
+
+  def prescripteur?
+    false
+  end
+
+  def organisation_id
+    @user_selected_organisation_id
+  end
+end

--- a/app/services/web_invitation_search_context.rb
+++ b/app/services/web_invitation_search_context.rb
@@ -36,4 +36,9 @@ class WebInvitationSearchContext < InvitationSearchContext
   def organisation_id
     @user_selected_organisation_id
   end
+
+  def public_link_organisation
+    # public_link_organisation is not used in web invitation context
+    nil
+  end
 end

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class WebSearchContext < SearchContext
+  include Users::CreneauxWizardConcern
+  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude
+
+  def initialize(user:, query_params: {})
+    super
+    @latitude = query_params[:latitude]
+    @longitude = query_params[:longitude]
+    @address = query_params[:address]
+    @city_code = query_params[:city_code]
+    @street_ban_id = query_params[:street_ban_id]
+    @public_link_organisation_id = query_params[:public_link_organisation_id]
+    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
+    @external_organisation_ids = query_params[:external_organisation_ids]
+    @motif_id = query_params[:motif_id]
+    @motif_category_short_name = query_params[:motif_category_short_name]
+    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
+    @service_id = query_params[:service_id]
+    @lieu_id = query_params[:lieu_id]
+    @referent_ids = query_params[:referent_ids]
+    @prescripteur = query_params[:prescripteur]
+  end
+
+  def invitation?
+    false
+  end
+
+  def prescripteur?
+    @prescripteur
+  end
+
+  def departement
+    @departement ||= (@query_params[:departement] || public_link_organisation&.departement_number)
+  end
+
+  def organisation_id
+    @public_link_organisation_id || @user_selected_organisation_id
+  end
+
+  def filter_motifs(available_motifs)
+    motifs = super
+    motifs = if prescripteur?
+               motifs.where(bookable_by: %i[agents_and_prescripteurs agents_and_prescripteurs_and_invited_users everyone])
+             else
+               motifs.bookable_by_everyone
+             end
+
+    motifs = motifs.where(organisations: { external_id: @external_organisation_ids.compact }) if @external_organisation_ids.present?
+
+    # dupliqué de WebInvitationSearchContext
+    motifs = motifs.search_by_name_with_location_type(@motif_name_with_location_type) if @motif_name_with_location_type.present?
+    motifs = motifs.where(service: service) if @service_id.present?
+    motifs = motifs.where(organisation_id: organisation_id) if organisation_id.present?
+    motifs = motifs.where(id: @motif_id) if @motif_id.present?
+    motifs
+  end
+
+  private
+
+  attr_reader :referent_ids, :lieu_id
+
+  def matching_motifs
+    @matching_motifs ||= filter_motifs(geo_search.available_motifs)
+  end
+
+  # TODO : move this to a specific search context https://github.com/betagouv/rdv-solidarites.fr/pull/3827#discussion_r1351988739
+  def public_link_organisation
+    @public_link_organisation ||= \
+      @public_link_organisation_id.present? ? Organisation.find(@public_link_organisation_id) : nil
+  end
+end

--- a/app/views/search/address_selection/_rdv_mairie.html.slim
+++ b/app/views/search/address_selection/_rdv_mairie.html.slim
@@ -3,7 +3,7 @@ section.bg-primary.p-4
     #search_form
       = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
         = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
-        - if context.prescripteur.to_boolean
+        - if context.prescripteur?
           = f.input :prescripteur, as: :hidden, input_html: { name: "prescripteur", value: 1 }
         = f.input :city_code, as: :hidden, input_html: { name: "city_code", value: context.city_code }
         = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }

--- a/app/views/search/address_selection/_rdv_solidarites.html.slim
+++ b/app/views/search/address_selection/_rdv_solidarites.html.slim
@@ -3,7 +3,7 @@ section.bg-primary.p-4
     #search_form
       = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
         = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
-        - if context.prescripteur.to_boolean
+        - if context.prescripteur?
           = f.input :prescripteur, as: :hidden, input_html: { name: "prescripteur", value: 1 }
         = f.input :city_code,  as: :hidden, input_html: { name: "city_code", value: context.city_code }
         = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -28,6 +28,12 @@ namespace :api do
     get "availableTimeSlots", to: "editor#available_time_slots"
     get "searchApplicationIds", to: "editor#search_application_ids"
   end
+
+  namespace :rdvinsertion do
+    resources :invitations, only: [] do
+      get 'creneau_availability', to: 'invitations#creneau_availability', on: :collection
+    end
+  end
 end
 
 # This one has been published before versioning the public API and unification with auth API:

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -99,37 +99,7 @@ RSpec.describe SearchController, type: :controller do
         expect(subject).not_to include("RSA orientation 3")
       end
 
-      context "when a motif category is passed" do
-        it "retrieves motifs from the selected category" do
-          get :search_rdv, params: {
-            address: address, departement: departement_number, city_code: city_code, motif_category_short_name: "rsa_orientation",
-          }
-          expect(subject).to include("RSA orientation 1")
-          expect(subject).not_to include("RSA orientation 2")
-        end
-      end
-
-      context "when there are seach terms" do
-        let!(:geo_search) do
-          instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id, motif3.id, motif4.id]))
-        end
-
-        it "lists the available motifs that match the search terms" do
-          get :search_rdv, params: {
-            address: address, departement: departement_number, city_code: city_code, motif_search_terms: "RSA orientation",
-          }
-          expect(subject).to include("RSA orientation 1")
-          expect(subject).to include("RSA orientation 2")
-          expect(subject).to include("RSA orientation 3")
-          expect(subject).not_to include("Motif numéro 4")
-        end
-      end
-
       context "for an invitation" do
-        let!(:geo_search) do
-          instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif2.id]))
-        end
-
         before do
           request.session["invitation"] = {
             address: address, departement: departement_number, city_code: city_code, invitation_token: invitation_token,
@@ -137,7 +107,21 @@ RSpec.describe SearchController, type: :controller do
           }
         end
 
+        context "when a motif category is passed" do
+          it "retrieves motifs from the selected category" do
+            get :search_rdv, params: {
+              address: address, departement: departement_number, city_code: city_code, motif_category_short_name: "rsa_orientation",
+            }
+            expect(subject).to include("RSA orientation 1")
+            expect(subject).not_to include("RSA orientation 2")
+          end
+        end
+
         context "when there are matching motifs for the geo search available_motifs" do
+          let(:geo_search) do
+            instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif2.id]))
+          end
+
           it "lists the available motifs" do
             get :search_rdv
             expect(subject).to include("RSA orientation 2")
@@ -156,14 +140,6 @@ RSpec.describe SearchController, type: :controller do
             expect(subject).not_to include("RSA orientation 2")
             expect(subject).not_to include("RSA orientation 3")
             expect(subject).not_to include("Motif numéro 4")
-          end
-
-          it "reveals a problem when no motifs are available" do
-            get :search_rdv, params: {
-              organisation_ids: [other_org.id], motif_search_terms: "something random",
-            }
-            expect(subject).to include("Un problème semble s'être produit pour votre invitation. Toutes nos excuses pour cela.")
-            expect(subject).to include("support@rdv-solidarites.fr")
           end
         end
       end

--- a/spec/features/allocation_for_search_context_spec.rb
+++ b/spec/features/allocation_for_search_context_spec.rb
@@ -21,7 +21,7 @@ describe "Allocation For Search Context" do
 
     params = { address: address, departement: departement_number, city_code: city_code, lieu_id: lieu.id, motif_name_with_location_type: "#{motif.name}-#{motif.location_type}" }
 
-    search_context = SearchContext.new(user: nil, query_params: params)
+    search_context = WebSearchContext.new(user: nil, query_params: params)
 
     before = GC.stat[:total_allocated_objects]
     search_context.unique_motifs_by_name_and_location_type

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -143,7 +143,7 @@ describe "User can be invited" do
   describe "in motifs selection page" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
     let!(:motif2) do
-      create(:motif, name: "RSA orientation telephone", bookable_by: "everyone", organisation: organisation2, service: agent.service, motif_category:)
+      create(:motif, name: "RSA orientation telephone", bookable_by: "everyone", organisation: organisation2, service: agent.service, motif_category:, location_type: "phone")
     end
     let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], organisation: organisation2) }
 
@@ -223,6 +223,45 @@ describe "User can be invited" do
 
         expect(page).to have_content(motif2.name)
         expect(page).not_to have_content(motif.name)
+      end
+    end
+
+    context "when the motif is a phone motif" do
+      let!(:motif) do
+        create(:motif, name: "RSA orientation telephone", bookable_by: "everyone", organisation: organisation, service: agent.service, motif_category:, location_type: "phone")
+      end
+
+      it "shows the geo search available organisation to take a rdv", js: true do
+        visit prendre_rdv_path(
+          departement: departement_number, city_code: city_code, invitation_token: invitation_token,
+          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
+        )
+
+        # Organisation selection
+        expect(page).to have_content(organisation.name)
+        find(".card-title", text: /#{organisation.name}/).ancestor(".card").find("a.stretched-link").click
+
+        # Creneau selection
+        first(:link, "11:00").click
+
+        # RDV informations
+        expect(page).to have_content("Vos informations")
+        expect(page).not_to have_field("Date de naissance")
+        expect(page).not_to have_field("Adresse")
+        expect(page).to have_field("Email", with: user.email, disabled: true)
+        expect(page).to have_field("Téléphone", with: user.phone_number)
+        click_button("Continuer")
+
+        # Confirmation
+        expect(page).to have_content("Informations de contact")
+        expect(page).to have_content("johndoe@gmail.com")
+        expect(page).to have_content("0682605955")
+        click_link("Confirmer mon RDV")
+
+        # RDV page
+        expect(page).to have_content("Votre RDV")
+        expect(page).to have_content("RDV Téléphonique")
+        expect(page).to have_content("11h00")
       end
     end
   end

--- a/spec/features/users/user_can_be_invited_spec.rb
+++ b/spec/features/users/user_can_be_invited_spec.rb
@@ -202,7 +202,7 @@ describe "User can be invited" do
       it "shows the available motifs for the preselected orgs" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_search_terms: "RSA orientation", organisation_ids: [organisation.id]
+          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation", organisation_ids: [organisation.id]
         )
 
         # It directly selects the first motif and goes to lieu selection
@@ -230,11 +230,11 @@ describe "User can be invited" do
   describe "when no motifs are found through geo search" do
     let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.none) }
     let!(:second_motif) do
-      create(:motif, name: "RSA orientation telephone", bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation2, service: agent.service)
+      create(:motif, name: "RSA orientation telephone", bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation2, service: agent.service, motif_category:)
     end
     let!(:second_plage_ouverture) { create(:plage_ouverture, motifs: [second_motif], organisation: organisation2) }
     let!(:collectif_motif) do
-      create(:motif, name: "RSA orientation collectif", collectif: true, bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation, service: agent.service)
+      create(:motif, name: "RSA orientation collectif", collectif: true, bookable_by: "agents_and_prescripteurs_and_invited_users", organisation: organisation, service: agent.service, motif_category:)
     end
     let!(:collectif_rdv) { create(:rdv, motif: collectif_motif, starts_at: 1.week.from_now, max_participants_count: 10) }
 
@@ -244,7 +244,7 @@ describe "User can be invited" do
 
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_search_terms: "RSA orientation",
+        address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation",
         organisation_ids: [organisation.id, organisation2.id]
       )
     end

--- a/spec/requests/api/rdvinsertion/creneau_availability_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+describe "Available Creneaux Count for Invitation" do
+  with_examples
+
+  path "/api/rdvinsertion/invitations/creneau_availability" do
+    get "Renvoi true si au moins un créneau est disponible pour une invitation" do
+      with_authentication
+
+      tags "CreneauxCount"
+      produces "application/json"
+      operationId "availableCreneauxCount"
+      description "Renvoi true si au moins un créneau est disponible pour une invitation"
+
+      parameter name: "invitation_token", in: :query, type: :string, description: "Le token d'invitation", example: "123456789", required: false
+      parameter name: "address", in: :query, type: :string, description: "L'adresse de recherche", example: "1 rue de la paix", required: false
+      parameter name: "latitude", in: :query, type: :string, description: "La latitude de recherche", example: "45.188529", required: false
+      parameter name: "longitude", in: :query, type: :string, description: "La longitude de recherche", example: "5.724524", required: false
+      parameter name: "city_code", in: :query, type: :string, description: "Le code INSEE de la commune de recherche", example: "26001", required: false
+      parameter name: "departement", in: :query, type: :string, description: "Le numéro ou code de département de recherche", example: "26", required: false
+      parameter name: "street_ban_id", in: :query, type: :string, description: "L'ID de la voie de recherche", example: "260010000Rue de la Paix", required: false
+      parameter name: "motif_category_short_name", in: :query, type: :string, description: "Le nom court de la catégorie de motif de recherche", example: "rsa_orientation", required: false
+      parameter name: "lieu_id", in: :query, type: :string, description: "L'ID du lieu de recherche", example: "1", required: false
+      parameter name: "organisation_ids[]", in: :query, schema: { type: :array, items: { type: :string } }, description: "Les IDs des organisations de recherche", example: %w[1 2 3], required: false
+      parameter name: "referent_ids[]", in: :query, schema: { type: :array, items: { type: :string } }, description: "Les IDs des référents de recherche", example: %w[1 2 3], required: false
+
+      let!(:user) { create(:user, organisations: [organisation1], rdv_invitation_token: "user_token") }
+      let!(:user_with_referent) { create(:user, referent_agents: [agent], organisations: [organisation1], rdv_invitation_token: "user_with_referent_token") }
+      let!(:agent) { create(:agent, admin_role_in_organisations: [organisation1]) }
+      let!(:territory33) { create(:territory, departement_number: "33") }
+      let!(:territory92) { create(:territory, departement_number: "92") }
+
+      let!(:organisation1) { create(:organisation, territory: territory33) }
+      let!(:org_with_secto) { create(:organisation, territory: territory33) }
+      let!(:other_org_without_po) { create(:organisation, territory: territory33) }
+
+      let!(:sector) { create(:sector, territory: territory33) }
+      let!(:sector_attribution) { create(:sector_attribution, sector: sector, organisation: org_with_secto) }
+      let!(:zone_attributes) do
+        {
+          sector: sector,
+          level: "city",
+          city_name: "Bordeaux",
+          city_code: "33000",
+        }
+      end
+
+      let!(:rsa_orientation) { create(:motif_category, name: "RSA orientation sur site", short_name: "rsa_orientation") }
+      let!(:rsa_orientation_on_phone_platform) { create(:motif_category, name: "RSA orientation sur plateforme téléphonique", short_name: "rsa_orientation_on_phone_platform") }
+
+      let!(:motif) do
+        create(
+          :motif,
+          min_public_booking_delay: 3.days,
+          max_public_booking_delay: 1.month,
+          bookable_by: "agents_and_prescripteurs_and_invited_users",
+          name: "RSA orientation",
+          motif_category: rsa_orientation,
+          organisation: organisation1
+        )
+      end
+      let!(:motif2) do
+        create(
+          :motif,
+          min_public_booking_delay: 3.days,
+          max_public_booking_delay: 1.month,
+          bookable_by: "agents_and_prescripteurs_and_invited_users",
+          name: "RSA orientation phone",
+          motif_category: rsa_orientation_on_phone_platform,
+          organisation: organisation1
+        )
+      end
+      let!(:motif_follow_up) do
+        create(
+          :motif,
+          follow_up: true,
+          min_public_booking_delay: 3.days,
+          max_public_booking_delay: 1.month,
+          bookable_by: "agents_and_prescripteurs_and_invited_users",
+          name: "RSA orientation",
+          motif_category: rsa_orientation,
+          organisation: organisation1
+        )
+      end
+      let!(:motif_with_secto) do
+        create(
+          :motif,
+          min_public_booking_delay: 3.days,
+          max_public_booking_delay: 1.month,
+          bookable_by: "agents_and_prescripteurs_and_invited_users",
+          name: "Motif numéro 4",
+          sectorisation_level: Motif::SECTORISATION_LEVEL_ORGANISATION,
+          organisation: org_with_secto
+        )
+      end
+
+      let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation1) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], lieu: lieu2, organisation: organisation1) }
+      let!(:plage_ouverture_follow_up) { create(:plage_ouverture, agent: agent, motifs: [motif_follow_up], lieu: lieu2, organisation: organisation1) }
+      let!(:plage_ouverture_with_secto) { create(:plage_ouverture, motifs: [motif_with_secto], lieu: lieu, organisation: org_with_secto) }
+
+      let!(:lieu) { create(:lieu, name: "Bordeaux Centre", address: "Place de la bourse, 33000 Bordeaux", organisation: organisation1) }
+      let!(:lieu2) { create(:lieu, name: "Bruges", address: "3 Rue Gabriel Fauré, 33520 Bruges", organisation: organisation1) }
+      let!(:lieu3) { create(:lieu, name: "Loin de Bordeaux", address: "7 Av. du Commandant l'Herminier, 33740 Arès", organisation: other_org_without_po) }
+
+      let(:auth_headers) { api_auth_headers_for_agent(agent) }
+      let(:"access-token") { auth_headers["access-token"].to_s }
+      let(:uid) { auth_headers["uid"].to_s }
+      let(:client) { auth_headers["client"].to_s }
+
+      response 200, "Retourne false quand il n'y a pas de créneau disponible" do
+        run_test!
+
+        it "Quand il n'y a pas de params" do
+          expect(parsed_response_body["creneau_availability"]).to be_falsey
+        end
+
+        context "Si le lieu n'existe pas" do
+          let!(:lieu_id) { "666" }
+
+          it do
+            expect(parsed_response_body["creneau_availability"]).to be_falsey
+            expect(parsed_response_body["error"]).to eq("Couldn't find Lieu with 'id'=666")
+          end
+        end
+
+        context "Avec un lieu d'une autre organisation" do
+          let!(:lieu_id) { lieu3.id }
+          let!(:"organisation_ids[]") { [organisation1.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_falsey }
+        end
+
+        context "Avec un département sans plage d'ouverture" do
+          let!(:departement) { "92" }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_falsey }
+        end
+
+        context "Avec une organisation sans plage d'ouverture" do
+          let!(:"organisation_ids[]") { [other_org_without_po.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_falsey }
+        end
+
+        context "Avec un motif_category_shortname qui n'existe pas" do
+          let!(:motif_category_short_name) { "autre_categorie" }
+          let!(:"organisation_ids[]") { [organisation1.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_falsey }
+        end
+
+        context "Quand le user est spécifié" do
+          let!(:invitation_token) { "user_with_referent_token" }
+
+          context "Avec des ids de référents invalides" do
+            let!(:"referent_ids[]") { %w[5 6] }
+            let!(:"organisation_ids[]") { [organisation1.id] }
+
+            it { expect(parsed_response_body["creneau_availability"]).to be_falsey }
+          end
+        end
+      end
+
+      response 200, "Retourne true quand il y a des créneaux disponibles" do
+        run_test!
+
+        context "Avec le params lieu_id" do
+          let!(:lieu_id) { lieu.id }
+          let!(:"organisation_ids[]") { [organisation1.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+        end
+
+        context "Avec le params organisation_ids[]" do
+          let!(:"organisation_ids[]") { [organisation1.id, other_org_without_po.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+        end
+
+        context "Avec un numéro de département" do
+          let!(:departement) { "33" }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+        end
+
+        context "Avec un motif_category_shortname" do
+          let!(:motif_category_short_name) { "rsa_orientation" }
+          let!(:"organisation_ids[]") { [organisation1.id] }
+
+          it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+        end
+
+        context "Quand le user est spécifié" do
+          let!(:invitation_token) { "user_token" }
+
+          context "avec un user et son organisation" do
+            let!(:"organisation_ids[]") { [organisation1.id] }
+
+            it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          end
+
+          context "avec un referent_ids" do
+            let!(:"referent_ids[]") { [agent.id] }
+            let!(:invitation_token) { "user_with_referent_token" }
+            let!(:"organisation_ids[]") { [organisation1.id] }
+
+            it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          end
+
+          context "Avec un motif_category_shortname" do
+            let!(:motif_category_short_name) { "rsa_orientation" }
+            let!(:"organisation_ids[]") { [organisation1.id] }
+
+            it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          end
+
+          context "avec une adresse complète et la sectorisation" do
+            let!(:"organisation_ids[]") { [org_with_secto.id] }
+            let!(:address) { "Place de la Bourse, Bordeaux, 33000" }
+            let!(:city_code) { "33063" }
+            let!(:street_ban_id) { "33063_1155" }
+
+            it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          end
+
+          context "avec une adresse complète et sans sectorisation" do
+            let!(:departement) { "33" }
+            let!(:address) { "Place de la Bourse, Bordeaux, 33000" }
+            let!(:city_code) { "33063" }
+            let!(:street_ban_id) { "33063_1155" }
+
+            it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/web_invitation_search_context_spec.rb
+++ b/spec/services/web_invitation_search_context_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe WebInvitationSearchContext, type: :service do
+  subject { described_class.new(user: user, query_params: query_params) }
+
+  include_context "SearchContext"
+
+  describe "#matching_motifs" do
+    context "when there are two available motifs from the geo search" do
+      context "when one of the motif does not belong to the preselected orgs" do
+        let!(:other_org) { create(:organisation) }
+
+        before { motif2.update! organisation: other_org }
+
+        it "returns only the matching motif from the preselected orgs" do
+          expect(subject.send(:matching_motifs)).to eq([motif])
+        end
+      end
+    end
+
+    context "for an invitation" do
+      subject { described_class.new(user: user, query_params: query_params) }
+
+      before do
+        query_params[:motif_category_short_name] = "rsa_orientation"
+      end
+
+      context "when there are matching motifs for the geo search" do
+        it "is the geo maching motif" do
+          expect(subject.send(:matching_motifs)).to eq([motif])
+        end
+      end
+
+      context "when there are no matching motifs for the geo search" do
+        before do
+          allow(Motif).to receive(:available_for_booking)
+            .and_return(Motif.where(id: motif2.id))
+          query_params[:motif_category_short_name] = "rsa_orientation_on_phone_platform"
+        end
+
+        it "is the organisation matching motif" do
+          expect(subject.send(:matching_motifs)).to eq([motif2])
+        end
+      end
+
+      context "when agents are specified" do
+        before { query_params[:referent_ids] = [agent.id] }
+
+        let!(:agent) { create(:agent, users: [user]) }
+        let!(:motif) { create(:motif, follow_up: true, motif_category: rsa_orientation, organisation: organisation) }
+        let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif]) }
+        let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
+
+        it "is the motifs related to agent" do
+          expect(subject.send(:matching_motifs)).to eq([motif])
+        end
+      end
+    end
+  end
+
+  describe "#filter_motifs" do
+    it "returns motif when user is invited (and motif's bookable_by is agents_and_prescripteurs_and_invited_users)" do
+      # This test will be obsolete when the invitation behavior will be integrated in Rdv-s (https://github.com/betagouv/rdv-solidarites.fr/issues/3438)
+      lieu = create(:lieu)
+      query_params[:motif_category_short_name] = "rsa_orientation"
+      query_params[:lieu_id] = lieu.id
+      search_context = described_class.new(user: nil, query_params: query_params)
+      motif = create(:motif, bookable_by: :agents_and_prescripteurs_and_invited_users, motif_category: rsa_orientation, organisation: organisation)
+      create(:plage_ouverture, motifs: [motif], lieu: lieu)
+      expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([motif])
+    end
+  end
+end

--- a/spec/services/web_search_context_spec.rb
+++ b/spec/services/web_search_context_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe WebSearchContext, type: :service do
+  subject { described_class.new(user: user, query_params: query_params) }
+
+  include_examples "SearchContext"
+
+  describe "#filter_motifs" do
+    it "doesnt returns motif when user is not invited (and motif's bookable_by is agents_and_prescripteurs_and_invited_users)" do
+      lieu = create(:lieu)
+      query_params[:motif_category_short_name] = "rsa_orientation"
+      query_params[:lieu_id] = lieu.id
+      search_context = described_class.new(user: nil, query_params: query_params)
+      motif = create(:motif, bookable_by: :agents_and_prescripteurs_and_invited_users, motif_category: rsa_orientation, organisation: organisation)
+      create(:plage_ouverture, motifs: [motif], lieu: lieu)
+      expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([])
+    end
+  end
+end

--- a/spec/support/shared_context/search_context.rb
+++ b/spec/support/shared_context/search_context.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-describe SearchContext, type: :service do
-  subject { described_class.new(user: user, query_params: query_params) }
-
+RSpec.shared_examples "SearchContext" do
   let!(:user) { create(:user, organisations: [organisation]) }
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
@@ -66,56 +64,7 @@ describe SearchContext, type: :service do
       let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
 
       it "is the returns the two matching motifs" do
-        expect(subject.send(:matching_motifs)).to match_array([motif, motif2])
-      end
-
-      context "when one of the motif does not belong to the preselected orgs" do
-        let!(:other_org) { create(:organisation) }
-
-        before { motif2.update! organisation: other_org }
-
-        it "returns only the matching motif from the preselected orgs" do
-          expect(subject.send(:matching_motifs)).to eq([motif])
-        end
-      end
-    end
-
-    context "for an invitation" do
-      subject { described_class.new(user: user, query_params: query_params, through_invitation: true) }
-
-      before do
-        query_params[:motif_category_short_name] = "rsa_orientation"
-      end
-
-      context "when there are matching motifs for the geo search" do
-        it "is the geo maching motif" do
-          expect(subject.send(:matching_motifs)).to eq([motif])
-        end
-      end
-
-      context "when there are no matching motifs for the geo search" do
-        before do
-          allow(Motif).to receive(:available_for_booking)
-            .and_return(Motif.where(id: motif2.id))
-          query_params[:motif_category_short_name] = "rsa_orientation_on_phone_platform"
-        end
-
-        it "is the organisation matching motif" do
-          expect(subject.send(:matching_motifs)).to eq([motif2])
-        end
-      end
-
-      context "when agents are specified" do
-        before { query_params[:referent_ids] = [agent.id] }
-
-        let!(:agent) { create(:agent, users: [user]) }
-        let!(:motif) { create(:motif, follow_up: true, motif_category: rsa_orientation, organisation: organisation) }
-        let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, motifs: [motif]) }
-        let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
-
-        it "is the motifs related to agent" do
-          expect(subject.send(:matching_motifs)).to eq([motif])
-        end
+        expect(subject.send(:matching_motifs)).to contain_exactly(motif, motif2)
       end
     end
   end
@@ -134,7 +83,7 @@ describe SearchContext, type: :service do
   end
 
   describe "#service" do
-    it "returns serice from service_id params when given" do
+    it "returns service from service_id params when given" do
       service = create(:service)
       search_context = described_class.new(user: nil, query_params: { service_id: service.id })
       expect(search_context.service).to eq(service)
@@ -246,27 +195,6 @@ describe SearchContext, type: :service do
       motif = create(:motif, collectif: false)
       create(:plage_ouverture, motifs: [motif], lieu: lieu)
       expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([motif])
-    end
-
-    it "returns motif when user is invited (and motif's bookable_by is agents_and_prescripteurs_and_invited_users)" do
-      # This test will be obsolete when the invitation behavior will be integrated in Rdv-s (https://github.com/betagouv/rdv-solidarites.fr/issues/3438)
-      lieu = create(:lieu)
-      query_params[:motif_category_short_name] = "rsa_orientation"
-      query_params[:lieu_id] = lieu.id
-      search_context = described_class.new(user: nil, query_params: query_params, through_invitation: true)
-      motif = create(:motif, bookable_by: :agents_and_prescripteurs_and_invited_users, motif_category: rsa_orientation, organisation: organisation)
-      create(:plage_ouverture, motifs: [motif], lieu: lieu)
-      expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([motif])
-    end
-
-    it "doesnt returns motif when user is not invited (and motif's bookable_by is agents_and_prescripteurs_and_invited_users)" do
-      lieu = create(:lieu)
-      query_params[:motif_category_short_name] = "rsa_orientation"
-      query_params[:lieu_id] = lieu.id
-      search_context = described_class.new(user: nil, query_params: query_params)
-      motif = create(:motif, bookable_by: :agents_and_prescripteurs_and_invited_users, motif_category: rsa_orientation, organisation: organisation)
-      create(:plage_ouverture, motifs: [motif], lieu: lieu)
-      expect(search_context.filter_motifs(Motif.where(id: motif.id))).to eq([])
     end
   end
 end


### PR DESCRIPTION
Restore après revert betagouv/rdv-solidarites.fr#3844

Fix d'une methode manquante (`public_link_organisation`) dans le `WebInvitationSearchContext`
Celle ci n'étant pas utilisée dans le contexte des invitations j'ai ajouté une méthode `public_link_organisation` qui renvoi nil et le test qui va bien.