### PR TITLE
Généralisation du texte montré aux usagers quand aucun créneau n'est trouvé

### DIFF
--- a/app/views/search/_nothing_to_show.html.slim
+++ b/app/views/search/_nothing_to_show.html.slim
@@ -17,4 +17,4 @@
           i.fa.fa-envelope
         | Envoyer une demande à l'équipe technique
     - else
-      .font-weight-bold La prise de rendez-vous n'est pas disponible pour ce département.
+      .font-weight-bold Aucun créneau ne correspond à votre recherche

--- a/app/views/search/_nothing_to_show.html.slim
+++ b/app/views/search/_nothing_to_show.html.slim
@@ -17,4 +17,4 @@
           i.fa.fa-envelope
         | Envoyer une demande à l'équipe technique
     - else
-      .font-weight-bold Aucun créneau ne correspond à votre recherche
+      .font-weight-bold Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -317,14 +317,14 @@ RSpec.describe "Adding a user to a collective RDV" do
         rdv.status = "revoked"
         rdv.save
         select_motif
-        expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
+        expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
 
         rdv2.max_participants_count = 2
         create(:rdvs_user, rdv: rdv2)
         create(:rdvs_user, rdv: rdv2)
         rdv2.save
         visit root_path(params)
-        expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
+        expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
       end
 
       it "correctly display message of participation already existing" do

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -317,14 +317,14 @@ RSpec.describe "Adding a user to a collective RDV" do
         rdv.status = "revoked"
         rdv.save
         select_motif
-        expect(page).to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
+        expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
 
         rdv2.max_participants_count = 2
         create(:rdvs_user, rdv: rdv2)
         create(:rdvs_user, rdv: rdv2)
         rdv2.save
         visit root_path(params)
-        expect(page).to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
+        expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
       end
 
       it "correctly display message of participation already existing" do

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -279,23 +279,23 @@ describe "User can search for rdvs" do
 
     it "isn't shown to the users" do
       visit root_path(departement: "92")
-      expect(page).to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
+      expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
 
       motif.update!(bookable_by: "everyone") # to make sure this spec isn't a false positive
 
       visit root_path(departement: "92")
-      expect(page).not_to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
+      expect(page).not_to have_content("Aucun créneau ne correspond à votre recherche")
     end
 
     it "isn't shown to the users when bookable_by is agents_and_prescripteurs_and_invited_users" do
       motif.update!(bookable_by: "agents_and_prescripteurs_and_invited_users")
       visit root_path(departement: "92")
-      expect(page).to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
+      expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
 
       motif.update!(bookable_by: "everyone") # to make sure this spec isn't a false positive
 
       visit root_path(departement: "92")
-      expect(page).not_to have_content("La prise de rendez-vous n'est pas disponible pour ce département.")
+      expect(page).not_to have_content("Aucun créneau ne correspond à votre recherche")
     end
   end
 

--- a/spec/features/users/user_can_search_rdv_spec.rb
+++ b/spec/features/users/user_can_search_rdv_spec.rb
@@ -279,23 +279,23 @@ describe "User can search for rdvs" do
 
     it "isn't shown to the users" do
       visit root_path(departement: "92")
-      expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
+      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
 
       motif.update!(bookable_by: "everyone") # to make sure this spec isn't a false positive
 
       visit root_path(departement: "92")
-      expect(page).not_to have_content("Aucun créneau ne correspond à votre recherche")
+      expect(page).not_to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
     end
 
     it "isn't shown to the users when bookable_by is agents_and_prescripteurs_and_invited_users" do
       motif.update!(bookable_by: "agents_and_prescripteurs_and_invited_users")
       visit root_path(departement: "92")
-      expect(page).to have_content("Aucun créneau ne correspond à votre recherche")
+      expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
 
       motif.update!(bookable_by: "everyone") # to make sure this spec isn't a false positive
 
       visit root_path(departement: "92")
-      expect(page).not_to have_content("Aucun créneau ne correspond à votre recherche")
+      expect(page).not_to have_content("Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.")
     end
   end
 


### PR DESCRIPTION
Dans la continuité de #3831 , on rend plus générique le texte montré aux usagers quand aucun créneau n'est trouvé.

#### Avant
<img width="600" alt="Screenshot 2023-10-26 at 17 16 34" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/0a1ee6c6-ce6c-4ba7-a278-13b9eb1f0d83">

#### Après
<img width="600" alt="Screenshot 2023-10-26 at 17 16 18" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/50c6582d-b08c-4140-af61-1a4e3430c765">