### PR TITLE
Éviter une édition accidentelle des motifs d'un service

### DIFF
--- a/app/dashboards/service_dashboard.rb
+++ b/app/dashboards/service_dashboard.rb
@@ -49,7 +49,6 @@ class ServiceDashboard < Administrate::BaseDashboard
     name
     short_name
     verticale
-    motifs
   ].freeze
 
   def display_resource(service)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -13,7 +13,7 @@ class Service < ApplicationRecord
 
   # Relations
   has_many :agents, dependent: :nullify
-  has_many :motifs, dependent: :destroy
+  has_many :motifs, dependent: :restrict_with_error
 
   # Validations
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }


### PR DESCRIPTION
Problème : sur l'interface super-admin, sur le formulaire d'édition de service, il y a un select pour modifier les motifs. 

![image](https://github.com/betagouv/rdv-solidarites.fr/assets/6357692/304368c3-6819-4e9d-a134-008f9a9a9bbc)

Ce select liste tous les motifs de toutes les orgas. Il est donc facile d'arriver sur ce formulaire (pour éditer la verticale, par exemple :wink: ) et de se retrouver à modifier accidentellement la liste des motifs pour une raison quelconque, par exemple :
- le multiselect JS tronque les valeurs
- on clique sur une petite croix à cause d'un trackpad de laptop bon marché

Et si on retire un motif de la liste et que l'on clique sur "Enregistrer", le motif est supprimé (sauf si il a des RDV, auquel cas ça plante).

Ce select est donc dangereux en plus d'être inutile, donc je propose de le virer. :wink: 

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
