### PR TITLE
fix(job): Fix regex condition in webhook job

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -11,7 +11,7 @@ class WebhookJob < ApplicationJob
   def perform(payload, webhook_endpoint_id)
     webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 
-    return if Rails.env.development? && !webhook_endpoint.target_url =~ /localhost/
+    return if Rails.env.development? && webhook_endpoint.target_url !~ /localhost/
 
     request = Typhoeus::Request.new(
       webhook_endpoint.target_url,


### PR DESCRIPTION
Les jobs de webhooks échouaient en dev parce qu'on essayait de matcher un booléen retourné par `!webhook_endpoint.target_url` avec une expression régulière.
Je change la condition ici pour qu'on check le match sur le string `webhook_endpoint.target_url`. 