### PR TITLE
Participations Policy fix pour l'api

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -51,8 +51,11 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
     )
   end
 
-  def record_not_found(_)
-    head :not_found
+  def record_not_found(exception)
+    render(
+      status: :not_found,
+      json: { success: false, errors: [exception.to_s] }
+    )
   end
 
   def record_invalid(exception)

--- a/app/controllers/api/v1/participations_controller.rb
+++ b/app/controllers/api/v1/participations_controller.rb
@@ -11,6 +11,14 @@ class Api::V1::ParticipationsController < Api::V1::AgentAuthBaseController
 
   private
 
+  # On fait cela sinon current_organisation est nil
+  # Cela empêche can_access_others_planning? de renvoyer une valeur dans le scope de la policy RDV et on limite les rdvs visibles même quand on doit y avoir accés
+  # TODO : Revoir le fonctionnement de current_organisation dans les scopes
+
+  def current_organisation
+    @current_organisation ||= Participation.find(params[:id]).rdv.organisation
+  end
+
   def participation_params
     params.require(:participation).permit(:status)
   end


### PR DESCRIPTION
On a découvert un bug remontée par rdvi sur l'enpoint d'api particpations#update.
Celui ci ne fonctionne pas correctement quand on est admin ou quand on veut mettre à jour des rdvs qui ne sont pas du service de l'agent qui fait la demande.