### PR TITLE
Ne pas envoyer de données personnelles sur les serveurs Outlook hors de l'union européenne

### DIFF
--- a/app/models/concerns/outlook/event_serializer_and_listener.rb
+++ b/app/models/concerns/outlook/event_serializer_and_listener.rb
@@ -105,15 +105,7 @@ module Outlook
       show_link = url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv.id, host: agent.domain.host_name)
       edit_link = url_helpers.edit_admin_organisation_rdv_url(rdv.organisation, rdv.id, host: agent.domain.host_name)
 
-      participants_list = rdv.participations.not_cancelled.map do |participation|
-        "<li>#{participation.user.full_name}</li>"
-      end.join
-
       <<~HTML
-        Participants:
-        <ul>#{participants_list}</ul>
-        <br />
-
         Plus d'infos sur <a href="#{show_link}">#{agent.domain_name}</a>:
         <br />
 

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe Outlook::EventSerializerAndListener do
   end
   let(:expected_description) do
     <<~HTML
-      Participants:
-      <ul><li>First LAST</li></ul>
-      <br />
-
       Plus d'infos sur <a href="http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}">RDV Solidarités</a>:
       <br />
 


### PR DESCRIPTION
Suite à la discussion avec le responsable sécurité de l'ANCT, il est fortement déconseillé (et bloquant pour l'homologation de sécurité) d'envoyer des données personnelles sur des serveurs outlook aux états unis (ça serait possible si c'est les serveurs outlook du SI d'un département qui sont physiquement en france).
Ça rend la fonctionnalité un petit peu moins pratique, mais on garde un lien vers l'appli dans la description de l'event outlook.


Cette fonctionnalité n'est utilisée que par 7 cnfs, donc c'est pas critique de la modifier.