### PR TITLE
Diminuer l'ambiguïté sur `secretariat`

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -21,7 +21,7 @@ module MotifsHelper
     tag.span(motif_name_and_location_type(motif)) + motif_badges(motif)
   end
 
-  def motif_badges(motif, only: %i[bookable_by_invited_users bookable_by_everyone secretariat follow_up collectif])
+  def motif_badges(motif, only: %i[bookable_by_invited_users bookable_by_everyone for_secretariat follow_up collectif])
     safe_join(only.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) })
   end
 

--- a/app/javascript/stylesheets/components/_motifs.scss
+++ b/app/javascript/stylesheets/components/_motifs.scss
@@ -19,7 +19,7 @@
   color: $white;
 }
 
-.badge-motif-secretariat {
+.badge-motif-for_secretariat {
   background-color: $orange;
   color: $dark;
 }

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -96,7 +96,6 @@ class Agent < ApplicationRecord
   }
   scope :active, -> { where(deleted_at: nil) }
   scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
-  scope :secretaires, -> { joins(:services).where(services: Service.secretariat) }
   scope :in_any_of_these_services, lambda { |services|
     joins(:agent_services).where(agent_services: { service_id: services.map(&:id) })
   }

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -96,7 +96,7 @@ class Agent < ApplicationRecord
   }
   scope :active, -> { where(deleted_at: nil) }
   scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
-  scope :secretariat, -> { joins(:services).where(services: { name: Service::SECRETARIAT }) }
+  scope :secretaires, -> { joins(:services).where(services: Service.secretariat) }
   scope :in_any_of_these_services, lambda { |services|
     joins(:agent_services).where(agent_services: { service_id: services.map(&:id) })
   }

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -146,10 +146,6 @@ class Motif < ApplicationRecord
     for_secretariat ? [service, Service.secretariat.first] : [service]
   end
 
-  def secretariat?
-    for_secretariat?
-  end
-
   def visible_and_notified?
     visibility_type == VISIBLE_AND_NOTIFIED
   end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -143,7 +143,7 @@ class Motif < ApplicationRecord
   end
 
   def authorized_services
-    for_secretariat ? [service, Service.secretariat.first] : [service]
+    for_secretariat ? [service, Service.secretariat] : [service]
   end
 
   def visible_and_notified?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -20,8 +20,6 @@ class Service < ApplicationRecord
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
 
   # Scopes
-  scope :with_motifs, -> { where.not(name: SECRETARIAT) }
-  scope :secretariat, -> { where(name: SECRETARIAT) }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
   scope :in_verticale, ->(verticale) { where(verticale: [verticale, nil]) }
 
@@ -31,6 +29,10 @@ class Service < ApplicationRecord
   def self.used_by_agents_of_territory(territory)
     agents_of_territory = Agent.joins(:organisations).merge(territory.organisations)
     joins(:agent_services).where(agent_services: { agents: agents_of_territory }).distinct
+  end
+
+  def self.secretariat
+    find_by!(name: SECRETARIAT)
   end
 
   def secretariat?

--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -11,7 +11,8 @@ class Agent::ServicePolicy < Agent::AdminPolicy
 
   class AdminScope < Scope
     def resolve
-      return scope.secretariat if current_agent.conseiller_numerique?
+      # https://github.com/betagouv/rdv-solidarites.fr/pull/3868#pullrequestreview-1729410580
+      return scope.where(id: Service.secretariat.id) if current_agent.conseiller_numerique?
       return scope.in_verticale(current_agent_role.organisation.verticale) if current_agent_role.admin?
 
       scope.where(id: current_agent.services.select(:id))

--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -11,6 +11,7 @@ class Agent::ServicePolicy < Agent::AdminPolicy
 
   class AdminScope < Scope
     def resolve
+      return scope.secretariat if current_agent.conseiller_numerique?
       return scope.in_verticale(current_agent_role.organisation.verticale) if current_agent_role.admin?
 
       scope.where(id: current_agent.services.select(:id))

--- a/app/policies/agent/service_policy.rb
+++ b/app/policies/agent/service_policy.rb
@@ -11,7 +11,6 @@ class Agent::ServicePolicy < Agent::AdminPolicy
 
   class AdminScope < Scope
     def resolve
-      return scope.secretariat if current_agent.conseiller_numerique?
       return scope.in_verticale(current_agent_role.organisation.verticale) if current_agent_role.admin?
 
       scope.where(id: current_agent.services.select(:id))

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -3,7 +3,7 @@ tr
     span.badge.badge-pill.ml-0.mr-2 style="background: #{motif.color};" &nbsp;
   td
     = link_to motif.name, admin_organisation_motif_path(motif.organisation, motif)
-    = motif_badges(motif, only: %i[secretariat follow_up collectif])
+    = motif_badges(motif, only: %i[for_secretariat follow_up collectif])
   td
     = motif_badges(motif, only: %i[bookable_by_everyone bookable_by_invited_users])
   - if @display_sectorisation_level

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -6,7 +6,7 @@ fr:
       bookable_by_invited_users: "En ligne sur invitation"
       phone: "Par tél."
       home: "À domicile"
-      secretariat: "Secrétariat"
+      for_secretariat: "Secrétariat"
       follow_up: "Suivi"
       sectorisation_level_agent: "Sectorisé à l'agent"
       sectorisation_level_organisation: "Sectorisé à l'organisation"

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Admin::AgentsController, type: :controller do
                        invitation_accepted_at: nil, service: create(:service, :conseiller_numerique))
       end
 
+      before { create(:service, :secretariat) }
+
       it "only allows inviting agents for the secretariat" do
         get :new, params: { organisation_id: organisation.id }
         expect(response).not_to have_content("Admin")

--- a/spec/helpers/motifs_helper_spec.rb
+++ b/spec/helpers/motifs_helper_spec.rb
@@ -4,7 +4,7 @@ describe MotifsHelper do
       motif = build(:motif, bookable_by: :agents, for_secretariat: true)
       badges = motif_badges(motif)
       expect(badges).to include("Secrétariat")
-      expect(badges).to include("badge-motif-secretariat")
+      expect(badges).to include("badge-motif-for_secretariat")
     end
 
     it "affiche le badge Suivi pour un motif `follow_up`" do
@@ -25,7 +25,7 @@ describe MotifsHelper do
       motif = build(:motif, bookable_by: :agents, follow_up: true, for_secretariat: true)
       badges = motif_badges(motif)
       expect(badges).to include("Secrétariat")
-      expect(badges).to include("badge-motif-secretariat")
+      expect(badges).to include("badge-motif-for_secretariat")
       expect(badges).to include("Suivi")
       expect(badges).to include("badge-motif-follow_up")
     end

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -111,15 +111,15 @@ describe Motif, type: :model do
     end
   end
 
-  describe "secretariat?" do
+  describe "for_secretariat?" do
     it "return true if motif for_secretariat" do
       motif = build(:motif, for_secretariat: true, organisation: organisation)
-      expect(motif.secretariat?).to be true
+      expect(motif.for_secretariat?).to be true
     end
 
     it "return false if motif for_secretariat" do
       motif = build(:motif, for_secretariat: false, organisation: organisation)
-      expect(motif.secretariat?).to be false
+      expect(motif.for_secretariat?).to be false
     end
   end
 


### PR DESCRIPTION
Dans #3866 j'ai déjà entrepris de renommer `Agent#secretariat` en `Agent#secretaire`.

Dans cette PR je vais un peu plus loin pour clarifier notre sémantique autour de la notion de secrétariat :
- renommer `Motif#secretariat?` en `Motif#for_secretariat?`, ça aide aussi à trouver facilement les usages dans le code
- faire en sorte que `Service.secretariat` retourne un record et non une scope (ça me paraît plus logique)

Point important glissé à l'occasion, la suppression de

```ruby
      return scope.secretariat if current_agent.conseiller_numerique?
```

dans `Agent::ServicePolicy`. D'après Nesserine ce n'est plus nécessaire, je laisse Victor confirmer si il le veut.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
