### PR TITLE
Ne pas retry un `WebhookJob` quand on a `ActiveRecord::RecordNotFound`

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -4,6 +4,7 @@ class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
   queue_as :webhook
+  discard_on(ActiveRecord::RecordNotFound) { |_job, error| Sentry.capture_exception(error) }
 
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false


### PR DESCRIPTION
On a ces remontées où les retries sont inutiles et font du bruit : 
https://sentry.incubateur.net/organizations/betagouv/issues/67093

Avec cette PR on ne retry pas, et on peut configurer Sentry en "ignore until 10 per week" et paf.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
