### PR TITLE
Ouverture de la fonctionnalité intervenants à tout le monde

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -117,20 +117,11 @@ class Admin::AgentsController < AgentAuthController
   end
 
   def access_levels_collection
-    if activate_intervenants_feature? && @agent != current_agent && @agent.organisations.count < 2
+    if @agent != current_agent && @agent.organisations.count < 2
       AgentRole::ACCESS_LEVELS_WITH_INTERVENANT
     else
       AgentRole::ACCESS_LEVELS
     end
-  end
-
-  def activate_intervenants_feature?
-    # For CDAD Expe
-    current_organisation.territory_id.in?([59, 147, 148]) ||
-      Rails.env.development? ||
-      Rails.env.test? ||
-      ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO" ||
-      ENV["IS_REVIEW_APP"] == "true"
   end
 
   def create_agent_params

--- a/config/locales/models/agent_role.fr.yml
+++ b/config/locales/models/agent_role.fr.yml
@@ -13,7 +13,7 @@ fr:
       agent_role/access_levels/explanation:
         basic: "<i class='far fa-user'></i> Basique<br><ul><li>Peut consulter et modifier son agenda et celui des agents de son service</li><li>Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation</li></ul>"
         admin: <i class='fa fa-user-cog'></i> Administrateur<br><ul><li>Peut consulter et modifier l'agenda de tous les agents de l'organisation</li><li>Peut créer, modifier et supprimer des lieux, des motifs et des agents</li><li>Peut accéder aux statistiques de l'organisation</li></ul>
-        intervenant: <i class="fas fa-user-lock"></i> Intervenant<br><ul><li>Ne nécessite pas d'email et ne peut pas se connecter à un compte</li><li>Ne peut pas modifier son agenda</li><li>Ne reçoit aucune notification</li></ul>
+        intervenant: <i class="fas fa-user-lock"></i> Intervenant<br><ul><li>Ne nécessite pas d'email et donc ne peut pas se connecter</li><li>Ne peut pas modifier son agenda</li><li>Ne reçoit aucune notification</li></ul>
     warnings:
       models:
         agent_role:

--- a/config/locales/models/agent_role.fr.yml
+++ b/config/locales/models/agent_role.fr.yml
@@ -13,7 +13,7 @@ fr:
       agent_role/access_levels/explanation:
         basic: "<i class='far fa-user'></i> Basique<br><ul><li>Peut consulter et modifier son agenda et celui des agents de son service</li><li>Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation</li></ul>"
         admin: <i class='fa fa-user-cog'></i> Administrateur<br><ul><li>Peut consulter et modifier l'agenda de tous les agents de l'organisation</li><li>Peut créer, modifier et supprimer des lieux, des motifs et des agents</li><li>Peut accéder aux statistiques de l'organisation</li></ul>
-        intervenant: <i class="fas fa-user-lock"></i> Intervenant<br><ul><li>Ne peut pas modifier son agenda</li><li>Ne peut pas se connecter à un compte car il n'a pas d'e-mail</li><li>Ne reçoit aucune notification</li></ul>
+        intervenant: <i class="fas fa-user-lock"></i> Intervenant<br><ul><li>Ne nécessite pas d'email et ne peut pas se connecter à un compte</li><li>Ne peut pas modifier son agenda</li><li>Ne reçoit aucune notification</li></ul>
     warnings:
       models:
         agent_role:


### PR DESCRIPTION
La fonctionnalité marche bien, il y a des petites améliorations possibles, mais rien de bloquant pour ouvrir à tout le monde (il y a de la demande côté médico-social).
Du coup on ouvre à tout le monde.

Les petits points qui seront à gérer plus tard :
- ajouter un lien vers un texte d'explication
- gérer le problème des réponses des usagers aux notifs pour les rdv avec intervenants qui n'arrivent nulle part
- décider de si on active la possibilité d'ajouter des intervenants depuis l'interface d'admin de territoire (ça demande de rembourser un peu de dette technique)