### PR TITLE
perfs : Ajout d'un index pour accélérer la connexion avec FranceConnect

### DIFF
--- a/db/migrate/20231120094146_add_users_franceconnect_openid_sub_index.rb
+++ b/db/migrate/20231120094146_add_users_franceconnect_openid_sub_index.rb
@@ -1,0 +1,5 @@
+class AddUsersFranceconnectOpenidSubIndex < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :franceconnect_openid_sub
+  end
+end

--- a/db/migrate/20231120094146_add_users_franceconnect_openid_sub_index.rb
+++ b/db/migrate/20231120094146_add_users_franceconnect_openid_sub_index.rb
@@ -1,5 +1,5 @@
 class AddUsersFranceconnectOpenidSubIndex < ActiveRecord::Migration[7.0]
   def change
-    add_index :users, :franceconnect_openid_sub
+    add_index :users, :franceconnect_openid_sub, where: "franceconnect_openid_sub IS NOT NULL"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_16_160522) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_20_094146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -704,6 +704,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_160522) do
     t.index ["created_through"], name: "index_users_on_created_through"
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["first_name"], name: "index_users_on_first_name"
+    t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -704,7 +704,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_20_094146) do
     t.index ["created_through"], name: "index_users_on_created_through"
     t.index ["email"], name: "index_users_on_email", unique: true, where: "(email IS NOT NULL)"
     t.index ["first_name"], name: "index_users_on_first_name"
-    t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub"
+    t.index ["franceconnect_openid_sub"], name: "index_users_on_franceconnect_openid_sub", where: "(franceconnect_openid_sub IS NOT NULL)"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"


### PR DESCRIPTION
Les metrics sur postgres indiquent qu'on a beaucoup de lenteur sur cette recherche
On fait effectivement un `User.find_by(franceconnect_openid_sub: omniauth_info.sub)` lors de la connexion avec France Connect.

<img width="1294" alt="Screenshot 2023-11-20 at 10 41 11" src="https://github.com/betagouv/rdv-solidarites.fr/assets/1840367/9134ce10-4649-491c-9f85-0f666e18d7f3">


J'espère que ça ira mieux avec cet index