### PR TITLE
SuperAdmin - Formulaire lieu - faciliter la sélection de l'orga

### DIFF
--- a/app/dashboards/lieu_dashboard.rb
+++ b/app/dashboards/lieu_dashboard.rb
@@ -11,7 +11,7 @@ class LieuDashboard < Administrate::BaseDashboard
     id: Field::Number,
     name: Field::String,
     versions: Field::HasMany,
-    organisation: Field::BelongsTo,
+    organisation: Field::BelongsTo.with_options(order: { id: :asc }),
     plage_ouvertures: Field::HasMany,
     rdvs: Field::HasMany,
     motifs: Field::HasMany,


### PR DESCRIPTION
Actuellement les orgas sont dans un ordre indéterminé, c'est donc très difficile pour le support de trouver l'orga désirée ! 

Cette PR ordonne les orgas par ID, selon @NesserineZarouri c'est plus pratique que par nom.

# Avant

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/0f64d546-5fa4-4e17-926a-ea567be003aa)

# Après

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/2efea37e-c13e-435f-9f24-5cca987da844)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
