### PR TITLE
hotfix: ne pas partager la liste des usagers pour les mairies et les cnfs

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -18,12 +18,12 @@ class Agents::UsersController < AgentAuthController
 
     results_count = users_from_organisation.size
 
-    users_from_territory = if results_count < MAX_RESULTS
+    users_from_territory = if agent_in_cnfs_or_mairies_territories? || results_count >= MAX_RESULTS
+                             []
+                           else
                              user_scope.joins(:territories).where(territories: { id: current_agent.agent_territorial_access_rights.select(:territory_id) })
                                .where.not(id: users_from_organisation.map(&:id))
                                .limit(MAX_RESULTS - results_count).to_a
-                           else
-                             []
                            end
 
     results = []
@@ -46,6 +46,11 @@ class Agents::UsersController < AgentAuthController
   end
 
   private
+
+  def agent_in_cnfs_or_mairies_territories?
+    cnfs_and_mairies_territory_ids = [Territory.mairies&.id, Territory.find_by(departement_number: "CN")&.id].compact
+    (cnfs_and_mairies_territory_ids & current_agent.organisations.pluck(:territory_id)).any? # & does an array overlap here
+  end
 
   def serialize(users)
     users.map do |user|


### PR DESCRIPTION
hotfix suite à ce retour : https://zammad10.ethibox.fr/#ticket/zoom/8913

A plus long terme, on va mettre une option dans la configuration du territoire