### PR TITLE
Corriger deux flaky specs (ignorer ordre des résultats)

### DIFF
--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::AbsencesController, type: :controller do
                                  end_day: today + 1.month + 3.days)
 
         get :index, params: { organisation_id: organisation.id, agent_id: agent.id }
-        expect(assigns(:absences).sort).to eq([absence_juin, absence_juillet].sort)
+        expect(assigns(:absences)).to contain_exactly(absence_juin, absence_juillet)
       end
     end
 

--- a/spec/controllers/admin/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/agents/rdvs_controller_spec.rb
@@ -20,7 +20,7 @@ describe Admin::Agents::RdvsController, type: :controller do
         rdv = create(:rdv, agents: [given_agent], organisation: organisation, starts_at: now + 3.days)
         rdv_from_other_organisation = create(:rdv, agents: [given_agent], organisation: other_organisation, starts_at: now + 4.days)
         get :index, params: { agent_id: given_agent.id, organisation_id: organisation.id, format: :json }
-        expect(assigns(:rdvs).sort).to eq([rdv, rdv_from_other_organisation].sort)
+        expect(assigns(:rdvs)).to contain_exactly(rdv, rdv_from_other_organisation)
         travel_back
       end
 

--- a/spec/controllers/admin/motifs_controller_spec.rb
+++ b/spec/controllers/admin/motifs_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Admin::MotifsController, type: :controller do
         bla_motif = create(:motif, name: "Bla", organisation: organisation)
         get :index, params: { organisation_id: organisation.id, search: "bla" }
         expect(assigns(:motifs)).to eq([bla_motif])
-        expect(assigns(:unfiltered_motifs).sort).to eq([bla_motif, motif].sort)
+        expect(assigns(:unfiltered_motifs)).to contain_exactly(bla_motif, motif)
       end
     end
   end

--- a/spec/controllers/admin/referent_assignations_controller_spec.rb
+++ b/spec/controllers/admin/referent_assignations_controller_spec.rb
@@ -12,7 +12,7 @@ describe Admin::ReferentAssignationsController, type: :controller do
       get :index, params: { organisation_id: organisation.id, user_id: user.id }
 
       expect(response).to be_successful
-      expect(assigns(:agents).sort).to eq([agent, lea].sort)
+      expect(assigns(:agents)).to contain_exactly(agent, lea)
       expect(assigns(:referents)).to eq([])
     end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -322,7 +322,7 @@ describe Rdv, type: :model do
           rdv_that_ongoing,
         ]
 
-        expect(described_class.ongoing(time_margin: 1.hour).sort).to eq(expected_rdvs.sort)
+        expect(described_class.ongoing(time_margin: 1.hour)).to match_array(expected_rdvs)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,7 +62,7 @@ describe User, type: :model do
     it "when user is responsible" do
       responsive = create(:user, organisations: [create(:organisation), create(:organisation)])
       relative = create(:user, responsible: responsive)
-      expect(relative.organisations.sort).to eq(responsive.organisations.sort)
+      expect(relative.organisations).to match_array(responsive.organisations)
     end
   end
 

--- a/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
+++ b/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "CRUDS teams configuration", type: :request do
       get admin_territory_teams_path(territory)
 
       expect(response).to be_successful
-      expect(assigns(:teams).sort).to eq(teams.sort)
+      expect(assigns(:teams)).to match_array(teams)
     end
 
     it "returns searched teams" do

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -112,7 +112,7 @@ describe SlotBuilder, type: :service do
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, nil, date_range, [])
 
-      expect(plage_ouvertures).to match([matching_po1, matching_po2])
+      expect(plage_ouvertures).to contain_exactly(matching_po1, matching_po2)
     end
 
     it "returns all plage_ouverture for the range" do
@@ -121,7 +121,7 @@ describe SlotBuilder, type: :service do
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
 
-      expect(plage_ouvertures).to eq([matching_po, other_matching_po])
+      expect(plage_ouvertures).to contain_exactly(matching_po, other_matching_po)
     end
 
     it "returns only without recurrence PO where first_day is in range" do

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -167,7 +167,7 @@ describe SlotBuilder, type: :service do
                                               recurrence: Montrose.every(:week, starts: first_day - 1.day))
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
-      expect(plage_ouvertures.sort).to eq([matching_po, recurring_po].sort)
+      expect(plage_ouvertures).to contain_exactly(matching_po, recurring_po)
     end
 
     it "returns without recurrence PO that start in range" do


### PR DESCRIPTION
Deux specs ont échoué ici : https://github.com/betagouv/rdv-service-public/actions/runs/6961525949/job/18943310993

On voit que les plages sont obtenues dans le mauvais ordre, ce qui n'est pas un problème puisqu'elles commencent au même moment.

```

2023-11-22T18:51:41.7183574Z Failures:
2023-11-22T18:51:41.7183968Z 
2023-11-22T18:51:41.7185262Z   1) SlotBuilder#plage_ouvertures_for return plage_ouverture that match without no lieu given
2023-11-22T18:51:41.7187105Z      Failure/Error: expect(plage_ouvertures).to match([matching_po1, matching_po2])
2023-11-22T18:51:41.7188070Z 
2023-11-22T18:51:41.7200603Z        expected #<ActiveRecord::Relation [#<PlageOuverture id: 59, agent_id: 470, title: "Plage 2", organisation_id: ...0.000000000 +0200", recurrence: nil, lieu_id: nil, expired_cached: false, recurrence_ends_at: nil>]> to match [#<PlageOuverture id: 58, agent_id: 469, title: "Plage 1", organisation_id: 486, first_day: "2021-05-03", start_time: #<Tod::TimeOfDay:0x00007f1e0c1c0d28 @hour=9, @minute=0, @second=0, @second_of_day=32400>, end_time: #<Tod::TimeOfDay:0x00007f1e0c1c0cd8 @hour=11, @minute=20, @second=0, @second_of_day=40800>, created_at: "2021-04-30 08:00:00.000000000 +0200", updated_at: "2021-04-30 08:00:00.000000000 +0200", recurrence: nil, lieu_id: nil, expired_cached: false, recurrence_ends_at: nil>, #<PlageOuverture id: 59, agent_id: 470, title: "Plage 2", organisation_id: 487, first_day: "2021-05-03", start_time: #<Tod::TimeOfDay:0x00007f1e0c1c0288 @hour=9, @minute=0, @second=0, @second_of_day=32400>, end_time: #<Tod::TimeOfDay:0x00007f1e0c1c01e8 @hour=11, @minute=20, @second=0, @second_of_day=40800>, created_at: "2021-04-30 08:00:00.000000000 +0200", updated_at: "2021-04-30 08:00:00.000000000 +0200", recurrence: nil, lieu_id: 222, expired_cached: false, recurrence_ends_at: nil>]
2023-11-22T18:51:41.7208897Z        Diff:
2023-11-22T18:51:41.7209418Z        @@ -1,3 +1,49 @@
2023-11-22T18:51:41.7214734Z        -[#<PlageOuverture id: 58, agent_id: 469, title: "Plage 1", organisation_id: 486, first_day: "2021-05-03", start_time: #<Tod::TimeOfDay:0x00007f1e0c1c0d28 @hour=9, @minute=0, @second=0, @second_of_day=32400>, end_time: #<Tod::TimeOfDay:0x00007f1e0c1c0cd8 @hour=11, @minute=20, @second=0, @second_of_day=40800>, created_at: "2021-04-30 08:00:00.000000000 +0200", updated_at: "2021-04-30 08:00:00.000000000 +0200", recurrence: nil, lieu_id: nil, expired_cached: false, recurrence_ends_at: nil>,
2023-11-22T18:51:41.7223037Z        - #<PlageOuverture id: 59, agent_id: 470, title: "Plage 2", organisation_id: 487, first_day: "2021-05-03", start_time: #<Tod::TimeOfDay:0x00007f1e0c1c0288 @hour=9, @minute=0, @second=0, @second_of_day=32400>, end_time: #<Tod::TimeOfDay:0x00007f1e0c1c01e8 @hour=11, @minute=20, @second=0, @second_of_day=40800>, created_at: "2021-04-30 08:00:00.000000000 +0200", updated_at: "2021-04-30 08:00:00.000000000 +0200", recurrence: nil, lieu_id: 222, expired_cached: false, recurrence_ends_at: nil>]
2023-11-22T18:51:41.7227093Z        +[#<PlageOuverture:0x00007f1e0baf0ca0
2023-11-22T18:51:41.7227735Z        +  id: 59,
2023-11-22T18:51:41.7228169Z        +  agent_id: 470,
2023-11-22T18:51:41.7228656Z        +  title: "Plage 2",
2023-11-22T18:51:41.7229211Z        +  organisation_id: 487,
2023-11-22T18:51:41.7229800Z        +  first_day: Mon, 03 May 2021,
2023-11-22T18:51:41.7230369Z        +  start_time:
2023-11-22T18:51:41.7230893Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c2fd8
2023-11-22T18:51:41.7231431Z        +    @hour=9,
2023-11-22T18:51:41.7231821Z        +    @minute=0,
2023-11-22T18:51:41.7232227Z        +    @second=0,
2023-11-22T18:51:41.7232680Z        +    @second_of_day=32400>,
2023-11-22T18:51:41.7233143Z        +  end_time:
2023-11-22T18:51:41.7233598Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c2e48
2023-11-22T18:51:41.7234096Z        +    @hour=11,
2023-11-22T18:51:41.7234446Z        +    @minute=20,
2023-11-22T18:51:41.7234829Z        +    @second=0,
2023-11-22T18:51:41.7235236Z        +    @second_of_day=40800>,
2023-11-22T18:51:41.7235863Z        +  created_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7236714Z        +  updated_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7237309Z        +  recurrence: nil,
2023-11-22T18:51:41.7237707Z        +  lieu_id: 222,
2023-11-22T18:51:41.7238138Z        +  expired_cached: false,
2023-11-22T18:51:41.7238611Z        +  recurrence_ends_at: nil>,
2023-11-22T18:51:41.7239144Z        + #<PlageOuverture:0x00007f1e0baf0b60
2023-11-22T18:51:41.7239606Z        +  id: 58,
2023-11-22T18:51:41.7239963Z        +  agent_id: 469,
2023-11-22T18:51:41.7240366Z        +  title: "Plage 1",
2023-11-22T18:51:41.7240798Z        +  organisation_id: 486,
2023-11-22T18:51:41.7241280Z        +  first_day: Mon, 03 May 2021,
2023-11-22T18:51:41.7241727Z        +  start_time:
2023-11-22T18:51:41.7242185Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c2178
2023-11-22T18:51:41.7242677Z        +    @hour=9,
2023-11-22T18:51:41.7243028Z        +    @minute=0,
2023-11-22T18:51:41.7243383Z        +    @second=0,
2023-11-22T18:51:41.7243781Z        +    @second_of_day=32400>,
2023-11-22T18:51:41.7244251Z        +  end_time:
2023-11-22T18:51:41.7244716Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c1fe8
2023-11-22T18:51:41.7245233Z        +    @hour=11,
2023-11-22T18:51:41.7245613Z        +    @minute=20,
2023-11-22T18:51:41.7246002Z        +    @second=0,
2023-11-22T18:51:41.7246411Z        +    @second_of_day=40800>,
2023-11-22T18:51:41.7247083Z        +  created_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7247911Z        +  updated_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7248552Z        +  recurrence: nil,
2023-11-22T18:51:41.7248978Z        +  lieu_id: nil,
2023-11-22T18:51:41.7249416Z        +  expired_cached: false,
2023-11-22T18:51:41.7249934Z        +  recurrence_ends_at: nil>]
2023-11-22T18:51:41.7250783Z      # ./spec/services/slot_builder_spec.rb:115:in `block (3 levels) in <top (required)>'
2023-11-22T18:51:41.7251840Z      # ./spec/rails_helper.rb:95:in `block (3 levels) in <top (required)>'
2023-11-22T18:51:41.7252775Z      # ./spec/rails_helper.rb:94:in `block (2 levels) in <top (required)>'
2023-11-22T18:51:41.7253553Z 
2023-11-22T18:51:41.7254054Z   2) SlotBuilder#plage_ouvertures_for returns all plage_ouverture for the range
2023-11-22T18:51:41.7255145Z      Failure/Error: expect(plage_ouvertures).to eq([matching_po, other_matching_po])
2023-11-22T18:51:41.7256017Z 
2023-11-22T18:51:41.7257620Z        expected: [#<PlageOuverture id: 64, agent_id: 475, title: "Plage 1", organisation_id: 495, first_day: "2021-05-...00.000000000 +0200", recurrence: nil, lieu_id: 225, expired_cached: false, recurrence_ends_at: nil>]
2023-11-22T18:51:41.7260492Z             got: #<ActiveRecord::Relation [#<PlageOuverture id: 65, agent_id: 476, title: "Plage 2", organisation_id: ...0.000000000 +0200", recurrence: nil, lieu_id: 225, expired_cached: false, recurrence_ends_at: nil>]>
2023-11-22T18:51:41.7261941Z 
2023-11-22T18:51:41.7262112Z        (compared using ==)
2023-11-22T18:51:41.7262421Z 
2023-11-22T18:51:41.7262567Z        Diff:
2023-11-22T18:51:41.7262982Z        @@ -1,3 +1,49 @@
2023-11-22T18:51:41.7267475Z        -[#<PlageOuverture id: 64, agent_id: 475, title: "Plage 1", organisation_id: 495, first_day: "2021-05-03", start_time: #<Tod::TimeOfDay:0x00007f1e0c1c64a8 @hour=9, @minute=0, @second=0, @second_of_day=32400>, end_time: #<Tod::TimeOfDay:0x00007f1e0c1c6408 @hour=11, @minute=20, @second=0, @second_of_day=40800>, created_at: "2021-04-30 08:00:00.000000000 +0200", updated_at: "2021-04-30 08:00:00.000000000 +0200", recurrence: nil, lieu_id: 225, expired_cached: false, recurrence_ends_at: nil>,
2023-11-22T18:51:41.7274480Z        - #<PlageOuverture id: 65, agent_id: 476, title: "Plage 2", organisation_id: 496, first_day: "2021-05-03", start_time: #<Tod::TimeOfDay:0x00007f1e0c1c5cd8 @hour=9, @minute=0, @second=0, @second_of_day=32400>, end_time: #<Tod::TimeOfDay:0x00007f1e0c1c5c88 @hour=11, @minute=0, @second=0, @second_of_day=39600>, created_at: "2021-04-30 08:00:00.000000000 +0200", updated_at: "2021-04-30 08:00:00.000000000 +0200", recurrence: nil, lieu_id: 225, expired_cached: false, recurrence_ends_at: nil>]
2023-11-22T18:51:41.7278062Z        +[#<PlageOuverture:0x00007f1e0baf2460
2023-11-22T18:51:41.7278660Z        +  id: 65,
2023-11-22T18:51:41.7279083Z        +  agent_id: 476,
2023-11-22T18:51:41.7279548Z        +  title: "Plage 2",
2023-11-22T18:51:41.7280077Z        +  organisation_id: 496,
2023-11-22T18:51:41.7280667Z        +  first_day: Mon, 03 May 2021,
2023-11-22T18:51:41.7281215Z        +  start_time:
2023-11-22T18:51:41.7281746Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c4608
2023-11-22T18:51:41.7282332Z        +    @hour=9,
2023-11-22T18:51:41.7282745Z        +    @minute=0,
2023-11-22T18:51:41.7283177Z        +    @second=0,
2023-11-22T18:51:41.7283648Z        +    @second_of_day=32400>,
2023-11-22T18:51:41.7284160Z        +  end_time:
2023-11-22T18:51:41.7284675Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c44c8
2023-11-22T18:51:41.7285249Z        +    @hour=11,
2023-11-22T18:51:41.7285676Z        +    @minute=0,
2023-11-22T18:51:41.7286114Z        +    @second=0,
2023-11-22T18:51:41.7286600Z        +    @second_of_day=39600>,
2023-11-22T18:51:41.7287385Z        +  created_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7288325Z        +  updated_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7289050Z        +  recurrence: nil,
2023-11-22T18:51:41.7289537Z        +  lieu_id: 225,
2023-11-22T18:51:41.7290032Z        +  expired_cached: false,
2023-11-22T18:51:41.7290596Z        +  recurrence_ends_at: nil>,
2023-11-22T18:51:41.7291211Z        + #<PlageOuverture:0x00007f1e0baf2320
2023-11-22T18:51:41.7291780Z        +  id: 64,
2023-11-22T18:51:41.7292198Z        +  agent_id: 475,
2023-11-22T18:51:41.7292679Z        +  title: "Plage 1",
2023-11-22T18:51:41.7293212Z        +  organisation_id: 495,
2023-11-22T18:51:41.7293788Z        +  first_day: Mon, 03 May 2021,
2023-11-22T18:51:41.7294302Z        +  start_time:
2023-11-22T18:51:41.7294779Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c3a78
2023-11-22T18:51:41.7295325Z        +    @hour=9,
2023-11-22T18:51:41.7295994Z        +    @minute=0,
2023-11-22T18:51:41.7296468Z        +    @second=0,
2023-11-22T18:51:41.7296952Z        +    @second_of_day=32400>,
2023-11-22T18:51:41.7297480Z        +  end_time:
2023-11-22T18:51:41.7298013Z        +   #<Tod::TimeOfDay:0x00007f1e0c1c37f8
2023-11-22T18:51:41.7298838Z        +    @hour=11,
2023-11-22T18:51:41.7299281Z        +    @minute=20,
2023-11-22T18:51:41.7299730Z        +    @second=0,
2023-11-22T18:51:41.7300230Z        +    @second_of_day=40800>,
2023-11-22T18:51:41.7301005Z        +  created_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7301934Z        +  updated_at: Fri, 30 Apr 2021 08:00:00.000000000 CEST +02:00,
2023-11-22T18:51:41.7302656Z        +  recurrence: nil,
2023-11-22T18:51:41.7303121Z        +  lieu_id: 225,
2023-11-22T18:51:41.7303619Z        +  expired_cached: false,
2023-11-22T18:51:41.7304195Z        +  recurrence_ends_at: nil>]
2023-11-22T18:51:41.7305382Z      # ./spec/services/slot_builder_spec.rb:124:in `block (3 levels) in <top (required)>'
2023-11-22T18:51:41.7306597Z      # ./spec/rails_helper.rb:95:in `block (3 levels) in <top (required)>'
2023-11-22T18:51:41.7307675Z      # ./spec/rails_helper.rb:94:in `block (2 levels) in <top (required)>'
2023-11-22T18:51:41.7308320Z 
2023-11-22T18:51:41.7308880Z Finished in 2 minutes 1.4 seconds (files took 11.37 seconds to load)
2023-11-22T18:51:41.7309791Z 681 examples, 2 failures, 1 pending
2023-11-22T18:51:41.7310169Z 
2023-11-22T18:51:41.7310317Z Failed examples:
2023-11-22T18:51:41.7310555Z 
2023-11-22T18:51:41.7311502Z rspec ./spec/services/slot_builder_spec.rb:108 # SlotBuilder#plage_ouvertures_for return plage_ouverture that match without no lieu given
2023-11-22T18:51:41.7313273Z rspec ./spec/services/slot_builder_spec.rb:118 # SlotBuilder#plage_ouvertures_for returns all plage_ouverture for the range
2023-11-22T18:51:41.7314329Z 
2023-11-22T18:51:41.7314549Z Randomized with seed 23524
```

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
