### PR TITLE
Fix de sécurité : évite les timing attacks sur l'authentification d'api via un secret partagé

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -107,7 +107,9 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       email: agent.email,
     }
 
-    OpenSSL::HMAC.hexdigest("SHA256", ENV.fetch("SHARED_SECRET_FOR_AGENTS_AUTH"), payload.to_json) ==
+    ActiveSupport::SecurityUtils.secure_compare(
+      OpenSSL::HMAC.hexdigest("SHA256", ENV.fetch("SHARED_SECRET_FOR_AGENTS_AUTH"), payload.to_json),
       request.headers["X-Agent-Auth-Signature"]
+    )
   end
 end


### PR DESCRIPTION
petite vulnérabilité introduite dans : https://github.com/betagouv/rdv-service-public/pull/3369/files#diff-2075bc36e9b7d0459bba7244e379c97f8959129cde375aacc4b4a146b04b8d37L100