### PR TITLE
Agent::MotifPolicy explicite et indépendante du contexte

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -15,7 +15,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       skip_policy_scope # TODO: improve pundit checks for creneaux
       redirect_to admin_organisation_slots_path(current_organisation, creneaux_search_params)
     else
-      @motifs = policy_scope(Motif).active.ordered_by_name
+      @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).where(organisation: current_organisation).active.ordered_by_name
       @services = Service.where(id: @motifs.pluck(:service_id).uniq)
       @form.service_id = @services.first.id if @services.count == 1
       @teams = current_organisation.territory.teams

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -5,7 +5,7 @@ class Admin::MotifsController < AgentAuthController
   before_action :set_motif, only: %i[show edit update destroy]
 
   def index
-    @unfiltered_motifs = policy_scope(Motif).where(organisation: current_organisation).active
+    @unfiltered_motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy).where(organisation: current_organisation).active
     @motifs = params[:search].present? ? @unfiltered_motifs.search_by_text(params[:search]) : @unfiltered_motifs.ordered_by_name
     @motifs = filtered(@motifs, params)
     @motifs = @motifs.includes(:organisation).includes(:service).page(params[:page])

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -13,10 +13,12 @@ class Admin::MotifsController < AgentAuthController
     @sectors_attributed_to_organisation_count = Sector.attributed_to_organisation(current_organisation).count
     @sectorisation_level_agent_counts_by_service = SectorAttribution.level_agent_grouped_by_service(current_organisation)
     @display_sectorisation_level = current_organisation.motifs.active.where.not(sectorisation_level: Motif::SECTORISATION_LEVEL_DEPARTEMENT).any?
+
+    @motif_policy = Agent::MotifPolicy.new(current_agent, Motif.new(organisation: current_organisation))
   end
 
   def new
-    @motif = Motif.new(organisation_id: current_organisation.id)
+    @motif = Motif.new(organisation: current_organisation)
     authorize(@motif)
   end
 

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -85,7 +85,7 @@ class Admin::MotifsController < AgentAuthController
   end
 
   def set_motif
-    @motif = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
+    @motif = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy::Scope)
       .where(organisation: current_organisation)
       .find(params[:id])
   end

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -5,7 +5,7 @@ class Admin::MotifsController < AgentAuthController
   before_action :set_motif, only: %i[show edit update destroy]
 
   def index
-    @unfiltered_motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy).where(organisation: current_organisation).active
+    @unfiltered_motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy::Scope).where(organisation: current_organisation).active
     @motifs = params[:search].present? ? @unfiltered_motifs.search_by_text(params[:search]) : @unfiltered_motifs.ordered_by_name
     @motifs = filtered(@motifs, params)
     @motifs = @motifs.includes(:organisation).includes(:service).page(params[:page])

--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -5,7 +5,8 @@ class Admin::MotifsController < AgentAuthController
   before_action :set_motif, only: %i[show edit update destroy]
 
   def index
-    @unfiltered_motifs = policy_scope(Motif).active
+    @unfiltered_motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
+      .where(organisation: current_organisation).active
     @motifs = params[:search].present? ? @unfiltered_motifs.search_by_text(params[:search]) : @unfiltered_motifs.ordered_by_name
     @motifs = filtered(@motifs, params)
     @motifs = @motifs.includes(:organisation).includes(:service).page(params[:page])
@@ -78,7 +79,9 @@ class Admin::MotifsController < AgentAuthController
   end
 
   def set_motif
-    @motif = policy_scope(Motif).find(params[:id])
+    @motif = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
+      .where(organisation: current_organisation)
+      .find(params[:id])
   end
 
   def motif_params

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -4,8 +4,8 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
   def show
     authorize(@organisation)
 
-    @motifs = policy_scope(Motif)
-      .available_motifs_for_organisation_and_agent(current_organisation, current_agent)
+    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
+      .available_motifs_for_organisation_and_agent(current_organisation, current_agent) # this should probably be replaced by a filter on the current organisation
       .active
       .includes(:organisation)
       .includes(:service)

--- a/app/controllers/admin/organisations/online_bookings_controller.rb
+++ b/app/controllers/admin/organisations/online_bookings_controller.rb
@@ -5,7 +5,7 @@ class Admin::Organisations::OnlineBookingsController < AgentAuthController
     authorize(@organisation)
 
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
-      .available_motifs_for_organisation_and_agent(current_organisation, current_agent) # this should probably be replaced by a filter on the current organisation
+      .available_motifs_for_organisation_and_agent(current_organisation, current_agent)
       .active
       .includes(:organisation)
       .includes(:service)

--- a/app/controllers/admin/organisations/setup_checklists_controller.rb
+++ b/app/controllers/admin/organisations/setup_checklists_controller.rb
@@ -4,7 +4,7 @@ class Admin::Organisations::SetupChecklistsController < AgentAuthController
   def show
     authorize(@organisation)
     @lieux = policy_scope(Lieu)
-    @motifs = policy_scope(Motif)
+    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).where(organisation: current_organisation)
 
     if current_agent.conseiller_numerique?
       render "show_conseiller_numerique"

--- a/app/controllers/admin/rdv_wizard_steps_controller.rb
+++ b/app/controllers/admin/rdv_wizard_steps_controller.rb
@@ -65,7 +65,7 @@ class Admin::RdvWizardStepsController < AgentAuthController
   end
 
   def set_services_and_motifs
-    @motifs = policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent)
+    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).available_motifs_for_organisation_and_agent(current_organisation, @agent)
     @services = Service.where(id: @motifs.pluck(:service_id).uniq)
     @rdv_wizard.service_id = @services.first.id if @services.count == 1
   end

--- a/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
@@ -1,5 +1,5 @@
 class Admin::RdvsCollectifs::MotifsController < AgentAuthController
   def index
-    @motifs = policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
+    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
   end
 end

--- a/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
@@ -1,5 +1,11 @@
 class Admin::RdvsCollectifs::MotifsController < AgentAuthController
   def index
-    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
+    @motifs = policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
+  end
+
+  private
+
+  def pundit_user
+    current_agent
   end
 end

--- a/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
@@ -1,6 +1,6 @@
 class Admin::RdvsCollectifs::MotifsController < AgentAuthController
   def index
-    @motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy)
+    @motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy::Scope)
       .available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
   end
 

--- a/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs/motifs_controller.rb
@@ -1,6 +1,7 @@
 class Admin::RdvsCollectifs::MotifsController < AgentAuthController
   def index
-    @motifs = policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
+    @motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy)
+      .available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
   end
 
   private

--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -2,7 +2,6 @@ class Admin::RdvsCollectifsController < AgentAuthController
   include RdvsHelper
 
   def index
-    # TODO: not sure if available_motifs_for_organisation_and_agent is correct here
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
 
     @rdvs = policy_scope(Rdv).where(organisation: current_organisation).collectif
@@ -14,7 +13,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
   end
 
   def new
-    motif = Agent::MotifPolicy::Scope.apply(current_agent, Motif).find(params[:motif_id]) # TODO: this might need a available_motifs_for_organisation_and_agent(current_organisation, current_agent)
+    motif = Agent::MotifPolicy::Scope.apply(current_agent, Motif).find(params[:motif_id])
     @rdv_form = Admin::NewRdvForm.new(pundit_user, organisation: current_organisation, motif: motif, duration_in_min: motif.default_duration_in_min)
     @rdv = @rdv_form.rdv
 
@@ -25,7 +24,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
       @rdv.assign_attributes(new_rdv_attributes)
       @rdv.agents = duplicated_rdv.agents
     end
-    authorize(@rdv) # TODO: est-ce qu'il faut une règle sur le type de motif dans le rdv policy ?
+    authorize(@rdv)
   end
 
   def create

--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -2,7 +2,8 @@ class Admin::RdvsCollectifsController < AgentAuthController
   include RdvsHelper
 
   def index
-    @motifs = policy_scope(Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
+    # TODO: not sure if available_motifs_for_organisation_and_agent is correct here
+    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).available_motifs_for_organisation_and_agent(current_organisation, current_agent).collectif
 
     @rdvs = policy_scope(Rdv).where(organisation: current_organisation).collectif
     @rdvs = @rdvs.order(starts_at: :asc).page(params[:page])
@@ -13,7 +14,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
   end
 
   def new
-    motif = policy_scope(Motif).find(params[:motif_id])
+    motif = Agent::MotifPolicy::Scope.apply(current_agent, Motif).find(params[:motif_id]) # TODO: this might need a available_motifs_for_organisation_and_agent(current_organisation, current_agent)
     @rdv_form = Admin::NewRdvForm.new(pundit_user, organisation: current_organisation, motif: motif, duration_in_min: motif.default_duration_in_min)
     @rdv = @rdv_form.rdv
 
@@ -24,7 +25,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
       @rdv.assign_attributes(new_rdv_attributes)
       @rdv.agents = duplicated_rdv.agents
     end
-    authorize(@rdv)
+    authorize(@rdv) # TODO: est-ce qu'il faut une règle sur le type de motif dans le rdv policy ?
   end
 
   def create

--- a/app/controllers/admin/slots_controller.rb
+++ b/app/controllers/admin/slots_controller.rb
@@ -9,7 +9,9 @@ class Admin::SlotsController < AgentAuthController
     # À terme, ça pourrait également être un calcul plus réduit. Dans le cas de la recherche sur plusieurs lieux, nous avons besoin de connaitre la prochaine dispo, pas TOUTES les dispo
     @search_result = search_result
 
-    @motifs = policy_scope(Motif).active.ordered_by_name
+    @motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif)
+      .where(organisation: current_organisation)
+      .active.ordered_by_name
     @services = Service.where(id: @motifs.pluck(:service_id).uniq)
     @form.service_id = @services.first.id if @services.count == 1
     @agents = policy_scope(Agent)

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -19,8 +19,12 @@ class AgentAuthController < ApplicationController
     record.class.module_parent == Agent ? super(record, *args) : super([:agent, record], *args)
   end
 
-  def policy_scope(clasz, policy_scope_class: nil)
-    super([:agent, clasz], policy_scope_class: policy_scope_class)
+  def policy_scope(scope, policy_scope_class: nil)
+    if policy_scope_class
+      super([:agent, scope])
+    else
+      super(scope, policy_scope_class: policy_scope_class)
+    end
   end
 
   def set_organisation

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -19,12 +19,13 @@ class AgentAuthController < ApplicationController
     record.class.module_parent == Agent ? super(record, *args) : super([:agent, record], *args)
   end
 
+  # L'usage recommandé est de passer explicitement une policy_scope_class pour savoir quelle policy est utilisé
+  # A terme, on voudra forcer l'argument policy_scope_class
   def policy_scope(scope, policy_scope_class: nil)
     if policy_scope_class
-      # TODO: ajouter une deprecation ici
-      super([:agent, scope])
-    else
       super(scope, policy_scope_class: policy_scope_class)
+    else
+      super([:agent, scope])
     end
   end
 

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -19,8 +19,8 @@ class AgentAuthController < ApplicationController
     record.class.module_parent == Agent ? super(record, *args) : super([:agent, record], *args)
   end
 
-  def policy_scope(clasz)
-    clasz.module_parent == Agent ? super(record) : super([:agent, clasz])
+  def policy_scope(clasz, policy_scope_class: nil)
+    super([:agent, clasz], policy_scope_class: policy_scope_class)
   end
 
   def set_organisation

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -21,6 +21,7 @@ class AgentAuthController < ApplicationController
 
   def policy_scope(scope, policy_scope_class: nil)
     if policy_scope_class
+      # TODO: ajouter une deprecation ici
       super([:agent, scope])
     else
       super(scope, policy_scope_class: policy_scope_class)

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -18,10 +18,6 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       end
   end
 
-  def policy_scope(clasz)
-    super([:agent, clasz])
-  end
-
   def authorize(record, *args)
     super([:agent, record], *args)
   end
@@ -70,6 +66,16 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   end
 
   private
+
+  # L'usage recommandé est de passer explicitement une policy_scope_class pour savoir quelle policy est utilisé
+  # A terme, on voudra forcer l'argument policy_scope_class
+  def policy_scope(scope, policy_scope_class: nil)
+    if policy_scope_class
+      super(scope, policy_scope_class: policy_scope_class)
+    else
+      super([:agent, scope])
+    end
+  end
 
   def authenticate_agent
     if request.headers.include?("X-Agent-Auth-Signature")

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
   def index
-    motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).where(organisation: current_organisation)
+    motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy).where(organisation: current_organisation)
     motifs = motifs.active(params[:active].to_b) unless params[:active].nil?
 
     if params.key?(:bookable_publicly)
@@ -16,5 +16,11 @@ class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
     motifs = motifs.with_motif_category_short_name(@params[:motif_category_short_name]) if params[:motif_category_short_name].present?
 
     render_collection(motifs.order(:id))
+  end
+
+  private
+
+  def pundit_user
+    current_agent
   end
 end

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
   def index
-    motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy).where(organisation: current_organisation)
+    motifs = policy_scope(Motif, policy_scope_class: Agent::MotifPolicy::Scope).where(organisation: current_organisation)
     motifs = motifs.active(params[:active].to_b) unless params[:active].nil?
 
     if params.key?(:bookable_publicly)

--- a/app/controllers/api/v1/motifs_controller.rb
+++ b/app/controllers/api/v1/motifs_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::MotifsController < Api::V1::AgentAuthBaseController
   def index
-    motifs = policy_scope(Motif)
+    motifs = Agent::MotifPolicy::Scope.apply(current_agent, Motif).where(organisation: current_organisation)
     motifs = motifs.active(params[:active].to_b) unless params[:active].nil?
 
     if params.key?(:bookable_publicly)

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -32,8 +32,8 @@ class Agent::MotifPolicy < ApplicationPolicy
       if current_agent.secretaire?
         scope.where(organisation_id: current_agent.organisation_ids)
       else
-        scope.where(organisation_id: current_agent.roles.where.not(access_level: :admin).pluck("organisation_id"), service: pundit_user.services)
-          .or(scope.where(organisation_id: current_agent.roles.where(access_level: :admin).pluck("organisation_id")))
+        scope.where(organisation_id: current_agent.roles.where.not(access_level: :admin).pluck(:organisation_id), service: pundit_user.services)
+          .or(scope.where(organisation_id: current_agent.roles.where(access_level: :admin).pluck(:organisation_id)))
       end
     end
 

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -10,7 +10,10 @@ class Agent::MotifPolicy < ApplicationPolicy
   alias versions? update?
 
   def show?
-    current_agent.secretaire? || admin_of_the_motif_organisation? || @record.service.in?(current_agent.services)
+    return unless agent_role_in_motif_organisation
+
+    current_agent.secretaire? || admin_of_the_motif_organisation? ||
+      @record.service.in?(current_agent.services)
   end
 
   private

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -1,6 +1,14 @@
 class Agent::MotifPolicy < ApplicationPolicy
+  def new?
+    update?
+  end
+
   def create?
-    admin_of_the_motif_organisation?
+    update?
+  end
+
+  def edit?
+    update?
   end
 
   def update?
@@ -8,11 +16,11 @@ class Agent::MotifPolicy < ApplicationPolicy
   end
 
   def destroy?
-    admin_of_the_motif_organisation?
+    update?
   end
 
   def versions?
-    admin_of_the_motif_organisation?
+    update?
   end
 
   def show?
@@ -34,10 +42,10 @@ class Agent::MotifPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       if pundit_user.secretaire?
-        scope.where(organisation_id: agent.organisation_ids)
+        scope.where(organisation_id: pundit_user.organisation_ids)
       else
-        scope.where(organisation_id: agent.roles.where.not(access_level: :admin).organisation_ids, service: pundit_user.services)
-          .or(scope.where(organisation_id: agent.roles.where(access_level: :admin).organisation_ids))
+        scope.where(organisation_id: pundit_user.roles.where.not(access_level: :admin).pluck("organisation_id"), service: pundit_user.services)
+          .or(scope.where(organisation_id: pundit_user.roles.where(access_level: :admin).pluck("organisation_id")))
       end
     end
   end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -16,7 +16,7 @@ class Agent::MotifPolicy < ApplicationPolicy
   end
 
   def show?
-    admin_of_the_motif_organisation? || @record.service.in?(current_agent.services)
+    admin_of_the_motif_organisation? || @record.service.in?(pundit_user.services)
   end
 
   private
@@ -28,15 +28,15 @@ class Agent::MotifPolicy < ApplicationPolicy
   end
 
   def agent_role_in_motif_organisation
-    @agent_role_in_motif_organisation ||= current_agent.roles.find_by(organisation_id: @record.organisation_id)
+    @agent_role_in_motif_organisation ||= pundit_user.roles.find_by(organisation_id: @record.organisation_id)
   end
 
-  class Scope < Scope
+  class Scope < ApplicationPolicy::Scope
     def resolve
-      if current_agent.secretaire?
+      if pundit_user.secretaire?
         scope.where(organisation_id: agent.organisation_ids)
       else
-        scope.where(organisation_id: agent.roles.where.not(access_level: :admin).organisation_ids, service: current_agent.services)
+        scope.where(organisation_id: agent.roles.where.not(access_level: :admin).organisation_ids, service: pundit_user.services)
           .or(scope.where(organisation_id: agent.roles.where(access_level: :admin).organisation_ids))
       end
     end

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -10,7 +10,7 @@ class Agent::MotifPolicy < ApplicationPolicy
   alias versions? update?
 
   def show?
-    admin_of_the_motif_organisation? || @record.service.in?(current_agent.services)
+    current_agent.secretaire? || admin_of_the_motif_organisation? || @record.service.in?(current_agent.services)
   end
 
   private

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -14,6 +14,10 @@ class ApplicationPolicy
       @scope = scope
     end
 
+    def self.apply(pundit_user, scope)
+      new(pundit_user, scope).resolve
+    end
+
     def in_scope?(object)
       return false if object&.id.blank?
 

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -25,4 +25,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @absence
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @absence]), resource: @absence

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -70,4 +70,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @agent
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @agent]), resource: @agent

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -18,4 +18,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @lieu
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @lieu]), resource: @lieu

--- a/app/views/admin/motifs/_visibility.html.slim
+++ b/app/views/admin/motifs/_visibility.html.slim
@@ -1,6 +1,6 @@
 h6.mb-2
   i.fa.fa-clipboard-check.mr-1
-  span.mr-1= t(".default_html", motif: admin_link_to_if_permitted(current_organisation, motif))
+  span.mr-1= t(".default_html", motif: link_to(motif.name, admin_organisation_motif_path(current_organisation, motif)))
 .ml-3
   = boolean_tag(motif.visible_and_notified?) do
     = motif.human_attribute_value(:visibility_type)

--- a/app/views/admin/motifs/_visibility.html.slim
+++ b/app/views/admin/motifs/_visibility.html.slim
@@ -1,6 +1,6 @@
 h6.mb-2
   i.fa.fa-clipboard-check.mr-1
-  span.mr-1= t(".default_html", motif: link_to(motif.name, admin_organisation_motif_path(current_organisation, motif)))
+  span.mr-1= t(".default_html", motif: link_to(motif.name, admin_organisation_motif_path(current_organisation, motif), target: "_blank"))
 .ml-3
   = boolean_tag(motif.visible_and_notified?) do
     = motif.human_attribute_value(:visibility_type)

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -3,8 +3,7 @@
 - content_for :title do
   | Vos motifs
 
-- # TODO: replace current_agent_can? by explicit method calls
-- if current_agent_can?(:create, Motif)
+- if @motif_policy.create?
   - content_for :breadcrumb do
     = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-primary"
 
@@ -43,7 +42,7 @@
               - options = options_for_select(Motif.location_types.map{|l| [Motif.human_attribute_value(:location_type, l[0]), l[1]] }, params[:location_type_filter])
               = select_tag("location_type_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           th= Motif.human_attribute_name(:default_duration)
-          - if current_agent_can?(:edit, Motif) || current_agent_can?(:destroy, Motif)
+          - if @motif_policy.edit? || @motif_policy.destroy?
             th Actions
       tbody
         - if @motifs.any?
@@ -63,13 +62,13 @@
                   span.fa-stack.fa-4x
                     i.fa.fa-circle.fa-stack-2x.text-primary
                     i.far.fa-calendar.fa-stack-1x.text-white
-                  - if current_agent_can?(:create, Motif)
+                  - if @motif_policy.create?
                     .text-center.m-3
                       = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
 
     - if @motifs.any?
       .d-flex.justify-content-center
         = paginate @motifs, theme: "twitter-bootstrap-4"
-      - if current_agent_can?(:create, Motif)
+      - if @motif_policy.create?
         .text-center.m-3
           = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -3,6 +3,7 @@
 - content_for :title do
   | Vos motifs
 
+- # TODO: replace current_agent_can? by explicit method calls
 - if current_agent_can?(:create, Motif)
   - content_for :breadcrumb do
     = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-primary"

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -1,4 +1,3 @@
-- motif_policy = policy([:agent, @motif])
 - content_for(:menu_item) { "menu-motifs" }
 
 .row.justify-content-center
@@ -84,14 +83,14 @@
           @motif.custom_cancel_warning_message, \
           hint: Motif.human_attribute_name(:custom_cancel_warning_message_hint)
 
-      - if motif_policy.edit? || motif_policy.destroy?
+      - if @motif_policy.edit? || @motif_policy.destroy?
         .card-footer
           .d-flex.justify-content-end
-            - if motif_policy.destroy?
+            - if @motif_policy.destroy?
               div.mr-2= link_to "Supprimer", admin_organisation_motif_path(current_organisation, @motif), method: :delete, data: { confirm: "Confirmez-vous la suppression de ce motif ?"}, class: "btn btn-danger w-100"
-            - if motif_policy.edit?
+            - if @motif_policy.edit?
               div= link_to "Éditer", edit_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @motif
+    = render "admin/versions/resource_versions_row", resource_policy: @motif_policy, resource: @motif

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -28,4 +28,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @organisation
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @organisation]), resource: @organisation

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -87,4 +87,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @plage_ouverture
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @plage_ouverture]), resource: @plage_ouverture

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -23,4 +23,4 @@
 
 .row.justify-content-center
   .col-md-11
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @rdv
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @rdv]), resource: @rdv

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -14,7 +14,7 @@
 
       .card-body
         - if @motifs.empty?
-          - if current_agent_can?(:create, Motif)
+          - if Agent::MotifPolicy.new(current_agent, Motif.new(organisation_id: current_organisation.id)).new?
             div Il n'existe aucun motif de RDV collectif. Veuillez en créer un pour continuer.
             .d-flex.justify-content-center.my-2
               = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class:"btn btn-outline-primary"

--- a/app/views/admin/territories/teams/edit.html.slim
+++ b/app/views/admin/territories/teams/edit.html.slim
@@ -5,4 +5,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :configuration, resource: @team
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:configuration,  @team]), resource: @team

--- a/app/views/admin/territories/webhook_endpoints/edit.html.slim
+++ b/app/views/admin/territories/webhook_endpoints/edit.html.slim
@@ -8,4 +8,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @webhook
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @webhook]), resource: @webhook

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -150,4 +150,4 @@
 
 .row.justify-content-center
   .col-md-8
-    = render "admin/versions/resource_versions_row", policy_scope: :agent, resource: @user
+    = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @user]), resource: @user

--- a/app/views/admin/versions/_resource_versions_row.html.slim
+++ b/app/views/admin/versions/_resource_versions_row.html.slim
@@ -1,4 +1,4 @@
-- if policy([policy_scope, resource]).versions?
+- if resource_policy.versions?
   .card
     .card-header
       button.btn.btn-link data-toggle="collapse" data-target="#history-collapse"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,13 +117,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "dbc547a8dd5fb563f0985da5f12c7151422fe71c4868cbcd0b98ca2da76037c3",
+      "fingerprint": "eb506d328b83df32612498e9b12e59e4d8ac5141325ab5d62ac8b7579af4b391",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
       "line": 49,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => filtered((policy_scope(Motif).where(:organisation => current_organisation).active.search_by_text(params[:search]) or policy_scope(Motif).where(:organisation => current_organisation).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif, :policy_scope_class => (Agent::MotifPolicy::Scope)).where(:organisation => current_organisation).active.search_by_text(params[:search]) or policy_scope(Motif, :policy_scope_class => (Agent::MotifPolicy::Scope)).where(:organisation => current_organisation).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
@@ -151,13 +151,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "dbc547a8dd5fb563f0985da5f12c7151422fe71c4868cbcd0b98ca2da76037c3",
+      "fingerprint": "eb506d328b83df32612498e9b12e59e4d8ac5141325ab5d62ac8b7579af4b391",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
       "line": 75,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => filtered((policy_scope(Motif).where(:organisation => current_organisation).active.search_by_text(params[:search]) or policy_scope(Motif).where(:organisation => current_organisation).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif, :policy_scope_class => (Agent::MotifPolicy::Scope)).where(:organisation => current_organisation).active.search_by_text(params[:search]) or policy_scope(Motif, :policy_scope_class => (Agent::MotifPolicy::Scope)).where(:organisation => current_organisation).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
@@ -183,6 +183,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-11-28 11:33:49 +0100",
+  "updated": "2023-11-28 18:59:06 +0100",
   "brakeman_version": "5.3.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,19 +117,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "d8dbbc60b51eb0beb5bc2f943b01142aad77a449260029dedf5a293e96f074a8",
+      "fingerprint": "dbc547a8dd5fb563f0985da5f12c7151422fe71c4868cbcd0b98ca2da76037c3",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
       "line": 49,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif).where(:organisation => current_organisation).active.search_by_text(params[:search]) or policy_scope(Motif).where(:organisation => current_organisation).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
           "class": "Admin::MotifsController",
           "method": "index",
-          "line": 16,
+          "line": 18,
           "file": "app/controllers/admin/motifs_controller.rb",
           "rendered": {
             "name": "admin/motifs/index",
@@ -151,19 +151,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "d8dbbc60b51eb0beb5bc2f943b01142aad77a449260029dedf5a293e96f074a8",
+      "fingerprint": "dbc547a8dd5fb563f0985da5f12c7151422fe71c4868cbcd0b98ca2da76037c3",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/motifs/index.html.slim",
       "line": 75,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => filtered((policy_scope(Motif).active.search_by_text(params[:search]) or policy_scope(Motif).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
+      "code": "render(action => filtered((policy_scope(Motif).where(:organisation => current_organisation).active.search_by_text(params[:search]) or policy_scope(Motif).where(:organisation => current_organisation).active.ordered_by_name), params).includes(:organisation).includes(:service).page(params[:page]), {})",
       "render_path": [
         {
           "type": "controller",
           "class": "Admin::MotifsController",
           "method": "index",
-          "line": 16,
+          "line": 18,
           "file": "app/controllers/admin/motifs_controller.rb",
           "rendered": {
             "name": "admin/motifs/index",
@@ -183,6 +183,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-11-23 18:29:41 +0100",
+  "updated": "2023-11-28 11:33:49 +0100",
   "brakeman_version": "5.3.1"
 }

--- a/spec/policies/agent/motif_policy_spec.rb
+++ b/spec/policies/agent/motif_policy_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable RSpec/PredicateMatcher
 describe Agent::MotifPolicy do
   subject { described_class }
 
@@ -55,8 +56,10 @@ describe Agent::MotifPolicy do
   end
 
   context "for an organisation admin" do
+    let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: create(:service)) }
   end
 
   context "for the admin of a different organisation" do
   end
 end
+# rubocop:enable RSpec/PredicateMatcher

--- a/spec/policies/agent/motif_policy_spec.rb
+++ b/spec/policies/agent/motif_policy_spec.rb
@@ -56,10 +56,37 @@ describe Agent::MotifPolicy do
   end
 
   context "for an organisation admin" do
-    let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: create(:service)) }
+    let(:agent) { create(:agent, admin_role_in_organisations: [motif.organisation], service: create(:service)) }
+
+    it "allows seeing and modifying the motif" do
+      policy = described_class.new(agent, motif)
+      expect(policy.show?).to be_truthy
+
+      expect(policy.new?).to be_truthy
+      expect(policy.create?).to be_truthy
+      expect(policy.edit?).to be_truthy
+      expect(policy.update?).to be_truthy
+      expect(policy.destroy?).to be_truthy
+
+      expect(policy.versions?).to be_truthy
+    end
   end
 
   context "for the admin of a different organisation" do
+    let(:agent) { create(:agent, admin_role_in_organisations: [create(:organisation)], service: motif.service) }
+
+    it "allows nothing" do
+      policy = described_class.new(agent, motif)
+      expect(policy.show?).to be_falsey
+
+      expect(policy.new?).to be_falsey
+      expect(policy.create?).to be_falsey
+      expect(policy.edit?).to be_falsey
+      expect(policy.update?).to be_falsey
+      expect(policy.destroy?).to be_falsey
+
+      expect(policy.versions?).to be_falsey
+    end
   end
 end
 # rubocop:enable RSpec/PredicateMatcher

--- a/spec/policies/agent/motif_policy_spec.rb
+++ b/spec/policies/agent/motif_policy_spec.rb
@@ -1,0 +1,62 @@
+describe Agent::MotifPolicy do
+  subject { described_class }
+
+  let!(:motif) { create(:motif) }
+
+  context "for a basic agent of the same service" do
+    let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: motif.service) }
+
+    it "allows seeing but not modifying the motif" do
+      policy = described_class.new(agent, motif)
+      expect(policy.show?).to be_truthy
+
+      expect(policy.new?).to be_falsey
+      expect(policy.create?).to be_falsey
+      expect(policy.edit?).to be_falsey
+      expect(policy.update?).to be_falsey
+      expect(policy.destroy?).to be_falsey
+
+      expect(policy.versions?).to be_falsey
+    end
+  end
+
+  context "for a basic agent of a different service" do
+    let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: create(:service)) }
+
+    it "doesn't allow seeing or modifying the motif" do
+      policy = described_class.new(agent, motif)
+      expect(policy.show?).to be_falsey
+
+      expect(policy.new?).to be_falsey
+      expect(policy.create?).to be_falsey
+      expect(policy.edit?).to be_falsey
+      expect(policy.update?).to be_falsey
+      expect(policy.destroy?).to be_falsey
+
+      expect(policy.versions?).to be_falsey
+    end
+  end
+
+  context "for a secretaire" do
+    let(:agent) { create(:agent, basic_role_in_organisations: [motif.organisation], service: create(:service, :secretariat)) }
+
+    it "allows seeing but not modifying the motif" do
+      policy = described_class.new(agent, motif)
+      expect(policy.show?).to be_truthy
+
+      expect(policy.new?).to be_falsey
+      expect(policy.create?).to be_falsey
+      expect(policy.edit?).to be_falsey
+      expect(policy.update?).to be_falsey
+      expect(policy.destroy?).to be_falsey
+
+      expect(policy.versions?).to be_falsey
+    end
+  end
+
+  context "for an organisation admin" do
+  end
+
+  context "for the admin of a different organisation" do
+  end
+end


### PR DESCRIPTION
Suite aux discussions en point tech, le but de cette PR est de proposer une gestion des autorisations indépendante du contexte de navigation, et d'expliciter les usages des Policy.

Cette PR est une première version de refactoring de la `Agent::MotifPolicy`. A la base j'espérais pouvoir faire ce refacto sur la `Agent::UserPolicy`, mais les règles métiers sur la visibilité des usagers sont malheureusement trop complexes pour faire ça (notamment le fait que la config de territoire détermine si on voit les agents de tout le territoire ou seulement de l'organisation courante).

## Idée centrale

### Fonctionnement actuel

Aujourd'hui, nos policy côté agent contiennent le contexte de l'organisation courante en plus des règles d'autorisation. Elles dépendent de cette implémentation de `AgentAuthController#pundit_user` :
```
  def pundit_user
    @pundit_user ||= AgentOrganisationContext.new(current_agent, current_organisation)
  end
```

Ce pundit_user qui est un wrapper autour de l'agent et l'organisation est utilisé implicitement par `#authorize` et `#policy_scope` pour initialiser les policy et les policy scopes.

Par ailleurs, ces deux méthodes de pundit sont redéfinies dans `AgentAuthController` comme il suit :
```
  def authorize(record, *args)
    record.class.module_parent == Agent ? super(record, *args) : super([:agent, record], *args)
  end

  def policy_scope(clasz)
    clasz.module_parent == Agent ? super(record) : super([:agent, clasz]) # on remarquera ici que la première branche lève une exception
  end
```

On peut ensuite faire des `authorize(@motif)` ou `policy_scope(Motif)` dans les controllers pour gérer les autorisations et la restriction à la current_organisation

### Nouveau fonctionnement proposé

#### current_organisation dans le controller et plus dans la policy
Ne plus avoir de current_organisation dans les policy ! Ça veut dire qu'on pourra utiliser cette définition de pundit_user

```
def pundit_user
  current_agent
```

et ensuite si au niveau du controller on a besoin de filtrer par organisation pour des raisons de navigation et pas d'autorisation, on pourra ajouter un simple `where(organisation: current_organisation)`.

#### appels explicites

Pour rendre les appels aux policy explicites, on a deux cas

#### le pundit_user est un agent

Dans ce cas on peut utiliser les arguments optionnels du pundit, comment `policy_scope(Motif, policy_scope_class: Agent::MotifPolicy)`, ce qui a l'avantage d'exécuter cette ligne de pundit : https://github.com/varvet/pundit/blob/main/lib/pundit/authorization.rb#L93
qui fera que les `after_action :verify_policy_scoped` ne lèveront pas d'erreur

#### le pundit_user est un contexte

Dans ce cas on ne peut pas utiliser notre nouvelle policy via les helpers de pundit directement, parce qu'elle serait initialisée avec un contexte. On veut donc l'initialiser explicitement en appelant `Agent::MotifPolicy::Scope.apply(current_agent, Motif)` ou `@motif_policy = Agent::MotifPolicy.new(current_agent, Motif.new(organisation: current_organisation))`


## Prochaines étapes

Généraliser ce fonctionnement aux autres policy des agents (avec un fonctionnement légèrement différent pour les users), pour aboutir à ces implémentations dans `AgentAuthController`

```
def pundit_user
  current_agent
end

def policy_scope(scope, policy_scope_class:) # on veut forcer l'appel explicite à la policy
      super(scope, policy_scope_class: policy_scope_class)
end

def authorize(record, query = nil, policy_class:) # idem
  super(record, query, policy_class: policy_class)
end
```