### PR TITLE
Suppression d'une colonne inutilisée

### DIFF
--- a/app/models/concerns/ical_helpers/ics.rb
+++ b/app/models/concerns/ical_helpers/ics.rb
@@ -57,7 +57,7 @@ module IcalHelpers
       event.summary = payload[:summary]
       event.location = payload[:address]
       event.rrule = payload[:recurrence]
-      event.sequence = payload[:sequence]
+      event.sequence = 0 # not sure if this is necessary, but not worth investigating right now
       event.description = payload[:description]
       event.organizer = "mailto:#{payload[:domain].secretariat_email}"
     end

--- a/app/models/concerns/payloads/rdv.rb
+++ b/app/models/concerns/payloads/rdv.rb
@@ -8,7 +8,6 @@ module Payloads
         ical_uid: uuid,
         summary: "RDV #{motif&.name}",
         address: motif.phone? ? nil : address,
-        sequence: sequence,
         domain: domain,
       }
 

--- a/db/migrate/20231129111050_remove_rdvs_sequence.rb
+++ b/db/migrate/20231129111050_remove_rdvs_sequence.rb
@@ -1,0 +1,5 @@
+class RemoveRdvsSequence < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :rdvs, :sequence, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_20_141913) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_29_111050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -497,7 +497,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_20_141913) do
     t.datetime "updated_at", null: false
     t.datetime "cancelled_at"
     t.bigint "motif_id", null: false
-    t.integer "sequence", default: 0, null: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.string "old_location"
     t.integer "created_by", default: 0

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -1,6 +1,6 @@
 describe Payloads::Rdv, type: :service do
   describe "#payload" do
-    %i[name ical_uid summary ends_at sequence description address].each do |key|
+    %i[name ical_uid summary ends_at description address].each do |key|
       it "return an hash with key #{key}" do
         user = build(:user)
         rdv = build(:rdv, users: [user])
@@ -29,13 +29,6 @@ describe Payloads::Rdv, type: :service do
       let(:rdv) { build(:rdv, users: [user], starts_at: Time.zone.parse("20201123 15h50"), duration_in_min: 10) }
 
       it { expect(rdv.payload[:ends_at]).to eq(starts_at + 10.minutes) }
-    end
-
-    describe ":sequence" do
-      let(:user) { build(:user) }
-      let(:rdv) { build(:rdv, users: [user], sequence: 1) }
-
-      it { expect(rdv.payload[:sequence]).to eq(1) }
     end
 
     describe ":description" do


### PR DESCRIPTION
En faisant les recherches pour l'anonymisation, je suis tombé sur cette colonne inutilisée.

Au moment où on fera tourner la migration, c'est possible de que jobs échouent, puis qu'ils réussissent pendant le retry, donc je pense qu'on peut la mettre en prod sans risque.