### PR TITLE
Fix agent role deletion from the SuperAdmin

### DIFF
--- a/app/controllers/super_admins/agent_roles_controller.rb
+++ b/app/controllers/super_admins/agent_roles_controller.rb
@@ -1,21 +1,13 @@
 module SuperAdmins
   class AgentRolesController < SuperAdmins::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Agent.
-    #     page(params[:page]).
-    #     per(10)
-    # end
+    def destroy
+      if requested_resource.destroy
+        flash[:notice] = translate_with_resource("destroy.success")
+      else
+        flash[:error] = requested_resource.errors.full_messages.join("<br/>")
+      end
 
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Agent.find_by!(slug: param)
-    # end
-
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+      redirect_to(after_resource_created_path(requested_resource.agent), notice: flash[:notice])
+    end
   end
 end


### PR DESCRIPTION
## Contexte
Il est impossible de supprimer un agent d'une organisation depuis le SuperAdmin.
Notamment, la suppression d'un AgentRole lève l'exception suivante: [Voir Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/70671/?query=is%3Aunresolved)

## Description

Le bug est dû à une restriction `except: %i[index]` sur la route `agent_roles`, introduite [ici](https://github.com/betagouv/rdv-service-public/pull/3643/files#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R30).

L'absence de la route `super_admins/agent_roles` (index) cause une erreur lors de la redirection après suppression, et donc un rollback de la suppression.
La restriction avait été introduite afin de ne pas afficher une section AgentsRoles, dans le menu latéral gauche du SuperAdmin. 

## Solution

Pour solutionner le problème, nous avons `overridé` la méthode `destroy` par défaut de Administrate, dans le controller `SuperAdmins::AgentRolesController`