### PR TITLE
Empêcher suppression accidentelle d'organisation depuis la page agent SuperAdmin

### DIFF
--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -42,7 +42,6 @@ class AgentDashboard < Administrate::BaseDashboard
     email
     first_name
     last_name
-    organisations
     roles
     territorial_roles
     services


### PR DESCRIPTION
Sur la page agent du superadmin, nous avons :
- la liste des organisations de l'agent
- la liste des roles de l'agent (org + niveau d'accès)

Si on clique sur "Supprimer" en face d'un rôle, on retire bien l'agent de l'orga. **Si on clique sur "Supprimer" en face d'une orga, on supprime l'orga.**

J'ai testé avec une copie de la prod, et j'ai pu supprimer des orgas de CNFS sans être prévenu ni empêché. :wastebasket: 

Pour reproduire, visiter la page de Maya Patrick (données de seed), puis cliquer sur "Supprimer" en face de MDS Arras Nord :

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/666c0914-d15b-4ba0-8142-fcf78a681f24)

L'organisation est supprimée : 

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/7717d7ef-f3b3-494b-b2cf-3100d75d59e0)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
