### PR TITLE
[Tech] `Agent::MotifPolicy` - Rendre le code plus lisible et performant

### DIFF
--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -35,8 +35,8 @@ class Agent::MotifPolicy < ApplicationPolicy
       if current_agent.secretaire?
         scope.where(organisation_id: current_agent.organisation_ids)
       else
-        scope.where(organisation_id: current_agent.roles.where.not(access_level: :admin).pluck(:organisation_id), service: pundit_user.services)
-          .or(scope.where(organisation_id: current_agent.roles.where(access_level: :admin).pluck(:organisation_id)))
+        scope.where(organisation: current_agent.basic_orgs, service: current_agent.services)
+          .or(scope.where(organisation: current_agent.admin_orgs))
       end
     end
 


### PR DESCRIPTION
Si c'était seulement une question de performance, j'aurais pu remplacer les `pluck` par des `select`, et on aurait eu la subquery suivante : 

```sql
SELECT 
  "motifs".* 
FROM 
  "motifs" 
WHERE 
  "motifs"."organisation_id" IN (
    SELECT 
      "agent_roles"."organisation_id" 
    FROM 
      "agent_roles" 
    WHERE 
      "agent_roles"."agent_id" = 2 
      AND "agent_roles"."access_level" = 'admin'
  )
```

Il m'a paru opportun d'également utiliser `basic_orgs` et `admin_orgs` pour améliorer la lisibilité du code. La requête qui en résulte fait un JOIN supplémentaire vers `organisations` mais je doute que l'impact de perf soit significatif :

```sql
SELECT 
  "motifs".* 
FROM 
  "motifs" 
WHERE 
  "motifs"."organisation_id" IN (
    SELECT 
      "organisations"."id" 
    FROM 
      "organisations" 
      INNER JOIN "agent_roles" ON "organisations"."id" = "agent_roles"."organisation_id" 
    WHERE 
      "agent_roles"."agent_id" = 2 
      AND "agent_roles"."access_level" = 'admin'
  )
```

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
