### PR TITLE
Cacher partiellement les données d'un usager lors de la recherche à l'échelle du territoire

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -29,33 +29,41 @@ class Agents::UsersController < AgentAuthController
     results = []
 
     if users_from_organisation.any?
-      results << {
-        text: nil,
-        children: users_from_organisation.map do |user|
-          {
-            id: user.id,
-            text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
-          }
-        end,
-      }
+      results << formatted_users_from_organisation(users_from_organisation)
     end
 
     if users_from_territory.any?
-      results << {
-        text: "Usagers des autres organisations",
-        children: users_from_territory.map do |user|
-          {
-            id: user.id,
-            text: UsersHelper.partially_hidden_reverse_full_name_and_notification_coordinates(user),
-          }
-        end,
-      }
+      results << formatted_users_from_territory(users_from_territory)
     end
 
     render json: { results: results }
   end
 
   private
+
+  def formatted_users_from_organisation(users)
+    {
+      text: nil,
+      children: users.map do |user|
+        {
+          id: user.id,
+          text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+        }
+      end,
+    }
+  end
+
+  def formatted_users_from_territory(users)
+    {
+      text: "Usagers des autres organisations",
+      children: users.map do |user|
+        {
+          id: user.id,
+          text: UsersHelper.partially_hidden_reverse_full_name_and_notification_coordinates(user),
+        }
+      end,
+    }
+  end
 
   def agent_in_cnfs_or_mairies_territories?
     cnfs_and_mairies_territory_ids = [Territory.mairies&.id, Territory.find_by(departement_number: "CN")&.id].compact

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -31,14 +31,24 @@ class Agents::UsersController < AgentAuthController
     if users_from_organisation.any?
       results << {
         text: nil,
-        children: serialize(users_from_organisation),
+        children: users_from_organisation.map do |user|
+          {
+            id: user.id,
+            text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+          }
+        end,
       }
     end
 
     if users_from_territory.any?
       results << {
         text: "Usagers des autres organisations",
-        children: serialize(users_from_territory),
+        children: users_from_territory.map do |user|
+          {
+            id: user.id,
+            text: UsersHelper.partially_hidden_reverse_full_name_and_notification_coordinates(user),
+          }
+        end,
       }
     end
 
@@ -52,12 +62,5 @@ class Agents::UsersController < AgentAuthController
     (cnfs_and_mairies_territory_ids & current_agent.organisations.pluck(:territory_id)).any? # & does an array overlap here
   end
 
-  def serialize(users)
-    users.map do |user|
-      {
-        id: user.id,
-        text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
-      }
-    end
-  end
+  def serialize(users); end
 end

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -69,6 +69,4 @@ class Agents::UsersController < AgentAuthController
     cnfs_and_mairies_territory_ids = [Territory.mairies&.id, Territory.find_by(departement_number: "CN")&.id].compact
     (cnfs_and_mairies_territory_ids & current_agent.organisations.pluck(:territory_id)).any? # & does an array overlap here
   end
-
-  def serialize(users); end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -57,6 +57,17 @@ module UsersHelper
     user.reverse_full_name + birth_date_and_age_if_exist(user)
   end
 
+  def self.partially_hidden_reverse_full_name_and_notification_coordinates(user)
+    username, domain = user.email.split("@")
+    partially_hidden_email = "#{username[0]}******#{username[-1]}@#{domain}"
+    [
+      user.reverse_full_name,
+      user.birth_date && I18n.l(user.birth_date, format: "%d/%m/****"),
+      user.partially_hidden_phone_number,
+      partially_hidden_email,
+    ].compact.join(" - ")
+  end
+
   def self.reverse_full_name_and_notification_coordinates(user)
     [user.reverse_full_name, user.birth_date && I18n.l(user.birth_date), user.humanized_phone_number, user.email].compact.join(" - ")
   end

--- a/app/lib/phone_number_validation.rb
+++ b/app/lib/phone_number_validation.rb
@@ -58,5 +58,9 @@ module PhoneNumberValidation
     def humanized_phone_number
       Phonelib.parse(phone_number_formatted).national
     end
+
+    def partially_hidden_phone_number
+      humanized_phone_number.gsub(" ", "").tap { |number| number[-8..-3] = "******" }
+    end
   end
 end

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -25,6 +25,13 @@ org_paris_nord = Organisation.create!(
   territory: territory75
 )
 
+org_paris_sud = Organisation.create!(
+  name: "MDS Paris Sud",
+  phone_number: "0123456789",
+  human_id: "paris-sud",
+  territory: territory75
+)
+
 human_id_map = [
   { human_id: "1030", name: "MDS Arques" },
   { human_id: "1031", name: "MDS Arras Nord" },
@@ -331,6 +338,21 @@ user_org_paris_nord_jean = User.new(
 user_org_paris_nord_jean.skip_confirmation!
 user_org_paris_nord_jean.save!
 user_org_paris_nord_jean.profile_for(org_paris_nord).update!(logement: 2)
+
+user_org_paris_sud = User.new(
+  first_name: "Francis",
+  last_name: "Factice",
+  email: "francis.factice@demo.rdv-solidarites.fr",
+  birth_date: Date.parse("10/01/1973"),
+  password: "lapinlapin",
+  phone_number: "0101010103",
+  organisation_ids: [org_paris_sud.id],
+  created_through: "user_sign_up"
+)
+
+user_org_paris_sud.skip_confirmation!
+user_org_paris_sud.save!
+user_org_paris_sud.profile_for(org_paris_sud).update!(logement: 2)
 
 user_org_arques = User.new(
   first_name: "Francis",

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -65,4 +65,11 @@ describe UsersHelper, type: :helper do
       expect(full_name_and_birthdate(user)).to eq("James BOND - 21/12/1950 - 70 ans")
     end
   end
+
+  describe "partially_hidden_reverse_full_name_and_notification_coordinates" do
+    it "hides most of the personal data while allowing verification" do
+      user = build(:user, birth_date: Date.new(1950, 12, 21), first_name: "Francis", last_name: "Factice", phone_number: "0611223344", email: "francis@factice.com")
+      expect(described_class.partially_hidden_reverse_full_name_and_notification_coordinates(user)).to eq("FACTICE Francis - 21/12/**** - 06******44 - f******s@factice.com")
+    end
+  end
 end


### PR DESCRIPTION
Pour limiter les informations personnelles qu'on affiche à des agents qui ne font pas partie de l'organisation d'un usager, on cache partiellement les infos dans l'autocomplete.
Le but de ces infos est de permettre de vérifier que la personne en face correspond bien à la fiche trouvée (on peut imaginer la secrétaire demander "est-ce que votre numéro c'est bien un 06 qui se finit en 44 ?", ou "votre date de naissance c'est bien le 31/12 ? ok j'ai retrouvé votre fiche").

Une fois qu'on clique sur l'usager (donc qu'on a fait une action pour volontairement choisir sa fiche, on affiche toutes ses infos).

Cette PR est dans la continuité de https://github.com/betagouv/rdv-service-public/pull/3888

### Avant 

<img width="1148" alt="Screenshot 2023-12-06 at 16 35 41" src="https://github.com/betagouv/rdv-service-public/assets/1840367/e8d6e3ae-b76c-4561-b8dd-77889de9241a">



### Après
<img width="1130" alt="Screenshot 2023-12-06 at 16 35 01" src="https://github.com/betagouv/rdv-service-public/assets/1840367/04e2a733-7935-4f5b-aab4-110d86638049">
<img width="1138" alt="Screenshot 2023-12-06 at 16 35 53" src="https://github.com/betagouv/rdv-service-public/assets/1840367/e8a5a72d-0a9a-49de-972e-844e740ad726">
Je laisse @NesserineZarouri compléter d'éventuelles infos supplémentaires pour l'historique de cette modification.