### PR TITLE
Ajouter les services de territoires dans les seeds

### DIFF
--- a/db/seeds/cdad.rb
+++ b/db/seeds/cdad.rb
@@ -24,6 +24,7 @@ org_cdad2 = Organisation.create!(
 
 # Service
 service_cdad = Service.create!(name: "CDAD (Conseils Départementaux de l’Accès au Droit)", short_name: "CDAD")
+territory_gironde.services << service_cdad
 
 # Motifs
 motif1_cdad1 = Motif.create!(

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -6,6 +6,7 @@ territory_cnfs = Territory.create!(
 )
 
 service_cnfs = Service.create!(name: Service::CONSEILLER_NUMERIQUE, short_name: Service::CONSEILLER_NUMERIQUE)
+territory_cnfs.services << service_cnfs
 
 org_cnfs = Organisation.create!(
   name: "Mediathèque Paris Nord",

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -75,7 +75,8 @@ Organisation.set_callback(:create, :after, :notify_admin_organisation_created)
 service_pmi = Service.create!(name: "PMI (Protection Maternelle Infantile)", short_name: "PMI")
 service_social = Service.create!(name: "Service social", short_name: "Service Social")
 service_secretariat = Service.create!(name: Service::SECRETARIAT, short_name: "Secrétariat")
-_service_nouveau = Service.create!(name: "Médico-social", short_name: "Médico-social")
+territory62.services << [service_pmi, service_social, service_secretariat]
+territory75.services << [service_pmi, service_social, service_secretariat]
 
 # MOTIFS org_paris_nord
 

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -44,6 +44,8 @@ org_yonne = Organisation.create!(
 
 # Service
 service_rsa = Service.create!(name: "Service RSA", short_name: "RSA")
+territory_drome.services << service_rsa
+territory_yonne.services << service_rsa
 
 # MOTIFS Drome
 motif1_drome1 = Motif.create!(

--- a/db/seeds/rdv_mairie.rb
+++ b/db/seeds/rdv_mairie.rb
@@ -18,6 +18,8 @@ org_mairie_de_sannois = Organisation.create!(
 # Service
 service_titres = Service.create!(name: "Service Titres Sécurisés", short_name: "STS")
 
+territory_val_doise.services << service_titres
+
 MotifCategory.create!(name: "Carte d'identité disponible sur le site de l'ANTS", short_name: "CNI")
 MotifCategory.create!(name: "Passeport disponible sur le site de l'ANTS", short_name: "PASSPORT")
 MotifCategory.create!(name: "Carte d'identité et passeport disponible sur le site de l'ANTS", short_name: "CNI-PASSPORT")


### PR DESCRIPTION
Correction d'un oubli dans #3871.

Je me suis rendu compte du souci en voulant tester une création de motif en local sur les données médico sociales des seeds : le formulaire ne me proposait aucun service à sélectionner.

On pourrait ajouter un mécanisme qui vérifié qu'on a bien au moins un service activé dans un territoire, mais ça me paraît bien overkill.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
