### PR TITLE
Modification de l'historique des versions quand les super admins se connecte en tant que

### DIFF
--- a/app/controllers/concerns/admin/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/admin/authenticated_controller_concern.rb
@@ -21,7 +21,11 @@ module Admin::AuthenticatedControllerConcern
   protected
 
   def user_for_paper_trail
-    current_agent.name_for_paper_trail
+    if current_super_admin.present?
+      current_super_admin.name_for_paper_trail(impersonated: current_agent)
+    else
+      current_agent.name_for_paper_trail
+    end
   end
 
   def agent_not_authorized(exception)

--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -24,9 +24,9 @@ module SuperAdmins
     private
 
     def user_for_paper_trail
-      return "SuperAdmin" if current_super_admin.nil?
+      return "Local SuperAdmin" if current_super_admin.nil?
 
-      "[SuperAdmin] #{current_super_admin.email}"
+      current_super_admin.name_for_paper_trail
     end
 
     def authenticate_super_admin!

--- a/app/controllers/super_admins/sessions_controller.rb
+++ b/app/controllers/super_admins/sessions_controller.rb
@@ -1,7 +1,7 @@
 module SuperAdmins
   class SessionsController < ApplicationController
     def destroy
-      sign_out :super_admin if super_admin_signed_in?
+      sign_out_all_scopes if super_admin_signed_in?
 
       redirect_to root_path
     end

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -10,7 +10,11 @@ class UserAuthController < ApplicationController
   private
 
   def user_for_paper_trail
-    current_user.name_for_paper_trail
+    if current_super_admin.present?
+      current_super_admin.name_for_paper_trail(impersonated: current_user)
+    else
+      current_user.name_for_paper_trail
+    end
   end
 
   def authorize(record, *args)

--- a/app/dashboards/super_admin_dashboard.rb
+++ b/app/dashboards/super_admin_dashboard.rb
@@ -10,6 +10,8 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     email: Field::String,
+    first_name: Field::String,
+    last_name: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -22,6 +24,8 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     email
+    first_name
+    last_name
     created_at
     updated_at
   ].freeze
@@ -31,6 +35,8 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     email
+    first_name
+    last_name
     created_at
     updated_at
   ].freeze
@@ -38,8 +44,10 @@ class SuperAdminDashboard < Administrate::BaseDashboard
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = [
-    :email,
+  FORM_ATTRIBUTES = %i[
+    email
+    first_name
+    last_name
   ].freeze
 
   # Overwrite this method to customize how super admins are displayed

--- a/app/models/super_admin.rb
+++ b/app/models/super_admin.rb
@@ -1,12 +1,17 @@
 class SuperAdmin < ApplicationRecord
   # Mixins
   include DeviseInvitable::Inviter
+  include FullNameConcern
+
+  # Validations
+  validates :first_name, presence: true
+  validates :last_name, presence: true
 
   devise :authenticatable
 
-  ## -
+  def name_for_paper_trail(impersonated: nil)
+    return "[Admin] #{full_name}" if impersonated.blank?
 
-  def full_name
-    "Équipe de RDV Service Public"
+    "[Admin] #{full_name} pour #{impersonated.full_name}"
   end
 end

--- a/app/models/super_admin.rb
+++ b/app/models/super_admin.rb
@@ -6,6 +6,7 @@ class SuperAdmin < ApplicationRecord
   # Validations
   validates :first_name, presence: true
   validates :last_name, presence: true
+  validates :email, presence: true
 
   devise :authenticatable
 

--- a/db/migrate/20231207155659_add_first_name_and_last_name_to_super_admin.rb
+++ b/db/migrate/20231207155659_add_first_name_and_last_name_to_super_admin.rb
@@ -1,0 +1,6 @@
+class AddFirstNameAndLastNameToSuperAdmin < ActiveRecord::Migration[7.0]
+  def change
+    add_column :super_admins, :first_name, :string
+    add_column :super_admins, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_29_111050) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_07_155659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -590,6 +590,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_29_111050) do
     t.string "email", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
   end
 
   create_table "teams", force: :cascade do |t|

--- a/spec/factories/super_admin.rb
+++ b/spec/factories/super_admin.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
 
   factory :super_admin do
     email { generate(:super_admin_email) }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
   end
 end

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -8,7 +8,7 @@ describe "agents page", js: true do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as agent
+    login_as(agent, scope: :agent)
 
     path = admin_organisation_agent_agenda_path(organisation, agent)
     expect_page_to_be_axe_clean(path)
@@ -20,7 +20,7 @@ describe "agents page", js: true do
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
     create_list(:rdv, 3, agents: [agent], starts_at: 2.days.from_now)
-    login_as agent, scope: :agent
+    login_as(agent, scope: :agent)
 
     path = admin_organisation_agent_agenda_path(organisation, agent)
 
@@ -35,7 +35,7 @@ describe "agents page", js: true do
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
     create_list(:plage_ouverture, 3, agent: agent)
-    login_as agent
+    login_as(agent, scope: :agent)
 
     path = admin_organisation_agent_plage_ouvertures_path(organisation, agent)
     expect_page_to_be_axe_clean(path)
@@ -46,7 +46,7 @@ describe "agents page", js: true do
     organisation = create(:organisation, territory: territory)
     create_list(:user, 3, organisations: [organisation])
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as agent
+    login_as(agent, scope: :agent)
 
     path = admin_organisation_users_path(organisation)
     expect_page_to_be_axe_clean(path)
@@ -57,7 +57,7 @@ describe "agents page", js: true do
     organisation = create(:organisation, territory: territory)
     user = create(:user, email: "testuser@test.net", referent_agents: [], organisations: [organisation])
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as agent
+    login_as(agent, scope: :agent)
 
     path = admin_organisation_user_path(organisation, user)
     expect_page_to_be_axe_clean(path)
@@ -67,7 +67,7 @@ describe "agents page", js: true do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as agent
+    login_as(agent, scope: :agent)
     expect_page_to_be_axe_clean(agents_preferences_path)
   end
 
@@ -75,7 +75,7 @@ describe "agents page", js: true do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as agent
+    login_as(agent, scope: :agent)
     create_list(:rdv, 3, agents: [agent])
     expect_page_to_be_axe_clean(admin_organisation_rdvs_path(organisation))
   end

--- a/spec/features/accessibility/configuration_pages_spec.rb
+++ b/spec/features/accessibility/configuration_pages_spec.rb
@@ -2,7 +2,7 @@ describe "configuration pages", js: true do
   it "index of configuration" do
     territory = create(:territory)
     agent = create(:agent, role_in_territories: [territory])
-    login_as agent
+    login_as(agent, scope: :agent)
 
     path = admin_territory_path(territory)
     expect_page_to_be_axe_clean(path)

--- a/spec/features/accessibility/users_pages_spec.rb
+++ b/spec/features/accessibility/users_pages_spec.rb
@@ -2,21 +2,21 @@ describe "users pages", js: true do
   describe "users_rdvs_path page" do
     it "without RDV is accessible" do
       user = create(:user, email: "toto@example.com")
-      login_as user
+      login_as(user, scope: :user)
       expect_page_to_be_axe_clean(users_rdvs_path)
     end
 
     it "with RDV is accessible" do
       user = create(:user, email: "toto@example.com")
       create_list(:rdv, 3, users: [user])
-      login_as user
+      login_as(user, scope: :user)
       expect_page_to_be_axe_clean(users_rdvs_path)
     end
   end
 
   it "users_informations_path is accessible" do
     user = create(:user, email: "toto@example.com")
-    login_as user
+    login_as(user, scope: :user)
     expect_page_to_be_axe_clean(users_informations_path)
   end
 
@@ -26,13 +26,13 @@ describe "users pages", js: true do
 
   it "edit_relative_path is accessible" do
     user = create(:user)
-    login_as user
+    login_as(user, scope: :user)
     expect_page_to_be_axe_clean(edit_relative_path(user))
   end
 
   it "edit_user_path is accessible" do
     user = create(:user)
-    login_as user
+    login_as(user, scope: :user)
     expect_page_to_be_axe_clean(edit_user_registration_path)
   end
 

--- a/spec/features/agents/agent_can_destroy_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_destroy_plage_ouverture_spec.rb
@@ -4,7 +4,7 @@ describe "Admin can configure the organisation" do
     agent = create(:agent, organisations: [organisation])
     plage_ouverture = create(:plage_ouverture, agent: agent, organisation: organisation)
 
-    login_as agent
+    login_as(agent, scope: :agent)
 
     visit admin_organisation_agent_plage_ouvertures_path(organisation, agent)
 

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -106,12 +106,12 @@ RSpec.describe "Agents can be managed by organisation admins" do
     end
 
     it "requires the territory admin to activate the new service" do
-      login_as(organisation_admin)
+      login_as(organisation_admin, scope: :agent)
       visit new_admin_organisation_agent_path(organisation1)
       expect(page).not_to(have_content("CSS"))
       logout
 
-      login_as(territory_admin)
+      login_as(territory_admin, scope: :agent)
       visit admin_territory_path(territory.id)
       click_link("Services")
       check("CSS")
@@ -119,7 +119,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       expect(page).to have_content("Configuration enregistrée")
       logout
 
-      login_as(organisation_admin)
+      login_as(organisation_admin, scope: :agent)
 
       visit new_admin_organisation_agent_path(organisation1)
       fill_in "Email", with: "jean@paul.com"

--- a/spec/features/super_admin/use_correct_history_version_spec.rb
+++ b/spec/features/super_admin/use_correct_history_version_spec.rb
@@ -1,0 +1,32 @@
+describe "Use correct history version when a super admin is logged in and use impersonate" do
+  let!(:organisation) { create(:organisation) }
+  let!(:service) { create(:service) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+  let!(:user) { create(:user, organisations: [organisation]) }
+  let!(:super_admin) { create(:super_admin) }
+
+  before do
+    login_as(super_admin, scope: :super_admin)
+  end
+
+  it "for an agent", js: true do
+    login_as(agent, scope: :agent)
+    visit admin_organisation_user_path(organisation, user)
+    within("#spec-primary-user-card") { click_link "Modifier" }
+    fill_in :user_first_name, with: "jeanne d'arc"
+    click_button "Enregistrer"
+
+    click_button("Historique des changements")
+    expect(page).to have_content("[Admin] #{super_admin.full_name} pour #{agent.full_name}")
+  end
+
+  it "for a user", js: true do
+    login_as(user, scope: :user)
+    visit root_path
+    click_link "Vos informations"
+    fill_in("Téléphone", with: "0612345678")
+    click_on("Modifier")
+
+    expect(user.reload.versions.last.whodunnit).to eq "[Admin] #{super_admin.full_name} pour #{user.full_name}"
+  end
+end

--- a/spec/models/super_admin_spec.rb
+++ b/spec/models/super_admin_spec.rb
@@ -1,0 +1,35 @@
+describe SuperAdmin, type: :model do
+  let(:super_admin) { create(:super_admin) }
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(super_admin).to be_valid
+    end
+
+    it "is not valid without a first name" do
+      super_admin.first_name = nil
+      expect(super_admin).not_to be_valid
+    end
+
+    it "is not valid without a last name" do
+      super_admin.last_name = nil
+      expect(super_admin).not_to be_valid
+    end
+  end
+
+  describe "#name_for_paper_trail" do
+    context "when impersonated is blank" do
+      it "returns the correct string" do
+        expect(super_admin.name_for_paper_trail).to eq("[Admin] #{super_admin.full_name}")
+      end
+    end
+
+    context "when impersonated is not blank" do
+      let(:agent) { create(:agent) }
+
+      it "returns the correct string" do
+        expect(super_admin.name_for_paper_trail(impersonated: agent)).to eq("[Admin] #{super_admin.full_name} pour #{agent.full_name}")
+      end
+    end
+  end
+end

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Search", type: :request do
       let(:user) { create(:user, organisations: [organisation], referent_agents: [agent]) }
 
       before do
-        login_as(user)
+        login_as(user, scope: :user)
       end
 
       context "with agent_id params" do


### PR DESCRIPTION
close https://github.com/betagouv/rdv-service-public/issues/3915

Cette PR améliore la sécurité et le versionning papertrail dans le cas ou un super admin se connecte en tant qu'usager ou agent. Pour garder une cohérence et pour des questions d'identification, j'ajoute le nom et le prénom à la table super admin et je les rend obligatoire (je mettrai à jour la prod et la démo).
Quand un super admin se déconnecte, il se déconnecte de tout ces scopes (sans cela il pourrait se faire passer pour qqun d'autre).
Cette PR prépare https://github.com/betagouv/rdv-service-public/issues/3696 et https://github.com/betagouv/rdv-service-public/issues/3622

Avant :

<img width="1551" alt="Capture d’écran 2023-12-08 à 12 04 23" src="https://github.com/betagouv/rdv-service-public/assets/28594222/68593cfa-aa89-430d-a219-96df70bf5e3d">

Après :

<img width="1551" alt="Capture d’écran 2023-12-08 à 12 03 46" src="https://github.com/betagouv/rdv-service-public/assets/28594222/7edd1689-1628-4535-876c-1da62dc3ab56">