### PR TITLE
Correctif pour l'anonymisation partielle dans la recherche d'usagers

### DIFF
--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -29,17 +29,11 @@ class Agents::UsersController < AgentAuthController
     results = []
 
     if users_from_organisation.any?
-      results << {
-        text: nil,
-        children: serialize(users_from_organisation),
-      }
+      results << formatted_users_from_organisation(users_from_organisation)
     end
 
     if users_from_territory.any?
-      results << {
-        text: "Usagers des autres organisations",
-        children: serialize(users_from_territory),
-      }
+      results << formatted_users_from_territory(users_from_territory)
     end
 
     render json: { results: results }
@@ -47,17 +41,32 @@ class Agents::UsersController < AgentAuthController
 
   private
 
+  def formatted_users_from_organisation(users)
+    {
+      text: nil,
+      children: users.map do |user|
+        {
+          id: user.id,
+          text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
+        }
+      end,
+    }
+  end
+
+  def formatted_users_from_territory(users)
+    {
+      text: "Usagers des autres organisations",
+      children: users.map do |user|
+        {
+          id: user.id,
+          text: UsersHelper.partially_hidden_reverse_full_name_and_notification_coordinates(user),
+        }
+      end,
+    }
+  end
+
   def agent_in_cnfs_or_mairies_territories?
     cnfs_and_mairies_territory_ids = [Territory.mairies&.id, Territory.find_by(departement_number: "CN")&.id].compact
     (cnfs_and_mairies_territory_ids & current_agent.organisations.pluck(:territory_id)).any? # & does an array overlap here
-  end
-
-  def serialize(users)
-    users.map do |user|
-      {
-        id: user.id,
-        text: UsersHelper.reverse_full_name_and_notification_coordinates(user),
-      }
-    end
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -57,6 +57,17 @@ module UsersHelper
     user.reverse_full_name + birth_date_and_age_if_exist(user)
   end
 
+  def self.partially_hidden_reverse_full_name_and_notification_coordinates(user)
+    username, domain = user.email.split("@")
+    partially_hidden_email = "#{username[0]}******#{username[-1]}@#{domain}"
+    [
+      user.reverse_full_name,
+      user.birth_date && I18n.l(user.birth_date, format: "%d/%m/****"),
+      user.partially_hidden_phone_number,
+      partially_hidden_email,
+    ].compact.join(" - ")
+  end
+
   def self.reverse_full_name_and_notification_coordinates(user)
     [user.reverse_full_name, user.birth_date && I18n.l(user.birth_date), user.humanized_phone_number, user.email].compact.join(" - ")
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -58,8 +58,12 @@ module UsersHelper
   end
 
   def self.partially_hidden_reverse_full_name_and_notification_coordinates(user)
-    username, domain = user.email.split("@")
-    partially_hidden_email = "#{username[0]}******#{username[-1]}@#{domain}"
+    if user.email.present?
+      username, domain = user.email&.split("@")
+      partially_hidden_email = "#{username[0]}******#{username[-1]}@#{domain}"
+    else
+      partially_hidden_email = nil
+    end
     [
       user.reverse_full_name,
       user.birth_date && I18n.l(user.birth_date, format: "%d/%m/****"),

--- a/app/lib/phone_number_validation.rb
+++ b/app/lib/phone_number_validation.rb
@@ -60,7 +60,7 @@ module PhoneNumberValidation
     end
 
     def partially_hidden_phone_number
-      humanized_phone_number.gsub(" ", "").tap { |number| number[-8..-3] = "******" }
+      humanized_phone_number&.gsub(" ", "")&.tap { |number| number[-8..-3] = "******" }
     end
   end
 end

--- a/app/lib/phone_number_validation.rb
+++ b/app/lib/phone_number_validation.rb
@@ -58,5 +58,9 @@ module PhoneNumberValidation
     def humanized_phone_number
       Phonelib.parse(phone_number_formatted).national
     end
+
+    def partially_hidden_phone_number
+      humanized_phone_number.gsub(" ", "").tap { |number| number[-8..-3] = "******" }
+    end
   end
 end

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -25,6 +25,13 @@ org_paris_nord = Organisation.create!(
   territory: territory75
 )
 
+org_paris_sud = Organisation.create!(
+  name: "MDS Paris Sud",
+  phone_number: "0123456789",
+  human_id: "paris-sud",
+  territory: territory75
+)
+
 human_id_map = [
   { human_id: "1030", name: "MDS Arques" },
   { human_id: "1031", name: "MDS Arras Nord" },
@@ -332,6 +339,21 @@ user_org_paris_nord_jean = User.new(
 user_org_paris_nord_jean.skip_confirmation!
 user_org_paris_nord_jean.save!
 user_org_paris_nord_jean.profile_for(org_paris_nord).update!(logement: 2)
+
+user_org_paris_sud = User.new(
+  first_name: "Francis",
+  last_name: "Factice",
+  email: "francis.factice@demo.rdv-solidarites.fr",
+  birth_date: Date.parse("10/01/1973"),
+  password: "lapinlapin",
+  phone_number: "0101010103",
+  organisation_ids: [org_paris_sud.id],
+  created_through: "user_sign_up"
+)
+
+user_org_paris_sud.skip_confirmation!
+user_org_paris_sud.save!
+user_org_paris_sud.profile_for(org_paris_sud).update!(logement: 2)
 
 user_org_arques = User.new(
   first_name: "Francis",

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -71,5 +71,13 @@ describe UsersHelper, type: :helper do
       user = build(:user, birth_date: Date.new(1950, 12, 21), first_name: "Francis", last_name: "Factice", phone_number: "0611223344", email: "francis@factice.com")
       expect(described_class.partially_hidden_reverse_full_name_and_notification_coordinates(user)).to eq("FACTICE Francis - 21/12/**** - 06******44 - f******s@factice.com")
     end
+
+    it "doesn't fail for a user with missing info" do
+      user = build(:user, birth_date: nil, first_name: "Francis", last_name: "Factice", phone_number: nil, email: nil)
+      expect(described_class.partially_hidden_reverse_full_name_and_notification_coordinates(user)).to eq("FACTICE Francis")
+
+      user = build(:user, birth_date: nil, first_name: "Francis", last_name: "Factice", phone_number: "", email: "")
+      expect(described_class.partially_hidden_reverse_full_name_and_notification_coordinates(user)).to eq("FACTICE Francis")
+    end
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -65,4 +65,11 @@ describe UsersHelper, type: :helper do
       expect(full_name_and_birthdate(user)).to eq("James BOND - 21/12/1950 - 70 ans")
     end
   end
+
+  describe "partially_hidden_reverse_full_name_and_notification_coordinates" do
+    it "hides most of the personal data while allowing verification" do
+      user = build(:user, birth_date: Date.new(1950, 12, 21), first_name: "Francis", last_name: "Factice", phone_number: "0611223344", email: "francis@factice.com")
+      expect(described_class.partially_hidden_reverse_full_name_and_notification_coordinates(user)).to eq("FACTICE Francis - 21/12/**** - 06******44 - f******s@factice.com")
+    end
+  end
 end


### PR DESCRIPTION
correctif de #3914 suite au rollback de #3920  😿 
Le premier commit restaure ce qui avait été fait dans la première PR, et le deuxième ajoute une spec et un fix pour l'erreur