### PR TITLE
Installation de Strong Migrations et préparation de suppression de colonnes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -235,3 +235,6 @@ RSpec/FilePath:
 
 Style/NumericPredicate:
   Enabled: false
+
+Style/Literals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -236,5 +236,5 @@ RSpec/FilePath:
 Style/NumericPredicate:
   Enabled: false
 
-Style/Literals:
+Style/NumericLiterals:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "rack-attack"
 gem "pg"
 # PgSearch builds Active Record named scopes that take advantage of PostgreSQL's full text search
 gem "pg_search"
+# Strong Migrations catches unsafe migrations in development
+gem "strong_migrations"
 # A pagination engine plugin for Rails 4+ and other modern frameworks
 gem "kaminari"
 # Bootstrap 4 styling for Kaminari gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,6 +557,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strong_migrations (1.6.4)
+      activerecord (>= 5.2)
     swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -698,6 +700,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sprockets-rails
+  strong_migrations
   tod (~> 2.2)
   turbolinks (~> 5)
   typhoeus

--- a/app/dashboards/lieu_dashboard.rb
+++ b/app/dashboards/lieu_dashboard.rb
@@ -18,12 +18,10 @@ class LieuDashboard < Administrate::BaseDashboard
     agents: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    old_address: Field::String,
     latitude: Field::Number.with_options(decimals: 6),
     longitude: Field::Number.with_options(decimals: 6),
     phone_number: Field::String,
     phone_number_formatted: Field::String,
-    old_enabled: Field::Boolean,
     availability: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     address: Field::String,
   }.freeze

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -1,4 +1,6 @@
 class Lieu < ApplicationRecord
+  self.ignored_columns = %w[old_address old_enabled]
+
   # Mixins
   has_paper_trail
   include PhoneNumberValidation::HasPhoneNumber
@@ -8,7 +10,6 @@ class Lieu < ApplicationRecord
   auto_strip_attributes :name
   enum availability: { enabled: "enabled", disabled: "disabled", single_use: "single_use" }
 
-  # TODO: supprimer cet attribut `:enabled` si bien lié au champ `old_enabled` (cf `schema.rb`)
   attribute :enabled, :boolean
 
   # Relations

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -1,4 +1,5 @@
 class Motif < ApplicationRecord
+  self.ignored_columns = %w[legacy_bookable_publicly old_location_type]
   # Mixins
   has_paper_trail
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -1,4 +1,6 @@
 class Rdv < ApplicationRecord
+  self.ignored_columns = %w[old_location]
+
   # Mixins
   has_paper_trail(
     only: %w[user_ids agent_ids status starts_at ends_at lieu_id notes context participations],

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,26 @@
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20231213170333
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -167,7 +167,6 @@ lieu_org_drome2_valence = Lieu.create!(
 lieu_org_yonne = Lieu.create!(
   name: "PE Avallon",
   organisation: org_yonne,
-  old_address: "3 Rue Joubert, Auxerre, 89000, 89, Yonne, Bourgogne-Franche-Comté",
   latitude: 47.796413,
   longitude: 3.572016,
   availability: :enabled,


### PR DESCRIPTION
fixes https://github.com/betagouv/rdv-service-public/issues/3838

Suite à la dernière douloureuse tentative de supprimer une colonne inutilisée (https://github.com/betagouv/rdv-service-public/pull/3902), cette PR installe Strong Migrations et prépare en douceur la suppression des colonnes indiquée dans https://github.com/betagouv/rdv-service-public/issues/3838

Maintenant que notre équipe non-tech utilise Metabase, c'est encore plus sympa d'avoir moins de colonnes inutiles.