### PR TITLE
Anonymisation plus précise et plus rapide

### DIFF
--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -65,8 +65,10 @@ class Anonymizer
   def anonymize_column(column, model_class)
     ActiveRecord::Encryption.without_encryption do # The columns may be encrypted, but we still want to overwrite the anonymized value
       scope = model_class.unscoped.where.not(column.name => nil)
+
       if column.type.in?(%i[string text])
-        scope = scope.where.not(column.name => "")
+        # Pour limiter la confusion lors de l'exploitation des données, on transforme les chaines vides en null
+        scope.where(column.name => "").update_all(column.name => nil) # rubocop:disable Rails/SkipsModelValidations
       end
 
       scope.update_all(column.name => anonymous_value(column)) # rubocop:disable Rails/SkipsModelValidations

--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -35,7 +35,7 @@ class Anonymizer
     end
     # Sanity checks supplémentaires
     # Ces variables d'envs n'ont rien à voir avec l'ETL, et ne devraient donc pas être présentes
-    if ENV["DEFAULT_SMS_PROVIDER"].present?
+    if ENV["HOST"].present? || ENV["DEFAULT_SMS_PROVIDER"].present?
       raise "Attention, il semble que vous êtes en train d'anonymiser des données d'une appli web"
     end
 

--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -35,7 +35,7 @@ class Anonymizer
     end
     # Sanity checks supplémentaires
     # Ces variables d'envs n'ont rien à voir avec l'ETL, et ne devraient donc pas être présentes
-    if ENV["RACK_ENV"].present? || ENV["DEFAULT_SMS_PROVIDER"].present?
+    if ENV["DEFAULT_SMS_PROVIDER"].present?
       raise "Attention, il semble que vous êtes en train d'anonymiser des données d'une appli web"
     end
 

--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -57,12 +57,14 @@ class Anonymizer
     end
 
     anonymized_columns.each do |column|
-      scope = model_class.unscoped.where.not(column.name => nil)
-      if column.type.in?(%i[string text])
-        scope = scope.where.not(column.name => "")
-      end
+      ActiveRecord::Encryption.without_encryption do # The columns may be encrypted, but we still want to overwrite the anonymized value
+        scope = model_class.unscoped.where.not(column.name => nil)
+        if column.type.in?(%i[string text])
+          scope = scope.where.not(column.name => "")
+        end
 
-      scope.update_all(column.name => anonymous_value(column)) # rubocop:disable Rails/SkipsModelValidations
+        scope.update_all(column.name => anonymous_value(column)) # rubocop:disable Rails/SkipsModelValidations
+      end
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -57,11 +57,12 @@ class Anonymizer
     end
 
     anonymized_columns.each do |column|
+      scope = model_class.unscoped.where.not(column.name => nil)
       if column.type.in?(%i[string text])
-        model_class.unscoped.where.not(column.name => nil).where.not(column.name => "").update_all(column.name => anonymous_value(column)) # rubocop:disable Rails/SkipsModelValidations
-      else
-        model_class.unscoped.where.not(column.name => nil).update_all(column.name => anonymous_value(column)) # rubocop:disable Rails/SkipsModelValidations
+        scope = scope.where.not(column.name => "")
       end
+
+      scope.update_all(column.name => anonymous_value(column)) # rubocop:disable Rails/SkipsModelValidations
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/scripts/anonymize_database.rb
+++ b/scripts/anonymize_database.rb
@@ -1,7 +1,7 @@
 Anonymizer.anonymize_all_data!
 
 # Sanity checks
-if User.where.not(first_name: "[valeur anonymisée]").any?
+if User.where.not(last_name: "[valeur anonymisée]").any?
   raise "Certains usagers n'ont pas été anonymisés !"
 end
 

--- a/spec/lib/anonymizer_spec.rb
+++ b/spec/lib/anonymizer_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Anonymizer do
     let!(:rdv_with_blank_context) { create(:rdv, context: "") }
     let!(:rdv_with_null_context) { create(:rdv, context: nil) }
 
-    it "doesn't anonymize empty and null values, so we can know if a field is used or not" do
+    it "turns blank strings into null to avoid confusion when non-tech people use the data in metabase" do
       described_class.anonymize_all_data!
 
       expect(rdv_with_context.reload.context).to eq "[valeur anonymisée]"
-      expect(rdv_with_blank_context.reload.context).to eq ""
+      expect(rdv_with_blank_context.reload.context).to be_nil
       expect(rdv_with_null_context.reload.context).to be_nil
     end
   end

--- a/spec/lib/anonymizer_spec.rb
+++ b/spec/lib/anonymizer_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe Anonymizer do
   let!(:user_with_email) { create(:user, email: "user@example.com") }
 
   around do |example|
-    rack_env = ENV.delete("RACK_ENV")
+    host = ENV.delete("HOST")
 
     example.run
 
-    ENV["RACK_ENV"] = rack_env
+    ENV["HOST"] = host
   end
 
   context "general case" do

--- a/spec/lib/anonymizer_spec.rb
+++ b/spec/lib/anonymizer_spec.rb
@@ -40,4 +40,18 @@ RSpec.describe Anonymizer do
     expect(user_without_email.reload.email).to be_nil
     expect(user_with_email.reload.email).to eq "[valeur unique anonymisée #{user_with_email.id}]"
   end
+
+  describe "null and empty values" do
+    let!(:rdv_with_context) { create(:rdv, context: "Des infos sensisbles sur le rdv") }
+    let!(:rdv_with_blank_context) { create(:rdv, context: "") }
+    let!(:rdv_with_null_context) { create(:rdv, context: nil) }
+
+    it "doesn't anonymize empty and null values, so we can know if a field is used or not" do
+      described_class.anonymize_all_data!
+
+      expect(rdv_with_context.reload.context).to eq "[valeur anonymisée]"
+      expect(rdv_with_blank_context.reload.context).to eq ""
+      expect(rdv_with_null_context.reload.context).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Cette PR apporte deux améliorations à notre script d'anoymisation

# Gestion des chaines vides lors de l'anonymisation

Jusqu'à maintenant, si la valeur pour une colonne anonymisée était `""`, on la remplaçait par `[valeur anonymisée]`. Ça fait que ce n'est pas possible de voir si un champs apparait sur un formulaire, mais n'est pas utilisée (typiquement le champs contexte d'un rdv).
Maintenant, on laisse la valeur chaine vide, pour permettre d'avoir une distinction entre les cas où le champs et rempli et celui où il ne l'est pas.

# Anonymisation colonne par colonne

Le changement précédent est rendu possible par le fait qu'on anonymise maintenant colonne par colonne plutôt que table par table.

Ça permet aussi d'éviter les `CASE`, et de gagner un peu en perfs. Par exemple, le temps d'exécution de la commande `bundle exec rails runner "Anonymizer.anonymize_table('absences')"` passe de 39 à 31 secondes.