### PR TITLE
Ignorer strong_migrations pour une migration sur une mini table

### DIFF
--- a/db/migrate/20231214155817_set_not_null_on_super_admins_names.rb
+++ b/db/migrate/20231214155817_set_not_null_on_super_admins_names.rb
@@ -1,6 +1,9 @@
 class SetNotNullOnSuperAdminsNames < ActiveRecord::Migration[7.0]
   def change
-    change_column_null :super_admins, :first_name, false
-    change_column_null :super_admins, :last_name, false
+    # Cette table est peu lue donc ce n'est pas dangereux qu'elle soit bloquée le temps de la migration
+    safety_assured do
+      change_column_null :super_admins, :first_name, false
+      change_column_null :super_admins, :last_name, false
+    end
   end
 end


### PR DESCRIPTION
Entre la création de #3930 et son merge, on a ajouté la gem `strong_migrations`. Cette gem a montré les dents lors du déploiement de la PR.

J'ai choisi d'ignorer le safeguard fourni par `strong_migrations` puisque la table en question est minuscule et lue peu fréquemment.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
