### PR TITLE
Documentation des colonnes (1/n)

### DIFF
--- a/db/migrate/20231219151419_add_comments_for_metabase.rb
+++ b/db/migrate/20231219151419_add_comments_for_metabase.rb
@@ -1,0 +1,131 @@
+class AddCommentsForMetabase < ActiveRecord::Migration[7.0]
+  def change # rubocop:disable Metrics/MethodLength
+    change_column_comment(
+      :agents,
+      :display_saturdays,
+      from: nil,
+      to: <<~COMMENT
+        Indique si l'agent veut que les samedis s'affichent quand il consulte un calendrier (pas forcément le sien). Cela n'affecte pas ce que voient les autres agents. Modifiable par le bouton en bas de la vue calendrier.
+      COMMENT
+    )
+
+    change_column_comment(
+      :agents, :display_cancelled_rdv,
+      from: nil, to: <<~COMMENT
+        Indique si l'agent veut que les rdv annulés s'affichent quand il consulte un calendrier (pas forcément le sien). Cela n'affecte pas ce que voient les autres agents. Modifiable par le bouton en bas de la vue calendrier
+      COMMENT
+    )
+
+    change_column_comment(
+      :agents, :account_deletion_warning_sent_at,
+      from: nil, to: <<~COMMENT
+        Quand le compte de l'agent est inactif depuis bientôt deux ans, on lui envoie un mail qui le prévient que sont compte sera bientôt supprimé, et qu'il doit se connecter à nouveau s'il souhaite conserver son compte. On enregistre la date d'envoi de cet email ici pour s'assure qu'on lui laisse un délai d'au moins un mois pour réagir.
+      COMMENT
+    )
+
+    change_column_comment(
+      :lieux, :availability,
+      from: nil, to: <<~COMMENT
+        Permet de savoir si le lieu est un lieu normal (enabled), un lieu ponctuel qui sera utilisé pour un seul rdv (single_use), ou un lieu supprimé par soft-delete (disabled). Dans la plupart des cas on s'intéresse uniquement aux lieux enabled
+      COMMENT
+    )
+
+    change_column_comment(
+      :motif_categories, :short_name,
+      from: nil, to: <<~COMMENT
+        Le nom "technique" de la catégorie de motif, qui permet de l'identifier dans les paramètres de formulaires"
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :min_public_booking_delay,
+      from: nil, to: <<~COMMENT
+        Permet de savoir combien de secondes il y aura au minimum entre la prise de rdv par un usager ou un prescripteur et le début du rdv. Par exemple si la valeur est 1800, et qu'il est 10h, le premier rdv qui pourra être pris (s'il y a une plage d'ouverture libre) sera à 10h30, puisque 1800 = 30 x 60. Cela permet à l'agent d'être prévenu suffisamment à l'avance.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :max_public_booking_delay,
+      from: nil, to: <<~COMMENT
+        Permet de savoir combien de temps à l'avance il est possible de prendre rdv pour un usager ou un prescripteur. Le délai est mesuré en secondes. Cela évite que des gens prennent des rdv dans trop longtemps, et évite aux agents de s'engager à assurer des rdv alors qu'ils ne connaissent pas leur emploi du temps suffisamment à l'avance.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :deleted_at,
+      from: nil, to: <<~COMMENT
+        Permet de savoir à quelle date le motif a été soft-deleted
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :restriction_for_rdv,
+      from: nil, to: <<~COMMENT
+        Instructions à accepter avant la prise du rendez-vous par l'usager
+      COMMENT
+
+    )
+    change_column_comment(
+      :motifs, :instruction_for_rdv,
+      from: nil, to: <<~COMMENT
+        Indications affichées à l'usager après la confirmation du rendez-vous. Apparait dans le mail de confirmation pour l'usager.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :for_secretariat,
+      from: nil, to: <<~COMMENT
+        Permet aux agents du secrétariat d'assurer des rdv pour ce motif
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :follow_up,
+      from: nil, to: <<~COMMENT
+        Indique s'il s'agit d'un motif de suivi. Si c'est le cas, le rdv pourra uniquement être assuré par un agent référent de l'usager.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :visibility_type,
+      from: nil, to: <<~COMMENT
+        Niveau de visibilité du motif pour l'usager. Cette option permet de cacher des rdvs sensibles pour assurer la sécurité d'un usager dont des proches pourraient consulter le téléphone ou le compte RDV Solidarités.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :sectorisation_level,
+      from: nil, to: <<~COMMENT
+        Indique à quel point la sectorisation restreint la prise de rdv des usagers pour ce motif. Le niveau "departement" indique qu'il n'y a pas de restriction.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :custom_cancel_warning_message,
+      from: nil, to: <<~COMMENT
+        Message d'avertissement montré à l'usager en cas d'annulation
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :collectif,
+      from: nil, to: <<~COMMENT
+        Indique s'il s'agit d'un rdv collectif ou individuel. Un rdv considéré comme individuel peut quand même avoir plusieurs participants, par exemple un parent et son enfant qui renouvellent tous les deux leur carte d'indentité en même temps. Un rdv collectif sera ouvert à plusieurs participants qui ne se connaissent pas entre eux.
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :location_type,
+      from: nil, to: <<~COMMENT
+        Là où le rdv aura lieu : "public_office" pour "Sur place" (généralement dans les bureaux de l'organisation), "phone" pour au téléphone (l'agent appelle l'usager), "home" pour le domicile de l'usager
+      COMMENT
+    )
+
+    change_column_comment(
+      :motifs, :rdvs_editable_by_user,
+      from: nil, to: <<~COMMENT
+        Indique si on autorise aux usagers de changer la date du rdv via l'interface web
+      COMMENT
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,8 +223,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_14_155817) do
     t.boolean "display_cancelled_rdv", default: true
     t.enum "plage_ouverture_notification_level", default: "all", enum_type: "agents_plage_ouverture_notification_level"
     t.enum "absence_notification_level", default: "all", enum_type: "agents_absence_notification_level"
-    t.string "external_id"
-    t.string "calendar_uid"
+    t.string "external_id", comment: "The agent's unique and immutable id in the system managing them and adding them to our application"
+    t.string "calendar_uid", comment: "the uid used for the url of the agent's ics calendar"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
@@ -415,7 +415,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_14_155817) do
     t.string "website"
     t.string "email"
     t.bigint "territory_id", null: false
-    t.string "external_id"
+    t.string "external_id", comment: "The organisation's unique and immutable id in the system managing them and adding them to our application"
     t.enum "verticale", default: "rdv_solidarites", null: false, enum_type: "verticale"
     t.index ["external_id", "territory_id"], name: "index_organisations_on_external_id_and_territory_id", unique: true
     t.index ["human_id", "territory_id"], name: "index_organisations_on_human_id_and_territory_id", unique: true, where: "((human_id)::text <> ''::text)"

--- a/docs/charger-territoire-sur-review-app.md
+++ b/docs/charger-territoire-sur-review-app.md
@@ -2,7 +2,7 @@
 
 # 1. Préparer les données en local
 
-Télécharger un dump de prod depuis Scalingo, puis le charger en local : 
+Télécharger un dump de prod depuis Scalingo, puis le charger en local :
 
 ```bash
  ./scripts/db_dump_load.sh nom_du_dump.pgsql
@@ -28,14 +28,14 @@ scalingo --app $REVIEW_APP_NAME --region osc-secnum-fr1 pgsql-console
 puis supprimer les tables du schema public :
 
 ```sql
-DO $$ 
-DECLARE 
-   tabname RECORD; 
-BEGIN 
-   FOR tabname IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') 
-   LOOP 
-      EXECUTE 'DROP TABLE IF EXISTS ' || tabname.tablename || ' CASCADE'; 
-   END LOOP; 
+DO $$
+DECLARE
+   tabname RECORD;
+BEGIN
+   FOR tabname IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public')
+   LOOP
+      EXECUTE 'DROP TABLE IF EXISTS ' || tabname.tablename || ' CASCADE';
+   END LOOP;
 END $$;
 ```
 
@@ -43,7 +43,7 @@ Nous allons maintenant dumper les données locales :
 
 ```bash
 LOCAL_DATABASE_URL=postgresql://postgres:mot_de_passe_local@localhost/lapin_development
-pg_dump --clean --if-exists --format c --dbname $LOCAL_DATABASE_URL --no-owner --no-privileges --no-comments --exclude-schema 'information_schema' --exclude-schema '^pg_*' --file tmp/dump.pgsql
+pg_dump --clean --if-exists --format c --dbname $LOCAL_DATABASE_URL --no-owner --no-privileges --exclude-schema 'information_schema' --exclude-schema '^pg_*' --file tmp/dump.pgsql
 ```
 
 Afin de charger ce dump sur la review app, il faut rendre la DB de la review app accessible depuis internet. Pour ce faire :
@@ -57,7 +57,7 @@ Nous allons alors pouvoir restaurer la base locale vers la DB distante en fourni
 
 ```bash
 REVIEW_APP_DB_URL=url_trouvee_dans_les_variables_denv_de_la_review_app
-pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname $REVIEW_APP_DB_URL tmp/dump.pgsql
+pg_restore --clean --if-exists --no-owner --no-privileges --dbname $REVIEW_APP_DB_URL tmp/dump.pgsql
 ```
 
 La base locale est désormais copiée sur la review app !

--- a/scripts/db_dump_load.sh
+++ b/scripts/db_dump_load.sh
@@ -11,7 +11,7 @@ DUMP_NAME=$1
 
 # import
 bundle exec rails db:drop db:create
-pg_restore --clean --if-exists --no-owner --no-privileges --no-comments --dbname lapin_development "$DUMP_NAME"
+pg_restore --clean --if-exists --no-owner --no-privileges --dbname lapin_development "$DUMP_NAME"
 
 rm -f "$DUMP_NAME"
 


### PR DESCRIPTION
Pour la plus grande joie de François, les commentaires sont de retour dans le schema.rb !

En ajoutant des commentaires dans postgres, ils sont automatiquement visible dans l'interface metabase. Ils permettent donc à l'équipe non-tech de comprendre encore mieux notre application. C'est une forme de documentation comme une autre, je sais pas à quel point ça sera facile à maintenir, mais ça vaut le coup d'essayer.

J'ai pas réussi à rédiger des explications pour tout le schéma d'un coup, donc je préfère passer ça en plusieurs PR quotidiennes.