### PR TITLE
Fix un oubli lors d'un renommage

### DIFF
--- a/app/controllers/super_admins/super_admins_controller.rb
+++ b/app/controllers/super_admins/super_admins_controller.rb
@@ -14,7 +14,7 @@ module SuperAdmins
     end
 
     def privilege_escalation?
-      current_super_admin.support_member? && resource_params[:role] == "super_admin"
+      current_super_admin.support_member? && resource_params[:role] == "legacy_admin"
     end
   end
 end


### PR DESCRIPTION
Oubli de ce commit https://github.com/betagouv/rdv-service-public/pull/3918/commits/2d767ae250d4235e6bc72748519177a021efcd0e

Je me permet de merge sans review, il s'agit d'un fix évitant un bug d'escalade de privilége suite à un oubli de renommage.