### PR TITLE
Modification de permission pour les membres du support sur les organisaitions (super_admin)

### DIFF
--- a/app/policies/super_admin/organisation_policy.rb
+++ b/app/policies/super_admin/organisation_policy.rb
@@ -1,9 +1,9 @@
 class SuperAdmin::OrganisationPolicy < DefaultSuperAdminPolicy
   alias index? team_member?
   alias show? team_member?
-  alias create? legacy_admin_member?
-  alias new? legacy_admin_member?
-  alias edit? legacy_admin_member?
-  alias update? legacy_admin_member?
+  alias create? team_member?
+  alias new? team_member?
+  alias edit? team_member?
+  alias update? team_member?
   alias destroy? legacy_admin_member?
 end

--- a/spec/policies/super_admin/organisation_policy_spec.rb
+++ b/spec/policies/super_admin/organisation_policy_spec.rb
@@ -12,7 +12,7 @@ describe SuperAdmin::OrganisationPolicy, type: :policy do
   context "permitted actions for support" do
     let!(:pundit_context) { create(:super_admin, :support) }
 
-    it_behaves_like "permit actions", :organisation, :index?, :show?
-    it_behaves_like "not permit actions", :organisation, :new?, :create?, :edit?, :update?, :destroy?
+    it_behaves_like "permit actions", :organisation, :index?, :show?, :new?, :create?, :edit?, :update?
+    it_behaves_like "not permit actions", :organisation, :destroy?
   end
 end


### PR DESCRIPTION
On autorise ici les membres du support (team_members) à pouvoir créer et modifier les organisations. C'est un besoin coté support pour rdv-insertion. La suppression des organisaitons reste pour le moment uniquement du domaine des super admins (avec le role legacy_admin).
