### PR TITLE
Apply policy scope to list of relative's responsable referents

### DIFF
--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -84,7 +84,7 @@
         .card-header Agents référents du responsable
         .card-body
           ul.list-unstyled.mb-2
-            - @user.responsible.referent_agents.includes([:services]).each do |agent|
+            - policy_scope(@user.responsible.referent_agents.includes([:services])).each do |agent|
               li.mb-2
               | #{agent.full_name_and_service}
             - if @user.responsible.referent_agents.empty?


### PR DESCRIPTION
Cette PR rétablit la cohérence entre la liste des référents d'un usager sur la fiche usager, et sur la fiche d'un proche à cet usager.
Nous appliquons désormais la même règle d'affichage aussi biens sur la fiche usager que sur la fiche des proches.

Pour plus d'infos, voir [l'issue](https://github.com/betagouv/rdv-service-public/issues/3826).

Close  https://github.com/betagouv/rdv-service-public/issues/3826

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
