### PR TITLE
Ajout d'un action GitHub de review des changements de dépendances

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -1,0 +1,14 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+   runs-on: ubuntu-latest
+     steps:
+     - name: 'Checkout Repository'
+       uses: actions/checkout@v4
+     - name: Dependency Review
+       uses: actions/dependency-review-action@v3

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -7,8 +7,8 @@ permissions:
 jobs:
   dependency-review:
    runs-on: ubuntu-latest
-     steps:
-     - name: 'Checkout Repository'
-       uses: actions/checkout@v4
-     - name: Dependency Review
-       uses: actions/dependency-review-action@v3
+   steps:
+   - name: 'Checkout Repository'
+     uses: actions/checkout@v4
+   - name: Dependency Review
+     uses: actions/dependency-review-action@v3

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -12,3 +12,6 @@ jobs:
      uses: actions/checkout@v4
    - name: Dependency Review
      uses: actions/dependency-review-action@v3
+     with:
+       # Possible values: "critical", "high", "moderate", "low"
+       fail-on-severity: high


### PR DESCRIPTION
J'ai suivi ce guide : https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-dependency-review

En gros, si le job détecte une nouvelle dépendance avec un niveau d'alerte de "high" ou "critical", il tourne au rouge.

Exemple de résultat de l'action lors d'un changement de dépendances : 
https://github.com/betagouv/rdv-service-public/actions/runs/7450410314/job/20269242721?pr=3953

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/ea2741f5-a358-4a62-905a-4d1b6326f893)

En gros, si le job détecte une nouvelle dépendance avec un niveau d'alerte de "high" ou "critical", il tourne au rouge.

Contexte : préparation pour une homologation de sécurité. Discussion avec notre contact à l'ANCT : https://mattermost.incubateur.net/betagouv/pl/hefuypwe1bf13ba8za7xt8dmrc

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
