### PR TITLE
Lors de l'upload d'un fichier au mauvais format, informer l'agent, pas Sentry

### DIFF
--- a/app/controllers/admin/territories/zone_imports_controller.rb
+++ b/app/controllers/admin/territories/zone_imports_controller.rb
@@ -17,6 +17,9 @@ class Admin::Territories::ZoneImportsController < Admin::Territories::BaseContro
     else
       render :new
     end
+  rescue CsvOrXlsReader::FileFormatError => e
+    flash.now[:error] = e.message
+    render :new
   end
 
   private

--- a/app/lib/csv_or_xls_reader.rb
+++ b/app/lib/csv_or_xls_reader.rb
@@ -14,7 +14,7 @@ module CsvOrXlsReader
       when :xls
         extend XlsImporter
       else
-        raise FileFormatError, "unsupported format: #{@extension}"
+        raise FileFormatError, "Le format #{@extension} n'est pas géré. Veuillez utiliser un fichier .csv ou .xls (pas de .xlsx)"
       end
     end
   end

--- a/app/lib/csv_or_xls_reader.rb
+++ b/app/lib/csv_or_xls_reader.rb
@@ -1,6 +1,8 @@
 require "csv"
 
 module CsvOrXlsReader
+  class FileFormatError < StandardError; end
+
   class Importer
     def initialize(form_file)
       @form_file = form_file
@@ -12,7 +14,7 @@ module CsvOrXlsReader
       when :xls
         extend XlsImporter
       else
-        raise "unsupported format: #{@extension}"
+        raise FileFormatError, "unsupported format: #{@extension}"
       end
     end
   end


### PR DESCRIPTION
Nous avons régulièrement [cette erreur qui remonte dans Sentry : `unsupported format: xlsx (RuntimeError)`](https://sentry.incubateur.net/organizations/betagouv/issues/80085)

J'ai donc ajouté une petite gestion d'exception dans le contrôleur. Je vais au plus simple car c'est une erreur sur une fonctionnalité de niche, mais j'aimerais quand-même qu'on se débarrasse du bruit dans Sentry.

# Avant

**Erreur 500 classique**

# Après

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/827aad2a-784c-4b5f-9713-a308ed0c25ad)


# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
