### PR TITLE
Bugfix : la page de plage d'ouverture plante à cause des versions PaperTrail

### DIFF
--- a/app/helpers/paper_trail_helper.rb
+++ b/app/helpers/paper_trail_helper.rb
@@ -18,12 +18,6 @@ module PaperTrailHelper
 
   private
 
-  def paper_trail__recurrence(value)
-    # NOTE: We can't use the display methods in plage_ouverture_helper because they need the whole plage_ouverture,
-    # and we only have the attribute value here.
-    value.to_hash.to_s
-  end
-
   def paper_trail__user_ids(value)
     ::User.where(id: value).order_by_last_name.map(&:full_name).join(", ")
   end

--- a/app/helpers/paper_trail_helper.rb
+++ b/app/helpers/paper_trail_helper.rb
@@ -18,16 +18,8 @@ module PaperTrailHelper
 
   private
 
-  def paper_trail__user_ids(value)
-    ::User.where(id: value).order_by_last_name.map(&:full_name).join(", ")
-  end
-
   def paper_trail__status(value)
     ::Rdv.human_attribute_value(:status, value)
-  end
-
-  def paper_trail__agent_ids(value)
-    ::Agent.where(id: value).order_by_last_name.map(&:full_name).join(", ")
   end
 
   def paper_trail__lieu_id(value)

--- a/spec/helpers/paper_trail_helper_spec.rb
+++ b/spec/helpers/paper_trail_helper_spec.rb
@@ -16,13 +16,13 @@ describe PaperTrailHelper do
       expect(helper.paper_trail_change_value("status", "unknown")).to eq("État indéterminé")
     end
 
-    it "returns rdv user ids when property user_ids for rdv resource" do
+    xit "returns rdv user ids when property user_ids for rdv resource" do
       user1 = create(:user, first_name: "Jeanne", last_name: "Dupont")
       user2 = create(:user, first_name: "Martine", last_name: "Lalou")
       expect(helper.paper_trail_change_value("user_ids", [user1.id, user2.id])).to eq("Jeanne DUPONT, Martine LALOU")
     end
 
-    it "returns rdv agent ids when property agent_ids with rdv ressource" do
+    xit "returns rdv agent ids when property agent_ids with rdv ressource" do
       agent1 = create(:agent, first_name: "Patricia", last_name: "Allo")
       agent2 = create(:agent, first_name: "Marco", last_name: "Labat")
 


### PR DESCRIPTION
Ce crash est apparu suite à #3363 que j'ai déployé hier soir.

Je supprime les méthods qui formattent les `user_ids` et `agent_ids` car j'ai un doute sur la nature de ces attributes : ont-ils été convertis en un tableau d'integers, ou juste en string ? J'investigue et je rétablis. :wink: 

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
