### PR TITLE
Nettoyage des colonnes et indexes après #3946

### DIFF
--- a/app/lib/anonymizer_rules.rb
+++ b/app/lib/anonymizer_rules.rb
@@ -96,7 +96,7 @@ class AnonymizerRules
       anonymized_column_names: %w[context name],
       non_anonymized_column_names: %w[
         starts_at organisation_id created_at updated_at cancelled_at motif_id uuid
-        lieu_id old_location old_created_by created_by_id created_by_type ends_at max_participants_count users_count status
+        lieu_id old_location created_by_id created_by_type ends_at max_participants_count users_count status
       ],
     },
     receipts: {
@@ -137,7 +137,7 @@ class AnonymizerRules
       class_name: "Participation",
       anonymized_column_names: %w[invitation_token],
       non_anonymized_column_names: %w[created_at updated_at send_lifecycle_notifications send_reminder_notification invitation_created_at invitation_sent_at invitation_accepted_at
-                                      invitation_limit invited_by_type invited_by_id invitations_count status old_created_by created_by_id created_by_type],
+                                      invitation_limit invited_by_type invited_by_id invitations_count status created_by_id created_by_type],
     },
     plage_ouvertures: {
       class_name: "PlageOuverture",

--- a/app/lib/anonymizer_rules.rb
+++ b/app/lib/anonymizer_rules.rb
@@ -96,7 +96,7 @@ class AnonymizerRules
       anonymized_column_names: %w[context name],
       non_anonymized_column_names: %w[
         starts_at organisation_id created_at updated_at cancelled_at motif_id uuid
-        lieu_id old_location created_by created_by_id created_by_type ends_at max_participants_count users_count status
+        lieu_id old_location old_created_by created_by_id created_by_type ends_at max_participants_count users_count status
       ],
     },
     receipts: {
@@ -137,7 +137,7 @@ class AnonymizerRules
       class_name: "Participation",
       anonymized_column_names: %w[invitation_token],
       non_anonymized_column_names: %w[created_at updated_at send_lifecycle_notifications send_reminder_notification invitation_created_at invitation_sent_at invitation_accepted_at
-                                      invitation_limit invited_by_type invited_by_id invitations_count status created_by created_by_id created_by_type],
+                                      invitation_limit invited_by_type invited_by_id invitations_count status old_created_by created_by_id created_by_type],
     },
     plage_ouvertures: {
       class_name: "PlageOuverture",

--- a/db/migrate/20240110142710_cleanup_created_by_migration.rb
+++ b/db/migrate/20240110142710_cleanup_created_by_migration.rb
@@ -1,8 +1,8 @@
 class CleanupCreatedByMigration < ActiveRecord::Migration[7.0]
   def change
     safety_assured do
-      change_column_null :rdvs, :created_by_type, false
-      change_column_null :participations, :created_by_type, false
+      add_check_constraint :rdvs, "created_by_type IS NOT NULL", name: "rdvs_created_by_type_null", validate: false
+      add_check_constraint :participations, "created_by_type IS NOT NULL", name: "participations_created_by_type_null", validate: false
 
       remove_column :rdvs, :created_by, :integer, index: true
       remove_column :participations, :created_by, :created_by

--- a/db/migrate/20240110142710_cleanup_created_by_migration.rb
+++ b/db/migrate/20240110142710_cleanup_created_by_migration.rb
@@ -1,10 +1,6 @@
 class CleanupCreatedByMigration < ActiveRecord::Migration[7.0]
   def change
     safety_assured do
-      # See https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column
-      add_check_constraint :rdvs, "created_by_type IS NOT NULL", name: "rdvs_created_by_type_null", validate: false
-      add_check_constraint :participations, "created_by_type IS NOT NULL", name: "participations_created_by_type_null", validate: false
-
       remove_column :rdvs, :created_by, :integer, index: true
       remove_column :participations, :created_by, :created_by
 
@@ -19,5 +15,10 @@ class CleanupCreatedByMigration < ActiveRecord::Migration[7.0]
         end
       end
     end
+
+    # Première étape de :
+    # https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column
+    add_check_constraint :rdvs, "created_by_type IS NOT NULL", name: "rdvs_created_by_type_null", validate: false
+    add_check_constraint :participations, "created_by_type IS NOT NULL", name: "participations_created_by_type_null", validate: false
   end
 end

--- a/db/migrate/20240110142710_cleanup_created_by_migration.rb
+++ b/db/migrate/20240110142710_cleanup_created_by_migration.rb
@@ -4,9 +4,8 @@ class CleanupCreatedByMigration < ActiveRecord::Migration[7.0]
       change_column_null :rdvs, :created_by_type, false
       change_column_null :participations, :created_by_type, false
 
-      remove_index :rdvs, :created_by
-      rename_column :rdvs, :created_by, :old_created_by
-      rename_column :participations, :created_by, :old_created_by
+      remove_column :rdvs, :created_by, :integer, index: true
+      remove_column :participations, :created_by, :created_by
 
       reversible do |direction|
         direction.up do

--- a/db/migrate/20240110142710_cleanup_created_by_migration.rb
+++ b/db/migrate/20240110142710_cleanup_created_by_migration.rb
@@ -1,0 +1,23 @@
+class CleanupCreatedByMigration < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      change_column_null :rdvs, :created_by_type, false
+      change_column_null :participations, :created_by_type, false
+
+      remove_index :rdvs, :created_by
+      rename_column :rdvs, :created_by, :old_created_by
+      rename_column :participations, :created_by, :old_created_by
+
+      reversible do |direction|
+        direction.up do
+          remove_column :prescripteurs, :participation_id
+        end
+        direction.down do
+          add_column :prescripteurs, :participation_id, :bigint
+          add_index :prescripteurs, :participation_id, unique: true
+          add_foreign_key :prescripteurs, :participations
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240110142710_cleanup_created_by_migration.rb
+++ b/db/migrate/20240110142710_cleanup_created_by_migration.rb
@@ -1,6 +1,7 @@
 class CleanupCreatedByMigration < ActiveRecord::Migration[7.0]
   def change
     safety_assured do
+      # See https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column
       add_check_constraint :rdvs, "created_by_type IS NOT NULL", name: "rdvs_created_by_type_null", validate: false
       add_check_constraint :participations, "created_by_type IS NOT NULL", name: "participations_created_by_type_null", validate: false
 

--- a/db/migrate/20240110163312_cleanup_created_by_migration_episode_two.rb
+++ b/db/migrate/20240110163312_cleanup_created_by_migration_episode_two.rb
@@ -1,5 +1,6 @@
 class CleanupCreatedByMigrationEpisodeTwo < ActiveRecord::Migration[7.0]
-  # See https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column
+  # Seconde étape de :
+  # https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column
   def change
     validate_check_constraint :rdvs, name: "rdvs_created_by_type_null"
     validate_check_constraint :participations, name: "participations_created_by_type_null"

--- a/db/migrate/20240110163312_cleanup_created_by_migration_episode_two.rb
+++ b/db/migrate/20240110163312_cleanup_created_by_migration_episode_two.rb
@@ -1,0 +1,13 @@
+class CleanupCreatedByMigrationEpisodeTwo < ActiveRecord::Migration[7.0]
+  # See https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column
+  def change
+    validate_check_constraint :rdvs, name: "rdvs_created_by_type_null"
+    validate_check_constraint :participations, name: "participations_created_by_type_null"
+
+    change_column_null :rdvs, :created_by_type, false
+    change_column_null :participations, :created_by_type, false
+
+    remove_check_constraint :rdvs, name: "rdvs_created_by_type_null"
+    remove_check_constraint :participations, name: "participations_created_by_type_null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -443,7 +443,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
-    t.string "created_by_type", null: false
+    t.string "created_by_type"
     t.index ["created_by_type", "created_by_id"], name: "index_participations_on_created_by_type_and_created_by_id"
     t.index ["invitation_token"], name: "index_participations_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_participations_on_invited_by_id"
@@ -452,6 +452,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.index ["rdv_id"], name: "index_participations_on_rdv_id"
     t.index ["status"], name: "index_participations_on_status"
     t.index ["user_id"], name: "index_participations_on_user_id"
+    t.check_constraint "created_by_type IS NOT NULL", name: "participations_created_by_type_null"
   end
 
   create_table "plage_ouvertures", force: :cascade do |t|
@@ -503,7 +504,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.integer "users_count", default: 0
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
     t.integer "created_by_id"
-    t.string "created_by_type", null: false
+    t.string "created_by_type"
     t.index "tsrange(starts_at, ends_at, '[)'::text)", name: "index_rdvs_on_tsrange_starts_at_ends_at", using: :gist
     t.index ["created_by_type", "created_by_id"], name: "index_rdvs_on_created_by_type_and_created_by_id"
     t.index ["ends_at"], name: "index_rdvs_on_ends_at"
@@ -516,6 +517,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.index ["updated_at"], name: "index_rdvs_on_updated_at"
     t.index ["users_count"], name: "index_rdvs_on_users_count"
     t.index ["uuid"], name: "index_rdvs_on_uuid"
+    t.check_constraint "created_by_type IS NOT NULL", name: "rdvs_created_by_type_null"
   end
 
   create_table "receipts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -440,7 +440,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
-    t.enum "old_created_by", enum_type: "created_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
@@ -496,7 +495,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.datetime "cancelled_at"
     t.bigint "motif_id", null: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
-    t.integer "old_created_by", default: 0
     t.text "context"
     t.bigint "lieu_id"
     t.datetime "ends_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_163312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -443,7 +443,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
-    t.string "created_by_type"
+    t.string "created_by_type", null: false
     t.index ["created_by_type", "created_by_id"], name: "index_participations_on_created_by_type_and_created_by_id"
     t.index ["invitation_token"], name: "index_participations_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_participations_on_invited_by_id"
@@ -452,7 +452,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.index ["rdv_id"], name: "index_participations_on_rdv_id"
     t.index ["status"], name: "index_participations_on_status"
     t.index ["user_id"], name: "index_participations_on_user_id"
-    t.check_constraint "created_by_type IS NOT NULL", name: "participations_created_by_type_null"
   end
 
   create_table "plage_ouvertures", force: :cascade do |t|
@@ -504,7 +503,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.integer "users_count", default: 0
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
     t.integer "created_by_id"
-    t.string "created_by_type"
+    t.string "created_by_type", null: false
     t.index "tsrange(starts_at, ends_at, '[)'::text)", name: "index_rdvs_on_tsrange_starts_at_ends_at", using: :gist
     t.index ["created_by_type", "created_by_id"], name: "index_rdvs_on_created_by_type_and_created_by_id"
     t.index ["ends_at"], name: "index_rdvs_on_ends_at"
@@ -517,7 +516,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
     t.index ["updated_at"], name: "index_rdvs_on_updated_at"
     t.index ["users_count"], name: "index_rdvs_on_users_count"
     t.index ["uuid"], name: "index_rdvs_on_uuid"
-    t.check_constraint "created_by_type IS NOT NULL", name: "rdvs_created_by_type_null"
   end
 
   create_table "receipts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_10_142710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -440,11 +440,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
-    t.enum "created_by", enum_type: "created_by"
+    t.enum "old_created_by", enum_type: "created_by"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
-    t.string "created_by_type"
+    t.string "created_by_type", null: false
     t.index ["created_by_type", "created_by_id"], name: "index_participations_on_created_by_type_and_created_by_id"
     t.index ["invitation_token"], name: "index_participations_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_participations_on_invited_by_id"
@@ -479,7 +479,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
   end
 
   create_table "prescripteurs", force: :cascade do |t|
-    t.bigint "participation_id"
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "email", null: false
@@ -487,7 +486,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
     t.string "phone_number_formatted"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["participation_id"], name: "index_prescripteurs_on_participation_id", unique: true
   end
 
   create_table "rdvs", force: :cascade do |t|
@@ -498,7 +496,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
     t.datetime "cancelled_at"
     t.bigint "motif_id", null: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
-    t.integer "created_by", default: 0
+    t.integer "old_created_by", default: 0
     t.text "context"
     t.bigint "lieu_id"
     t.datetime "ends_at", null: false
@@ -507,9 +505,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
     t.integer "users_count", default: 0
     t.enum "status", default: "unknown", null: false, enum_type: "rdv_status"
     t.integer "created_by_id"
-    t.string "created_by_type"
+    t.string "created_by_type", null: false
     t.index "tsrange(starts_at, ends_at, '[)'::text)", name: "index_rdvs_on_tsrange_starts_at_ends_at", using: :gist
-    t.index ["created_by"], name: "index_rdvs_on_created_by"
     t.index ["created_by_type", "created_by_id"], name: "index_rdvs_on_created_by_type_and_created_by_id"
     t.index ["ends_at"], name: "index_rdvs_on_ends_at"
     t.index ["lieu_id"], name: "index_rdvs_on_lieu_id"
@@ -780,7 +777,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_190123) do
   add_foreign_key "plage_ouvertures", "agents"
   add_foreign_key "plage_ouvertures", "lieux"
   add_foreign_key "plage_ouvertures", "organisations"
-  add_foreign_key "prescripteurs", "participations"
   add_foreign_key "rdvs", "lieux"
   add_foreign_key "rdvs", "motifs"
   add_foreign_key "rdvs", "organisations"


### PR DESCRIPTION
Avant toute chose, je supprime la colonnes `prescripteurs.participation_id` et la foriegn key associée, ce qui permet d'éviter ce crash : https://sentry.incubateur.net/organizations/betagouv/issues/80477

Au passage, puisque nous avons vérifié en base que tous les `created_by_type` sont remplis, j'ajoute un NOT NULL sur cette colonne (dans les deux tables).

Enfin je supprime les colonnes `created_by` car nous les avons copiées dans `created_by_type`.

 # Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
