### PR TITLE
Correction du rafraichissement de token Outlook

### DIFF
--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -89,9 +89,7 @@ module Outlook
       refresh_token_response = JSON.parse(refresh_token_query.response_body)
 
       if refresh_token_response["error"].present?
-        # TODO: Revoir comment gérer les erreurs de rafraichissement de token, cela créé beaucoup trop de bruit dans Sentry quand on fix ca
-        # Je remet comme c'était avant (erreur sur la variable email) pour le moment et j'ouvre un ticket pour revoir ça ici : https://github.com/betagouv/rdv-solidarites.fr/issues/3721
-        Sentry.capture_message("Error refreshing Microsoft Graph Token for #{email}: #{refresh_token_response['error_description']}")
+        raise "Error refreshing Microsoft Graph Token"
       elsif refresh_token_response["access_token"].present?
         @agent.update!(microsoft_graph_token: refresh_token_response["access_token"])
       end

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -174,9 +174,8 @@ describe Outlook::ApiClient do
           .to_return(status: 500, body: { error: "Unknwon error" }.to_json, headers: {})
       end
 
-      it "notifies Sentry" do
-        expect(Sentry).to receive(:capture_message)
-        described_class.new(agent).create_event!(expected_body)
+      it "raises an error" do
+        expect { described_class.new(agent).create_event!(expected_body) }.to raise_error("Error refreshing Microsoft Graph Token")
       end
     end
   end

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -1,11 +1,5 @@
 describe Outlook::ApiClient do
   let(:organisation) { create(:organisation) }
-  let(:motif) { create(:motif, name: "Super Motif", location_type: :phone) }
-  let(:agent) { create(:agent, microsoft_graph_token: "token", refresh_microsoft_graph_token: "refresh_token") }
-  let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
-  let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [agent]) }
-  let(:agents_rdv) { rdv.agents_rdvs.first }
-
   let(:expected_body) do
     {
       subject: "Super Motif",
@@ -37,6 +31,24 @@ describe Outlook::ApiClient do
       attendees: [],
       transactionId: "agents_rdv-#{agents_rdv.id}",
     }
+  end
+  let(:motif) { create(:motif, name: "Super Motif", location_type: :phone) }
+  let(:agent) { create(:agent, microsoft_graph_token: "token", refresh_microsoft_graph_token: "refresh_token") }
+  let(:user) { create(:user, email: "user@example.fr", first_name: "First", last_name: "Last", organisations: [organisation]) }
+  let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [agent]) }
+  let(:agents_rdv) { rdv.agents_rdvs.first }
+
+  around do |example|
+    client_id = ENV.delete("AZURE_APPLICATION_CLIENT_ID")
+    ENV["AZURE_APPLICATION_CLIENT_ID"] = "fake_client_id"
+
+    client_secret = ENV.delete("AZURE_APPLICATION_CLIENT_SECRET")
+    ENV["AZURE_APPLICATION_CLIENT_SECRET"] = "fake_client_secret"
+
+    example.run
+
+    ENV["AZURE_APPLICATION_CLIENT_ID"] = client_id
+    ENV["AZURE_APPLICATION_CLIENT_SECRET"] = client_secret
   end
 
   context "when a call fails" do
@@ -128,25 +140,44 @@ describe Outlook::ApiClient do
       stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
         .with(body: expected_body, headers: expected_headers)
         .to_return(status: 401, body: { error: "wrong token" }.to_json, headers: {})
-
-      stub_request(:post, "https://login.microsoftonline.com/common/oauth2/v2.0/token")
-        .with(
-          body: { "client_id" => nil, "client_secret" => nil, "grant_type" => "refresh_token", "refresh_token" => "refresh_token" }
-        )
-        .to_return(status: 200, body: { access_token: "abc" }.to_json, headers: {})
-
-      stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
-        .with(body: expected_body, headers: expected_updated_headers)
-        .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
     end
 
-    it "refreshes it and retries, and saves the refresh token on the agent" do
-      described_class.new(agent).create_event!(expected_body)
+    context "when the token refresh works" do
+      before do
+        stub_request(:post, "https://login.microsoftonline.com/common/oauth2/v2.0/token")
+          .with(
+            body: { "client_id" => "fake_client_id", "client_secret" => "fake_client_secret", "grant_type" => "refresh_token", "refresh_token" => "refresh_token" }
+          )
+          .to_return(status: 200, body: { access_token: "abc" }.to_json, headers: {})
 
-      expect(a_request(:post,
-                       "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_body)).to have_been_made.twice
+        stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
+          .with(body: expected_body, headers: expected_updated_headers)
+          .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
+      end
 
-      expect(agent.reload.microsoft_graph_token).to eq("abc")
+      it "refreshes it and retries, and saves the refresh token on the agent" do
+        described_class.new(agent).create_event!(expected_body)
+
+        expect(a_request(:post,
+                         "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_body)).to have_been_made.twice
+
+        expect(agent.reload.microsoft_graph_token).to eq("abc")
+      end
+    end
+
+    context "when the token refresh fails" do
+      before do
+        stub_request(:post, "https://login.microsoftonline.com/common/oauth2/v2.0/token")
+          .with(
+            body: { "client_id" => "fake_client_id", "client_secret" => "fake_client_secret", "grant_type" => "refresh_token", "refresh_token" => "refresh_token" }
+          )
+          .to_return(status: 500, body: { error: "Unknwon error" }.to_json, headers: {})
+      end
+
+      it "notifies Sentry" do
+        expect(Sentry).to receive(:capture_message)
+        described_class.new(agent).create_event!(expected_body)
+      end
     end
   end
 end

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -38,17 +38,9 @@ describe Outlook::ApiClient do
   let(:rdv) { create(:rdv, users: [user], motif: motif, organisation: organisation, starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30, agents: [agent]) }
   let(:agents_rdv) { rdv.agents_rdvs.first }
 
-  around do |example|
-    client_id = ENV.delete("AZURE_APPLICATION_CLIENT_ID")
-    ENV["AZURE_APPLICATION_CLIENT_ID"] = "fake_client_id"
-
-    client_secret = ENV.delete("AZURE_APPLICATION_CLIENT_SECRET")
-    ENV["AZURE_APPLICATION_CLIENT_SECRET"] = "fake_client_secret"
-
-    example.run
-
-    ENV["AZURE_APPLICATION_CLIENT_ID"] = client_id
-    ENV["AZURE_APPLICATION_CLIENT_SECRET"] = client_secret
+  before do
+    allow(ENV).to receive(:fetch).with("AZURE_APPLICATION_CLIENT_ID", nil).and_return("fake_client_id")
+    allow(ENV).to receive(:fetch).with("AZURE_APPLICATION_CLIENT_SECRET", nil).and_return("fake_client_secret")
   end
 
   context "when a call fails" do


### PR DESCRIPTION
Dans le cadre de dépoussiérage de la synchro Outlook, ce PR corrige le rafraichissement de token Outlook (sans introduire de boucle infinie 😬 ). On lève simplement une erreur, et on ne fait pas de retry si l'appel échoue, mais on aura les infos dans Sentry.

Closes #3721
Corrige cette erreur Sentry https://sentry.incubateur.net/organizations/betagouv/issues/67063/?environment=production&query=is%3Aunresolved&referrer=issue-stream

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
