### PR TITLE
Dernière étape de migration des `created_by`

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,5 +1,4 @@
 class Organisation < ApplicationRecord
-  self.ignored_columns = %w[human_id departement]
   # Mixins
   has_paper_trail
   include WebhookDeliverable

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,6 +1,4 @@
 class Participation < ApplicationRecord
-  self.ignored_columns = %w[created_by]
-
   # Mixins
   devise :invitable
 

--- a/app/models/prescripteur.rb
+++ b/app/models/prescripteur.rb
@@ -1,6 +1,4 @@
 class Prescripteur < ApplicationRecord
-  self.ignored_columns = %w[participation_id]
-
   include FullNameConcern
   include PhoneNumberValidation::HasPhoneNumber
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -1,6 +1,4 @@
 class Rdv < ApplicationRecord
-  self.ignored_columns = %w[created_by]
-
   # Mixins
   has_paper_trail(
     only: %w[user_ids agent_ids status starts_at ends_at lieu_id notes context participations],

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -1,6 +1,4 @@
 class Sector < ApplicationRecord
-  self.ignored_columns = %w[departement]
-
   # Attributes
   auto_strip_attributes :name
 

--- a/db/migrate/20240111075716_remove_created_by_enum.rb
+++ b/db/migrate/20240111075716_remove_created_by_enum.rb
@@ -1,0 +1,13 @@
+class RemoveCreatedByEnum < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured do
+      execute <<-SQL.squish
+        DROP TYPE created_by;
+      SQL
+    end
+  end
+
+  def down
+    create_enum :created_by, %i[agent user prescripteur]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_10_163312) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_11_075716) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -46,12 +46,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_10_163312) do
     "agents_and_prescripteurs",
     "everyone",
     "agents_and_prescripteurs_and_invited_users",
-  ], force: :cascade
-
-  create_enum :created_by, [
-    "agent",
-    "user",
-    "prescripteur",
   ], force: :cascade
 
   create_enum :lieu_availability, [

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -743,6 +743,8 @@ rdv_attributes = 1000.times.flat_map do |i|
       lieu_id: lieu_org_paris_nord_bd_aubervilliers.id,
       organisation_id: org_paris_nord.id,
       context: "Context #{day} #{hour}",
+      created_by_type: "Agent",
+      created_by_id: agent_org_paris_nord_pmi_martine.id,
     }
   end
 end
@@ -751,7 +753,13 @@ rdv_ids = results.flat_map(&:values) # [1, 2, ...]
 agent_rdv_attributes = rdv_ids.map { |id| { agent_id: agent_org_paris_nord_pmi_martine.id, rdv_id: id } }
 AgentsRdv.insert_all!(agent_rdv_attributes)
 participations_attributes = rdv_ids.map do |id|
-  { user_id: user_org_paris_nord_josephine.id, rdv_id: id, send_lifecycle_notifications: true, send_reminder_notification: true }
+  {
+    user_id: user_org_paris_nord_josephine.id,
+    rdv_id: id, send_lifecycle_notifications: true,
+    send_reminder_notification: true,
+    created_by_type: "Agent",
+    created_by_id: agent_org_paris_nord_pmi_martine.id,
+  }
 end
 Participation.insert_all!(participations_attributes)
 events = %w[new_creneau_available rdv_cancelled rdv_created rdv_date_updated rdv_upcoming_reminder]


### PR DESCRIPTION
Étape 1 : #3946 
Étape 2 : #3961

Dans cette étape 3 :
- on vire les `ignored_columns` qui ne sont plus nécessaires (il en restait d'autres d'ailleurs)
- on vire l'enum `created_by` de Postgres
- bonus : les seeds sont pétés depuis l'étape 2, on corrige ça

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
