### PR TITLE
Ne pas tenter d'envoyer d'e-mail à un agent sans adresse e-mail

### DIFF
--- a/app/controllers/admin/user_in_waiting_rooms_controller.rb
+++ b/app/controllers/admin/user_in_waiting_rooms_controller.rb
@@ -9,7 +9,7 @@ class Admin::UserInWaitingRoomsController < AgentAuthController
       @rdv.set_user_in_waiting_room!
 
       if current_organisation.territory.enable_waiting_room_mail_field
-        @rdv.agents.map do |agent|
+        @rdv.agents.select(&:email?).map do |agent|
           Agents::WaitingRoomMailer.with(agent: agent, rdv: @rdv).user_in_waiting_room.deliver_later
         end
       end


### PR DESCRIPTION
Erreur Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/80429
Job en erreur : https://www.rdv-solidarites.fr/super_admins/good_job/jobs/098806c9-4e38-4012-bb95-6a316d7fb763

On a mis en file un job de mailer pour un agent sans e-mail, une conséquence encore non détectée de #3628. :wink: 

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
