### PR TITLE
Clarification du formulaire de motif

### DIFF
--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -173,7 +173,7 @@
 
   .card
     .card-body
-      h5 Instructions
+      h5.card-title Instructions
       p.text-muted.font-14 Ces instructions sont affichées à l'usager avant et après sa prise de RDV. Laissez ces champs vides si vous ne souhaitez pas donner d'instructions.
       = f.input :restriction_for_rdv, input_html: {rows: 6}
       = f.input :instruction_for_rdv, input_html: {rows: 6}

--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -53,18 +53,6 @@
 
   .card
     .card-body
-      h5.card-title= Motif.human_attribute_name("follow_up_short")
-      p.text-muted.font-14= Motif.human_attribute_name("follow_up_warning")
-      = f.input :follow_up
-
-  .card
-    .card-body
-      h5.card-title= Motif.human_attribute_name("for_secretariat_short")
-      p.text-muted.font-14= Motif.human_attribute_name("for_secretariat_hint")
-      = f.input :for_secretariat, label: Motif.human_attribute_name("for_secretariat_label")
-
-  .card
-    .card-body
       h5.card-title= Motif.human_attribute_name(:collectif)
 
       = label_tag do
@@ -123,10 +111,16 @@
         = f.input(:rdvs_editable_by_user)
         p.text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
 
+  .card
+    .card-body
+      h5.card-title= Motif.human_attribute_name("follow_up_short")
+      p.text-muted.font-14= Motif.human_attribute_name("follow_up_warning")
+      = f.input :follow_up
+
   - unless current_domain.online_reservation_with_public_link
     .card.js-sectorisation-card
       .card-body
-        h5.mb-2= Motif.human_attribute_name("sectorisation_level_title")
+        h5.card-title.mb-2= Motif.human_attribute_name("sectorisation_level_title")
         .text-muted.mb-3
           span>= Motif.human_attribute_name("sectorisation_level_hint")
           = link_to "https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-territoire/sectorisation-geographique/" do
@@ -157,6 +151,12 @@
                 )
         - if current_agent.territorial_admin_in?(current_organisation.territory)
           = link_to "Configuration des secteurs", admin_territory_sectors_path(current_organisation.territory)
+
+  .card
+    .card-body
+      h5.card-title= Motif.human_attribute_name("for_secretariat_short")
+      p.text-muted.font-14= Motif.human_attribute_name("for_secretariat_hint")
+      = f.input :for_secretariat, label: Motif.human_attribute_name("for_secretariat_label")
 
   .card
     .card-body

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -22,9 +22,9 @@ fr:
         for_secretariat_label: Le RDV pourra être effectué par le service secrétariat
         for_secretariat_short: RDV Secrétariat
         for_secretariat_hint: Les membres du service Secrétariat pourront poser des RDV dans leur agenda et configurer les plages d'ouverture avec ce motif
-        follow_up: Ce motif est réservé uniquement aux usagers bénéficiant d'un accompagnement
+        follow_up: Restreindre ce motif aux rdv de suivi
         follow_up_short: RDV de suivi
-        follow_up_warning: Ne cochez cette case que si vous savez ce que vous faîtes
+        follow_up_warning: Les motifs pour rdv de suivi ne sont pas visible lors de la réservation en ligne par les usagers sans compte et sans référent. Les usagers avec un référent pourront prendre rdv depuis leur espace personnel.
         follow_up_hint: Ce motif est réservé uniquement aux usagers bénéficiant d'un accompagnement
         default_duration_in_min: Durée par défaut en minutes
         default_duration_in_min_short: Durée par défaut

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -19,10 +19,10 @@ fr:
         sectorisation_level_hint: Seules les recherches des usagers sont concernées par ces règles de sectorisation. Elles n'ont donc pas d'effet si le motif n'est pas réservable en ligne.
         location_type: Type de RDV
         for_secretariat: Motif accessible au secrétariat
-        for_secretariat_label: Le RDV pourra être effectué par le service secrétariat
+        for_secretariat_label: Autoriser les secrétaires à assurer ces rdv
         for_secretariat_short: RDV Secrétariat
         for_secretariat_hint: Les membres du service Secrétariat pourront poser des RDV dans leur agenda et configurer les plages d'ouverture avec ce motif
-        follow_up: Restreindre ce motif aux rdv de suivi
+        follow_up: Limiter ces rdv aux usagers bénéficiant d'un suivi par un référent
         follow_up_short: RDV de suivi
         follow_up_warning: Les motifs pour rdv de suivi ne sont pas visible lors de la réservation en ligne par les usagers sans compte et sans référent. Les usagers avec un référent pourront prendre rdv depuis leur espace personnel.
         follow_up_hint: Ce motif est réservé uniquement aux usagers bénéficiant d'un accompagnement

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -19,12 +19,12 @@ fr:
         sectorisation_level_hint: Seules les recherches des usagers sont concernées par ces règles de sectorisation. Elles n'ont donc pas d'effet si le motif n'est pas réservable en ligne.
         location_type: Type de RDV
         for_secretariat: Motif accessible au secrétariat
-        for_secretariat_label: Autoriser les secrétaires à assurer ces rdv
+        for_secretariat_label: Autoriser les agents du service Secrétariat à assurer ces RDV
         for_secretariat_short: RDV Secrétariat
-        for_secretariat_hint: Les membres du service Secrétariat pourront poser des RDV dans leur agenda et configurer les plages d'ouverture avec ce motif
-        follow_up: Limiter ces rdv aux usagers bénéficiant d'un suivi par un référent
+        for_secretariat_hint: En plus des agents du service de ce motif, les agents du service Secrétariat pourront aussi assurer ces RDV et ouvrir des plages d'ouverture dans leur agenda avec ce motif
+        follow_up: Limiter ces RDV aux usagers bénéficiant d'un suivi par un référent
         follow_up_short: RDV de suivi
-        follow_up_warning: Les motifs pour rdv de suivi ne sont pas visible lors de la réservation en ligne par les usagers sans compte et sans référent. Les usagers avec un référent pourront prendre rdv depuis leur espace personnel.
+        follow_up_warning: Les motifs pour RDV de suivi ne sont pas visible lors de la réservation en ligne par les usagers sans compte et sans référent. Les usagers avec un référent pourront prendre rdv depuis leur espace personnel.
         follow_up_hint: Ce motif est réservé uniquement aux usagers bénéficiant d'un accompagnement
         default_duration_in_min: Durée par défaut en minutes
         default_duration_in_min_short: Durée par défaut


### PR DESCRIPTION
Suite à une discussion avec @NesserineZarouri on s'est dit qu'on allait supprimer le texte "Ne cochez cette case que si vous savez ce que vous faites", et on s'est retrouvé à clarifier pas mal de choses sur le formulaire de motifs.

### Avant

<img width="869" alt="Screenshot 2024-01-11 at 12 15 35" src="https://github.com/betagouv/rdv-service-public/assets/1840367/d0ea0c5f-c769-401c-b8a1-1b7d81467d88">

### Après

<img width="831" alt="Screenshot 2024-01-11 at 12 15 47" src="https://github.com/betagouv/rdv-service-public/assets/1840367/7a65f05c-fd75-4684-be3d-c47c46a667ac">

### RDV Secrétariat

On s'est aussi rendu compte via metabase que certains CDAD ont activé les rdv de secrétariat pour tous leur motifs, probablement parce qu'ils ont mal compris ce que permet cette option. On a donc changé le texte pour clarifier que cette option permet aux secrétaires d'assurer ces rdv, pas juste de prendre le rdv.
On a hésité à remplacer "membre du service secrétariat" par "secrétaire", mais apparemment c'est un terme qui pouvait avoir une connotation négative pour certains agents, donc on l'a laissé tel quel.

### Changement de l'ordre des champs

Ces champs sur utilisés pour 12% à 15% des motifs (merci metabase), donc on les a descendus pour les grouper avec les options de réservation en ligne (qui sont liés à ces options de toutes façons)