### PR TITLE
Vérification de l'expiration des secrets outlook

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -60,5 +60,9 @@ Rails.application.configure do
       cron: "every day at 23:00 Europe/Paris",
       class: "CronJob::DestroyOldVersions",
     },
+    warn_about_expiring_azure_app_secrets: {
+      cron: "every day at 10:00 Europe/Paris",
+      class: "CronJob::WarnAboutExpiringAzureAppSecrets",
+    },
   }
 end

--- a/spec/requests/domain_verification_spec.rb
+++ b/spec/requests/domain_verification_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe "Microsoft domain verification" do
     parsed_response = JSON.parse(response.body)
     expect(parsed_response.dig("associatedApplications", 0, "applicationId")).to eq "public_client_id_123456"
   end
+
+  it "raises an error when our application key is about to expire" do
+    application_key_expiration_date = Date.new(2025, 1, 10)
+    key_refresh_url = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/ad7b4a46-0051-47b6-bf31-713aa849e5d4/isMSAApp~/true"
+
+    if 2.months.from_now > application_key_expiration_date
+      raise <<~ERROR
+        Le secret de client de l'application d'oauth Microsoft expire dans moins de 2 mois.
+        Pour que la synchro Outlook continue de fonctionner, vous générez un nouveau secret via #{key_refresh_url}
+      ERROR
+    end
+  end
 end

--- a/spec/requests/domain_verification_spec.rb
+++ b/spec/requests/domain_verification_spec.rb
@@ -14,16 +14,4 @@ RSpec.describe "Microsoft domain verification" do
     parsed_response = JSON.parse(response.body)
     expect(parsed_response.dig("associatedApplications", 0, "applicationId")).to eq "public_client_id_123456"
   end
-
-  it "raises an error when our application key is about to expire" do
-    application_key_expiration_date = Date.new(2025, 1, 10)
-    key_refresh_url = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/ad7b4a46-0051-47b6-bf31-713aa849e5d4/isMSAApp~/true"
-
-    if 2.months.from_now > application_key_expiration_date
-      raise <<~ERROR
-        Le secret de client de l'application d'oauth Microsoft expire dans moins de 2 mois.
-        Pour que la synchro Outlook continue de fonctionner, vous générez un nouveau secret via #{key_refresh_url}
-      ERROR
-    end
-  end
 end


### PR DESCRIPTION
Récemment, on a eu des erreurs sur la synchro outlook parce que notre clé d'api microsoft avait expiré sans qu'on ne s'en rende compte.
J'ai généré une nouvelle clé, et je propose qu'on ajoute une vérification dans un cron job (sur les bons conseils de François) pour s'assurer qu'on n'oublie pas de le faire à l'avance la prochaine fois. 🙈 