### PR TITLE
Limitation des exécution parallèles de jobs outlook

### DIFF
--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -1,6 +1,10 @@
 module Outlook
   class SyncEventJob < ApplicationJob
     queue_as :outlook_sync
+    good_job_control_concurrency_with(
+      perform_limit: 1,
+      key: -> { "Outlook::SyncEventJob-#{arguments.first}-#{arguments.last.id}" }
+    )
 
     def self.perform_later_for(agents_rdv)
       if agents_rdv.outlook_id.nil? && !agents_rdv.destroyed?

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -1,6 +1,8 @@
 module Outlook
   class SyncEventJob < ApplicationJob
     queue_as :outlook_sync
+
+    include GoodJob::ActiveJobExtensions::Concurrency
     good_job_control_concurrency_with(
       perform_limit: 1,
       # Pour limiter les risque d'une race condition de deux création d'event en même temps

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -3,7 +3,9 @@ module Outlook
     queue_as :outlook_sync
     good_job_control_concurrency_with(
       perform_limit: 1,
-      key: -> { "Outlook::SyncEventJob-#{arguments.first}-#{arguments.last.id}" }
+      # Pour limiter les risque d'une race condition de deux création d'event en même temps
+      # on limite les exécutions concurrentes à un job pour un agents_rdv.
+      key: -> { "Outlook::SyncEventJob-#{arguments.first}" }
     )
 
     def self.perform_later_for(agents_rdv)


### PR DESCRIPTION
En refaisant des tests en prod, j'ai eu un nouveau cas de jobs qui tournent en parallèle et qui créent un event en double dans mon calendrier outlook.

Le but de cette PR est donc de limiter les exécution des jobs en parallèle pour un même agents_rdv (donc un même event outlook).