### PR TITLE
Permet aux agents prescripteurs de continuer à utiliser le front

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,7 @@ class SearchController < ApplicationController
 
   def search_rdv
     # TODO : public_link_organisation_id has to work if agent is logged in ?
-    if current_agent && query_params[:user_ids].present?
+    if current_agent && params[:user_ids].present?
       redirect_to search_creneau_admin_organisation_prescription_path(session[:agent_prescripteur_organisation_id], agent_search_params)
     end
     @context = if invitation?

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,7 @@ class SearchController < ApplicationController
 
   def search_rdv
     # TODO : public_link_organisation_id has to work if agent is logged in ?
-    if current_agent && query_params[:public_link_organisation_id].nil?
+    if current_agent && query_params[:user_ids].present?
       redirect_to search_creneau_admin_organisation_prescription_path(session[:agent_prescripteur_organisation_id], agent_search_params)
     end
     @context = if invitation?


### PR DESCRIPTION
Pour corriger https://sentry.incubateur.net/organizations/betagouv/issues/80835/?project=74&referrer=webhooks_plugin

Des agents connectés utilisent encore la prescription classique, en passant par le front office. On veut leur permettre de garder le fonctionnement existant.