### PR TITLE
Petit correctif de front pour les agents prescripteurs

### DIFF
--- a/app/views/admin/prescription/search_creneau.html.slim
+++ b/app/views/admin/prescription/search_creneau.html.slim
@@ -8,4 +8,5 @@ p
   - else
     = "Pas d'adresse "
     = link_to("ajouter une addresse", edit_admin_organisation_user_path(current_organisation, @context.user))
-= render partial: @context.to_partial_path, locals: { context: @context }
+section
+  = render partial: @context.to_partial_path, locals: { context: @context }

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,40 +1,39 @@
-section.bg-light.p-4
-  .container
-    = render "search/selected_motif_recap", context: context
-    - if context.lieu.present?
+.container
+  = render "search/selected_motif_recap", context: context
+  - if context.lieu.present?
+    .card.card-hoverable
+      .card-body
+        = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+          .row
+            .col-auto.align-self-center
+              i.fa.fa-chevron-left
+            .col
+              h2.pb-1.mb-1.card-title= context.lieu.name
+              .card-subtitle= context.lieu.address
+  - elsif context.user_selected_organisation.present?
       .card.card-hoverable
         .card-body
-          = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+          = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
             .row
               .col-auto.align-self-center
                 i.fa.fa-chevron-left
               .col
-                h2.pb-1.mb-1.card-title= context.lieu.name
-                .card-subtitle= context.lieu.address
-    - elsif context.user_selected_organisation.present?
-        .card.card-hoverable
-          .card-body
-            = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
-              .row
-                .col-auto.align-self-center
-                  i.fa.fa-chevron-left
-                .col
-                  h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
-                  = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
-    - if context.first_matching_motif.collectif?
-      h3.font-weight-bold = "Inscrivez-vous à l'atelier de votre choix :"
-    - else
-      h3.font-weight-bold = "Sélectionnez un créneau :"
-    .card.mb-3
-      .card-body
-        - if context.first_matching_motif.collectif?
-          - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
-            = render "search/rdv_collectif", rdv: rdv
-        - elsif context.unique_motifs_by_name_and_location_type.present?
-          = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
-        - else
-          .alert.alert-warning
-            = "Le motif "
-            b= context.first_matching_motif.name
-            = " n'est plus disponible à la réservation à "
-            b= context.lieu.name
+                h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
+                = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
+  - if context.first_matching_motif.collectif?
+    h3.font-weight-bold = "Inscrivez-vous à l'atelier de votre choix :"
+  - else
+    h3.font-weight-bold = "Sélectionnez un créneau :"
+  .card.mb-3
+    .card-body
+      - if context.first_matching_motif.collectif?
+        - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
+          = render "search/rdv_collectif", rdv: rdv
+      - elsif context.unique_motifs_by_name_and_location_type.present?
+        = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
+      - else
+        .alert.alert-warning
+          = "Le motif "
+          b= context.first_matching_motif.name
+          = " n'est plus disponible à la réservation à "
+          b= context.lieu.name

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -1,38 +1,37 @@
-section.bg-light.p-4
-  .container
-    = render "search/selected_motif_recap", context: context
-    - if context.shown_lieux.empty?
-      = render "search/nothing_to_show", context: context
-    - else
-      h3.font-weight-bold = t(".select_lieu")
-      p = t(".lieu_available", count: context.shown_lieux.count)
-      - context.next_availability_by_lieux.each do |lieu, next_availability|
-        .card.mb-3 class=("card-hoverable" if next_availability)
-          .card-body
-            .row
-              .col-md
-                h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
-                .card-subtitle= lieu.address
-                .card-subtitle= context.service.name
-              .col-md.align-self-center.pt-3.pt-md-0.position-static
-                - motif = next_availability.motif
-                - if motif.restriction_for_rdv.blank?
-                  = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
-                    .row
-                      .col
-                        = t(".next_availability")
-                        br
-                        strong= l(next_availability.starts_at, format: :human)
-                      .col-auto.align-self-center
-                          i.fa.fa-chevron-right
-                - else
-                  = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{lieu.id}" } do
-                    .row
-                      .col
-                        = t(".next_availability")
-                        br
-                        strong= l(next_availability.starts_at, format: :human)
-                      .col-auto.align-self-center
-                          i.fa.fa-chevron-right
-                  = render "/common/modal", id: "js-rdv-restriction-motif#{lieu.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)) do
-                    = restriction_for_rdv_to_html(motif)
+.container
+  = render "search/selected_motif_recap", context: context
+  - if context.shown_lieux.empty?
+    = render "search/nothing_to_show", context: context
+  - else
+    h3.font-weight-bold = t(".select_lieu")
+    p = t(".lieu_available", count: context.shown_lieux.count)
+    - context.next_availability_by_lieux.each do |lieu, next_availability|
+      .card.mb-3 class=("card-hoverable" if next_availability)
+        .card-body
+          .row
+            .col-md
+              h4.card-title.mb-3.mt-0.text-success.font-weight-bold= lieu.name
+              .card-subtitle= lieu.address
+              .card-subtitle= context.service.name
+            .col-md.align-self-center.pt-3.pt-md-0.position-static
+              - motif = next_availability.motif
+              - if motif.restriction_for_rdv.blank?
+                = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+                  .row
+                    .col
+                      = t(".next_availability")
+                      br
+                      strong= l(next_availability.starts_at, format: :human)
+                    .col-auto.align-self-center
+                        i.fa.fa-chevron-right
+              - else
+                = link_to prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)), class: "d-block stretched-link", "data-turbolinks": false, data: { toggle: "modal", target: "#js-rdv-restriction-motif#{lieu.id}" } do
+                  .row
+                    .col
+                      = t(".next_availability")
+                      br
+                      strong= l(next_availability.starts_at, format: :human)
+                    .col-auto.align-self-center
+                        i.fa.fa-chevron-right
+                = render "/common/modal", id: "js-rdv-restriction-motif#{lieu.id}" , title: "À lire avant de prendre un rendez-vous", confirm_path: prendre_rdv_path(context.query_params.merge(lieu_id: lieu.id, date: next_availability.starts_at)) do
+                  = restriction_for_rdv_to_html(motif)

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,20 +1,19 @@
-section.bg-light.p-4
-  .container
-    .card
-      .card-body
-        = link_to path_to_service_selection(params), class: "d-block stretched-link" do
-          .row
-            .col-auto.align-self-center
-              i.fa.fa-chevron-left
-            .col
-              h2.pb-1.mb-1 = context.service.name
-  .container
-    - if context.unique_motifs_by_name_and_location_type.empty?
-      = render "search/nothing_to_show", context: context
-    - else
-      h2.font-weight-bold Sélectionnez le motif de votre RDV :
-      - context.unique_motifs_by_name_and_location_type.each do |motif|
-        .card.mb-3
-          = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do
-            = render "search/motif_selection_card", motif: motif
-    = render "search/referent_booking_card", context: context
+.container
+  .card
+    .card-body
+      = link_to path_to_service_selection(params), class: "d-block stretched-link" do
+        .row
+          .col-auto.align-self-center
+            i.fa.fa-chevron-left
+          .col
+            h2.pb-1.mb-1 = context.service.name
+.container
+  - if context.unique_motifs_by_name_and_location_type.empty?
+    = render "search/nothing_to_show", context: context
+  - else
+    h2.font-weight-bold Sélectionnez le motif de votre RDV :
+    - context.unique_motifs_by_name_and_location_type.each do |motif|
+      .card.mb-3
+        = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+          = render "search/motif_selection_card", motif: motif
+  = render "search/referent_booking_card", context: context

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -1,23 +1,22 @@
-section.bg-light.p-4
-  .container
-    = render "search/selected_motif_recap", context: context
-    - if context.next_availability_by_motifs_organisations.empty?
-      = render "search/nothing_to_show", context: context
-    - else
-      h3.font-weight-bold Sélectionnez la structure avec laquelle prendre RDV:
-      - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
-        .card.mb-3 class="card-hoverable"
-          .card-body
-            .row
-              .col-md
-                h3.card-title.mb-3.mt-0.text-success.font-weight-bold= organisation.name
-                = render "search/organisation_card_subtitles", organisation: organisation
-              .col-md.align-self-center.pt-3.pt-md-0.position-static
-                = link_to prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
-                  .row
-                    .col
-                      | Prochaine disponibilité le
-                      br
-                      strong= l(next_availability.starts_at, format: :human)
-                    .col-auto.align-self-center
-                        i.fa.fa-chevron-right
+.container
+  = render "search/selected_motif_recap", context: context
+  - if context.next_availability_by_motifs_organisations.empty?
+    = render "search/nothing_to_show", context: context
+  - else
+    h3.font-weight-bold Sélectionnez la structure avec laquelle prendre RDV:
+    - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
+      .card.mb-3 class="card-hoverable"
+        .card-body
+          .row
+            .col-md
+              h3.card-title.mb-3.mt-0.text-success.font-weight-bold= organisation.name
+              = render "search/organisation_card_subtitles", organisation: organisation
+            .col-md.align-self-center.pt-3.pt-md-0.position-static
+              = link_to prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)), class: "d-block stretched-link" do
+                .row
+                  .col
+                    | Prochaine disponibilité le
+                    br
+                    strong= l(next_availability.starts_at, format: :human)
+                  .col-auto.align-self-center
+                      i.fa.fa-chevron-right

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -1,15 +1,14 @@
-section.bg-light.p-4
-  .container
-    - if context.unique_motifs_by_name_and_location_type.empty?
-      = render "search/nothing_to_show", context: context
-    - else
-      h2.font-weight-bold Sélectionnez le service avec qui vous voulez prendre un RDV :
-      - unless context.invitation?
-      - context.services.each do |service|
-        .card.mb-3
-          = link_to prendre_rdv_path(context.query_params.merge(service_id: service.id)) do
-            .card-body
-              .row
-                .col-md
-                  h3.card-title.mb-3.mt-0.text-success.font-weight-bold= service.name
-    = render "search/referent_booking_card", context: context
+.container
+  - if context.unique_motifs_by_name_and_location_type.empty?
+    = render "search/nothing_to_show", context: context
+  - else
+    h2.font-weight-bold Sélectionnez le service avec qui vous voulez prendre un RDV :
+    - unless context.invitation?
+    - context.services.each do |service|
+      .card.mb-3
+        = link_to prendre_rdv_path(context.query_params.merge(service_id: service.id)) do
+          .card-body
+            .row
+              .col-md
+                h3.card-title.mb-3.mt-0.text-success.font-weight-bold= service.name
+  = render "search/referent_booking_card", context: context

--- a/app/views/search/search_rdv.html.slim
+++ b/app/views/search/search_rdv.html.slim
@@ -1,3 +1,8 @@
 = render "banner", context: @context
 
-= render @context, context: @context
+/ Adress selection partials have multiple sections
+- if @context.current_step == :address_selection
+  = render @context, context: @context
+- else
+  section.bg-light.p-4
+    = render @context, context: @context


### PR DESCRIPTION
Le but de cette PR est d'enlever le rectangle moche dans l'interface de prescription pour les agents.
Il y aura sans doute d'autres améliorations à faire mais c'est un premier pas.
Ça fait un gros diff, mais c'est surtout parce que du whitespace a bougé.

C'est un correctif qui avait été tenté dans le premier spike, mais la première version cassait l'interface pour les usagers. C'est maintenant géré via un if dans `app/views/search/search_rdv.html.slim`

### Avant
<img width="1920" alt="Screenshot 2024-01-15 at 12 05 24" src="https://github.com/betagouv/rdv-service-public/assets/1840367/79a64c29-af8c-46d9-902f-7e90e2f409b8">

## Après
<img width="1920" alt="Screenshot 2024-01-15 at 12 05 47" src="https://github.com/betagouv/rdv-service-public/assets/1840367/81ed6261-a78d-41d4-891a-a9e7629c940f">
