### PR TITLE
Permettre l'utilisation de l'anonymisation en local

### DIFF
--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -35,7 +35,7 @@ class Anonymizer
     end
     # Sanity checks supplémentaires
     # Ces variables d'envs n'ont rien à voir avec l'ETL, et ne devraient donc pas être présentes
-    if ENV["HOST"].present? || ENV["DEFAULT_SMS_PROVIDER"].present?
+    if !Rails.env.development? && (ENV["HOST"].present? || ENV["DEFAULT_SMS_PROVIDER"].present?)
       raise "Attention, il semble que vous êtes en train d'anonymiser des données d'une appli web"
     end
 
@@ -66,7 +66,7 @@ class Anonymizer
     ActiveRecord::Encryption.without_encryption do # The columns may be encrypted, but we still want to overwrite the anonymized value
       scope = model_class.unscoped.where.not(column.name => nil)
 
-      if column.type.in?(%i[string text])
+      if column.type.in?(%i[string text]) && column.nil? # On vérifie que la colonne est nullable
         # Pour limiter la confusion lors de l'exploitation des données, on transforme les chaines vides en null
         scope.where(column.name => "").update_all(column.name => nil) # rubocop:disable Rails/SkipsModelValidations
       end

--- a/app/lib/anonymizer.rb
+++ b/app/lib/anonymizer.rb
@@ -66,7 +66,7 @@ class Anonymizer
     ActiveRecord::Encryption.without_encryption do # The columns may be encrypted, but we still want to overwrite the anonymized value
       scope = model_class.unscoped.where.not(column.name => nil)
 
-      if column.type.in?(%i[string text]) && column.nil? # On vérifie que la colonne est nullable
+      if column.type.in?(%i[string text]) && column.null # On vérifie que la colonne est nullable
         # Pour limiter la confusion lors de l'exploitation des données, on transforme les chaines vides en null
         scope.where(column.name => "").update_all(column.name => nil) # rubocop:disable Rails/SkipsModelValidations
       end

--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -12,7 +12,7 @@ dbclient-fetcher pgsql
 
 # Cette commande nécessite un login par un membre de l'équipe
 # On préfère faire un login à chaque rafraichissement des données plutôt que de laisser un token scalingo en variable d'env
-scalingo login
+scalingo login --password-only
 
 # Retrieve the production addon id:
 prod_addon_id="$( scalingo --region osc-secnum-fr1 --app production-rdv-solidarites addons \

--- a/spec/lib/anonymizer_spec.rb
+++ b/spec/lib/anonymizer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Anonymizer do
     let!(:super_admin) { SuperAdmin.create!(email: "admin@example.com", first_name: "Francis", last_name: "Factice") }
     let!(:organisation) { create(:organisation, email: "email_perso_de_cnfs_alors_que_ce_champs_est_prevu_pour_une_adresse_mail_generique@example") }
     let!(:lieu) { create(:lieu, phone_number: "06 11 22 33 44", phone_number_formatted: "+33611223344") }
+    let!(:user_without_password) { create(:user, encrypted_password: "") }
 
     it "anonymizes all the data" do
       described_class.anonymize_all_data!


### PR DESCRIPTION
Cette PR ajoute des petits correctifs sur l'ETL pour permettre de l'utiliser en local et éviter d'avoir un bug au moment du passage à null d'une colonne sur les usagers