### PR TITLE
Corrige certaines specs non-déterministes

### DIFF
--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -111,6 +111,8 @@ describe InclusionConnectController, type: :controller do
       expect(sentry_events.last.breadcrumbs.compact.map(&:message).uniq).to eq(["HTTP request", "HTTP response"])
     end
 
+    stub_sentry_events
+
     it "call sentry about authentification failure" do
       stub_const("InclusionConnect::IC_CLIENT_ID", "truc")
       stub_const("InclusionConnect::IC_CLIENT_SECRET", "truc secret")
@@ -120,8 +122,9 @@ describe InclusionConnectController, type: :controller do
 
       session[:ic_state] = "a state"
 
-      expect(Sentry).to receive(:capture_message).with("Failed to authentify agent with inclusionConnect")
       get :callback, params: { state: "a state", session_state: "a state", code: "klzefklzejlf" }
+
+      expect(sentry_events.last.message).to eq("Failed to authentify agent with inclusionConnect")
     end
   end
 

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
     it "redirects to the homepage with an error message" do
       visit "http://www.rdv-solidarites-test.localhost/prescripteur/new_prescripteur"
       expect(page).to have_content("Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous.")
+      sleep 1
       expect(sentry_events.last.message).to eq "Prescripteur sans infos de creneau. Voir https://github.com/betagouv/rdv-solidarites.fr/issues/3420"
     end
   end

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -219,10 +219,12 @@ RSpec.describe "prescripteur can create RDV for a user" do
   end
 
   context "when going directly to a prescripteur form without having selected a creneau" do
+    stub_sentry_events
+
     it "redirects to the homepage with an error message" do
-      expect(Sentry).to receive(:capture_message)
       visit "http://www.rdv-solidarites-test.localhost/prescripteur/new_prescripteur"
       expect(page).to have_content("Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous.")
+      expect(sentry_events.last.message).to eq "Prescripteur sans infos de creneau. Voir https://github.com/betagouv/rdv-solidarites.fr/issues/3420"
     end
   end
 end

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -224,7 +224,6 @@ RSpec.describe "prescripteur can create RDV for a user" do
     it "redirects to the homepage with an error message" do
       visit "http://www.rdv-solidarites-test.localhost/prescripteur/new_prescripteur"
       expect(page).to have_content("Nous n'avons pas trouvé le créneau pour lequel vous souhaitiez prendre rendez-vous.")
-      sleep 1
       expect(sentry_events.last.message).to eq "Prescripteur sans infos de creneau. Voir https://github.com/betagouv/rdv-solidarites.fr/issues/3420"
     end
   end

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -82,7 +82,7 @@ describe "ANTS API: availableTimeSlots" do
   end
 
   context 'when the "reason" param is invalid' do
-    xit "adds crumb with request details to Sentry" do
+    it "adds crumb with request details to Sentry" do
       invalid_reason = "no"
       get "/api/ants/availableTimeSlots?meeting_point_ids=#{lieu1.id}&meeting_point_ids=#{lieu2.id}&start_date=2022-11-01&end_date=2022-11-02&documents_number=1&reason=#{invalid_reason}"
 

--- a/spec/requests/api_authentication_spec.rb
+++ b/spec/requests/api_authentication_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe "API auth", type: :request do
           "X-Agent-Auth-Signature": "BAD_PAYLOAD",
         }
       )
+      expect(sentry_events.last.message).to eq "API authentication agent was called with an invalid signature !"
       expect(response).to have_http_status(:unauthorized)
       expect(parsed_response_body).to eq({ "errors" => ["Vous devez vous connecter ou vous inscrire pour continuer."] })
-      expect(sentry_events.last.message).to eq "API authentication agent was called with an invalid signature !"
     end
 
     it "log sentry and return error when shared secret is nil" do
@@ -109,9 +109,9 @@ RSpec.describe "API auth", type: :request do
           "X-Agent-Auth-Signature": nil,
         }
       )
+      expect(sentry_events.last.message).to be_present
       expect(response).to have_http_status(:unauthorized)
       expect(parsed_response_body).to eq({ "errors" => ["Vous devez vous connecter ou vous inscrire pour continuer."] })
-      expect(sentry_events.last.message).to be_present
     end
 
     it "query is correctly processed with the agent authorizations when shared secret is valid" do

--- a/spec/requests/api_authentication_spec.rb
+++ b/spec/requests/api_authentication_spec.rb
@@ -96,9 +96,9 @@ RSpec.describe "API auth", type: :request do
           "X-Agent-Auth-Signature": "BAD_PAYLOAD",
         }
       )
-      expect(sentry_events.last.message).to eq "API authentication agent was called with an invalid signature !"
       expect(response).to have_http_status(:unauthorized)
       expect(parsed_response_body).to eq({ "errors" => ["Vous devez vous connecter ou vous inscrire pour continuer."] })
+      expect(sentry_events.last.message).to eq "API authentication agent was called with an invalid signature !"
     end
 
     it "log sentry and return error when shared secret is nil" do
@@ -109,9 +109,9 @@ RSpec.describe "API auth", type: :request do
           "X-Agent-Auth-Signature": nil,
         }
       )
-      expect(sentry_events.last.message).to be_present
       expect(response).to have_http_status(:unauthorized)
       expect(parsed_response_body).to eq({ "errors" => ["Vous devez vous connecter ou vous inscrire pour continuer."] })
+      expect(sentry_events.last.message).to be_present
     end
 
     it "query is correctly processed with the agent authorizations when shared secret is valid" do

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -26,9 +26,11 @@ RSpec.describe "Handling an email reply from a user" do
       expect { receive_sendinblue_callback }.not_to have_enqueued_job
     end
 
+    stub_sentry_events
+
     it "warns Sentry" do
-      expect(Sentry).to receive(:capture_message).with("Sendinblue inbound controller was called without valid password")
       receive_sendinblue_callback
+      expect(sentry_events.last.message).to eq "Sendinblue inbound controller was called without valid password"
     end
   end
 end

--- a/spec/support/sentry_helper.rb
+++ b/spec/support/sentry_helper.rb
@@ -1,9 +1,11 @@
 # Sentry test helper setup, see:
 # https://github.com/getsentry/sentry-ruby/blob/5fc11d9/sentry-ruby/lib/sentry/test_helper.rb
 def stub_sentry_events
-  around do |example|
+  before do
     setup_sentry_test
-    example.run
+  end
+
+  after do
     teardown_sentry_test
   end
 end


### PR DESCRIPTION
Les stubs sur l'objet global `Sentry` ne sont pas nettoyés d'une spec à l'autre 😿 