### PR TITLE
Ajout des changements d'options de synchronisation d'agenda aux versions papertrail des agents

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -3,7 +3,7 @@ class SoftDeleteError < StandardError; end
 class Agent < ApplicationRecord
   # Mixins
   has_paper_trail(
-    only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at]
+    only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at microsoft_graph_token rdv_notifications_level calendar_uid]
   )
 
   include Outlook::Connectable


### PR DESCRIPTION
Pour débugger et comprendre plus facilement ce qui s'est passé.
A vérifier : est-ce que ça risque pas d'afficher des données sensibles (token) dans l'historique de l'agent ?