### PR TITLE
Revert le MAJ de GoodJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem "common_french_passwords"
 
 # Jobs
 # A multithreaded, Postgres-based ActiveJob backend for Ruby on Rails
-gem "good_job"
+gem "good_job", "3.12.8"
 # A toolkit to create and control daemons in different ways
 gem "daemons"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,13 +226,14 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (3.21.5)
+    good_job (3.12.8)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
+      webrick (>= 1.3)
     groupdate (6.1.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
@@ -684,7 +685,7 @@ DEPENDENCIES
   dsfr-view-components
   factory_bot
   faker
-  good_job
+  good_job (= 3.12.8)
   groupdate (~> 6.1)
   icalendar (~> 2.5)
   jbuilder


### PR DESCRIPTION
Une MAJ de GoodJob a créé un crash en prod, je revert la MAJ

https://sentry.incubateur.net/organizations/betagouv/issues/82096

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
