### PR TITLE
[Saas] Affichage du nom de l'organisation pour la prise de rdv en ligne sur RDV Service Public

### DIFF
--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -55,17 +55,17 @@ class WebSearchContext < SearchContext
     motifs
   end
 
+  # TODO : move this to a specific search context https://github.com/betagouv/rdv-solidarites.fr/pull/3827#discussion_r1351988739
+  def public_link_organisation
+    @public_link_organisation ||= \
+      @public_link_organisation_id.present? ? Organisation.find(@public_link_organisation_id) : nil
+  end
+
   private
 
   attr_reader :referent_ids, :lieu_id
 
   def matching_motifs
     @matching_motifs ||= filter_motifs(geo_search.available_motifs)
-  end
-
-  # TODO : move this to a specific search context https://github.com/betagouv/rdv-solidarites.fr/pull/3827#discussion_r1351988739
-  def public_link_organisation
-    @public_link_organisation ||= \
-      @public_link_organisation_id.present? ? Organisation.find(@public_link_organisation_id) : nil
   end
 end

--- a/app/views/search/banners/_rdv_mairie.html.slim
+++ b/app/views/search/banners/_rdv_mairie.html.slim
@@ -1,3 +1,7 @@
 ' Prenez rendez-vous avec
 br
-span> votre mairie
+span
+  - if @context&.public_link_organisation
+    = @context.public_link_organisation.name
+  - else
+    =votre mairie


### PR DESCRIPTION
J'aimerais utiliser RDV Service Public pour que des agents prennent rdv avec moi pour tester la synchronisation Outlook. Petit problème : aujourd'hui le texte de prise de rdv dit toujours qu'on va prendre rdv avec une mairie, donc cette PR permet d'afficher directement le nom de l'organisation quand on utilise un lien public vers une orga précise.

Fun fact, c'était aussi le dernier petit bout d'interface qui était bloquant pour une expérience générique côté usager, donc c'est un pas en avant pour le Saas

### Avant

<img width="1348" alt="Screenshot 2024-01-19 at 17 53 48" src="https://github.com/betagouv/rdv-service-public/assets/1840367/1ddf149f-0547-4057-b42d-3109d99f8033">

### Après 

<img width="1366" alt="Screenshot 2024-01-19 at 17 53 22" src="https://github.com/betagouv/rdv-service-public/assets/1840367/f6cd9173-47c5-4885-848c-7c608ac42d39">
