### PR TITLE
Autoriser plusieurs territoires à avoir le même numéro de département

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -37,7 +37,6 @@ class Territory < ApplicationRecord
   # Validations
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }
   validates :name, presence: true, if: -> { persisted? }
-  validates :departement_number, uniqueness: true, allow_blank: true
   validate do
     if name_was == MAIRIES_NAME
       errors.add(:name, "Le nom de ce territoire permet de le brancher au moteur de recherche de l'ANTS et ne peut pas être changé")

--- a/config/locales/models/territory.fr.yml
+++ b/config/locales/models/territory.fr.yml
@@ -9,10 +9,3 @@ fr:
         sms_configuration: "Clef d’API / Mot de passe"
         sms_provider: "Fournisseur pour l’envoi de SMS"
         visible_users_throughout_the_territory: Usagers visible sur tout le territoire
-    errors:
-      models:
-        territory:
-          attributes:
-            departement_number:
-              taken: "Il y a déjà des organisations et des agents créés dans ce département, veuillez entrer en contact avec eux"
-              format: "%{message}"

--- a/db/migrate/20240122082202_drop_unicity_on_territories_departement_number.rb
+++ b/db/migrate/20240122082202_drop_unicity_on_territories_departement_number.rb
@@ -1,0 +1,10 @@
+class DropUnicityOnTerritoriesDepartementNumber < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      remove_index  :territories, :departement_number, unique: true, where: "((departement_number)::text <> ''::text)"
+      add_index     :territories, :departement_number, unique: false, where: "((departement_number)::text <> ''::text)"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_17_133500) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_22_082202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -615,7 +615,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_17_133500) do
     t.boolean "enable_waiting_room_mail_field", default: false
     t.boolean "enable_waiting_room_color_field", default: false
     t.boolean "visible_users_throughout_the_territory", default: false
-    t.index ["departement_number"], name: "index_territories_on_departement_number", unique: true, where: "((departement_number)::text <> ''::text)"
+    t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
   end
 
   create_table "territory_services", force: :cascade do |t|

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -14,53 +14,6 @@ describe Territory, type: :model do
     end
   end
 
-  describe "departement_number uniqueness validation" do
-    context "no collision" do
-      let(:territory) { build(:territory, name: "Oise", departement_number: "60") }
-
-      it { expect(territory).to be_valid }
-    end
-
-    context "blank departement_number" do
-      let!(:territory_existing) { create(:territory, departement_number: "60") }
-      let(:territory) { build(:territory, name: "Oise", departement_number: "") }
-
-      it { expect(territory).to be_valid }
-    end
-
-    context "colliding departement_number" do
-      let!(:territory_existing) { create(:territory, departement_number: "60") }
-      let(:territory) { build(:territory, name: "Oise", departement_number: "60") }
-
-      it "adds errors" do
-        expect(territory).not_to be_valid
-        expect(territory.errors.details).to eq({ departement_number: [{ error: :taken, value: "60" }] })
-        expect(territory.errors.full_messages.to_sentence).to include("agents créés dans ce département")
-      end
-    end
-
-    context "update existing territory to free departement_number" do
-      let!(:territory) { create(:territory, departement_number: "60") }
-
-      before { territory.departement_number = "80" }
-
-      it { expect(territory).to be_valid }
-    end
-
-    context "update existing territory to colliding departement_number" do
-      let!(:territory_existing) { create(:territory, departement_number: "80") }
-      let!(:territory) { create(:territory, departement_number: "60") }
-
-      before { territory.departement_number = "80" }
-
-      it "adds errors" do
-        expect(territory).not_to be_valid
-        expect(territory.errors.details).to eq({ departement_number: [{ error: :taken, value: "80" }] })
-        expect(territory.errors.full_messages.to_sentence).to include("agents créés dans ce département")
-      end
-    end
-  end
-
   describe "#fill_name_for_departements before_create" do
     subject { territory.reload.name }
 


### PR DESCRIPTION
Suite à [l'atelier sur les territoires](https://metroretro.io/BO3LOIMQV4MF), nous avons décidé de supprimer la contrainte d'unicité sur le département afin de permettre à des "territoires" différents d'être trouvables via la résa en ligne (qui utilise `departement_number`). 

L’avantage d'avoir un "territoire" séparé pour chaque entité (par exemple "Drôme Médico-social" et "Drôme Insertion") est de permettre à chaque "territoire" d'avoir des paramétrages et feature flags différents.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
