### PR TITLE
Correction d'une spec qui casse au bout de 2 ans

### DIFF
--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -12,7 +12,7 @@ describe "Agent can create a Rdv collectif from the agenda" do
 
   let!(:lieu) { create(:lieu, organisation: organisation) }
 
-  let(:now) { Time.zone.parse("20220123 13:00") }
+  let(:now) { Time.zone.parse("2024-01-21 13:00") }
 
   before do
     stub_netsize_ok


### PR DESCRIPTION
La spec cassait parce qu'on se `travel_to` au 23 janvier 2022, et quand on fait le parcours, le datepicker JS choisit la dat du jour d'exécution (aujourd'hui, 22 janvier 2024). On essaye donc de créer un RDV pour dans plus de 2 ans (presque), et donc la validation `must_be_within_two_years` passe au rouge.

Si quelqu'un a un idée maline pour qu'on ait pas à mettre à jour cette spec dans 2 ans, je vous en prie.

En attendant ça permet de débloquer la CI.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
