### PR TITLE
Logger correctement et complètement la ligne CNFS qui plante lors de l'import

### DIFF
--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -12,7 +12,6 @@ class AddConseillerNumerique
   end
 
   def initialize(conseiller_numerique_attributes)
-    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "AddConseillerNumerique params", data: conseiller_numerique_attributes))
     structure_attributes = conseiller_numerique_attributes.delete(:structure)
     @conseiller_numerique = ConseillerNumerique.new(conseiller_numerique_attributes)
     @structure = Structure.new(structure_attributes)


### PR DESCRIPTION
J'avais tenté d'utiliser les breadcrumbs mais en fait ils s'accumulent et donc nous avons chaque ligne dans les breadcrumbs : 

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/8f1bcee0-b0c8-495b-8f8e-11724ccb43b3)

Avec cet usage de `scope` et `context`, on a un log correct en contexte : 

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/3ffd151c-6def-495f-be7e-e4ab399eb615)


# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
