### PR TITLE
[Second essai] Ne pas envoyer à Sentry les ConcurrencyExceededError

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,20 +1,22 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN_RAILS"]
 
+  # Most 4xx errors are excluded by default.
+  # See Sentry::Configuration::IGNORE_DEFAULT
+  # and Sentry::Rails::IGNORE_DEFAULT
+  # Cf https://docs.sentry.io/platforms/ruby/configuration/options/#optional-settings
+  # config.excluded_exceptions += []
+
   # Par défault, Sentry ignore les erreurs ActiveRecord::RecordNotFound pour éviter de faire remonter
   # des erreurs en cas de visite de page obsolètes
   # par exemple pour des ids non trouvés.
   # Dans le contexte des jobs, on a besoin de savoir s'il y a cette erreur
   # Par ailleurs, on préfère mettre une règle dans Sentry pour ignorer ces erreurs en dessous d'un
   # certain volume plutôt que de les rendre complètement invisibles.
-  config.excluded_exceptions -= [
-    'ActiveRecord::RecordNotFound',
-    'GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError', # Ces erreurs permettent de lancer de retry https://github.com/bensheldon/good_job?tab=readme-ov-file#how-concurrency-controls-work
-  ]
+  config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
 
-  # Most 4xx errors are excluded by default.
-  # See Sentry::Configuration::IGNORE_DEFAULT
-  # and Sentry::Rails::IGNORE_DEFAULT
-  # Cf https://docs.sentry.io/platforms/ruby/configuration/options/#optional-settings
-  # config.excluded_exceptions += []
+  # Ces erreurs déclenchent un retry :
+  # https://github.com/bensheldon/good_job?tab=readme-ov-file#how-concurrency-controls-work
+  # Il ne nous est pas utile de les voir dans Sentry puisqu'elles ont un rôle de contrôle de flux.
+  config.excluded_exceptions += ["GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError"]
 end


### PR DESCRIPTION
La modif faite dans #3973 était en réalité un contresens. :zany_face: 

J'ai monté le commentaire d'exemple en haut du fichier, ça me semble plus logique.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
