### PR TITLE
Accélération et correction du script d'ETL

### DIFF
--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -42,12 +42,11 @@ etl_addon_id="$( scalingo --region osc-secnum-fr1 --app rdv-service-public-etl a
 
 
 echo "Chargement du dump..."
-# TODO: try speeding up the process by using the --jobs option
 # voir https://stackoverflow.com/questions/37038193/exclude-table-during-pg-restore pour l'explication des tables à exclure
 # TODO: réutiliser AnonymizerRules::TRUNCATED_TABLES ici
 # C'est compliqué à écrire en bash, et il vaudrait mieux utiliser du ruby pour ce genre de logique
 # tables_to_exclude="$(bundle exec rails runner \"puts AnonymizerRules::TRUNCATED_TABLES.join\(\'\|\'\)\") | tail -n1"
-time pg_restore --clean --if-exists --no-owner --no-privileges --jobs=2 --dbname "${DATABASE_URL}" -L <(pg_restore -l /app/*.pgsql | grep -vE 'TABLE DATA public (versions|good_jobs|good_job_settings|good_job_batches|good_job_processes)') /app/*.pgsql
+time pg_restore --clean --if-exists --no-owner --no-privileges --jobs=4 --dbname "${DATABASE_URL}" -L <(pg_restore -l /app/*.pgsql | grep -vE 'TABLE DATA public (versions|good_jobs|good_job_settings|good_job_batches|good_job_processes)') /app/*.pgsql
 
 
 echo "Anonymisation de la base"


### PR DESCRIPTION
Comme chaque semaine, l'update des données dans metabase a été l'occasion d'améliorer un peu notre script d'ETL.

Pour éviter les erreurs causées par le downtime du changement de plan, je met les changements de plan au tout début et à la fin du script, pour que pendant qu'on télécharge le backup de la prod, le postgres de l'appli d'ETL ai le temps d'être provisionné.

J'ai testé de passer à 4 workers pour le `pg_restore`, et ça fait passer le temps de pg_restore d'environ 20mn à environ 10mn