### PR TITLE
Flaky spec : encore une histoire de factory de plage d'ouverture

### DIFF
--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -3,6 +3,10 @@ require "swagger_helper"
 describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.json" do
   with_examples
 
+  before do
+    travel_to(Time.zone.parse("2023-10-23 16:00"))
+  end
+
   path "/api/rdvinsertion/invitations/creneau_availability" do
     get "Renvoi true si au moins un créneau est disponible pour une invitation" do
       with_authentication


### PR DESCRIPTION
Cette spec pète en ce samedi, et ça me gâche mon plaisir de chasser les bugs du SDK Sentry pendant mon temps libre.

CI au rouge : https://github.com/betagouv/rdv-service-public/actions/runs/7679123409/job/20929699356

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
