### PR TITLE
Ouverture de la prescription interne à la Drôme

### DIFF
--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -1,7 +1,7 @@
 module FeatureHelper
   def show_agent_prescription_feature?
     current_organisation.territory.name.starts_with?("CDAD") ||
-      current_organisation.territory.departement_number.in?(%w[83]) ||
+      current_organisation.territory.departement_number.in?(%w[83 26]) ||
       Rails.env.development? ||
       ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
   end


### PR DESCRIPTION
Lors de la discussion de cet après-midi, la référente du méico social dans la Drôme nous a confirmé qu'elle souhaitait essayer la prescription en interne, et qu'on pouvait lui ouvrir.

Cette PR ouvre la prescription pour les deux territoires de la Drôme (médico-social et insertion), mais je pense que c'est raisonnable vu comme elle est discrète pour le moment (et que l'équipe RDV insertion prévoit de l'ouvrir à tout le monde).