### PR TITLE
Fix timezone mismatch in Recurrence objects

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -39,11 +39,6 @@ class Absence < ApplicationRecord
 
     not_recurring_start_in_range.or(recurring_in_range)
   }
-  scope :overlapping_range, lambda { |range|
-    in_range(range).select do |absence|
-      absence.occurrences_for(range).any? { range.overlaps?(_1.starts_at.._1.ends_at) }
-    end
-  }
 
   # Delegations
   delegate :domain, to: :agent

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -53,11 +53,6 @@ class PlageOuverture < ApplicationRecord
 
     not_recurring_start_in_range.or(recurring_in_range)
   }
-  scope :overlapping_range, lambda { |range|
-    in_range(range).select do |plage_ouverture|
-      plage_ouverture.occurrences_for(range).any? { range.overlaps?(_1.starts_at.._1.ends_at) }
-    end
-  }
   scope :bookable_by_everyone, -> { joins(:motifs).merge(Motif.bookable_by_everyone) }
   scope :bookable_by_everyone_or_bookable_by_invited_users, -> { joins(:motifs).merge(Motif.bookable_by_everyone_or_bookable_by_invited_users) }
 


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-service-public/issues/3974

Les objets de récurrence (`Montrose::Recurrence`) pour les indisponibilités (`Absence`) et les plages d'ouverture (`PlageOuverture`) est sauvegardé avec le timezone.

Cela pose un bug, lorsque l'objet de récurrence est sérialisé dans un fuseau horaire donné (temps d'hiver) et déserialisé dans un autre fuseau horaire (temps d'été), nous observons des inconsistences dans les calculs horaires ; notamment 1h de différence.

La solution implémentée consiste à "fixer" le timezone en UTC lors du calcul des éventuels conflits entre les occurences d'une récurrence et un intervalle donné.

L'idéal aurait été de ne pas sauvegarder du tout le timezone, mais cette solution s'avère compliquée car la Gem Montrose n'offre pas tant de flexibilité. Voir PRs et Issues:
- https://github.com/rossta/montrose/pull/46
- https://github.com/rossta/montrose/pull/58
- https://github.com/rossta/montrose/issues/65#issuecomment-518230668

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
