### PR TITLE
Afficher une 404 plutôt qu'une 500 lors d'une tentative d'accès à un agent supprimé

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -59,7 +59,7 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
   private
 
   def set_agent
-    @agent = Agent.find(params[:id])
+    @agent = Agent.active.find(params[:id])
   end
 
   def authorize_agent


### PR DESCRIPTION
Petit correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/84373/?project=74&referrer=webhooks_plugin

Ça semble être juste une admin qui réutilise un lien direct vers l'édition d'un agent supprimé, je pense que c'est un cas suffisamment isolé pour pas justifier un fix plus complet.