### PR TITLE
Correctif pour le domaine d'envoi des mails d'invitations

### DIFF
--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -2,7 +2,7 @@ module SuperAdmins
   class ComptesController < SuperAdmins::ApplicationController
     def create
       compte_params[:agent][:invited_by] = current_super_admin
-      compte = Compte.new(compte_params)
+      compte = Compte.new(compte_params, current_domain)
       authorize_resource(compte)
 
       if compte.save

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -4,13 +4,17 @@ class Compte
 
   attr_accessor :territory, :organisation, :lieu, :agent
 
-  def initialize(attributes)
+  def initialize(attributes, current_domain = nil)
     @attributes = attributes
+    @current_domain = current_domain
   end
 
   def save
     self.territory = Territory.new(@attributes[:territory])
-    self.organisation = Organisation.new(@attributes[:organisation].merge(territory: territory))
+    self.organisation = Organisation.new(@attributes[:organisation].merge(
+                                           territory: territory,
+                                           verticale: @current_domain&.verticale
+                                         ))
     self.lieu = Lieu.new(@attributes[:lieu].merge(
                            organisation: organisation,
                            name: organisation.name,

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -15,6 +15,7 @@ Domain = Struct.new(
   :documentation_url,
   :support_email,
   :secretariat_email,
+  :verticale,
   keyword_init: true
 )
 
@@ -36,6 +37,7 @@ class Domain
       faq_url: "https://rdv-solidarites.notion.site/F-A-Q-M-dico-social-aaf94709c0ea448b8eb9d93f548acdb9",
       france_connect_enabled: true,
       support_email: "support@rdv-solidarites.fr",
+      verticale: :rdv_solidarites,
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"
       # secretariat_email est utilisé comme adresse de "Reply-To" pour les e-mails
       # qui contiennent des ICS. Lorsque l'événement ICS est acceptée par le
@@ -59,6 +61,7 @@ class Domain
       faq_url: "https://rdvs.notion.site/FAQ-CNFS-c55933f66f054aaba60fe4799851000e",
       france_connect_enabled: false,
       support_email: "support@rdv-aide-numerique.fr",
+      verticale: :rdv_aide_numerique,
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"
     ),
 
@@ -78,6 +81,7 @@ class Domain
       faq_url: "https://rdvs.notion.site/FAQ-RDV-Mairie-6baf4af187a14e42beafe56b7005d199",
       france_connect_enabled: true,
       support_email: "support@rdv-service-public.fr",
+      verticale: :rdv_mairie,
       secretariat_email: "secretariat-auto@rdv-service-public.fr"
     ),
   ].freeze

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -16,7 +16,7 @@ describe "Creating a new account for a new project, other than a mairie", js: tr
 
   it "creates a new organisation" do
     login_as(super_admin, scope: :super_admin)
-    visit super_admins_root_path
+    visit super_admins_root_url(host: "http://www.rdv-mairie-test.localhost")
 
     click_link "Comptes"
     click_link "Création compte"
@@ -68,6 +68,14 @@ describe "Creating a new account for a new project, other than a mairie", js: tr
     new_motif = new_organisation.motifs.first
     expect(new_motif).to have_attributes(
       name: "Mon premier motif"
+    )
+
+    perform_enqueued_jobs
+    invitation_email = ActionMailer::Base.deliveries.last
+
+    expect(invitation_email).to have_attributes(
+      subject: "Vous avez été invité sur RDV Service Public",
+      reply_to: ["support@rdv-service-public.fr"]
     )
   end
 end


### PR DESCRIPTION
On envoyait des mails d'invitation pour RDV Solidarités alors que l'invitation est faite de RDV Service Public (voir https://mattermost.incubateur.net/betagouv/pl/ui8godibhtymtyfzx7hddsuibr)