### PR TITLE
Eviter de renvoyer des creneaux en double à l'ANTS

### DIFF
--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -52,7 +52,7 @@ class Api::Ants::EditorController < Api::Ants::BaseController
             duration: rdv_duration(motif)
           ),
         }
-      end
+      end.uniq
     end.flatten
   end
 

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -19,6 +19,12 @@ describe "ANTS API: availableTimeSlots" do
     create(:plage_ouverture, lieu: lieu1, first_day: Date.new(2022, 11, 1),
                              start_time: Tod::TimeOfDay(9), end_time: Tod::TimeOfDay(10),
                              organisation: organisation, motifs: [motif])
+
+    # Une deuxième plage d'ouverture identique pour vérifier qu'il n'y a pas de doublon
+    create(:plage_ouverture, lieu: lieu1, first_day: Date.new(2022, 11, 1),
+                             start_time: Tod::TimeOfDay(9), end_time: Tod::TimeOfDay(10),
+                             organisation: organisation, motifs: [motif])
+
     create(:plage_ouverture, lieu: lieu2, first_day: Date.new(2022, 11, 2),
                              start_time: Tod::TimeOfDay(12), end_time: Tod::TimeOfDay(13),
                              organisation: organisation2, motifs: [motif2])


### PR DESCRIPTION
Si on renvoie les créneaux en double, ils s'affichent en double sur https://rendezvouspasseport.ants.gouv.fr/
