### PR TITLE
[Bug] Rafraîchir l'agenda immédiatement lors d'un retour sur l'onglet

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -40,9 +40,22 @@ class CalendarRdvSolidarites {
     this.setRefetchInterval()
   }
 
+  refreshDelay = 20000
+  lastRefresh = 0
+  refreshEventsIfNeeded = () => {
+    if (this.lastRefresh + this.refreshDelay < Date.now()) {
+      this.fullCalendarInstance.refetchEvents();
+      this.lastRefresh = Date.now();
+    }
+  };
+
   setRefetchInterval = () => {
     if (this.refreshCalendarInterval) return
-    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 60000)
+    this.refreshCalendarInterval = setInterval(() => {
+      if (document.visibilityState === "visible") {
+        this.refreshEventsIfNeeded();
+      }
+    }, 200)
   }
 
   clearRefetchInterval = () => {

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -23,9 +23,12 @@ class CalendarRdvSolidarites {
     document.addEventListener('turbolinks:before-render', this.clearRefetchInterval);
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'visible') {
+        // when agent comes back to tab, refresh immediately
+        this.fullCalendarInstance.refetchEvents();
+
         this.setRefetchInterval();
       } else if (this.refreshCalendarInterval) {
-        this.clearRefetchInterval()
+        this.clearRefetchInterval();
       }
     })
     document.addEventListener("turbolinks:before-cache", () => {

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -40,22 +40,9 @@ class CalendarRdvSolidarites {
     this.setRefetchInterval()
   }
 
-  refreshDelay = 20000
-  lastRefresh = 0
-  refreshEventsIfNeeded = () => {
-    if (this.lastRefresh + this.refreshDelay < Date.now()) {
-      this.fullCalendarInstance.refetchEvents();
-      this.lastRefresh = Date.now();
-    }
-  };
-
   setRefetchInterval = () => {
     if (this.refreshCalendarInterval) return
-    this.refreshCalendarInterval = setInterval(() => {
-      if (document.visibilityState === "visible") {
-        this.refreshEventsIfNeeded();
-      }
-    }, 200)
+    this.refreshCalendarInterval = setInterval(() => this.fullCalendarInstance.refetchEvents(), 60000)
   }
 
   clearRefetchInterval = () => {


### PR DESCRIPTION
Jusqu'à maintenant, le comportement était le suivant : 

1. l'agent revient sur l'onglet agenda précédemment ouvert
2. notre appli lance un chrono de 60 secondes au bout duquel l'agenda est rafraîchi (!)
3. l'agenda est ensuite rafraîchi toutes les 60 secondes, sauf si l'agent change d'onglet

Désormais : 

1. l'agent revient sur l'onglet agenda précédemment ouvert
2. l'agenda est rafraîchi immédiatement
3. l'agenda est ensuite rafraîchi toutes les 60 secondes, sauf si l'agent change d'onglet

Note : lorsque l'onglet n'est pas actif, l'agenda n'est jamais rafraîchi, pour éviter des appels inutiles.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
