### PR TITLE
Cesser de passer les provider credentials dans les args de SmsJob

### DIFF
--- a/app/sms/users/base_sms.rb
+++ b/app/sms/users/base_sms.rb
@@ -17,29 +17,12 @@ class Users::BaseSms < ApplicationSms
       sender_name: @rdv.domain.sms_sender_name,
       phone_number: @user.phone_number_formatted,
       content: content,
-      provider: provider,
-      api_key: api_key,
+      territory_id: @rdv.territory.id,
       receipt_params: @receipt_params
     )
   end
 
   private
-
-  def provider
-    if Rails.env.development? && ENV["DEVELOPMENT_FORCE_SMS_PROVIDER"].present?
-      return ENV["DEVELOPMENT_FORCE_SMS_PROVIDER"]
-    end
-
-    @rdv.organisation&.territory&.sms_provider || ENV["DEFAULT_SMS_PROVIDER"].presence || :debug_logger
-  end
-
-  def api_key
-    if Rails.env.development? && ENV["DEVELOPMENT_FORCE_SMS_PROVIDER_KEY"].present?
-      return ENV["DEVELOPMENT_FORCE_SMS_PROVIDER_KEY"]
-    end
-
-    @rdv.organisation&.territory&.sms_configuration || ENV["DEFAULT_SMS_PROVIDER_KEY"]
-  end
 
   def domain_host
     @rdv.domain.host_name

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -31,4 +31,32 @@ describe SmsJob do
       expect(sentry_events.last.exception.values.last.value).to eq("erreur inattendue (RuntimeError)")
     end
   end
+
+  describe "arguments delegation" do
+    it "works with :provider and :api_key" do
+      expect(SmsSender).to receive(:perform_with).with("RdvSoli", "0611223344", "test", "netsize", "fake_key", {})
+      described_class.perform_later(
+        sender_name: "RdvSoli",
+        phone_number: "0611223344",
+        content: "test",
+        provider: "netsize",
+        api_key: "fake_key",
+        receipt_params: {}
+      )
+      perform_enqueued_jobs
+    end
+
+    it "works with :territory_id" do
+      territory = create(:territory)
+      expect(SmsSender).to receive(:perform_with).with("RdvSoli", "0611223344", "test", territory.sms_provider, territory.sms_configuration, {})
+      described_class.perform_later(
+        sender_name: "RdvSoli",
+        phone_number: "0611223344",
+        content: "test",
+        territory_id: territory.id,
+        receipt_params: {}
+      )
+      perform_enqueued_jobs
+    end
+  end
 end

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -1,39 +1,11 @@
 describe SmsJob do
-  describe "phone number validation" do
-    subject(:perform) do
-      described_class.new.perform(
-        sender_name: "RdvSoli",
-        phone_number: phone_number,
-        content: "test",
-        provider: "netsize",
-        api_key: "fake_key",
-        receipt_params: {}
-      )
-    end
-
-    context "phone_number is mobile" do
-      let(:phone_number) { "0612345678" }
-
-      specify do
-        expect(SmsSender).to receive(:perform_with)
-        expect { subject }.not_to raise_error
-      end
-    end
-
-    context "phone_number is landline" do
-      let(:phone_number) { "0130303030" }
-
-      specify do
-        expect { subject }.to raise_error(SmsJob::InvalidMobilePhoneNumberError)
-      end
-    end
-  end
-
   describe "error logging" do
     it "only sends error to Sentry after 3rd error" do
+      allow(SmsSender).to receive(:perform_with).and_raise("erreur inattendue")
+
       described_class.perform_later(
         sender_name: "RdvSoli",
-        phone_number: "0123456789",
+        phone_number: "0611223344",
         content: "test",
         provider: "netsize",
         api_key: "fake_key",
@@ -55,7 +27,8 @@ describe SmsJob do
       # third execution, error is logged
       perform_enqueued_jobs
       expect(enqueued_jobs.first["executions"]).to eq(3)
-      expect(sentry_events.last.exception.values.last.type).to eq("SmsJob::InvalidMobilePhoneNumberError")
+      expect(sentry_events.last.exception.values.last.type).to eq("RuntimeError")
+      expect(sentry_events.last.exception.values.last.value).to eq("erreur inattendue (RuntimeError)")
     end
   end
 end


### PR DESCRIPTION
Ces credentials sont actuellement visibles partout (dashboard GoodJob, Sentry), il est temps que ça cesse.

Je pense que dans une prochaine PR on pourra fusionner `SmsJob` et `SmsSender` car ça nous facilitera la vie sur la définition de retries custom selon les providers par exemple.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
