### PR TITLE
Désactiver le monkey patching de RSpec

### DIFF
--- a/docs/bonnes-pratiques-de-tests.md
+++ b/docs/bonnes-pratiques-de-tests.md
@@ -54,7 +54,7 @@ Les cas aux limites sont souvent enrichis avec les couvertures de bug fix réali
 Comme les request specs sont des tests d'intégration, on peut défendre qu'un test peut contenir plusieurs assertions. Par exemple : 
 
 ```rb
-describe "creating a rdv" do
+RSpec.describe "creating a rdv" do
   subject(:create_request) { post rdvs_path, params: params }
   let(:params) { ... }
   
@@ -70,7 +70,7 @@ end
 Toutefois, lorsque la spec plante, on a plutôt envie de savoir ce qui n'a pas fonctionné. Est-ce la création du RDV qui a échoué ? Est-ce le template qui n'a pas été rendu ? Ou le flash a-t-il changé ? Aussi, il semble plus confortable pour la personne qui constate le crash que celui-ci indique immédiatement l'erreur. Pour cela, on recommande plutôt d'avoir, autant que possible, une assertion par test : 
 
 ```rb
-describe "creating a rdv" do
+RSpec.describe "creating a rdv" do
   subject(:create_request) { post rdvs_path, params: params }
   let(:params) { ... }
   

--- a/spec/blueprint/absence_blueprint_spec.rb
+++ b/spec/blueprint/absence_blueprint_spec.rb
@@ -1,4 +1,4 @@
-describe AbsenceBlueprint do
+RSpec.describe AbsenceBlueprint do
   describe "#render" do
     it "contains an agent" do
       absence = build(:absence, agent: build(:agent, email: "bob@example.com", first_name: "Bob", last_name: "Henri"))

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -1,4 +1,4 @@
-describe RdvBlueprint do
+RSpec.describe RdvBlueprint do
   subject(:json) { JSON.parse(rendered) }
 
   let(:rendered) { described_class.render(rdv, { root: :rdv }) }

--- a/spec/controllers/admin/absences_controller_spec.rb
+++ b/spec/controllers/admin/absences_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::AbsencesController, type: :controller do
+RSpec.describe Admin::AbsencesController, type: :controller do
   render_views
 
   let!(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/agent_agendas_controller_spec.rb
+++ b/spec/controllers/admin/agent_agendas_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::AgentAgendasController, type: :controller do
+RSpec.describe Admin::AgentAgendasController, type: :controller do
   let(:organisation) { create(:organisation) }
   let(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 

--- a/spec/controllers/admin/agents/absences_controller_spec.rb
+++ b/spec/controllers/admin/agents/absences_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Agents::AbsencesController, type: :controller do
+RSpec.describe Admin::Agents::AbsencesController, type: :controller do
   describe "GET index" do
     context "with a signed in agent" do
       let(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Agents::PlageOuverturesController, type: :controller do
+RSpec.describe Admin::Agents::PlageOuverturesController, type: :controller do
   describe "GET index" do
     context "with a signed in agent" do
       let(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/agents/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/agents/rdvs_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Agents::RdvsController, type: :controller do
+RSpec.describe Admin::Agents::RdvsController, type: :controller do
   describe "GET index" do
     context "with a signed in agent" do
       let(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/creneaux/agent_searches_controller_spec.rb
+++ b/spec/controllers/admin/creneaux/agent_searches_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Creneaux::AgentSearchesController, type: :controller do
+RSpec.describe Admin::Creneaux::AgentSearchesController, type: :controller do
   context "with a secretaire signed_in" do
     let(:organisation) { create(:organisation) }
     let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }

--- a/spec/controllers/admin/lieux_controller_spec.rb
+++ b/spec/controllers/admin/lieux_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::LieuxController, type: :controller do
+RSpec.describe Admin::LieuxController, type: :controller do
   render_views
 
   let!(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/organisations_controller_spec.rb
+++ b/spec/controllers/admin/organisations_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::OrganisationsController, type: :controller do
+RSpec.describe Admin::OrganisationsController, type: :controller do
   let!(:territory) { create(:territory) }
   let!(:organisation) { create(:organisation, territory: territory) }
 

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::PlageOuverturesController, type: :controller do
+RSpec.describe Admin::PlageOuverturesController, type: :controller do
   render_views
 
   let!(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/admin/rdv_wizard_steps_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvWizardStepsController, type: :controller do
+RSpec.describe Admin::RdvWizardStepsController, type: :controller do
   let(:motif) { create(:motif) }
   let(:organisation) { motif.organisation }
   let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }

--- a/spec/controllers/admin/rdvs_collectifs/motifs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_collectifs/motifs_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvsCollectifs::MotifsController, type: :controller do
+RSpec.describe Admin::RdvsCollectifs::MotifsController, type: :controller do
   describe "GET index" do
     context "with a signed in agent" do
       let(:organisation) { create(:organisation) }

--- a/spec/controllers/admin/rdvs_collectifs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_collectifs_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvsCollectifsController, type: :controller do
+RSpec.describe Admin::RdvsCollectifsController, type: :controller do
   let(:motif) { create(:motif, :collectif) }
   let(:organisation) { motif.organisation }
   let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvsController, type: :controller do
+RSpec.describe Admin::RdvsController, type: :controller do
   let(:now) { Time.zone.parse("19/07/2019 15:00") }
   let!(:organisation) { create(:organisation) }
   let!(:territory) { organisation.territory }

--- a/spec/controllers/admin/referent_assignations_controller_spec.rb
+++ b/spec/controllers/admin/referent_assignations_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::ReferentAssignationsController, type: :controller do
+RSpec.describe Admin::ReferentAssignationsController, type: :controller do
   describe "#index" do
     it "assigns available agents and respond success" do
       organisation = create(:organisation)

--- a/spec/controllers/admin/slots_controller_spec.rb
+++ b/spec/controllers/admin/slots_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::SlotsController, type: :controller do
+RSpec.describe Admin::SlotsController, type: :controller do
   let(:organisation) { create(:organisation) }
 
   describe "#index" do

--- a/spec/controllers/admin/stats_controller_spec.rb
+++ b/spec/controllers/admin/stats_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::StatsController, type: :controller do
+RSpec.describe Admin::StatsController, type: :controller do
   describe "#rdvs" do
     it "returns sucess" do
       organisation = create(:organisation)

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::AgentRolesController, type: :controller do
+RSpec.describe Admin::Territories::AgentRolesController, type: :controller do
   # Le territoire doit avoir au moins un agent admin de territoire restant
   let!(:territory) { create(:territory).tap { |t| t.roles.create!(agent: create(:agent)) } }
 

--- a/spec/controllers/admin/territories/motif_categories_controller_spec.rb
+++ b/spec/controllers/admin/territories/motif_categories_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::MotifCategoriesController, type: :controller do
+RSpec.describe Admin::Territories::MotifCategoriesController, type: :controller do
   describe "#update" do
     it "responds redirect" do
       territory = create(:territory)

--- a/spec/controllers/admin/territories/motif_fields_controller_spec.rb
+++ b/spec/controllers/admin/territories/motif_fields_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::MotifFieldsController, type: :controller do
+RSpec.describe Admin::Territories::MotifFieldsController, type: :controller do
   describe "#edit" do
     it "responds success" do
       territory = create(:territory)

--- a/spec/controllers/admin/territories/rdv_fields_controller_spec.rb
+++ b/spec/controllers/admin/territories/rdv_fields_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::RdvFieldsController, type: :controller do
+RSpec.describe Admin::Territories::RdvFieldsController, type: :controller do
   describe "#edit" do
     it "responds success" do
       territory = create(:territory)

--- a/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
+++ b/spec/controllers/admin/territories/sectorisation_tests_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::SectorisationTestsController, type: :controller do
+RSpec.describe Admin::Territories::SectorisationTestsController, type: :controller do
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
   let(:agent) { create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory]) }

--- a/spec/controllers/admin/territories/teams_controller_spec.rb
+++ b/spec/controllers/admin/territories/teams_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::TeamsController, type: :controller do
+RSpec.describe Admin::Territories::TeamsController, type: :controller do
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
 

--- a/spec/controllers/admin/territories/webhook_endpoints_controller_spec.rb
+++ b/spec/controllers/admin/territories/webhook_endpoints_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::Territories::WebhookEndpointsController, type: :controller do
+RSpec.describe Admin::Territories::WebhookEndpointsController, type: :controller do
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
   let(:agent) { create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory]) }

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -1,4 +1,4 @@
-describe TokenInvitable, type: :controller do
+RSpec.describe TokenInvitable, type: :controller do
   controller(ApplicationController) do
     include TokenInvitable
 

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -1,4 +1,4 @@
-describe InclusionConnectController, type: :controller do
+RSpec.describe InclusionConnectController, type: :controller do
   let(:base_url) { "https://test.inclusion.connect.fr" }
 
   describe "#callback" do

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Users::RdvWizardStepsController, type: :controller do
+RSpec.describe Users::RdvWizardStepsController, type: :controller do
   describe "#new" do
     let!(:organisation) { create(:organisation) }
     let!(:user) { create(:user) }

--- a/spec/controllers/users/user_name_initials_verification_controller_spec.rb
+++ b/spec/controllers/users/user_name_initials_verification_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Users::UserNameInitialsVerificationController, type: :controller do
+RSpec.describe Users::UserNameInitialsVerificationController, type: :controller do
   render_views
   let!(:user) { create(:user, last_name: "Dylan") }
 

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -1,4 +1,4 @@
-describe "agents page", js: true do
+RSpec.describe "agents page", js: true do
   it "login is accessible" do
     path = new_agent_session_path
     expect_page_to_be_axe_clean(path)

--- a/spec/features/accessibility/configuration_pages_spec.rb
+++ b/spec/features/accessibility/configuration_pages_spec.rb
@@ -1,4 +1,4 @@
-describe "configuration pages", js: true do
+RSpec.describe "configuration pages", js: true do
   it "index of configuration" do
     territory = create(:territory)
     agent = create(:agent, role_in_territories: [territory])

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -1,4 +1,4 @@
-describe "public pages", js: true do
+RSpec.describe "public pages", js: true do
   it "accessibility_path page is accessible" do
     expect_page_to_be_axe_clean(accessibility_path)
   end

--- a/spec/features/accessibility/users_pages_spec.rb
+++ b/spec/features/accessibility/users_pages_spec.rb
@@ -1,4 +1,4 @@
-describe "users pages", js: true do
+RSpec.describe "users pages", js: true do
   describe "users_rdvs_path page" do
     it "without RDV is accessible" do
       user = create(:user, email: "toto@example.com")

--- a/spec/features/agents/admin_can_configure_agent_access_rights_spec.rb
+++ b/spec/features/agents/admin_can_configure_agent_access_rights_spec.rb
@@ -1,4 +1,4 @@
-describe "Admin can configure the organisation" do
+RSpec.describe "Admin can configure the organisation" do
   let(:territory) { create(:territory) }
   let(:organisation) { create(:organisation, territory: territory) }
 

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -1,4 +1,4 @@
-describe "Admin can configure the organisation" do
+RSpec.describe "Admin can configure the organisation" do
   let!(:organisation) { create(:organisation) }
   let!(:pmi) { create(:service, name: "PMI", territories: [organisation.territory]) }
   let!(:service_social) { create(:service, name: "Service social", territories: [organisation.territory]) }

--- a/spec/features/agents/admin_can_configure_the_territory_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_territory_spec.rb
@@ -1,4 +1,4 @@
-describe "Admin can configure the territory", type: :feature do
+RSpec.describe "Admin can configure the territory", type: :feature do
   context "with admin agent" do
     it "update territory phone number", type: :feature do
       territory = create(:territory, phone_number: nil)

--- a/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
+++ b/spec/features/agents/admin_can_see_the_organisation_stats_spec.rb
@@ -1,4 +1,4 @@
-describe "Admin can configure the organisation" do
+RSpec.describe "Admin can configure the organisation" do
   it "displays all the stats" do
     organisation = create(:organisation)
     agent_admin = create(:agent, admin_role_in_organisations: [organisation])

--- a/spec/features/agents/agent_can_configure_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_configure_online_booking_spec.rb
@@ -1,4 +1,4 @@
-describe "Agents can configure online booking" do
+RSpec.describe "Agents can configure online booking" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, :cnfs, admin_role_in_organisations: [organisation]) }
 

--- a/spec/features/agents/agent_can_configure_their_preferences_spec.rb
+++ b/spec/features/agents/agent_can_configure_their_preferences_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can configure their preferences" do
+RSpec.describe "Agent can configure their preferences" do
   let!(:agent) do
     create(
       :agent,

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can create a Rdv with creneau search" do
+RSpec.describe "Agent can create a Rdv with creneau search" do
   include UsersHelper
 
   before { login_as(agent, scope: :agent) }

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can create a Rdv with wizard" do
+RSpec.describe "Agent can create a Rdv with wizard" do
   include UsersHelper
 
   let(:territory) { create(:territory, enable_context_field: true) }

--- a/spec/features/agents/agent_can_create_relative_and_responsible_spec.rb
+++ b/spec/features/agents/agent_can_create_relative_and_responsible_spec.rb
@@ -1,4 +1,4 @@
-describe "Admin can configure the organisation" do
+RSpec.describe "Admin can configure the organisation" do
   let(:organisation) { create(:organisation) }
   let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can CRUD absences" do
+RSpec.describe "Agent can CRUD absences" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can CRUD intervenants" do
+RSpec.describe "Agent can CRUD intervenants" do
   let(:organisation) { create(:organisation) }
   let!(:service) { create(:service, name: "CDAD", territories: [organisation.territory]) }
   let!(:agent_admin) { create(:agent, service: service, admin_role_in_organisations: [organisation], email: "admin@example.com", first_name: "Francis", last_name: "Admin") }

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can CRUD motifs" do
+RSpec.describe "Agent can CRUD motifs" do
   let(:organisation) { create(:organisation) }
   let!(:service) { create(:service, name: "PMI", territories: [organisation.territory]) }
   let!(:motif) { create(:motif, name: "Suivi bonjour", service: service, organisation: organisation) }

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can CRUD plage d'ouverture" do
+RSpec.describe "Agent can CRUD plage d'ouverture" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service, name: "PMI") }
   let!(:motif) { create(:motif, name: "Suivi bonjour", service: service, organisation: organisation) }

--- a/spec/features/agents/agent_can_destroy_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_destroy_plage_ouverture_spec.rb
@@ -1,4 +1,4 @@
-describe "Admin can configure the organisation" do
+RSpec.describe "Admin can configure the organisation" do
   specify do
     organisation = create(:organisation)
     agent = create(:agent, organisations: [organisation])

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can list RDVs" do
+RSpec.describe "Agent can list RDVs" do
   let!(:organisation) { create(:organisation) }
   let!(:current_agent) { create(:agent, organisations: [organisation]) }
 

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can manage recurrence on plage d'ouverture" do
+RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -1,4 +1,4 @@
-describe "agents can prescribe rdvs" do
+RSpec.describe "agents can prescribe rdvs" do
   before do
     travel_to(now)
     stub_request(

--- a/spec/features/agents/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/agent_can_reset_his_password_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent resets his password spec" do
+RSpec.describe "Agent resets his password spec" do
   let!(:agent) { create(:agent) }
 
   around { |example| perform_enqueued_jobs { example.run } }

--- a/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_search_plage_ouverture_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can search plage ouverture" do
+RSpec.describe "Agent can search plage ouverture" do
   let(:organisation) { create(:organisation) }
   let(:agent) { create(:agent, organisations: [organisation]) }
   let!(:perm_enfance) { create(:plage_ouverture, title: "Permanence Enfance en cours", agent: agent, organisation: organisation) }

--- a/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
+++ b/spec/features/agents/agent_can_see_rdv_in_calendar_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can see rdvs in their calendar", js: true do
+RSpec.describe "Agent can see rdvs in their calendar", js: true do
   context "for a rdv collectif" do
     it "shows the number of participants and the max number of participants" do
       organisation = create(:organisation)

--- a/spec/features/agents/agent_can_see_stats_spec.rb
+++ b/spec/features/agents/agent_can_see_stats_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can see stats" do
+RSpec.describe "Agent can see stats" do
   let!(:territory1) { create(:territory) }
   let!(:organisation1a) { create(:organisation, territory: territory1) }
   let!(:organisation1b) { create(:organisation, territory: territory1) }

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -1,4 +1,4 @@
-describe "can see users' RDV" do
+RSpec.describe "can see users' RDV" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }

--- a/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_sync_his_account_to_outlook_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can sync his account to outlook" do
+RSpec.describe "Agent can sync his account to outlook" do
   let!(:organisation) { create(:organisation) }
   let!(:admin_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -1,4 +1,4 @@
-describe "Agents can try the user-facing online booking pages" do
+RSpec.describe "Agents can try the user-facing online booking pages" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
 

--- a/spec/features/agents/agent_can_unsync_his_account_to_outlook_spec.rb
+++ b/spec/features/agents/agent_can_unsync_his_account_to_outlook_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can unsync his account to outlook" do
+RSpec.describe "Agent can unsync his account to outlook" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, microsoft_graph_token: "super_token", refresh_microsoft_graph_token: "super_refresh_token", basic_role_in_organisations: [organisation]) }
   # Organisation needs at least one admin

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can update a RDV", js: true do
+RSpec.describe "Agent can update a RDV", js: true do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, basic_role_in_organisations: [organisation]) }

--- a/spec/features/agents/calendar_export_spec.rb
+++ b/spec/features/agents/calendar_export_spec.rb
@@ -1,4 +1,4 @@
-describe "Agents can export their calendar to other tools, such as Outlook or Google calendar" do
+RSpec.describe "Agents can export their calendar to other tools, such as Outlook or Google calendar" do
   it "allows resetting the link and shows the agent's name in the link to make it clear that it's their info" do
     uid = "37b24280-7015-4a8a-b752-907e33171106"
     allow(SecureRandom).to receive(:uuid).and_return(uid)

--- a/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
+++ b/spec/features/agents/rdv_collectifs/finding_creneau_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can find a creneau for a rdv collectif" do
+RSpec.describe "Agent can find a creneau for a rdv collectif" do
   let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
   let!(:motif) do
     create(:motif, :collectif, name: "Atelier participatif", organisation: organisation, service: service)

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can see RDV details correctly" do
+RSpec.describe "Agent can see RDV details correctly" do
   before do
     travel_to(Time.zone.local(2022, 4, 4))
     login_as(agent, scope: :agent)

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can create a Rdv collectif from the agenda" do
+RSpec.describe "Agent can create a Rdv collectif from the agenda" do
   include UsersHelper
 
   let!(:organisation) { create(:organisation) }

--- a/spec/features/agents/rdvs_collectifs/duplicating_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/duplicating_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can duplicate a Rdv collectif" do
+RSpec.describe "Agent can duplicate a Rdv collectif" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, first_name: "Alain", last_name: "Tiptop", service: service, admin_role_in_organisations: [organisation]) }

--- a/spec/features/agents/rdvs_collectifs/editing_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/editing_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can edit a Rdv collectif" do
+RSpec.describe "Agent can edit a Rdv collectif" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can organize a rdv collectif", js: true do
+RSpec.describe "Agent can organize a rdv collectif", js: true do
   let(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service, first_name: "Alain", last_name: "DIALO") }
   let!(:motif) do
     create(:motif, :collectif, name: "Atelier participatif", organisation: organisation, service: service)

--- a/spec/features/agents/relatives/agent_can_create_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_create_relative_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can create a relative" do
+RSpec.describe "Agent can create a relative" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do

--- a/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_delete_relative_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can delete a relative" do
+RSpec.describe "Agent can delete a relative" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do

--- a/spec/features/agents/relatives/agent_can_update_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_update_relative_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can update a relative" do
+RSpec.describe "Agent can update a relative" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do

--- a/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can create user" do
+RSpec.describe "Agent can create user" do
   include_context "rdv_mairie_api_authentication"
 
   let!(:organisation) { create(:organisation, name: "Mairie de Romainville") }

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can create user" do
+RSpec.describe "Agent can create user" do
   let!(:organisation) { create(:organisation, name: "MDS des Champs") }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do

--- a/spec/features/agents/users/agent_can_delete_user_spec.rb
+++ b/spec/features/agents/users/agent_can_delete_user_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can delete user" do
+RSpec.describe "Agent can delete user" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) { create(:user, first_name: "Lala", last_name: "LAND", organisations: [organisation]) }

--- a/spec/features/agents/users/agent_can_display_user_spec.rb
+++ b/spec/features/agents/users/agent_can_display_user_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can display user" do
+RSpec.describe "Agent can display user" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 

--- a/spec/features/agents/users/agent_can_merge_users_spec.rb
+++ b/spec/features/agents/users/agent_can_merge_users_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can delete user" do
+RSpec.describe "Agent can delete user" do
   let!(:organisation) { create(:organisation, territory: territory) }
   let!(:territory) { create(:territory, enable_logement_field: true) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -1,4 +1,4 @@
-describe "Agent can update user" do
+RSpec.describe "Agent can update user" do
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do

--- a/spec/features/agents/users/users_spec.rb
+++ b/spec/features/agents/users/users_spec.rb
@@ -1,4 +1,4 @@
-describe "can search users" do
+RSpec.describe "can search users" do
   context "when user is visible only in organisation" do
     it "can't see user that match search query from other organsiation" do
       territory = create(:territory, visible_users_throughout_the_territory: false)

--- a/spec/features/allocation_for_search_context_spec.rb
+++ b/spec/features/allocation_for_search_context_spec.rb
@@ -1,4 +1,4 @@
-describe "Allocation For Search Context" do
+RSpec.describe "Allocation For Search Context" do
   it "stay under 5500" do
     departement_number = "75"
     address = "20 avenue de Ségur 75007 Paris"

--- a/spec/features/anybody/anybody_can_see_legal_pages_spec.rb
+++ b/spec/features/anybody/anybody_can_see_legal_pages_spec.rb
@@ -1,4 +1,4 @@
-describe "Anybody can see legal pages" do
+RSpec.describe "Anybody can see legal pages" do
   it "displays legal mention" do
     visit root_path
     expect(page).to have_content("Mentions Légales")

--- a/spec/features/anybody/anybody_can_see_stats_spec.rb
+++ b/spec/features/anybody/anybody_can_see_stats_spec.rb
@@ -1,4 +1,4 @@
-describe "Anybody can see stats" do
+RSpec.describe "Anybody can see stats" do
   it "displays all the stats" do
     visit root_path
     click_link "Statistiques"

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -1,4 +1,4 @@
-describe "Creating a new account for a new project, other than a mairie", js: true do
+RSpec.describe "Creating a new account for a new project, other than a mairie", js: true do
   let(:super_admin) { create(:super_admin, :support) }
 
   let(:autocomplete_response) do

--- a/spec/features/super_admin/creating_a_new_mairie_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_mairie_account_spec.rb
@@ -1,4 +1,4 @@
-describe "Creating a new account for a mairie", js: true do
+RSpec.describe "Creating a new account for a mairie", js: true do
   let(:super_admin) { create :super_admin }
   let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }
   let!(:passport_motif_category) { create(:motif_category, name: Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME) }

--- a/spec/features/super_admin/migrating_an_agent_spec.rb
+++ b/spec/features/super_admin/migrating_an_agent_spec.rb
@@ -1,4 +1,4 @@
-describe "Migrating an agent from one organisation to another" do
+RSpec.describe "Migrating an agent from one organisation to another" do
   let(:super_admin) { create :super_admin }
   let!(:old_organisation) { create :organisation }
   let!(:new_organisation) { create :organisation, territory: old_organisation.territory }

--- a/spec/features/super_admin/use_correct_history_version_spec.rb
+++ b/spec/features/super_admin/use_correct_history_version_spec.rb
@@ -1,4 +1,4 @@
-describe "Use correct history version when a super admin is logged in and use impersonate" do
+RSpec.describe "Use correct history version when a super admin is logged in and use impersonate" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }

--- a/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
@@ -1,4 +1,4 @@
-describe "territory admin can manage agents", type: :feature do
+RSpec.describe "territory admin can manage agents", type: :feature do
   let(:territory) { create(:territory, departement_number: "62") }
   let(:organisation) { create(:organisation, territory: territory) }
 

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -1,4 +1,4 @@
-describe "User can select a creneau" do
+RSpec.describe "User can select a creneau" do
   let(:now) { Time.zone.parse("2021-12-13 8:00") }
 
   let!(:territory92) { create(:territory, departement_number: "92") }

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -1,4 +1,4 @@
-describe "User can search for rdvs" do
+RSpec.describe "User can search for rdvs" do
   let(:now) { Time.zone.parse("2021-12-13 8:00") }
 
   around { |example| perform_enqueued_jobs { example.run } }

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -1,4 +1,4 @@
-describe "User can search rdv on rdv mairie" do
+RSpec.describe "User can search rdv on rdv mairie" do
   include_context "rdv_mairie_api_authentication"
 
   let(:now) { Time.zone.parse("2021-12-13 8:00") }

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -1,4 +1,4 @@
-describe "User can search rdv on rdv service public" do
+RSpec.describe "User can search rdv on rdv service public" do
   include_context "rdv_mairie_api_authentication"
 
   let(:now) { Time.zone.parse("2021-12-13 8:00") }

--- a/spec/features/users/online_booking/sectorisation_with_two_territories_spec.rb
+++ b/spec/features/users/online_booking/sectorisation_with_two_territories_spec.rb
@@ -1,4 +1,4 @@
-describe "Prise de rdv avec sectorisations pour deux territoires dans le même département" do
+RSpec.describe "Prise de rdv avec sectorisations pour deux territoires dans le même département" do
   let!(:territory_medico_social) { create(:territory, name: "Drome social", departement_number: "26") }
   let!(:territory_insertion) { create(:territory, name: "Drome insertion", departement_number: "26") }
 

--- a/spec/features/users/online_booking/with_invitation_spec.rb
+++ b/spec/features/users/online_booking/with_invitation_spec.rb
@@ -1,4 +1,4 @@
-describe "User can be invited" do
+RSpec.describe "User can be invited" do
   around { |example| perform_enqueued_jobs { example.run } }
 
   # needed for encrypted cookies

--- a/spec/features/users/user_can_change_rdv_participant_spec.rb
+++ b/spec/features/users/user_can_change_rdv_participant_spec.rb
@@ -1,4 +1,4 @@
-describe "User can change rdv participant" do
+RSpec.describe "User can change rdv participant" do
   let(:rdv) { create(:rdv) }
   let(:user) { rdv.users.first }
   let!(:child) { create(:user, first_name: "Petit", last_name: "BEBE", responsible_id: user.id) }

--- a/spec/features/users/user_can_login_using_france_connect_spec.rb
+++ b/spec/features/users/user_can_login_using_france_connect_spec.rb
@@ -1,4 +1,4 @@
-describe "User can login using FranceConnect" do
+RSpec.describe "User can login using FranceConnect" do
   before do
     mock_france_connect_profile = {
       sub: "12345",

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -1,4 +1,4 @@
-describe "User can manage their rdvs" do
+RSpec.describe "User can manage their rdvs" do
   let(:rdv) { create(:rdv, starts_at: starts_at) }
   let(:user) { rdv.users.first }
 

--- a/spec/features/users/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/user_can_reset_his_password_spec.rb
@@ -1,4 +1,4 @@
-describe "User resets his password spec" do
+RSpec.describe "User resets his password spec" do
   let!(:user) { create(:user) }
 
   around { |example| perform_enqueued_jobs { example.run } }

--- a/spec/features/users/user_can_see_rdv_instruction_spec.rb
+++ b/spec/features/users/user_can_see_rdv_instruction_spec.rb
@@ -1,4 +1,4 @@
-describe "User can see RDV instructions" do
+RSpec.describe "User can see RDV instructions" do
   it "can see RDV inscrution on RDV page" do
     motif = create(:motif, restriction_for_rdv: "Pensez à prendre votre carnet de santé")
     rdv = create(:rdv, motif: motif)

--- a/spec/features/users/user_can_update_their_information_spec.rb
+++ b/spec/features/users/user_can_update_their_information_spec.rb
@@ -1,4 +1,4 @@
-describe "User can update their information" do
+RSpec.describe "User can update their information" do
   let!(:organisation) { create(:organisation, territory: territory) }
   let(:user) { create(:user, organisations: [organisation]) }
 

--- a/spec/features/users/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/user_signs_up_and_signs_in_spec.rb
@@ -1,4 +1,4 @@
-describe "User signs up and signs in" do
+RSpec.describe "User signs up and signs in" do
   around { |example| perform_enqueued_jobs { example.run } }
 
   context "for regular new user" do

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -1,4 +1,4 @@
-describe "User views his rdv" do
+RSpec.describe "User views his rdv" do
   let!(:organisation) { create(:organisation) }
   let(:user) { create(:user, organisations: [organisation]) }
 

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::EditRdvForm, type: :form do
+RSpec.describe Admin::EditRdvForm, type: :form do
   let(:organisation) { create(:organisation) }
   let(:agent) { create(:agent) }
   let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }

--- a/spec/form_models/admin/rdv_form_concern_spec.rb
+++ b/spec/form_models/admin/rdv_form_concern_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvFormConcern, type: :form do
+RSpec.describe Admin::RdvFormConcern, type: :form do
   subject(:form) { dummy_form_class.new(rdv, agent_author) }
 
   let(:dummy_form_class) do

--- a/spec/form_models/admin/rdv_search_form_spec.rb
+++ b/spec/form_models/admin/rdv_search_form_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvSearchForm do
+RSpec.describe Admin::RdvSearchForm do
   describe "#lieu" do
     it "have a lieu when given" do
       lieu = create(:lieu)

--- a/spec/form_models/admin/rdv_wizard_form/step1_spec.rb
+++ b/spec/form_models/admin/rdv_wizard_form/step1_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvWizardForm::Step1 do
+RSpec.describe Admin::RdvWizardForm::Step1 do
   let(:organisation) { build(:organisation) }
   let!(:agent) { create(:agent) }
   let!(:user) { create(:user) }

--- a/spec/form_models/admin/rdv_wizard_form/step2_spec.rb
+++ b/spec/form_models/admin/rdv_wizard_form/step2_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::RdvWizardForm::Step2 do
+RSpec.describe Admin::RdvWizardForm::Step2 do
   let(:organisation) { build(:organisation) }
   let!(:agent) { create(:agent) }
   let!(:user) { create(:user) }

--- a/spec/form_models/admin/user_form_spec.rb
+++ b/spec/form_models/admin/user_form_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::UserForm, type: :form do
+RSpec.describe Admin::UserForm, type: :form do
   subject { described_class.new(user, view_locals: { current_organisation: organisation }) }
 
   let!(:organisation) { create(:organisation) }

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -1,4 +1,4 @@
-describe MergeUsersForm, type: :form do
+RSpec.describe MergeUsersForm, type: :form do
   let(:organisation) { create(:organisation) }
 
   it "is valid when no franceConnected user" do

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -1,4 +1,4 @@
-describe UserRdvWizard do
+RSpec.describe UserRdvWizard do
   let!(:organisation) { create(:organisation) }
   let!(:user) { create(:user) }
   let!(:user_for_rdv) { create(:user) }

--- a/spec/form_models/users/registration_form_spec.rb
+++ b/spec/form_models/users/registration_form_spec.rb
@@ -1,4 +1,4 @@
-describe Users::RegistrationForm, type: :form_model do
+RSpec.describe Users::RegistrationForm, type: :form_model do
   let(:attributes) do
     {
       first_name: "jean",

--- a/spec/helpers/absences_helper_spec.rb
+++ b/spec/helpers/absences_helper_spec.rb
@@ -1,4 +1,4 @@
-describe AbsencesHelper do
+RSpec.describe AbsencesHelper do
   describe "#absence_tag" do
     it "return En cours when absence is today" do
       today = Time.zone.parse("2020-12-24 13:56")

--- a/spec/helpers/agents_helper_spec.rb
+++ b/spec/helpers/agents_helper_spec.rb
@@ -1,4 +1,4 @@
-describe AgentsHelper do
+RSpec.describe AgentsHelper do
   describe "#build_link_to_rdv_wizard_params" do
     it "step 2 par défaut" do
       creneau = Creneau.new

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -1,4 +1,4 @@
-describe DateHelper do
+RSpec.describe DateHelper do
   describe "#relative_date" do
     # def relative_date(date, fallback_format = :short)
     it "returns 23 déc." do

--- a/spec/helpers/lieux_helper_spec.rb
+++ b/spec/helpers/lieux_helper_spec.rb
@@ -1,4 +1,4 @@
-describe LieuxHelper do
+RSpec.describe LieuxHelper do
   describe ".lieu_tag" do
     context "when the lieu is nil" do
       it { expect(lieu_tag(nil)).to be_nil }

--- a/spec/helpers/motifs_helper_spec.rb
+++ b/spec/helpers/motifs_helper_spec.rb
@@ -1,4 +1,4 @@
-describe MotifsHelper do
+RSpec.describe MotifsHelper do
   describe "#motif_badges" do
     it "affiche le badge Secrétariat pour un motif `secretariat`" do
       motif = build(:motif, bookable_by: :agents, for_secretariat: true)

--- a/spec/helpers/online_bookings_helper_spec.rb
+++ b/spec/helpers/online_bookings_helper_spec.rb
@@ -1,4 +1,4 @@
-describe OnlineBookingsHelper do
+RSpec.describe OnlineBookingsHelper do
   describe "#motifs_checkbox_text" do
     context "when there is no motifs" do
       it { expect(motifs_checkbox_text([])).to match(/Ouvrir un motif à la réservation en ligne/) }

--- a/spec/helpers/paper_trail_helper_spec.rb
+++ b/spec/helpers/paper_trail_helper_spec.rb
@@ -1,4 +1,4 @@
-describe PaperTrailHelper do
+RSpec.describe PaperTrailHelper do
   describe "#paper_trail_change_value" do
     it "returns N/A when nil value" do
       expect(helper.paper_trail_change_value("some_value", nil)).to eq("N/A")

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -1,4 +1,4 @@
-describe PlageOuverturesHelper do
+RSpec.describe PlageOuverturesHelper do
   let(:now) { Time.zone.parse("2021-12-23 09:00") }
 
   before do

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -1,4 +1,4 @@
-describe RdvsHelper do
+RSpec.describe RdvsHelper do
   include ActionView::Helpers::DateHelper
 
   let(:motif) { build(:motif, name: "Consultation normale") }

--- a/spec/helpers/user_notifications_helper_spec.rb
+++ b/spec/helpers/user_notifications_helper_spec.rb
@@ -1,4 +1,4 @@
-describe UserNotificationsHelper do
+RSpec.describe UserNotificationsHelper do
   describe "#user_notifiable_by_sms_text" do
     it "allow SMS notifications" do
       user = build(:user, phone_number: "06 65 87 89 53")

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,4 +1,4 @@
-describe UsersHelper, type: :helper do
+RSpec.describe UsersHelper, type: :helper do
   describe "#age" do
     it "return 4 ans when born 4 years ago" do
       user = build(:user, birth_date: 4.years.ago)

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,4 +1,4 @@
-describe ApplicationJob, type: :job do
+RSpec.describe ApplicationJob, type: :job do
   describe "error logging" do
     let(:job_class) do
       stub_const "MyJob", Class.new(described_class)

--- a/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
@@ -1,4 +1,4 @@
-describe CronJob::DestroyInactiveAgents do
+RSpec.describe CronJob::DestroyInactiveAgents do
   it "warns and deletes old agents" do
     # agents that will not be modified
     agent_created_12_months_ago_with_warning = travel_to(12.months.ago) { create(:agent, account_deletion_warning_sent_at: Time.zone.now) }

--- a/spec/jobs/cron_job/destroy_old_plage_ouverture_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_plage_ouverture_job_spec.rb
@@ -1,4 +1,4 @@
-describe CronJob::DestroyOldPlageOuvertureJob do
+RSpec.describe CronJob::DestroyOldPlageOuvertureJob do
   it "Destroy exceptional po closed since 2 years" do
     now = Time.zone.parse("20220405 10:00")
     travel_to(now)

--- a/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_accounts_job_spec.rb
+++ b/spec/jobs/cron_job/destroy_old_rdvs_and_inactive_accounts_job_spec.rb
@@ -1,4 +1,4 @@
-describe CronJob::DestroyOldRdvsAndInactiveAccountsJob do
+RSpec.describe CronJob::DestroyOldRdvsAndInactiveAccountsJob do
   let!(:organisation) { create(:organisation) }
   let!(:webhook_endpoint) do
     create(

--- a/spec/jobs/cron_job/update_expirations_job_spec.rb
+++ b/spec/jobs/cron_job/update_expirations_job_spec.rb
@@ -1,4 +1,4 @@
-describe CronJob::UpdateExpirationsJob, type: :job do
+RSpec.describe CronJob::UpdateExpirationsJob, type: :job do
   let(:now) { Time.zone.parse("20211015 8:50") }
 
   before do

--- a/spec/jobs/participations_export_job_spec.rb
+++ b/spec/jobs/participations_export_job_spec.rb
@@ -1,4 +1,4 @@
-describe ParticipationsExportJob do
+RSpec.describe ParticipationsExportJob do
   describe "#participations_export" do
     it "has an attachment which contains the current date" do
       organisation = create(:organisation)

--- a/spec/jobs/rdvs_export_job_spec.rb
+++ b/spec/jobs/rdvs_export_job_spec.rb
@@ -1,4 +1,4 @@
-describe RdvsExportJob do
+RSpec.describe RdvsExportJob do
   describe "#rdv_export" do
     it "has an attachment file name which contains the current date without org ID when more than one orga" do
       organisation = create(:organisation)

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -1,4 +1,4 @@
-describe SmsJob do
+RSpec.describe SmsJob do
   describe "phone number validation" do
     subject(:perform) do
       described_class.new.perform(

--- a/spec/jobs/trigger_webhook_job_spec.rb
+++ b/spec/jobs/trigger_webhook_job_spec.rb
@@ -1,4 +1,4 @@
-describe TriggerWebhookJob, type: :job do
+RSpec.describe TriggerWebhookJob, type: :job do
   subject do
     described_class.perform_now(webhook_endpoint_id)
   end

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -1,4 +1,4 @@
-describe WebhookJob, type: :job do
+RSpec.describe WebhookJob, type: :job do
   describe "#perform" do
     let(:payload) { "{}" }
     let(:webhook_endpoint) { create(:webhook_endpoint, secret: "bla", target_url: "https://example.com/rdv-s-endpoint") }

--- a/spec/lib/csv_or_xls_reader/importer_spec.rb
+++ b/spec/lib/csv_or_xls_reader/importer_spec.rb
@@ -1,4 +1,4 @@
-describe CsvOrXlsReader::Importer do
+RSpec.describe CsvOrXlsReader::Importer do
   subject { described_class.new(form_file).rows }
 
   let(:form_file) { double }

--- a/spec/lib/geo_coding_spec.rb
+++ b/spec/lib/geo_coding_spec.rb
@@ -1,4 +1,4 @@
-describe GeoCoding do
+RSpec.describe GeoCoding do
   describe "#find_geo_coordinates" do
     before do
       stub_request(

--- a/spec/lib/lapin/range_spec.rb
+++ b/spec/lib/lapin/range_spec.rb
@@ -1,4 +1,4 @@
-describe Lapin::Range do
+RSpec.describe Lapin::Range do
   describe "#ensure_date_range_with_time" do
     subject { described_class.ensure_date_range_with_time(date_range) }
 

--- a/spec/lib/phone_number_validation_spec.rb
+++ b/spec/lib/phone_number_validation_spec.rb
@@ -1,4 +1,4 @@
-describe PhoneNumberValidation do
+RSpec.describe PhoneNumberValidation do
   describe "parsed_number" do
     it "prevents malformed numbers" do
       expect(described_class.parsed_number("wrong value")).to be_nil

--- a/spec/mailers/agents/absence_mailer_spec.rb
+++ b/spec/mailers/agents/absence_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe Agents::AbsenceMailer, type: :mailer do
+RSpec.describe Agents::AbsenceMailer, type: :mailer do
   { created: "créée", updated: "modifiée", destroyed: "supprimée" }.each do |action, verb|
     context "when #{action}" do
       let(:agent) { create(:agent, email: "bob@demo.rdv-solidarites.fr", basic_role_in_organisations: [create(:organisation)]) }

--- a/spec/mailers/agents/plage_ouverture_mailer_spec.rb
+++ b/spec/mailers/agents/plage_ouverture_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe Agents::PlageOuvertureMailer, type: :mailer do
+RSpec.describe Agents::PlageOuvertureMailer, type: :mailer do
   { created: "créée", updated: "modifiée", destroyed: "supprimée" }.each do |action, verb|
     context "when #{action}" do
       let(:agent) { create(:agent, email: "bob@demo.rdv-solidarites.fr") }

--- a/spec/mailers/concerns/ics_multipart_attached_spec.rb
+++ b/spec/mailers/concerns/ics_multipart_attached_spec.rb
@@ -1,6 +1,6 @@
 # This specs checks that the ICS attachments are added correctly.
 # It was after a bug was discovered: several copies of the ICS file were present.
-describe IcsMultipartAttached, type: :mailer do
+RSpec.describe IcsMultipartAttached, type: :mailer do
   let(:agent) { create(:agent, email: "bob@demo.rdv-solidarites.fr") }
   let(:plage_ouverture) { create :plage_ouverture, agent: agent }
 

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -1,4 +1,4 @@
-describe CustomDeviseMailer, "#domain" do
+RSpec.describe CustomDeviseMailer, "#domain" do
   subject(:sent_email) { described_class.reset_password_instructions(user, "t0k3n") }
 
   def expect_to_use_domain(domain)

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -1,4 +1,4 @@
-describe Absence, type: :model do
+RSpec.describe Absence, type: :model do
   it_behaves_like "recurrence"
 
   describe "title mandatory" do

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -1,4 +1,4 @@
-describe AgentRole, type: :model do
+RSpec.describe AgentRole, type: :model do
   describe "#can_access_others_planning?" do
     subject { agent_role.can_access_others_planning? }
 

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1,4 +1,4 @@
-describe Agent, type: :model do
+RSpec.describe Agent, type: :model do
   describe "#soft_delete" do
     context "with remaining organisations attached" do
       let(:organisation) { create(:organisation) }

--- a/spec/models/agent_territorial_role_spec.rb
+++ b/spec/models/agent_territorial_role_spec.rb
@@ -1,4 +1,4 @@
-describe AgentTerritorialRole, type: :model do
+RSpec.describe AgentTerritorialRole, type: :model do
   describe "#territory_has_at_least_one_role_before_destroy" do
     context "there is another agent with territory role" do
       let!(:territory) { create(:territory) }

--- a/spec/models/concerns/can_have_territorial_access_spec.rb
+++ b/spec/models/concerns/can_have_territorial_access_spec.rb
@@ -1,4 +1,4 @@
-describe CanHaveTerritorialAccess, type: :concern do
+RSpec.describe CanHaveTerritorialAccess, type: :concern do
   describe "#territorial_admin!" do
     it "update agent territorial admin access to true" do
       territory = create(:territory)

--- a/spec/models/concerns/expiration_spec.rb
+++ b/spec/models/concerns/expiration_spec.rb
@@ -1,4 +1,4 @@
-describe Expiration, type: :concern do
+RSpec.describe Expiration, type: :concern do
   shared_examples "#expired?" do
     def build(factory, params)
       # Absence has a :end_day attribute, but not PlageOuverture

--- a/spec/models/concerns/full_name_concern_spec.rb
+++ b/spec/models/concerns/full_name_concern_spec.rb
@@ -1,4 +1,4 @@
-describe FullNameConcern do
+RSpec.describe FullNameConcern do
   let(:marie) { build :user, first_name: "Marie", last_name: "Curie", birth_name: "Skłodowska" }
   let(:pierre) { build :user, first_name: "Pierre", last_name: "Curie", birth_name: "" }
 

--- a/spec/models/concerns/human_attribute_value_spec.rb
+++ b/spec/models/concerns/human_attribute_value_spec.rb
@@ -20,7 +20,7 @@ class DemoThing
   end
 end
 
-describe HumanAttributeValue do
+RSpec.describe HumanAttributeValue do
   describe "#human_attribute_value" do
     subject { DemoThing.human_attribute_value(attr_name, value, options) }
 

--- a/spec/models/concerns/ical_helpers/ics_spec.rb
+++ b/spec/models/concerns/ical_helpers/ics_spec.rb
@@ -1,4 +1,4 @@
-describe IcalHelpers::Ics do
+RSpec.describe IcalHelpers::Ics do
   describe "from_payload" do
     subject { described_class.from_payload(payload).to_ical }
 

--- a/spec/models/concerns/ical_helpers/rrule_spec.rb
+++ b/spec/models/concerns/ical_helpers/rrule_spec.rb
@@ -1,4 +1,4 @@
-describe IcalHelpers::Rrule do
+RSpec.describe IcalHelpers::Rrule do
   describe "#from_recurrence" do
     subject { described_class.from_recurrence(recurrence) }
 

--- a/spec/models/concerns/payloads/absence_spec.rb
+++ b/spec/models/concerns/payloads/absence_spec.rb
@@ -1,4 +1,4 @@
-describe Payloads::Absence do
+RSpec.describe Payloads::Absence do
   describe "#payload" do
     %i[name starts_at recurrence ical_uid ends_at].each do |key|
       it "return an hash with key #{key}" do

--- a/spec/models/concerns/payloads/plage_ouverture_spec.rb
+++ b/spec/models/concerns/payloads/plage_ouverture_spec.rb
@@ -1,4 +1,4 @@
-describe Payloads::PlageOuverture do
+RSpec.describe Payloads::PlageOuverture do
   describe "#payload" do
     %i[name starts_at recurrence ical_uid ends_at].each do |key|
       it "return an hash with key #{key}" do

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -1,4 +1,4 @@
-describe Payloads::Rdv, type: :service do
+RSpec.describe Payloads::Rdv, type: :service do
   describe "#payload" do
     %i[name ical_uid summary ends_at description address].each do |key|
       it "return an hash with key #{key}" do

--- a/spec/models/concerns/rdv/authored_concern_spec.rb
+++ b/spec/models/concerns/rdv/authored_concern_spec.rb
@@ -1,4 +1,4 @@
-describe Rdv::AuthoredConcern, type: :concern do
+RSpec.describe Rdv::AuthoredConcern, type: :concern do
   describe ".author" do
     let(:rdv) { create(:rdv) }
 

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -1,4 +1,4 @@
-describe RecurrenceConcern do
+RSpec.describe RecurrenceConcern do
   shared_examples "#set_recurrence_ends_at" do
     it "set to ends of day of last occurrence" do
       first_day = Date.new(2019, 8, 15)

--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -1,4 +1,4 @@
-describe TextSearch, type: :concern do
+RSpec.describe TextSearch, type: :concern do
   # Tester les methods du concerns sans un objet des modèles...
   # Peut-être difficile sans activerecord ?
 

--- a/spec/models/concerns/user/franceconnect_frozen_fields_concern_spec.rb
+++ b/spec/models/concerns/user/franceconnect_frozen_fields_concern_spec.rb
@@ -1,4 +1,4 @@
-describe User::FranceconnectFrozenFieldsConcern do
+RSpec.describe User::FranceconnectFrozenFieldsConcern do
   context "never logged with FC" do
     let!(:user) { create(:user, first_name: "Jean", birth_name: "DUPONT", logged_once_with_franceconnect: false) }
 

--- a/spec/models/concerns/user/improved_unicity_error_concern_spec.rb
+++ b/spec/models/concerns/user/improved_unicity_error_concern_spec.rb
@@ -1,4 +1,4 @@
-describe User::ImprovedUnicityErrorConcern do
+RSpec.describe User::ImprovedUnicityErrorConcern do
   context "email is not yet taken" do
     let(:user) { build(:user) }
 

--- a/spec/models/concerns/user/notificable_concern_spec.rb
+++ b/spec/models/concerns/user/notificable_concern_spec.rb
@@ -1,4 +1,4 @@
-describe User::NotificableConcern do
+RSpec.describe User::NotificableConcern do
   describe "#notifiable_by_email?" do
     subject { user.notifiable_by_email? }
 

--- a/spec/models/concerns/webhook_deliverable_spec.rb
+++ b/spec/models/concerns/webhook_deliverable_spec.rb
@@ -1,4 +1,4 @@
-describe WebhookDeliverable, type: :concern do
+RSpec.describe WebhookDeliverable, type: :concern do
   include ActiveJob::TestHelper
 
   let!(:organisation) { create(:organisation) }

--- a/spec/models/creneau_spec.rb
+++ b/spec/models/creneau_spec.rb
@@ -1,4 +1,4 @@
-describe Creneau, type: :model do
+RSpec.describe Creneau, type: :model do
   let(:organisation) { create(:organisation) }
   let!(:motif) { create(:motif, name: "Vaccination", default_duration_in_min: 30, organisation: organisation) }
   let!(:lieu) { create(:lieu, organisation: organisation) }

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,4 +1,4 @@
-describe Domain do
+RSpec.describe Domain do
   it "has domains initialized with all the required keys" do
     Domain::ALL.each do |domain|
       expect(domain.to_h.compact.keys).to match_array(described_class.members)

--- a/spec/models/factories_spec.rb
+++ b/spec/models/factories_spec.rb
@@ -1,5 +1,5 @@
 FactoryBot.factories.each do |factory|
-  describe "The #{factory.name} factory" do
+  RSpec.describe "The #{factory.name} factory" do
     it "is valid" do
       expect(build(factory.name)).to be_valid
     end

--- a/spec/models/file_attente_spec.rb
+++ b/spec/models/file_attente_spec.rb
@@ -1,4 +1,4 @@
-describe FileAttente, type: :model do
+RSpec.describe FileAttente, type: :model do
   let(:now) { Time.zone.parse("01-01-2019 09:00 +0100") }
 
   before do

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -1,4 +1,4 @@
-describe Lieu, type: :model do
+RSpec.describe Lieu, type: :model do
   let!(:territory) { create(:territory, departement_number: "62") }
   let!(:organisation) { create(:organisation, territory: territory) }
   let!(:user) { create(:user) }

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -1,4 +1,4 @@
-describe Motif, type: :model do
+RSpec.describe Motif, type: :model do
   let(:secretariat) { create(:service, :secretariat) }
   let(:motif) { create(:motif, organisation: organisation) }
   let!(:organisation) { create(:organisation) }

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,4 +1,4 @@
-describe Organisation, type: :model do
+RSpec.describe Organisation, type: :model do
   describe ".contactable" do
     it "return nothing when no organisation" do
       expect(described_class.contactable).to be_empty

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -1,4 +1,4 @@
-describe Outlook::ApiClient do
+RSpec.describe Outlook::ApiClient do
   let(:organisation) { create(:organisation) }
   let(:expected_body) do
     {

--- a/spec/models/paper_trail_version_spec.rb
+++ b/spec/models/paper_trail_version_spec.rb
@@ -1,4 +1,4 @@
-describe "PaperTrail::Version" do
+RSpec.describe "PaperTrail::Version" do
   describe "changes" do
     it "can read changes" do
       user = create(:user, first_name: "Frédérique")

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -1,4 +1,4 @@
-describe Participation, type: :model do
+RSpec.describe Participation, type: :model do
   describe "Participation is getting Rdv parent status" do
     %w[collectif individuel].each do |rdv_type|
       describe "For #{rdv_type} rdv" do

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -1,4 +1,4 @@
-describe PlageOuverture, type: :model do
+RSpec.describe PlageOuverture, type: :model do
   let!(:organisation) { create(:organisation) }
 
   describe "#end_after_start" do

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -1,4 +1,4 @@
-describe Rdv, type: :model do
+RSpec.describe Rdv, type: :model do
   describe "#starts_at_is_plausible" do
     let(:now) { Time.zone.parse("2021-05-03 14h00") }
     let(:rdv) { build :rdv, starts_at: starts_at }

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -1,4 +1,4 @@
-describe Service, type: :model do
+RSpec.describe Service, type: :model do
   describe "#pmi?" do
     it "returns false when social service" do
       expect(build(:service, :social).pmi?).to be false

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -1,4 +1,4 @@
-describe Stat, type: :model do
+RSpec.describe Stat, type: :model do
   describe "#rdvs_group_by_type" do
     it "return empty hash without rdv" do
       stats = described_class.new(rdvs: Rdv.all)

--- a/spec/models/super_admin_spec.rb
+++ b/spec/models/super_admin_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin, type: :model do
+RSpec.describe SuperAdmin, type: :model do
   let(:super_admin) { create(:super_admin) }
 
   describe "validations" do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,4 +1,4 @@
-describe Team, type: :model do
+RSpec.describe Team, type: :model do
   describe "validation" do
     it "invalid without name" do
       expect(build(:team, name: "")).to be_invalid

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -1,4 +1,4 @@
-describe Territory, type: :model do
+RSpec.describe Territory, type: :model do
   it "have a valid factory" do
     expect(build(:territory)).to be_valid
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-describe User, type: :model do
+RSpec.describe User, type: :model do
   describe "#add_organisation" do
     subject do
       user.add_organisation(organisation)

--- a/spec/models/webhook_endpoint_spec.rb
+++ b/spec/models/webhook_endpoint_spec.rb
@@ -1,4 +1,4 @@
-describe WebhookEndpoint, type: :model do
+RSpec.describe WebhookEndpoint, type: :model do
   describe "target_url validation" do
     subject { webhook_endpoint.valid? }
 

--- a/spec/policies/agent/absence_policy_spec.rb
+++ b/spec/policies/agent/absence_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::AbsencePolicy, type: :policy do
+RSpec.describe Agent::AbsencePolicy, type: :policy do
   subject { described_class }
 
   let(:pundit_context) { AgentContext.new(agent) }
@@ -41,7 +41,7 @@ describe Agent::AbsencePolicy, type: :policy do
   end
 end
 
-describe Agent::AbsencePolicy::Scope, type: :policy do
+RSpec.describe Agent::AbsencePolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject(:scope) { described_class.new(AgentContext.new(current_agent), Absence).resolve }
 

--- a/spec/policies/agent/agent_agenda_policy_spec.rb
+++ b/spec/policies/agent/agent_agenda_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::AgentAgendaPolicy, type: :policy do
+RSpec.describe Agent::AgentAgendaPolicy, type: :policy do
   subject { described_class }
 
   let(:pundit_context) { AgentContext.new(agent) }

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::AgentPolicy, type: :policy do
+RSpec.describe Agent::AgentPolicy, type: :policy do
   subject { described_class }
 
   let(:pundit_context) { AgentContext.new(agent) }
@@ -66,7 +66,7 @@ describe Agent::AgentPolicy, type: :policy do
   end
 end
 
-describe Agent::AgentPolicy::Scope, type: :policy do
+RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject { described_class.new(AgentContext.new(agent), Agent).resolve }
 

--- a/spec/policies/agent/agent_role_policy_spec.rb
+++ b/spec/policies/agent/agent_role_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::AgentRolePolicy, type: :policy do
+RSpec.describe Agent::AgentRolePolicy, type: :policy do
   subject { described_class }
 
   let(:pundit_context) { AgentContext.new(agent) }
@@ -38,7 +38,7 @@ describe Agent::AgentRolePolicy, type: :policy do
   end
 end
 
-describe Agent::AgentRolePolicy::Scope, type: :policy do
+RSpec.describe Agent::AgentRolePolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject { described_class.new(AgentContext.new(agent), AgentRole).resolve }
 

--- a/spec/policies/agent/agent_territorial_role_policy_spec.rb
+++ b/spec/policies/agent/agent_territorial_role_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::AgentTerritorialRolePolicy, type: :policy do
+RSpec.describe Agent::AgentTerritorialRolePolicy, type: :policy do
   subject { described_class }
 
   let!(:territory) { create(:territory) }
@@ -23,7 +23,7 @@ describe Agent::AgentTerritorialRolePolicy, type: :policy do
   end
 end
 
-describe Agent::AgentTerritorialRolePolicy::Scope, type: :policy do
+RSpec.describe Agent::AgentTerritorialRolePolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject do
       described_class

--- a/spec/policies/agent/lieu_policy_spec.rb
+++ b/spec/policies/agent/lieu_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::LieuPolicy do
+RSpec.describe Agent::LieuPolicy do
   subject(:policy) { described_class.new(agent, lieu) }
 
   let!(:lieu) { create(:lieu) }

--- a/spec/policies/agent/motif_policy_spec.rb
+++ b/spec/policies/agent/motif_policy_spec.rb
@@ -1,5 +1,5 @@
 # rubocop:disable RSpec/PredicateMatcher
-describe Agent::MotifPolicy do
+RSpec.describe Agent::MotifPolicy do
   subject { described_class }
 
   let!(:motif) { create(:motif) }

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::RdvPolicy, type: :policy do
+RSpec.describe Agent::RdvPolicy, type: :policy do
   subject { described_class }
 
   shared_examples "included in scope" do

--- a/spec/policies/agent/sector_attribution_policy_spec.rb
+++ b/spec/policies/agent/sector_attribution_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::SectorAttributionPolicy, type: :policy do
+RSpec.describe Agent::SectorAttributionPolicy, type: :policy do
   subject { described_class }
 
   let!(:territory) { create(:territory) }
@@ -28,7 +28,7 @@ describe Agent::SectorAttributionPolicy, type: :policy do
   end
 end
 
-describe Agent::SectorAttributionPolicy::Scope, type: :policy do
+RSpec.describe Agent::SectorAttributionPolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject do
       described_class.new(AgentContext.new(agent), SectorAttribution).resolve

--- a/spec/policies/agent/sector_policy_spec.rb
+++ b/spec/policies/agent/sector_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::SectorPolicy, type: :policy do
+RSpec.describe Agent::SectorPolicy, type: :policy do
   subject { described_class }
 
   let!(:territory) { create(:territory) }
@@ -24,7 +24,7 @@ describe Agent::SectorPolicy, type: :policy do
   end
 end
 
-describe Agent::SectorPolicy::Scope, type: :policy do
+RSpec.describe Agent::SectorPolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject do
       described_class.new(AgentContext.new(agent), Sector).resolve

--- a/spec/policies/agent/territory_policy_spec.rb
+++ b/spec/policies/agent/territory_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::TerritoryPolicy, type: :policy do
+RSpec.describe Agent::TerritoryPolicy, type: :policy do
   subject { described_class }
 
   let!(:territory) { create(:territory) }
@@ -17,7 +17,7 @@ describe Agent::TerritoryPolicy, type: :policy do
   end
 end
 
-describe Agent::TerritoryPolicy::Scope, type: :policy do
+RSpec.describe Agent::TerritoryPolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject do
       described_class.new(AgentContext.new(agent), Territory).resolve

--- a/spec/policies/agent/user_policy_spec.rb
+++ b/spec/policies/agent/user_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::UserPolicy, type: :policy do
+RSpec.describe Agent::UserPolicy, type: :policy do
   subject { described_class }
 
   describe "creating user is always allowed" do

--- a/spec/policies/agent/webhook_endpoint_policy_spec.rb
+++ b/spec/policies/agent/webhook_endpoint_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::WebhookEndpointPolicy, type: :policy do
+RSpec.describe Agent::WebhookEndpointPolicy, type: :policy do
   subject { described_class }
 
   let(:pundit_context) { AgentContext.new(agent) }
@@ -19,7 +19,7 @@ describe Agent::WebhookEndpointPolicy, type: :policy do
   end
 end
 
-describe Agent::WebhookEndpointPolicy::Scope, type: :policy do
+RSpec.describe Agent::WebhookEndpointPolicy::Scope, type: :policy do
   describe "#resolve?" do
     let(:organisation) { create(:organisation) }
 

--- a/spec/policies/agent/zone_policy_spec.rb
+++ b/spec/policies/agent/zone_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Agent::ZonePolicy, type: :policy do
+RSpec.describe Agent::ZonePolicy, type: :policy do
   subject { described_class }
 
   let!(:territory) { create(:territory) }
@@ -26,7 +26,7 @@ describe Agent::ZonePolicy, type: :policy do
   end
 end
 
-describe Agent::ZonePolicy::Scope, type: :policy do
+RSpec.describe Agent::ZonePolicy::Scope, type: :policy do
   describe "#resolve?" do
     subject do
       described_class.new(AgentContext.new(agent), Zone).resolve

--- a/spec/policies/configuration/agent_policy/scope_spec.rb
+++ b/spec/policies/configuration/agent_policy/scope_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::AgentPolicy::Scope, type: :policy do
+RSpec.describe Configuration::AgentPolicy::Scope, type: :policy do
   it "returns agents of same territory and same organisation and same service" do
     territory = create(:territory)
     service = create(:service)

--- a/spec/policies/configuration/agent_policy_spec.rb
+++ b/spec/policies/configuration/agent_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::AgentPolicy, type: :policy do
+RSpec.describe Configuration::AgentPolicy, type: :policy do
   subject { described_class }
 
   let(:territory) { create(:territory) }

--- a/spec/policies/configuration/agent_role_policy_spec.rb
+++ b/spec/policies/configuration/agent_role_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::AgentRolePolicy, type: :policy do
+RSpec.describe Configuration::AgentRolePolicy, type: :policy do
   subject { described_class }
 
   let(:territory) { create(:territory) }

--- a/spec/policies/configuration/agent_territorial_access_right_policy_spec.rb
+++ b/spec/policies/configuration/agent_territorial_access_right_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::AgentTerritorialAccessRightPolicy, type: :policy do
+RSpec.describe Configuration::AgentTerritorialAccessRightPolicy, type: :policy do
   describe "#update?" do
     it "returns false with agent without admin access to this territory" do
       territory = create(:territory)

--- a/spec/policies/configuration/agent_territorial_role_policy_spec.rb
+++ b/spec/policies/configuration/agent_territorial_role_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::AgentTerritorialRolePolicy, type: :policy do
+RSpec.describe Configuration::AgentTerritorialRolePolicy, type: :policy do
   %i[display? new? create? destroy?].each do |action|
     describe "##{action}" do
       it "returns false with agent without admin access to this territory" do

--- a/spec/policies/configuration/sector_attribution_policy_spec.rb
+++ b/spec/policies/configuration/sector_attribution_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::SectorAttributionPolicy, type: :policy do
+RSpec.describe Configuration::SectorAttributionPolicy, type: :policy do
   %i[new? create? destroy?].each do |action|
     describe "##{action}" do
       it "returns false with agent without admin access to this territory" do

--- a/spec/policies/configuration/sector_policy_spec.rb
+++ b/spec/policies/configuration/sector_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::SectorPolicy, type: :policy do
+RSpec.describe Configuration::SectorPolicy, type: :policy do
   %i[display? edit? show? update?].each do |action|
     describe "##{action}" do
       it "returns false with agent without admin access to this territory" do

--- a/spec/policies/configuration/team_policy_spec.rb
+++ b/spec/policies/configuration/team_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::TeamPolicy, type: :policy do
+RSpec.describe Configuration::TeamPolicy, type: :policy do
   %i[new? destroy? edit? update?].each do |action|
     describe "##{action}" do
       it "returns false with agent disllowed to manage teams" do

--- a/spec/policies/configuration/territory_policy_spec.rb
+++ b/spec/policies/configuration/territory_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::TerritoryPolicy, type: :policy do
+RSpec.describe Configuration::TerritoryPolicy, type: :policy do
   subject { described_class }
 
   let(:territory) { create(:territory) }

--- a/spec/policies/configuration/webhook_endpoint_policy_spec.rb
+++ b/spec/policies/configuration/webhook_endpoint_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::WebhookEndpointPolicy, type: :policy do
+RSpec.describe Configuration::WebhookEndpointPolicy, type: :policy do
   %i[display? new? create? edit? update? destroy?].each do |action|
     describe "##{action}" do
       it "returns false with agent without admin access to this territory" do

--- a/spec/policies/configuration/zone_policy_spec.rb
+++ b/spec/policies/configuration/zone_policy_spec.rb
@@ -1,4 +1,4 @@
-describe Configuration::ZonePolicy, type: :policy do
+RSpec.describe Configuration::ZonePolicy, type: :policy do
   %i[new? create? destroy?].each do |action|
     describe "##{action}" do
       it "returns false with agent without admin access to this territory" do

--- a/spec/policies/super_admin/agent_policy_spec.rb
+++ b/spec/policies/super_admin/agent_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::AgentPolicy, type: :policy do
+RSpec.describe SuperAdmin::AgentPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/agent_role_policy_spec.rb
+++ b/spec/policies/super_admin/agent_role_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::AgentRolePolicy, type: :policy do
+RSpec.describe SuperAdmin::AgentRolePolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/agent_service_policy_spec.rb
+++ b/spec/policies/super_admin/agent_service_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::AgentServicePolicy, type: :policy do
+RSpec.describe SuperAdmin::AgentServicePolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/lieu_policy_spec.rb
+++ b/spec/policies/super_admin/lieu_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::LieuPolicy, type: :policy do
+RSpec.describe SuperAdmin::LieuPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/mairie_compte_policy_spec.rb
+++ b/spec/policies/super_admin/mairie_compte_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::MairieComptePolicy, type: :policy do
+RSpec.describe SuperAdmin::MairieComptePolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/migration_policy_spec.rb
+++ b/spec/policies/super_admin/migration_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::MigrationPolicy, type: :policy do
+RSpec.describe SuperAdmin::MigrationPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/motif_policy_spec.rb
+++ b/spec/policies/super_admin/motif_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::MotifPolicy, type: :policy do
+RSpec.describe SuperAdmin::MotifPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/organisation_policy_spec.rb
+++ b/spec/policies/super_admin/organisation_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::OrganisationPolicy, type: :policy do
+RSpec.describe SuperAdmin::OrganisationPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/service_policy_spec.rb
+++ b/spec/policies/super_admin/service_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::ServicePolicy, type: :policy do
+RSpec.describe SuperAdmin::ServicePolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/super_admin_policy_spec.rb
+++ b/spec/policies/super_admin/super_admin_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::SuperAdminPolicy, type: :policy do
+RSpec.describe SuperAdmin::SuperAdminPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/territory_policy_spec.rb
+++ b/spec/policies/super_admin/territory_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::TerritoryPolicy, type: :policy do
+RSpec.describe SuperAdmin::TerritoryPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/user_policy_spec.rb
+++ b/spec/policies/super_admin/user_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::UserPolicy, type: :policy do
+RSpec.describe SuperAdmin::UserPolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/super_admin/user_profile_policy_spec.rb
+++ b/spec/policies/super_admin/user_profile_policy_spec.rb
@@ -1,4 +1,4 @@
-describe SuperAdmin::UserProfilePolicy, type: :policy do
+RSpec.describe SuperAdmin::UserProfilePolicy, type: :policy do
   subject { described_class }
 
   let!(:super_admin) { create(:super_admin) }

--- a/spec/policies/user/participation_policy_spec.rb
+++ b/spec/policies/user/participation_policy_spec.rb
@@ -1,4 +1,4 @@
-describe User::ParticipationPolicy, type: :policy do
+RSpec.describe User::ParticipationPolicy, type: :policy do
   subject { described_class }
 
   shared_examples "included in scope" do

--- a/spec/policies/user/rdv_policy_spec.rb
+++ b/spec/policies/user/rdv_policy_spec.rb
@@ -1,4 +1,4 @@
-describe User::RdvPolicy, type: :policy do
+RSpec.describe User::RdvPolicy, type: :policy do
   subject { described_class }
 
   shared_examples "included in scope" do

--- a/spec/presenters/admin/participation_presenter_spec.rb
+++ b/spec/presenters/admin/participation_presenter_spec.rb
@@ -1,4 +1,4 @@
-describe Admin::ParticipationPresenter do
+RSpec.describe Admin::ParticipationPresenter do
   let(:organisation) { create(:organisation) }
   let(:user) { create(:user, organisations: [organisation]) }
 

--- a/spec/presenters/paper_trail_augmented_version_spec.rb
+++ b/spec/presenters/paper_trail_augmented_version_spec.rb
@@ -1,4 +1,4 @@
-describe PaperTrailAugmentedVersion do
+RSpec.describe PaperTrailAugmentedVersion do
   describe "#changes" do
     context "no previous version" do
       it "works with only object_changes" do

--- a/spec/presenters/plage_ouverture_presenter_spec.rb
+++ b/spec/presenters/plage_ouverture_presenter_spec.rb
@@ -1,4 +1,4 @@
-describe PlageOuverturePresenter, type: :presenter do
+RSpec.describe PlageOuverturePresenter, type: :presenter do
   describe "#overlaps_rdv_error_message" do
     subject { presenter.overlaps_rdv_error_message }
 

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -1,4 +1,4 @@
-describe RdvEndingShortlyBeforePresenter, type: :presenter do
+RSpec.describe RdvEndingShortlyBeforePresenter, type: :presenter do
   let(:presenter) { described_class.new(rdv: rdv, agent: agent, rdv_context: rdv_context, agent_context: agent_context) }
 
   describe "#warning_message" do

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -1,4 +1,4 @@
-describe "ANTS API: availableTimeSlots" do
+RSpec.describe "ANTS API: availableTimeSlots" do
   include_context "rdv_mairie_api_authentication"
 
   let(:lieu1) do

--- a/spec/requests/api/ants/get_managed_meeting_points_spec.rb
+++ b/spec/requests/api/ants/get_managed_meeting_points_spec.rb
@@ -1,4 +1,4 @@
-describe "ANTS API: getManagedMeetingPoints" do
+RSpec.describe "ANTS API: getManagedMeetingPoints" do
   include_context "rdv_mairie_api_authentication"
 
   context "with the wrong authentication header" do

--- a/spec/requests/api/ants/search_application_ids_spec.rb
+++ b/spec/requests/api/ants/search_application_ids_spec.rb
@@ -1,4 +1,4 @@
-describe "ANTS API: searchApplicationIds" do
+RSpec.describe "ANTS API: searchApplicationIds" do
   include_context "rdv_mairie_api_authentication"
 
   context "with the wrong authentication header" do

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.json" do
+RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.json" do
   with_examples
 
   before do

--- a/spec/requests/api/rdvinsertion/motif_categories_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/motif_categories_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Motif Category API", swagger_doc: "v1/api.json" do
+RSpec.describe "Motif Category API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/rdvinsertion/motif_categories/" do

--- a/spec/requests/api/rdvinsertion/motif_category_territories_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/motif_category_territories_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Motif Category Territory API", swagger_doc: "v1/api.json" do
+RSpec.describe "Motif Category Territory API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/rdvinsertion/motif_category_territories/" do

--- a/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Referent Assignation authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "Referent Assignation authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/rdvinsertion/referent_assignations/create_many" do

--- a/spec/requests/api/rdvinsertion/user_profiles_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/user_profiles_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "User Profile authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "User Profile authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/rdvinsertion/user_profiles/create_many" do

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Absence authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/absences" do

--- a/spec/requests/api/v1/agents_request_spec.rb
+++ b/spec/requests/api/v1/agents_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Agents API", swagger_doc: "v1/api.json" do
+RSpec.describe "Agents API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/agents" do

--- a/spec/requests/api/v1/motifs_request_spec.rb
+++ b/spec/requests/api/v1/motifs_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "RDV authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
   path "/api/v1/organisations/{organisation_id}/motifs" do
     get "Lister les motifs" do
       tags "Motif"

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Organisations API", swagger_doc: "v1/api.json" do
+RSpec.describe "Organisations API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/organisations" do

--- a/spec/requests/api/v1/paginated_request_spec.rb
+++ b/spec/requests/api/v1/paginated_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "paginated requests", type: :request do
+RSpec.describe "paginated requests", type: :request do
   let(:agent) { create(:agent) }
   let(:auth_headers) { api_auth_headers_for_agent(agent) }
   let(:"access-token") { auth_headers["access-token"].to_s }

--- a/spec/requests/api/v1/participations_request_spec.rb
+++ b/spec/requests/api/v1/participations_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "RDVs Users authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "RDVs Users authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "api/v1/participations/{id}/" do

--- a/spec/requests/api/v1/public_links_request_spec.rb
+++ b/spec/requests/api/v1/public_links_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Public links API", swagger_doc: "v1/api.json" do
+RSpec.describe "Public links API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/public_links" do

--- a/spec/requests/api/v1/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/rdvs_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "RDV authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/organisations/{organisation_id}/rdvs" do

--- a/spec/requests/api/v1/referent_assignations_request_spec.rb
+++ b/spec/requests/api/v1/referent_assignations_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Referent Assignation authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "Referent Assignation authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/referent_assignations" do

--- a/spec/requests/api/v1/user_profiles_request_spec.rb
+++ b/spec/requests/api/v1/user_profiles_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "User Profile authentified API", swagger_doc: "v1/api.json" do
+RSpec.describe "User Profile authentified API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "/api/v1/user_profiles" do

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "Users API", swagger_doc: "v1/api.json" do
+RSpec.describe "Users API", swagger_doc: "v1/api.json" do
   with_examples
 
   let(:organisation) { create(:organisation) }

--- a/spec/requests/api/v1/webhook_endpoints_request_spec.rb
+++ b/spec/requests/api/v1/webhook_endpoints_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
+RSpec.describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
   with_examples
 
   path "api/v1/organisations/{organisation_id}/webhook_endpoints" do

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -8,7 +8,7 @@
 # check est interne au réseau Kubernetes (le HTTPS en géré à l'extérieur).
 # Nous avons donc défini une config.ssl_options qui exclut cette route.
 #
-describe "/health_check" do
+RSpec.describe "/health_check" do
   it "returns HTTP 200" do
     get "/health_check"
     expect(response).to have_http_status(:ok)

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -1,4 +1,4 @@
-describe AddConseillerNumerique do
+RSpec.describe AddConseillerNumerique do
   let!(:territory) { create(:territory, name: "Conseillers Numériques") }
   let(:params) do
     {

--- a/spec/services/agent_removal_spec.rb
+++ b/spec/services/agent_removal_spec.rb
@@ -1,4 +1,4 @@
-describe AgentRemoval, type: :service do
+RSpec.describe AgentRemoval, type: :service do
   context "agent belongs to single organisation, with a few absences and plages ouvertures" do
     # orgs must have at least one admin
     let!(:admin_agent) { create(:agent, admin_role_in_organisations: [organisation]) }

--- a/spec/services/ants_api/appointment_spec.rb
+++ b/spec/services/ants_api/appointment_spec.rb
@@ -1,4 +1,4 @@
-describe AntsApi::Appointment, type: :service do
+RSpec.describe AntsApi::Appointment, type: :service do
   include_context "rdv_mairie_api_authentication"
 
   describe "#request" do

--- a/spec/services/duplicate_users_finder_service_spec.rb
+++ b/spec/services/duplicate_users_finder_service_spec.rb
@@ -1,4 +1,4 @@
-describe DuplicateUsersFinderService, type: :service do
+RSpec.describe DuplicateUsersFinderService, type: :service do
   let(:user) { build(:user, first_name: "Mathieu", last_name: "Lapin", email: "lapin@beta.fr", birth_date: "21/10/2000", phone_number: "0658032518") }
 
   describe ".perform" do

--- a/spec/services/export_zones_service_spec.rb
+++ b/spec/services/export_zones_service_spec.rb
@@ -1,4 +1,4 @@
-describe ExportZonesService, type: :service do
+RSpec.describe ExportZonesService, type: :service do
   describe "#perform" do
     subject { described_class.new(territory.zones).perform }
 

--- a/spec/services/import_zone_rows_service_spec.rb
+++ b/spec/services/import_zone_rows_service_spec.rb
@@ -1,4 +1,4 @@
-describe ImportZoneRowsService, type: :service do
+RSpec.describe ImportZoneRowsService, type: :service do
   # TODO: this spec should mock ZoneImportRow calls and tests should be moved
 
   let!(:territory62) { create(:territory, departement_number: "62") }

--- a/spec/services/merge_users_service_spec.rb
+++ b/spec/services/merge_users_service_spec.rb
@@ -1,4 +1,4 @@
-describe MergeUsersService, type: :service do
+RSpec.describe MergeUsersService, type: :service do
   subject(:perform) { described_class.perform_with(user_target, user_to_merge, attributes_to_merge, organisation) }
 
   # defaults

--- a/spec/services/next_availability_service_spec.rb
+++ b/spec/services/next_availability_service_spec.rb
@@ -1,4 +1,4 @@
-describe NextAvailabilityService, type: :service do
+RSpec.describe NextAvailabilityService, type: :service do
   let(:today) { Date.new(2021, 3, 18) }
   let(:now) { Time.zone.parse("20210318 8:23") }
 

--- a/spec/services/notifiers/rdv_base_spec.rb
+++ b/spec/services/notifiers/rdv_base_spec.rb
@@ -10,7 +10,7 @@ class TestService < Notifiers::RdvBase
   end
 end
 
-describe Notifiers::RdvBase, type: :service do
+RSpec.describe Notifiers::RdvBase, type: :service do
   let(:service) { TestService.new(rdv, author) }
 
   describe "user notifications" do

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -1,4 +1,4 @@
-describe Notifiers::RdvCancelled, type: :service do
+RSpec.describe Notifiers::RdvCancelled, type: :service do
   subject { described_class.perform_with(rdv, author) }
 
   let!(:agent1) { create(:agent) }

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -1,4 +1,4 @@
-describe Notifiers::RdvCreated, type: :service do
+RSpec.describe Notifiers::RdvCreated, type: :service do
   subject { described_class.perform_with(rdv, user1) }
 
   let(:user1) { create(:user) }

--- a/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
+++ b/spec/services/notifiers/rdv_upcoming_reminder_spec.rb
@@ -1,4 +1,4 @@
-describe Notifiers::RdvUpcomingReminder, type: :service do
+RSpec.describe Notifiers::RdvUpcomingReminder, type: :service do
   subject { described_class.perform_with(rdv, nil) }
 
   let!(:rdv) { create(:rdv, starts_at: 2.days.from_now, users: [user1, user2]) }

--- a/spec/services/notifiers/rdv_updated_spec.rb
+++ b/spec/services/notifiers/rdv_updated_spec.rb
@@ -1,4 +1,4 @@
-describe Notifiers::RdvUpdated, type: :service do
+RSpec.describe Notifiers::RdvUpdated, type: :service do
   subject { described_class.perform_with(rdv, agent1) }
 
   let(:user1) { create(:user) }

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -1,4 +1,4 @@
-describe OffDays, type: :service do
+RSpec.describe OffDays, type: :service do
   it "is up to date" do
     # Il faut ajouter de nouveaux jours fériés si cette spec échoue
     expect(described_class::JOURS_FERIES.to_a.last).to be > 3.months.from_now

--- a/spec/services/plage_ouverture_overlap_spec.rb
+++ b/spec/services/plage_ouverture_overlap_spec.rb
@@ -1,4 +1,4 @@
-describe PlageOuvertureOverlap do
+RSpec.describe PlageOuvertureOverlap do
   let(:organisation) { build(:organisation) }
   let(:agent) { build(:agent, organisations: [organisation]) }
   let(:monday) { Date.new(2021, 9, 20) }

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -1,4 +1,4 @@
-describe RdvExporter, type: :service do
+RSpec.describe RdvExporter, type: :service do
   describe "#xls_string_from_rdvs_rows" do
     # rubocop:disable RSpec/ExampleLength
     it "return export with header" do

--- a/spec/services/rdv_start_coherence_spec.rb
+++ b/spec/services/rdv_start_coherence_spec.rb
@@ -1,4 +1,4 @@
-describe RdvStartCoherence, type: :service do
+RSpec.describe RdvStartCoherence, type: :service do
   describe "#rdvs_ending_shortly_before" do
     subject { described_class.new(rdv).rdvs_ending_shortly_before }
 

--- a/spec/services/rdvs_overlapping_spec.rb
+++ b/spec/services/rdvs_overlapping_spec.rb
@@ -1,4 +1,4 @@
-describe RdvsOverlapping, type: :service do
+RSpec.describe RdvsOverlapping, type: :service do
   describe "#rdvs_overlapping_rdv" do
     it "return rdvs that end during rdv" do
       now = Time.zone.parse("2020-12-23 12h40")

--- a/spec/services/search_creneaux_for_agents_base_spec.rb
+++ b/spec/services/search_creneaux_for_agents_base_spec.rb
@@ -1,4 +1,4 @@
-describe SearchCreneauxForAgentsBase, type: :service do
+RSpec.describe SearchCreneauxForAgentsBase, type: :service do
   describe "#all_agents" do
     subject { described_class.new(form).all_agents }
 

--- a/spec/services/search_creneaux_for_agents_service_spec.rb
+++ b/spec/services/search_creneaux_for_agents_service_spec.rb
@@ -1,4 +1,4 @@
-describe SearchCreneauxForAgentsService, type: :service do
+RSpec.describe SearchCreneauxForAgentsService, type: :service do
   describe "lieux" do
     subject { described_class.new(form).lieux }
 

--- a/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
+++ b/spec/services/search_creneaux_without_lieu_for_agents_service_spec.rb
@@ -1,4 +1,4 @@
-describe SearchCreneauxWithoutLieuForAgentsService, type: :service do
+RSpec.describe SearchCreneauxWithoutLieuForAgentsService, type: :service do
   describe "creneaux" do
     before do
       travel_to(Time.zone.local(2022, 10, 15, 10, 0, 0))

--- a/spec/services/slot_builder/busy_time_spec.rb
+++ b/spec/services/slot_builder/busy_time_spec.rb
@@ -1,4 +1,4 @@
-describe SlotBuilder::BusyTime, type: :service do
+RSpec.describe SlotBuilder::BusyTime, type: :service do
   let(:monday) { Time.zone.parse("20211025 10:00") }
   let(:range) { Time.zone.parse("2021-10-26 8:00")..Time.zone.parse("2021-10-29 12:00") }
   let(:plage_ouverture) { create(:plage_ouverture) }

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -1,4 +1,4 @@
-describe SlotBuilder, type: :service do
+RSpec.describe SlotBuilder, type: :service do
   let(:friday) { Time.zone.parse("20210430 8:00") }
   let(:organisation) { create(:organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -1,4 +1,4 @@
-describe SmsSender, type: :service do
+RSpec.describe SmsSender, type: :service do
   let(:rdv) { create(:rdv) }
   let(:user) { create(:user) }
   let(:receipt_params) { { event: "rdv_created", rdv: rdv, user: user } }

--- a/spec/services/upsert_user_for_franceconnect_service_spec.rb
+++ b/spec/services/upsert_user_for_franceconnect_service_spec.rb
@@ -1,4 +1,4 @@
-describe UpsertUserForFranceconnectService, type: :service do
+RSpec.describe UpsertUserForFranceconnectService, type: :service do
   let(:omniauth_info) do
     OpenStruct.new(email: "jeanne@longo.fr",
                    given_name: "jeanne",

--- a/spec/services/users/creneau_search_spec.rb
+++ b/spec/services/users/creneau_search_spec.rb
@@ -1,4 +1,4 @@
-describe Users::CreneauSearch do
+RSpec.describe Users::CreneauSearch do
   let(:organisation) { create(:organisation) }
   let(:user) { create(:user) }
   let(:motif) { create(:motif, name: "Coucou", location_type: :home, organisation: organisation) }

--- a/spec/services/users/creneaux_search_spec.rb
+++ b/spec/services/users/creneaux_search_spec.rb
@@ -1,4 +1,4 @@
-describe Users::CreneauxSearch, type: :service do
+RSpec.describe Users::CreneauxSearch, type: :service do
   let(:organisation) { create(:organisation) }
   let(:lieu) { create(:lieu, organisation: organisation) }
   let(:date_range) { (Date.parse("2020-10-20")..Date.parse("2020-10-23")) }

--- a/spec/services/users/geo_search_cases_spec.rb
+++ b/spec/services/users/geo_search_cases_spec.rb
@@ -1,6 +1,6 @@
 # this file contains ~integration specs, there is another with ~unit tests
 
-describe Users::GeoSearch, type: :service_model do
+RSpec.describe Users::GeoSearch, type: :service_model do
   let!(:territory62) { create(:territory, departement_number: "62") }
 
   context "with a few motifs sectorised with departement level" do

--- a/spec/services/users/geo_search_spec.rb
+++ b/spec/services/users/geo_search_spec.rb
@@ -1,6 +1,6 @@
 # this file contains ~unit tests, there is another with ~integration specs
 
-describe Users::GeoSearch, type: :service_model do
+RSpec.describe Users::GeoSearch, type: :service_model do
   let!(:territory62) { create(:territory, departement_number: "62") }
 
   describe "#matching_zones" do

--- a/spec/services/web_invitation_search_context_spec.rb
+++ b/spec/services/web_invitation_search_context_spec.rb
@@ -1,4 +1,4 @@
-describe WebInvitationSearchContext, type: :service do
+RSpec.describe WebInvitationSearchContext, type: :service do
   subject { described_class.new(user: user, query_params: query_params) }
 
   include_context "SearchContext"

--- a/spec/services/web_search_context_spec.rb
+++ b/spec/services/web_search_context_spec.rb
@@ -1,4 +1,4 @@
-describe WebSearchContext, type: :service do
+RSpec.describe WebSearchContext, type: :service do
   subject { described_class.new(user: user, query_params: query_params) }
 
   include_examples "SearchContext"

--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -1,4 +1,4 @@
-describe "using netsize to send an SMS" do
+RSpec.describe "using netsize to send an SMS" do
   let(:territory) { create(:territory, sms_provider: "netsize") }
   let(:organisation) { create(:organisation, territory: territory) }
   let(:user) { create(:user, phone_number: "+33601020304") }

--- a/spec/sms/users/file_attente_sms_spec.rb
+++ b/spec/sms/users/file_attente_sms_spec.rb
@@ -1,4 +1,4 @@
-describe Users::FileAttenteSms, type: :service do
+RSpec.describe Users::FileAttenteSms, type: :service do
   describe "#new_creneau_available" do
     subject { described_class.new_creneau_available(rdv, user, token).content }
 

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -1,4 +1,4 @@
-describe Users::RdvSms, type: :service do
+RSpec.describe Users::RdvSms, type: :service do
   describe "#rdv_created" do
     context "with a basic rdv" do
       subject { described_class.rdv_created(rdv, user, token).content }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,7 +77,8 @@ RSpec.configure do |config|
   #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  #   config.disable_monkey_patching!
+  config.disable_monkey_patching!
+
   #
   #   # Many RSpec users commonly either run the entire suite or an individual
   #   # file, and it's useful to allow more verbose output when running an

--- a/spec/support/api_spec_shared_examples.rb
+++ b/spec/support/api_spec_shared_examples.rb
@@ -1,5 +1,5 @@
 module ApiSpecSharedExamples
-  shared_context "an endpoint that returns 401 - unauthorized" do
+  RSpec.shared_context "an endpoint that returns 401 - unauthorized" do
     response 401, "Renvoie 'unauthorized' quand l'authentification est impossible" do
       let(:"access-token") { "false" }
 
@@ -9,7 +9,7 @@ module ApiSpecSharedExamples
     end
   end
 
-  shared_context "an endpoint that returns 403 - forbidden" do |details|
+  RSpec.shared_context "an endpoint that returns 403 - forbidden" do |details|
     response 403, "Renvoie 'forbidden' quand #{details}" do
       schema "$ref" => "#/components/schemas/error_forbidden"
 
@@ -17,7 +17,7 @@ module ApiSpecSharedExamples
     end
   end
 
-  shared_context "an endpoint that returns 404 - not found" do |details|
+  RSpec.shared_context "an endpoint that returns 404 - not found" do |details|
     response 404, "Renvoie 'not_found' quand #{details}" do
       schema "$ref" => "#/components/schemas/error_not_found"
 
@@ -25,7 +25,7 @@ module ApiSpecSharedExamples
     end
   end
 
-  shared_context "an endpoint that returns 422 - unprocessable_entity" do |details, document|
+  RSpec.shared_context "an endpoint that returns 422 - unprocessable_entity" do |details, document|
     response 422, "Renvoie 'unprocessable_entity' quand #{details}", document: document do
       schema "$ref" => "#/components/schemas/error_unprocessable_entity"
 
@@ -33,7 +33,7 @@ module ApiSpecSharedExamples
     end
   end
 
-  shared_context "an endpoint that returns 429 - too_many_requests" do |method, path|
+  RSpec.shared_context "an endpoint that returns 429 - too_many_requests" do |method, path|
     response 429, "Renvoie 'too_many_requests' quand la limite d'appels est atteinte" do
       schema "$ref" => "#/components/schemas/error_too_many_request"
 
@@ -49,7 +49,7 @@ module ApiSpecSharedExamples
     end
   end
 
-  shared_context "rdv_mairie_api_authentication", :rdv_mairie_api_authentication do
+  RSpec.shared_context "rdv_mairie_api_authentication", :rdv_mairie_api_authentication do
     before do
       ENV["ANTS_RDV_API_URL"] = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api"
       ENV["ANTS_RDV_OPT_AUTH_TOKEN"] = "fake-token"

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -1,4 +1,4 @@
-shared_examples_for "recurrence" do
+RSpec.shared_examples_for "recurrence" do
   let(:model) { described_class }
   let(:model_symbol) { model.to_s.underscore.to_sym }
 


### PR DESCRIPTION
Le changement principal ici, c'est l'ajout de 

```ruby
config.disable_monkey_patching!
```

dans `spec/spec_helper.rb`.

Ça fait 10 ans qu'on n'est plus obligés de monkey patcher `Kernel`, et je pense qu'il est plus sûr de ne pas le faire.

http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
https://rubydoc.info/github/rspec/rspec-core/RSpec/Core/Configuration#disable_monkey_patching%21-instance_method

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
