### PR TITLE
Ajouter une spec qui vérifier que les seeds ne plantent pas

### DIFF
--- a/spec/lib/seeds_spec.rb
+++ b/spec/lib/seeds_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe "loading seeds" do
+  it "does not crash" do
+    Rails.application.load_seed
+  end
+end

--- a/spec/lib/seeds_spec.rb
+++ b/spec/lib/seeds_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "loading seeds" do
+RSpec.describe "loading seeds" do # rubocop:disable RSpec/DescribeClass
   it "does not crash" do
     Rails.application.load_seed
   end


### PR DESCRIPTION
Sur une suggestion de @victormours :wink: 

Ça fait plusieurs fois qu'on a des deploy qui échouent parce que les seeds plante. C'est pénible en review app car ça oblige à fermer puis ré-ouvrir la PR pour re-déclencher un seed au premier deploy.

Ce test prend 7 secondes sur ma machine, c'est pas un plaisir mais c'est raisonnable.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
