### PR TITLE
Supprimer les colonnes d'adresses ip pour les agents

### DIFF
--- a/app/lib/anonymizer_rules.rb
+++ b/app/lib/anonymizer_rules.rb
@@ -55,8 +55,6 @@ class AnonymizerRules
         calendar_uid
         current_sign_in_at
         last_sign_in_at
-        current_sign_in_ip
-        last_sign_in_ip
         reset_password_token
         confirmation_token
         invitation_token
@@ -84,7 +82,6 @@ class AnonymizerRules
         display_cancelled_rdv
         plage_ouverture_notification_level
         absence_notification_level
-        sign_in_count
         outlook_disconnect_in_progress
         account_deletion_warning_sent_at
         deleted_at

--- a/db/migrate/20240213134755_remove_unused_agent_ip_columns.rb
+++ b/db/migrate/20240213134755_remove_unused_agent_ip_columns.rb
@@ -1,0 +1,9 @@
+class RemoveUnusedAgentIpColumns < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :agents,  :current_sign_in_ip, :string
+      remove_column :agents,  :last_sign_in_ip, :string
+      remove_column :agents,  :sign_in_count, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_07_093459) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_13_134755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -224,11 +224,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_093459) do
     t.enum "absence_notification_level", default: "all", enum_type: "agents_absence_notification_level"
     t.string "external_id", comment: "The agent's unique and immutable id in the system managing them and adding them to our application"
     t.string "calendar_uid", comment: "the uid used for the url of the agent's ics calendar"
-    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
     t.text "microsoft_graph_token"
     t.text "refresh_microsoft_graph_token"
     t.string "cnfs_secondary_email"


### PR DESCRIPTION
Dans la continuité de https://github.com/betagouv/rdv-service-public/pull/4053, cette PR supprime les colonnes (et donc les données) inutilisées
