### PR TITLE
Supprimer la colonne users.last_sign_in_at

### DIFF
--- a/app/lib/anonymizer_rules.rb
+++ b/app/lib/anonymizer_rules.rb
@@ -31,7 +31,6 @@ class AnonymizerRules
         confirmation_token
         reset_password_token
         invitation_token
-        last_sign_in_at
         remember_created_at
         rdv_invitation_token
       ],

--- a/db/migrate/20240213140717_remove_unused_users_last_sign_in_at.rb
+++ b/db/migrate/20240213140717_remove_unused_users_last_sign_in_at.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedUsersLastSignInAt < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :users, :last_sign_in_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_13_134755) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_13_140717) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -668,7 +668,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_13_134755) do
     t.string "phone_number_formatted"
     t.boolean "notify_by_sms", default: true
     t.boolean "notify_by_email", default: true
-    t.datetime "last_sign_in_at"
     t.string "franceconnect_openid_sub"
     t.boolean "logged_once_with_franceconnect"
     t.string "city_code"


### PR DESCRIPTION
Dans la continuité de https://github.com/betagouv/rdv-service-public/pull/4052 on supprime la colonne et donc les données inutilisées
