### PR TITLE
Petites améliorations d'UI

### DIFF
--- a/app/javascript/stylesheets/components/_select2.scss
+++ b/app/javascript/stylesheets/components/_select2.scss
@@ -20,6 +20,10 @@
   font-size: initial;
 }
 
+.select2-container--bootstrap4 .select2-results > .select2-results__options {
+    max-height: 360px;
+}
+
 // Alignement des valeurs dans le multiselect
 .select2-container--bootstrap4 .select2-selection--multiple .select2-selection__rendered {
   padding: 2px;

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -24,5 +24,5 @@
         = render "form", absence: @absence, agent: @agent
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @absence]), resource: @absence

--- a/app/views/admin/agent_intervenants/_name_form.html.slim
+++ b/app/views/admin/agent_intervenants/_name_form.html.slim
@@ -1,5 +1,5 @@
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-body
         = simple_form_for [:admin, current_organisation,  agent_intervenant], url: admin_organisation_agent_intervenant_path(current_organisation, agent_intervenant), html: { method: :put, class: "form-inline full-width-inline-form" }, wrapper: :inline_form do |f|

--- a/app/views/admin/agents/edit.html.slim
+++ b/app/views/admin/agents/edit.html.slim
@@ -14,7 +14,7 @@
   = render "admin/agent_intervenants/name_form", agent_intervenant: @agent
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-body.js_agent_role_form
         = simple_form_for [:admin, current_organisation, @agent] do |f|
@@ -69,5 +69,5 @@
                   = f.button :submit, data: { confirm: "Cet agent ne pourra plus se connecter à son compter. Êtes vous sûr de vouloir continuer ?" }
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @agent]), resource: @agent

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -4,7 +4,7 @@
   = t("agents.create_cta")
 
 .row.justify-content-center
-  .col-md-6
+  .col-md-12.col-lg-8
     .card
       .card-body.js_agent_role_form
         = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation, @agent), html: { method: :post } do |f|

--- a/app/views/admin/lieux/edit.html.slim
+++ b/app/views/admin/lieux/edit.html.slim
@@ -10,12 +10,12 @@
     li.breadcrumb-item.active= @lieu.name
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-body
         = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|
           = render "lieu_fields", f: f
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: @lieu_policy, resource: @lieu

--- a/app/views/admin/lieux/new.html.slim
+++ b/app/views/admin/lieux/new.html.slim
@@ -10,7 +10,7 @@
     li.breadcrumb-item.active Nouveau lieu
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-body
         = simple_form_for [:admin, @lieu.organisation, @lieu] do |f|

--- a/app/views/admin/motifs/edit.html.slim
+++ b/app/views/admin/motifs/edit.html.slim
@@ -10,5 +10,5 @@
     li.breadcrumb-item.active #{@motif.name}
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "form", motif: @motif

--- a/app/views/admin/motifs/new.html.slim
+++ b/app/views/admin/motifs/new.html.slim
@@ -10,5 +10,5 @@
     li.breadcrumb-item.active Nouveau un motif
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "form", motif: @motif

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -1,7 +1,7 @@
 - content_for(:menu_item) { "menu-motifs" }
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card.mt-2
       .card-header
         h3.text-center Motif #{@motif.name} (#{@motif.service.short_name})
@@ -95,5 +95,5 @@
               div= link_to "Éditer", edit_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: @motif_policy, resource: @motif

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -4,7 +4,7 @@
   | Votre organisation
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-body
         ul.list-unstyled
@@ -26,5 +26,5 @@
         .text-right= link_to "Modifier", edit_admin_organisation_path(@organisation), class: "btn btn-primary"
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @organisation]), resource: @organisation

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -86,5 +86,5 @@
           )
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @plage_ouverture]), resource: @plage_ouverture

--- a/app/views/admin/rdv_wizard_steps/_card.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_card.html.slim
@@ -1,5 +1,5 @@
 .row.justify-content-md-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       - if local_assigns[:previous_steps]
         = render "admin/rdv_wizard_steps/stepper", rdv_wizard_form: rdv_wizard_form, steps: previous_steps

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -19,7 +19,7 @@
   | Modifier le RDV
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-body
         = simple_form_for([:admin, @rdv_form.organisation, @rdv]) do |f|

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -59,13 +59,13 @@
       label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
 
   .row.justify-content-center.pb-3
-    .col-md-8
+    .col-md-12.col-lg-8
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
       = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
 - else
   .row.justify-content-center.pb-3
-    .col-md-8
+    .col-md-12.col-lg-8
       .card
         .card-body
           .row.justify-content-md-center

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -1,7 +1,7 @@
 - content_for(:title) { "Ajouter un participant" }
 
 .row.justify-content-md-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = simple_form_for(@rdv, url: admin_organisation_rdvs_collectif_path(current_organisation), method: :put) do |f|
       .card
         .card-header

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -29,7 +29,7 @@
           = f.submit "Filtrer", class: "btn btn-outline-primary"
 
 .row.justify-content-center.pb-3
-  .col-md-8
+  .col-md-12.col-lg-8
     - if @rdvs.any?
       = render(partial: "admin/rdvs_collectifs/rdv", collection: @rdvs.includes(:organisation, :users, :lieu, :motif, agents: :services))
       .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -7,7 +7,7 @@
     li.breadcrumb-item.active Nouveau RDV Collectif
 
 .row.justify-content-md-center
-  .col-md-8
+  .col-md-12.col-lg-8
     .card
       .card-header
         h3.text-center Choisissez un motif

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -7,7 +7,7 @@
     li.breadcrumb-item.active Nouveau RDV Collectif
 
 .row.justify-content-md-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = simple_form_for(@rdv, url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :post) do |f|
       .card
         .card-header

--- a/app/views/admin/slots/index.html.slim
+++ b/app/views/admin/slots/index.html.slim
@@ -24,7 +24,7 @@
 
   - if  @form.motif.collectif?
     .row.justify-content-center.pb-3
-      .col-md-8
+      .col-md-12.col-lg-8
         - @search_result.creneaux.each do |search_result|
           = render "admin/rdvs_collectifs/rdv", rdv: search_result
 

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -19,7 +19,7 @@
   = render "form", user: @user, user_form: @user_form
 - else
   .row.justify-content-center
-    .col-md-8
+    .col-md-12.col-lg-8
       .card
         .card-body
           = render "form", user: @user, user_form: @user_form

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -149,5 +149,5 @@
           | Les RDV sont supprimés au bout de 2 ans.
 
 .row.justify-content-center
-  .col-md-8
+  .col-md-12.col-lg-8
     = render "admin/versions/resource_versions_row", resource_policy: policy([:agent, @user]), resource: @user


### PR DESCRIPTION
Deux petites améliorations d'UI suite à une discussion avec @Teodora-Stanki ce matin :
- on agrandit les dropdown des selects pour montrer plus d'options
- sur les petites résolutions (qui sont marquées md dans no breakpoints bootstrap), on met les cards sur toute la largeur disponible dans l'interface principale des agents.

Les deux commits représentent ce deux changements.

### Avant/Après

#### Dropdown
<img width="1440" alt="Screenshot 2024-02-14 at 12 10 20" src="https://github.com/betagouv/rdv-service-public/assets/1840367/67983040-b55e-436d-9966-d08bccf9d21d">
<img width="1440" alt="Screenshot 2024-02-14 at 12 10 07" src="https://github.com/betagouv/rdv-service-public/assets/1840367/8cac38b0-bf40-4a2e-8f28-692712f26bc5">


### Cards
<img width="931" alt="Screenshot 2024-02-14 at 12 09 22" src="https://github.com/betagouv/rdv-service-public/assets/1840367/bf8812d3-4065-4af7-a04d-e3932b474abe">
<img width="931" alt="Screenshot 2024-02-14 at 12 09 13" src="https://github.com/betagouv/rdv-service-public/assets/1840367/57f02356-f51c-476c-a885-437bb7888332">




