### PR TITLE
Correctif pour les verticales des organisations créées par les agents

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -43,6 +43,7 @@ class Admin::OrganisationsController < AgentAuthController
   def create
     @organisation = Organisation.new(
       agent_roles_attributes: [{ agent: current_agent, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
+      verticale: current_domain.verticale,
       **new_organisation_params
     )
     authorize(@organisation)

--- a/spec/features/agents/create_organisation_spec.rb
+++ b/spec/features/agents/create_organisation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Organisations" do
   before { login_as(agent, scope: :agent) }
 
   it "shows the list of organisations when an agent with multiple organisations logs in" do
-    visit root_path
+    visit "http://www.rdv-mairie-test.localhost/"
     expect(page).to have_content("MDS de Paris Nord")
     expect(page).to have_content("MDS de Paris Sud")
     click_link "Ajouter une organisation"
@@ -25,7 +25,8 @@ RSpec.describe "Organisations" do
     expect(Organisation.last).to have_attributes(
       name: "MDS Paris Est",
       territory: territory,
-      agents: [agent]
+      agents: [agent],
+      verticale: "rdv_mairie"
     )
   end
 end


### PR DESCRIPTION
On a eu le cas de d'organisations créées sur rdv.anct.gouv.fr qui avaient la mauvaise valeur pour `organisations.verticale`, ce qui faisait que des mails d'invitations pour les nouveaux agents avaient des urls en rdv-solidarites.fr alors qu'ils étaient pour rdv.anct.gouv.fr.

Ce fix est assez minimaliste, peut-être qu'il faudrait réfléchir à utiliser `ENV['HOST']` ou les domaines configurés au niveau de scalingo pour avoir un meilleur sanity check pour cette catégorie de bugs.