### PR TITLE
Ne pas afficher le select de service quand il n'y a qu'une seule option

### DIFF
--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -9,16 +9,18 @@
       user_ids: @rdv.user_ids, agent_ids: @rdv.agent_ids,
       lieu_attributes: @rdv.nested_lieu_attributes
 
-    = f.input :service_id, \
-      collection: @services, \
-      input_html: { \
-        class: "select2-input js-service-filter", \
-        data: { \
-          placeholder: "Sélectionnez un service pour filtrer les motifs", \
-          "select-options": { disableSearch: true }, \
-        }, \
-      }
+    - if @services.count > 1
+      = f.input :service_id, \
+        collection: @services, \
+        input_html: { \
+          class: "select2-input js-service-filter", \
+          data: { \
+            placeholder: "Sélectionnez un service pour filtrer les motifs", \
+            "select-options": { disableSearch: true }, \
+          }, \
+        }
     = f.input :motif_id, \
+      label: "Motif du rendez-vous", \
       required: true, \
       include_blank: true, \
       collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
@@ -27,7 +29,7 @@
       label_method: -> { motif_name_with_location_and_group_type(_1) }, \
       input_html: { \
         data: { placeholder: "Sélectionnez un motif" },
-        class: "js-filtered-motifs", \
+        class: @services.count > 1 ? "js-filtered-motifs" : "select2-input", \
       }
 
     = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f


### PR DESCRIPTION
Cette PR concerne la création d'un nouveau rendez-vous par un agent en cliquant dans l'agenda. Pour les agents basiques avec un seul service (donc la plupart des cas),il n'y a qu'un seul service d'utilisable, donc le select de services qui sert ensuite à filtrer les motifs ne sert à rien.

Actuellement, on pré-rempli ce select, mais dans le cadre de l'amélioration de l'interface pour le Saas, on se rend compte que c'est plus simple de ne pas l'afficher du tout. Ça fait un input de moins, on gagne en clarté, et on évite aux agents qui découvrent l'application de se poser des questions inutiles sur les services.

Au passage, le label qui dit en toutes lettres "motif du rendez-vous" vise à clarifier un peu ce champs.

voir les maquettes sur la page notion : https://www.notion.so/rdvs/Solution-SaaS-7d6c2f96ba5441c4abc2fe5801dff6d2

### Avant


<img width="1588" alt="Screenshot 2024-02-15 at 11 27 05" src="https://github.com/betagouv/rdv-service-public/assets/1840367/2580fe99-4425-47ec-b2ea-7ed5d8d04be8">

### Après
<img width="1512" alt="Screenshot 2024-02-15 at 11 27 17" src="https://github.com/betagouv/rdv-service-public/assets/1840367/fc38c47a-4550-4211-8a65-c656367a9b74">
