### PR TITLE
[Bugfix] Crash lors de la création d'un RDV sans lieu sur RDV Mairie

### DIFF
--- a/app/models/concerns/ants/appointment_serializer_and_listener.rb
+++ b/app/models/concerns/ants/appointment_serializer_and_listener.rb
@@ -48,7 +48,7 @@ module Ants
 
     def self.mark_for_sync(rdvs, obsolete_application_id: nil)
       rdvs.each do |rdv|
-        next unless rdv.organisation.rdv_mairie?
+        next unless rdv.requires_ants_predemande_number?
 
         rdv.assign_attributes(needs_sync_to_ants: true)
         rdv.assign_attributes(obsolete_application_id: obsolete_application_id) if obsolete_application_id

--- a/spec/factories/motif_category.rb
+++ b/spec/factories/motif_category.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
   factory :motif_category do
     name { generate(:name) }
     short_name { generate(:short_name) }
+
+    trait :passeport do
+      name { Api::Ants::EditorController::PASSPORT_MOTIF_CATEGORY_NAME }
+    end
   end
 end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
   let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
   let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
   let(:lieu) { create(:lieu, organisation: organisation, name: "Lieu1") }
-  let(:rdv) { build(:rdv, users: [user], lieu: lieu, organisation: organisation, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+  let(:motif_passeport) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+  let(:rdv) { build(:rdv, motif: motif_passeport, users: [user], lieu: lieu, organisation: organisation, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
   let(:ants_api_headers) do
     {
       "Accept" => "application/json",


### PR DESCRIPTION
Quand on essaye de créer un RDV sans lieu (par téléphone par exemple) dans une orga qui la la verticale `rdv_mairie`, on rencontre ce crash : 

https://sentry.incubateur.net/organizations/betagouv/issues/86642

Ce fix change la condition de synchro ANTS pour qu'elle se base sur la catégorie de motif plutôt que la verticale, car la verticale ne veut parfois pas dire grand chose.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
