### PR TITLE
[Soft delete] Supprimer les files d'attentes et référents d'un usager au soft delete

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -274,6 +274,8 @@ class User < ApplicationRecord
     Anonymizer.anonymize_record!(self)
     receipts.each { |r| Anonymizer.anonymize_record!(r) }
     rdvs.each { |r| Anonymizer.anonymize_record!(r) }
+    file_attentes.destroy_all
+    referent_assignations.destroy_all
     versions.destroy_all
     update_columns(
       first_name: "Usager supprimé",

--- a/db/migrate/20240215143545_cleanup_soft_delete_users_file_attentes_and_referents.rb
+++ b/db/migrate/20240215143545_cleanup_soft_delete_users_file_attentes_and_referents.rb
@@ -1,0 +1,8 @@
+class CleanupSoftDeleteUsersFileAttentesAndReferents < ActiveRecord::Migration[7.0]
+  def up
+    FileAttente.where(user: User.unscoped.where.not(deleted_at: nil)).destroy_all
+    ReferentAssignation.where(user: User.unscoped.where.not(deleted_at: nil)).destroy_all
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_13_140717) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_15_143545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe User, type: :model do
       expect(user.versions).to be_empty
     end
 
+    it "deletes file_attentes and referent_assignations" do
+      user = create(:user)
+      file_attente = create(:file_attente, user: user)
+      referent_assignation = create(:referent_assignation, user: user)
+
+      user.soft_delete
+
+      expect { file_attente.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { referent_assignation.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it "is hidden user by default" do
       user = create(:user)
       user.soft_delete


### PR DESCRIPTION
D'après metabase, nous avons 896 usagers soft deleted qui ont des référents. Je propose donc de supprimer les référents lorsqu'un usager est supprimé.

J'en profite pour aussi faire la même chose côté files d'attente (14 usagers soft deleted en ont).

Pourquoi ? Ces données peuvent fausser nos stats et nos requêtes et nous pouvons considérer qu'elles sont incohérentes. Cela reste à discuter d'un point de vue produit.

PS : nous avons eu les même problématiques d'associations fantômes pour les agents soft deleted. Une tentative de correction : #3939.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
