### PR TITLE
Désactiver turbolinks sur le bouton InclusionConnect

### DIFF
--- a/app/views/common/_inclusionconnect_button.html.slim
+++ b/app/views/common/_inclusionconnect_button.html.slim
@@ -2,7 +2,7 @@
   .text-center.mb-3
     p Inclusion Connect vous permet d'utiliser le même identifiant et mot de passe pour vous connecter à différents services. Simple, sécurisé, efficace !
     - image_path = image_path("logo-inclusion-connect-bg.svg")
-    a.btn-inclusion-connect href=inclusion_connect_auth_path style="background-image: url(#{image_path})"
+    a.btn-inclusion-connect href=inclusion_connect_auth_path data-turbolinks="false" style="background-image: url(#{image_path})"
       = image_tag("logo-inclusion-connect-one-line.svg", alt: "Se connecter avec Inclusion Connect", height: 14)
 
   .row.pt-3

--- a/app/views/common/_inclusionconnect_button.html.slim
+++ b/app/views/common/_inclusionconnect_button.html.slim
@@ -2,6 +2,8 @@
   .text-center.mb-3
     p Inclusion Connect vous permet d'utiliser le même identifiant et mot de passe pour vous connecter à différents services. Simple, sécurisé, efficace !
     - image_path = image_path("logo-inclusion-connect-bg.svg")
+
+    / Voir ici pourquoi on désactive Turbolinks : https://github.com/betagouv/rdv-service-public/pull/4070
     a.btn-inclusion-connect href=inclusion_connect_auth_path data-turbolinks="false" style="background-image: url(#{image_path})"
       = image_tag("logo-inclusion-connect-one-line.svg", alt: "Se connecter avec Inclusion Connect", height: 14)
 


### PR DESCRIPTION
Nous avons le comportement suivant : 
- au clic sur le bouton, Turbolinks envoie une XHR vers `/inclusion_connect/auth`
- l'appli répond avec une 302 (redirect) vers `https://connect.inclusion.beta.gouv.fr/...`
- notre CSP n'autorise pas ce domaine et donc le navigateur refuse de rediriger via XHR
- Turbolinks ré-essaye d'envoyer la requête vers `/inclusion_connect/auth` mais pas en XHR (navigation normale)
- le redirect est bien suivi

Cela signifie qu'on passe deux fois dans `InclusionConnectController#auth` et donc qu'on écrit deux fois dans `session[:ic_state]`. Ça pourrait être la cause de ces erreurs Sentry mais pas sûr : 

[InclusionConnect states do not match](https://sentry.incubateur.net/organizations/betagouv/issues/18673/?environment=production&project=74&query=is%3Aunresolved+inclusion&referrer=issue-stream&statsPeriod=14d)

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
