### PR TITLE
Fix Overlapping incoherence

### DIFF
--- a/app/models/absence.rb
+++ b/app/models/absence.rb
@@ -39,11 +39,6 @@ class Absence < ApplicationRecord
 
     not_recurring_start_in_range.or(recurring_in_range)
   }
-  scope :overlapping_range, lambda { |range|
-    in_range(range).select do |absence|
-      absence.occurrences_for(range).any? { range.overlaps?(_1.starts_at.._1.ends_at) }
-    end
-  }
 
   # Delegations
   delegate :domain, to: :agent

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -17,7 +17,7 @@ module RecurrenceConcern
     scope :overlapping_range, lambda { |range|
       # model is either plage_ouverture or absence
       in_range(range).select do |model|
-        model.occurrences_for(range).any? { range.overlaps?(_1.starts_at.._1.ends_at) }
+        model.occurrences_for(range).any? { _1.overlapping_range?(range) }
       end
     }
   end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -15,9 +15,7 @@ module RecurrenceConcern
     scope :exceptionnelles, -> { where(recurrence: nil) }
     scope :regulieres, -> { where.not(recurrence: nil) }
     scope :overlapping_range, lambda { |range|
-      in_range(range).select do |recurrence_object|
-        recurrence_object.occurrences_for(range).any? { _1.overlapping_range?(range) }
-      end
+      in_range(range).select { _1.occurrences_for(range).any? { |occurence| occurence.overlaps?(range) } }
     }
   end
 

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -14,6 +14,12 @@ module RecurrenceConcern
 
     scope :exceptionnelles, -> { where(recurrence: nil) }
     scope :regulieres, -> { where.not(recurrence: nil) }
+    scope :overlapping_range, lambda { |range|
+      # model is either plage_ouverture or absence
+      in_range(range).select do |model|
+        model.occurrences_for(range).any? { range.overlaps?(_1.starts_at.._1.ends_at) }
+      end
+    }
   end
 
   def starts_at

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -15,9 +15,8 @@ module RecurrenceConcern
     scope :exceptionnelles, -> { where(recurrence: nil) }
     scope :regulieres, -> { where.not(recurrence: nil) }
     scope :overlapping_range, lambda { |range|
-      # model is either plage_ouverture or absence
-      in_range(range).select do |model|
-        model.occurrences_for(range).any? { _1.overlapping_range?(range) }
+      in_range(range).select do |recurrence_object|
+        recurrence_object.occurrences_for(range).any? { _1.overlapping_range?(range) }
       end
     }
   end

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -53,11 +53,6 @@ class PlageOuverture < ApplicationRecord
 
     not_recurring_start_in_range.or(recurring_in_range)
   }
-  scope :overlapping_range, lambda { |range|
-    in_range(range).select do |plage_ouverture|
-      plage_ouverture.occurrences_for(range).any? { range.overlaps?(_1.starts_at.._1.ends_at) }
-    end
-  }
   scope :bookable_by_everyone, -> { joins(:motifs).merge(Motif.bookable_by_everyone) }
   scope :bookable_by_everyone_or_bookable_by_invited_users, -> { joins(:motifs).merge(Motif.bookable_by_everyone_or_bookable_by_invited_users) }
 

--- a/app/models/recurrence/occurrence.rb
+++ b/app/models/recurrence/occurrence.rb
@@ -9,4 +9,12 @@ class Recurrence::Occurrence
   end
 
   delegate :to_date, to: :starts_at
+
+  def overlapping_range?(range)
+    # Pour des intervalles de temps consécutifs, nous ne considérons pas qu'il y a conflit des horaires
+    # (8..9).overlapping_range?(9..10) => False
+    return false if range.first == ends_at || range.last == starts_at
+
+    range.overlaps?(starts_at..ends_at)
+  end
 end

--- a/app/models/recurrence/occurrence.rb
+++ b/app/models/recurrence/occurrence.rb
@@ -10,7 +10,7 @@ class Recurrence::Occurrence
 
   delegate :to_date, to: :starts_at
 
-  def overlapping_range?(range)
+  def overlaps?(range)
     # Pour des intervalles de temps consécutifs, nous ne considérons pas qu'il y a conflit des horaires
     # (8..9).overlapping_range?(9..10) => False
     return false if range.first == ends_at || range.last == starts_at

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -781,4 +781,40 @@ RSpec.describe Rdv, type: :model do
       expect(rdv.status).to eq("unknown")
     end
   end
+
+  describe "#overlapping_absences" do
+    subject { rdv.overlapping_absences }
+
+    let(:agent) { create(:agent) }
+    let(:now) { Time.zone.parse("2021-05-03 09h00") }
+    let(:rdv) { create(:rdv, starts_at: now, ends_at: now + 1.hour, agents: [agent]) }
+    let!(:absence) do
+      create(
+        :absence,
+        agent: agent,
+        first_day: now.to_date,
+        start_time: Tod::TimeOfDay.new(9),
+        end_time: Tod::TimeOfDay.new(10),
+        recurrence: Montrose.every(:week, on: ["monday"], starts: Time.zone.parse("20210503 00:00"), until: nil)
+      )
+    end
+
+    before { travel_to now }
+
+    it "returns absence overlapping rdv" do
+      expect(subject).to match_array([absence])
+    end
+
+    context "rdv interval is consecutive to absence interval: Absence for 08h-09h and Rdv for 09h-10h" do
+      before do
+        absence.start_time = Tod::TimeOfDay.new(9)
+        absence.start_time = Tod::TimeOfDay.new(10)
+        absence.save!
+      end
+
+      it "does not find any overlapping absence" do
+        expect(subject).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Amélioration de la logique pour déterminer s'il y a chevauchement entre les horaires d'un RDV et d'une absence

## Description du bug
Lorsqu'un RDV et une absence ont des intervalles horaires consécutives, nous signalons un chevauchement.

Exemple:
```
rdv.starts => 08h
rdv.ends_at => 09h

absence_occurence.starts_at => 07h
absence_occurence.ends_at => 08h

absence_occurence.overlaps?(rdv.starts_at..rdv.ends_at) => TRUE # Comportement indésirable
```

Pour déterminer s'il y a chevauchement, nous utilisons la méthode `Range#overlaps?` https://github.com/betagouv/rdv-service-public/blob/33a09a317a20c298b545f6c7977207c54cbb8c55/app/models/absence.rb#L44

Toutefois, le comportement de `Range#overlaps?` tel que défini par [Rails](https://github.com/rails/rails/blob/fc734f28e65ef8829a1a939ee6702c1f349a1d5a/activesupport/lib/active_support/core_ext/range/overlaps.rb#L8), considère qu'il y chevauchement lorsque l'extrémité gauche d'une intervalle est égale à l'extrémité droite de l'autre 


Exemple:

```
irb(main):001> (1..5).overlaps?(5..10)
=> true
irb(main):002> 
```

## Solution
Ne plus se baser uniquement sur `Range#overlaps?` et vérifier les extrémités des intervalles.