### PR TITLE
InclusionConnect : Pré-remplir l'adresse e-mail de l'agent invité

### DIFF
--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -3,7 +3,7 @@ class InclusionConnectController < ApplicationController
 
   def auth
     session[:ic_state] = Digest::SHA1.hexdigest("InclusionConnect - #{SecureRandom.hex(13)}")
-    redirect_to InclusionConnect.auth_path(session[:ic_state], inclusion_connect_callback_url), allow_other_host: true
+    redirect_to InclusionConnect.auth_path(session[:ic_state], inclusion_connect_callback_url, login_hint: params[:login_hint]), allow_other_host: true
   end
 
   def callback

--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -4,7 +4,7 @@ module InclusionConnect
   IC_BASE_URL = ENV["INCLUSION_CONNECT_BASE_URL"]
 
   class << self
-    def auth_path(ic_state, inclusion_connect_callback_url)
+    def auth_path(ic_state, inclusion_connect_callback_url, login_hint: nil)
       query = {
         response_type: "code",
         client_id: IC_CLIENT_ID,
@@ -13,6 +13,7 @@ module InclusionConnect
         state: ic_state,
         nonce: Digest::SHA1.hexdigest("Something to check when it come back ?"),
         from: "community",
+        login_hint: login_hint,
       }
       "#{IC_BASE_URL}/authorize/?#{query.to_query}"
     end

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -1,7 +1,7 @@
 .text-center.w-75.m-auto
-  h4.text-dark-50.text-center.mt-0.font-weight-bold  Inscription
+  h1.text-dark.mt-0.font-weight-bold.mb-4 Inscription
 
-  = render "common/inclusionconnect_button"
+  = render "common/inclusionconnect_button", locals: { login_hint: resource.email }
 
   = simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, class: "text-left" } do |f|
     p.text-muted.text-center.mb-4 Complétez vos informations.

--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,7 +1,7 @@
 .text-center.w-75.m-auto
-  h1.text-dark.mt-0.font-weight-bold.mb-4  Se connecter
+  h1.text-dark.mt-0.font-weight-bold.mb-4 Se connecter
 
-= render "common/inclusionconnect_button"
+= render "common/inclusionconnect_button", locals: {}
 
 .text-center.w-75.m-auto
   p.text-muted.mb-2 Entrez votre email et votre mot de passe.

--- a/app/views/common/_inclusionconnect_button.html.slim
+++ b/app/views/common/_inclusionconnect_button.html.slim
@@ -4,7 +4,7 @@
     - image_path = image_path("logo-inclusion-connect-bg.svg")
 
     / Voir ici pourquoi on désactive Turbolinks : https://github.com/betagouv/rdv-service-public/pull/4070
-    a.btn-inclusion-connect href=inclusion_connect_auth_path data-turbolinks="false" style="background-image: url(#{image_path})"
+    a.btn-inclusion-connect href=inclusion_connect_auth_path(login_hint: locals[:login_hint]) data-turbolinks="false" style="background-image: url(#{image_path})"
       = image_tag("logo-inclusion-connect-one-line.svg", alt: "Se connecter avec Inclusion Connect", height: 14)
 
   .row.pt-3


### PR DESCRIPTION
Pour éviter que l'agent se connecter à InclusionConnect avec une autre adresse que celle de l'invitation. En effet, si il utilise une autre adresse, nous ne trouverons pas son compte et il ne pourra pas se connecter chez nous. 

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
