### PR TITLE
Utilisation des statuts de participations dans l'export de participations

### DIFF
--- a/app/services/participation_exporter.rb
+++ b/app/services/participation_exporter.rb
@@ -79,7 +79,7 @@ module ParticipationExporter
       rdv.motif.service.name,
       rdv.motif_name,
       rdv.context,
-      Rdv.human_attribute_value(:status, rdv.temporal_status, disable_cast: true),
+      Rdv.human_attribute_value(:status, participation.temporal_status, disable_cast: true),
       rdv.address_without_personal_information || "",
       rdv.agents.map(&:full_name).join(", "),
       user.user_to_notify.city_name,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require "sentry/test_helper"
+require "paper_trail/frameworks/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,6 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require "sentry/test_helper"
-require "paper_trail/frameworks/rspec"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -97,7 +96,15 @@ RSpec.configure do |config|
     end
   end
 
-  config.before { setup_sentry_test }
+  config.before do
+    setup_sentry_test
+
+    # Si on fait un require 'paper_trail/frameworks/rspec' comme le recommande la documentation de PaperTrail,
+    # on désactive le versionning par défaut, et donc les specs n'ont plus le comportement de la prod
+    # Par contre, on a besoin de réinitialiser le whodunnit entre chaque spec pour éviter d'avoir de
+    # la pollution sur cet état partagé d'une spec à l'autre
+    ::PaperTrail.request.whodunnit = nil
+  end
   config.after { teardown_sentry_test }
 
   config.after do

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -1,0 +1,188 @@
+RSpec.describe ParticipationExporter, type: :service do
+  describe "#xls_string_from_rdvs_rows" do
+    # rubocop:disable RSpec/ExampleLength
+    it "return export with header" do
+      rdv = create(
+        :rdv,
+        created_at: Time.zone.parse("2023-01-01 12h50"),
+        starts_at: Time.zone.parse("2023-04-07 14h30"),
+        status: :unknown,
+        context: "des infos sur le rdv",
+        lieu: create(:lieu, name: "MDS Paris Nord", address: "21 rue des Ardennes, 75019 Paris"),
+        motif: build(:motif, name: "Consultation", service: build(:service, name: "PMI")),
+        organisation: create(:organisation, name: "MDS Paris"),
+        agents: [create(:agent, email: "agent@mail.com", first_name: "Francis", last_name: "Factice")],
+        users: [create(:user, first_name: "Gaston", last_name: "Bidon", birth_date: Date.new(2000, 1, 1))]
+      )
+      participation_row = described_class.row_array_from(rdv.participations.first)
+      xls_string = described_class.xls_string_from_participations_rows([participation_row])
+
+      header_row, first_data_row = Spreadsheet.open(StringIO.new(xls_string)).worksheets.first.rows
+
+      # Les lettres sont les noms de colonnes Excel.
+      # Il est important de toujours ajouter les nouvelles colonnes
+      # à la fin pour ne pas gêner les SI des départements,
+      # qui se basent parfois sur la position et non le libellé.
+      expect(header_row).to match_array(
+        [
+          "usager",
+          "rdv_id",
+          "année",
+          "date prise rdv",
+          "heure prise rdv",
+          "origine",
+          "date rdv",
+          "heure rdv",
+          "service",
+          "motif",
+          "contexte",
+          "statut",
+          "lieu",
+          "professionnel.le(s)",
+          "commune du responsable",
+          "usager mineur ?",
+          "résultat des notifications",
+          "Organisation",
+          "date naissance",
+          "code postal du responsable",
+          "créé par",
+          "email(s) professionnel.le(s)",
+        ]
+      )
+
+      expect(first_data_row).to match_array(
+        [
+          "Gaston BIDON",
+          rdv.id,
+          2023, "01/01/2023", "12h50",
+          "Créé par un agent",
+          "07/04/2023", "14h30",
+          "PMI",
+          "Consultation",
+          "des infos sur le rdv",
+          "À renseigner",
+          "MDS Paris Nord (21 rue des Ardennes, 75019 Paris)",
+          "Francis FACTICE",
+          nil,
+          "non",
+          nil,
+          "MDS Paris",
+          "01/01/2000",
+          nil,
+          nil,
+          "agent@mail.com",
+        ]
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe "#row_array_from rdv" do
+    describe "origine" do
+      let(:agent) { create(:agent) }
+      let(:user) { create(:user) }
+
+      it "return « Créé par un agent » when rdv created by an agent" do
+        rdv = build(:rdv, :with_fake_timestamps, created_by: agent)
+        expect(described_class.row_array_from(rdv.participations.first)[5]).to eq("Créé par un agent")
+      end
+
+      it "return « RDV pris sur internet » when rdv taken by user" do
+        rdv = build(:rdv, :with_fake_timestamps, created_by: user)
+        expect(described_class.row_array_from(rdv.participations.first)[5]).to eq("RDV Pris sur internet")
+      end
+    end
+
+    describe "lieu" do
+      it "return « par Téléphone » when rdv by phone" do
+        rdv = build(:rdv, :with_fake_timestamps, :by_phone)
+        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("Par téléphone")
+      end
+
+      it "return « [domicile] adresse of user » when rdv is at home" do
+        user = build(:user, address: "20 avenue de Ségur, Paris", first_name: "Lisa", last_name: "PAUL")
+        rdv = build(:rdv, :with_fake_timestamps, :at_home, users: [user])
+        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("À domicile")
+      end
+
+      it "return « lieu name and adresse » when rdv in place" do
+        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république 56700 Hennebont")
+        rdv = build(:rdv, :with_fake_timestamps, lieu: lieu)
+        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("Centre ville (3 place de la république 56700 Hennebont)")
+      end
+    end
+
+    describe "professionnel.le(s)" do
+      it "return all agent's names" do
+        caro = build(:agent, first_name: "Caroline", last_name: "DUPUIS")
+        karima = build(:agent, first_name: "Karima", last_name: "CHARNI")
+        rdv = build(:rdv, :with_fake_timestamps, agents: [karima, caro])
+        expect(described_class.row_array_from(rdv.participations.first)[13]).to eq("Karima CHARNI, Caroline DUPUIS")
+      end
+    end
+
+    describe "commune du premier responsable" do
+      it "return Châtillon when first responsable leave there" do
+        first_major = create(:user, birth_date: Date.new(2002, 3, 12), city_name: "Châtillon")
+        minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: first_major.id)
+        other_major = create(:user, birth_date: Date.new(2002, 3, 12))
+        other_minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: other_major.id)
+        rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, other_minor, first_major, other_major])
+        expect(described_class.row_array_from(rdv.participations.first)[14]).to eq("Châtillon")
+      end
+
+      it "return responsible's commune for relative" do
+        first_major = create(:user, birth_date: Date.new(2002, 3, 12), city_name: "Châtillon")
+        minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: first_major.id)
+        rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor])
+        expect(described_class.row_array_from(rdv.participations.first)[14]).to eq("Châtillon")
+      end
+    end
+
+    describe "un usager mineur ?" do
+      it "return oui when one minor user" do
+        now = Time.zone.parse("2020-4-3 13:45")
+        travel_to(now)
+        major = build(:user, birth_date: Date.new(2002, 3, 12))
+        minor = build(:user, birth_date: Date.new(2016, 5, 30))
+        rdv = build(:rdv, :with_fake_timestamps, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
+        expect(described_class.row_array_from(rdv.participations.first)[15]).to eq("oui")
+        expect(described_class.row_array_from(rdv.participations.last)[15]).to eq("non")
+      end
+    end
+  end
+
+  describe "synthesized_receipts_result (résultat des notifications)" do
+    it "return rdv synthesized_receipts_result" do
+      rdv = build(:rdv, :with_fake_timestamps, starts_at: 1.day.ago)
+      allow(rdv).to receive(:synthesized_receipts_result).and_return(:processed)
+      expect(described_class.row_array_from(rdv.participations.first)[16]).to eq("Traité")
+    end
+  end
+
+  describe "code postal du responsable" do
+    it "return 92320 (Chatillon's postal code) when first responsable lives there" do
+      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
+      rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
+      expect(described_class.row_array_from(rdv.participations.first)[19]).to eq("92320")
+    end
+
+    it "return responsible's postal code for relative" do
+      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
+      rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor])
+      expect(described_class.row_array_from(rdv.participations.first)[19]).to eq("92320")
+    end
+  end
+
+  describe "créé par" do
+    let(:agent) { create(:agent) }
+
+    it "return the agent name when rdv created by an agent" do
+      rdv = create(:rdv, created_by: agent)
+      rdv.versions.first.update!(whodunnit: "agent 008")
+      expect(described_class.row_array_from(rdv.participations.first)[20]).to eq("agent 008")
+    end
+  end
+end


### PR DESCRIPTION
On a eu une remontée de bug de la part de l'équipe support de RDV Insertion : quelqu'un voulait calculer le taux d'absentéisme à un atelier collectif, et a donc utilisé l'export de participations plutôt que l'export de rdvs.

Or cet export indiquait le statut du rdv, et pas de la participation concernée, ce qui est contre-intuitif pour cet export.

Cette PR corrige ce bug.

J'ai remarqué qu'il n'y avait pas de specs unitaires pour l'exporter de participations, donc j'en ai ajouté en m'inspirant de celles qu'on avait pour le rdv exporter.

### Papertrail et les specs

Le deuxième commit résulte d'une spec non-déterministe un peu rigolote :
- en faisant `bundle exec rspec spec/controllers/users/rdvs_controller_spec.rb spec/services/participation_exporter_spec.rb:4` la spec était au vert
- en faisant `bundle exec rspec spec/controllers/users/rdvs_controller_spec.rb spec/services/participation_exporter_spec.rb:4 --order=defined`, j'avais systématiquement une erreur sur `spec/services/participation_exporter_spec.rb:4`, parce que `rdv.author` n'était pas nil. C'est parce que le whodunnit de papertrail était setté par une spec précédente, et jamais effacé.

Le fix est expliqué en commentaire