### PR TITLE
Définir notre config SMTP dans des variables d'ENV

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,15 +78,14 @@ Rails.application.configure do
   if ENV["DISABLE_SENDING_EMAILS"]
     config.action_mailer.delivery_method = :file
   else
-    config.action_mailer.smtp_settings = {
-      address: "smtp-relay.sendinblue.com",
-      port: "587",
-      authentication: :plain,
-      user_name: ENV["SENDINBLUE_USERNAME"],
-      password: ENV["SENDINBLUE_PASSWORD"],
-      domain: "rdv-solidarites.fr",
-    }
     config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address: ENV.fetch("SMTP_ADDRESS"),
+      port: ENV.fetch("SMTP_PORT"),
+      authentication: :plain,
+      user_name: ENV.fetch("SMTP_USERNAME"),
+      password: ENV.fetch("SMTP_PASSWORD"),
+    }
   end
 
   config.action_mailer.show_previews = ENV["IS_REVIEW_APP"] == "true"


### PR DESCRIPTION
Dans la perspective de tester d'autres fournisseurs de mails transactionnels que Brevo / SendInBlue, je mets en place l'usage de variables d'ENV pour l'ensemble de notre paramètres SMTP.

Nous pensons tester [Scaleway TEM](https://www.scaleway.com/fr/email-transactionnel-tem/) en démo dès que possible pour aviser ensuite sur un changement en prod.

Note : j'ai créé les variables sur nos 3 apps Scalingo, je nettoierai les anciennes une fois cette PR mergée.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
