### PR TITLE
Suppression de la colonne de permissions sur les téléchargements de participations

### DIFF
--- a/app/controllers/admin/territories/agent_territorial_access_rights_controller.rb
+++ b/app/controllers/admin/territories/agent_territorial_access_rights_controller.rb
@@ -9,6 +9,6 @@ class Admin::Territories::AgentTerritorialAccessRightsController < Admin::Territ
   end
 
   def agent_territorial_access_right_params
-    params.require(:agent_territorial_access_right).permit(:allow_to_manage_teams, :allow_to_manage_access_rights, :allow_to_invite_agents, :allow_to_download_metrics)
+    params.require(:agent_territorial_access_right).permit(:allow_to_manage_teams, :allow_to_manage_access_rights, :allow_to_invite_agents)
   end
 end

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -41,8 +41,7 @@ class Compte
       AgentTerritorialAccessRight.create!(
         agent: agent, territory: territory,
         allow_to_manage_access_rights: true,
-        allow_to_invite_agents: true,
-        allow_to_download_metrics: true
+        allow_to_invite_agents: true
       )
     end
   end

--- a/app/models/agent_territorial_access_right.rb
+++ b/app/models/agent_territorial_access_right.rb
@@ -1,4 +1,6 @@
 class AgentTerritorialAccessRight < ApplicationRecord
+  self.ignored_columns = ["allow_to_download_metrics"]
+
   # Mixins
   has_paper_trail
 

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -32,12 +32,6 @@ class Agent::AgentPolicy < ApplicationPolicy
     admin_in_record_organisation? && record != current_agent
   end
 
-  def participations_export?
-    current_territory = context&.organisation&.territory
-    access_rights = current_agent.access_rights_for_territory(current_territory)
-    access_rights&.allow_to_download_metrics?
-  end
-
   class Scope < Scope
     include CurrentAgentInPolicyConcern
 

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -13,8 +13,7 @@ class Configuration::TerritoryPolicy
     territorial_admin? ||
       allow_to_manage_teams? ||
       allow_to_manage_access_rights? ||
-      allow_to_invite_agents? ||
-      allow_to_download_metrics?
+      allow_to_invite_agents?
   end
 
   def allow_to_manage_access_rights?
@@ -27,10 +26,6 @@ class Configuration::TerritoryPolicy
 
   def allow_to_manage_teams?
     @access_rights&.allow_to_manage_teams?
-  end
-
-  def allow_to_download_metrics?
-    @access_rights&.allow_to_download_metrics?
   end
 
   alias display_user_fields_configuration? territorial_admin?

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -33,7 +33,6 @@ h1
           = f.input :allow_to_manage_teams, as: :boolean, hint: t(".hint_allow_to_manage_teams")
           = f.input :allow_to_manage_access_rights, as: :boolean, hint: t(".hint_allow_to_manage_access_rights")
           = f.input :allow_to_invite_agents, as: :boolean, hint: t(".hint_allow_to_invite_agents")
-          = f.input :allow_to_download_metrics, as: :boolean, hint: t(".hint_allow_to_download_metrics")
         .card-footer
           .row
             .col.text-right

--- a/config/locales/models/agent.fr.yml
+++ b/config/locales/models/agent.fr.yml
@@ -16,7 +16,6 @@ fr:
         allow_to_manage_teams: Autorisé à créer, supprimer, modifier des équipes
         allow_to_manage_access_rights: Autorisé à gérer les droits d'accès
         allow_to_invite_agents: Autorisé à inviter et affecter des agents sur des organisations
-        allow_to_download_metrics: Autorisé à télécharger les rendez-vous par usager sur plusieurs organisations
       agent/rdv_notifications_levels:
         all: À chaque modification
         others: Uniquement les modifications faites par un usager (ou par un autre agent)

--- a/config/locales/views/admin_territories_agents.yml
+++ b/config/locales/views/admin_territories_agents.yml
@@ -10,4 +10,3 @@ fr:
           hint_allow_to_manage_teams: "Créer, supprimer, modifier toutes les équipes du territoires"
           hint_allow_to_manage_access_rights: "Modifier les droits d'accès de tous les agents du territoire"
           hint_allow_to_invite_agents: "Inviter d'autre personne sur le territoire, les affecter ou retirer de chacune des organisations du territoire"
-          hint_allow_to_download_metrics: "Recevoir par mail un fichier contenant tous les rendez-vous par usager sur plusieurs organisations"

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -63,7 +63,6 @@ agent_cnfs = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
-    allow_to_download_metrics: false,
   }]
 )
 agent_cnfs.skip_confirmation!

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -411,7 +411,6 @@ agent_org_paris_nord_pmi_martine = Agent.new(
     allow_to_manage_teams: true,
     allow_to_manage_access_rights: true,
     allow_to_invite_agents: true,
-    allow_to_download_metrics: true,
   }]
 )
 agent_org_paris_nord_pmi_martine.skip_confirmation!
@@ -432,7 +431,6 @@ agent_org_paris_nord_pmi_marco = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
-    allow_to_download_metrics: false,
   }]
 )
 agent_org_paris_nord_pmi_marco.skip_confirmation!
@@ -452,7 +450,6 @@ agent_org_paris_nord_social_polo = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
-    allow_to_download_metrics: false,
   }]
 )
 agent_org_paris_nord_social_polo.skip_confirmation!
@@ -472,7 +469,6 @@ org_arques_pmi_maya = Agent.new(
     allow_to_manage_teams: true,
     allow_to_manage_access_rights: true,
     allow_to_invite_agents: true,
-    allow_to_download_metrics: true,
   }]
 )
 org_arques_pmi_maya.skip_confirmation!
@@ -492,7 +488,6 @@ agent_org_bapaume_pmi_bruno = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
-    allow_to_download_metrics: false,
   }]
 )
 agent_org_bapaume_pmi_bruno.skip_confirmation!
@@ -513,7 +508,6 @@ agent_org_bapaume_pmi_gina = Agent.new(
     allow_to_manage_teams: false,
     allow_to_manage_access_rights: false,
     allow_to_invite_agents: false,
-    allow_to_download_metrics: false,
   }]
 )
 agent_org_bapaume_pmi_gina.skip_confirmation!

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -203,46 +203,42 @@ RSpec.describe Admin::RdvsController, type: :controller do
   end
 
   describe "POST #participations_export" do
-    context "agent with rights" do
-      let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_download_metrics: true) }
+    it "redirect to index" do
+      post :participations_export, params: { organisation_id: organisation.id }
+      expect(response).to redirect_to(admin_organisation_rdvs_path)
+    end
 
-      it "redirect to index" do
-        post :participations_export, params: { organisation_id: organisation.id }
-        expect(response).to redirect_to(admin_organisation_rdvs_path)
-      end
+    it "sends export email" do
+      params = {
+        start: nil,
+        end: nil,
+        organisation_id: organisation.id.to_s,
+        agent_id: "",
+        user_id: "",
+        status: "",
+        motif_ids: [""],
+        lieu_ids: [""],
+        scoped_organisation_ids: [""],
+      }
 
-      it "sends export email" do
+      expect do
+        post :participations_export, params: { organisation_id: organisation.id }.merge(params)
+      end.to have_enqueued_job(ParticipationsExportJob).with(agent: agent, organisation_ids: [organisation.id], options: params.stringify_keys)
+    end
+
+    context "when passing scoped_organisation_id param to which agent not belong" do
+      it "does not enqueue e-mail" do
+        other_organisation = create(:organisation)
         params = {
-          start: nil,
-          end: nil,
-          organisation_id: organisation.id.to_s,
-          agent_id: "",
-          user_id: "",
-          status: "",
-          motif_ids: [""],
-          lieu_ids: [""],
-          scoped_organisation_ids: [""],
+          organisation_id: organisation.id,
+          scoped_organisation_id: [other_organisation.id],
         }
 
         expect do
-          post :participations_export, params: { organisation_id: organisation.id }.merge(params)
-        end.to have_enqueued_job(ParticipationsExportJob).with(agent: agent, organisation_ids: [organisation.id], options: params.stringify_keys)
-      end
+          post :participations_export, params: params
+        end.not_to have_enqueued_mail
 
-      context "when passing scoped_organisation_id param to which agent not belong" do
-        it "does not enqueue e-mail" do
-          other_organisation = create(:organisation)
-          params = {
-            organisation_id: organisation.id,
-            scoped_organisation_id: [other_organisation.id],
-          }
-
-          expect do
-            post :participations_export, params: params
-          end.not_to have_enqueued_mail
-
-          expect(response).to have_http_status(:redirect) # Pundit redirects when authorization fails
-        end
+        expect(response).to have_http_status(:redirect) # Pundit redirects when authorization fails
       end
     end
   end

--- a/spec/policies/configuration/territory_policy_spec.rb
+++ b/spec/policies/configuration/territory_policy_spec.rb
@@ -102,26 +102,5 @@ RSpec.describe Configuration::TerritoryPolicy, type: :policy do
                       :display_rdv_fields_configuration?,
                       :display_motif_fields_configuration?
     end
-
-    context "allowed to download metrics access right" do
-      let(:agent) { create(:agent, role_in_territories: []) }
-      let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_download_metrics: true) }
-
-      it_behaves_like "permit actions",
-                      :territory,
-                      :show?,
-                      :allow_to_download_metrics?
-
-      it_behaves_like "not permit actions",
-                      :territory,
-                      :update?,
-                      :edit?,
-                      :allow_to_invite_agents?,
-                      :allow_to_manage_access_rights?,
-                      :allow_to_manage_teams?,
-                      :display_user_fields_configuration?,
-                      :display_rdv_fields_configuration?,
-                      :display_motif_fields_configuration?
-    end
   end
 end

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -80,8 +80,7 @@ RSpec.describe AddConseillerNumerique do
             territory: territory,
             allow_to_manage_teams: false,
             allow_to_manage_access_rights: false,
-            allow_to_invite_agents: false,
-            allow_to_download_metrics: false
+            allow_to_invite_agents: false
           )
         end
       end


### PR DESCRIPTION
Dans le cadre de https://github.com/betagouv/rdv-service-public/pull/4077, on a découvert que la colonne `agent_territorial_access_rights.allow_to_download_metrics` n'avait pas d'impact sur le comportement de l'application. 

Cette permission peut être activée ou désactivée dans le formulaire d'agents de la configuration de territoire, mais elle ne change rien. Tous les agents peuvent télécharger des exports de participations (contrairement au comportement prévu à la base).
Je crois comprendre que l'objectif de cette fonctionnalité était de limiter qui utilise ce type d'export pour mieux comprendre comment on peut les faire évoluer. Malheureusement, ça fait donc plus d'un an que tout le monde a accès a cet export, et s'en sert, donc ça serait difficile de revenir arrière sur cette fonctionnalité pour la fermer à tous les gens qui n'ont pas explicitement cette permissions.

On préfère donc éviter d'avoir une interface mensongère, et supprimer la checkbox et la colonnes associée plutôt que de changer le comportement.