### PR TITLE
Correctif pour l'etl 

### DIFF
--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -14,6 +14,11 @@ dbclient-fetcher pgsql
 # On préfère faire un login à chaque rafraichissement des données plutôt que de laisser un token scalingo en variable d'env
 scalingo login --password-only
 
+etl_addon_id="$( scalingo --region osc-secnum-fr1 --app rdv-service-public-etl addons \
+  | grep "PostgreSQL" \
+  | cut -d "|" -f 3 \
+  | tr -d " " )"
+
 echo "Upgrade du Postgres d'ETL pour avoir plus de RAM"
 # On fait cette opération avant de télécharger le dump pour que le provisionnement du nouveau plan ai le temps de se finir avant le pg_restore
 scalingo --region osc-secnum-fr1 --app rdv-service-public-etl addons-upgrade "${etl_addon_id}"  postgresql-starter-8192
@@ -33,12 +38,6 @@ tar --extract --verbose --file="${archive_name}" --directory="/app/"
 echo "Suppression du role postgres utilisé par metabase"
 scalingo database-delete-user --region osc-secnum-fr1 --app rdv-service-public-etl --addon "${etl_addon_id}" rdv_service_public_metabase
 echo "La base de données n'est plus accessible par metabase"
-
-
-etl_addon_id="$( scalingo --region osc-secnum-fr1 --app rdv-service-public-etl addons \
-                 | grep "PostgreSQL" \
-                 | cut -d "|" -f 3 \
-                 | tr -d " " )"
 
 
 echo "Chargement du dump..."


### PR DESCRIPTION
l'addon id est utilisé pour augmenter la ram de postgres

Je me permets de merger ça rapidement vu que c'est un fix sur l'etl (et ça contribue à me faire penser que ça serait bien qu'on sorte ce bout de logique dans un autre repo)