### PR TITLE
Changement du layout de la config et territoires et améliorations pour le Saas

### DIFF
--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -11,8 +11,14 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
   def update
     authorize current_territory
     current_territory.update(services_params)
-    flash[:alert] = "Configuration enregistrée"
-    redirect_to edit_admin_territory_services_path(current_territory)
+    flash[:alert] = "Liste des services disponibles mise à jour"
+
+    if params[:redirect_to_organisation_id].present?
+      redirect_to new_admin_organisation_agent_path(params[:redirect_to_organisation_id])
+    else
+      flash[:alert] = "Liste des services disponibles mise à jour"
+      redirect_to edit_admin_territory_services_path(current_territory)
+    end
   end
 
   private

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,27 +1,29 @@
 module ConfigurationHelper
   def territory_navigation(title = nil, previous_links = [])
-    tag.nav class: "configuration-title pb-2 mb-2" do
-      tag.ol class: "breadcrumb m-0 p-0" do
-        concat(tag.li(class: "breadcrumb-item") do
-          link_to root_path do
-            concat(current_domain.name)
-          end
-        end)
-        concat(tag.li(class: "breadcrumb-item") do
-          link_to admin_territory_path(current_territory) do
-            concat(t("admin.territories.nav.configuration_title"))
-          end
-        end)
-        previous_links.each do |prev_link|
+    content_for(:breadcrumbs) do
+      tag.nav class: "configuration-title pb-2 mb-2" do
+        tag.ol class: "breadcrumb m-0 p-0" do
           concat(tag.li(class: "breadcrumb-item") do
-            prev_link
+            link_to root_path do
+              concat(current_domain.name)
+            end
           end)
-        end
+          concat(tag.li(class: "breadcrumb-item") do
+            link_to admin_territory_path(current_territory) do
+              concat(t("admin.territories.nav.configuration_title"))
+            end
+          end)
+          previous_links.each do |prev_link|
+            concat(tag.li(class: "breadcrumb-item") do
+              prev_link
+            end)
+          end
 
-        if title.present?
-          concat(tag.li(class: "breadcrumb-item active") do
-            title
-          end)
+          if title.present?
+            concat(tag.li(class: "breadcrumb-item active") do
+              title
+            end)
+          end
         end
       end
     end

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,20 +1,21 @@
 module ConfigurationHelper
   def territory_navigation(title = nil, previous_links = [])
-    tag.nav class: "border-bottom configuration-title border-bottom pb-2 configuration-title mb-2" do
+    tag.nav class: "configuration-title pb-2 mb-2" do
       tag.ol class: "breadcrumb m-0 p-0" do
         concat(tag.li(class: "breadcrumb-item") do
+          link_to root_path do
+            concat(current_domain.name)
+          end
+        end)
+        concat(tag.li(class: "breadcrumb-item") do
           link_to admin_territory_path(current_territory) do
-            concat(tag.i(class: "fa fa-cogs"))
-            concat(" ")
             concat(t("admin.territories.nav.configuration_title"))
           end
         end)
-        if previous_links.any?
-          previous_links.each do |prev_link|
-            concat(tag.li(class: "breadcrumb-item") do
-              prev_link
-            end)
-          end
+        previous_links.each do |prev_link|
+          concat(tag.li(class: "breadcrumb-item") do
+            prev_link
+          end)
         end
 
         if title.present?

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -17,6 +17,7 @@
 
 // Structure
 @import "./structure/general";
+@import "./structure/header";
 @import "./structure/left-menu";
 @import "./structure/footer";
 @import "./structure/page-head";

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -10,13 +10,19 @@
         = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation, @agent), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: @agent
           = f.association :services, collection: @services, include_blank: false, input_html: { class: "select2-input" }
+          - if policy([:agent, current_territory]).edit?
+            small.form-text.text-muted.mb-4
+              = "Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez "
+              = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))
+
           - # rubocop:disable Rails/OutputSafety
           = f.simple_fields_for @agent_role do |ff|
             = ff.input :access_level, \
               collection: @roles, \
               label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
               hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
-              as: :radio_buttons
+              as: :radio_buttons,
+              html: { class: "mt-4" }
           - # rubocop:enable Rails/OutputSafety
 
           .js_agent_role_form__agent_with_account_fields

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -7,7 +7,7 @@
         h1.card-title Services
         p Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
 
-        = simple_form_for current_territory, url: admin_territory_services_path(current_territory) do |f|
+        = simple_form_for current_territory, url: admin_territory_services_path(current_territory, redirect_to_organisation_id: params[:redirect_to_organisation_id]) do |f|
           = render "model_errors", model: current_territory
 
           = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -5,12 +5,17 @@
     .card
       .card-body
         h1.card-title Services
-        p.text-muted.font-14 Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
+        p Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
 
         = simple_form_for current_territory, url: admin_territory_services_path(current_territory) do |f|
           = render "model_errors", model: current_territory
 
           = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second
+
+          p.text-muted.font-14
+            | Si vous avez besoin d'un service qui n'apparaît pas dans cette liste, contactez-nous via
+            = mail_to(current_domain.support_email, current_domain.support_email)
+            | .
 
           .text-right
             = f.button :submit

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -13,7 +13,7 @@
           = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second
 
           p.text-muted.font-14
-            | Si vous avez besoin d'un service qui n'apparaît pas dans cette liste, contactez-nous via
+            = "Si vous avez besoin d'un service qui n'apparaît pas dans cette liste, contactez-nous via "
             = mail_to(current_domain.support_email, current_domain.support_email)
             | .
 

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,6 +1,6 @@
 = territory_navigation
 
-h1.m-2.text-center.border-bottom.pb-2 Configuration - #{current_territory.name}
+h1.m-2.text-center.border-bottom.pb-2 Espace Admin - #{current_territory.name}
 .row.mb-3
   - if policy([:configuration, AgentTerritorialRole]).display?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,5 +1,6 @@
 = territory_navigation
 
+h1.m-2.text-center.border-bottom.pb-2 Configuration - #{current_territory.name}
 .row.mb-3
   - if policy([:configuration, AgentTerritorialRole]).display?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -1,0 +1,15 @@
+footer.footer
+  .container-fluid
+    .row
+      .col-md-12
+        .footer-links.d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
+          | Accessibilité : non conforme
+          = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
+            span>= ENV["RDV_SOLIDARITES_VERSION"]
+            i.fa.fa-external-link-alt
+          = link_to mentions_legales_path do
+            span> Mentions Légales
+          = link_to cgu_path do
+            span> C.G.U.
+          = link_to politique_de_confidentialite_path do
+            span> Politique de confidentialité

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -3,7 +3,7 @@ header.header.bg-white.mb-4
   = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
 
   .container
-    nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr
+    nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr title="navigation"
       = link_logo_dsfr
       button.navbar-toggler.navbar-toggler-right aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
         i.fa.fa-bars.text-primary-blue

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -1,0 +1,14 @@
+header.header.bg-white.mb-4
+  = render "layouts/rdv_solidarites_instance_name"
+  = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
+
+  .container
+    nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr
+      = link_logo_dsfr
+      button.navbar-toggler.navbar-toggler-right aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
+        i.fa.fa-bars.text-primary-blue
+      #navbarSupportedContent.collapse.navbar-collapse
+        ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
+          li.list-inline-item
+            = link_to current_agent.full_name, edit_agent_registration_path, class: "btn text-primary-blue link-dsfr"
+

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -11,4 +11,3 @@ header.header.bg-white.mb-4
         ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
           li.list-inline-item
             = link_to current_agent.full_name, edit_agent_registration_path, class: "btn text-primary-blue link-dsfr"
-

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -11,3 +11,7 @@ header.header.bg-white.mb-4
         ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
           li.list-inline-item
             = link_to current_agent.full_name, edit_agent_registration_path, class: "btn text-primary-blue link-dsfr"
+          li.list-inline-item
+            = link_to destroy_agent_session_path, method: :delete, class: "btn text-primary-blue link-dsfr" do
+              i.fa.fa-sign-out-alt>
+              span> Se déconnecter

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -26,18 +26,5 @@ html lang="fr"
               = yield
 
     #modal-holder
-    footer.footer
-      .container-fluid
-        .row
-          .col-md-12
-            .footer-links.d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
-              | Accessibilité : non conforme
-              = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
-                span>= ENV["RDV_SOLIDARITES_VERSION"]
-                i.fa.fa-external-link-alt
-              = link_to mentions_legales_path do
-                span> Mentions Légales
-              = link_to cgu_path do
-                span> C.G.U.
-              = link_to politique_de_confidentialite_path do
-                span> Politique de confidentialité
+    = render "layouts/agent_footer"
+

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -27,4 +27,3 @@ html lang="fr"
 
     #modal-holder
     = render "layouts/agent_footer"
-

--- a/app/views/layouts/application_configuration.html.slim
+++ b/app/views/layouts/application_configuration.html.slim
@@ -4,11 +4,7 @@ html lang="fr"
     = yield :html_head_prepend
     = render "common/head_agent"
   body
-    = render "layouts/rdv_solidarites_instance_name"
-    = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
-
-    header.container.px-8.mb-2.mt-1.text-center
-        h1.m-2 #{current_domain.name} - #{current_territory.name}
+    = render "layouts/agent_header"
 
     main.container-fluid
 
@@ -17,5 +13,4 @@ html lang="fr"
         = yield
 
     #modal-holder
-    footer.main-footer
-      = render "common/footer_users"
+    = render "layouts/agent_footer"

--- a/app/views/layouts/application_configuration.html.slim
+++ b/app/views/layouts/application_configuration.html.slim
@@ -9,6 +9,7 @@ html lang="fr"
     main.container-fluid
 
       .container.px-4#icon-grid
+        = content_for(:breadcrumbs)
         = render "layouts/flash"
         = yield
 

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_link("Services")
       check("CSS")
       click_button("Enregistrer")
-      expect(page).to have_content("Configuration enregistrée")
+      expect(page).to have_content("Liste des services disponibles mise à jour")
       logout
 
       login_as(organisation_admin, scope: :agent)


### PR DESCRIPTION
Cette PR ajuste le texte de la liste des services dans la configuration de territoire, et ajoute un vrai header et corrige le footer dans la config de territoire

voir https://www.notion.so/rdvs/Solution-SaaS-7d6c2f96ba5441c4abc2fe5801dff6d2

### Avant

<img width="1423" alt="Screenshot 2024-02-21 at 10 23 56" src="https://github.com/betagouv/rdv-service-public/assets/1840367/fa134df2-c0c6-4cab-aa1d-affe77caeedb">


### Après
<img width="1438" alt="Screenshot 2024-02-21 at 10 56 24" src="https://github.com/betagouv/rdv-service-public/assets/1840367/7bec2180-f372-4f93-8c39-20eda5de2d53">

