### PR TITLE
Nettoyage de content_security_policy.rb

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -3,41 +3,52 @@
 # Define an application-wide content security policy
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+#
+# InStatus est le service dont on se sert pour communiquer les incidents
+in_status = "*.instatus.com"
 
-unless Rails.env.test?
+# Nous hébergeons la vidéo de la page d'accueil de RDV_MAIRIE sur le s3 de RDV-Insertion
+s3_de_rdv_insertion = "rdv-insertion-medias-production.s3.fr-par.scw.cloud"
 
-  Rails.application.config.content_security_policy do |policy|
-    policy.default_src :self
-    policy.font_src    :self, :data, "github.com"
-    policy.object_src  :none
-    policy.worker_src :blob
-    policy.child_src :blob, :self
-    policy.frame_src :self, "*.instatus.com"
-    policy.media_src :self, "*.instatus.com", "rdv-insertion-medias-production.s3.fr-par.scw.cloud"
+# Nous faisons des appels vers cette API dans notre recherche par adresse
+api_adresse_data_gouv = "api-adresse.data.gouv.fr"
 
-    if Rails.env.development?
-      policy.script_src :self, :unsafe_inline, "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "localhost:3035", "data1.gryplex.com", "lb.apicit.net",
-                        "tags.clickintext.net", "api.mapbox.com", "blob:", "www.ssa.gov", "ajax.googleapis.com"
-      policy.connect_src :self, "api-adresse.data.gouv.fr", "localhost:3035", "ws://localhost:3035", "etalab-tiles.fr"
-      policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com", "www.ssa.gov"
-      policy.img_src     :self, :data, :blob, "voxusagers.numerique.gouv.fr", "www.ssa.gov"
-    else
-      policy.script_src :self, :unsafe_inline, "api-adresse.data.gouv.fr", "data1.ollapges.com", "fidoapi.com", "data1.gryplex.com", "lb.apicit.net", "tags.clickintext.net",
-                        "api.mapbox.com", "blob:"
-      policy.connect_src :self, "api-adresse.data.gouv.fr", "cdnjs.cloudflare.com", "etalab-tiles.fr"
-      policy.style_src   :self, :unsafe_inline, "*.bootstrapcdn.com", "cdnjs.cloudflare.com", "api.mapbox.com"
-      policy.img_src     :self, :data, :blob, "voxusagers.numerique.gouv.fr"
-    end
+# Nous utilisons mapbox et les tiles etalab pour les interfaces de config de sectorisation
+api_mapbox = "api.mapbox.com"
+tiles_etalab = "etalab-tiles.fr"
+
+# Bouton "Je donne mon avis sur cette démarche"
+voxusagers = "voxusagers.numerique.gouv.fr"
+
+# Utilisé sur nos pages statiques (404.html, 500.html)
+bootstrap_cdn = "*.bootstrapcdn.com"
+
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+  policy.font_src    :self
+  policy.object_src  :none
+  policy.worker_src :blob
+  policy.child_src :blob, :self
+  policy.frame_src :self, in_status
+  policy.media_src :self, in_status, s3_de_rdv_insertion
+  policy.img_src :self, :data, voxusagers
+  policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox
+  policy.connect_src :self, api_adresse_data_gouv, tiles_etalab
+  policy.script_src :self, :unsafe_inline, api_mapbox
+
+  if ENV["CI"].present?
+    # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI
+    policy.script_src(*(policy.script_src + ["ajax.googleapis.com"]))
   end
-
-  # If you are using UJS then enable automatic nonce generation
-  # Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
-
-  # Set the nonce only to specific directives
-  # Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
-
-  # Report CSP violations to a specified URI
-  # For further information see the following documentation:
-  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-  # Rails.application.config.content_security_policy_report_only = true
 end
+
+# If you are using UJS then enable automatic nonce generation
+# Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+
+# Set the nonce only to specific directives
+# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
+
+# Report CSP violations to a specified URI
+# For further information see the following documentation:
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+# Rails.application.config.content_security_policy_report_only = true

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -2,7 +2,7 @@ WebMock.disable_net_connect!(allow: [
                                "127.0.0.1",
                                "localhost",
                                "www.rdv-solidarites-test.localhost",
-                               "chromedriver.storage.googleapis.com", # Autorise Chromedrive storage pour l'execution de la CI
+                               "chromedriver.storage.googleapis.com", # Autorise à télécharger le binaire chromedriver pour l'exécution de la CI
                              ])
 
 Capybara.register_driver :selenium do |app|


### PR DESCRIPTION
Il y avait vraiment des artefacts millénaires là-dedans. ⛏️🏺🗿⚱️

Je n'ai pas compris la cause de l'ajout de certaines valeurs, par exemple dans #559 il n'y avais aucun contexte.

J'ai viré certains trucs techniques, dîtes-moi si vous pensez que ça peut penser problème :
- `localhost:3035` est l'adresse utilisée par webpacker pour faire un auto-reload de la page quand on change le code JS/SCSS, mais on n'utilise plus webpacker
- `blob` (voir [la doc sur les sources](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources)) : je n'ai pas trouvé d'usages de `blob` dans notre code
- `www.ssa.gov` ([ajouté ici](https://github.com/betagouv/rdv-service-public/commit/2706251e)) : c'est une URL utilisée par une extension qui permet d'analyser l'accessibilité, mais à ma connaissance nous ne l'utilisons pas actuellement


# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
