### PR TITLE
Improve Liste des RDVs

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -123,6 +123,15 @@ module RdvsHelper
     "#{rdv.users_count} / #{rdv.max_participants_count}"
   end
 
+  def rdv_list_period
+    return nil unless valid_date?(params[:start]) && valid_date?(params[:end])
+
+    [
+      I18n.l(Date.parse(params[:start]), format: :human).capitalize,
+      I18n.l(Date.parse(params[:end]), format: :human).capitalize,
+    ].uniq.join(" - ")
+  end
+
   private
 
   def rdv_individuel_title_for_agent(rdv)
@@ -130,5 +139,9 @@ module RdvsHelper
       rdv.users&.map(&:full_name)&.to_sentence +
       (rdv.motif.home? ? " 🏠" : "") +
       (rdv.motif.phone? ? " ☎️" : "")
+  end
+
+  def valid_date?(date)
+    date.present? && date != "__/__/____"
   end
 end

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -84,7 +84,6 @@ module RdvsHelper
     end
   end
 
-
   def individual_rdv_status_dropdown_toggle(rdv)
     tag.div(data: { toggle: "dropdown" },
             class: "dropdown-toggle btn rdv-status-#{rdv.temporal_status}") do

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -71,6 +71,15 @@ module RdvsHelper
     "#{l(rdv.starts_at, format: format)} - #{l(rdv.starts_at + rdv.duration_in_min.minutes, format: format)}"
   end
 
+  def dates_interval
+    return nil unless valid_date?(params[:start]) && valid_date?(params[:end])
+
+    [
+      I18n.l(Date.parse(params[:start]), format: :human).capitalize,
+      I18n.l(Date.parse(params[:end]), format: :human).capitalize,
+    ].uniq.join(" - ")
+  end
+
   def individual_rdv_status_dropdown_toggle(rdv)
     tag.div(data: { toggle: "dropdown" },
             class: "dropdown-toggle btn rdv-status-#{rdv.temporal_status}") do
@@ -121,15 +130,6 @@ module RdvsHelper
     return rdv.users_count.to_s if rdv.max_participants_count.blank?
 
     "#{rdv.users_count} / #{rdv.max_participants_count}"
-  end
-
-  def rdv_list_period
-    return nil unless valid_date?(params[:start]) && valid_date?(params[:end])
-
-    [
-      I18n.l(Date.parse(params[:start]), format: :human).capitalize,
-      I18n.l(Date.parse(params[:end]), format: :human).capitalize,
-    ].uniq.join(" - ")
   end
 
   private

--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -72,13 +72,18 @@ module RdvsHelper
   end
 
   def dates_interval
-    return nil unless valid_date?(params[:start]) && valid_date?(params[:end])
+    return nil if no_date_filters?
 
-    [
-      I18n.l(Date.parse(params[:start]), format: :human).capitalize,
-      I18n.l(Date.parse(params[:end]), format: :human).capitalize,
-    ].uniq.join(" - ")
+    if valid_date?(params[:start]) && !valid_date?(params[:end])
+      dates_interval_from(params[:start])
+    elsif valid_date?(params[:end]) && !valid_date?(params[:start])
+      dates_interval_until(params[:end])
+    else
+      # Both Dates are valid
+      [format_date(params[:start]), format_date(params[:end])].uniq.join(" - ")
+    end
   end
+
 
   def individual_rdv_status_dropdown_toggle(rdv)
     tag.div(data: { toggle: "dropdown" },
@@ -143,5 +148,21 @@ module RdvsHelper
 
   def valid_date?(date)
     date.present? && date != "__/__/____"
+  end
+
+  def no_date_filters?
+    !valid_date?(params[:start]) && !valid_date?(params[:end])
+  end
+
+  def dates_interval_from(date)
+    "A partir du #{format_date(date)}"
+  end
+
+  def dates_interval_until(date)
+    "Jusqu'au #{format_date(date)}"
+  end
+
+  def format_date(date)
+    I18n.l(Date.parse(date), format: :human).capitalize
   end
 end

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -87,5 +87,5 @@
       = current_organisation.name
 
   h3.mt-4
-    = rdv_list_period
+    = dates_interval
   = render(partial: "admin/rdvs/print/rdv", collection: @rdvs_in_page)

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -87,5 +87,5 @@
       = current_organisation.name
 
   h3.mt-4
-    = I18n.l(Time.zone.today, format: :human).capitalize
+    = rdv_list_period
   = render(partial: "admin/rdvs/print/rdv", collection: @rdvs_in_page)

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -39,7 +39,7 @@
         .mt-2
           | Contexte :
           | &nbsp
-          - if rdv.context
+          - if rdv.context.present?
             = rdv.context
           - else
             span.font-weight-light.font-italic

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -30,14 +30,14 @@
               - if email.present?
                 = email
               - else
-                span.font-weight-light.font-italic
+                span.font-weight-light.font-italic.text-muted
                   | Email non renseigné
             | &nbsp - &nbsp
             span.mx-1
               - if phone_number.present?
                 = phone_number
               - else
-                span.font-weight-light.font-italic
+                span.font-weight-light.font-italic.text-muted
                   | Téléphone non renseigné
         .mt-2
           | Contexte :
@@ -45,7 +45,7 @@
           - if rdv.context.present?
             = rdv.context
           - else
-            span.font-weight-light.font-italic
+            span.font-weight-light.font-italic.text-muted
               | Pas de contexte renseigné
         .mt-2
           i.fa.fa-map-marker-alt>

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -39,14 +39,15 @@
               - else
                 span.font-weight-light.font-italic.text-muted
                   | Téléphone non renseigné
-        .mt-2
-          | Contexte :
-          | &nbsp
-          - if rdv.context.present?
-            = rdv.context
-          - else
-            span.font-weight-light.font-italic.text-muted
-              | Pas de contexte renseigné
+        - if current_organisation.territory.enable_context_field
+          .mt-2
+            | Contexte :
+            | &nbsp
+            - if rdv.context.present?
+              = rdv.context
+            - else
+              span.font-weight-light.font-italic.text-muted
+                | Pas de contexte renseigné
         .mt-2
           i.fa.fa-map-marker-alt>
           = rdv.lieu.name

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -11,7 +11,7 @@
       .d-flex
         .flex-grow-1.lead.pl-3.pt-2
           = rdv.motif_name
-        .rdv-status.px-2.py-2 class="rdv-status-#{rdv.status}"
+        .rdv-status.px-2.py-2 class="rdv-status-#{rdv.status}" id="rdv-#{rdv.id}-status"
           = rdv.human_attribute_value(:status).upcase
       .card-body
         - rdv.participations.each do |participation|
@@ -19,25 +19,26 @@
             user = participation.user
             phone_number = user.user_to_notify&.phone_number
             email = user.user_to_notify&.email
-          span.font-weight-bold.lead
-            = user
-          - if user.birth_date
+          div
+            span.font-weight-bold.lead
+              = user
+            - if user.birth_date
+              span.mx-1
+                = "(né(e) le #{I18n.l(participation.user.birth_date)})"
+            | &nbsp - &nbsp
             span.mx-1
-              = "(né(e) le #{I18n.l(participation.user.birth_date)})"
-          | &nbsp - &nbsp
-          span.mx-1
-            - if email
-              = email
-            - else
-              span.font-weight-light.font-italic
-                | Email non renseigné
-          | &nbsp - &nbsp
-          span.mx-1
-            - if phone_number
-              = phone_number
-            - else
-              span.font-weight-light.font-italic
-                | Téléphone non renseigné
+              - if email.present?
+                = email
+              - else
+                span.font-weight-light.font-italic
+                  | Email non renseigné
+            | &nbsp - &nbsp
+            span.mx-1
+              - if phone_number.present?
+                = phone_number
+              - else
+                span.font-weight-light.font-italic
+                  | Téléphone non renseigné
         .mt-2
           | Contexte :
           | &nbsp
@@ -50,6 +51,6 @@
           i.fa.fa-map-marker-alt>
           = rdv.lieu.name
         .mt-2
-          | Agent :
+          | Agent(s) :
           | &nbsp
           = agents_to_sentence(rdv.agents)

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -7,35 +7,37 @@
       div
         = "(#{rdv.duration_in_min} minutes)"
   .col-md-10.col-sm-10
-    .card.rdv-card
-      .card-body style="border-left: 8px solid #{rdv.motif.color}"
-        div
+    .card.rdv-card.rounded-0 style="border-left: 8px solid #{rdv.motif.color}"
+      .d-flex
+        .flex-grow-1.lead.pl-3.pt-2
           = rdv.motif_name
-        .mt-2
-          - rdv.participations.each do |participation|
-            ruby:
-              user = participation.user
-              phone_number = user.user_to_notify&.phone_number
-              email = user.user_to_notify&.email
-            span.font-weight-bold.lead
-              = user
-            - if user.birth_date
-              span.mx-1
-                = "(né(e) le #{I18n.l(participation.user.birth_date)})"
-            | &nbsp - &nbsp
+        .rdv-status.px-2.py-2 class="rdv-status-#{rdv.status}"
+          = rdv.human_attribute_value(:status).upcase
+      .card-body
+        - rdv.participations.each do |participation|
+          ruby:
+            user = participation.user
+            phone_number = user.user_to_notify&.phone_number
+            email = user.user_to_notify&.email
+          span.font-weight-bold.lead
+            = user
+          - if user.birth_date
             span.mx-1
-              - if email
-                = email
-              - else
-                span.font-weight-light.font-italic
-                  | Email non renseigné
-            | &nbsp - &nbsp
-            span.mx-1
-              - if phone_number
-                = phone_number
-              - else
-                span.font-weight-light.font-italic
-                  | Téléphone non renseigné
+              = "(né(e) le #{I18n.l(participation.user.birth_date)})"
+          | &nbsp - &nbsp
+          span.mx-1
+            - if email
+              = email
+            - else
+              span.font-weight-light.font-italic
+                | Email non renseigné
+          | &nbsp - &nbsp
+          span.mx-1
+            - if phone_number
+              = phone_number
+            - else
+              span.font-weight-light.font-italic
+                | Téléphone non renseigné
         .mt-2
           | Contexte :
           | &nbsp

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -12,16 +12,42 @@
         div
           = rdv.motif_name
         .mt-2
-          - if rdv.users.present?
-            .font-weight-bold.lead
-              = rdv.users.first
-            div
-              - if rdv.users.size > 1
-                i.fa.fa-users>
+          - rdv.participations.each do |participation|
+            ruby:
+              user = participation.user
+              phone_number = user.user_to_notify&.phone_number
+              email = user.user_to_notify&.email
+            span.font-weight-bold.lead
+              = user
+            - if user.birth_date
+              span.mx-1
+                = "(né(e) le #{I18n.l(participation.user.birth_date)})"
+            | &nbsp - &nbsp
+            span.mx-1
+              - if email
+                = email
               - else
-                i.fa.fa-user>
-              = "#{rdv.users.size} #{'participant'.pluralize(rdv.users.size)}"
-          - else
-            p Il n'y a pas encore de participant pour ce RDV
+                span.font-weight-light.font-italic
+                  | Email non renseigné
+            | &nbsp - &nbsp
+            span.mx-1
+              - if phone_number
+                = phone_number
+              - else
+                span.font-weight-light.font-italic
+                  | Téléphone non renseigné
         .mt-2
+          | Contexte :
+          | &nbsp
+          - if rdv.context
+            = rdv.context
+          - else
+            span.font-weight-light.font-italic
+              | Pas de contexte renseigné
+        .mt-2
+          i.fa.fa-map-marker-alt>
+          = rdv.lieu.name
+        .mt-2
+          | Agent :
+          | &nbsp
           = agents_to_sentence(rdv.agents)


### PR DESCRIPTION
Suite à certains retours utilisateurs, cette PR vient augmenter le nombre d'infos visibles sur la vue d'impression d'une liste de RDVs, notamment:
- La date de naissance, le numéro de téléphone et l'email de l'usager
- La liste des participants au lieu du nombre de participants
- Le lieu et le contexte du RDV
- La période du RDV au lieu de la date du jour
- Le nom de l'agent