### PR TITLE
Changement du layout de la config de territoires

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,26 +1,24 @@
 module ConfigurationHelper
   def territory_navigation(title = nil, previous_links = [])
-    tag.nav class: "border-bottom configuration-title border-bottom pb-2 configuration-title mb-2" do
-      tag.ol class: "breadcrumb m-0 p-0" do
-        concat(tag.li(class: "breadcrumb-item") do
-          link_to admin_territory_path(current_territory) do
-            concat(tag.i(class: "fa fa-cogs"))
-            concat(" ")
-            concat(t("admin.territories.nav.configuration_title"))
-          end
-        end)
-        if previous_links.any?
+    content_for(:breadcrumbs) do
+      tag.nav class: "configuration-title pb-2 mb-2" do
+        tag.ol class: "breadcrumb m-0 p-0" do
+          concat(tag.li(class: "breadcrumb-item") do
+            link_to admin_territory_path(current_territory) do
+              concat(t("admin.territories.nav.configuration_title"))
+            end
+          end)
           previous_links.each do |prev_link|
             concat(tag.li(class: "breadcrumb-item") do
               prev_link
             end)
           end
-        end
 
-        if title.present?
-          concat(tag.li(class: "breadcrumb-item active") do
-            title
-          end)
+          if title.present?
+            concat(tag.li(class: "breadcrumb-item active") do
+              title
+            end)
+          end
         end
       end
     end

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -17,6 +17,7 @@
 
 // Structure
 @import "./structure/general";
+@import "./structure/header";
 @import "./structure/left-menu";
 @import "./structure/footer";
 @import "./structure/page-head";

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -5,12 +5,17 @@
     .card
       .card-body
         h1.card-title Services
-        p.text-muted.font-14 Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
+        p Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
 
         = simple_form_for current_territory, url: admin_territory_services_path(current_territory) do |f|
           = render "model_errors", model: current_territory
 
           = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second
+
+          p.text-muted.font-14
+            | Si vous avez besoin d'un service qui n'apparaît pas dans cette liste, contactez-nous via
+            = mail_to(current_domain.support_email, current_domain.support_email)
+            | .
 
           .text-right
             = f.button :submit

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -7,13 +7,13 @@
         h1.card-title Services
         p Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.
 
-        = simple_form_for current_territory, url: admin_territory_services_path(current_territory) do |f|
+        = simple_form_for current_territory, url: admin_territory_services_path(current_territory, redirect_to_organisation_id: params[:redirect_to_organisation_id]) do |f|
           = render "model_errors", model: current_territory
 
           = f.association :services, collection: @services, label: "", as: :check_boxes, label_method: :first, value_method: :second
 
           p.text-muted.font-14
-            | Si vous avez besoin d'un service qui n'apparaît pas dans cette liste, contactez-nous via
+            = "Si vous avez besoin d'un service qui n'apparaît pas dans cette liste, contactez-nous via "
             = mail_to(current_domain.support_email, current_domain.support_email)
             | .
 

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,5 +1,8 @@
-= territory_navigation
+= link_to(root_path, class: "pt-1 pb-4") do
+  i.fa.fa-arrow-left
+  = " Retour à l'accueil"
 
+h1.m-2.text-center.border-bottom.pb-2 Espace Admin - #{current_territory.name}
 .row.mb-3
   - if policy([:configuration, AgentTerritorialRole]).display?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -1,0 +1,15 @@
+footer.footer
+  .container-fluid
+    .row
+      .col-md-12
+        .footer-links.d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
+          | Accessibilité : non conforme
+          = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
+            span>= ENV["RDV_SOLIDARITES_VERSION"]
+            i.fa.fa-external-link-alt
+          = link_to mentions_legales_path do
+            span> Mentions Légales
+          = link_to cgu_path do
+            span> C.G.U.
+          = link_to politique_de_confidentialite_path do
+            span> Politique de confidentialité

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -4,7 +4,8 @@ header.header.bg-white.mb-4
 
   .container
     nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr title="navigation"
-      = link_logo_dsfr
+      = link_to root_path, class: "header-brand" do
+        = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "logo-dsfr"
       button.navbar-toggler.navbar-toggler-right aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
         i.fa.fa-bars.text-primary-blue
       #navbarSupportedContent.collapse.navbar-collapse

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -1,0 +1,17 @@
+header.header.bg-white.mb-4
+  = render "layouts/rdv_solidarites_instance_name"
+  = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
+
+  .container
+    nav.navbar.navbar-expand-lg.bg-transparent.navbar-dsfr title="navigation"
+      = link_logo_dsfr
+      button.navbar-toggler.navbar-toggler-right aria-controls="navbarSupportedContent" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarSupportedContent" data-toggle="collapse" type="button"
+        i.fa.fa-bars.text-primary-blue
+      #navbarSupportedContent.collapse.navbar-collapse
+        ul.navbar-nav.ml-auto.align-items-start.align-items-lg-center
+          li.list-inline-item
+            = link_to current_agent.full_name, edit_agent_registration_path, class: "btn text-primary-blue link-dsfr"
+          li.list-inline-item
+            = link_to destroy_agent_session_path, method: :delete, class: "btn text-primary-blue link-dsfr" do
+              i.fa.fa-sign-out-alt>
+              span> Se déconnecter

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -26,18 +26,4 @@ html lang="fr"
               = yield
 
     #modal-holder
-    footer.footer
-      .container-fluid
-        .row
-          .col-md-12
-            .footer-links.d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
-              | Accessibilité : non conforme
-              = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
-                span>= ENV["RDV_SOLIDARITES_VERSION"]
-                i.fa.fa-external-link-alt
-              = link_to mentions_legales_path do
-                span> Mentions Légales
-              = link_to cgu_path do
-                span> C.G.U.
-              = link_to politique_de_confidentialite_path do
-                span> Politique de confidentialité
+    = render "layouts/agent_footer"

--- a/app/views/layouts/application_configuration.html.slim
+++ b/app/views/layouts/application_configuration.html.slim
@@ -4,18 +4,14 @@ html lang="fr"
     = yield :html_head_prepend
     = render "common/head_agent"
   body
-    = render "layouts/rdv_solidarites_instance_name"
-    = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
-
-    header.container.px-8.mb-2.mt-1.text-center
-        h1.m-2 #{current_domain.name} - #{current_territory.name}
+    = render "layouts/agent_header"
 
     main.container-fluid
 
       .container.px-4#icon-grid
+        = content_for(:breadcrumbs)
         = render "layouts/flash"
         = yield
 
     #modal-holder
-    footer.main-footer
-      = render "common/footer_users"
+    = render "layouts/agent_footer"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,7 +3,7 @@ fr:
   admin:
     organisations:
       index:
-        configuration: Configuration
+        configuration: Espace Admin
         create: Créer
     rdvs:
       message:

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -8,11 +8,11 @@ fr:
         new:
           title: Nouvelle attribution pour le secteur %{name}
       nav:
-        configuration_title: Configuration
+        configuration_title: Espace Admin
       show:
-        title: Configuration
+        title: Espace Admin
       index:
-        configuration_title: Configuration
+        configuration_title: Espace Admin
       edit:
         title: Configuration %{name}
 

--- a/config/locales/views/left_menu.fr.yml
+++ b/config/locales/views/left_menu.fr.yml
@@ -2,4 +2,4 @@ fr:
   layouts:
     left_menu:
       busy_times: Indisponibilités
-      configuration: Configuration
+      configuration: Espace Admin


### PR DESCRIPTION
La page de config de territoire fait peau neuve : un nouveau header, un nouveau footer, des breadcrumbs, et un nouveau nom ! C'est désormais l'Espace Admin

On profite de la mise en place du Saas pour améliorer le layout de cette interface


Merci à téo pour les maquettes 🙏 , voir aussi https://www.notion.so/rdvs/Solution-SaaS-7d6c2f96ba5441c4abc2fe5801dff6d2

### Avant

<img width="1426" alt="Screenshot 2024-02-21 at 16 21 03" src="https://github.com/betagouv/rdv-service-public/assets/1840367/2dec4e46-3b9f-4bae-9d88-cc661cad83f6">
<img width="1423" alt="Screenshot 2024-02-21 at 10 23 56" src="https://github.com/betagouv/rdv-service-public/assets/1840367/fa134df2-c0c6-4cab-aa1d-affe77caeedb">



### Après
<img width="1434" alt="Screenshot 2024-02-21 at 16 20 00" src="https://github.com/betagouv/rdv-service-public/assets/1840367/0bff49b6-38c8-416c-b7e1-a669a3440638">
<img width="1438" alt="Screenshot 2024-02-21 at 10 56 24" src="https://github.com/betagouv/rdv-service-public/assets/1840367/7bec2180-f372-4f93-8c39-20eda5de2d53">

