### PR TITLE
MAJ de la gem `parser`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,8 +356,9 @@ GEM
     parallel (1.22.1)
     parallel_tests (4.0.0)
       parallel
-    parser (3.1.3.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
+      racc
     pg (1.4.6)
     pg_search (2.3.6)
       activerecord (>= 5.2)


### PR DESCRIPTION
Le linter slim nous affichait un waring :

```
bundle exec slim-lint app/views/
warning: parser/current is loading parser/ruby31, which recognizes3.1.x-compliant syntax, but you are running 3.3.0.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
