### PR TITLE
CSP : pas besoin d'autoriser instatus.com en media-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -3,23 +3,18 @@
 # Define an application-wide content security policy
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
-#
+
 # InStatus est le service dont on se sert pour communiquer les incidents
 in_status = "*.instatus.com"
-
 # Nous hébergeons la vidéo de la page d'accueil de RDV_MAIRIE sur le s3 de RDV-Insertion
 s3_de_rdv_insertion = "rdv-insertion-medias-production.s3.fr-par.scw.cloud"
-
 # Nous faisons des appels vers cette API dans notre recherche par adresse
 api_adresse_data_gouv = "api-adresse.data.gouv.fr"
-
 # Nous utilisons mapbox et les tiles etalab pour les interfaces de config de sectorisation
 api_mapbox = "api.mapbox.com"
 tiles_etalab = "etalab-tiles.fr"
-
 # Bouton "Je donne mon avis sur cette démarche"
 voxusagers = "voxusagers.numerique.gouv.fr"
-
 # Utilisé sur nos pages statiques (404.html, 500.html)
 bootstrap_cdn = "*.bootstrapcdn.com"
 
@@ -30,7 +25,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.worker_src :blob
   policy.child_src :blob, :self
   policy.frame_src :self, in_status
-  policy.media_src :self, in_status, s3_de_rdv_insertion
+  policy.media_src :self, s3_de_rdv_insertion
   policy.img_src :self, :data, voxusagers
   policy.style_src :self, :unsafe_inline, bootstrap_cdn, api_mapbox
   policy.connect_src :self, api_adresse_data_gouv, tiles_etalab


### PR DESCRIPTION
Suite de #4084

On ne fait qu'utiliser une iframe, pas de `<audio>` ou `<video>`.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
