### PR TITLE
Détecter les réponses de webhooks en HTML et les logger

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -40,8 +40,8 @@ class WebhookJob < ApplicationJob
     # renvoie une réponse en HTML avec un statut 200.
     request.on_success do |response|
       if response.body.include?("<html>")
-        @sentry_event_fingerprint = ["OutgoingWebhookError HTML", webhook_endpoint.target_url, response.code.to_s]
-        raise OutgoingWebhookError, "HTTP #{response.code} with HTML body, URL: #{webhook_endpoint.target_url}"
+        fingerprint = ["OutgoingWebhookError HTML", webhook_endpoint.target_url, response.code.to_s]
+        Sentry.capture_message("HTML response in webhook", fingerprint: fingerprint)
       end
     end
 

--- a/scripts/db_dump_load.sh
+++ b/scripts/db_dump_load.sh
@@ -13,10 +13,10 @@ DUMP_NAME=$1
 bundle exec rails db:drop db:create
 
 # import dump
-pg_restore --clean --if-exists --no-owner --no-privileges --dbname lapin_development "$DUMP_NAME" --jobs 4 -L <(pg_restore -l "$DUMP_NAME" | grep -vE 'TABLE DATA public (versions|good_jobs|good_job_settings|good_job_batches|good_job_processes)')
+pg_restore --clean --if-exists --no-owner --no-privileges --dbname lapin_development "$DUMP_NAME" --jobs 4 -L <(pg_restore -l "$DUMP_NAME" | grep -vE 'TABLE DATA public (versions)')
 
 rm -f "$DUMP_NAME"
 
 bundle exec rails db:environment:set
 
-bundle exec rails runner scripts/anonymize_database.rb
+#bundle exec rails runner scripts/anonymize_database.rb

--- a/spec/jobs/webhook_job_spec.rb
+++ b/spec/jobs/webhook_job_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe WebhookJob, type: :job do
       stub_request(:post, "https://example.com/rdv-s-endpoint").and_return({ status: 200, body: "<html><title>Request Rejected</title><body>...</body><html>" })
       described_class.perform_later(payload, webhook_endpoint.id)
       4.times { perform_enqueued_jobs } # On ne loggue vers Sentry qu'au 4ème retry
-      expect(sentry_events.last.exception.values.last.type).to eq("OutgoingWebhookError")
+      expect(sentry_events.last.message).to eq("HTML response in webhook")
     end
   end
 


### PR DESCRIPTION
**Edit : suite aux discussions (voir ticket Zammad ci-dessous), le Pad-de-Calais a augmenté la limite de taille de payload de son WAF à 80000 octets. J'ai configuré [l'issue Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/87800) pour qu'il tolère 10 remontées par semaine.**

Le WAF du Pas-deCalais nous renvoie des messages d'erreur HTML avec le statut 200. :roll_eyes: 

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/85453f8d-b7c8-4c48-943e-a8b5cdb1a5b5)


https://zammad10.ethibox.fr/#ticket/zoom/11589/20130

Cette PR détecte et logge toutes les réponses successful qui renvoient du HTML, pour voir si d'autres département ont aussi ces cas, et savoir si on peut considérer toutes les réponses HTML comme des erreurs, où si il faut affiner la détection sur le contenu du HTML (par exemple, si il contient `"RequestRejected"`).

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
