### PR TITLE
Activation d'un nouveau service lors de l'ajout d'un agent

### DIFF
--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -16,7 +16,6 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
     if params[:redirect_to_organisation_id].present?
       redirect_to new_admin_organisation_agent_path(params[:redirect_to_organisation_id])
     else
-      flash[:alert] = "Liste des services disponibles mise à jour"
       redirect_to edit_admin_territory_services_path(current_territory)
     end
   end

--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -11,8 +11,14 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
   def update
     authorize current_territory
     current_territory.update(services_params)
-    flash[:alert] = "Configuration enregistrée"
-    redirect_to edit_admin_territory_services_path(current_territory)
+    flash[:alert] = "Liste des services disponibles mise à jour"
+
+    if params[:redirect_to_organisation_id].present?
+      redirect_to new_admin_organisation_agent_path(params[:redirect_to_organisation_id])
+    else
+      flash[:alert] = "Liste des services disponibles mise à jour"
+      redirect_to edit_admin_territory_services_path(current_territory)
+    end
   end
 
   private

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -74,4 +74,8 @@ module AgentsHelper
       }
     )
   end
+
+  def access_level_label(access_level)
+    AgentRole.human_attribute_value(:access_level, access_level, context: :explanation).html_safe # rubocop:disable Rails/OutputSafety
+  end
 end

--- a/app/javascript/stylesheets/components/_forms.scss
+++ b/app/javascript/stylesheets/components/_forms.scss
@@ -155,3 +155,8 @@ button.fa {
 input:placeholder-shown {
    font-style: italic;
 }
+
+.big-label {
+  color: $blue;
+  font-size: 1.5rem;
+}

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -3,7 +3,7 @@ class Agent::TerritoryPolicy < ApplicationPolicy
   delegate :agent, to: :context, prefix: :current # defines current_agent
 
   def agent_has_role_in_record_territory?
-    current_agent.territorial_roles.find_by(territory_id: record.id).present?
+    current_agent.territorial_roles.exists?(territory_id: record.id)
   end
 
   alias show? agent_has_role_in_record_territory?

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -3,7 +3,7 @@ class Agent::TerritoryPolicy < ApplicationPolicy
   delegate :agent, to: :context, prefix: :current # defines current_agent
 
   def agent_has_role_in_record_territory?
-    current_agent.territorial_roles.pluck(:territory_id).include?(record.id)
+    current_agent.territorial_roles.find_by(territory_id: record.id).present?
   end
 
   alias show? agent_has_role_in_record_territory?

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -15,10 +15,10 @@
             .text-muted.form-text
               | Quel type d'agent souhaitez-vous ajouter ?
             - # rubocop:disable Rails/OutputSafety
-            = ff.input :access_level, \
-              collection: @roles, \
-              label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
-              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if @current_territory.organisations.count > 1), \
+            = ff.input :access_level,
+              collection: @roles,
+              label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe },
+              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if @current_territory.organisations.count > 1),
               as: :radio_buttons,
               label: "",
               html: { class: "mt-4" }

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -41,4 +41,3 @@
 
           .text-right
             = f.button :submit, "Enregistrer"
-

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -9,7 +9,15 @@
       .card-body.js_agent_role_form
         = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation, @agent), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: @agent
-          = f.association :services, collection: @services, include_blank: false, as: :check_boxes
+          label Services
+          .text-muted.form-text
+            | Pour quel service est-ce que cet agent travaille ?
+            br
+            | Les agents basiques peuvent uniquement consulter les agendas de leurs collègues du même services.
+            br
+            | Les agents du secrétariat peuvent voir les agenda de tous les autres agents de l'organisation.
+
+          = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""
           - if policy([:agent, current_territory]).edit?
             small.form-text.text-muted.mb-4
               = "Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez "

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -14,15 +14,13 @@
             label.big-label Niveau de permissions
             .text-muted.form-text
               | Quel type d'agent souhaitez-vous ajouter ?
-            - # rubocop:disable Rails/OutputSafety
             = ff.input :access_level,
               collection: @roles,
-              label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe },
+              label_method: -> { access_level_label(_1) },
               hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if @current_territory.organisations.count > 1),
               as: :radio_buttons,
               label: "",
               html: { class: "mt-4" }
-          - # rubocop:enable Rails/OutputSafety
 
           .js_agent_role_form__agent_with_account_fields
             = f.input :email, placeholder: "a.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: { class: "big-label mt-3" }, hint: "Une invitation sera envoyée automatiquement à cette adresse"

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -9,14 +9,20 @@
       .card-body.js_agent_role_form
         = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation, @agent), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: @agent
-          = f.association :services, collection: @services, include_blank: false, input_html: { class: "select2-input" }
+          = f.association :services, collection: @services, include_blank: false, as: :check_boxes
+          - if policy([:agent, current_territory]).edit?
+            small.form-text.text-muted.mb-4
+              = "Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez "
+              = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))
+
           - # rubocop:disable Rails/OutputSafety
           = f.simple_fields_for @agent_role do |ff|
             = ff.input :access_level, \
               collection: @roles, \
               label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
               hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
-              as: :radio_buttons
+              as: :radio_buttons,
+              html: { class: "mt-4" }
           - # rubocop:enable Rails/OutputSafety
 
           .js_agent_role_form__agent_with_account_fields

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -11,7 +11,7 @@
           = render "devise/shared/error_messages", resource: @agent
           = f.simple_fields_for @agent_role do |ff|
 
-            label.card-title Niveau de permissions
+            label.big-label Niveau de permissions
             .text-muted.form-text
               | Quel type d'agent souhaitez-vous ajouter ?
             - # rubocop:disable Rails/OutputSafety
@@ -25,12 +25,12 @@
           - # rubocop:enable Rails/OutputSafety
 
           .js_agent_role_form__agent_with_account_fields
-            = f.input :email, placeholder: "a.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: { class: "card-title mt-3" }, hint: "Une invitation sera envoyée automatiquement à cette adresse"
+            = f.input :email, placeholder: "a.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: { class: "big-label mt-3" }, hint: "Une invitation sera envoyée automatiquement à cette adresse"
 
           .js_agent_role_form__intervenant_fields
-            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom", label_html: { class: "card-title mt-3" }
+            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom", label_html: { class: "big-label mt-3" }
 
-          label.card-title.mt-3 Services
+          label.big-label.mt-3 Services
           .text-muted.form-text
             | Pour quel service est-ce que cet agent travaille ?
           = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -9,12 +9,12 @@
       .card-body.js_agent_role_form
         = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation, @agent), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: @agent
-          - # rubocop:disable Rails/OutputSafety
           = f.simple_fields_for @agent_role do |ff|
 
             label.card-title Niveau de permissions
             .text-muted.form-text
               | Quel type d'agent souhaitez-vous ajouter ?
+            - # rubocop:disable Rails/OutputSafety
             = ff.input :access_level, \
               collection: @roles, \
               label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
@@ -25,12 +25,12 @@
           - # rubocop:enable Rails/OutputSafety
 
           .js_agent_role_form__agent_with_account_fields
-            = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: {class: "card-title"}, hint: "Une invitation sera envoyée automatiquement à cette adresse"
+            = f.input :email, placeholder: "a.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: { class: "card-title mt-3" }, hint: "Une invitation sera envoyée automatiquement à cette adresse"
 
           .js_agent_role_form__intervenant_fields
-            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom", label_html: {class: "card-title"}
+            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom", label_html: { class: "card-title mt-3" }
 
-          label.card-title Services
+          label.card-title.mt-3 Services
           .text-muted.form-text
             | Pour quel service est-ce que cet agent travaille ?
           = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -11,31 +11,34 @@
           = render "devise/shared/error_messages", resource: @agent
           - # rubocop:disable Rails/OutputSafety
           = f.simple_fields_for @agent_role do |ff|
+
+            label.card-title Niveau de permissions
+            .text-muted.form-text
+              | Quel type d'agent souhaitez-vous ajouter ?
             = ff.input :access_level, \
               collection: @roles, \
               label_method: -> { AgentRole.human_attribute_value(:access_level, _1, context: :explanation).html_safe }, \
-              hint: "Les agents peuvent avoir des permissions différentes sur chaque organisation.", \
+              hint: ("Les agents peuvent avoir des permissions différentes sur chaque organisation." if @current_territory.organisations.count > 1), \
               as: :radio_buttons,
+              label: "",
               html: { class: "mt-4" }
           - # rubocop:enable Rails/OutputSafety
 
           .js_agent_role_form__agent_with_account_fields
-            = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}
-            .text-right
-              = f.button :submit, "Envoyer une invitation"
+            = f.input :email, placeholder: "jean.dupond@departement.fr", input_html: { autocomplete: "off"}, label_html: {class: "card-title"}, hint: "Une invitation sera envoyée automatiquement à cette adresse"
 
           .js_agent_role_form__intervenant_fields
-            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom"
-            .text-right
-              = f.button :submit, "Ajouter l'intervenant"
+            = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom", label_html: {class: "card-title"}
 
-          label Services
+          label.card-title Services
           .text-muted.form-text
-            | Le service correspond généralement à un ensemble d’agents qui exercent une profession similaire ou identique (exemple : le service PMI, le service RSA). Chaque agent est obligatoirement rattaché à au moins un service et a donc accès aux plannings des agents de ce même service : il peut alors y ajouter, modifier ou supprimer des rendez-vous pour ses collègues ou pour lui-même.
-            br
-            | Sélectionnez ci-dessous le ou les services auquel votre agent sera rattaché.  :
+            | Pour quel service est-ce que cet agent travaille ?
           = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""
           - if policy([:agent, current_territory]).edit?
             small.form-text.text-muted.mb-4
               = "Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez "
               = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))
+
+          .text-right
+            = f.button :submit, "Enregistrer"
+

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -9,17 +9,6 @@
       .card-body.js_agent_role_form
         = simple_form_for [:admin, @agent], url: admin_organisation_agents_path(current_organisation, @agent), html: { method: :post } do |f|
           = render "devise/shared/error_messages", resource: @agent
-          label Services
-          .text-muted.form-text
-            | Le service correspond généralement à un ensemble d’agents qui exercent une profession similaire ou identique (exemple : le service PMI, le service RSA). Chaque agent est obligatoirement rattaché à au moins un service et a donc accès aux plannings des agents de ce même service : il peut alors y ajouter, modifier ou supprimer des rendez-vous pour ses collègues ou pour lui-même.
-            br
-            | Sélectionnez ci-dessous le ou les services auquel votre agent sera rattaché.  :
-          = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""
-          - if policy([:agent, current_territory]).edit?
-            small.form-text.text-muted.mb-4
-              = "Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez "
-              = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))
-
           - # rubocop:disable Rails/OutputSafety
           = f.simple_fields_for @agent_role do |ff|
             = ff.input :access_level, \
@@ -39,3 +28,14 @@
             = f.input :last_name, input_html: { autocomplete: "off"}, label: "Nom"
             .text-right
               = f.button :submit, "Ajouter l'intervenant"
+
+          label Services
+          .text-muted.form-text
+            | Le service correspond généralement à un ensemble d’agents qui exercent une profession similaire ou identique (exemple : le service PMI, le service RSA). Chaque agent est obligatoirement rattaché à au moins un service et a donc accès aux plannings des agents de ce même service : il peut alors y ajouter, modifier ou supprimer des rendez-vous pour ses collègues ou pour lui-même.
+            br
+            | Sélectionnez ci-dessous le ou les services auquel votre agent sera rattaché.  :
+          = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""
+          - if policy([:agent, current_territory]).edit?
+            small.form-text.text-muted.mb-4
+              = "Si le service dont vous avez besoin n'apparaît pas dans cette liste, vous pouvez "
+              = link_to("activer des services supplémentaires", edit_admin_territory_services_path(current_territory, redirect_to_organisation_id: current_organisation.id))

--- a/app/views/admin/agents/new.html.slim
+++ b/app/views/admin/agents/new.html.slim
@@ -11,12 +11,9 @@
           = render "devise/shared/error_messages", resource: @agent
           label Services
           .text-muted.form-text
-            | Pour quel service est-ce que cet agent travaille ?
+            | Le service correspond généralement à un ensemble d’agents qui exercent une profession similaire ou identique (exemple : le service PMI, le service RSA). Chaque agent est obligatoirement rattaché à au moins un service et a donc accès aux plannings des agents de ce même service : il peut alors y ajouter, modifier ou supprimer des rendez-vous pour ses collègues ou pour lui-même.
             br
-            | Les agents basiques peuvent uniquement consulter les agendas de leurs collègues du même services.
-            br
-            | Les agents du secrétariat peuvent voir les agenda de tous les autres agents de l'organisation.
-
+            | Sélectionnez ci-dessous le ou les services auquel votre agent sera rattaché.  :
           = f.association :services, collection: @services, include_blank: false, as: :check_boxes, label: ""
           - if policy([:agent, current_territory]).edit?
             small.form-text.text-muted.mb-4

--- a/app/views/admin/territories/services/edit.html.slim
+++ b/app/views/admin/territories/services/edit.html.slim
@@ -17,5 +17,9 @@
             = mail_to(current_domain.support_email, current_domain.support_email)
             | .
 
-          .text-right
-            = f.button :submit
+          .row.align-items-center.mt-3
+            - if params[:redirect_to_organisation_id]
+              .col.text-left
+                = link_to("Annuler", new_admin_organisation_agent_path(params[:redirect_to_organisation_id]))
+            .col.text-right
+              = f.button :submit

--- a/config/locales/models/agent_role.fr.yml
+++ b/config/locales/models/agent_role.fr.yml
@@ -12,7 +12,7 @@ fr:
         intervenant: Intervenant
       agent_role/access_levels/explanation:
         basic: "<i class='far fa-user'></i> Basique<br><ul><li>Peut consulter et modifier son agenda et celui des agents de son service</li><li>Service secrétariat: peut consulter et modifier les agendas de tous les agents de l'organisation</li></ul>"
-        admin: <i class='fa fa-user-cog'></i> Administrateur<br><ul><li>Peut consulter et modifier l'agenda de tous les agents de l'organisation</li><li>Peut créer, modifier et supprimer des lieux, des motifs et des agents</li><li>Peut accéder aux statistiques de l'organisation</li></ul>
+        admin: <i class='fa fa-user-cog'></i> Administrateur<br><ul><li>Peut consulter et modifier l'agenda des agents de tous les services</li><li>Peut créer, modifier et supprimer des lieux, des motifs et des agents</li><li>Peut accéder aux statistiques de l'organisation</li></ul>
         intervenant: <i class="fas fa-user-lock"></i> Intervenant<br><ul><li>Ne nécessite pas d'email et donc ne peut pas se connecter</li><li>Ne peut pas modifier son agenda</li><li>Ne reçoit aucune notification</li></ul>
     warnings:
       models:

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
       it "does not create a new agent and renders the form" do
         expect { subject }.not_to change(Agent, :count)
         expect(response.body).to have_content("Email n'est pas valide")
-        expect(response.body).to have_content("Les agents peuvent avoir des permissions différentes sur chaque organisation.")
+        expect(response.body).to have_content("Ajouter un agent")
       end
     end
 

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Agent can CRUD intervenants" do
     check(service.name)
     find("label", text: "Intervenant").click
     fill_in "Nom", with: "Avocat 1"
-    click_button("Ajouter l'intervenant")
+    click_button("Enregistrer")
     expect_page_title("Agents de Organisation n°1")
     expect(page).to have_content("AVOCAT 1")
     expect(Agent.last).to have_attributes(

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Agent can CRUD intervenants" do
     # Create an intervenant
     click_link "Ajouter un agent", match: :first
     expect_page_title("Ajouter un agent")
-    select(service.name, from: "Services")
+    check(service.name)
     find("label", text: "Intervenant").click
     fill_in "Nom", with: "Avocat 1"
     click_button("Ajouter l'intervenant")

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
     it "allows adding an agent in two different organisations" do
       click_link("Ajouter un agent", match: :first)
       fill_in("Email", with: "bob@test.com")
-      select(pmi.name, from: "Services")
+      check(pmi.name)
       click_button("Envoyer une invitation")
       expect(Agent.count).to eq(2)
 
@@ -43,7 +43,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
           click_link "Agents"
           click_link "Ajouter un agent", match: :first
           fill_in "Email", with: "jean@paul.com"
-          select(pmi.name, from: "Services")
+          check(pmi.name)
           click_button "Envoyer une invitation"
 
           open_email("jean@paul.com")
@@ -59,7 +59,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
           click_link "Agents"
           click_link "Ajouter un agent", match: :first
           fill_in "Email", with: "jean@paul.com"
-          select(pmi.name, from: "Services")
+          check(pmi.name)
           click_button "Envoyer une invitation"
 
           open_email("jean@paul.com")
@@ -90,7 +90,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
 
       click_link "Ajouter un agent", match: :first
       fill_in "Email", with: "jean@paul.com"
-      select(pmi.name, from: "Services")
+      check(pmi.name)
       click_button "Envoyer une invitation"
 
       expect_page_title("Invitations en cours pour Organisation n°1")
@@ -136,14 +136,14 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_link("Services")
       check("CSS")
       click_button("Enregistrer")
-      expect(page).to have_content("Configuration enregistrée")
+      expect(page).to have_content("Liste des services disponibles mise à jour")
       logout
 
       login_as(organisation_admin, scope: :agent)
 
       visit new_admin_organisation_agent_path(organisation1)
       fill_in "Email", with: "jean@paul.com"
-      select("CSS", from: "Services")
+      check("CSS")
       click_button "Envoyer une invitation"
 
       expect(Agent.last.services.first).to eq(new_service)

--- a/spec/features/agents/agents/crud_on_agents_spec.rb
+++ b/spec/features/agents/agents/crud_on_agents_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_link("Ajouter un agent", match: :first)
       fill_in("Email", with: "bob@test.com")
       check(pmi.name)
-      click_button("Envoyer une invitation")
+      click_button("Enregistrer")
       expect(Agent.count).to eq(2)
 
       visit admin_organisation_agents_path(organisation2)
       click_link("Ajouter un agent", match: :first)
       fill_in("Email", with: "bob@test.com")
-      click_button("Envoyer une invitation")
+      click_button("Enregistrer")
       expect(Agent.count).to eq(2)
 
       expect(page).to have_content("Invitations en cours")
@@ -44,7 +44,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
           click_link "Ajouter un agent", match: :first
           fill_in "Email", with: "jean@paul.com"
           check(pmi.name)
-          click_button "Envoyer une invitation"
+          click_button "Enregistrer"
 
           open_email("jean@paul.com")
           expect(current_email.subject).to eq "Vous avez été invité sur RDV Aide Numérique"
@@ -60,7 +60,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
           click_link "Ajouter un agent", match: :first
           fill_in "Email", with: "jean@paul.com"
           check(pmi.name)
-          click_button "Envoyer une invitation"
+          click_button "Enregistrer"
 
           open_email("jean@paul.com")
           expect(current_email.subject).to eq "Vous avez été invité sur RDV Solidarités"
@@ -91,7 +91,7 @@ RSpec.describe "Agents can be managed by organisation admins" do
       click_link "Ajouter un agent", match: :first
       fill_in "Email", with: "jean@paul.com"
       check(pmi.name)
-      click_button "Envoyer une invitation"
+      click_button "Enregistrer"
 
       expect_page_title("Invitations en cours pour Organisation n°1")
       expect(page).to have_content("jean@paul.com")
@@ -118,33 +118,26 @@ RSpec.describe "Agents can be managed by organisation admins" do
   end
 
   describe "adding an agent to a new service" do
-    let(:territory_admin) { create(:agent, service: pmi, role_in_territories: [territory]) }
     let!(:new_service) { create(:service, name: "CSS", territories: []) }
 
     before do
-      create(:agent_territorial_access_right, agent: territory_admin, territory: territory)
+      create(:agent_territorial_role, agent: organisation_admin, territory: territory)
     end
 
     it "requires the territory admin to activate the new service" do
       login_as(organisation_admin, scope: :agent)
       visit new_admin_organisation_agent_path(organisation1)
       expect(page).not_to(have_content("CSS"))
-      logout
 
-      login_as(territory_admin, scope: :agent)
-      visit admin_territory_path(territory.id)
-      click_link("Services")
+      click_link("activer des services supplémentaires")
+
       check("CSS")
       click_button("Enregistrer")
       expect(page).to have_content("Liste des services disponibles mise à jour")
-      logout
 
-      login_as(organisation_admin, scope: :agent)
-
-      visit new_admin_organisation_agent_path(organisation1)
       fill_in "Email", with: "jean@paul.com"
       check("CSS")
-      click_button "Envoyer une invitation"
+      click_button "Enregistrer"
 
       expect(Agent.last.services.first).to eq(new_service)
     end


### PR DESCRIPTION
Cette pr répond au cas d'usage suivant :

En tant que premier agent d'un territoire nouvellement créé
Je souhaite ajouter un nouvel agent à mon organisation
Afin de donner accès à l'application au reste de mon équipe
Mais le service de cet agent n'a pas encore été activé pour le territoire

Actuellement, pour activer un nouveau service, l'agent a besoin de savoir que cette option existe, puis d'aller dans l'espace admin, puis dans le bon menu, puis revenir au formulaire de nouvel agent.

Dans cette nouvelle version, on se concentre sur le job to be done qu'essaye d'accomplir l'agent : ajouter un nouvel agent, et on intègre l'activation de service à cette tâche.

On fournit en bas de la liste des services un lien vers l'activation de services, et on le redirige vers le formulaire d'agent une fois que les services sont activés.

On en profite aussi pour améliorer l'UI du formulaire.

On met le choix du niveau de permissions en premier, puisque ce choix donne des informations sur l'importance du choix de service (important pour les agents basiques, moins pour les admins).

### Avant
<img width="1920" alt="Screenshot 2024-02-26 at 11 19 27" src="https://github.com/betagouv/rdv-service-public/assets/1840367/3ad11ef5-4878-43c8-859a-bf1e97503c95">


### Après 


![www rdv-solidarites localhost_3000_admin_organisations_4_agents_new](https://github.com/betagouv/rdv-service-public/assets/1840367/cdc42166-438a-4802-aff4-20fd803a9cd8)