### PR TITLE
Correction de spec non déterministe

### DIFF
--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :team do
     territory { association(:territory) }
-    name { Faker::Team.name }
+    name { "#{Faker::Team.name} #{id}" }
   end
 end


### PR DESCRIPTION
On a eu un build sur lequel deux équipes avaient aléatoirement le même nom, ce qui a causé une erreur
 voir https://github.com/betagouv/rdv-service-public/actions/runs/8049683402/job/21983570991