### PR TITLE
Réparer `db_dump_load.sh`

### DIFF
--- a/scripts/db_dump_load.sh
+++ b/scripts/db_dump_load.sh
@@ -19,4 +19,8 @@ rm -f "$DUMP_NAME"
 
 bundle exec rails db:environment:set
 
+# Si vous avez besoin de débugger et que l'anonymisation complète vous bloque,
+# vous pouvez au moins anonymiser les données usager avec:
+# bundle exec rails runner 'Anonymizer.anonymize_user_data!'
+
 bundle exec rails runner scripts/anonymize_database.rb

--- a/scripts/db_dump_load.sh
+++ b/scripts/db_dump_load.sh
@@ -20,7 +20,7 @@ rm -f "$DUMP_NAME"
 bundle exec rails db:environment:set
 
 # Si vous avez besoin de débugger et que l'anonymisation complète vous bloque,
-# vous devez au moins anonymiser les données usager avec:
+# vous devez au moins anonymiser les données usager avec :
 # bundle exec rails runner 'Anonymizer.anonymize_user_data!'
 
 bundle exec rails runner scripts/anonymize_database.rb

--- a/scripts/db_dump_load.sh
+++ b/scripts/db_dump_load.sh
@@ -13,10 +13,10 @@ DUMP_NAME=$1
 bundle exec rails db:drop db:create
 
 # import dump
-pg_restore --clean --if-exists --no-owner --no-privileges --dbname lapin_development "$DUMP_NAME" --jobs 4 -L <(pg_restore -l "$DUMP_NAME" | grep -vE 'TABLE DATA public (versions)')
+pg_restore --clean --if-exists --no-owner --no-privileges --dbname lapin_development "$DUMP_NAME" --jobs 4 -L <(pg_restore -l "$DUMP_NAME" | grep -vE 'TABLE DATA public (versions|good_jobs|good_job_settings|good_job_batches|good_job_processes)')
 
 rm -f "$DUMP_NAME"
 
 bundle exec rails db:environment:set
 
-#bundle exec rails runner scripts/anonymize_database.rb
+bundle exec rails runner scripts/anonymize_database.rb

--- a/scripts/db_dump_load.sh
+++ b/scripts/db_dump_load.sh
@@ -20,7 +20,7 @@ rm -f "$DUMP_NAME"
 bundle exec rails db:environment:set
 
 # Si vous avez besoin de débugger et que l'anonymisation complète vous bloque,
-# vous pouvez au moins anonymiser les données usager avec:
+# vous devez au moins anonymiser les données usager avec:
 # bundle exec rails runner 'Anonymizer.anonymize_user_data!'
 
 bundle exec rails runner scripts/anonymize_database.rb


### PR DESCRIPTION
Je vais mettre mes doigts comme ça pour recevoir les coups de règle : 🤌

Dans #4094 j'ai édité le fichier de chargement de dump parce que j'avais besoin d'accéder aux données des jobs. J'ai mergé la PR tout seul parce que c'était vendredi (dit comme ça, c'est pas mieux) et que j'étais en vigie pour [débugger les webhooks du Pas-de-Calais](https://zammad10.ethibox.fr/#ticket/zoom/11589/20370).

J'ai discuté avec Romain et il me dit que parfois il a aussi besoin des données de prod pour débugger, et donc je pense que le script peut proposer une solution intermédiaire qui protège les données de usagers tout en gardant d'autres données nécessaires au debug.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
