### PR TITLE
[Vigie] Appliquer le mécanisme de retry aux Mails de Devise

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,5 +6,5 @@ class ApplicationMailer < ActionMailer::Base
 
   append_view_path Rails.root.join("app/views/mailers")
 
-  self.delivery_job = CustomMailerDeliveryJob
+  self.delivery_job = ApplicationMailerDeliveryJob
 end

--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -1,5 +1,5 @@
 # See https://www.bigbinary.com/blog/rails-5-2-allows-mailers-to-use-custom-active-job-class
-class CustomMailerDeliveryJob < ActionMailer::MailDeliveryJob
+class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
   include DefaultJobBehaviour
 
   # Only discard DeserializationError if it is caused by a ActiveRecord::RecordNotFound.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -22,7 +22,7 @@ Devise.setup do |config|
   config.mailer = "CustomDeviseMailer"
 
   # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
+  config.parent_mailer = 'ApplicationMailer'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
       phone_number: "0611223344"
     )
 
-    perform_enqueued_jobs(queue: "mailers")
+    perform_enqueued_jobs(queue: "devise")
     expect(email_sent_to(agent.email).subject).to include("Nouvelle participation au RDV collectif sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
     expect(created_rdv.created_by_prescripteur?).to be(true)
     expect(created_rdv.participations.first.created_by_prescripteur?).to be(true)
 
-    perform_enqueued_jobs(queue: "mailers")
+    perform_enqueued_jobs(queue: "devise")
     expect(email_sent_to(agent.email).subject).to include("Nouveau RDV ajouté sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")

--- a/spec/jobs/application_mailer_delivery_job_spec.rb
+++ b/spec/jobs/application_mailer_delivery_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CustomMailerDeliveryJob do
+RSpec.describe ApplicationMailerDeliveryJob do
   mailer = Class.new(ApplicationMailer) do
     def a_sample_email(absence)
       mail(body: "Voici l'info: #{absence}")
@@ -16,7 +16,7 @@ RSpec.describe CustomMailerDeliveryJob do
   it "logs to sentry and retries job when hitting a ActiveJob::DeserializationError error that is not a RecordNotFound" do
     absence = create(:absence)
     mailer.a_sample_email(absence).deliver_later
-    expect(enqueued_jobs.last["job_class"]).to eq("CustomMailerDeliveryJob")
+    expect(enqueued_jobs.last["job_class"]).to eq("ApplicationMailerDeliveryJob")
     expect(enqueued_jobs.last["executions"]).to eq(0)
     expect(sentry_events).to be_empty
 
@@ -29,7 +29,7 @@ RSpec.describe CustomMailerDeliveryJob do
     expect(sentry_events.last.exception.values.last.value).to eq("Error while trying to deserialize arguments: No connection pool for 'ActiveRecord::Base' found. (ActiveJob::DeserializationError)")
 
     # It re-enqueues the job
-    expect(enqueued_jobs.last["job_class"]).to eq("CustomMailerDeliveryJob")
+    expect(enqueued_jobs.last["job_class"]).to eq("ApplicationMailerDeliveryJob")
     expect(enqueued_jobs.last["executions"]).to eq(1)
     expect(enqueued_jobs.last[:args][1]).to eq("a_sample_email")
     expect(enqueued_jobs.last[:args][3]["args"]).to eq([{ "_aj_globalid" => "gid://lapin/Absence/#{absence.id}" }])

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -94,4 +94,13 @@ RSpec.describe CustomDeviseMailer, "#domain" do
       expect_to_use_domain(Domain::RDV_SOLIDARITES)
     end
   end
+
+  context "when delivery fails" do
+    it "retries on exception" do
+      described_class.invitation_instructions("invalid_param_to_make_job_crash").deliver_later
+      expect(enqueued_jobs.pluck("executions")).to eq([0]) # job not executed yet
+      perform_enqueued_jobs
+      expect(enqueued_jobs.pluck("executions")).to eq([1]) # job enqueued for retry
+    end
+  end
 end


### PR DESCRIPTION
# Appliquer le mécanisme de retry aux Mails de Devise 

Les erreurs [Sentry#88513](https://sentry.incubateur.net/organizations/betagouv/issues/88513/?project=74) et [Sentry#88616](https://sentry.incubateur.net/organizations/betagouv/issues/88616/?project=74) nous font comprendre que le mécanisme de retry commun aux jobs et mailers (héritant de ApplicationMailer) ne fonctionne pas sur `CustomDeviseMailer`.

Dans cette PR, nous:
- [Faisons en sorte que `Devise::Mailer` dont hérite `CustomDeviseMailer`, puisse lui-même hériter directement de `ApplicationMailer`](https://github.com/heartcombo/devise/blob/bb18f4d3805be0bf5f45e21be39625c7cfd9c1d6/app/mailers/devise/mailer.rb#L4 ).

Ceci permet d'uniformiser le comportement de nos Mailers, mais le point principal étant la ligne https://github.com/betagouv/rdv-service-public/blob/d3ed3e9df8ec2f44b00c28b3a996ebe221e5bc35/app/mailers/application_mailer.rb#L9

Cette ligne nous assure que le Mailer se base sur le bon `delivery_job` contenant le mécanisme de retry.

- Nous en profitons également pour renommer  `CustomMailerDeliveryJob`  en `ApplicationMailerDeliveryJob`. Cela a plus de sens puisque cette classe est utilisé dans `ApplicationMailer`.