### PR TITLE
[Liste des RDV] Afficher plus de détails usagers lors de l'impression

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -101,7 +101,7 @@ module ApplicationHelper
     value ||= object.human_attribute_value(attribute_name)
 
     tag.strong(tag.span(name) + tag.span(" : ")) +
-      tag.span(value.presence || "N/A", class: class_names("text-muted": value.blank?))
+      tag.span(value.presence || "Non renseigné", class: class_names("text-muted": value.blank?))
   end
 
   def admin_link_to_if_permitted(organisation, object, name = object.to_s)

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -39,6 +39,11 @@
               - else
                 span.font-weight-light.font-italic.text-muted
                   | Téléphone non renseigné
+          .users-details.collapse
+            - if user.responsible.present?
+              div.mb-2
+                = "proche de #{user.responsible}"
+            = render "admin/rdvs/print/user_details", user: user
         - if current_organisation.territory.enable_context_field
           .mt-2
             | Contexte :

--- a/app/views/admin/rdvs/print/_user_details.html.slim
+++ b/app/views/admin/rdvs/print/_user_details.html.slim
@@ -1,0 +1,10 @@
+div= object_attribute_tag(user, :address)
+- if current_territory.enable_notes_field?
+  div= object_attribute_tag(user, :notes)
+- if current_territory.enable_logement_field
+  div= object_attribute_tag(user, :logement)
+- Territory::SOCIAL_FIELD_TOGGLES.each do |toggle, field_name|
+  - if current_territory.attributes.with_indifferent_access[toggle]
+    div
+      = object_attribute_tag(user, field_name)
+hr


### PR DESCRIPTION
## Liste des RDV: Afficher plus de details usagers lors de l'impression

Sur la base des retours utilisateurs, cette PR vient permettre à l'agent d'imprimer une liste de RDV avec tous les détails usagers.

Par défaut, nous imprimons une liste des RDV plutôt succincte. Lorsque l'agent opte pour "Afficher plus de détails usagers" sur la version Web, la version imprimée s'adapte également en affichant autant de détails usagers que la version Web.

Voir le [Figma](https://www.figma.com/file/wOGNWqTuagc8G4ectZFQZd/Liste-des-rdvs-du-jour?type=design&node-id=351-4243&mode=design&t=CPIsuxFjn171zQHo-0) pour la maquette

## Version simple
![Screenshot 2024-02-29 at 12 14 46](https://github.com/betagouv/rdv-service-public/assets/11911945/ba0c4f9e-9779-44cb-b89a-0a1d8d6c1214)

## Version détaillée
![Screenshot 2024-02-29 at 12 15 09](https://github.com/betagouv/rdv-service-public/assets/11911945/35528297-7e36-4258-bf3c-9762ebc48c92)
