### PR TITLE
Correctif de build

### DIFF
--- a/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
+++ b/spec/jobs/cron_job/destroy_inactive_agents_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe CronJob::DestroyInactiveAgents do
+  before { travel_to Date.new(2024, 1, 1) }
+
   it "warns and deletes old agents" do
     # agents that will not be modified
     agent_created_12_months_ago_with_warning = travel_to(12.months.ago) { create(:agent, account_deletion_warning_sent_at: Time.zone.now) }


### PR DESCRIPTION
Comme d'hab, on met une date constante pour éviter d'avoir une spec avec un comportement qui change pour les années avec un 29 février (et c'est un bug acceptable d'avoir un jour de décalage dans ce cas pour la période de 2 ans de suppression des comptes agents)