### PR TITLE
Accélération du build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,8 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
-  test_features_for_agents_only:
-    name: Feature Tests for agents
+  test_features:
+    name: Feature Tests
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -166,16 +166,8 @@ jobs:
         run: yarn install
       - name: Precompile assets
         run: RAILS_ENV=test bundle exec rake assets:precompile
-      - name: Setup tests
-        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: lapin_test
-          POSTGRES_PASSWORD: lapin_test
-          POSTGRES_DB: lapin_test
-      - name: Run specs
-        run: bundle exec rspec spec/features/agents
+      - name: Setup parallel tests
+        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -183,52 +175,8 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
-  test_features_for_other_cases:
-    name: Feature Tests for other cases
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_USER: lapin_test
-          POSTGRES_PASSWORD: lapin_test
-          POSTGRES_DB: lapin_test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports: ["5432:5432"]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: szenius/set-timezone@v1.0
-        with:
-          timezoneLinux: "Europe/Paris"
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.14.1
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.3.0
-          bundler-cache: true
-      - name: Set up Redis
-        uses: zhulik/redis-action@1.1.0
-      - name: Install JS dependencies
-        run: yarn install
-      - name: Precompile assets
-        run: RAILS_ENV=test bundle exec rake assets:precompile
-      - name: Setup tests
-        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
-        env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: lapin_test
-          POSTGRES_PASSWORD: lapin_test
-          POSTGRES_DB: lapin_test
       - name: Run specs
-        run: bundle exec rspec spec/features --exclude-pattern="spec/features/agents/**/*.rb"
+        run: RAILS_ENV=test bundle exec rake parallel:spec[spec/features]
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,15 @@ jobs:
           bundler-cache: true
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
+      - name: Cache js dependencies
+        uses: actions/cache@v3
+        with:
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          path: node_modules
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec rake assets:precompile
+        run: yarn run build
       - name: Prepare runtime log cache key
         run: ls spec/features/**/*.rb > tmp/feature_spec_files.txt
       - name: Cache parallel test unit spec runtime log
@@ -170,17 +175,9 @@ jobs:
         with:
           key: feature-spec-runtime-log-${{ hashFiles('tmp/feature_spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
-      - name: Setup parallel tests
-        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
-        env:
-          HOST: http://example.com
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: lapin_test
-          POSTGRES_PASSWORD: lapin_test
-          POSTGRES_DB: lapin_test
-      - name: Run specs
-        run: RAILS_ENV=test bundle exec rake parallel:spec[spec/features]
+        # By setting up and running in the same call, we save the app boot time
+      - name: Setup parallel tests and run spec
+        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema parallel:spec[spec/features]
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,17 +117,9 @@ jobs:
         with:
           key: unit-spec-runtime-log-${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
-      - name: Setup parallel tests
-        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
-        env:
-          HOST: http://example.com
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          POSTGRES_USER: lapin_test
-          POSTGRES_PASSWORD: lapin_test
-          POSTGRES_DB: lapin_test
-      - name: Run specs
-        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)']
+      # By setting up and running in the same call, we save the app boot time
+      - name: Setup parallel tests and run spec
+        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema parallel:spec['spec\/(?!features)']
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
         run: RAILS_ENV=test bundle exec rake assets:precompile
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
-      - name: Cache parallel test runtime log
+      - name: Cache parallel test unit spec runtime log
         uses: actions/cache@v3
         with:
-          key: ${{ hashFiles('tmp/spec_files.txt') }}
+          key: unit-spec-runtime-log-${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
         run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
@@ -166,6 +166,13 @@ jobs:
         run: yarn install
       - name: Precompile assets
         run: RAILS_ENV=test bundle exec rake assets:precompile
+      - name: Prepare runtime log cache key
+        run: ls spec/features/**/*.rb > tmp/feature_spec_files.txt
+      - name: Cache parallel test unit spec runtime log
+        uses: actions/cache@v3
+        with:
+          key: feature-spec-runtime-log-${{ hashFiles('tmp/feature_spec_files.txt') }}
+          path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
         run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,13 +170,13 @@ jobs:
         run: yarn run build
       - name: Prepare runtime log cache key
         run: ls spec/features/**/*.rb > tmp/feature_spec_files.txt
-      - name: Cache parallel test unit spec runtime log
+      - name: Cache parallel test feature spec runtime log
         uses: actions/cache@v3
         with:
           key: feature-spec-runtime-log-${{ hashFiles('tmp/feature_spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
         # By setting up and running in the same call, we save the app boot time
-      - name: Setup parallel tests and run spec
+      - name: Setup parallel tests and run feature specs
         run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema parallel:spec[spec/features]
         env:
           HOST: http://example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec spring rake assets:precompile
+        run: RAILS_ENV=test bundle exec rake assets:precompile
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test runtime log
@@ -113,7 +113,7 @@ jobs:
           key: ${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
-        run: RAILS_ENV=test bundle exec spring rake parallel:drop parallel:create parallel:load_schema
+        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -122,7 +122,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: RAILS_ENV=test bundle exec spring rake parallel:spec['spec\/(?!features)']
+        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)']
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -165,9 +165,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec spring rake assets:precompile
+        run: RAILS_ENV=test bundle exec rake assets:precompile
       - name: Setup tests
-        run: RAILS_ENV=test bundle exec spring rake db:create db:test:prepare
+        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -175,7 +175,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: bundle exec spring rspec spec/features/agents
+        run: bundle exec rspec spec/features/agents
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -218,9 +218,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec spring rake assets:precompile
+        run: RAILS_ENV=test bundle exec rake assets:precompile
       - name: Setup tests
-        run: RAILS_ENV=test bundle exec spring rake db:create db:test:prepare
+        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -228,7 +228,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: bundle exe spring rspec spec/features --exclude-pattern="spec/features/agents/**/*.rb"
+        run: bundle exec rspec spec/features --exclude-pattern="spec/features/agents/**/*.rb"
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec rake assets:precompile
+        run: RAILS_ENV=test bundle exec spring rake assets:precompile
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test runtime log
@@ -113,7 +113,7 @@ jobs:
           key: ${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
-        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
+        run: RAILS_ENV=test bundle exec spring rake parallel:drop parallel:create parallel:load_schema
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -122,7 +122,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)']
+        run: RAILS_ENV=test bundle exec spring rake parallel:spec['spec\/(?!features)']
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -165,9 +165,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec rake assets:precompile
+        run: RAILS_ENV=test bundle exec spring rake assets:precompile
       - name: Setup tests
-        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
+        run: RAILS_ENV=test bundle exec spring rake db:create db:test:prepare
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -175,7 +175,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: bundle exec rspec spec/features/agents
+        run: bundle exec spring rspec spec/features/agents
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -218,9 +218,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec rake assets:precompile
+        run: RAILS_ENV=test bundle exec spring rake assets:precompile
       - name: Setup tests
-        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
+        run: RAILS_ENV=test bundle exec spring rake db:create db:test:prepare
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
@@ -228,7 +228,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: bundle exec rspec spec/features --exclude-pattern="spec/features/agents/**/*.rb"
+        run: bundle exe spring rspec spec/features --exclude-pattern="spec/features/agents/**/*.rb"
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,6 @@ jobs:
         uses: zhulik/redis-action@1.1.0
       - name: Install JS dependencies
         run: yarn install
-      - name: Rails assets cache
-        uses: actions/cache@v3
-        with:
-          path: tmp/cache
-          key: ${{ GITHUB_REF_NAME }}-assets-cache
       - name: Precompile assets
         run: RAILS_ENV=test bundle exec rake assets:precompile
       - name: Prepare runtime log cache key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           key: unit-spec-runtime-log-${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
-        run: RAILS_ENV=test bundle exec rake parallel:drop[6] parallel:create[6] parallel:load_schema[6]
+        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -122,7 +122,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)',6]
+        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)']
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           key: unit-spec-runtime-log-${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
-        run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
+        run: RAILS_ENV=test bundle exec rake parallel:drop[6] parallel:create[6] parallel:load_schema[6]
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost
@@ -122,7 +122,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)']
+        run: RAILS_ENV=test bundle exec rake parallel:spec['spec\/(?!features)',6]
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,20 @@ jobs:
         uses: zhulik/redis-action@1.1.0
       - name: Install JS dependencies
         run: yarn install
+      - name: Rails assets cache
+        uses: actions/cache@v3
+        with:
+          path: tmp/cache
+          key: ${{ GITHUB_REF_NAME }}-assets-cache
       - name: Precompile assets
         run: RAILS_ENV=test bundle exec rake assets:precompile
+      - name: Prepare runtime log cache key
+        run: ls spec/**/*.rb > tmp/spec_files.txt
+      - name: Cache parallel test runtime log
+        uses: actions/cache@v3
+        with:
+          key: ${{ hashFiles('tmp/spec_files.txt') }}
+          path: tmp/parallel_runtime_rspec.log
       - name: Setup parallel tests
         run: RAILS_ENV=test bundle exec rake parallel:drop parallel:create parallel:load_schema
         env:
@@ -123,8 +135,8 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
-  test_features:
-    name: Feature Tests
+  test_features_for_agents_only:
+    name: Feature Tests for agents
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -168,7 +180,60 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - name: Run specs
-        run: bundle exec rspec spec/features
+        run: bundle exec rspec spec/features/agents
+        env:
+          HOST: http://example.com
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
+  test_features_for_other_cases:
+    name: Feature Tests for other cases
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["5432:5432"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Europe/Paris"
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.14.1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.0
+          bundler-cache: true
+      - name: Set up Redis
+        uses: zhulik/redis-action@1.1.0
+      - name: Install JS dependencies
+        run: yarn install
+      - name: Precompile assets
+        run: RAILS_ENV=test bundle exec rake assets:precompile
+      - name: Setup tests
+        run: RAILS_ENV=test bundle exec rake db:create db:test:prepare
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: lapin_test
+          POSTGRES_PASSWORD: lapin_test
+          POSTGRES_DB: lapin_test
+      - name: Run specs
+        run: bundle exec rspec spec/features --exclude-pattern="spec/features/agents/**/*.rb"
         env:
           HOST: http://example.com
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,15 @@ jobs:
           bundler-cache: true
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
+      - name: Cache js dependencies
+        uses: actions/cache@v3
+        with:
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          path: node_modules
       - name: Install JS dependencies
         run: yarn install
       - name: Precompile assets
-        run: RAILS_ENV=test bundle exec rake assets:precompile
+        run: yarn run build
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test unit spec runtime log

--- a/Gemfile
+++ b/Gemfile
@@ -172,8 +172,6 @@ group :development, :test do
   gem "faker"
   # Run Test::Unit / RSpec / Cucumber / Spinach in parallel
   gem "parallel_tests"
-  # Code coverage for Ruby
-  gem "simplecov", require: false
   # Slim template linting tool
   gem "slim_lint", require: false
   # Axe API utility methods

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,6 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 7.1)
     diff-lcs (1.5.0)
-    docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -531,12 +530,6 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    simplecov (0.21.2)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
     skylight (6.0.1)
       activesupport (>= 5.2.0)
     slim (4.1.0)
@@ -695,7 +688,6 @@ DEPENDENCIES
   sentry-ruby
   sib-api-v3-sdk
   simple_form (~> 5.0)
-  simplecov
   skylight
   slim
   slim_lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
       activerecord (>= 5.2)
       request_store (~> 1.1)
     parallel (1.22.1)
-    parallel_tests (4.0.0)
+    parallel_tests (4.5.1)
       parallel
     parser (3.3.0.5)
       ast (~> 2.4.1)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ L’objectif de ce service numérique public est de réduire le nombre de rendez
 
 Ce service est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 
-- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/) et rdv.anct.gouv.fr
+- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/)
 - En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/)
 
 ## Statistiques

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ L’objectif de ce service numérique public est de réduire le nombre de rendez
 
 Ce service est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 
-- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/).
-- En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/).
+- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/)
+- En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/)
 
 ## Statistiques
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RDV-Solidarités
+# RDV Service Public
 
 [![View performance data on Skylight](https://badges.skylight.io/status/RgR7i58P67xN.svg)](https://oss.skylight.io/app/applications/RgR7i58P67xN)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![View performance data on Skylight](https://badges.skylight.io/status/RgR7i58P67xN.svg)](https://oss.skylight.io/app/applications/RgR7i58P67xN)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-L’objectif de ce service numérique public est de réduire le nombre de rendez-vous non honorés dans les maisons des solidarités.
+L’objectif de ce service numérique public est de réduire le nombre de rendez-vous non honorés dans les maisons des solidarités et d'autres services publics.
 
 Ce service est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![View performance data on Skylight](https://badges.skylight.io/status/RgR7i58P67xN.svg)](https://oss.skylight.io/app/applications/RgR7i58P67xN)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-L’objectif de ce service numérique public est de réduire le nombre de rendez-vous non honorés dans les maisons des solidarités et d'autres services publics.
+L’objectif de ce service numérique public est de réduire le nombre de rendez-vous non honorés dans les maisons des solidarités.
 
 Ce service est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 
-- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/)
-- En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/)
+- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/).
+- En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/).
 
 ## Statistiques
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ L’objectif de ce service numérique public est de réduire le nombre de rendez
 
 Ce service est soutenu par un consortium de plusieurs départements et l'[incubateur des territoires de l'ANCT](https://incubateur.anct.gouv.fr/).
 
-- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/)
+- En production sur [rdv-solidarites.fr/](https://www.rdv-solidarites.fr/) et rdv.anct.gouv.fr
 - En démo sur [demo.rdv-solidarites.fr/](https://demo.rdv-solidarites.fr/)
 
 ## Statistiques

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # When running tests locally, using Spring to speed up test start time requires to set config.cache_classes to false
   # when running tests in the CI, we want our configuration to be as close as possible to the production one, so we set this to true
   # (we rely on the fact that ENV["CI"] is true in github actions)
-  config.cache_classes = false
+  config.cache_classes = ENV["CI"].present?
   config.action_view.cache_template_loading = true
 
   # Eager loading loads your whole application. When running a single test locally,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # When running tests locally, using Spring to speed up test start time requires to set config.cache_classes to false
   # when running tests in the CI, we want our configuration to be as close as possible to the production one, so we set this to true
   # (we rely on the fact that ENV["CI"] is true in github actions)
-  config.cache_classes = ENV["CI"].present?
+  config.cache_classes = false
   config.action_view.cache_template_loading = true
 
   # Eager loading loads your whole application. When running a single test locally,

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe "agents can prescribe rdvs" do
       fill_in :user_first_name, with: "Jean-Paul"
       fill_in :user_last_name, with: "Orvoir"
       click_on "Créer usager"
+      expect(page).to have_content("Jean-Paul")
       click_on "Continuer"
       expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)
       expect(Rdv.last.users.first.organisations).to match_array([org_mds, org_insertion])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,6 @@ require "webmock/rspec"
 require "simplecov"
 require "selenium-webdriver"
 
-SimpleCov.minimum_coverage 80
 SimpleCov.start
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,6 @@ require "webmock/rspec"
 require "simplecov"
 require "selenium-webdriver"
 
-SimpleCov.start
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,6 @@ require "capybara/email/rspec"
 require "capybara-screenshot/rspec"
 require "pundit/rspec"
 require "webmock/rspec"
-require "simplecov"
 require "selenium-webdriver"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Cette PR ajoute plusieurs optimisations à notre build, principalement en utilisant le cache des actions github et le parallélisme de parallel_test pour le rendre plus rapide, et faire que sa durée augmente moins rapidement.

L'historique de commits est chaotique, donc j'ai directement commenté dans le diff pour expliquer