### PR TITLE
Correctif du texte de création d'un agent dans l'espace admin

### DIFF
--- a/config/locales/views/admin_territories_invitation_devise.fr.yml
+++ b/config/locales/views/admin_territories_invitation_devise.fr.yml
@@ -6,6 +6,6 @@ fr:
           title: Inviter un agent
           header: Envoyer une invitation
           submit_button: Envoyer une invitation
-          services_hint: Attention, le service d'un agent est définitif, il ne pourra pas changer de service par la suite. Si un agent appartient à deux services il faut pour l'instant lui créer deux comptes avec deux emails différents.
+          services_hint: Dans quel domaine d'activité est-ce que cet agent effectue des rendez-vous ?
           email_placeholder: camille.dupond@departement.fr
           organisations: Organisations


### PR DESCRIPTION
Le texte était faux depuis qu'on permet les agents multi-service