### PR TITLE
[Vigie] Fix Nil error on Motif

### DIFF
--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -14,7 +14,7 @@ module CanHaveRdvWizardContext
     parsed_params = Rack::Utils.parse_nested_query(parsed_uri.query).to_h.symbolize_keys
     rdv_wizard = UserRdvWizard::Step1.new(nil, parsed_params)
     # L'usager doit être connecté afin de voir les créneaux pour un motif de Follow Up
-    return if rdv_wizard.motif.follow_up?
+    return if rdv_wizard.motif&.follow_up?
 
     if rdv_wizard.creneau.blank?
       session.delete(:user_return_to)


### PR DESCRIPTION
Fix pour l'erreur [Sentry#89333](https://sentry.incubateur.net/organizations/betagouv/issues/89333/events/393640ce8ff04675b55da1038ac3a086/?project=74)

Elle fût introduite par la PR https://github.com/betagouv/rdv-service-public/pull/4104 qui appelle une méthode sur `motif` qui pourrait être `nil`.

