### PR TITLE
Ouverture de la prescription interne au CD55

### DIFF
--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -4,7 +4,7 @@ module FeatureHelper
     return false if current_organisation.territory.sectorized? && !user_provided
 
     current_organisation.territory.name.starts_with?("CDAD") ||
-      current_organisation.territory.departement_number.in?(%w[83 26 13]) ||
+      current_organisation.territory.departement_number.in?(%w[83 26 13 55]) ||
       Rails.env.development? ||
       ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
   end


### PR DESCRIPTION
Close : https://github.com/betagouv/rdv-insertion/issues/1769

Je pensais que la fonctionnalité était ouverte à tous.
Pour l'instant ce n'est pas le cas, c'est en cours de discussion/travail en interne.
En attendant que cela soit fait il faudrait l'ouvrir au 55 qui a fait la demande de l'utilisation de la fonctionnalité.