### PR TITLE
Eviter la duplication de css

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -33,6 +33,7 @@
 @import "./structure/footer";
 @import "./structure/page-head";
 @import "./structure/authentication";
+@import "./structure/left-menu";
 
 h1 {
   font-size: 3rem;

--- a/app/javascript/stylesheets/structure/_authentication.scss
+++ b/app/javascript/stylesheets/structure/_authentication.scss
@@ -31,10 +31,6 @@ body.authentication-bg {
       padding: 6rem 3rem 0rem 3rem;
     }
 
-    a {
-      color: $white;
-    }
-
     .sidemenu__item {
       padding: 0 1rem;
       a {

--- a/app/javascript/stylesheets/structure/_authentication.scss
+++ b/app/javascript/stylesheets/structure/_authentication.scss
@@ -31,29 +31,6 @@ body.authentication-bg {
       padding: 6rem 3rem 0rem 3rem;
     }
 
-    .sidemenu__item {
-      padding: 0 1rem;
-      a {
-        color: $menu-item;
-        transition: all 0.4s;
-
-        &:focus,
-        &:hover {
-          color: $white;
-        }
-      }
-
-    }
-    .sidemenu__item--active {
-      margin-left: -2px;
-      border-left-width: 2px;
-      border-left-style: solid;
-      border-left-color: $white;
-      a {
-        color: $white;
-      }
-    }
-
     body.agents & {
       background-color: $blue;
       color: $white;

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -43,21 +43,9 @@
         border-left-style: solid;
         border-left-color: $white;
       }
-    }
 
-    &.side-menu__sub-item {
-      display: block;
-      width: 100%; //permet d'augmenter la surface du lien pour le rendre plus facilement clickable
-      padding: 6px 12px;
-
-      &:hover {
-        background-color: lighten($bg-leftbar, 5%);
-      }
-
-      &.active {
-        border-left-width: 2px;
-        border-left-style: solid;
-        border-left-color: $white;
+      &.side-menu__item--small {
+        padding: 6px 12px;
       }
     }
 

--- a/app/views/agents/_preferences_menu.html.slim
+++ b/app/views/agents/_preferences_menu.html.slim
@@ -7,12 +7,13 @@ ruby:
     ]
 
 .d-flex.flex-row.justify-content-center
-  div.text-left.text-white
+  div.text-left.text-white.left-side-menu
     h3 = current_agent.full_name
     ul.list-unstyled
       - menu_items.each do |item|
-        li class="side-menu__item #{"active" if @active_agent_preferences_menu_item == item[0]}"
-          = link_to item[2] do
+        li
+          = link_to(item[2], class: "px-1 py-2 side-menu__item #{"active" if @active_agent_preferences_menu_item == item[0]}") do
             span.ml-1 = item[1]
-      li.mt-3.mb-3.sidemenu__item
-        = link_to "Se déconnecter", destroy_agent_session_path, method: :delete
+      li
+        = link_to destroy_agent_session_path, method: :delete, class: "px-1 py-2 side-menu__item" do
+          span.ml-1 = "Se déconnecter"

--- a/app/views/agents/_preferences_menu.html.slim
+++ b/app/views/agents/_preferences_menu.html.slim
@@ -11,7 +11,8 @@ ruby:
     h3 = current_agent.full_name
     ul.list-unstyled
       - menu_items.each do |item|
-        li.mt-3.mb-3 class="sidemenu__item #{"sidemenu__item--active" if @active_agent_preferences_menu_item == item[0]}"
-          = link_to item[1], item[2]
+        li class="side-menu__item #{"active" if @active_agent_preferences_menu_item == item[0]}"
+          = link_to item[2] do
+            span.ml-1 = item[1]
       li.mt-3.mb-3.sidemenu__item
         = link_to "Se déconnecter", destroy_agent_session_path, method: :delete

--- a/app/views/agents/_preferences_menu.html.slim
+++ b/app/views/agents/_preferences_menu.html.slim
@@ -12,7 +12,7 @@ ruby:
     ul.list-unstyled
       - menu_items.each do |item|
         li
-          = link_to(item[2], class: "px-1 py-2 side-menu__item #{"active" if @active_agent_preferences_menu_item == item[0]}") do
+          = link_to(item[2], class: "px-1 py-2 side-menu__item #{'active' if @active_agent_preferences_menu_item == item[0]}") do
             span.ml-1 = item[1]
       li
         = link_to destroy_agent_session_path, method: :delete, class: "px-1 py-2 side-menu__item" do

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -48,13 +48,13 @@ nav.left-side-menu-wrapper
               form.my-2.pl-2
                 = planning_agent_select(agent_for_left_menu, path_helper_name)
             li
-              = active_link_to "Agenda", admin_organisation_agent_agenda_path(current_organisation, agent_for_left_menu), class: "side-menu__sub-item"
+              = active_link_to "Agenda", admin_organisation_agent_agenda_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
-              = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu), class: "side-menu__sub-item"
+              = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
-              = active_link_to t(".busy_times"), admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__sub-item"
+              = active_link_to t(".busy_times"), admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
-              = active_link_to "RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__sub-item"
+              = active_link_to "RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__item side-menu__item--small"
 
         li
           = active_link_to(admin_organisation_users_path(current_organisation), class: "side-menu__item")
@@ -99,20 +99,20 @@ nav.left-side-menu-wrapper
               class=("show" if menu_top_level_item == "settings")
             ]
               li
-                = active_link_to "Organisation", admin_organisation_path(current_organisation), active: :exact, class: "side-menu__sub-item"
+                = active_link_to "Organisation", admin_organisation_path(current_organisation), active: :exact, class: "side-menu__item side-menu__item--small"
               - if current_domain.online_reservation_with_public_link
                 li
-                  = active_link_to "Réservation en ligne", admin_organisation_online_booking_path(current_organisation), class: "side-menu__sub-item"
+                  = active_link_to "Réservation en ligne", admin_organisation_online_booking_path(current_organisation), class: "side-menu__item side-menu__item--small"
               li
-                = active_link_to "Lieux", admin_organisation_lieux_path(current_organisation), class: "side-menu__sub-item"
+                = active_link_to "Lieux", admin_organisation_lieux_path(current_organisation), class: "side-menu__item side-menu__item--small"
               li
-                = active_link_to "Agents", admin_organisation_agents_path(current_organisation), class: "side-menu__sub-item"
+                = active_link_to "Agents", admin_organisation_agents_path(current_organisation), class: "side-menu__item side-menu__item--small"
               li
-                = active_link_to "Invitations", admin_organisation_invitations_path(current_organisation), class: "side-menu__sub-item"
+                = active_link_to "Invitations", admin_organisation_invitations_path(current_organisation), class: "side-menu__item side-menu__item--small"
               li
-                = active_link_to "Motifs", admin_organisation_motifs_path(current_organisation), class: "side-menu__sub-item"
+                = active_link_to "Motifs", admin_organisation_motifs_path(current_organisation), class: "side-menu__item side-menu__item--small"
               - if current_agent.territorial_admin_in?(current_organisation.territory)
-                = link_to admin_territory_path(current_organisation.territory), class: "side-menu__sub-item" do
+                = link_to admin_territory_path(current_organisation.territory), class: "side-menu__item side-menu__item--small" do
                   i.fa.fa-cog>
                   = t(".configuration")
         li

--- a/app/views/layouts/left_menu/_organisation_switcher.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher.html.slim
@@ -1,8 +1,8 @@
 ul.list-unstyled.left-submenu-account.collapse
   - if current_agent.organisations.count > 10
     li
-      = link_to "Changer d'organisation", admin_organisations_path, class: "side-menu__sub-item pl-4"
+      = link_to "Changer d'organisation", admin_organisations_path, class: "side-menu__item side-menu__item--small pl-4"
   - else
     - current_agent.organisations.order_by_name.each do |organisation|
       li
-        = link_to organisation.name, admin_organisation_agent_agenda_path(organisation, current_agent), class: "side-menu__sub-item #{'active' if organisation == current_organisation} pl-4 "
+        = link_to organisation.name, admin_organisation_agent_agenda_path(organisation, current_agent), class: "side-menu__item side-menu__item--small #{'active' if organisation == current_organisation} pl-4 "

--- a/app/views/layouts/registration.html.slim
+++ b/app/views/layouts/registration.html.slim
@@ -14,7 +14,7 @@ html lang="fr"
           .p-2
             = link_logo
           - if current_agent.present?
-            = link_to(root_path, class: "pt-1 pb-4") do
+            = link_to(root_path, class: "pt-1 pb-4 text-white") do
               i.fa.fa-arrow-left
               = " Retour à l'accueil"
           .align-items-center.d-flex.mt-2.mt-lg-4


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-service-public/pull/4091, on avait deux versions légèrement différentes de menu latéral entre la navigation principale des agents, et celle des paramètres de leur compte.

Cette PR harmonise ces deux menus et évite la duplication de css

### Avant

<img width="466" alt="Screenshot 2024-03-05 at 17 42 51" src="https://github.com/betagouv/rdv-service-public/assets/1840367/3ea9d329-ed15-4ae6-83ac-5e39b92f6426">


### Après 

<img width="471" alt="Screenshot 2024-03-05 at 17 42 39" src="https://github.com/betagouv/rdv-service-public/assets/1840367/dcfbf06d-7c29-455c-bad2-f47f58372cfd">