### PR TITLE
Correctif pour le scroll dans le menu latéral pour les agents

### DIFF
--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -110,6 +110,7 @@
     bottom: 0;
     position: sticky;
     top: 0;
+    max-height: 100vh; // pour permettre de scroller dans le menu
     overflow-y: auto;
     overflow-x: hidden;
 


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-service-public/pull/4091 on a un petit bug sur la navigation : quand elle est plus grande que la hauteur de l'écran et qu'on essaye de scroller dedans, ça fait scroller sur le contenu principal, et on ne scrolle dans le menu que quand on arrive en bas de la page principale.
Cette PR corrige ce bug.