### PR TITLE
Update puma to from 5.6.8 to 6.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rails", "~> 7.0.8"
 # Rack-based asset packaging system
 gem "sprockets-rails"
 # Puma is a simple, fast, threaded, and highly parallel HTTP 1.1 server for Ruby/Rack applications
-gem "puma", "< 6.0" # Lock < 6.O until Puma stops returning HTTP 501 on PROPFIND requests: https://github.com/puma/puma/issues/3014
+gem "puma"
 # Bundle and transpile JavaScript in Rails with esbuild, rollup.js, or Webpack.
 gem "jsbundling-rails"
 # Turbolinks makes navigating your web application faster

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ GEM
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
     public_suffix (5.0.4)
-    puma (5.6.8)
+    puma (6.4.2)
       nio4r (~> 2.0)
     pundit (2.2.0)
       activesupport (>= 3.0.0)
@@ -663,7 +663,7 @@ DEPENDENCIES
   pg_search
   phonelib
   premailer-rails
-  puma (< 6.0)
+  puma
   pundit
   rack-attack
   rack-cors

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,3 +41,5 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+supported_http_methods Puma::Const::IANA_HTTP_METHODS


### PR DESCRIPTION
La dernière fois qu'on a update puma, on a eu des erreurs 500 dans nos metrics Scalingo car certains clients calendrier nous envoyaient des requêtes HTTP PROPFIND : #3108

En effet, la version 6 de puma s'est mise à lever des exceptions si la méthode HTTP n'est pas "standard" (`HEAD GET POST PUT DELETE OPTIONS TRACE PATCH`). Suite à des [discussions](https://github.com/puma/puma/issues/3014) (auxquelles j'ai participé mais finalement c'est pas ma PR qui a été prise), il est [désormais possible](https://github.com/puma/puma/pull/3106) de configurer les méthodes autorisées via le DSL `supported_http_methods`.

J'ai lancé

```
curl --location --request PROPFIND 'https://demo-rdv-solidarites-pr4140.osc-secnum-fr1.scalingo.io/principals/users/monmail@example.com'
```

et ça répond une 404 sans prévenir Sentry.

Au passage, on a un gain de performance en passant à Puma 6 ! :tada: 
https://github.com/puma/puma/blob/master/6.0-Upgrade.md

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
