### PR TITLE
Supprimer les invitations du menu latéral

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -1,5 +1,6 @@
 class Admin::InvitationsController < AgentAuthController
   def index
+    @active_agents_menu = true
     @invited_agents = policy_scope(Agent)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .invitation_not_accepted.where.not(invitation_sent_at: nil)

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -33,7 +33,6 @@ module AgentsHelper
       "menu-absences" => "planning",
       "menu-rdvs-collectifs-list" => "planning",
       "menu-agents" => "settings",
-      "menu-invitations" => "settings",
       "menu-lieux" => "settings",
       "menu-motifs" => "settings",
       "menu-organisation" => "settings",

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -1,4 +1,4 @@
-- content_for(:menu_item) { "menu-invitations" }
+- content_for(:menu_item) { "menu-agents" }
 
 - content_for(:title, "Invitations en cours pour #{current_organisation.name}")
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -106,9 +106,7 @@ nav.left-side-menu-wrapper
               li
                 = active_link_to "Lieux", admin_organisation_lieux_path(current_organisation), class: "side-menu__sub-item"
               li
-                = active_link_to "Agents", admin_organisation_agents_path(current_organisation), class: "side-menu__sub-item"
-              li
-                = active_link_to "Invitations", admin_organisation_invitations_path(current_organisation), class: "side-menu__sub-item"
+                = active_link_to "Agents", admin_organisation_agents_path(current_organisation), class: "side-menu__sub-item #{'active' if @active_agents_menu }"
               li
                 = active_link_to "Motifs", admin_organisation_motifs_path(current_organisation), class: "side-menu__sub-item"
               - if current_agent.territorial_admin_in?(current_organisation.territory)


### PR DESCRIPTION
Discussion avec l'équipe design : le terme invitation dans les paramètres cause de la confusion pour les agents. Cette entrée de menu n'est pas nécessaire, puisqu'on peut retrouver la liste des agents qui ont des invitations en attente depuis la liste des agents.
