### PR TITLE
Correctif pour une flaky spec

### DIFF
--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe "agents can prescribe rdvs" do
       click_on "Créer un usager"
       fill_in :user_first_name, with: "Jean-Paul"
       fill_in :user_last_name, with: "Orvoir"
-      expect(page).to have_content("Jean-Paul")
       click_on "Créer usager"
+      expect(page).to have_content("Jean-Paul")
       click_on "Continuer"
       # go back to user selection
       page.all("a").find { _1.text == "modifier" && _1[:href].include?("user_selection") }.click

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe "agents can prescribe rdvs" do
       click_on "Créer un usager"
       fill_in :user_first_name, with: "Jean-Paul"
       fill_in :user_last_name, with: "Orvoir"
+      expect(page).to have_content("Jean-Paul")
       click_on "Créer usager"
       click_on "Continuer"
       # go back to user selection


### PR DESCRIPTION
La parallélisation des specs de features nous rend plus vulnérables aux specs qui échouent à cause de race conditiosn entre le navigateur et le script de tests. Cette spec a échoué pour d'autres builds