### PR TITLE
Corriger le warning sur `Redis#sadd`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "paper_trail", "< 13.0"
 # Integrate PostgreSQL's enum data type into ActiveRecord's schema and migrations.
 gem "activerecord-postgres_enum"
 # A Ruby client library for Redis
-gem "redis", "< 5.0"
+gem "redis"
 # Adds a Redis::Namespace class which can be used to namespace calls to Redis.
 gem "redis-namespace"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       descendants_tracker (~> 0.0.1)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -443,7 +444,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.1)
+    redis (5.1.0)
+      redis-client (>= 0.17.0)
+    redis-client (0.21.0)
+      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.8.2)
@@ -672,7 +676,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rails_autolink
-  redis (< 5.0)
+  redis
   redis-namespace
   rspec-rails
   rspec_junit_formatter

--- a/app/models/concerns/rdv/using_waiting_room.rb
+++ b/app/models/concerns/rdv/using_waiting_room.rb
@@ -13,7 +13,7 @@ module Rdv::UsingWaitingRoom
 
   def set_user_in_waiting_room!
     Redis.with_connection do |redis|
-      redis.sadd(REDIS_WAITING_ROOM_KEY, id)
+      redis.sadd?(REDIS_WAITING_ROOM_KEY, id)
     end
   end
 


### PR DESCRIPTION
Le warning était : 

> Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.(called from: /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.3.0/gems/redis-namespace-1.11.0/lib/redis/namespace.rb:564:in `wrapped_send')


# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
