### PR TITLE
Corriger les warnings sur les default gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -217,4 +217,7 @@ group :test do
   gem "database_cleaner"
   # Library for stubbing HTTP requests in Ruby.
   gem "webmock"
+
+  # Dépendence indirecte de axe-core-api
+  gem "axiom-types", git: "https://github.com/francois-ferrandis/axiom-types.git", ref: "f75b18b"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -239,5 +239,5 @@ group :test do
   gem "webmock"
 
   # Dépendence indirecte de axe-core-api
-  gem "axiom-types", git: "https://github.com/francois-ferrandis/axiom-types.git", ref: "f75b18b"
+  gem "axiom-types", git: "https://github.com/rdv-solidarites/axiom-types.git", ref: "b9b204c"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,9 @@ gem "icalendar", "~> 2.5"
 # Tame Rails' multi-line logging into a single line per request
 gem "lograge"
 
+# TODO: retirer cette ligne quand une nouvelle version de httpclient est released
+gem "httpclient", git: "https://github.com/nahi/httpclient.git", ref: "d57cc6d"
+
 group :development, :test do
   # Identify database issues before they hit production.
   gem "active_record_doctor"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/francois-ferrandis/axiom-types.git
+  revision: f75b18be7481e81131878bdfba096acb7150303a
+  ref: f75b18b
+  specs:
+    axiom-types (0.1.1)
+      bigdecimal (~> 1.2, >= 1.2.7)
+      descendants_tracker (~> 0.0, >= 0.0.4)
+      ice_nine (~> 0.11, >= 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+
+GIT
   remote: https://github.com/nahi/httpclient.git
   revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
   ref: d57cc6d
@@ -103,16 +114,13 @@ GEM
       axe-core-api
       dumb_delegator
       virtus
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bcrypt (3.1.20)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bigdecimal (1.4.4)
     bindata (2.5.0)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
@@ -625,6 +633,7 @@ DEPENDENCIES
   auto_strip_attributes
   axe-core-api (= 4.3.2)
   axe-core-rspec (= 4.3.2)
+  axiom-types!
   better_errors
   binding_of_caller
   blueprinter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GIT
-  remote: https://github.com/francois-ferrandis/axiom-types.git
-  revision: f75b18be7481e81131878bdfba096acb7150303a
-  ref: f75b18b
-  specs:
-    axiom-types (0.1.1)
-      bigdecimal (~> 1.2, >= 1.2.7)
-      descendants_tracker (~> 0.0, >= 0.0.4)
-      ice_nine (~> 0.11, >= 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
-
-GIT
   remote: https://github.com/nahi/httpclient.git
   revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
   ref: d57cc6d
   specs:
     httpclient (2.8.3)
+
+GIT
+  remote: https://github.com/rdv-solidarites/axiom-types.git
+  revision: b9b204cebda7af20feea40c6c3e2dadb5766480f
+  ref: b9b204c
+  specs:
+    axiom-types (0.1.1)
+      bigdecimal (>= 1.2.7)
+      descendants_tracker (~> 0.0, >= 0.0.4)
+      ice_nine (~> 0.11, >= 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -120,7 +120,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    bigdecimal (1.4.4)
+    bigdecimal (3.1.6)
     bindata (2.5.0)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/nahi/httpclient.git
+  revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
+  ref: d57cc6d
+  specs:
+    httpclient (2.8.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -220,7 +227,6 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
-    httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     icalendar (2.8.0)
@@ -644,6 +650,7 @@ DEPENDENCIES
   faker
   good_job
   groupdate (~> 6.1)
+  httpclient!
   icalendar (~> 2.5)
   jbuilder
   jsbundling-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,8 @@ GIT
   ref: d57cc6d
   specs:
     httpclient (2.8.3)
+      mutex_m
+      webrick
 
 GIT
   remote: https://github.com/rdv-solidarites/axiom-types.git
@@ -307,6 +309,7 @@ GEM
       activesupport (>= 5.2, < 8)
     msgpack (1.7.2)
     multi_xml (0.6.0)
+    mutex_m (0.2.0)
     net-http (0.4.1)
       uri
     net-imap (0.4.10)
@@ -613,6 +616,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)


### PR DESCRIPTION
Les warnings étaient :

> /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.3.0/gems/axiom-types-0.1.1/lib/axiom/types.rb:3: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of axiom-types-0.1.1 to add bigdecimal into its gemspec.

et

> /home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.3.0/gems/httpclient-2.8.3/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of httpclient-2.8.3 to add mutex_m into its gemspec.


# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
