### PR TITLE
Ajout yarn install dans bin/setup + ajout copie .env.sample doc

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,7 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
+  system! "yarn install"
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/docs/1-installation.md
+++ b/docs/1-installation.md
@@ -3,7 +3,7 @@
 ## Prérequis
 
 - Déploiement:
-  - Ruby 3.0 (nous conseillons l’utilisation de [rbenv](https://github.com/rbenv/rbenv-installer#rbenv-installer--doctor-scripts))
+  - Ruby 3.3.0 (nous conseillons l’utilisation de [rbenv](https://github.com/rbenv/rbenv-installer#rbenv-installer--doctor-scripts))
   - PostgreSQL >= 12, l’utilisateur doit avoir les droits `superuser`. C'est nécessaire pour pouvoir activer les extensions utilisés.
 - Développement
   - [Yarn](https://yarnpkg.com/en/docs/install)
@@ -15,9 +15,9 @@
 
 ## Setup
 
-Voir les variables d'environnement pour configurer l'accès à PostgreSQL
+Commencer par copier `.env.sample` vers `.env` et définissez-y les variables POSTGRES_HOST, POSTGRES_USER et POSTGRES_PASSWORD pour la connexion à la db locale
 
-Le script se charge d’installer les gems et packages et de créer la base de données.
+Puis exécuter ce script pour installer les gems et packages et créer la base de données :
 ```bash
 make install  ## appelle bin/setup
 ```


### PR DESCRIPTION
J’ai du faire ces modifications pour l’installation en local du projet

Je pense que le `yarn install` est un oubli du `bin/setup`.

En revanche pour le fichier `.env` sa présence est peut être devenue nécessaire récemment, peut-être que ça fonctionnait avant sans. Aujourd’hui ça échoue sur une ligne du genre `ENV['HOST'].sub('https'...)` où `ENV['HOST']` est `nil`.