### PR TITLE
suppression de la gem Daemons non utilisée

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,8 +81,6 @@ gem "common_french_passwords"
 # Jobs
 # A multithreaded, Postgres-based ActiveJob backend for Ruby on Rails
 gem "good_job"
-# A toolkit to create and control daemons in different ways
-gem "daemons"
 
 # JSON serialization and queries
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,6 @@ GEM
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
-    daemons (1.4.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.0.1)
@@ -632,7 +631,6 @@ DEPENDENCIES
   capybara-screenshot
   chartkick (~> 5.0.1)
   common_french_passwords
-  daemons
   database_cleaner
   devise
   devise-async


### PR DESCRIPTION
La gem `daemons` n’est à ma compréhension pas utilisée. Cette PR la supprime.

Elle ne l’a même peut-être jamais été ? cf le commit qui l’introduit il y a 5 ans https://github.com/betagouv/rdv-service-public/commit/a2f1ef50aba49de72b114e57297f633a1efafed7 on dirait qu’elle n’y est pas utilisée.