### PR TITLE
Downgrade `redis` gem (to set default timeout back to 5 seconds)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "paper_trail", "< 13.0"
 # Integrate PostgreSQL's enum data type into ActiveRecord's schema and migrations.
 gem "activerecord-postgres_enum"
 # A Ruby client library for Redis
-gem "redis"
+gem "redis", "< 5.0"
 # Adds a Redis::Namespace class which can be used to namespace calls to Redis.
 gem "redis-namespace"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
       descendants_tracker (~> 0.0.1)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.2.3)
-    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -443,10 +442,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.1.0)
-      redis-client (>= 0.17.0)
-    redis-client (0.21.0)
-      connection_pool
+    redis (4.8.1)
     redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.8.2)
@@ -674,7 +670,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rails_autolink
-  redis
+  redis (< 5.0)
   redis-namespace
   rspec-rails
   rspec_junit_formatter


### PR DESCRIPTION
J'avais fait un upgrade dans #4144 mais le [nouveau default sur les timeouts](https://github.com/redis/redis-rb/pull/1225) nous lève des erreurs (surtout sur les lectures nombreuses de `user_in_waiting_room?`).

En attendant de faire mieux, je downgrade ici la gem.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
