### PR TITLE
Corriger les erreurs de timeout Redis liées à la MAJ de `redis`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,27 +39,19 @@ module Lapin
     config.action_mailer.preview_path = Rails.root.join("spec/mailers/previews")
     config.active_model.i18n_customize_full_message = true
 
-    config.x.redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379" }
-
     config.active_support.cache_format_version = 7.0
 
-    # Both cache and sessions are stored in the same Redis database:
-    # - cache keys are prefixed with "cache:"
-    # - session keys are prefixed with "session:"
-    redis_settings = {
+    config.x.redis_app_namespace = Rails.env.test? ? "test:app:#{ENV['TEST_ENV_NUMBER']}" : "app"
+    config.x.redis_settings = {
+      url: ENV.fetch("REDIS_URL") { "redis://localhost:6379" },
       connect_timeout: 30, # Defaults to 20 seconds
       read_timeout: 1, # Defaults to 1 second
       write_timeout: 1, # Defaults to 1 second
       reconnect_attempts: 1, # Defaults to 0
     }
 
-    config.cache_store = :redis_cache_store, {
-      url: config.x.redis_url,
-      namespace: "cache",
-      **redis_settings,
-    }
-
-    config.x.redis_namespace = "app"
+    redis_cache_namespace = Rails.env.test? ? "test:cache#{ENV['TEST_ENV_NUMBER']}" : "cache"
+    config.cache_store = :redis_cache_store, config.x.redis_settings.merge({ namespace: redis_cache_namespace })
 
     config.session_store :cookie_store, key: "_rdv_sp_session"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,15 +29,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Test env has the same config as the global one (defined in application.rb)
-  # except we separate Redis keys in each parallel test using TEST_ENV_NUMBER.
-  config.cache_store = :redis_cache_store, {
-    url: "redis://localhost:6379",
-    namespace: "test:cache#{ENV['TEST_ENV_NUMBER']}",
-  }
-
-  config.x.redis_namespace = "test:app:#{ENV['TEST_ENV_NUMBER']}"
-
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -2,8 +2,8 @@ raise "Prevent monkey patch" if Redis.respond_to?(:with_connection)
 
 class Redis
   def self.with_connection
-    redis_connection = new(url: Rails.configuration.x.redis_url)
-    redis_connection = Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
+    redis_connection = new(Rails.configuration.x.redis_settings)
+    redis_connection = Redis::Namespace.new(Rails.configuration.x.redis_app_namespace, redis: redis_connection)
     yield(redis_connection)
   ensure
     redis_connection&.close

--- a/spec/lib/redis_spec.rb
+++ b/spec/lib/redis_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "Redis connection" do
+  it "timeouts at 5 seconds" do
+    allow(Redis).to receive(:new).and_wrap_original do |original_method, args, &block|
+      new_settings = args.except(:connect_timeout, :read_timeout, :write_timeout).merge(timeout: 0.00000000001)
+      original_method.call(new_settings, &block)
+    end
+
+    expect do
+      Redis.with_connection do |redis|
+        redis.get("key")
+      end
+    end.to raise_error(Redis::TimeoutError)
+  end
+end


### PR DESCRIPTION
Le problème : 
- nous utilisons le timeout par défaut lorsque nous ouvrons manuellement une connexion Redis (`Redis.with_connection`)
- le timeout par défaut de la gem a changé de 5 secondes à 1 seconde en v5.0.0 (https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#500)

Donc lorsque j'ai mis à jour la gem ce midi, nous avons commencé à avoir quelques timeouts (moins de 10), essentiellement sur un appel qui est fait en grands volumes : `user_in_waiting_room?`.

Je pense suivre ce guide : https://tejasbubane.github.io/posts/2020-04-22-redis-connection-pool-in-rails/

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
