### PR TITLE
Passer la durée d'invitation à 1 semaine pour améliorer la sécurité

### DIFF
--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,6 +1,6 @@
 class Participation < ApplicationRecord
   # Mixins
-  devise :invitable, invite_for: 8.weeks
+  devise :invitable, invite_for: 12.weeks
 
   include Participation::StatusChangeable
   include Participation::Creatable

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,6 +1,6 @@
 class Participation < ApplicationRecord
   # Mixins
-  devise :invitable
+  devise :invitable, invite_for: 8.weeks
 
   include Participation::StatusChangeable
   include Participation::Creatable

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -124,7 +124,7 @@ Devise.setup do |config|
   # The period the generated invitation token is valid.
   # After this period, the invited resource won't be able to accept the invitation.
   # When invite_for is 0 (the default), the invitation won't expire.
-  config.invite_for = 4.weeks
+  config.invite_for = 1.week
 
   Rails.application.reloader.to_prepare do
     # Replace the token generator normally instantiated here : https://github.com/heartcombo/devise/blob/88724e10adaf9ffd1d8dbfbaadda2b9d40de756a/lib/devise/rails.rb#L41


### PR DESCRIPTION
Suite à discussion avec Numéricité, pour améliorer la sécurité de notre mécanisme d'invitation, il vaut mieux que les liens d'invitation des agents (et des usagers) expirent en 1 semaine plutôt qu'un mois.