### PR TITLE
Suppression des vieilles versions

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -117,8 +117,11 @@ class CronJob < ApplicationJob
 
   class DestroyOldVersions < CronJob
     def perform
-      # Versions are used in RDV exports, and RDVs are currently kept for 2 years.
-      PaperTrail::Version.where("created_at < ?", 2.years.ago).delete_all
+      # voir https://www.cnil.fr/fr/la-cnil-publie-une-recommandation-relative-aux-mesures-de-journalisation
+      PaperTrail::Version.where("created_at < ?", 6.months.ago).where.not(event: :create, item_type: "Rdv").delete_all
+
+      # Les versions qui permettent de connaitre les authors sont conservées plus longtemps, voir Rdv::AuthoredConcern
+      PaperTrail::Version.where(event: :create, item_type: "Rdv").where("created_at < ?", 2.years.ago).delete_all
     end
   end
 

--- a/app/views/admin/versions/_resource_versions_row.html.slim
+++ b/app/views/admin/versions/_resource_versions_row.html.slim
@@ -10,3 +10,4 @@
         = cache([resource, resource.class.paper_trail_options[:only]], expires_in: 7.days) do
           - versions = PaperTrailAugmentedVersion.for_resource(resource)
           = render "admin/versions/versions", versions: versions.reverse
+        p = "Cet historique affiche uniquement les changements des 6 derniers mois."


### PR DESCRIPTION
Suite aux discussions avec numéricité, on a des consignes plus claires sur combien de temps on peut garder les versions, voir https://www.cnil.fr/fr/la-cnil-publie-une-recommandation-relative-aux-mesures-de-journalisation