### PR TITLE
[Vigie] Improve error handling in API for ANTS

### DIFF
--- a/app/services/ants_api/appointment.rb
+++ b/app/services/ants_api/appointment.rb
@@ -69,7 +69,7 @@ module AntsApi
 
       def request(&block)
         response = block.call
-        if response.failure?
+        unless response.success?
           raise(ApiRequestError, "code:#{response.response_code}, body:#{response.response_body}")
         end
 

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -43,8 +43,9 @@ Typhoeus.on_complete do |response|
     message: "HTTP response",
     data: {
       code: response.code,
-      headers: response.headers,
+      headers: response.headers.to_h,
       body: response.body,
+      return_code: response.return_code,
     }
   )
   Sentry.add_breadcrumb(crumb)

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe "agents can prescribe rdvs" do
       click_on "Créer un usager"
       fill_in :user_first_name, with: "Jean-Pierre"
       fill_in :user_last_name, with: "Bonjour"
+      expect(page).to have_content("Jean-Pierre Bonjour")
       click_on "Créer usager"
       click_on "Continuer"
       expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -170,8 +170,8 @@ RSpec.describe "agents can prescribe rdvs" do
       click_on "Créer un usager"
       fill_in :user_first_name, with: "Jean-Pierre"
       fill_in :user_last_name, with: "Bonjour"
-      expect(page).to have_content("Jean-Pierre Bonjour")
       click_on "Créer usager"
+      expect(page).to have_content("BONJOUR Jean-Pierre")
       click_on "Continuer"
       expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)
       expect(Rdv.last.users.first.full_name).to eq("Jean-Pierre BONJOUR")

--- a/spec/sms/sms_netsize_spec.rb
+++ b/spec/sms/sms_netsize_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "using netsize to send an SMS" do
 
     breadcrumbs = sentry_events.last.breadcrumbs.compact
     expect(breadcrumbs[0]).to have_attributes(message: "HTTP request")
-    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: "", code: 0, headers: {} })
+    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: "", code: 0, headers: {}, return_code: :operation_timedout })
   end
 
   it "warns Sentry when netsize responds with an HTTP error" do
@@ -53,7 +53,7 @@ RSpec.describe "using netsize to send an SMS" do
 
     breadcrumbs = sentry_events.last.breadcrumbs.compact
     expect(breadcrumbs[0]).to have_attributes(message: "HTTP request")
-    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: "", code: 500, headers: {} })
+    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: "", code: 500, headers: {}, return_code: nil })
   end
 
   it "warns Sentry when netsize responds with a business error" do
@@ -69,6 +69,6 @@ RSpec.describe "using netsize to send an SMS" do
 
     breadcrumbs = sentry_events.last.breadcrumbs.compact
     expect(breadcrumbs[0]).to have_attributes(message: "HTTP request")
-    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: stubbed_body, code: 200, headers: {} })
+    expect(breadcrumbs[1]).to have_attributes(message: "HTTP response", data: { body: stubbed_body, code: 200, headers: {}, return_code: nil })
   end
 end


### PR DESCRIPTION
## Improve error handling in API for ANTS

Cette [erreur](https://sentry.incubateur.net/organizations/betagouv/issues/77676/?project=74) laisse découvrir un dysfonctionnement au niveau de :
https://github.com/betagouv/rdv-service-public/blob/a1a9610f98f6aa3519a7fbdcb69d3013bbc9bdb1/app/services/ants_api/appointment.rb#L72

La méthode [`failure` définie dans `Typhoeus::Response`]((https://github.com/typhoeus/typhoeus/blob/f5c5751df49089da89fc2683a23df04850a45604/lib/typhoeus/response/status.rb#L52-L60)), devrait retourner true, pour la réponse suivante:

```
HTTP response
 {
    body: Internal Server Error, 
    code: 500, 
    headers: {
      content-length: 21, 
      content-type: text/plain; charset=utf-8, 
      date: Sat, 09 Mar 2024 14:25:00 GMT, 
      strict-transport-security: max-age=31536000, 
      x-request-id: 4f7b3985-3863-4da5-9bc1-55a5a99f1ed5
    }
}
```

Etrangement, nous avons le comportement suivant après tests dans la console:
```
options = {response_code: 500, response_body: "Internal Server Error"}
=> {:response_code=>500, :response_body=>"Internal Server Error"}
r = Typhoeus::Response.new(options)
=> #<Typhoeus::Response:0x000000012e1bbf00 @options={:response_code=>500, :response_body=>"Internal Server Error"}
r.response_body
=> "Internal Server Error"
 r.response_code
=> 500
r.failure?
=> false
r.success?
=> false
```

La solution ici est de remplacer l'usage de `response#failure?` par `response#success?` qui est beaucoup plus déterministe.
