### PR TITLE
Suppression de code spec inutilisé

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,7 +40,6 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include PageSpecHelper
-  config.include SigninSpecHelper
   config.include UnescapeHtmlSpecHelper
   config.include Select2SpecHelper
   config.include ApiSpecHelper, type: :request

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -39,25 +39,6 @@ Capybara.configure do |config|
   config.always_include_port = true
 end
 
-RSpec.configure do |config|
-  config.after(:each, js: true) do |example|
-    next unless example.exception # only write logs for failed tests
-
-    FileUtils.mkdir_p "tmp/capybara"
-    %i[browser driver].each do |source|
-      errors = Capybara.page.driver.browser.logs.get(source)
-      fp = "tmp/capybara/chrome.#{example.full_description.parameterize}.#{source}.log"
-      File.open(fp, "w") do |f|
-        f << "// empty logs" if errors.empty?
-        errors.each do |e|
-          f << "#{e.timestamp} [#{e.level}]: #{e.message}"
-        end
-        f << "\n"
-      end
-    end
-  end
-end
-
 def expect_page_to_be_axe_clean(path)
   visit path # TODO: supprimer en même temps que app/javascript/components/header_tooltip.js
   # Le premier visit permet d'afficher le tooltip du header, et faire qu'il n'apparaisse pas la deuxieme fois

--- a/spec/support/signin_spec_helper.rb
+++ b/spec/support/signin_spec_helper.rb
@@ -1,7 +1,0 @@
-module SigninSpecHelper
-  def sign_in(user)
-    fill_in :user_email, with: user.email
-    fill_in :password, with: user.password
-    click_on "Se connecter"
-  end
-end


### PR DESCRIPTION
En regardant le coverage j'ai réalisé que ce code n'était pas utilisé.

Le truc de debug dans capybara_config.rb, on en avait parlé en équipe, personne ne l'utilise.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
