### PR TITLE
Considérer les domaines francetravail.fr et pole-emploi.fr comme équivalents

### DIFF
--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -187,9 +187,7 @@ RSpec.describe InclusionConnectController, type: :controller do
         it "search @francetravail.fr saves the sub" do
           agent = create(:agent, :invitation_not_accepted, email: "bob@francetravail.fr")
           get :callback, params: { state: ic_state, session_state: ic_state, code: "klzefklzejlf" }
-          expect(agent.reload).to have_attributes(
-            inclusion_connect_open_id_sub: "12345678-90ab-cdef-1234-567890abcdef",
-          )
+          expect(agent.reload.inclusion_connect_open_id_sub).to eq("12345678-90ab-cdef-1234-567890abcdef")
         end
       end
     end

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -187,7 +187,12 @@ RSpec.describe InclusionConnectController, type: :controller do
         it "search @francetravail.fr saves the sub" do
           agent = create(:agent, :invitation_not_accepted, email: "bob@francetravail.fr")
           get :callback, params: { state: ic_state, session_state: ic_state, code: "klzefklzejlf" }
-          expect(agent.reload.inclusion_connect_open_id_sub).to eq("12345678-90ab-cdef-1234-567890abcdef")
+          expect(agent.reload).to have_attributes(
+            id: agent.id,
+            email: "bob@pole-emploi.fr",
+            uid: "bob@pole-emploi.fr",
+            inclusion_connect_open_id_sub: "12345678-90ab-cdef-1234-567890abcdef",
+          )
         end
       end
     end

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe InclusionConnectController, type: :controller do
             id: agent.id,
             email: "bob@pole-emploi.fr",
             uid: "bob@pole-emploi.fr",
-            inclusion_connect_open_id_sub: "12345678-90ab-cdef-1234-567890abcdef",
+            inclusion_connect_open_id_sub: "12345678-90ab-cdef-1234-567890abcdef"
           )
         end
       end


### PR DESCRIPTION
J'ajoute la gestion du cas suivant :
- un agent est créé sur RDV-SP avec un mail @francetravail.fr
- il possédait préalablement un compte InclusionConnect en @pole-emploi.fr
- il se connecte via IC sur RDV-SP

Avant cette PR : un compte doublon est créé
Après cette PR : nous retrouvons son compte dans notre base et enregistrons le sub

La spec ajoutée est verbeuse mais de toute façon elle sera supprimée dans 1 mois.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
