### PR TITLE
Ajout d'une guard clause sur la recherche agent dans inclusion connect

### DIFF
--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -109,8 +109,7 @@ class InclusionConnect
   end
 
   def found_by_email
-    return if user_info["email"].nil?
-
+    return if user_info["email"].nil? && Sentry.capture_message("InclusionConnect email is nil", extra: user_info, fingerprint: "ic_email_nil")
     return @found_by_email if defined?(@found_by_email)
 
     @found_by_email = Agent.find_by(email: user_info["email"])
@@ -129,7 +128,7 @@ class InclusionConnect
   end
 
   def found_by_sub
-    return if user_info["sub"].nil?
+    return if user_info["sub"].nil? && Sentry.capture_message("InclusionConnect sub is nil", extra: user_info, fingerprint: "ic_sub_nil")
 
     @found_by_sub ||= Agent.find_by(inclusion_connect_open_id_sub: user_info["sub"])
   end

--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -109,7 +109,8 @@ class InclusionConnect
   end
 
   def found_by_email
-    return if user_info["email"].nil? && Sentry.capture_message("InclusionConnect email is nil", extra: user_info, fingerprint: "ic_email_nil")
+    return log_and_exit("email") if user_info["email"].nil?
+
     return @found_by_email if defined?(@found_by_email)
 
     @found_by_email = Agent.find_by(email: user_info["email"])
@@ -128,9 +129,17 @@ class InclusionConnect
   end
 
   def found_by_sub
+    return log_and_exit("sub") if user_info["sub"].nil?
+
     return if user_info["sub"].nil? && Sentry.capture_message("InclusionConnect sub is nil", extra: user_info, fingerprint: "ic_sub_nil")
 
     @found_by_sub ||= Agent.find_by(inclusion_connect_open_id_sub: user_info["sub"])
+  end
+
+  def log_and_exit(field)
+    # should not happen
+    Sentry.capture_message("InclusionConnect #{field} is nil", extra: user_info, fingerprint: "ic_#{field}_nil")
+    nil
   end
 
   def agent_mismatch?

--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -109,6 +109,8 @@ class InclusionConnect
   end
 
   def found_by_email
+    return if user_info["email"].nil?
+
     return @found_by_email if defined?(@found_by_email)
 
     @found_by_email = Agent.find_by(email: user_info["email"])
@@ -127,6 +129,8 @@ class InclusionConnect
   end
 
   def found_by_sub
+    return if user_info["sub"].nil?
+
     @found_by_sub ||= Agent.find_by(inclusion_connect_open_id_sub: user_info["sub"])
   end
 

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -265,9 +265,12 @@ RSpec.describe InclusionConnectController, type: :controller do
 
       get :callback, params: { state: "a state", session_state: "a state", code: "klzefklzejlf" }
       expect(sentry_events.last.message).to eq("Failed to authenticate agent with InclusionConnect")
+
+      expect(response).to redirect_to(new_agent_session_path)
+      expect(flash[:error]).to include("Nous n'avons pas pu vous authentifier. Contactez le support à l'adresse")
     end
 
-    context "call sentry about nil sub" do
+    context "call sentry about nil sub and email" do
       before do
         stub_token_request.to_return(status: 200, body: { access_token: "zekfjzeklfjl", expires_in: now + 1.week, scopes: "openid" }.to_json, headers: {})
 
@@ -290,6 +293,9 @@ RSpec.describe InclusionConnectController, type: :controller do
       it do
         get :callback, params: { state: ic_state, session_state: ic_state, code: "klzefklzejlf" }
         expect(sentry_events.map(&:message)).to include("InclusionConnect sub is nil", "InclusionConnect email is nil", "Failed to authenticate agent with InclusionConnect")
+
+        expect(response).to redirect_to(new_agent_session_path)
+        expect(flash[:error]).to include("Nous n'avons pas pu vous authentifier. Contactez le support à l'adresse")
       end
     end
   end


### PR DESCRIPTION
Pour éviter de connecter un autre agent, dans le cas ou Inclusion connect renverrai un sub ou un email à `nil`.