### PR TITLE
Log des call API dans une table dédiée

### DIFF
--- a/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
+++ b/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
@@ -1,6 +1,4 @@
 class Api::Rdvinsertion::AgentAuthBaseController < Api::V1::AgentAuthBaseController
-  before_action :authenticate_agent
-
   private
 
   def authenticate_agent

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -124,23 +124,21 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       method: request.method,
       path: request.fullpath,
       host: request.host,
-      headers: request.headers.to_h.select { |k, _v| k.start_with?("HTTP_") },
+      headers: request.headers.to_h.transform_values { |value| value.is_a?(String) ? value : value.inspect },
     }
 
-    begin
-      ApiCall.create!(
-        raw_http: raw_http,
-        controller_name: controller_name,
-        action_name: action_name,
-        agent_id: current_agent.id
-      )
-    rescue StandardError => e
-      Sentry.capture_exception(e, extra: {
-                                 raw_http: raw_http,
-                                 controller_name: controller_name,
-                                 action_name: action_name,
-                                 agent_id: current_agent&.id,
-                               })
-    end
+    ApiCall.create!(
+      raw_http: raw_http,
+      controller_name: controller_name,
+      action_name: action_name,
+      agent_id: current_agent.id
+    )
+  rescue StandardError => e
+    Sentry.capture_exception(e, extra: {
+                               raw_http: raw_http,
+                               controller_name: controller_name,
+                               action_name: action_name,
+                               agent_id: current_agent&.id,
+                             })
   end
 end

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   include DeviseTokenAuth::Concerns::SetUserByToken
 
   skip_before_action :verify_authenticity_token
-  before_action :authenticate_agent
+  before_action :authenticate_agent, :log_api_call_in_database
 
   def pundit_user
     AgentOrganisationContext.new(current_agent, current_organisation)
@@ -117,5 +117,30 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       OpenSSL::HMAC.hexdigest("SHA256", ENV.fetch("SHARED_SECRET_FOR_AGENTS_AUTH"), payload.to_json),
       request.headers["X-Agent-Auth-Signature"]
     )
+  end
+
+  def log_api_call_in_database
+    raw_http = {
+      method: request.method,
+      path: request.fullpath,
+      host: request.host,
+      headers: request.headers.to_h.select { |k, _v| k.start_with?("HTTP_") },
+    }
+
+    begin
+      ApiCall.create!(
+        raw_http: raw_http,
+        controller_name: controller_name,
+        action_name: action_name,
+        agent_id: current_agent.id
+      )
+    rescue StandardError => e
+      Sentry.capture_exception(e, extra: {
+                                 raw_http: raw_http,
+                                 controller_name: controller_name,
+                                 action_name: action_name,
+                                 agent_id: current_agent&.id,
+                               })
+    end
   end
 end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -128,6 +128,12 @@ class CronJob < ApplicationJob
     end
   end
 
+  class DestroyOldApiCalls < CronJob
+    def perform
+      ApiCall.where("received_at < ?", 1.year.ago).delete_all
+    end
+  end
+
   class DestroyRedisWaitingRoomKeys < CronJob
     def perform
       Rdv.reset_user_in_waiting_room!

--- a/app/lib/anonymizer/rules/rdv_service_public.rb
+++ b/app/lib/anonymizer/rules/rdv_service_public.rb
@@ -200,5 +200,10 @@ class Anonymizer::Rules::RdvServicePublic
     file_attentes: {
       non_anonymized_column_names: %w[created_at updated_at notifications_sent last_creneau_sent_at],
     },
+    api_calls: {
+      class_name: "ApiCall",
+      anonymized_column_names: %w[raw_http],
+      non_anonymized_column_names: %w[received_at controller_name action_name agent_id],
+    },
   }.with_indifferent_access.freeze
 end

--- a/app/models/api_call.rb
+++ b/app/models/api_call.rb
@@ -6,6 +6,6 @@ class ApiCall < ApplicationRecord
   private
 
   def set_received_at
-    self.received_at ||= Time.current
+    self.received_at ||= Time.zone.now
   end
 end

--- a/app/models/api_call.rb
+++ b/app/models/api_call.rb
@@ -1,3 +1,11 @@
 class ApiCall < ApplicationRecord
   belongs_to :agent
+
+  after_initialize :set_received_at
+
+  private
+
+  def set_received_at
+    self.received_at ||= Time.current
+  end
 end

--- a/app/models/api_call.rb
+++ b/app/models/api_call.rb
@@ -1,0 +1,3 @@
+class ApiCall < ApplicationRecord
+  belongs_to :agent
+end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -63,6 +63,10 @@ Rails.application.configure do
       cron: "every day at 23:00 Europe/Paris",
       class: "CronJob::DestroyOldVersions",
     },
+    destroy_old_api_calls: {
+      cron: "every day at 23:30 Europe/Paris",
+      class: "CronJob::DestroyOldApiCalls",
+    },
     warn_about_expiring_azure_app_secrets: {
       cron: "every day at 10:00 Europe/Paris",
       class: "CronJob::WarnAboutExpiringAzureAppSecrets",

--- a/db/migrate/20240312140713_create_api_calls.rb
+++ b/db/migrate/20240312140713_create_api_calls.rb
@@ -1,7 +1,7 @@
 class CreateApiCalls < ActiveRecord::Migration[7.0]
   def change
-    create_table :api_calls do |t|
-      t.timestamps
+    create_table :api_calls do |t| # rubocop:disable Rails/CreateTableWithTimestamps
+      t.time :received_at, null: false
       t.jsonb :raw_http, null: false
       t.string :controller_name, null: false
       t.string :action_name, null: false

--- a/db/migrate/20240312140713_create_api_calls.rb
+++ b/db/migrate/20240312140713_create_api_calls.rb
@@ -1,0 +1,13 @@
+class CreateApiCalls < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_calls do |t|
+      t.timestamps
+      t.jsonb :raw_http, null: false
+      t.string :controller_name, null: false
+      t.string :action_name, null: false
+      t.bigint :agent_id, null: false
+    end
+
+    add_foreign_key :api_calls, :agents, validate: false
+  end
+end

--- a/db/migrate/20240312140713_create_api_calls.rb
+++ b/db/migrate/20240312140713_create_api_calls.rb
@@ -1,7 +1,7 @@
 class CreateApiCalls < ActiveRecord::Migration[7.0]
   def change
     create_table :api_calls do |t| # rubocop:disable Rails/CreateTableWithTimestamps
-      t.time :received_at, null: false
+      t.datetime :received_at, null: false
       t.jsonb :raw_http, null: false
       t.string :controller_name, null: false
       t.string :action_name, null: false

--- a/db/migrate/20240312141447_validate_create_api_calls.rb
+++ b/db/migrate/20240312141447_validate_create_api_calls.rb
@@ -1,0 +1,5 @@
+class ValidateCreateApiCalls < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :api_calls, :agents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,7 +257,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_12_141447) do
   end
 
   create_table "api_calls", force: :cascade do |t|
-    t.time "received_at", null: false
+    t.datetime "received_at", null: false
     t.jsonb "raw_http", null: false
     t.string "controller_name", null: false
     t.string "action_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,8 +257,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_12_141447) do
   end
 
   create_table "api_calls", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.time "received_at", null: false
     t.jsonb "raw_http", null: false
     t.string "controller_name", null: false
     t.string "action_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_04_163238) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_12_141447) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -254,6 +254,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_04_163238) do
     t.index ["agent_id", "rdv_id"], name: "index_agents_rdvs_on_agent_id_and_rdv_id", unique: true
     t.index ["agent_id"], name: "index_agents_rdvs_on_agent_id"
     t.index ["rdv_id"], name: "index_agents_rdvs_on_rdv_id"
+  end
+
+  create_table "api_calls", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "raw_http", null: false
+    t.string "controller_name", null: false
+    t.string "action_name", null: false
+    t.bigint "agent_id", null: false
   end
 
   create_table "file_attentes", force: :cascade do |t|
@@ -771,6 +780,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_04_163238) do
   add_foreign_key "agent_territorial_roles", "territories"
   add_foreign_key "agents_rdvs", "agents"
   add_foreign_key "agents_rdvs", "rdvs"
+  add_foreign_key "api_calls", "agents"
   add_foreign_key "file_attentes", "rdvs"
   add_foreign_key "file_attentes", "users"
   add_foreign_key "lieux", "organisations"

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -2,9 +2,10 @@ require "swagger_helper"
 
 RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.json" do
   with_examples
+  let!(:now) { Time.zone.parse("2023-10-23 16:00") }
 
   before do
-    travel_to(Time.zone.parse("2023-10-23 16:00"))
+    travel_to(now)
   end
 
   path "/api/rdvinsertion/invitations/creneau_availability" do
@@ -123,7 +124,8 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
           expect(ApiCall.first.attributes.symbolize_keys).to include(
             controller_name: "invitations",
             action_name: "creneau_availability",
-            agent_id: agent.id
+            agent_id: agent.id,
+            received_at: now
           )
           expect(ApiCall.first.raw_http["method"]).to eq("GET")
           expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
@@ -190,7 +192,8 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
             expect(ApiCall.first.attributes.symbolize_keys).to include(
               controller_name: "invitations",
               action_name: "creneau_availability",
-              agent_id: agent.id
+              agent_id: agent.id,
+              received_at: now
             )
             expect(ApiCall.first.raw_http["method"]).to eq("GET")
             expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -117,7 +117,17 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
 
         it "Quand il n'y a pas de params" do
           expect(parsed_response_body["creneau_availability"]).to be_falsey
-          expect(ApiCall.count).to eq(1)
+        end
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "invitations",
+            action_name: "creneau_availability",
+            agent_id: agent.id
+          )
+          expect(ApiCall.first.raw_http["method"]).to eq("GET")
+          expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
+          expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
         end
 
         context "Si le lieu n'existe pas" do
@@ -126,7 +136,6 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
           it do
             expect(parsed_response_body["creneau_availability"]).to be_falsey
             expect(parsed_response_body["error"]).to eq("Couldn't find Lieu with 'id'=666")
-            expect(ApiCall.count).to eq(1)
           end
         end
 
@@ -176,6 +185,17 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
           let!(:"organisation_ids[]") { [organisation1.id] }
 
           it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+
+          it "logs the API call" do
+            expect(ApiCall.first.attributes.symbolize_keys).to include(
+              controller_name: "invitations",
+              action_name: "creneau_availability",
+              agent_id: agent.id
+            )
+            expect(ApiCall.first.raw_http["method"]).to eq("GET")
+            expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
+            expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
+          end
         end
 
         context "Avec le params organisation_ids[]" do

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
 
         it "Quand il n'y a pas de params" do
           expect(parsed_response_body["creneau_availability"]).to be_falsey
+          expect(ApiCall.count).to eq(1)
         end
 
         context "Si le lieu n'existe pas" do
@@ -125,6 +126,7 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
           it do
             expect(parsed_response_body["creneau_availability"]).to be_falsey
             expect(parsed_response_body["error"]).to eq("Couldn't find Lieu with 'id'=666")
+            expect(ApiCall.count).to eq(1)
           end
         end
 

--- a/spec/requests/api/rdvinsertion/motif_categories_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/motif_categories_request_spec.rb
@@ -42,7 +42,14 @@ RSpec.describe "Motif Category API", swagger_doc: "v1/api.json" do
         it { expect(MotifCategory.last.short_name).to eq(short_name) }
         it { expect(parsed_response_body["motif_category"]["name"]).to match(name) }
         it { expect(parsed_response_body["motif_category"]["short_name"]).to match(short_name) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "motif_categories",
+            action_name: "create",
+            agent_id: agent.id
+          )
+        end
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/motif_categories_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/motif_categories_request_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Motif Category API", swagger_doc: "v1/api.json" do
         it { expect(MotifCategory.last.short_name).to eq(short_name) }
         it { expect(parsed_response_body["motif_category"]["name"]).to match(name) }
         it { expect(parsed_response_body["motif_category"]["short_name"]).to match(short_name) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/motif_category_territories_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/motif_category_territories_request_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Motif Category Territory API", swagger_doc: "v1/api.json" do
         it { expect(territory.motif_categories.last.short_name).to eq(motif_category_short_name) }
         it { expect(parsed_response_body["territory"]["name"]).to match(territory.name) }
         it { expect(parsed_response_body["territory"]["motif_categories"][0]["short_name"]).to match(motif_category_short_name) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/motif_category_territories_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/motif_category_territories_request_spec.rb
@@ -44,7 +44,14 @@ RSpec.describe "Motif Category Territory API", swagger_doc: "v1/api.json" do
         it { expect(territory.motif_categories.last.short_name).to eq(motif_category_short_name) }
         it { expect(parsed_response_body["territory"]["name"]).to match(territory.name) }
         it { expect(parsed_response_body["territory"]["motif_categories"][0]["short_name"]).to match(motif_category_short_name) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "motif_category_territories",
+            action_name: "create",
+            agent_id: agent.id
+          )
+        end
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
@@ -44,7 +44,13 @@ RSpec.describe "Referent Assignation authentified API", swagger_doc: "v1/api.jso
 
         it { expect(user.reload.referent_agents).not_to include(agent2) }
 
-        it { expect(ApiCall.count).to eq(1) }
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "referent_assignations",
+            action_name: "create_many",
+            agent_id: agent1.id
+          )
+        end
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe "Referent Assignation authentified API", swagger_doc: "v1/api.jso
         it { expect(user.reload.referent_agents).to include(agent1) }
 
         it { expect(user.reload.referent_agents).not_to include(agent2) }
+
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/user_profiles_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/user_profiles_request_spec.rb
@@ -44,7 +44,14 @@ RSpec.describe "User Profile authentified API", swagger_doc: "v1/api.json" do
         it { expect(user.reload.organisations).to include(organisation1) }
         it { expect(user.reload.organisations).to include(organisation2) }
         it { expect(user.reload.organisations).not_to include(organisation3) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "user_profiles",
+            action_name: "create_many",
+            agent_id: agent.id
+          )
+        end
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/rdvinsertion/user_profiles_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/user_profiles_request_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "User Profile authentified API", swagger_doc: "v1/api.json" do
         it { expect(user.reload.organisations).to include(organisation1) }
         it { expect(user.reload.organisations).to include(organisation2) }
         it { expect(user.reload.organisations).not_to include(organisation3) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized" do

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -96,7 +96,8 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
           expect(ApiCall.first.attributes.symbolize_keys).to include(
             controller_name: "absences",
             action_name: "create",
-            agent_id: agent.id
+            agent_id: agent.id,
+            received_at: be_within(10.seconds).of(Time.zone.now)
           )
           expect(ApiCall.first.raw_http["method"]).to eq("POST")
           expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
         it { expect(created_absence.end_day).to eq(Date.new(2023, 11, 20)) }
 
         it { expect(created_absence.end_time).to eq(Tod::TimeOfDay.new(15, 0)) }
+
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       response 200, "Crée et renvoie une absence quand c'est l'email de l'agent qu'on utilise", document: false do

--- a/spec/requests/api/v1/absences_request_spec.rb
+++ b/spec/requests/api/v1/absences_request_spec.rb
@@ -92,7 +92,16 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
 
         it { expect(created_absence.end_time).to eq(Tod::TimeOfDay.new(15, 0)) }
 
-        it { expect(ApiCall.count).to eq(1) }
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "absences",
+            action_name: "create",
+            agent_id: agent.id
+          )
+          expect(ApiCall.first.raw_http["method"]).to eq("POST")
+          expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
+          expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
+        end
       end
 
       response 200, "Crée et renvoie une absence quand c'est l'email de l'agent qu'on utilise", document: false do

--- a/spec/requests/api/v1/agents_request_spec.rb
+++ b/spec/requests/api/v1/agents_request_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Agents API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(parsed_response_body["agents"].pluck("id")).to match_array([agent.id]) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       response 200, "policy scoped agents", document: false do

--- a/spec/requests/api/v1/agents_request_spec.rb
+++ b/spec/requests/api/v1/agents_request_spec.rb
@@ -35,7 +35,14 @@ RSpec.describe "Agents API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(parsed_response_body["agents"].pluck("id")).to match_array([agent.id]) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "agents",
+            action_name: "index",
+            agent_id: agent.id
+          )
+        end
       end
 
       response 200, "policy scoped agents", document: false do

--- a/spec/requests/api/v1/motifs_request_spec.rb
+++ b/spec/requests/api/v1/motifs_request_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           run_test!
 
           it { expect(parsed_response_body[:motifs]).to eq(MotifBlueprint.render_as_json([motif])) }
+          it { expect(ApiCall.count).to eq(1) }
         end
 
         response 200, "Renvoie les motifs liés à la bonne organisation" do

--- a/spec/requests/api/v1/motifs_request_spec.rb
+++ b/spec/requests/api/v1/motifs_request_spec.rb
@@ -38,7 +38,14 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           run_test!
 
           it { expect(parsed_response_body[:motifs]).to eq(MotifBlueprint.render_as_json([motif])) }
-          it { expect(ApiCall.count).to eq(1) }
+
+          it "logs the API call" do
+            expect(ApiCall.first.attributes.symbolize_keys).to include(
+              controller_name: "motifs",
+              action_name: "index",
+              agent_id: agent.id
+            )
+          end
         end
 
         response 200, "Renvoie les motifs liés à la bonne organisation" do

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -35,7 +35,13 @@ RSpec.describe "Organisations API", swagger_doc: "v1/api.json" do
 
         it { expect(parsed_response_body[:organisations]).to match(OrganisationBlueprint.render_as_hash(organisations)) }
 
-        it { expect(ApiCall.count).to eq(1) }
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "organisations",
+            action_name: "index",
+            agent_id: agent.id
+          )
+        end
       end
 
       response 200, "Retourne des Organisations, filtrées par secteur géographique", document: false do

--- a/spec/requests/api/v1/organisations_request_spec.rb
+++ b/spec/requests/api/v1/organisations_request_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "Organisations API", swagger_doc: "v1/api.json" do
         it { expect(response).to be_paginated(current_page: 1, next_page: nil, prev_page: nil, total_count: 5, total_pages: 1) }
 
         it { expect(parsed_response_body[:organisations]).to match(OrganisationBlueprint.render_as_hash(organisations)) }
+
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       response 200, "Retourne des Organisations, filtrées par secteur géographique", document: false do

--- a/spec/requests/api/v1/paginated_request_spec.rb
+++ b/spec/requests/api/v1/paginated_request_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "paginated requests", type: :request do
 
           it "is correctly paginated" do
             expect(response).to be_paginated(current_page: 1, next_page: 2, prev_page: nil, total_count: 7, total_pages: 3)
+            expect(ApiCall.count).to eq(1)
           end
         end
       end

--- a/spec/requests/api/v1/paginated_request_spec.rb
+++ b/spec/requests/api/v1/paginated_request_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "paginated requests", type: :request do
 
           it "is correctly paginated" do
             expect(response).to be_paginated(current_page: 1, next_page: 2, prev_page: nil, total_count: 7, total_pages: 3)
-            expect(ApiCall.count).to eq(1)
           end
         end
       end

--- a/spec/requests/api/v1/participations_request_spec.rb
+++ b/spec/requests/api/v1/participations_request_spec.rb
@@ -52,7 +52,14 @@ RSpec.describe "RDVs Users authentified API", swagger_doc: "v1/api.json" do
 
         it do
           expect(response.parsed_body["rdv"]["status"]).to eq(status)
-          expect(ApiCall.count).to eq(1)
+        end
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "participations",
+            action_name: "update",
+            agent_id: admin_agent.id
+          )
         end
       end
     end

--- a/spec/requests/api/v1/participations_request_spec.rb
+++ b/spec/requests/api/v1/participations_request_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "RDVs Users authentified API", swagger_doc: "v1/api.json" do
 
         it do
           expect(response.parsed_body["rdv"]["status"]).to eq(status)
+          expect(ApiCall.count).to eq(1)
         end
       end
     end

--- a/spec/requests/api/v1/public_links_request_spec.rb
+++ b/spec/requests/api/v1/public_links_request_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe "Public links API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(parsed_response_body).to match_array(expected_body) }
+        # No ApiCall log for public links
+        it { expect(ApiCall.count).to eq(0) }
       end
 
       response 400, "Retourne 'bad_request' quand le territory est manquant" do

--- a/spec/requests/api/v1/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/rdvs_request_spec.rb
@@ -63,7 +63,14 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(response.parsed_body["rdvs"]).to eq([]) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "rdvs",
+            action_name: "index",
+            agent_id: basic_agent.id
+          )
+        end
       end
 
       context "with starts_after and starts_before params" do

--- a/spec/requests/api/v1/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/rdvs_request_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(response.parsed_body["rdvs"]).to eq([]) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       context "with starts_after and starts_before params" do

--- a/spec/requests/api/v1/referent_assignations_request_spec.rb
+++ b/spec/requests/api/v1/referent_assignations_request_spec.rb
@@ -39,7 +39,14 @@ RSpec.describe "Referent Assignation authentified API", swagger_doc: "v1/api.jso
         it { expect(parsed_response_body.dig("referent_assignation", "agent", "id")).to eq(agent_id) }
 
         it { expect(user.reload.referent_agents).to include(referent) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "referent_assignations",
+            action_name: "create",
+            agent_id: agent.id
+          )
+        end
       end
 
       it_behaves_like "an endpoint that returns 403 - forbidden", "l'agent.e n'a pas accès à l'organisation de l'utilisateur" do

--- a/spec/requests/api/v1/referent_assignations_request_spec.rb
+++ b/spec/requests/api/v1/referent_assignations_request_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Referent Assignation authentified API", swagger_doc: "v1/api.jso
         it { expect(parsed_response_body.dig("referent_assignation", "agent", "id")).to eq(agent_id) }
 
         it { expect(user.reload.referent_agents).to include(referent) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       it_behaves_like "an endpoint that returns 403 - forbidden", "l'agent.e n'a pas accès à l'organisation de l'utilisateur" do

--- a/spec/requests/api/v1/user_profiles_request_spec.rb
+++ b/spec/requests/api/v1/user_profiles_request_spec.rb
@@ -42,7 +42,14 @@ RSpec.describe "User Profile authentified API", swagger_doc: "v1/api.json" do
         it { expect(created_user_profile.organisation).to eq(organisation) }
 
         it { expect(created_user_profile.user).to eq(user) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "user_profiles",
+            action_name: "create",
+            agent_id: agent.id
+          )
+        end
       end
 
       it_behaves_like "an endpoint that returns 403 - forbidden", "l'agent·e n'a pas accès à l'organisation" do

--- a/spec/requests/api/v1/user_profiles_request_spec.rb
+++ b/spec/requests/api/v1/user_profiles_request_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "User Profile authentified API", swagger_doc: "v1/api.json" do
         it { expect(created_user_profile.organisation).to eq(organisation) }
 
         it { expect(created_user_profile.user).to eq(user) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       it_behaves_like "an endpoint that returns 403 - forbidden", "l'agent·e n'a pas accès à l'organisation" do

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(parsed_response_body[:user][:id]).to eq(user.id) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       response 200, "authorized user ID also belongs to other organisation", document: false do

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -32,7 +32,14 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         run_test!
 
         it { expect(parsed_response_body[:user][:id]).to eq(user.id) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "users",
+            action_name: "show",
+            agent_id: agent.id
+          )
+        end
       end
 
       response 200, "authorized user ID also belongs to other organisation", document: false do

--- a/spec/requests/api/v1/webhook_endpoints_request_spec.rb
+++ b/spec/requests/api/v1/webhook_endpoints_request_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
         it { expect(response).to be_paginated(current_page: 1, next_page: nil, prev_page: nil, total_count: 5, total_pages: 1) }
 
         it { expect(parsed_response_body[:webhook_endpoints]).to match(WebhookEndpointBlueprint.render_as_hash(webhook_endpoints)) }
+        it { expect(ApiCall.count).to eq(1) }
       end
 
       response 200, "Retourne des WebhooksEndpoints, filtrés par target_url" do

--- a/spec/requests/api/v1/webhook_endpoints_request_spec.rb
+++ b/spec/requests/api/v1/webhook_endpoints_request_spec.rb
@@ -35,7 +35,14 @@ RSpec.describe "WebhookEndpoints API", swagger_doc: "v1/api.json" do
         it { expect(response).to be_paginated(current_page: 1, next_page: nil, prev_page: nil, total_count: 5, total_pages: 1) }
 
         it { expect(parsed_response_body[:webhook_endpoints]).to match(WebhookEndpointBlueprint.render_as_hash(webhook_endpoints)) }
-        it { expect(ApiCall.count).to eq(1) }
+
+        it "logs the API call" do
+          expect(ApiCall.first.attributes.symbolize_keys).to include(
+            controller_name: "webhook_endpoints",
+            action_name: "index",
+            agent_id: agent.id
+          )
+        end
       end
 
       response 200, "Retourne des WebhooksEndpoints, filtrés par target_url" do


### PR DESCRIPTION
Cela va nous permettre de savoir qui fait quoi sur notre api et si certains endpoint sont ou pas utilisés.
Notamment pour enlever les endpoints dépréciés, pouvoir suivre les migrations à venir. (changement de nom, d'authentification...)
