### PR TITLE
Correctif pour le reply-to des mails Devise

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -4,10 +4,9 @@ class CustomDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
 
   helper :application
-  default template_path: "devise/mailer",
-          reply_to: proc { inviter_or_default }
+  default template_path: "devise/mailer"
 
-  def invitation_instructions(record, token, opts = {})
+  def invitation_instructions(record, token, opts = {}) # rubocop:disable Metrics/PerceivedComplexity
     @token = token
     @user_params = opts[:user_params] || {}
     if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
@@ -15,18 +14,13 @@ class CustomDeviseMailer < Devise::Mailer
       opts[:cc] = record.cnfs_secondary_email if record.cnfs_secondary_email.present?
       devise_mail(record, :invitation_instructions_cnfs, opts)
     else
+      opts[:reply_to] = record.invited_by&.email || default_from
       opts[:subject] = I18n.t("devise.mailer.invitation_instructions.subject", domain_name: record.domain.name)
       devise_mail(record, :invitation_instructions, opts)
     end
   end
 
   private
-
-  def inviter_or_default
-    return unless resource.is_a? Agent
-
-    resource.invited_by&.email || default_from
-  end
 
   def domain
     resource.domain

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,7 +6,7 @@ class CustomDeviseMailer < Devise::Mailer
   helper :application
   default template_path: "devise/mailer"
 
-  def invitation_instructions(record, token, opts = {}) # rubocop:disable Metrics/PerceivedComplexity
+  def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}
     if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
@@ -14,7 +14,7 @@ class CustomDeviseMailer < Devise::Mailer
       opts[:cc] = record.cnfs_secondary_email if record.cnfs_secondary_email.present?
       devise_mail(record, :invitation_instructions_cnfs, opts)
     else
-      opts[:reply_to] = record.invited_by&.email || default_from
+      opts[:reply_to] = record.invited_by&.email
       opts[:subject] = I18n.t("devise.mailer.invitation_instructions.subject", domain_name: record.domain.name)
       devise_mail(record, :invitation_instructions, opts)
     end

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Creating a new account for a new project, other than a mairie", 
 
     expect(invitation_email).to have_attributes(
       subject: "Vous avez été invité sur RDV Service Public",
-      reply_to: ["support@rdv-service-public.fr"]
+      from: ["support@rdv-service-public.fr"]
     )
   end
 end

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -103,4 +103,16 @@ RSpec.describe CustomDeviseMailer, "#domain" do
       expect(enqueued_jobs.pluck("executions")).to eq([1]) # job enqueued for retry
     end
   end
+
+  context "for agent" do
+    subject(:sent_email) { described_class.reset_password_instructions(agent, "t0k3n") }
+
+    let(:inviter) { create(:agent) }
+    let(:agent) { create(:agent, invited_by: inviter) }
+
+    it "doesn't override the reply-to address" do
+      perform_enqueued_jobs
+      expect(sent_email.reply_to).to eq Domain::RDV_SOLIDARITES.support_email
+    end
+  end
 end

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AddConseillerNumerique do
       perform_enqueued_jobs
       invitation_email = ActionMailer::Base.deliveries.last
 
-      expect(invitation_email).to have_attributes(to: ["exemple@conseiller-numerique.fr"], reply_to: ["support@rdv-aide-numerique.fr"])
+      expect(invitation_email).to have_attributes(to: ["exemple@conseiller-numerique.fr"], from: ["support@rdv-aide-numerique.fr"])
     end
   end
 


### PR DESCRIPTION
On a découvert avec Nesserine que pour les agents, tous les mails Devise pour les agents

Ce comportement avait été introduit dans le cadre de cette issue : https://github.com/betagouv/rdv-service-public/issues/1087, uniquement pour les mails d'invitation et généralisé par erreur dans une PR plus récente (#3537).

Cette PR le remet uniquement pour les mails d'invitations.

A terme, on voudra plutôt mettre en place un mécanisme qui fait un renvoi automatique du mail d'invitation (comme le process de mot de passe oublié). Voir https://github.com/betagouv/rdv-service-public/pull/4154#issuecomment-1991760721