### PR TITLE
Correctif pour les rdv de suivi

### DIFF
--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -1,4 +1,4 @@
-- unless context.invitation? || current_agent
+- unless context.invitation? || current_agent || context.follow_up?
   - if current_user
     - if current_user.referent_agents.any?
       .card

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -34,8 +34,7 @@
           .card-body
             = agent.full_name_and_service
           .card-footer.text-right
-            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number, service_id: agent.services.first.id)
-            /= render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
+            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
     - else
       | Vous n'avez pas de référents
 

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -34,7 +34,8 @@
           .card-body
             = agent.full_name_and_service
           .card-footer.text-right
-            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
+            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number, service_id: agent.services.first.id)
+            /= render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
     - else
       | Vous n'avez pas de référents
 

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -34,7 +34,7 @@
           .card-body
             = agent.full_name_and_service
           .card-footer.text-right
-            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number, service_id: agent.services.first.id)
+            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
     - else
       | Vous n'avez pas de référents
 

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -182,6 +182,8 @@ RSpec.describe "User can search for rdvs" do
       expect(page).to have_content(motif1.name)
       expect(page).to have_content(collectif_motif.name)
 
+      expect(page).not_to have_content "Pour prendre un RDV avec un de vos agents référent" # Le CTA pour prendre un rdv de suivi ne s'affiche pas
+
       expect(page).not_to have_content(motif2.name)
       expect(page).not_to have_content(motif3.name)
 

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "User can search for rdvs" do
       create(
         :motif,
         name: "RSA Orientation", follow_up: false, organisation: organisation,
-        restriction_for_rdv: nil, service: service_social
+        restriction_for_rdv: nil, service: service_insertion
       )
     end
 
@@ -174,7 +174,7 @@ RSpec.describe "User can search for rdvs" do
 
     ## Collectif follow up motif linked to referent
     let!(:collectif_motif) do
-      create(:motif, follow_up: true, restriction_for_rdv: nil, collectif: true, organisation: organisation, service: service_social)
+      create(:motif, follow_up: true, restriction_for_rdv: nil, collectif: true, organisation: organisation, service: service_insertion)
     end
     let!(:collectif_rdv) { create(:rdv, motif: collectif_motif, agents: [agent], lieu: lieu, organisation: organisation, starts_at: 2.days.from_now) }
 
@@ -183,11 +183,6 @@ RSpec.describe "User can search for rdvs" do
     it "shows only the follow up motifs related to the agent", js: true do
       visit users_rdvs_path
       click_link "Prendre un RDV de suivi"
-
-      expect(page).to have_content("Service Social")
-      expect(page).to have_content("Service Insertion")
-
-      click_link "Service Insertion"
 
       ### Motif selection
       expect(page).to have_content(motif1.name)

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -103,10 +103,15 @@ RSpec.describe "User can search for rdvs" do
 
   describe "follow up rdvs" do
     let!(:user) { create(:user, referent_agents: [agent]) }
-    let!(:agent) { create(:agent) }
+    let!(:agent) do
+      create(:agent, basic_role_in_organisations: [organisation], services:).tap do |agent|
+        create(:agent_territorial_access_right, territory: organisation.territory, agent: agent)
+      end
+    end
     let!(:agent2) { create(:agent) }
     let!(:organisation) { create(:organisation, territory: create(:territory, departement_number: "92")) }
     let!(:service) { create(:service) }
+    let!(:other_service) { create(:service) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
 
     ## follow up motif linked to referent
@@ -114,7 +119,7 @@ RSpec.describe "User can search for rdvs" do
       create(
         :motif,
         name: "RSA Suivi", follow_up: true,
-        organisation: organisation, service: service, restriction_for_rdv: "Instructions pour le RDV"
+        organisation: organisation, service: other_service, restriction_for_rdv: "Instructions pour le RDV"
       )
     end
 
@@ -176,6 +181,7 @@ RSpec.describe "User can search for rdvs" do
     before { login_as(user, scope: :user) }
 
     it "shows only the follow up motifs related to the agent", js: true do
+      visit users_rdvs_path
       visit root_path(referent_ids: [agent.id], departement: "92", service_id: service.id)
 
       ### Motif selection


### PR DESCRIPTION
Correctif pour https://zammad10.ethibox.fr/#ticket/zoom/12104, suite à un bug introduit dans #3867

On filtrait les rdv de suivi en fonction du premier service de l'agent, mais si on veut prendre un rdv pour un motif dans un autre esrvice on est bloqué.

Au passage on arrête aussi d'afficher le texte pour suggérer de prendre un rdv de suivi si on est déjà en train de prendre un rdv de suivi