### PR TITLE
Ne pas logger les assets et routing vers Skylight

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,3 +1,9 @@
 ---
 # The authentication token for the application.
 authentication: <%= ENV['SKYLIGHT_AUTHENTICATION_KEY'] || '' %>
+ignored_endpoints:
+  - ActionDispatch::Static
+  - ActionDispatch::Routing::RouteSet
+  - ActionDispatch::SSL
+deploy:
+  git_sha: <%= ENV['SOURCE_VERSION'] || '' %>


### PR DESCRIPTION
En recevant la facture Skylight je me suis dit qu'on pouvait éviter de logger les requêtes d'assets, qui sont noter 4ème endpoint le plus populaire :

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/7ab02777-239a-46e4-aadc-98d509603920)

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/7e7ab3a3-6637-4d1a-9709-a3f1bb855915)


J'ai suivi cette doc :
https://www.skylight.io/support/advanced-setup


# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
