### PR TITLE
[Deploiement Scalingo] Optimiser la taille de l'image lors du build

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,5 @@
+spec
+docs
+/tmp/cache
+/node_modules
+/.cache/yarn


### PR DESCRIPTION
## Optimiser la taille de l'image lors du build

Les déploiements sur Scalingo se font notamment en 2 étapes:
- Build: L'image est compilée à partir de la code base
- Release: L'image compilée est déployée sur les serveurs

Le temps d'exécution du `Build` dépend de la taille de l'image à construire, qui elle dépend de la taille des fichiers contenus dans le repo Git. L'usage du fichier [.slugignore](https://doc.scalingo.com/platform/app/slugignore) traité par Scalingo, nous permet d'indiquer les fichiers à ignorer lors du Build, et par conséquent optimiser le temps de compilation de l'image.