### PR TITLE
Correctif pour les numéros de pré-demande ANTS manquants

### DIFF
--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -8,6 +8,8 @@ class Admin::UserForm
   delegate :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :user
   validate :warn_duplicates
   validate do
+    require "byebug"
+    byebug
     User::Ants.validate_ants_pre_demande_number(
       user: @user,
       ants_pre_demande_number: @user.ants_pre_demande_number,

--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -8,8 +8,6 @@ class Admin::UserForm
   delegate :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :user
   validate :warn_duplicates
   validate do
-    require "byebug"
-    byebug
     User::Ants.validate_ants_pre_demande_number(
       user: @user,
       ants_pre_demande_number: @user.ants_pre_demande_number,

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -49,10 +49,18 @@ module Ants
       users.each do |user|
         existing_appointment(user)&.delete
 
-        if user.ants_pre_demande_number.present? # Les usagers créés par les agent
+        if valid_pre_demande_number?(user)
           AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
         end
       end
+    end
+
+    def valid_pre_demande_number?(user)
+      form = Admin::UserForm.new(user)
+      form.validate
+      # require "byebug"
+      # byebug
+      true
     end
 
     def users

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -49,7 +49,9 @@ module Ants
       users.each do |user|
         existing_appointment(user)&.delete
 
-        AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
+        if user.ants_pre_demande_number.present? # Les usagers créés par les agent
+          AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
+        end
       end
     end
 

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -49,18 +49,10 @@ module Ants
       users.each do |user|
         existing_appointment(user)&.delete
 
-        if valid_pre_demande_number?(user)
+        if user.ants_pre_demande_number.present? # Les agents peuvent créer un rdv sans préciser le numéro de pré-demande ANTS
           AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
         end
       end
-    end
-
-    def valid_pre_demande_number?(user)
-      form = Admin::UserForm.new(user)
-      form.validate
-      require "byebug"
-      byebug
-      true
     end
 
     def users

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -58,8 +58,8 @@ module Ants
     def valid_pre_demande_number?(user)
       form = Admin::UserForm.new(user)
       form.validate
-      # require "byebug"
-      # byebug
+      require "byebug"
+      byebug
       true
     end
 

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           ).with(headers: ants_api_headers)
         end
       end
+
+      context "when the user is created by an agent who didn't fill in the pre_demande_number" do
+        let(:user) { create(:user, ants_pre_demande_number: "", organisations: [organisation]) }
+
+        it "doesn't send a request to the appointment ANTS api" do
+          perform_enqueued_jobs do
+            rdv.save!
+            expect(WebMock).not_to have_requested(
+              :post,
+              "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=Lieu1"
+            ).with(headers: ants_api_headers)
+          end
+        end
+      end
     end
 
     describe "after_commit on_destroy" do


### PR DESCRIPTION
Pour éviter de bloquer les agents, on leur permet de créer des rdv pour des titres sécurisés même s'ils n'ont pas le numéro de pré-demande ants de l'usager.

Maintenant qu'on a changé le tracking des erreurs ANTS (https://github.com/betagouv/rdv-service-public/pull/4156), on a maintenant beaucoup de jobs qui échouent dans le cas où le numéro n'est pas indiqué https://sentry.incubateur.net/organizations/betagouv/issues/91036/?environment=production&query=is%3Aunresolved&referrer=issue-stream