### PR TITLE
Correctif pour l'ordre des résultats dans le moteur de recherche de l'ants

### DIFF
--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -44,7 +44,9 @@ class Api::Ants::EditorController < Api::Ants::BaseController
       motif.default_duration_in_min = rdv_duration(motif)
       motif_creneaux = creneaux(lieu, motif)
       motif_creneaux.map { |creneau| time_slot_data(creneau) }.uniq
-    end.flatten.sort_by do |creneau| # rubocop:disable Style/MultilineBlockChain
+    end.flatten.uniq do |creneau| # rubocop:disable Style/MultilineBlockChain
+      creneau[:datetime]
+    end.sort_by do |creneau| # rubocop:disable Style/MultilineBlockChain
       creneau[:datetime]
     end
   end

--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -44,7 +44,9 @@ class Api::Ants::EditorController < Api::Ants::BaseController
       motif.default_duration_in_min = rdv_duration(motif)
       motif_creneaux = creneaux(lieu, motif)
       motif_creneaux.map { |creneau| time_slot_data(creneau) }.uniq
-    end.flatten
+    end.flatten.sort_by do |creneau| # rubocop:disable Style/MultilineBlockChain
+      creneau[:datetime]
+    end
   end
 
   def creneaux(lieu, motif)

--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -40,15 +40,13 @@ class Api::Ants::EditorController < Api::Ants::BaseController
   end
 
   def time_slots(lieu, reason)
-    motifs(lieu, reason).map do |motif|
+    creneaux = motifs(lieu, reason).map do |motif|
       motif.default_duration_in_min = rdv_duration(motif)
       motif_creneaux = creneaux(lieu, motif)
       motif_creneaux.map { |creneau| time_slot_data(creneau) }.uniq
-    end.flatten.uniq do |creneau| # rubocop:disable Style/MultilineBlockChain
-      creneau[:datetime]
-    end.sort_by do |creneau| # rubocop:disable Style/MultilineBlockChain
-      creneau[:datetime]
     end
+
+    creneaux.flatten.uniq { _1[:datetime] }.sort_by { _1[:datetime] }
   end
 
   def creneaux(lieu, motif)

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe "ANTS API: availableTimeSlots" do
 
     create(:plage_ouverture, lieu: lieu2, first_day: Date.new(2022, 11, 2),
                              start_time: Tod::TimeOfDay(12), end_time: Tod::TimeOfDay(13),
-                             organisation: organisation2, motifs: [motif2])
+                             organisation: organisation2, motifs: [motif2, motif3])
   end
 
-  it "returns an ordered list of slots because the ANTS side doesn't reorder them" do
+  it "returns an ordered list of slots without duplicates because the ANTS side doesn't reorder them" do
     create(:plage_ouverture, lieu: lieu2, first_day: Date.new(2022, 11, 2),
                              start_time: Tod::TimeOfDay("12:15"), end_time: Tod::TimeOfDay("13:15"),
                              organisation: organisation2, motifs: [motif3])

--- a/spec/requests/api/ants/available_time_slots_spec.rb
+++ b/spec/requests/api/ants/available_time_slots_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "ANTS API: availableTimeSlots" do
   let(:organisation2) { create(:organisation, territory: mairies_territory) }
   let(:motif) { create(:motif, organisation: organisation, default_duration_in_min: 30, motif_category: cni_motif_category) }
   let(:motif2) { create(:motif, organisation: organisation2, default_duration_in_min: 30, motif_category: cni_motif_category) }
+  let(:motif3) { create(:motif, organisation: organisation2, default_duration_in_min: 30, motif_category: cni_motif_category) }
   let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }
 
   before do
@@ -30,7 +31,11 @@ RSpec.describe "ANTS API: availableTimeSlots" do
                              organisation: organisation2, motifs: [motif2])
   end
 
-  it "returns a list of slots" do
+  it "returns an ordered list of slots because the ANTS side doesn't reorder them" do
+    create(:plage_ouverture, lieu: lieu2, first_day: Date.new(2022, 11, 2),
+                             start_time: Tod::TimeOfDay("12:15"), end_time: Tod::TimeOfDay("13:15"),
+                             organisation: organisation2, motifs: [motif3])
+
     # L'ANTS nous envoie la requête en utilisant la syntaxe meeting_point_ids=1&meeting_point_ids=2 pour envoyer un tableau d'ids
     # sans crochets donc on encode la querystring d'une manière similaire ici pour reproduire ce comportement
     get "/api/ants/availableTimeSlots?meeting_point_ids=#{lieu1.id}&meeting_point_ids=#{lieu2.id}&start_date=2022-11-01&end_date=2022-11-02&documents_number=1&reason=CNI"
@@ -53,8 +58,16 @@ RSpec.describe "ANTS API: availableTimeSlots" do
             callback_url: creneaux_url(starts_at: "2022-11-02 12:00", lieu_id: lieu2.id, motif_id: motif2.id, public_link_organisation_id: organisation2.id, duration: 30),
           },
           {
+            datetime: "2022-11-02T12:15Z",
+            callback_url: creneaux_url(starts_at: "2022-11-02 12:15", lieu_id: lieu2.id, motif_id: motif3.id, public_link_organisation_id: organisation2.id, duration: 30),
+          },
+          {
             datetime: "2022-11-02T12:30Z",
             callback_url: creneaux_url(starts_at: "2022-11-02 12:30", lieu_id: lieu2.id, motif_id: motif2.id, public_link_organisation_id: organisation2.id, duration: 30),
+          },
+          {
+            datetime: "2022-11-02T12:45Z",
+            callback_url: creneaux_url(starts_at: "2022-11-02 12:45", lieu_id: lieu2.id, motif_id: motif3.id, public_link_organisation_id: organisation2.id, duration: 30),
           },
         ],
       }.with_indifferent_access


### PR DESCRIPTION
Suite à ce ticket zammad : https://zammad10.ethibox.fr/#ticket/zoom/12123 on a découvert que l'ants ne réordonne pas les résultats de recherche, et que donc si on a plusieurs motifs pour une même catégorie de motifs, on va afficher les créneaux dans le désordre.

Et au passage, ça met en lumière qu'on risque d'avoir des doublons de créneaux dans ces cas, donc le deuxième commit gère ça