### PR TITLE
Complément pour le correctif sur les numéro de pré-demande ants manquants

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -201,6 +201,9 @@ Style/GuardClause:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 Style/OpenStructUse:
   Enabled: false
 

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -46,12 +46,12 @@ module Ants
     end
 
     def create_or_update_appointments
-      users.each do |user|
+      users.select do |user|
+        user.ants_pre_demande_number.present? # Les agents peuvent créer un rdv sans préciser le numéro de pré-demande ANTS
+      end.each do |user|
         existing_appointment(user)&.delete
 
-        if user.ants_pre_demande_number.present? # Les agents peuvent créer un rdv sans préciser le numéro de pré-demande ANTS
-          AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
-        end
+        AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
       end
     end
 

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         it "doesn't send a request to the appointment ANTS api" do
           perform_enqueued_jobs do
             rdv.save!
+
+            expect(WebMock).not_to have_requested(:get, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status})
             expect(WebMock).not_to have_requested(
               :post,
               "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=Lieu1"


### PR DESCRIPTION
J'avais zappé de gérer le cas des rdv existants dans https://github.com/betagouv/rdv-service-public/pull/4174