### PR TITLE
Fix issue inclusion connect et recherche d'agent soft deleted

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -161,7 +161,13 @@ class Agent < ApplicationRecord
       referent_assignations.destroy_all
       sector_attributions.destroy_all
 
-      update_columns(deleted_at: Time.zone.now, email_original: email, email: deleted_email, uid: deleted_email)
+      update_columns(
+        deleted_at: Time.zone.now,
+        email_original: email,
+        email: deleted_email,
+        uid: deleted_email,
+        inclusion_connect_open_id_sub: "deleted_#{inclusion_connect_open_id_sub}"
+      )
     end
   end
 

--- a/app/services/inclusion_connect.rb
+++ b/app/services/inclusion_connect.rb
@@ -115,7 +115,7 @@ class InclusionConnect
 
     return @found_by_email if defined?(@found_by_email)
 
-    @found_by_email = Agent.find_by(email: user_info["email"])
+    @found_by_email = Agent.active.find_by(email: user_info["email"])
 
     unless @found_by_email
       # Les domaines francetravail.fr et pole-emploi.fr sont équivalents
@@ -123,7 +123,7 @@ class InclusionConnect
       name, domain = user_info["email"].split("@")
       if domain.in?(["francetravail.fr", "pole-emploi.fr"])
         acceptable_emails = ["#{name}@francetravail.fr", "#{name}@pole-emploi.fr"]
-        @found_by_email = Agent.find_by(email: acceptable_emails)
+        @found_by_email = Agent.active.find_by(email: acceptable_emails)
       end
     end
 
@@ -135,7 +135,7 @@ class InclusionConnect
 
     return if user_info["sub"].nil? && Sentry.capture_message("InclusionConnect sub is nil", extra: user_info, fingerprint: "ic_sub_nil")
 
-    @found_by_sub ||= Agent.find_by(inclusion_connect_open_id_sub: user_info["sub"])
+    @found_by_sub ||= Agent.active.find_by(inclusion_connect_open_id_sub: user_info["sub"])
   end
 
   def log_and_exit(field)

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe InclusionConnectController, type: :controller do
           )
         end
       end
+
+      context "email and sub match two different agents but one is deleted" do
+        let!(:agent_with_sub) { create(:agent, :invitation_not_accepted, inclusion_connect_open_id_sub: "12345678-90ab-cdef-1234-567890abcdef") }
+        let!(:agent_with_email) { create(:agent, :invitation_not_accepted, email: "bob@demo.rdv-solidarites.fr") }
+
+        it "update agent and log in" do
+          agent_with_sub.soft_delete
+          get :callback, params: { state: ic_state, session_state: ic_state, code: "klzefklzejlf" }
+          expect(agent_with_email.reload).to have_attributes(
+            last_sign_in_at: be_within(10.seconds).of(now),
+            inclusion_connect_open_id_sub: "12345678-90ab-cdef-1234-567890abcdef"
+          )
+
+          expect(response).to redirect_to(root_path)
+        end
+      end
     end
 
     describe "with a francetravail.fr domain" do

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Agent, type: :model do
       expect(agent.email_original).to eq("karim@le64.fr")
     end
 
+    it "prepend deleted_ to inclusion_connect_open_id_sub" do
+      agent = create(:agent, email: "karim@le64.fr", inclusion_connect_open_id_sub: "123456", organisations: [])
+      create(:rdv, agents: [agent])
+      agent.soft_delete
+      expect(agent.inclusion_connect_open_id_sub).to eq("deleted_123456")
+    end
+
     it "update mail with a unique value" do
       agent = create(:agent, basic_role_in_organisations: [])
       create(:rdv, agents: [agent])


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/18673/?project=74&referrer=webhooks_plugin

On a une remontée d'alerte de mismatch sub et email lors d'une connexion d'un agent inclusion connect quand un agent correspondant a été soft deleted précédemment.
Ce cas devrait être assez rare mais je le fix ici.
Il faudra renommer manuellement en base les attributes `inclusion_connect_open_id_sub` existants pour les agents déjà soft deleted.