### PR TITLE
Correctif pour normaliser les numéros de pré-demande ants en minuscule

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,7 @@ class User < ApplicationRecord
   # Hooks
   before_save :set_email_to_null_if_blank
   # voir Ants::AppointmentSerializerAndListener pour d'autres callbacks
+  before_save -> { ants_pre_demande_number.upcase! }, if: -> { ants_pre_demande_number.present? }
 
   # Scopes
   default_scope { where(deleted_at: nil) }

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -29,7 +29,7 @@
     )
 
     - if current_organisation.motifs.requires_ants_predemande_number.any?
-      = f.input :ants_pre_demande_number, **input_opts, hint: t("simple_form.hints.agent.ants_pre_demande_number_html")
+      = f.input :ants_pre_demande_number, **input_opts, hint: t("simple_form.hints.agent.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
 
     div *div_opts[:responsible]
       = render "responsible_form_fields", f: f, input_opts: input_opts[:responsible]

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -19,7 +19,7 @@ main.container
             - if @rdv_wizard.rdv.requires_ants_predemande_number?
               .row
                 .col-12
-                  = f.input :ants_pre_demande_number, label: "Numéro de pré-demande ANTS", required: true
+                  = f.input :ants_pre_demande_number, label: "Numéro de pré-demande ANTS", required: true, input_html: {style: "text-transform: uppercase;"}
 
             = render("model_errors", model: @beneficiaire, f: f)
             .form-group

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -2,6 +2,6 @@
   .col-md-6= f.input :first_name
   .col-md-6= f.input :last_name
 - if current_domain == Domain::RDV_MAIRIE
-  = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html")
+  = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
 - else
   = date_input(f, :birth_date)

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -12,7 +12,7 @@
       .col-md-6= f.input :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
       .col-md-6= date_input(f, :birth_date, disabled: user.logged_once_with_franceconnect?)
   - if local_assigns[:rdv_wizard]&.rdv&.requires_ants_predemande_number? || current_user.rdvs.requires_ants_predemande_number.any?
-    = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html")
+    = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   - if user.logged_once_with_franceconnect?
     .alert.alert-info.d-flex.align-items-center
       .mr-3

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -57,11 +57,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           perform_enqueued_jobs do
             rdv.save!
 
-            expect(WebMock).not_to have_requested(:get, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status})
-            expect(WebMock).not_to have_requested(
-              :post,
-              "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=Lieu1"
-            ).with(headers: ants_api_headers)
+            expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -348,4 +348,14 @@ RSpec.describe User, type: :model do
       expect { parent.update!(responsible: child) }.to raise_error(ActiveRecord::RecordInvalid, /L'usager⋅e ne peut être responsable de son propre responsable/)
     end
   end
+
+  describe "#ants_pre_demande_number" do
+    it "accepts lowercase letters, but normalizes them to uppercase" do
+      user = create(:user)
+      user.ants_pre_demande_number = "abcde12345"
+      expect(user).to be_valid
+      user.save
+      expect(user.reload.ants_pre_demande_number).to eq "ABCDE12345"
+    end
+  end
 end


### PR DESCRIPTION
Notre validation des numéros de pré-demande ants permet de mettre des minuscules (ce qui est une bonne chose parce que c'est plus pratique pour les humains), mais l'api de l'ants nécessite que les lettres soient en majuscule (voir cette erreur : https://sentry.incubateur.net/organizations/betagouv/issues/91089/?project=74&referrer=webhooks_plugin)

Cette PR formatte les numéros au moment où on les enregistre pour éviter cette erreur.

Au passage, je normalise aussi les lettres en front pour montrer à l'usager que ce n'est pas grave s'il tape en minuscule alors que le texte est affiché en majuscules ailleurs (sur la communication de l'ants et dans notre appli).

et enfin le dernier commit intègre cette suggestion que j'avais pas vu passer la semaine dernière : https://github.com/betagouv/rdv-service-public/pull/4176/files#r1525253020