### PR TITLE
Correctif pour les rdv annulés sans numéros de pré-demande ants

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -46,9 +46,7 @@ module Ants
     end
 
     def create_or_update_appointments
-      users.select do |user|
-        user.ants_pre_demande_number.present? # Les agents peuvent créer un rdv sans préciser le numéro de pré-demande ANTS
-      end.each do |user|
+      users.each do |user|
         existing_appointment(user)&.delete
 
         AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
@@ -56,7 +54,9 @@ module Ants
     end
 
     def users
-      @users ||= User.where(id: @rdv_attributes[:users_ids])
+      @users ||= User.where(id: @rdv_attributes[:users_ids]).select do |user|
+        user.ants_pre_demande_number.present? # Les agents peuvent créer un rdv sans préciser le numéro de pré-demande ANTS
+      end
     end
 
     def rdv_cancelled_or_deleted?

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
           end
         end
+
+        context "and the rdv is cancelled" do
+          before { rdv.status = "excused" }
+
+          it "doesn't send a request to the appointment ANTS api" do
+            perform_enqueued_jobs do
+              rdv.save!
+
+              expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Dans la continuité de https://github.com/betagouv/rdv-service-public/pull/4176 on gère ici le cas des rdv annulés ou supprimés (et j'espère que c'est le dernier fix pour cette erreur 🤞 )