### PR TITLE
Correctif pour les mails à des agents suite à l'ajout d'une participation à un rdv collectif par un prescripteur

### DIFF
--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -13,6 +13,9 @@ class Agents::RdvMailer < ApplicationMailer
   def rdv_created
     self.ics_payload = @rdv.payload(:create, @agent)
     subject = if @rdv.collectif?
+                if @author.is_a?(Prescripteur)
+                  @user = @author.user
+                end
                 t("agents.rdv_mailer.rdv_created.title_participation", domain_name: domain.name, date: relative_date(@rdv.starts_at))
               else
                 t("agents.rdv_mailer.rdv_created.title", domain_name: domain.name, date: relative_date(@rdv.starts_at))

--- a/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
@@ -4,7 +4,7 @@ div
     - date = relative_date(@rdv.starts_at)
     - author = @author&.full_name
     - if @rdv.collectif?
-      = t(".created_participation_at_date_by_user", date: date , author: author)
+      = t(".created_participation_at_date_by_user", date: date , user: author)
     - else
       = t(".created_at_date_by_user", date: date , author: author)
 

--- a/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
+++ b/app/views/mailers/agents/rdv_mailer/rdv_created.html.slim
@@ -2,11 +2,11 @@ div
   p Bonjour,
   p
     - date = relative_date(@rdv.starts_at)
-    - author = @author&.full_name
+    - user = (@user || @author)&.full_name
     - if @rdv.collectif?
-      = t(".created_participation_at_date_by_user", date: date , user: author)
+      = t(".created_participation_at_date_by_user", date: date , user: user)
     - else
-      = t(".created_at_date_by_user", date: date , author: author)
+      = t(".created_at_date_by_user", date: date)
 
     = render "mailers/common/rdv_overview", rdv: @rdv, for_role: :agent
 

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -42,7 +42,7 @@ fr:
         title: Nouveau RDV ajouté sur votre agenda %{domain_name} pour %{date}
         title_participation: Nouvelle participation au RDV collectif sur votre agenda %{domain_name} pour %{date}
         created_at_date_by_user: Un nouveau RDV qui aura lieu %{date} vient d’être ajouté à votre agenda.
-        created_participation_at_date_by_user: La participation de %{author} au RDV collectif qui aura lieu %{date} vient d’être ajoutée.
+        created_participation_at_date_by_user: La participation de %{user} au RDV collectif qui aura lieu %{date} vient d’être ajoutée.
       rdv_updated:
         title: RDV du %{date} modifié
       rdv_cancelled:

--- a/spec/form_models/prescripteur_rdv_wizard_spec.rb
+++ b/spec/form_models/prescripteur_rdv_wizard_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PrescripteurRdvWizard do
       motif_id: motif.id,
       lieu_id: lieu.id,
       user: {
-        first_name: "Léa",
+        first_name: "Lea",
         last_name: "Boubakar",
         phone_number: "06 11 22 33 44",
       },
@@ -48,7 +48,7 @@ RSpec.describe PrescripteurRdvWizard do
       email_to_agent = emails.find { |email| email.to == [agent.email] }
 
       expect(email_to_agent.html_part.to_s).not_to include("La participation de Pres CRIPTEUR au RDV collectif")
-      expect(email_to_agent.html_part.to_s).to include("La participation de Léa BOUBAKAR au RDV collectif")
+      expect(email_to_agent.html_part.to_s).to include("La participation de Lea BOUBAKAR au RDV collectif")
     end
   end
 
@@ -68,8 +68,8 @@ RSpec.describe PrescripteurRdvWizard do
   context "when the existing users have a different first name, last name or phone number" do
     before do
       create(:user, first_name: "Leo", last_name: "BOUBAKAR", phone_number: "0611223344")
-      create(:user, first_name: "Léa", last_name: "BOUBAKA", phone_number: "0611223344")
-      create(:user, first_name: "Léa", last_name: "BOUBAKAR", phone_number: "0688889999")
+      create(:user, first_name: "Lea", last_name: "BOUBAKA", phone_number: "0611223344")
+      create(:user, first_name: "Lea", last_name: "BOUBAKAR", phone_number: "0688889999")
     end
 
     it "creates a new user" do

--- a/spec/form_models/prescripteur_rdv_wizard_spec.rb
+++ b/spec/form_models/prescripteur_rdv_wizard_spec.rb
@@ -38,14 +38,12 @@ RSpec.describe PrescripteurRdvWizard do
       stub_netsize_ok
     end
 
-    it "notifies the agent, the user and the prescripteur" do
-      wizard = described_class.new(attributes, Domain::ALL.first)
-      wizard.create!
+    it "notifies the agent with the proper name" do
+      described_class.new(attributes, Domain::ALL.first).create!
 
       perform_enqueued_jobs
 
-      emails = ActionMailer::Base.deliveries
-      email_to_agent = emails.find { |email| email.to == [agent.email] }
+      email_to_agent = ActionMailer::Base.deliveries.find { |email| email.to == [agent.email] }
 
       expect(email_to_agent.html_part.to_s).not_to include("La participation de Pres CRIPTEUR au RDV collectif")
       expect(email_to_agent.html_part.to_s).to include("La participation de Lea BOUBAKAR au RDV collectif")


### PR DESCRIPTION
Cette PR est un correctif pour https://zammad10.ethibox.fr/#ticket/zoom/12263

On corrige les notifications pour les participations créées par les prescripteurs, mais j'ai pas de correctif pour les participations créées par les agents (voir aussi https://github.com/betagouv/rdv-service-public/issues/3397).

Il y a encore pas mal de petits bugs sur les notifications autour des rdv collectifs, et c'est une partie du code vraiment pas facile à manipuler. 
Je pense qu'on pourrait améliorer les choses en faisant un peu de refacto, mais je suis pas sûr de la forme que ça aurait. Il faudrait passer un peu de temps d'investigation dessus.

Par ailleurs, je me demande s'il faudrait pas aussi réfléchir à comment ces mails sont formulés : c'est très robotique et pas forcément facile de comprendre quelle est l'info prioritaire. Un travail de refacto UX est peut-être pertinent aussi.