### PR TITLE
Corrections mineures sur le formulaire de motif

### DIFF
--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -22,8 +22,8 @@
             - Motif.where(organisation_id: current_agent.organisations).map(&:name).uniq.each do |org_name|
               option= org_name
       .form-row
-        .col-md-4= f.input :default_duration_in_min
-        .col-md-4= f.input :color, as: "color"
+        .col-md-6= f.input :default_duration_in_min
+        .col-md-6= f.input :color, as: "color"
 
   - if current_organisation.territory.motif_categories.present?
     .card
@@ -37,19 +37,20 @@
   .card
     .card-body
       h5.card-title= Motif.human_attribute_name("location_type")
-      - if motif.rdvs.empty?
-        - %i[public_office phone home].each do |value|
-          = label_tag do
-            = f.radio_button(:location_type, value)
-            span.ml-1= Motif.human_attribute_value(:location_type, value)
-            p.text-muted.font-14= Motif.human_attribute_value(:location_type, value, context: :hint)
-      - else
-        p.alert.alert-warning Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le type
-        - %i[public_office phone home].each do |value|
-          = label_tag do
-            = f.radio_button(:location_type, value, disabled: true)
-            span.text-muted.ml-1= Motif.human_attribute_value(:location_type, value)
-            p.text-muted.font-14= Motif.human_attribute_value(:location_type, value, context: :hint)
+      .mt-3.d-flex.flex-column
+        - if motif.rdvs.empty?
+          - %i[public_office phone home].each do |value|
+            = label_tag do
+              = f.radio_button(:location_type, value)
+              span.ml-1= Motif.human_attribute_value(:location_type, value)
+              p.text-muted.font-14= Motif.human_attribute_value(:location_type, value, context: :hint)
+        - else
+          p.alert.alert-warning Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le type
+          - %i[public_office phone home].each do |value|
+            = label_tag do
+              = f.radio_button(:location_type, value, disabled: true)
+              span.text-muted.ml-1= Motif.human_attribute_value(:location_type, value)
+              p.text-muted.font-14= Motif.human_attribute_value(:location_type, value, context: :hint)
 
   .card
     .card-body
@@ -104,8 +105,8 @@
             p.text-muted.font-14= "Les usagers pourront aussi prendre rendez-vous en ligne sur les plages d'ouverture définies par les agents de #{@motif.organisation.name}"
 
       .form-row.js-rdvs-editable
-        .col-md-4= f.input :min_public_booking_delay, collection: min_max_delay_options
-        .col-md-4= f.input :max_public_booking_delay, collection: min_max_delay_options
+        .col-md-6= f.input :min_public_booking_delay, collection: min_max_delay_options
+        .col-md-6= f.input :max_public_booking_delay, collection: min_max_delay_options
 
       .js-rdvs-editable
         = f.input(:rdvs_editable_by_user)


### PR DESCRIPTION
Je passe ces tout petits fixes avant le lift complet du formulaire de motifs.

Faire la review en ignorant le whitespace. ;)

# Avant

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/9b05c745-1410-48e1-a3cf-de0256b2a0a1)


![image](https://github.com/betagouv/rdv-service-public/assets/6357692/9797106d-f675-4ed8-8137-15acb7c71ce8)


![image](https://github.com/betagouv/rdv-service-public/assets/6357692/94ea76df-6b78-4204-850c-0d3d261e528c)

# Après

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/a488c807-fac9-4f09-aa73-8c5fe9529df8)

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/a374a3c7-6d89-4636-ac60-9191d0b89e34)


![image](https://github.com/betagouv/rdv-service-public/assets/6357692/2595aa45-378c-4512-ab81-02cba534df1d)


# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
