### PR TITLE
Fix pour les agents soft_deleted aprés https://github.com/betagouv/rdv-service-public/pull/4178

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -166,7 +166,7 @@ class Agent < ApplicationRecord
         email_original: email,
         email: deleted_email,
         uid: deleted_email,
-        inclusion_connect_open_id_sub: "deleted_#{inclusion_connect_open_id_sub}"
+        inclusion_connect_open_id_sub: ("deleted_#{inclusion_connect_open_id_sub}" if inclusion_connect_open_id_sub.present?)
       )
     end
   end


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-service-public/pull/4178
Petit fix pour éviter que les agents soft_delete aient `deleted_` sans valeur dans `inclusion_connect_open_id_sub`
