### PR TITLE
Retirer la case "Usagers visible sur tout le territoire"

### DIFF
--- a/app/controllers/admin/territories_controller.rb
+++ b/app/controllers/admin/territories_controller.rb
@@ -23,7 +23,7 @@ class Admin::TerritoriesController < Admin::Territories::BaseController
   private
 
   def territory_params
-    params.require(:territory).permit(:name, :phone_number, :visible_users_throughout_the_territory)
+    params.require(:territory).permit(:name, :phone_number)
   end
 
   def set_territory_with_id

--- a/app/views/admin/territories/edit.html.slim
+++ b/app/views/admin/territories/edit.html.slim
@@ -9,7 +9,5 @@
       = f.input :phone_number
       = f.input :departement_number, disabled: true
 
-      = f.input :visible_users_throughout_the_territory, hint: "Les usagers peuvent être visible sur tout le territoire, ou bien, uniquement sur une organisation. Cependant, les doublons sont analysé sur l'ensemble du territoire et un usager peut ainsi être référencé dans plusieurs organisations."
-
     .card-footer.text-right
       = f.submit class: "btn btn-primary"

--- a/config/locales/models/territory.fr.yml
+++ b/config/locales/models/territory.fr.yml
@@ -8,4 +8,3 @@ fr:
         departement_number: Département
         sms_configuration: "Clef d’API / Mot de passe"
         sms_provider: "Fournisseur pour l’envoi de SMS"
-        visible_users_throughout_the_territory: Usagers visible sur tout le territoire

--- a/spec/requests/admin/territories/edit_territory_spec.rb
+++ b/spec/requests/admin/territories/edit_territory_spec.rb
@@ -23,11 +23,5 @@ RSpec.describe "Edit territory", type: :request do
       put admin_territory_path(territory), params: { territory: { phone_number: "0101010101" } }
       expect(territory.reload.phone_number).to eq("0101010101")
     end
-
-    it "set user visibility to whole territory" do
-      expect(territory.reload.visible_users_throughout_the_territory).to eq(false)
-      put admin_territory_path(territory), params: { territory: { visible_users_throughout_the_territory: true } }
-      expect(territory.reload.visible_users_throughout_the_territory).to eq(true)
-    end
   end
 end


### PR DESCRIPTION
Il est dangereux de laisser cette case en libre accès.

Voir issue qui explique le contexte :
https://github.com/betagouv/rdv-service-public/issues/3429

Voir post mortem du 19 mars 2024 :
https://pad.numerique.gouv.fr/MlL20poRTd6X0N2cp_Jg5Q?edit

# Avant

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/0d52a30c-cf2e-421b-abaa-cc9f1904a009)

# Après

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/7f0eaa77-e271-4892-9dae-5a000d5dab58)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
