### PR TITLE
Validation pour les adresses de lieu, et correction du champ adresse dans le SuperAdmin

### DIFF
--- a/app/dashboards/lieu_dashboard.rb
+++ b/app/dashboards/lieu_dashboard.rb
@@ -23,7 +23,7 @@ class LieuDashboard < Administrate::BaseDashboard
     phone_number: Field::String,
     phone_number_formatted: Field::String,
     availability: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
-    address: Field::String,
+    address: PlacesField.with_options(searchable: true),
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/models/concerns/address_concern.rb
+++ b/app/models/concerns/address_concern.rb
@@ -1,0 +1,14 @@
+module AddressConcern
+  extend ActiveSupport::Concern
+
+  included do
+    validates(
+      :address,
+      format: {
+        with: /\A.+,\s.+,\s\d{5}\z/,
+        message: "Le format correct est : 139 Rue de Bercy, Paris, 75012",
+      },
+      if: -> { address.present? }
+    )
+  end
+end

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -3,6 +3,7 @@ class Lieu < ApplicationRecord
   has_paper_trail
   include PhoneNumberValidation::HasPhoneNumber
   include WebhookDeliverable
+  include AddressConcern
 
   # Attributes
   auto_strip_attributes :name
@@ -22,13 +23,6 @@ class Lieu < ApplicationRecord
 
   # Validations
   validates :name, :address, :availability, presence: true
-  validates(
-    :address,
-    format: {
-      with: /\A.+,\s.+,\s\d{5}\z/,
-      message: "Le format correct est : 139 Rue de Bercy, Paris, 75012",
-    }
-  )
   validate :longitude_and_latitude_must_be_present
   validate :cant_change_availibility_single_use
 

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -22,14 +22,6 @@ class Lieu < ApplicationRecord
 
   # Validations
   validates :name, :address, :availability, presence: true
-  validates(
-    :address,
-    format: {
-      with: /\A.+,\s.+,\s\d{5}\z/,
-      message: "Le format correct est : 139 Rue de Bercy, Paris, 75012",
-      if: -> { address.present? },
-    }
-  )
   validate :longitude_and_latitude_must_be_present
   validate :cant_change_availibility_single_use
 

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -22,6 +22,14 @@ class Lieu < ApplicationRecord
 
   # Validations
   validates :name, :address, :availability, presence: true
+  validates(
+    :address,
+    format: {
+      with: /\A.+,\s.+,\s\d{5}\z/,
+      message: "Le format correct est : 139 Rue de Bercy, Paris, 75012",
+      if: -> { address.present? },
+    }
+  )
   validate :longitude_and_latitude_must_be_present
   validate :cant_change_availibility_single_use
 

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -27,7 +27,6 @@ class Lieu < ApplicationRecord
     format: {
       with: /\A.+,\s.+,\s\d{5}\z/,
       message: "Le format correct est : 139 Rue de Bercy, Paris, 75012",
-      if: -> { address.present? },
     }
   )
   validate :longitude_and_latitude_must_be_present

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ class User < ApplicationRecord
   include WebhookDeliverable
   include TextSearch
   include UncommonPasswordConcern
+  include AddressConcern
 
   def self.search_options
     {

--- a/db/seeds/cdad.rb
+++ b/db/seeds/cdad.rb
@@ -179,7 +179,7 @@ lieu1_bordeaux = Lieu.create!(
   availability: :enabled,
   phone_number: "05.47.33.91.17",
   phone_number_formatted: "+33547339117",
-  address: "30 rue des Frères Bonie, 33000 BORDEAUX"
+  address: "30 rue des Frères Bonie, BORDEAUX, 33000"
 )
 Lieu.create!(
   name: "Point-justice de LANGON",
@@ -189,7 +189,7 @@ Lieu.create!(
   availability: :enabled,
   phone_number: "05.57.36.25.54",
   phone_number_formatted: "+330557362554",
-  address: "Résidence de l'Horloge, Place de l'horloge, 33210 LANGON"
+  address: "Résidence de l'Horloge, Place de l'horloge, LANGON, 33210"
 )
 
 ## Plages d'Ouvertures

--- a/db/seeds/cdad.rb
+++ b/db/seeds/cdad.rb
@@ -179,7 +179,7 @@ lieu1_bordeaux = Lieu.create!(
   availability: :enabled,
   phone_number: "05.47.33.91.17",
   phone_number_formatted: "+33547339117",
-  address: "30 rue des Frères Bonie, BORDEAUX, 33000"
+  address: "30 rue des Frères Bonie, 33000 BORDEAUX"
 )
 Lieu.create!(
   name: "Point-justice de LANGON",
@@ -189,7 +189,7 @@ Lieu.create!(
   availability: :enabled,
   phone_number: "05.57.36.25.54",
   phone_number_formatted: "+330557362554",
-  address: "Résidence de l'Horloge, Place de l'horloge, LANGON, 33210"
+  address: "Résidence de l'Horloge, Place de l'horloge, 33210 LANGON"
 )
 
 ## Plages d'Ouvertures

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -46,7 +46,7 @@ cnfs_lieu = Lieu.create!(
   longitude: 4.919825,
   availability: :enabled,
   phone_number: "01 53 24 69 70",
-  address: "8 Rue Léon Schwartzenberg, 75010 Paris"
+  address: "8 Rue Léon Schwartzenberg, Paris, 75010"
 )
 
 agent_cnfs = Agent.new(

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -46,7 +46,7 @@ cnfs_lieu = Lieu.create!(
   longitude: 4.919825,
   availability: :enabled,
   phone_number: "01 53 24 69 70",
-  address: "8 Rue Léon Schwartzenberg, Paris, 75010"
+  address: "8 Rue Léon Schwartzenberg, 75010 Paris"
 )
 
 agent_cnfs = Agent.new(

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -221,7 +221,7 @@ lieu_org_paris_nord_bolivar = Lieu.create!(
   name: "MDS Bolivar",
   organisation: org_paris_nord,
   availability: :enabled,
-  address: "126 Avenue Simon Bolivar, Paris, 75019",
+  address: "126 Avenue Simon Bolivar, 75019, Paris",
   latitude: 48.8809263,
   longitude: 2.3739077
 )
@@ -229,7 +229,7 @@ lieu_org_paris_nord_bd_aubervilliers = Lieu.create!(
   name: "MDS Bd Aubervilliers",
   organisation: org_paris_nord,
   availability: :enabled,
-  address: "18 Boulevard d'Aubervilliers, Paris, 75019",
+  address: "18 Boulevard d'Aubervilliers, 75019 Paris",
   latitude: 48.8882196,
   longitude: 2.3650464
 )
@@ -237,7 +237,7 @@ lieu_arques_nord = Lieu.create!(
   name: "Maison Arques Nord",
   organisation: org_arques,
   availability: :enabled,
-  address: "10 rue du marechal leclerc, Arques, 62410",
+  address: "10 rue du marechal leclerc, 62410 Arques",
   latitude: 50.7406,
   longitude: 2.3103
 )
@@ -245,7 +245,7 @@ lieu_bapaume_est = Lieu.create!(
   name: "MJC Bapaume Est",
   organisation: org_bapaume,
   availability: :enabled,
-  address: "10 rue emile delot, Arques, 62450",
+  address: "10 rue emile delot, 62450 Arques",
   latitude: 50.1026,
   longitude: 2.8486
 )

--- a/db/seeds/medico_social.rb
+++ b/db/seeds/medico_social.rb
@@ -221,7 +221,7 @@ lieu_org_paris_nord_bolivar = Lieu.create!(
   name: "MDS Bolivar",
   organisation: org_paris_nord,
   availability: :enabled,
-  address: "126 Avenue Simon Bolivar, 75019, Paris",
+  address: "126 Avenue Simon Bolivar, Paris, 75019",
   latitude: 48.8809263,
   longitude: 2.3739077
 )
@@ -229,7 +229,7 @@ lieu_org_paris_nord_bd_aubervilliers = Lieu.create!(
   name: "MDS Bd Aubervilliers",
   organisation: org_paris_nord,
   availability: :enabled,
-  address: "18 Boulevard d'Aubervilliers, 75019 Paris",
+  address: "18 Boulevard d'Aubervilliers, Paris, 75019",
   latitude: 48.8882196,
   longitude: 2.3650464
 )
@@ -237,7 +237,7 @@ lieu_arques_nord = Lieu.create!(
   name: "Maison Arques Nord",
   organisation: org_arques,
   availability: :enabled,
-  address: "10 rue du marechal leclerc, 62410 Arques",
+  address: "10 rue du marechal leclerc, Arques, 62410",
   latitude: 50.7406,
   longitude: 2.3103
 )
@@ -245,7 +245,7 @@ lieu_bapaume_est = Lieu.create!(
   name: "MJC Bapaume Est",
   organisation: org_bapaume,
   availability: :enabled,
-  address: "10 rue emile delot, 62450 Arques",
+  address: "10 rue emile delot, Arques, 62450",
   latitude: 50.1026,
   longitude: 2.8486
 )

--- a/db/seeds/rdv_mairie.rb
+++ b/db/seeds/rdv_mairie.rb
@@ -65,7 +65,7 @@ lieu_mairie_de_sannois = Lieu.create!(
   availability: :enabled,
   phone_number: "04.75.79.69.91",
   phone_number_formatted: "+33475796991",
-  address: "15 Place du Général Leclerc, 26400, Sannois"
+  address: "15 Place du Général Leclerc, Sannois, 26400"
 )
 
 ## Plages d'Ouvertures

--- a/db/seeds/rdv_mairie.rb
+++ b/db/seeds/rdv_mairie.rb
@@ -65,7 +65,7 @@ lieu_mairie_de_sannois = Lieu.create!(
   availability: :enabled,
   phone_number: "04.75.79.69.91",
   phone_number_formatted: "+33475796991",
-  address: "15 Place du Général Leclerc, Sannois, 26400"
+  address: "15 Place du Général Leclerc, 26400, Sannois"
 )
 
 ## Plages d'Ouvertures

--- a/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Admin::Agents::PlageOuverturesController, type: :controller do
               "url" => "/admin/organisations/#{organisation.id}/plage_ouvertures/#{plage_ouverture.id}",
               "extendedProps" => {
                 "organisationName" => organisation.name,
-                "location" => "1 rue de l'adresse 12345 Ville",
+                "location" => "1 rue de l'adresse, Ville, 12345",
                 "lieu" => plage_ouverture.lieu.name,
               },
             },

--- a/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/agents/plage_ouvertures_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Admin::Agents::PlageOuverturesController, type: :controller do
               "url" => "/admin/organisations/#{organisation.id}/plage_ouvertures/#{plage_ouverture.id}",
               "extendedProps" => {
                 "organisationName" => organisation.name,
-                "location" => "1 rue de l'adresse, Ville, 12345",
+                "location" => "1 rue de l'adresse 12345 Ville",
                 "lieu" => plage_ouverture.lieu.name,
               },
             },

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
   let!(:motif) { create(:motif, organisation: organisation, service: service) }
-  let!(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Sud", address: "10 rue Belsunce, Paris, 75016") }
+  let!(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Sud", address: "10 rue Belsunce") }
 
   shared_examples "agent can CRUD plage ouverture" do
     describe "GET #show" do

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
   let!(:motif) { create(:motif, organisation: organisation, service: service) }
-  let!(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Sud", address: "10 rue Belsunce") }
+  let!(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Sud", address: "10 rue Belsunce, Paris, 75016") }
 
   shared_examples "agent can CRUD plage ouverture" do
     describe "GET #show" do

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Users::RdvsController, type: :controller do
         expect(Rdv.count).to eq(0)
         expect(response).to redirect_to prendre_rdv_path(
           departement: "12", service: motif.service_id, motif_name_with_location_type: motif.name_with_location_type,
-          address: "1 rue de la, ville, 12345", organisation_ids: [organisation.id], city_code: "12100"
+          address: "1 rue de la, ville 12345", organisation_ids: [organisation.id], city_code: "12100"
         )
         expect(flash[:error]).to eq "Ce créneau n’est plus disponible. Veuillez en sélectionner un autre."
       end
@@ -387,7 +387,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:organisation) { create(:organisation) }
     let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie, Nantes, 44100", organisation: organisation) }
+    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation, max_public_booking_delay: 2.weeks.to_i) }
     let!(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: user) }
@@ -454,7 +454,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:starts_at) { 3.days.from_now }
     let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie, Nantes, 44100", organisation: organisation) }
+    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: user) }
@@ -509,7 +509,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:starts_at) { 3.days.from_now }
     let(:user) { create(:user) }
     let(:motif) { create(:motif, organisation: organisation) }
-    let(:lieu) { create(:lieu, address: "10 rue de la Ferronerie, Nantes, 44100", organisation: organisation) }
+    let(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: user) }
     let(:token) { "12345" }

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Users::RdvsController, type: :controller do
         expect(Rdv.count).to eq(0)
         expect(response).to redirect_to prendre_rdv_path(
           departement: "12", service: motif.service_id, motif_name_with_location_type: motif.name_with_location_type,
-          address: "1 rue de la, ville 12345", organisation_ids: [organisation.id], city_code: "12100"
+          address: "1 rue de la, ville, 12345", organisation_ids: [organisation.id], city_code: "12100"
         )
         expect(flash[:error]).to eq "Ce créneau n’est plus disponible. Veuillez en sélectionner un autre."
       end
@@ -387,7 +387,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:organisation) { create(:organisation) }
     let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
+    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie, Nantes, 44100", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation, max_public_booking_delay: 2.weeks.to_i) }
     let!(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: user) }
@@ -454,7 +454,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:starts_at) { 3.days.from_now }
     let(:now) { Time.zone.parse("01/01/2019 10:00") }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
+    let!(:lieu) { create(:lieu, address: "10 rue de la Ferronerie, Nantes, 44100", organisation: organisation) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:user) { create(:user) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: user) }
@@ -509,7 +509,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     let(:starts_at) { 3.days.from_now }
     let(:user) { create(:user) }
     let(:motif) { create(:motif, organisation: organisation) }
-    let(:lieu) { create(:lieu, address: "10 rue de la Ferronerie 44100 Nantes", organisation: organisation) }
+    let(:lieu) { create(:lieu, address: "10 rue de la Ferronerie, Nantes, 44100", organisation: organisation) }
     let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
     let(:rdv) { create(:rdv, users: [user], starts_at: 5.days.from_now, lieu: lieu, motif: motif, organisation: organisation, created_by: user) }
     let(:token) { "12345" }

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Users::RdvsController, type: :controller do
         lieu_id: lieu&.id,
         departement: "12",
         city_code: "12100",
-        where: "1 rue de la, ville 12345",
+        where: "1 rue de la, ville, 12345",
         motif_id: motif.id,
         starts_at: starts_at,
         organisation_ids: [organisation.id],

--- a/spec/factories/lieu.rb
+++ b/spec/factories/lieu.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   sequence(:lieu_name) { |n| "Lieu n°#{n}" }
-  sequence(:address) { |n| "#{n} rue de l'adresse 12345 Ville" }
+  sequence(:address) { |n| "#{n} rue de l'adresse, Ville, 12345" }
 
   factory :lieu do
     organisation

--- a/spec/factories/lieu.rb
+++ b/spec/factories/lieu.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   sequence(:lieu_name) { |n| "Lieu n°#{n}" }
-  sequence(:address) { |n| "#{n} rue de l'adresse, Ville, 12345" }
+  sequence(:address) { |n| "#{n} rue de l'adresse 12345 Ville" }
 
   factory :lieu do
     organisation

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
       num
     end
     birth_date { Date.parse("1985-07-20") }
-    address { "20 avenue de Ségur, Paris" }
+    address { "20 avenue de Ségur, Paris, 75012" }
     password { "correcthorse" }
     password_confirmation { "correcthorse" }
     confirmed_at { Time.zone.now }

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Admin can configure the organisation" do
 
     expect_page_title("Nouveau lieu")
     fill_in "Nom", with: "Un autre nouveau lieu"
-    fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est"
+    fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000"
     first("input#lieu_latitude", visible: false).set(48.583844)
     first("input#lieu_longitude", visible: false).set(7.735253)
     click_button "Enregistrer"

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Agent can create a Rdv with wizard" do
     else
       click_link("Définir un lieu ponctuel.")
       fill_in "Nom", with: "Café de la gare"
-      fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est"
+      fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000"
       page.execute_script("document.querySelector('input#rdv_lieu_attributes_latitude').value = '48.583844'")
       page.execute_script("document.querySelector('input#rdv_lieu_attributes_longitude').value = 7.735253")
     end

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "agents can prescribe rdvs" do
     travel_to(now)
     stub_request(
       :get,
-      "https://api-adresse.data.gouv.fr/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris"
+      "https://api-adresse.data.gouv.fr/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075012"
     ).to_return(status: 200, body: file_fixture("geocode_result.json").read, headers: {})
   end
 

--- a/spec/features/agents/agent_can_update_rdv_spec.rb
+++ b/spec/features/agents/agent_can_update_rdv_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe "Agent can update a RDV", js: true do
     visit edit_admin_organisation_rdv_path(organisation, rdv)
     click_link("Définir un lieu ponctuel.")
     fill_in "Nom", with: "Café de la gare"
-    fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est"
+    fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000"
     page.execute_script("document.querySelector('input#rdv_lieu_attributes_latitude').value = '48.583844'")
     page.execute_script("document.querySelector('input#rdv_lieu_attributes_longitude').value = 7.735253")
     click_button "Enregistrer"
 
     expect(page).to have_content("Café de la gare")
-    expect(page).to have_content("3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est")
+    expect(page).to have_content("3 Place de la Gare, Strasbourg, 67000")
     expect(page).to have_selector(".badge-info", text: /Ponctuel/)
   end
 

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
     else
       click_link("Définir un lieu ponctuel.")
       fill_in :rdv_lieu_attributes_name, with: "Café de la gare"
-      fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000, 67, Bas-Rhin, Grand Est"
+      fill_in "Adresse", with: "3 Place de la Gare, Strasbourg, 67000"
       page.execute_script("document.querySelector('input#rdv_lieu_attributes_latitude').value = '48.583844'")
       page.execute_script("document.querySelector('input#rdv_lieu_attributes_longitude').value = 7.735253")
     end

--- a/spec/features/users/online_booking/with_invitation_spec.rb
+++ b/spec/features/users/online_booking/with_invitation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "User can be invited" do
   let(:now) { Time.zone.parse("2021-12-13 10:30") }
   let!(:user) do
     create(:user, first_name: "john", last_name: "doe", email: "johndoe@gmail.com",
-                  phone_number: "0682605955", address: "26 avenue de la resistance",
+                  phone_number: "0682605955", address: "26 avenue de la resistance, Paris, 75016",
                   birth_date: Date.new(1988, 12, 20),
                   organisations: [organisation])
   end
@@ -49,7 +49,7 @@ RSpec.describe "User can be invited" do
     it "shows the available lieux to take a rdv", js: true do
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
+        address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation"
       )
 
       # Lieu selection
@@ -128,7 +128,7 @@ RSpec.describe "User can be invited" do
       it "does not show the lieux" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
+          address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation"
         )
 
         expect(page).not_to have_content(lieu.name)
@@ -155,7 +155,7 @@ RSpec.describe "User can be invited" do
 
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
+        address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation"
       )
 
       # Motif selection
@@ -200,7 +200,7 @@ RSpec.describe "User can be invited" do
       it "shows the available motifs for the preselected orgs" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation", organisation_ids: [organisation.id]
+          address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation", organisation_ids: [organisation.id]
         )
 
         # It directly selects the first motif and goes to lieu selection
@@ -216,7 +216,7 @@ RSpec.describe "User can be invited" do
       it "does not show the motifs that can be booked through invitation only" do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
+          address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation"
         )
 
         expect(page).to have_content(motif2.name)
@@ -232,7 +232,7 @@ RSpec.describe "User can be invited" do
       it "shows the geo search available organisation to take a rdv", js: true do
         visit prendre_rdv_path(
           departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-          address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation"
+          address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation"
         )
 
         # Organisation selection
@@ -282,7 +282,7 @@ RSpec.describe "User can be invited" do
 
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", motif_category_short_name: "rsa_orientation",
+        address: "16 rue de la résistance, Paris, 75016", motif_category_short_name: "rsa_orientation",
         organisation_ids: [organisation.id, organisation2.id]
       )
     end
@@ -299,7 +299,7 @@ RSpec.describe "User can be invited" do
     it "priorize the session invitation attributes to the url attributes" do
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code, invitation_token: invitation_token,
-        address: "16 rue de la résistance", lieu_id: lieu.id
+        address: "16 rue de la résistance, Paris, 75016", lieu_id: lieu.id
       )
 
       expect(page).to have_content(lieu.name)
@@ -307,7 +307,7 @@ RSpec.describe "User can be invited" do
 
       visit prendre_rdv_path(
         departement: departement_number, city_code: city_code,
-        address: "16 rue de la résistance", lieu_id: lieu2.id
+        address: "16 rue de la résistance, Paris, 75016", lieu_id: lieu2.id
       )
 
       expect(page).to have_content(lieu.name)

--- a/spec/form_models/admin/rdv_wizard_form/step1_spec.rb
+++ b/spec/form_models/admin/rdv_wizard_form/step1_spec.rb
@@ -39,16 +39,16 @@ RSpec.describe Admin::RdvWizardForm::Step1 do
 
         context "motif is public office" do
           let!(:motif) { create(:motif, :at_public_office) }
-          let!(:user) { create(:user, address: "10 rue du havre") }
+          let!(:user) { create(:user, address: "10 rue du havre, Paris, 75009") }
 
           it { is_expected.to be lieu.address }
         end
 
         context "motif is at home and user has address" do
           let!(:motif) { create(:motif, :at_home) }
-          let!(:user) { create(:user, address: "10 rue du havre") }
+          let!(:user) { create(:user, address: "10 rue du havre, Paris, 75009") }
 
-          it { is_expected.to eq "10 rue du havre" }
+          it { is_expected.to eq "10 rue du havre, Paris, 75009" }
         end
 
         context "motif is at home but user doesn't have an address" do
@@ -60,10 +60,10 @@ RSpec.describe Admin::RdvWizardForm::Step1 do
 
         context "motif is at home but user is a relative" do
           let!(:motif) { create(:motif, :at_home) }
-          let!(:user_responsible) { create(:user, address: "10 rue du havre") }
+          let!(:user_responsible) { create(:user, address: "10 rue du havre, Paris, 75009") }
           let!(:user) { create(:user, responsible: user_responsible, address: "") }
 
-          it { is_expected.to eq "10 rue du havre" }
+          it { is_expected.to eq "10 rue du havre, Paris, 75009" }
         end
       end
     end

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_updated" do
     let(:previous_starting_time) { 2.days.from_now }
     let(:new_starting_time) { 3.days.from_now }
-    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade") }
-    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous") }
+    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade, Paris, 75016") }
+    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous, Paris, 75016") }
     let(:rdv) { create(:rdv, lieu: new_lieu, starts_at: new_starting_time) }
     let(:agent) { rdv.agents.first }
     let(:token) { "12345" }

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
       mail = described_class.with(rdv: rdv, agent: agent, author: agent)
         .rdv_updated(starts_at: previous_starting_time, lieu_id: previous_lieu.id)
 
-      previous_details = "Un de vos RDV qui devait avoir lieu le 26 août à 09:00 à l&#39;adresse MJC Aix (rue du Previous) a été modifié"
+      previous_details = "Un de vos RDV qui devait avoir lieu le 26 août à 09:00 à l&#39;adresse MJC Aix (rue du Previous, Paris, 75016) a été modifié"
       expect(mail.html_part.body.to_s).to include(previous_details)
 
       # new details
       expect(mail.html_part.body.to_s).to include("samedi 27 août 2022 à 09h00")
-      expect(mail.html_part.body.to_s).to include("Stade de France (rue du Stade)")
+      expect(mail.html_part.body.to_s).to include("Stade de France (rue du Stade, Paris, 75016)")
     end
 
     it "works when no lieu_id is passed" do

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
   describe "#rdv_updated" do
     let(:previous_starting_time) { 2.days.from_now }
     let(:new_starting_time) { 3.days.from_now }
-    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade, Paris, 75016") }
-    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous, Paris, 75016") }
+    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade") }
+    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous") }
     let(:rdv) { create(:rdv, lieu: new_lieu, starts_at: new_starting_time) }
     let(:agent) { rdv.agents.first }
     let(:token) { "12345" }

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
   describe "#rdv_updated" do
     let(:previous_starting_time) { 2.days.from_now }
     let(:new_starting_time) { 3.days.from_now }
-    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade, Paris, 75016") }
-    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous, Paris, 75016") }
+    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade") }
+    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous") }
     let(:rdv) { create(:rdv, lieu: new_lieu, starts_at: new_starting_time) }
     let(:user) { rdv.users.first }
     let(:token) { "12345" }

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
   describe "#rdv_updated" do
     let(:previous_starting_time) { 2.days.from_now }
     let(:new_starting_time) { 3.days.from_now }
-    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade") }
-    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous") }
+    let(:new_lieu) { create(:lieu, name: "Stade de France", address: "rue du Stade, Paris, 75016") }
+    let(:previous_lieu) { create(:lieu, name: "MJC Aix", address: "rue du Previous, Paris, 75016") }
     let(:rdv) { create(:rdv, lieu: new_lieu, starts_at: new_starting_time) }
     let(:user) { rdv.users.first }
     let(:token) { "12345" }

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       mail = described_class.with(rdv: rdv, user: user, token: token)
         .rdv_updated(starts_at: previous_starting_time, lieu_id: previous_lieu.id)
 
-      previous_details = "Votre RDV qui devait avoir lieu le 26 août à 09:00 à l&#39;adresse MJC Aix (rue du Previous) a été modifié"
+      previous_details = "Votre RDV qui devait avoir lieu le 26 août à 09:00 à l&#39;adresse MJC Aix (rue du Previous, Paris, 75016) a été modifié"
       expect(mail.html_part.body.to_s).to include(previous_details)
 
       # new details
       expect(mail.html_part.body.to_s).to include("samedi 27 août 2022 à 09h00")
-      expect(mail.html_part.body.to_s).to include("Stade de France (rue du Stade)")
+      expect(mail.html_part.body.to_s).to include("Stade de France (rue du Stade, Paris, 75016)")
     end
 
     it "works when no lieu_id is passed" do

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Payloads::Rdv, type: :service do
       context "without a phone motif" do
         let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse, Paris, 75016")) }
 
-        it { expect(rdv.payload[:address]).to eq("17 rue de l'adresse") }
+        it { expect(rdv.payload[:address]).to eq("17 rue de l'adresse, Paris, 75016") }
       end
     end
 

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Payloads::Rdv, type: :service do
       end
 
       context "without a phone motif" do
-        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse, Paris, 75016")) }
+        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse")) }
 
         it { expect(rdv.payload[:address]).to eq("17 rue de l'adresse") }
       end

--- a/spec/models/concerns/payloads/rdv_spec.rb
+++ b/spec/models/concerns/payloads/rdv_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Payloads::Rdv, type: :service do
       end
 
       context "without a phone motif" do
-        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse")) }
+        let(:rdv) { build(:rdv, users: [user], motif: build(:motif, :public_office), lieu: build(:lieu, address: "17 rue de l'adresse, Paris, 75016")) }
 
         it { expect(rdv.payload[:address]).to eq("17 rue de l'adresse") }
       end

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Rdv::Updatable, type: :concern do
       end
 
       it "returns true when single_use lieu adress is updated" do
-        lieu = create(:lieu, availability: "single_use", address: "2 place de la gare, Paris, 75016")
+        lieu = create(:lieu, availability: "single_use", address: "2 place de la gare")
         rdv.update!(lieu: lieu)
         rdv.reload
         rdv.update(lieu_attributes: { address: "derrière l'arbre", id: lieu.id })

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe Rdv::Updatable, type: :concern do
       end
 
       it "returns true when single_use lieu adress is updated" do
-        lieu = create(:lieu, availability: "single_use", address: "2 place de la gare")
+        lieu = create(:lieu, availability: "single_use", address: "2 place de la gare, Paris, 75016")
         rdv.update!(lieu: lieu)
         rdv.reload
         rdv.update(lieu_attributes: { address: "derrière l'arbre", id: lieu.id })

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Rdv::Updatable, type: :concern do
         lieu = create(:lieu, availability: "single_use", address: "2 place de la gare, Paris, 75016")
         rdv.update!(lieu: lieu)
         rdv.reload
-        rdv.update(lieu_attributes: { address: "derrière l'arbre", id: lieu.id })
+        rdv.update(lieu_attributes: { address: "1 place de l'arbre, Paris, 75016", id: lieu.id })
         expect(rdv.lieu_changed?).to be(true)
       end
     end

--- a/spec/models/concerns/user/franceconnect_frozen_fields_concern_spec.rb
+++ b/spec/models/concerns/user/franceconnect_frozen_fields_concern_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe User::FranceconnectFrozenFieldsConcern do
     end
 
     it "allows change to non-frozen field" do
-      res = user.update(address: "10 rue du Havre, Paris")
+      res = user.update(address: "10 rue du Havre, Paris, 75016")
       expect(res).to be_truthy
-      expect(user.reload.address).to eq("10 rue du Havre, Paris")
+      expect(user.reload.address).to eq("10 rue du Havre, Paris, 75016")
     end
   end
 

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -51,28 +51,6 @@ RSpec.describe Lieu, type: :model do
         it { is_expected.to be_empty }
       end
     end
-
-    describe "address" do
-      context "address in wrong format" do
-        let(:lieu) { build :lieu, address: "139 Rue de Bercy, 75012 Paris" }
-
-        it "validates format with error" do
-          lieu.valid?
-
-          expect(lieu.errors.full_messages).to eq(["Adresse Le format correct est : 139 Rue de Bercy, Paris, 75012"])
-        end
-      end
-
-      context "address in correct format" do
-        let(:lieu) { build :lieu, address: "139 Rue de Bercy, Paris, 75012" }
-
-        it "validates format successfully" do
-          lieu.valid?
-
-          expect(lieu.errors).to be_empty
-        end
-      end
-    end
   end
 
   context "with motif" do

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -51,6 +51,28 @@ RSpec.describe Lieu, type: :model do
         it { is_expected.to be_empty }
       end
     end
+
+    describe "address" do
+      context "address in wrong format" do
+        let(:lieu) { build :lieu, address: "139 Rue de Bercy, 75012 Paris" }
+
+        it "validates format with error" do
+          lieu.valid?
+
+          expect(lieu.errors.full_messages).to eq(["Adresse Le format correct est : 139 Rue de Bercy, Paris, 75012"])
+        end
+      end
+
+      context "address in correct format" do
+        let(:lieu) { build :lieu, address: "139 Rue de Bercy, Paris, 75012" }
+
+        it "validates format successfully" do
+          lieu.valid?
+
+          expect(lieu.errors).to be_empty
+        end
+      end
+    end
   end
 
   context "with motif" do

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -203,25 +203,25 @@ RSpec.describe Rdv, type: :model do
     end
 
     it "return mds address for a public_office rdv" do
-      lieu = build(:lieu, address: "16 rue de l'adresse, Ville, 12345", name: "PMI centre ville")
+      lieu = build(:lieu, address: "16 rue de l'adresse 12345 Ville", name: "PMI centre ville")
       rdv = build(:rdv, motif: build(:motif, :at_public_office), lieu: lieu)
       expect(rdv.address_without_personal_information).to eq("PMI centre ville (16 rue de l'adresse 12345 Ville)")
     end
 
     it "indicates a lieu is single_use" do
-      lieu = build(:lieu, address: "16 rue de l'adresse, Ville, 12345", name: "Café de la gare", availability: :single_use)
+      lieu = build(:lieu, address: "16 rue de l'adresse 12345 Ville", name: "Café de la gare", availability: :single_use)
       rdv = build(:rdv, motif: build(:motif, :at_public_office), lieu: lieu)
       expect(rdv.address_without_personal_information).to eq("Café de la gare (16 rue de l'adresse 12345 Ville) (Ponctuel)")
     end
 
     it "return only city for a at_home rdv" do
-      user = build(:user, address: "3 rue de l'église, Paris, 75020", post_code: "75020", city_name: "Paris")
+      user = build(:user, address: "3 rue de l'église 75020 Paris", post_code: "75020", city_name: "Paris")
       rdv = build(:rdv, motif: build(:motif, :at_home), users: [user])
       expect(rdv.address_without_personal_information).to eq("À domicile (75020 Paris)")
     end
 
     it "return nothing for a at_home rdv if city is blank" do
-      user = build(:user, address: "3 rue de l'église, Paris, 75020")
+      user = build(:user, address: "3 rue de l'église 75020 Paris")
       rdv = build(:rdv, motif: build(:motif, :at_home), users: [user])
       expect(rdv.address_without_personal_information).to eq("À domicile")
     end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -203,25 +203,25 @@ RSpec.describe Rdv, type: :model do
     end
 
     it "return mds address for a public_office rdv" do
-      lieu = build(:lieu, address: "16 rue de l'adresse 12345 Ville", name: "PMI centre ville")
+      lieu = build(:lieu, address: "16 rue de l'adresse, Ville, 12345", name: "PMI centre ville")
       rdv = build(:rdv, motif: build(:motif, :at_public_office), lieu: lieu)
       expect(rdv.address_without_personal_information).to eq("PMI centre ville (16 rue de l'adresse 12345 Ville)")
     end
 
     it "indicates a lieu is single_use" do
-      lieu = build(:lieu, address: "16 rue de l'adresse 12345 Ville", name: "Café de la gare", availability: :single_use)
+      lieu = build(:lieu, address: "16 rue de l'adresse, Ville, 12345", name: "Café de la gare", availability: :single_use)
       rdv = build(:rdv, motif: build(:motif, :at_public_office), lieu: lieu)
       expect(rdv.address_without_personal_information).to eq("Café de la gare (16 rue de l'adresse 12345 Ville) (Ponctuel)")
     end
 
     it "return only city for a at_home rdv" do
-      user = build(:user, address: "3 rue de l'église 75020 Paris", post_code: "75020", city_name: "Paris")
+      user = build(:user, address: "3 rue de l'église, Paris, 75020", post_code: "75020", city_name: "Paris")
       rdv = build(:rdv, motif: build(:motif, :at_home), users: [user])
       expect(rdv.address_without_personal_information).to eq("À domicile (75020 Paris)")
     end
 
     it "return nothing for a at_home rdv if city is blank" do
-      user = build(:user, address: "3 rue de l'église 75020 Paris")
+      user = build(:user, address: "3 rue de l'église, Paris, 75020")
       rdv = build(:rdv, motif: build(:motif, :at_home), users: [user])
       expect(rdv.address_without_personal_information).to eq("À domicile")
     end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -205,13 +205,13 @@ RSpec.describe Rdv, type: :model do
     it "return mds address for a public_office rdv" do
       lieu = build(:lieu, address: "16 rue de l'adresse, Ville, 12345", name: "PMI centre ville")
       rdv = build(:rdv, motif: build(:motif, :at_public_office), lieu: lieu)
-      expect(rdv.address_without_personal_information).to eq("PMI centre ville (16 rue de l'adresse 12345 Ville)")
+      expect(rdv.address_without_personal_information).to eq("PMI centre ville (16 rue de l'adresse, Ville, 12345)")
     end
 
     it "indicates a lieu is single_use" do
       lieu = build(:lieu, address: "16 rue de l'adresse, Ville, 12345", name: "Café de la gare", availability: :single_use)
       rdv = build(:rdv, motif: build(:motif, :at_public_office), lieu: lieu)
-      expect(rdv.address_without_personal_information).to eq("Café de la gare (16 rue de l'adresse 12345 Ville) (Ponctuel)")
+      expect(rdv.address_without_personal_information).to eq("Café de la gare (16 rue de l'adresse, Ville, 12345) (Ponctuel)")
     end
 
     it "return only city for a at_home rdv" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -358,4 +358,28 @@ RSpec.describe User, type: :model do
       expect(user.reload.ants_pre_demande_number).to eq "ABCDE12345"
     end
   end
+
+  describe "validations" do
+    describe "#address" do
+      context "address in wrong format" do
+        let(:user) { build :user, address: "139 Rue de Bercy, 75012 Paris" }
+
+        it "validates format with error" do
+          user.valid?
+
+          expect(user.errors.full_messages).to eq(["Adresse Le format correct est : 139 Rue de Bercy, Paris, 75012"])
+        end
+      end
+
+      context "address in correct format" do
+        let(:user) { build :user, address: "139 Rue de Bercy, Paris, 75012" }
+
+        it "validates format successfully" do
+          user.valid?
+
+          expect(user.errors).to be_empty
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
       let!(:plage_ouverture_follow_up) { create(:plage_ouverture, agent: agent, motifs: [motif_follow_up], lieu: lieu2, organisation: organisation1) }
       let!(:plage_ouverture_with_secto) { create(:plage_ouverture, motifs: [motif_with_secto], lieu: lieu, organisation: org_with_secto) }
 
-      let!(:lieu) { create(:lieu, name: "Bordeaux Centre", address: "Place de la bourse, 33000 Bordeaux", organisation: organisation1) }
-      let!(:lieu2) { create(:lieu, name: "Bruges", address: "3 Rue Gabriel Fauré, 33520 Bruges", organisation: organisation1) }
-      let!(:lieu3) { create(:lieu, name: "Loin de Bordeaux", address: "7 Av. du Commandant l'Herminier, 33740 Arès", organisation: other_org_without_po) }
+      let!(:lieu) { create(:lieu, name: "Bordeaux Centre", address: "Place de la bourse, Bordeaux, 33000", organisation: organisation1) }
+      let!(:lieu2) { create(:lieu, name: "Bruges", address: "3 Rue Gabriel Fauré, Bruges, 33520", organisation: organisation1) }
+      let!(:lieu3) { create(:lieu, name: "Loin de Bordeaux", address: "7 Av. du Commandant l'Herminier, Arès, 33740", organisation: other_org_without_po) }
 
       let(:auth_headers) { api_auth_headers_for_agent(agent) }
       let(:"access-token") { auth_headers["access-token"].to_s }

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -103,9 +103,9 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
       let!(:plage_ouverture_follow_up) { create(:plage_ouverture, agent: agent, motifs: [motif_follow_up], lieu: lieu2, organisation: organisation1) }
       let!(:plage_ouverture_with_secto) { create(:plage_ouverture, motifs: [motif_with_secto], lieu: lieu, organisation: org_with_secto) }
 
-      let!(:lieu) { create(:lieu, name: "Bordeaux Centre", address: "Place de la bourse, Bordeaux, 33000", organisation: organisation1) }
-      let!(:lieu2) { create(:lieu, name: "Bruges", address: "3 Rue Gabriel Fauré, Bruges, 33520", organisation: organisation1) }
-      let!(:lieu3) { create(:lieu, name: "Loin de Bordeaux", address: "7 Av. du Commandant l'Herminier, Arès, 33740", organisation: other_org_without_po) }
+      let!(:lieu) { create(:lieu, name: "Bordeaux Centre", address: "Place de la bourse, 33000 Bordeaux", organisation: organisation1) }
+      let!(:lieu2) { create(:lieu, name: "Bruges", address: "3 Rue Gabriel Fauré, 33520 Bruges", organisation: organisation1) }
+      let!(:lieu3) { create(:lieu, name: "Loin de Bordeaux", address: "7 Av. du Commandant l'Herminier, 33740 Arès", organisation: other_org_without_po) }
 
       let(:auth_headers) { api_auth_headers_for_agent(agent) }
       let(:"access-token") { auth_headers["access-token"].to_s }

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
       parameter name: "birth_date", in: :query, type: :string, description: "Date de naissance", example: "1976-10-01", required: false
       parameter name: "email", in: :query, type: :string, description: "Email", example: "johnny@77.com", required: false
       parameter name: "phone_number", in: :query, type: :string, description: "Numéro de téléphone", example: "33600008012", required: false
-      parameter name: "address", in: :query, type: :string, description: "Adresse", example: "10 rue du Havre, Paris", required: false
+      parameter name: "address", in: :query, type: :string, description: "Adresse", example: "10 rue du Havre, Paris, 75016", required: false
       parameter name: "caisse_affiliation", in: :query, type: :string, description: "Caisse d'affiliation", example: "caf", required: false
       parameter name: "affiliation_number", in: :query, type: :string, description: "Numéro d'affiliation", example: "101010", required: false
       parameter name: "family_situation", in: :query, type: :string, description: "Situation familiale", example: "single", required: false
@@ -98,7 +98,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         let(:birth_date) { "1976-10-01" }
         let(:email) { "jean@jacques.fr" }
         let(:phone_number) { "33600008012" }
-        let(:address) { "10 rue du Havre, Paris" }
+        let(:address) { "10 rue du Havre, Paris, 75016" }
         let(:caisse_affiliation) { "caf" }
         let(:affiliation_number) { "101010" }
         let(:family_situation) { "single" }
@@ -171,7 +171,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         end
 
         let(:first_name) { "Alain" }
-        let(:address) { "10 rue du Havre, Paris" }
+        let(:address) { "10 rue du Havre, Paris, 75016" }
 
         schema "$ref" => "#/components/schemas/user_with_root"
 
@@ -313,7 +313,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
       parameter name: "birth_date", in: :query, type: :string, description: "Date de naissance", example: "1976-10-01", required: false
       parameter name: "email", in: :query, type: :string, description: "Email", example: "johnny@77.com", required: false
       parameter name: "phone_number", in: :query, type: :string, description: "Numéro de téléphone", example: "33600008012", required: false
-      parameter name: "address", in: :query, type: :string, description: "Adresse", example: "10 rue du Havre, Paris", required: false
+      parameter name: "address", in: :query, type: :string, description: "Adresse", example: "10 rue du Havre, Paris, 75016", required: false
       parameter name: "caisse_affiliation", in: :query, type: :string, description: "Caisse d'affiliation", example: "caf", required: false
       parameter name: "affiliation_number", in: :query, type: :string, description: "Numéro d'affiliation", example: "101010", required: false
       parameter name: "family_situation", in: :query, type: :string, description: "Situation familiale", example: "single", required: false
@@ -337,7 +337,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         let(:birth_date) { "1976-10-01" }
         let(:email) { "jean@jacques.fr" }
         let(:phone_number) { "33600008012" }
-        let(:address) { "10 rue du Havre, Paris" }
+        let(:address) { "10 rue du Havre, Paris, 75016" }
         let(:caisse_affiliation) { "caf" }
         let(:affiliation_number) { "101010" }
         let(:family_situation) { "single" }

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AddConseillerNumerique do
       structure: {
         external_id: "123456",
         name: "France Service 19e",
-        address: "16 quai de la Loire, 75019 Paris",
+        address: "16 quai de la Loire, Paris, 75019",
       },
     }
   end
@@ -19,7 +19,7 @@ RSpec.describe AddConseillerNumerique do
     create(:service, :conseiller_numerique)
     stub_request(
       :get,
-      "https://api-adresse.data.gouv.fr/search/?postcode=75019&q=16%20quai%20de%20la%20Loire,%2075019%20Paris"
+      "https://api-adresse.data.gouv.fr/search/?postcode=75019&q=16%20quai%20de%20la%20Loire,%20Paris,%2075019"
     ).to_return(status: 200, body: file_fixture("geocode_result.json").read, headers: {})
   end
 

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ParticipationExporter, type: :service do
         starts_at: Time.zone.parse("2023-04-07 14h30"),
         status: :unknown,
         context: "des infos sur le rdv",
-        lieu: create(:lieu, name: "MDS Paris Nord", address: "21 rue des Ardennes, 75019 Paris"),
+        lieu: create(:lieu, name: "MDS Paris Nord", address: "21 rue des Ardennes, Paris, 75019"),
         motif: build(:motif, name: "Consultation", service: build(:service, name: "PMI")),
         organisation: create(:organisation, name: "MDS Paris"),
         agents: [create(:agent, email: "agent@mail.com", first_name: "Francis", last_name: "Factice")],
@@ -61,7 +61,7 @@ RSpec.describe ParticipationExporter, type: :service do
           "Consultation",
           "des infos sur le rdv",
           "À renseigner",
-          "MDS Paris Nord (21 rue des Ardennes, 75019 Paris)",
+          "MDS Paris Nord (21 rue des Ardennes, Paris, 75019)",
           "Francis FACTICE",
           nil,
           "non",
@@ -106,9 +106,9 @@ RSpec.describe ParticipationExporter, type: :service do
       end
 
       it "return « lieu name and adresse » when rdv in place" do
-        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république 56700 Hennebont")
+        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république, Hennebont, 56700")
         rdv = build(:rdv, :with_fake_timestamps, lieu: lieu)
-        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("Centre ville (3 place de la république 56700 Hennebont)")
+        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("Centre ville (3 place de la république, Hennebont, 56700)")
       end
     end
 
@@ -162,14 +162,14 @@ RSpec.describe ParticipationExporter, type: :service do
 
   describe "code postal du responsable" do
     it "return 92320 (Chatillon's postal code) when first responsable lives there" do
-      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
       rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
       expect(described_class.row_array_from(rdv.participations.first)[19]).to eq("92320")
     end
 
     it "return responsible's postal code for relative" do
-      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
       rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor])
       expect(described_class.row_array_from(rdv.participations.first)[19]).to eq("92320")

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ParticipationExporter, type: :service do
         starts_at: Time.zone.parse("2023-04-07 14h30"),
         status: :unknown,
         context: "des infos sur le rdv",
-        lieu: create(:lieu, name: "MDS Paris Nord", address: "21 rue des Ardennes, Paris, 75019"),
+        lieu: create(:lieu, name: "MDS Paris Nord", address: "21 rue des Ardennes, 75019 Paris"),
         motif: build(:motif, name: "Consultation", service: build(:service, name: "PMI")),
         organisation: create(:organisation, name: "MDS Paris"),
         agents: [create(:agent, email: "agent@mail.com", first_name: "Francis", last_name: "Factice")],
@@ -61,7 +61,7 @@ RSpec.describe ParticipationExporter, type: :service do
           "Consultation",
           "des infos sur le rdv",
           "À renseigner",
-          "MDS Paris Nord (21 rue des Ardennes, Paris, 75019)",
+          "MDS Paris Nord (21 rue des Ardennes, 75019 Paris)",
           "Francis FACTICE",
           nil,
           "non",
@@ -106,9 +106,9 @@ RSpec.describe ParticipationExporter, type: :service do
       end
 
       it "return « lieu name and adresse » when rdv in place" do
-        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république, Hennebont, 56700")
+        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république 56700 Hennebont")
         rdv = build(:rdv, :with_fake_timestamps, lieu: lieu)
-        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("Centre ville (3 place de la république, Hennebont, 56700)")
+        expect(described_class.row_array_from(rdv.participations.first)[12]).to eq("Centre ville (3 place de la république 56700 Hennebont)")
       end
     end
 
@@ -162,14 +162,14 @@ RSpec.describe ParticipationExporter, type: :service do
 
   describe "code postal du responsable" do
     it "return 92320 (Chatillon's postal code) when first responsable lives there" do
-      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
+      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
       rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, major])
       expect(described_class.row_array_from(rdv.participations.first)[19]).to eq("92320")
     end
 
     it "return responsible's postal code for relative" do
-      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
+      major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
       rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor])
       expect(described_class.row_array_from(rdv.participations.first)[19]).to eq("92320")

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ParticipationExporter, type: :service do
         motif: build(:motif, name: "Consultation", service: build(:service, name: "PMI")),
         organisation: create(:organisation, name: "MDS Paris"),
         agents: [create(:agent, email: "agent@mail.com", first_name: "Francis", last_name: "Factice")],
-        users: [create(:user, first_name: "Gaston", last_name: "Bidon", birth_date: Date.new(2000, 1, 1))]
+        users: [create(:user, first_name: "Gaston", last_name: "Bidon", birth_date: Date.new(2000, 1, 1), address: nil)]
       )
       participation_row = described_class.row_array_from(rdv.participations.first)
       xls_string = described_class.xls_string_from_participations_rows([participation_row])

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe RdvExporter, type: :service do
 
   describe "code postal du premier responsable" do
     it "return 92320 (Chatillon's postal code) when first responsable leave there" do
-      first_major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      first_major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: first_major.id)
       other_major = create(:user, birth_date: Date.new(2002, 3, 12))
       other_minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: other_major.id)
@@ -236,7 +236,7 @@ RSpec.describe RdvExporter, type: :service do
     end
 
     it "return responsible's postal code for relative" do
-      first_major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      first_major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: first_major.id)
       rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor])
       expect(described_class.row_array_from(rdv)[18]).to eq("92320")
@@ -245,7 +245,7 @@ RSpec.describe RdvExporter, type: :service do
     it "return second responsible postal code when first does not have one" do
       major = create(:user, birth_date: Date.new(2002, 3, 12), address: nil)
       minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: major.id)
-      other_major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, 92320 Châtillon")
+      other_major = create(:user, birth_date: Date.new(2002, 3, 12), address: "Rue Jean Jaurès, Châtillon, 92320")
       other_minor = create(:user, birth_date: Date.new(2016, 5, 30), responsible_id: other_major.id)
       rdv = create(:rdv, created_at: Time.zone.local(2020, 3, 23, 9, 54, 33), users: [minor, other_minor, major, other_major])
       expect(described_class.row_array_from(rdv)[18]).to eq("92320")

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe RdvExporter, type: :service do
       end
 
       it "return « lieu name and adresse » when rdv in place" do
-        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république, Hennebont, 56700")
+        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république 56700 Hennebont")
         rdv = build(:rdv, :with_fake_timestamps, lieu: lieu)
-        expect(described_class.row_array_from(rdv)[10]).to eq("Centre ville (3 place de la république, Hennebont, 56700)")
+        expect(described_class.row_array_from(rdv)[10]).to eq("Centre ville (3 place de la république 56700 Hennebont)")
       end
     end
 

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -136,9 +136,9 @@ RSpec.describe RdvExporter, type: :service do
       end
 
       it "return « lieu name and adresse » when rdv in place" do
-        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république 56700 Hennebont")
+        lieu = build(:lieu, name: "Centre ville", address: "3 place de la république, Hennebont, 56700")
         rdv = build(:rdv, :with_fake_timestamps, lieu: lieu)
-        expect(described_class.row_array_from(rdv)[10]).to eq("Centre ville (3 place de la république 56700 Hennebont)")
+        expect(described_class.row_array_from(rdv)[10]).to eq("Centre ville (3 place de la république, Hennebont, 56700)")
       end
     end
 

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Users::RdvSms, type: :service do
       let(:organisation) { build(:organisation) }
       let(:pmi) { build(:service, short_name: "PMI") }
       let(:motif) { build(:motif, service: pmi) }
-      let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+      let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
       let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 123, name: "Ne Doit pas s'afficher") }
       let(:user) { build(:user) }
       let(:token) { "12345" }
@@ -70,7 +70,7 @@ RSpec.describe Users::RdvSms, type: :service do
     let(:pmi) { build(:service, short_name: "PMI") }
     let(:motif) { build(:motif, service: pmi) }
     let(:organisation) { build(:organisation) }
-    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
     let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 124) }
     let(:token) { "2345" }
     let(:user) { build(:user) }
@@ -145,7 +145,7 @@ RSpec.describe Users::RdvSms, type: :service do
 
     let(:pmi) { build(:service, short_name: "PMI") }
     let(:motif) { build(:motif, service: pmi) }
-    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
     let(:organisation) { build(:organisation) }
     let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 140) }
     let(:user) { build(:user) }
@@ -162,7 +162,7 @@ RSpec.describe Users::RdvSms, type: :service do
   describe "rdv footer" do
     subject { described_class.rdv_created(rdv, user, token).content }
 
-    let(:user) { build(:user, address: "10 rue de Toulon, Lille") }
+    let(:user) { build(:user, address: "10 rue de Toulon, Lille, 5000") }
     let(:token) { "12345" }
 
     describe "depending on motif" do

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Users::RdvSms, type: :service do
 
       it do
         expect(subject).to include("RDV PMI vendredi 10/12 à 13h10")
-        expect(subject).to include("MDS Centre (10 rue d'ici)")
+        expect(subject).to include("MDS Centre (10 rue d'ici, Paris, 75016)")
         expect(subject).to include("Infos et annulation")
         expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/123/12345")
         expect(subject).not_to include("Ne Doit pas s'afficher")
@@ -77,7 +77,7 @@ RSpec.describe Users::RdvSms, type: :service do
 
     it do
       expect(subject).to include("RDV modifié: PMI vendredi 10/12 à 13h10")
-      expect(subject).to include("MDS Centre (10 rue d'ici)")
+      expect(subject).to include("MDS Centre (10 rue d'ici, Paris, 75016)")
       expect(subject).to include("Infos et annulation")
       expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/124/2345")
     end
@@ -153,7 +153,7 @@ RSpec.describe Users::RdvSms, type: :service do
 
     it do
       expect(subject).to include("Rappel RDV PMI le vendredi 10/12 à 13h10")
-      expect(subject).to include("MDS Centre (10 rue d'ici)")
+      expect(subject).to include("MDS Centre (10 rue d'ici, Paris, 75016)")
       expect(subject).to include("Infos et annulation")
       expect(subject).to include("http://www.rdv-solidarites-test.localhost/r/140/7777")
     end

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Users::RdvSms, type: :service do
       let(:organisation) { build(:organisation) }
       let(:pmi) { build(:service, short_name: "PMI") }
       let(:motif) { build(:motif, service: pmi) }
-      let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
+      let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
       let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 123, name: "Ne Doit pas s'afficher") }
       let(:user) { build(:user) }
       let(:token) { "12345" }
@@ -70,7 +70,7 @@ RSpec.describe Users::RdvSms, type: :service do
     let(:pmi) { build(:service, short_name: "PMI") }
     let(:motif) { build(:motif, service: pmi) }
     let(:organisation) { build(:organisation) }
-    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
     let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 124) }
     let(:token) { "2345" }
     let(:user) { build(:user) }
@@ -145,7 +145,7 @@ RSpec.describe Users::RdvSms, type: :service do
 
     let(:pmi) { build(:service, short_name: "PMI") }
     let(:motif) { build(:motif, service: pmi) }
-    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
+    let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici") }
     let(:organisation) { build(:organisation) }
     let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 140) }
     let(:user) { build(:user) }
@@ -162,7 +162,7 @@ RSpec.describe Users::RdvSms, type: :service do
   describe "rdv footer" do
     subject { described_class.rdv_created(rdv, user, token).content }
 
-    let(:user) { build(:user, address: "10 rue de Toulon, Lille, 5000") }
+    let(:user) { build(:user, address: "10 rue de Toulon, Lille") }
     let(:token) { "12345" }
 
     describe "depending on motif" do

--- a/spec/support/calendar.ics
+++ b/spec/support/calendar.ics
@@ -28,7 +28,7 @@ DTSTART;TZID=Europe/Paris:20220711T000000
 DTEND;TZID=Europe/Paris:20220711T004500
 DESCRIPTION:plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-
  test.localhost/admin/organisations/123000/rdvs/123123
-LOCATION:Lieu n°3 (3 rue de l'adresse 12345 Ville)
+LOCATION:Lieu n°3 (3 rue de l'adresse\, Ville\, 12345)
 STATUS:CONFIRMED
 SUMMARY:Atelier collectif (1/5)
 END:VEVENT
@@ -39,7 +39,7 @@ DTSTART;TZID=Europe/Paris:20220710T000000
 DTEND;TZID=Europe/Paris:20220710T004500
 DESCRIPTION:plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-
  test.localhost/admin/organisations/123000/rdvs/789000
-LOCATION:Lieu n°2 (2 rue de l'adresse 12345 Ville)
+LOCATION:Lieu n°2 (2 rue de l'adresse\, Ville\, 12345)
 STATUS:CANCELLED
 SUMMARY:Accompagnement individuel
 END:VEVENT
@@ -50,7 +50,7 @@ DTSTART;TZID=Europe/Paris:20220709T000000
 DTEND;TZID=Europe/Paris:20220709T004500
 DESCRIPTION:plus d'infos dans RDV Solidarités: http://www.rdv-solidarites-
  test.localhost/admin/organisations/123000/rdvs/456000
-LOCATION:Lieu n°1 (1 rue de l'adresse 12345 Ville)
+LOCATION:Lieu n°1 (1 rue de l'adresse\, Ville\, 12345)
 STATUS:CONFIRMED
 SUMMARY:Accompagnement individuel
 END:VEVENT


### PR DESCRIPTION
##  [SuperAdmin] Changement d'adresse dans le bon format pour un Lieu

Au niveau du SuperAdmin, la modification de l'adresse d'un lieu se fait sur un champ de texte un peu libre.
Dans cette PR, nous rajoutons la configuration `places-js` afin de proposer un dropdown où sélectionner l'adresse, comme dans le reste de l'app.

### Avant
<img width="1296" alt="Screenshot 2024-03-21 at 14 19 23" src="https://github.com/betagouv/rdv-service-public/assets/11911945/85a886df-0add-49d4-92fa-f16fdd8d80dd">

### Après
<img width="1222" alt="Screenshot 2024-03-21 at 14 17 44" src="https://github.com/betagouv/rdv-service-public/assets/11911945/0debcfde-f420-47ef-945c-ae6f4eed0f44">
