### PR TITLE
Ne pas demander le numéro de pré-demande ANTS pour les proches quand le rdv ne le nécessite pas

### DIFF
--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -51,6 +51,6 @@
               = possible_participant.full_name
             br
           .form-group
-            = link_to "Ajouter un proche", new_relative_path, data: { modal: true }
+            = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?), data: { modal: true }
           .form-group
             = submit_tag "Enregistrer", class: "btn btn-primary"

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -32,7 +32,7 @@
                 wrapper_html: { class: "mb-0" },
                 input_html: { name: "rdv[user_ids][]" }
           .form-group
-            = link_to "Ajouter un proche", new_relative_path, data: { modal: true }
+            = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?), data: { modal: true }
           .row
             .col
               = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "btn btn-link"

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,3 +1,4 @@
+= raise "trying to see if this is in a spec"
 .form-row
   .col-md-6= f.input :first_name
   .col-md-6= f.input :last_name

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -3,5 +3,5 @@
   .col-md-6= f.input :last_name
 - if params[:ants_pre_demande_number_required].to_b
   = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
-- else
+- if current_domain != Domain::RDV_MAIRIE
   = date_input(f, :birth_date)

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,7 +1,7 @@
 .form-row
   .col-md-6= f.input :first_name
   .col-md-6= f.input :last_name
-- if current_domain == Domain::RDV_MAIRIE
+- if params[:ants_pre_demande_number_required].to_b
   = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
 - else
   = date_input(f, :birth_date)

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,4 +1,3 @@
-= raise "trying to see if this is in a spec"
 .form-row
   .col-md-6= f.input :first_name
   .col-md-6= f.input :last_name

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "User can search for rdvs" do
     stub_netsize_ok
   end
 
-  describe "default", js: true do
+  describe "default" do
     let!(:territory92) { create(:territory, departement_number: "92") }
     let!(:organisation) { create(:organisation, :with_contact, territory: territory92) }
     let(:service) { create(:service) }
@@ -22,7 +22,7 @@ RSpec.describe "User can search for rdvs" do
     let!(:lieu2) { create(:lieu, organisation: organisation) }
     let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
 
-    it "default" do
+    it "default", js: true do
       visit root_path
       execute_search
       choose_service(motif.service)
@@ -48,7 +48,7 @@ RSpec.describe "User can search for rdvs" do
         Capybara.app_host = previous_app_host
       end
 
-      it "doesn't require an ANTS predemande number for a relative" do
+      it "doesn't require an ANTS predemande number for a relative", js: true do
         visit creneau_choice_path
         choose_creneau
         sign_up

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -1,19 +1,5 @@
 RSpec.describe "User can search for rdvs" do
   let(:now) { Time.zone.parse("2021-12-13 8:00") }
-  let(:creneau_choice_path) do
-    prendre_rdv_path(
-      address: "79 Rue de Plaisance, 92250 La Garenne-Colombes",
-      city_code: "",
-      departement: 92,
-      date: "2022-01-13 08:00:00 +0100",
-      latitude: "",
-      lieu_id: lieu.id,
-      longitude: "",
-      motif_name_with_location_type: "vaccination-public_office",
-      service_id: service.id,
-      street_ban_id: ""
-    )
-  end
 
   around { |example| perform_enqueued_jobs { example.run } }
 
@@ -42,6 +28,9 @@ RSpec.describe "User can search for rdvs" do
       choose_service(motif.service)
       choose_motif(motif)
       choose_lieu(lieu)
+
+      expect(page).to have_current_path(creneau_choice_path) # Cet expect permet de vérifier que les tests qui se basent sur ce path pour éviter des étapes intermédiaires sont corrects
+
       choose_creneau
       sign_up
       continue_to_rdv(motif)
@@ -383,7 +372,6 @@ RSpec.describe "User can search for rdvs" do
   end
 
   def choose_creneau
-    expect(page).to have_current_path(creneau_choice_path) # Cet expect permet de vérifier que les tests qui se basent sur ce path pour éviter des étapes intermédiaires sont corrects
     first(:link, "11:00").click
   end
 
@@ -447,5 +435,20 @@ RSpec.describe "User can search for rdvs" do
 
   def expect_page_h1(title)
     expect(page).to have_selector("h1", text: title)
+  end
+
+  def creneau_choice_path
+    prendre_rdv_path(
+      address: "79 Rue de Plaisance, 92250 La Garenne-Colombes",
+      city_code: "",
+      departement: 92,
+      date: "2022-01-13 08:00:00 +0100",
+      latitude: "",
+      lieu_id: lieu&.id,
+      longitude: "",
+      motif_name_with_location_type: "vaccination-public_office",
+      service_id: service.id,
+      street_ban_id: ""
+    )
   end
 end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "User can search for rdvs" do
       choose_motif(motif)
       choose_lieu(lieu)
 
-      expect(page).to have_current_path(creneau_choice_path) # Cet expect permet de vérifier que les tests qui se basent sur ce path pour éviter des étapes intermédiaires sont corrects
+      expect(page).to have_current_path(path_for_creneau_choice) # Cet expect permet de vérifier que les tests qui se basent sur ce path pour éviter des étapes intermédiaires sont corrects
 
       choose_creneau
       sign_up
@@ -39,17 +39,8 @@ RSpec.describe "User can search for rdvs" do
     end
 
     describe "On RDV Service Public" do
-      around do |example|
-        previous_app_host = Capybara.app_host
-        Capybara.app_host = "http://#{Domain::RDV_MAIRIE.host_name}"
-
-        example.run
-
-        Capybara.app_host = previous_app_host
-      end
-
       it "doesn't require an ANTS predemande number for a relative", js: true do
-        visit creneau_choice_path
+        visit "http://www.rdv-mairie-test.localhost/#{path_for_creneau_choice}"
         choose_creneau
         sign_up
         click_button("Continuer")
@@ -437,7 +428,7 @@ RSpec.describe "User can search for rdvs" do
     expect(page).to have_selector("h1", text: title)
   end
 
-  def creneau_choice_path
+  def path_for_creneau_choice
     prendre_rdv_path(
       address: "79 Rue de Plaisance, 92250 La Garenne-Colombes",
       city_code: "",


### PR DESCRIPTION
correctif pour #4179

On se base sur le rdv pour ajouter un paramètre qui contrôle l'affichage de ce champs.

## Avant

<img width="755" alt="Screenshot 2024-03-20 at 15 16 40" src="https://github.com/betagouv/rdv-service-public/assets/1840367/d748b066-7109-4636-b871-877949e2ba3f">

## Après

<img width="691" alt="Screenshot 2024-03-20 at 15 20 19" src="https://github.com/betagouv/rdv-service-public/assets/1840367/537b0247-4301-4b3a-9214-2fd9371c7339">

