### PR TITLE
Utiliser `connection_pool` autour du client Redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem "activerecord-postgres_enum"
 gem "redis", "< 5.0"
 # Adds a Redis::Namespace class which can be used to namespace calls to Redis.
 gem "redis-namespace"
+# Generic connection pooling for Ruby
+gem "connection_pool"
 
 # Devise / auth
 # Flexible authentication solution for Rails with Warden

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
       descendants_tracker (~> 0.0.1)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -650,6 +651,7 @@ DEPENDENCIES
   capybara-screenshot
   chartkick (~> 5.0.1)
   common_french_passwords
+  connection_pool
   database_cleaner
   devise
   devise-async

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,9 +43,6 @@ module Lapin
 
     config.active_support.cache_format_version = 7.0
 
-    # Both cache and sessions are stored in the same Redis database:
-    # - cache keys are prefixed with "cache:"
-    # - session keys are prefixed with "session:"
     redis_settings = {
       connect_timeout: 30, # Defaults to 20 seconds
       read_timeout: 1, # Defaults to 1 second

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,11 +1,14 @@
 raise "Prevent monkey patch" if Redis.respond_to?(:with_connection)
 
 class Redis
-  def self.with_connection
+  raise "Prevent monkey patch chaos" if const_defined?(:CONNECTION_POOL)
+
+  CONNECTION_POOL = ConnectionPool.new(size: ENV.fetch("RAILS_MAX_THREADS", 5), timeout: 5) do
     redis_connection = new(url: Rails.configuration.x.redis_url)
-    redis_connection = Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
-    yield(redis_connection)
-  ensure
-    redis_connection&.close
+    Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
+  end
+
+  def self.with_connection(&block)
+    CONNECTION_POOL.with(&block)
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,14 +1,11 @@
 raise "Prevent monkey patch" if Redis.respond_to?(:with_connection)
 
 class Redis
-  raise "Prevent monkey patch chaos" if const_defined?(:CONNECTION_POOL)
-
-  CONNECTION_POOL = ConnectionPool.new(size: ENV.fetch("RAILS_MAX_THREADS", 5), timeout: 5) do
+  def self.with_connection
     redis_connection = new(url: Rails.configuration.x.redis_url)
-    Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
-  end
-
-  def self.with_connection(&block)
-    CONNECTION_POOL.with(&block)
+    redis_connection = Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
+    yield(redis_connection)
+  ensure
+    redis_connection&.close
   end
 end

--- a/spec/lib/redis_spec.rb
+++ b/spec/lib/redis_spec.rb
@@ -1,21 +1,14 @@
 RSpec.describe Redis do
   describe "#with_connection" do
-    it "is fast because it is pooled" do
-      starting_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    # L'usage d'une pool de connexion offre de bien meilleures performances,
+    # ce test a donc été ajouté pour inciter à continuer d'en utiliser une.
+    it "is pooled" do
+      allow(Redis::CONNECTION_POOL).to receive(:with).and_call_original
 
-      10000.times do
-        described_class.with_connection do |redis|
-          redis.set("key", "value")
-        end
-      end
+      described_class.with_connection { |redis| redis.set("key", "value") }
+      described_class.with_connection { |redis| expect(redis.get("key")).to eq("value") }
 
-      ending_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      elapsed_time = ending_time - starting_time
-
-      # Without using a connection pool, 10000 connection checkouts + SET takes about 3000ms.
-      # With a connection pool, 10000 connection checkouts + SET takes about 400ms.
-      # This test ensures that 10000 checkouts + SET stays under 1000ms
-      expect(elapsed_time).to be < 1.0
+      expect(Redis::CONNECTION_POOL).to have_received(:with).twice
     end
   end
 end

--- a/spec/lib/redis_spec.rb
+++ b/spec/lib/redis_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Redis do
     it "is fast because it is pooled" do
       starting_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-      1000.times do
+      10000.times do
         described_class.with_connection do |redis|
           redis.set("key", "value")
         end
@@ -12,10 +12,10 @@ RSpec.describe Redis do
       ending_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elapsed_time = ending_time - starting_time
 
-      # Without using a connection pool, 1000 connection checkouts + SET takes about 300ms.
-      # With a connection pool, 1000 connection checkouts + SET takes about 45ms.
-      # This test ensures that 1000 checkouts + SET stays under 100ms
-      expect(elapsed_time).to be < 0.1
+      # Without using a connection pool, 10000 connection checkouts + SET takes about 3000ms.
+      # With a connection pool, 10000 connection checkouts + SET takes about 400ms.
+      # This test ensures that 10000 checkouts + SET stays under 1000ms
+      expect(elapsed_time).to be < 1.0
     end
   end
 end

--- a/spec/lib/redis_spec.rb
+++ b/spec/lib/redis_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Redis do
+  describe "#with_connection" do
+    it "is fast because it is pooled" do
+      starting_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      1000.times do
+        described_class.with_connection do |redis|
+          redis.set("key", "value")
+        end
+      end
+
+      ending_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      elapsed_time = ending_time - starting_time
+
+      # Without using a connection pool, 1000 connection checkouts + SET takes about 300ms.
+      # With a connection pool, 1000 connection checkouts + SET takes about 45ms.
+      # This test ensures that 1000 checkouts + SET stays under 100ms
+      expect(elapsed_time).to be < 0.1
+    end
+  end
+end


### PR DESCRIPTION
Lecture utile : 
https://tejasbubane.github.io/posts/2020-04-22-redis-connection-pool-in-rails/

Depuis #4106, nous ouvrons une connexion pour chaque appel à `User#user_in_waiting_room?`, donc à chaque render d'un RDV sur l'agenda agent (refresh toutes les minutes :fearful: ).

Avec ce changement, on utilise la gem `connection_pool` pour implémenter notre méthode maison `Redis.with_connection`. Cela a pour effet de ne pas devoir ouvrir une connexion à chaque appel à `Redis.with_connection`, ce qui divise environ par 10 l'exécution d'une commande (on fait en général 1 commande par connection).

~~J'ai ajouté un test de perf qui se base sur les perfs de ma machine, on va voir ce que ça donne en CI.~~
Les specs de perfs étant souvent flaky, la spec vérifie désormais uniquement que la pool est utilisée, et sert à prévenir les futur⋅es devs qu'une pool, c'est cool.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
