### PR TITLE
[Bug] Temporairement desactiver la validation sur le format de User#address et Lieu#address

### DIFF
--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -3,7 +3,6 @@ class Lieu < ApplicationRecord
   has_paper_trail
   include PhoneNumberValidation::HasPhoneNumber
   include WebhookDeliverable
-  include AddressConcern
 
   # Attributes
   auto_strip_attributes :name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,6 @@ class User < ApplicationRecord
   include WebhookDeliverable
   include TextSearch
   include UncommonPasswordConcern
-  include AddressConcern
 
   def self.search_options
     {

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -32,8 +32,8 @@ ruby:
             small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
               = t(".existing_lieu_hint_html")
       - elsif @rdv.home?
-        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}"
+        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", input_html: { class: "places-js-container" }
       - elsif @rdv.phone?
-        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique"
+        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", input_html: { class: "places-js-container" }
       = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input" }
       = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -54,7 +54,7 @@
                     = t(".existing_lieu_hint_html")
 
             - elsif @rdv_form.motif.home?
-              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true
+              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { class: "places-js-container" }
             = f.association :agents,
               collection: @rdv_form.motif.authorized_agents,
               label_method: :full_name_and_service,

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -53,7 +53,7 @@
   = f.input :city_name, as: :hidden, **input_opts
 
 - if current_territory.enable_address_details
-  = f.input :address_details, **input_opts
+  = f.input :address_details, **(input_opts.deep_merge(input_html: { class: "places-js-container" }))
 
 - if current_territory.enable_case_number
   = f.input :case_number, **input_opts

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Lieu, type: :model do
       end
     end
 
-    describe "address" do
+    pending "address" do
       context "address in wrong format" do
         let(:lieu) { build :lieu, address: "139 Rue de Bercy, 75012 Paris" }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "validations" do
-    describe "#address" do
+    pending "#address" do
       context "address in wrong format" do
         let(:user) { build :user, address: "139 Rue de Bercy, 75012 Paris" }
 


### PR DESCRIPTION
## Temporairement desactiver la validation sur le format de User#address

https://github.com/betagouv/rdv-service-public/pull/4192 introduit une validation sur le format des adresses pour les modèles `Lieu` et `User`.

Toutefois, ce changement introduit cette [erreur](https://sentry.incubateur.net/organizations/betagouv/issues/19164/?environment=production&project=74&query=is%3Aunresolved), du fait qu'il existe pas mal de `User` et des `Lieu`, avec des adresses dans un format incorrect.

La présente PR a pour but de temporairement désactiver ces validations sur les `User#address` ainsi que `Lieu#address`, le temps de corriger à l'aide d'un script, les données existantes.  Nous en profitons également pour corriger les champs d'édition d'adresse aussi bien côté usager que côté agent.

Je propose ce rollback partiel au lieu d'un rollback complet, afin de maintenir notamment:
- Les tests mis à jour, avec le bon format des adresses
- La mise à jour du champ Adresse dans le SuperAdmin