### PR TITLE
Ne pas proposer le service "Secrétariat" dans le formulaire de motif

### DIFF
--- a/app/views/admin/motifs/_form.html.slim
+++ b/app/views/admin/motifs/_form.html.slim
@@ -7,7 +7,7 @@
       h5.card-title Configuration générale
       .form-row
         .col-md-6
-          = f.association :service, collection: current_territory.services, input_html: { \
+          = f.association :service, collection: current_territory.services.reject(&:secretariat?), input_html: { \
             class: "select2-input", \
             data: { \
               placeholder: "Sélectionnez un service", \


### PR DESCRIPTION
Un motif n'est jamais lié à ce service, cf. `Motif#not_associated_with_secretariat`

J'ai appris ça en lisant cette fiche notion sur le formulaire de motif :
https://www.notion.so/rdvs/Retravailler-le-formulaire-de-cr-ation-de-motif-22d65b065ed44c8b9cddb9ba86774a15

Et par pure coïncidence je viens de tomber sur `not_associated_with_secretariat`, donc je sors ce quick win (je l'espère, je ne vois pas de piège :crossed_fingers: ).

# Avant

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/50dc165b-29cd-40b1-8515-882a46c0d721)


# Après

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/107eda22-7f5a-40f1-bc0e-5d2361551138)


# Checklist

Avant la revue :
- [X] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
