### PR TITLE
[Bugfix] Remove non null constraint on optional column

### DIFF
--- a/db/migrate/20240328122622_remove_non_null_constraint_from_by_created_by_type_in_participations.rb
+++ b/db/migrate/20240328122622_remove_non_null_constraint_from_by_created_by_type_in_participations.rb
@@ -1,0 +1,5 @@
+class RemoveNonNullConstraintFromByCreatedByTypeInParticipations < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :participations, :created_by_type, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_21_114146) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_28_122622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -474,7 +474,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_21_114146) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
-    t.string "created_by_type", null: false
+    t.string "created_by_type"
     t.boolean "created_by_agent_prescripteur", default: false, null: false
     t.index ["created_by_type", "created_by_id"], name: "index_participations_on_created_by_type_and_created_by_id"
     t.index ["invitation_token"], name: "index_participations_on_invitation_token", unique: true


### PR DESCRIPTION
https://github.com/betagouv/rdv-service-public/pull/3961/ introduit une contrainte `non null` sur la colonne `created_by_type` dans la table `Participations`.

Ce changement cause l'erreur Sentry [87024](https://sentry.incubateur.net/organizations/betagouv/issues/87024/events/e1b4921129684d19a4652e2d648686d7/?project=74) lors de certaines prises de RDV par prescripteur.

Par ailleurs, d'un point de vue fonctionnel `created_by` est optionnel, comme le montre l'association ci-dessous, et donc contradictoire avec la contrainte non null en DB.
```ruby
module CreatedByConcern
  extend ActiveSupport::Concern

  included do
    belongs_to :created_by, polymorphic: true, optional: true
  end
....
```