### PR TITLE
Exiger l'adresse lors de la confirmation d'un RDV à domicile

### DIFF
--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -1,6 +1,7 @@
 ruby:
-  form_url = local_assigns[:rdv_wizard].present? ? users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query.except(:rdv)) : users_informations_path
-  form_method = local_assigns[:rdv_wizard].present? ? "post" : "patch"
+  rdv_wizard = local_assigns[:rdv_wizard]
+  form_url = rdv_wizard.present? ? users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query.except(:rdv)) : users_informations_path
+  form_method = rdv_wizard.present? ? "post" : "patch"
   territories = Territory.joins(organisations: :user_profiles).where(user_profiles: { user_id: user.id }).to_a
 
 = simple_form_for user, url: form_url, method: form_method  do |f|
@@ -12,14 +13,14 @@ ruby:
     - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
       .col-md-6= f.input :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
       .col-md-6= date_input(f, :birth_date, disabled: user.logged_once_with_franceconnect?)
-  - if local_assigns[:rdv_wizard]&.rdv&.requires_ants_predemande_number? || current_user.rdvs.requires_ants_predemande_number.any?
+  - if rdv_wizard&.rdv&.requires_ants_predemande_number? || current_user.rdvs.requires_ants_predemande_number.any?
     = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   - if user.logged_once_with_franceconnect?
     .alert.alert-info.d-flex.align-items-center
       .mr-3
         .fa.fa-info
       div= I18n.t("users.franceconnect_frozen_fields")
-  = f.input :phone_number, as: :tel, required: local_assigns[:rdv_wizard]&.motif&.phone?
+  = f.input :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
   - if current_user.only_invited?
     = f.input :email, disabled: user.email.present? && !user.email_changed?, required: true
   - if user.phone_number.present? && !user.phone_number_mobile?
@@ -28,7 +29,7 @@ ruby:
   div= f.input :notify_by_email
   div= f.input :notify_by_sms
   - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
-    - address_value = local_assigns[:rdv_wizard].present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
+    - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
     = f.input :address, input_html: {value: address_value, class: "places-js-container" }
 
   - if territories.map(&:enable_address_details).any?
@@ -53,7 +54,7 @@ ruby:
         - if territories.map(&:enable_number_of_children_field).any?
           .col-md-6= f.input :number_of_children, input_html: { min: "0", max: "15", step: "any" }
 
-    - if local_assigns[:rdv_wizard]
+    - if rdv_wizard
       ruby:
         current_organisation = Motif.find(rdv_wizard.to_query[:motif_id]).organisation
       - if current_organisation.territory.enable_logement_field
@@ -61,9 +62,9 @@ ruby:
     - elsif territories.map(&:enable_logement_field).any?
       = f.input :logement, collection: User.human_attribute_values(:logement)
 
-  - if local_assigns[:rdv_wizard].present?
+  - if rdv_wizard.present?
     - rdv_wizard.to_query.each do |wizard_key, wizard_value|
       = hidden_field_tag "rdv[#{wizard_key}]", wizard_value
 
   .text-right
-    = f.button :submit, (local_assigns[:rdv_wizard].present? ? "Continuer" : "Modifier")
+    = f.button :submit, (rdv_wizard.present? ? "Continuer" : "Modifier")

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -30,7 +30,7 @@ ruby:
   div= f.input :notify_by_sms
   - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
-    = f.input :address, input_html: {value: address_value, class: "places-js-container" }
+    = f.input :address, input_html: {value: address_value, class: "places-js-container" }, required: rdv_wizard&.motif&.home?
 
   - if territories.map(&:enable_address_details).any?
     = f.input :address_details, input_html: {class: "places-js-container" }

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "User can search for rdvs" do
     end
   end
 
-  describe "when the motifs don't require a lieu" do
+  describe "Prise de RDV en ligne" do
     let!(:service) { create(:service) }
     let!(:territory) { create(:territory, departement_number: "92") }
     let!(:first_organisation_with_po) { create(:organisation, :with_contact, territory: territory) }
@@ -75,7 +75,7 @@ RSpec.describe "User can search for rdvs" do
       create(:motif, :by_phone, name: "RSA orientation par téléphone", organisation: organisation_without_po, restriction_for_rdv: nil, service: service)
     end
 
-    shared_examples "take a rdv without lieu" do
+    context "when the motif is by phone" do
       it "can take a RDV in the available organisations", js: true do
         visit root_path
         execute_search
@@ -103,16 +103,36 @@ RSpec.describe "User can search for rdvs" do
       end
     end
 
-    context "when the motif is by phone" do
-      it_behaves_like "take a rdv without lieu"
-    end
-
     context "when the motif is at home" do
       before do
         [first_motif, other_motif_with_po, motif_without_po].each { |m| m.update!(location_type: "home") }
       end
 
-      it_behaves_like "take a rdv without lieu"
+      it "can take a RDV in the available organisations", js: true do
+        visit root_path
+        execute_search
+
+        ## Organisation selection
+        expect(page).to have_content(first_organisation_with_po.name)
+        expect(page).to have_content(first_organisation_with_po.phone_number)
+        expect(page).to have_content(first_organisation_with_po.website)
+        expect(page).to have_content("mercredi 15 décembre 2021 à 11h00")
+
+        expect(page).to have_content(other_organisation_with_po.name)
+        expect(page).to have_content(other_organisation_with_po.phone_number)
+        expect(page).to have_content(other_organisation_with_po.website)
+        expect(page).to have_content("jeudi 16 décembre 2021 à 10h00")
+
+        expect(page).not_to have_content(organisation_without_po.name)
+
+        find(".card-title", text: /#{first_organisation_with_po.name}/).ancestor(".card").find("a.stretched-link").click
+
+        choose_creneau
+        sign_up
+        continue_to_rdv(first_motif, address: "03 Rue Lambert, Paris, 75016")
+        add_relative
+        confirm_rdv(first_motif)
+      end
     end
   end
 
@@ -390,10 +410,11 @@ RSpec.describe "User can search for rdvs" do
     click_button("Enregistrer")
   end
 
-  def continue_to_rdv(motif)
+  def continue_to_rdv(motif, address: nil)
     expect(page).to have_content("Vos informations")
     fill_in("Date de naissance", with: Time.zone.yesterday.strftime("%d/%m/%Y"))
     fill_in("Nom de naissance", with: "Lapinou")
+    fill_in("Adresse", with: address) if address
     click_button("Continuer")
 
     expect(page).to have_content(motif.name)


### PR DESCRIPTION
Le champ Adresse sur le formulaire de confirmation de RDV devient obligatoire, lorsqu'il s'agit d'un RDV à domicile.

## Before
![Before](https://github.com/betagouv/rdv-service-public/assets/11911945/8def9e4c-3a11-4fa6-aa48-3b283a2c7ea6)

## After
![After](https://github.com/betagouv/rdv-service-public/assets/11911945/6ac8a640-779e-438a-92c1-6a1167fa276c)
