### PR TITLE
[Admin de territoires] Corriger l'edition de services

### DIFF
--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -10,7 +10,7 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
 
   def update
     authorize current_territory
-    current_territory.update(services_params)
+    current_territory.update!(services_params)
     flash[:alert] = "Liste des services disponibles mise à jour"
 
     if params[:redirect_to_organisation_id].present?

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -43,7 +43,7 @@ class Territory < ApplicationRecord
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }
   validates :name, presence: true, if: -> { persisted? }
   validate do
-    if name_was == MAIRIES_NAME
+    if name_changed? && name_was == MAIRIES_NAME
       errors.add(:name, "Le nom de ce territoire permet de le brancher au moteur de recherche de l'ANTS et ne peut pas être changé")
     end
   end

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe "territory admin can manage agents", type: :feature do
+  # Le territoire doit avoir au moins un agent admin de territoire restant
+  let!(:territory) { create(:territory, name: Territory::MAIRIES_NAME).tap { |t| t.roles.create!(agent: create(:agent)) } }
+  let!(:agent) { create(:agent, role_in_territories: [territory]) }
+  let!(:service_a) { create(:service) }
+  let!(:service_b) { create(:service) }
+  let!(:service_c) { create(:service) }
+
+  before do
+    create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
+    create(:agent_role, agent: agent, access_level: "basic")
+    login_as(agent, scope: :agent)
+  end
+
+  describe "Listing services" do
+    it "works" do
+      visit edit_admin_territory_services_path(territory)
+
+      expect(page).to have_content("Vous pouvez activer ou désactiver les services auxquels vos agents peuvent être affectés.")
+      expect(page).to have_content(service_a.name)
+      expect(page).to have_content(service_b.name)
+      expect(page).to have_content(service_c.name)
+    end
+  end
+
+  describe "Activating/Deactivating services" do
+    it "works" do
+      visit edit_admin_territory_services_path(territory)
+      check service_a.name
+      check service_b.name
+
+      expect { click_on "Enregistrer" }.to change {
+        territory.reload.services.ids
+      }.from([]).to([service_a.id, service_b.id])
+      expect(page).to have_content("Liste des services disponibles mise à jour")
+
+      uncheck service_b.name
+      check service_c.name
+
+      expect { click_on "Enregistrer" }.to change {
+        territory.reload.services.ids
+      }.from([service_a.id, service_b.id]).to([service_a.id, service_c.id])
+      expect(page).to have_content("Liste des services disponibles mise à jour")
+    end
+  end
+end


### PR DESCRIPTION
Le commit https://github.com/betagouv/rdv-service-public/pull/3875/commits/7cdd5954a15e87822b40b1e7498d98bc797317cb introduit une validation dans le modèle `Territory` empêchant toute modification d'un territoire dans Rdv Mairie. 

Visiblement, l'intention de cette validation est d'empêcher la modification du nom du territoire uniquement, afin de ne pas impacter le branchement avec le moteur de l'ANTS. Cette validation erronée empêche donc l'édition des services d'un territoire dans Rdv Mairie, avec l'erreur suivante (se produisant en silence) : 
```
 ActiveRecord::RecordInvalid:
       La validation a échoué : Nom Le nom de ce territoire permet de le brancher au moteur de recherche de l'ANTS et ne peut pas être changé
```

Dans cette PR, nous corrigeons la validation pour la limiter uniquement au nom de territoire. Nous en profitons pour rajouter un test sur l'édition des services (sur Rdv Mairie), et la possibilité de lever une exception dans Sentry en cas d'échec de la mise à jour des services d'un territoire.