### PR TITLE
Supprimer le code de rétro-compatibilité dans SmsJob

### DIFF
--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -4,21 +4,10 @@ class SmsJob < ApplicationJob
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
 
-  def perform(*_args, **kwargs)
-    sender_name = kwargs[:sender_name]
-    phone_number = kwargs[:phone_number]
-    content = kwargs[:content]
-    receipt_params = kwargs[:receipt_params]
-
-    # TODO: retirer la branche else 2 semaines après le merge (elle gère les args des anciens jobs)
-    if kwargs[:territory_id]
-      territory = Territory.find(kwargs[:territory_id])
-      provider = territory&.sms_provider || ENV["DEFAULT_SMS_PROVIDER"].presence || :debug_logger
-      api_key = territory&.sms_configuration || ENV["DEFAULT_SMS_PROVIDER_KEY"]
-    else
-      provider = kwargs[:provider]
-      api_key = kwargs[:api_key]
-    end
+  def perform(sender_name:, phone_number:, content:, territory_id:, receipt_params:)
+    territory = Territory.find(territory_id)
+    provider = ENV["FORCE_SMS_PROVIDER"].presence || territory&.sms_provider || ENV["DEFAULT_SMS_PROVIDER"].presence || :debug_logger
+    api_key = territory&.sms_configuration || ENV["DEFAULT_SMS_PROVIDER_KEY"]
 
     SmsSender.perform_with(sender_name, phone_number, content, provider, api_key, receipt_params)
   end

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -18,7 +18,7 @@ class SmsSender < BaseService
       content,
     ].compact
       .join("\n")
-      .tr("áâãëẽêíïîĩóôõúûũçÀÁÂÃÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ", "aaaeeeiiiiooouuucAAAAEEEEIIIIIOOOOUUUU")
+      .tr("áâãçëẽêíïîĩóôõúûũÀÁÂÃÇÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ", "aaaceeeiiiiooouuuAAAACEEEEIIIIIOOOOUUUU")
       .gsub("œ", "oe")
   end
 

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -1,16 +1,52 @@
 RSpec.describe SmsJob do
+  let!(:territory) { create(:territory) }
+  let(:content) { "contenu du message" }
+
+  def enqueue_sms_job
+    described_class.perform_later(
+      sender_name: "RdvSoli",
+      phone_number: "0611223344",
+      content: content,
+      territory_id: territory.id,
+      receipt_params: {}
+    )
+  end
+
+  it "works with netsize" do
+    stub_netsize_ok
+
+    enqueue_sms_job
+    perform_enqueued_jobs
+
+    expected_body = {
+      destinationAddress: "0611223344",
+      maxConcatenatedMessages: "10",
+      messageText: "contenu du message",
+      originatingAddress: "RdvSoli",
+      originatorTON: "1",
+    }
+    expect(WebMock).to have_requested(:post, "https://europe.ipx.com/restapi/v1/sms/send").with(body: expected_body)
+  end
+
+  describe "content processing" do
+    let(:content) { "Ça, du maïs grillé !? Mon œil ! áâãçëẽêíïîĩóôõúûũÀÁÂÃÇÈËẼÊÌÍÏÎĨÒÓÔÕÙÚÛŨ" }
+
+    it "removes exotic accents but preserves common ones" do
+      stub_netsize_ok
+
+      enqueue_sms_job
+      perform_enqueued_jobs
+
+      expected_content = "Ca, du mais grillé !? Mon oeil ! aaaceeeiiiiooouuuAAAACEEEEIIIIIOOOOUUUU"
+      expect(WebMock).to have_requested(:post, "https://europe.ipx.com/restapi/v1/sms/send").with(body: match(ERB::Util.url_encode(expected_content)))
+    end
+  end
+
   describe "error logging" do
     it "only sends error to Sentry after 3rd error" do
       allow(SmsSender).to receive(:perform_with).and_raise("erreur inattendue")
 
-      described_class.perform_later(
-        sender_name: "RdvSoli",
-        phone_number: "0611223344",
-        content: "test",
-        provider: "netsize",
-        api_key: "fake_key",
-        receipt_params: {}
-      )
+      enqueue_sms_job
 
       expect(enqueued_jobs.first["executions"]).to eq(0)
 
@@ -29,34 +65,6 @@ RSpec.describe SmsJob do
       expect(enqueued_jobs.first["executions"]).to eq(3)
       expect(sentry_events.last.exception.values.last.type).to eq("RuntimeError")
       expect(sentry_events.last.exception.values.last.value).to eq("erreur inattendue (RuntimeError)")
-    end
-  end
-
-  describe "arguments delegation" do
-    it "works with :provider and :api_key" do
-      expect(SmsSender).to receive(:perform_with).with("RdvSoli", "0611223344", "test", "netsize", "fake_key", {})
-      described_class.perform_later(
-        sender_name: "RdvSoli",
-        phone_number: "0611223344",
-        content: "test",
-        provider: "netsize",
-        api_key: "fake_key",
-        receipt_params: {}
-      )
-      perform_enqueued_jobs
-    end
-
-    it "works with :territory_id" do
-      territory = create(:territory)
-      expect(SmsSender).to receive(:perform_with).with("RdvSoli", "0611223344", "test", territory.sms_provider, territory.sms_configuration, {})
-      described_class.perform_later(
-        sender_name: "RdvSoli",
-        phone_number: "0611223344",
-        content: "test",
-        territory_id: territory.id,
-        receipt_params: {}
-      )
-      perform_enqueued_jobs
     end
   end
 end

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SmsSender, type: :service do
     context "remove accents and weird chars" do
       let(:content) { "àáäâãèéëẽêìíïîĩòóöôõùúüûũñçÀÁÄÂÃÈÉËẼÊÌÍÏÎĨÒÓÖÔÕÙÚÜÛŨÑÇ" }
 
-      it { is_expected.to eq("àaäaaèéeeeìiiiiòoöooùuüuuñcAAÄAAEÉEEEIIIIIOOÖOOUUÜUUÑÇ") }
+      it { is_expected.to eq("àaäaaèéeeeìiiiiòoöooùuüuuñcAAÄAAEÉEEEIIIIIOOÖOOUUÜUUÑC") }
     end
 
     context "oe character" do


### PR DESCRIPTION
Dans #4045 nous avions changé la "signature" de `SmsJob` pour ne plus lui passer en clair des credentials, mais plutôt un `territory_id` qui permet de récupérer ces credentials dans la config du territoire.

Du code de rétro-compatibilité avait été ajouté pour supporter les deux signatures.

Dans cette suite, je vire le code de rétro-compatibilité et j'ajoute une spec généraliste sur l'envoi de SMS (et oui, on avait rien de précis jusqu'ici hormis nos usages de `stub_netsize_ok` qui ne vérifier pas grand chose).

Prochaine étape de refacto : fusionner `SmsJob` et `SmsSender` puisque `SmsJob` ne fait que passer les args et introduit donc de l'indirection.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
