### PR TITLE
Spécifier `meeting_point_id` dans nos déclarations à l'ANTS

### DIFF
--- a/app/models/concerns/ants/appointment_serializer_and_listener.rb
+++ b/app/models/concerns/ants/appointment_serializer_and_listener.rb
@@ -36,6 +36,7 @@ module Ants
 
     def serialize_for_ants_api
       {
+        meeting_point_id: lieu.id.to_s,
         meeting_point: lieu.name,
         appointment_date: starts_at.strftime("%Y-%m-%d %H:%M:%S"),
         management_url: Rails.application.routes.url_helpers.users_rdv_url(self, host: organisation.domain.host_name),

--- a/app/services/ants_api/appointment.rb
+++ b/app/services/ants_api/appointment.rb
@@ -2,19 +2,20 @@ module AntsApi
   class Appointment
     class ApiRequestError < StandardError; end
 
-    attr_reader :application_id, :meeting_point, :appointment_date, :management_url
+    attr_reader :application_id, :meeting_point_id, :meeting_point, :appointment_date, :management_url
 
-    def initialize(application_id:, meeting_point:, appointment_date:, management_url:, editor_comment: nil)
+    def initialize(application_id:, meeting_point:, appointment_date:, management_url:, meeting_point_id: nil)
       @application_id = application_id
+      @meeting_point_id = meeting_point_id
       @meeting_point = meeting_point
       @appointment_date = appointment_date
       @management_url = management_url
-      @editor_comment = editor_comment
     end
 
     def to_request_params
       {
         application_id: application_id,
+        meeting_point_id: meeting_point_id,
         meeting_point: meeting_point,
         appointment_date: appointment_date,
         management_url: management_url,

--- a/app/services/ants_api/appointment.rb
+++ b/app/services/ants_api/appointment.rb
@@ -2,8 +2,6 @@ module AntsApi
   class Appointment
     class ApiRequestError < StandardError; end
 
-    attr_reader :application_id, :meeting_point_id, :meeting_point, :appointment_date, :management_url
-
     def initialize(application_id:, meeting_point:, appointment_date:, management_url:, meeting_point_id: nil)
       @application_id = application_id
       @meeting_point_id = meeting_point_id
@@ -14,11 +12,11 @@ module AntsApi
 
     def to_request_params
       {
-        application_id: application_id,
-        meeting_point_id: meeting_point_id,
-        meeting_point: meeting_point,
-        appointment_date: appointment_date,
-        management_url: management_url,
+        application_id: @application_id,
+        meeting_point_id: @meeting_point_id,
+        meeting_point: @meeting_point,
+        appointment_date: @appointment_date,
+        management_url: @management_url,
       }
     end
 

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           appointments: [
             {
               management_url: Rails.application.routes.url_helpers.users_rdv_url(rdv, host: organisation.domain.host_name),
+              meeting_point_id: rdv.lieu.id.to_s,
               meeting_point: rdv.lieu.name,
               appointment_date: rdv.starts_at.strftime("%Y-%m-%d %H:%M:%S"),
             },
@@ -55,8 +56,10 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           rdv.save
           expect(WebMock).to have_requested(
             :post,
-            "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=Lieu1"
-          ).with(headers: ants_api_headers)
+            "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=#{rdv.lieu.name}&meeting_point_id=#{rdv.lieu.id}"
+          ).with(
+            headers: ants_api_headers
+          )
         end
       end
 
@@ -97,7 +100,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           rdv.destroy
           expect(WebMock).to have_requested(
             :delete,
-            "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&meeting_point=Lieu1"
+            "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&meeting_point=#{rdv.lieu.name}&meeting_point_id=#{rdv.lieu.id}"
           ).with(headers: ants_api_headers).at_least_once
         end
       end
@@ -117,7 +120,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
             expect(WebMock).to have_requested(
               :delete,
-              "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&meeting_point=Lieu1"
+              "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&meeting_point=#{rdv.lieu.name}&meeting_point_id=#{rdv.lieu.id}"
             ).with(headers: ants_api_headers).at_least_once
           end
         end
@@ -133,7 +136,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             rdv.seen!
             expect(WebMock).to have_requested(
               :post,
-              "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=Lieu1"
+              "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=A123456789&appointment_date=2020-04-20%2008:00:00&management_url=http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}&meeting_point=#{rdv.lieu.name}&meeting_point_id=#{rdv.lieu.id}"
             ).with(headers: ants_api_headers)
           end
         end

--- a/spec/services/ants_api/appointment_spec.rb
+++ b/spec/services/ants_api/appointment_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AntsApi::Appointment, type: :service do
   describe "#create" do
     context "when creation is successful" do
       before do
-        stub_request(:post, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=XXXX&appointment_date=2023-04-03T08:45:00&management_url=https://gerer-rdv.com&meeting_point=Mairie%20de%20Sannois").to_return(
+        stub_request(:post, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments?application_id=XXXX&appointment_date=2023-04-03T08:45:00&management_url=https://gerer-rdv.com&meeting_point=Mairie%20de%20Sannois&meeting_point_id=123456").to_return(
           status: 200,
           body: <<~JSON
             {
@@ -36,7 +36,7 @@ RSpec.describe AntsApi::Appointment, type: :service do
       end
 
       it "returns request body" do
-        appointment = described_class.new(application_id: "XXXX", management_url: "https://gerer-rdv.com", meeting_point: "Mairie de Sannois", appointment_date: "2023-04-03T08:45:00")
+        appointment = described_class.new(application_id: "XXXX", management_url: "https://gerer-rdv.com", meeting_point_id: "123456", meeting_point: "Mairie de Sannois", appointment_date: "2023-04-03T08:45:00")
         expect(appointment.create).to eq({ "success" => true })
       end
     end

--- a/spec/services/ants_api/appointment_spec.rb
+++ b/spec/services/ants_api/appointment_spec.rb
@@ -36,7 +36,13 @@ RSpec.describe AntsApi::Appointment, type: :service do
       end
 
       it "returns request body" do
-        appointment = described_class.new(application_id: "XXXX", management_url: "https://gerer-rdv.com", meeting_point_id: "123456", meeting_point: "Mairie de Sannois", appointment_date: "2023-04-03T08:45:00")
+        appointment = described_class.new(
+          application_id: "XXXX",
+          management_url: "https://gerer-rdv.com",
+          meeting_point_id: "123456",
+          meeting_point: "Mairie de Sannois",
+          appointment_date: "2023-04-03T08:45:00"
+        )
         expect(appointment.create).to eq({ "success" => true })
       end
     end


### PR DESCRIPTION
# Pourquoi

Aujourd'hui lors d'un atelier d'échange avec l'ANTS, ils ont annoncé qu'à partir du 1er juillet 2024 le champ `meeting_point_id` sera obligatoire dans les appels à `/api/appointments` (**POST et DELETE**).

Doc API :
https://api-coordination.rendezvouspasseport.ants.gouv.fr/docs

Pour rappel, cette valeur est utilisée par l'ANTS pour croiser les données qu'on leur fournit dans `get_managed_meeting_points`. **Le but est pour eux d'identifier quelles mairies utilisent le système de détection de doublons afin de leur octroyer une aide financière.**

# Comment

Dans cette PR nous ajoutons `meeting_point_id` à la liste des attributs que nous spécifions lors de l'appel de l'API pour créer ou supprimer un appointment. 

Note : on utilise les ID des lieux directement, ce qui m'a fait un peu peur car ils ne sont pas du tout uniques sur l'ensemble de nos instances. J'aurais préféré qu'on leur communique un UUID, et c'est pas clair pour moi si c'est trop tard. Le plus probable c'est que l'ANTS ne communiquera qu'avec notre instance `production-rdv-mairie`, et le jour où ça change on traitera ce problème.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
