### PR TITLE
Hotfix: Crash lors de l'instanciation d'un Appointment dans sync_appointment_job.rb

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -49,7 +49,7 @@ module Ants
       users.each do |user|
         existing_appointment(user)&.delete
 
-        AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, **@appointment_data).create
+        AntsApi::Appointment.new(application_id: user.ants_pre_demande_number, appointment_data: @appointment_data).create
       end
     end
 

--- a/app/services/ants_api/appointment.rb
+++ b/app/services/ants_api/appointment.rb
@@ -2,12 +2,13 @@ module AntsApi
   class Appointment
     class ApiRequestError < StandardError; end
 
-    def initialize(application_id:, meeting_point:, appointment_date:, management_url:, meeting_point_id: nil)
+    def initialize(application_id:, appointment_data:)
       @application_id = application_id
-      @meeting_point_id = meeting_point_id
-      @meeting_point = meeting_point
-      @appointment_date = appointment_date
-      @management_url = management_url
+      appointment_data = appointment_data.with_indifferent_access
+      @meeting_point_id = appointment_data[:meeting_point_id]
+      @meeting_point = appointment_data[:meeting_point]
+      @appointment_date = appointment_data[:appointment_date]
+      @management_url = appointment_data[:management_url]
     end
 
     def to_request_params
@@ -51,12 +52,12 @@ module AntsApi
         appointment_data = load_appointments(application_id).find do |appointment|
           appointment["management_url"] == management_url
         end
-        Appointment.new(application_id: application_id, **appointment_data.symbolize_keys) if appointment_data
+        Appointment.new(application_id: application_id, appointment_data: appointment_data) if appointment_data
       end
 
       def first(application_id:, timeout: nil)
         appointment_data = load_appointments(application_id, timeout: timeout).first
-        Appointment.new(application_id: application_id, **appointment_data.symbolize_keys) if appointment_data
+        Appointment.new(application_id: application_id, appointment_data: appointment_data) if appointment_data
       end
 
       def status(application_id:, timeout: nil)

--- a/app/services/ants_api/appointment.rb
+++ b/app/services/ants_api/appointment.rb
@@ -2,13 +2,20 @@ module AntsApi
   class Appointment
     class ApiRequestError < StandardError; end
 
+    # Voir la liste des attributs sur la doc API :
+    # https://api-coordination.rendezvouspasseport.ants.gouv.fr/docs
     def initialize(application_id:, appointment_data:)
       @application_id = application_id
+
       appointment_data = appointment_data.with_indifferent_access
+
+      # required attrs
+      @appointment_date = appointment_data.fetch(:appointment_date)
+      @management_url = appointment_data.fetch(:management_url)
+      @meeting_point = appointment_data.fetch(:meeting_point)
+
+      # optional attrs
       @meeting_point_id = appointment_data[:meeting_point_id]
-      @meeting_point = appointment_data[:meeting_point]
-      @appointment_date = appointment_data[:appointment_date]
-      @management_url = appointment_data[:management_url]
     end
 
     def to_request_params

--- a/spec/services/ants_api/appointment_spec.rb
+++ b/spec/services/ants_api/appointment_spec.rb
@@ -38,10 +38,12 @@ RSpec.describe AntsApi::Appointment, type: :service do
       it "returns request body" do
         appointment = described_class.new(
           application_id: "XXXX",
-          management_url: "https://gerer-rdv.com",
-          meeting_point_id: "123456",
-          meeting_point: "Mairie de Sannois",
-          appointment_date: "2023-04-03T08:45:00"
+          appointment_data: {
+            management_url: "https://gerer-rdv.com",
+            meeting_point_id: "123456",
+            meeting_point: "Mairie de Sannois",
+            appointment_date: "2023-04-03T08:45:00",
+          }
         )
         expect(appointment.create).to eq({ "success" => true })
       end


### PR DESCRIPTION
Ce crash vient d'être causé par #4216, je n'avais pas anticipé que l'API allait nous fournir des attributs non déclarés dans la signature de `Appointment#initialize`. Je fais en sorte que cette signature accepte un hash, on voit quand-même ce qui est utilisé dans le corps de la méthode.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
