### PR TITLE
Enlever le bouton "invitations" du menu de droite

### DIFF
--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -2,19 +2,20 @@
 
 - content_for(:title, "Invitations en cours pour #{current_organisation.name}")
 
-- if current_agent_can?(:create, Agent)
-  - content_for :breadcrumb do
+
+- content_for :breadcrumb do
+  = link_to "Retour à la liste des agents", admin_organisation_agents_path(current_organisation), class:"mr-2"
+  - if current_agent_can?(:create, Agent)
     = link_to "Inviter un agent", new_admin_organisation_agent_path(current_organisation), class:"btn btn-outline-primary"
+
 
 = simple_form_for "", url: admin_organisation_invitations_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   .container-fluid.bg-white.rounded
-    .m-3.d-flex.justify-content-between
-      = link_to "Retour à la liste des agents", admin_organisation_agents_path(current_organisation)
+    .m-3.d-flex.justify-content-end
       - search = params[:search].blank? ? "d-none" : ""
-      div
-        = link_to t("helpers.reset"), admin_organisation_invitations_path(current_organisation), class: "btn btn-link #{search}"
-        = f.input :search, placeholder: "Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
-        = f.button :submit, t("helpers.search")
+      div= link_to t("helpers.reset"), admin_organisation_invitations_path(current_organisation), class: "btn btn-link #{search}"
+      = f.input :search, placeholder: "Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+      = f.button :submit, t("helpers.search")
     table.table
       thead
         tr

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -2,12 +2,10 @@
 
 - content_for(:title, "Invitations en cours pour #{current_organisation.name}")
 
-
 - content_for :breadcrumb do
   = link_to "Retour à la liste des agents", admin_organisation_agents_path(current_organisation), class:"mr-2"
   - if current_agent_can?(:create, Agent)
     = link_to "Inviter un agent", new_admin_organisation_agent_path(current_organisation), class:"btn btn-outline-primary"
-
 
 = simple_form_for "", url: admin_organisation_invitations_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   .container-fluid.bg-white.rounded

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -8,11 +8,13 @@
 
 = simple_form_for "", url: admin_organisation_invitations_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   .container-fluid.bg-white.rounded
-    .m-3.d-flex.justify-content-end
+    .m-3.d-flex.justify-content-between
+      = link_to "Retour à la liste des agents", admin_organisation_agents_path(current_organisation)
       - search = params[:search].blank? ? "d-none" : ""
-      div= link_to t("helpers.reset"), admin_organisation_invitations_path(current_organisation), class: "btn btn-link #{search}"
-      = f.input :search, placeholder: "Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
-      = f.button :submit, t("helpers.search")
+      div
+        = link_to t("helpers.reset"), admin_organisation_invitations_path(current_organisation), class: "btn btn-link #{search}"
+        = f.input :search, placeholder: "Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+        = f.button :submit, t("helpers.search")
     table.table
       thead
         tr

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -106,9 +106,7 @@ nav.left-side-menu-wrapper
               li
                 = active_link_to "Lieux", admin_organisation_lieux_path(current_organisation), class: "side-menu__item side-menu__item--small"
               li
-                = active_link_to "Agents", admin_organisation_agents_path(current_organisation), class: "side-menu__item side-menu__item--small"
-              li
-                = active_link_to "Invitations", admin_organisation_invitations_path(current_organisation), class: "side-menu__item side-menu__item--small"
+                = active_link_to "Agents", admin_organisation_agents_path(current_organisation), active: [["admin/agents", "admin/invitations"], []], class: "side-menu__item side-menu__item--small"
               li
                 = active_link_to "Motifs", admin_organisation_motifs_path(current_organisation), class: "side-menu__item side-menu__item--small"
               - if current_agent.territorial_admin_in?(current_organisation.territory)


### PR DESCRIPTION
Le bouton Invitations du menu de gauche porte à confusion pour les agents utilisateurs de RDVI (qui pensent qu'il s'agit des invitations usagers)
Dans cette PR j'enlève le bouton et je fait en sorte que "Agent" dans le menu de droite soit actif quand on se trouve sur la gestion des invitations des agents et j'ajoute un lien 'Retour à la liste des agents'. Il n'y a pas d'autre changements. J'y ai passé très peu de temps pour un quickwin et régler la demande de rdvi mais on peut aller plus loin si besoin (enlever l'index des invitations, ajouter un filtre dans l'index des agents par exemple)

Avant :

<img width="1677" alt="Capture d’écran 2024-04-11 à 19 04 03" src="https://github.com/betagouv/rdv-service-public/assets/28594222/35d6e918-ecff-413c-9ed6-4f16b5227097">

Après :
<img width="1677" alt="Capture d’écran 2024-04-12 à 11 02 36" src="https://github.com/betagouv/rdv-service-public/assets/28594222/ab02f8bb-9f15-426c-a462-1202461cb707">


La page de gestion des invitations reste accessible depuis la liste des agents : 

<img width="1677" alt="Capture d’écran 2024-04-11 à 19 04 43" src="https://github.com/betagouv/rdv-service-public/assets/28594222/806769d5-c38d-4c63-aff3-5127ee4d9a2a">
