### PR TITLE
Correctif pour les polices et icônes dsfr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
         run: yarn install
       - name: Precompile assets
         run: yarn run build
+      - name: Simulate Scalingo slug build
+        run: cat .slugignore | grep -v spec | xargs rm -r
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test unit spec runtime log
@@ -177,6 +179,8 @@ jobs:
         run: yarn install
       - name: Precompile assets
         run: yarn run build
+      - name: Simulate Scalingo slug build
+        run: cat .slugignore | grep -v spec | xargs rm -r
       - name: Prepare runtime log cache key
         run: ls spec/features/**/*.rb > tmp/feature_spec_files.txt
       - name: Cache parallel test feature spec runtime log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,6 @@ jobs:
         run: yarn install
       - name: Precompile assets
         run: yarn run build
-      - name: Simulate Scalingo slug build
-        run: cat .slugignore | grep -v spec | xargs rm -r
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test unit spec runtime log
@@ -179,8 +177,6 @@ jobs:
         run: yarn install
       - name: Precompile assets
         run: yarn run build
-      - name: Simulate Scalingo slug build
-        run: cat .slugignore | grep -v spec | xargs rm -r
       - name: Prepare runtime log cache key
         run: ls spec/features/**/*.rb > tmp/feature_spec_files.txt
       - name: Cache parallel test feature spec runtime log

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ coverage/
 !/app/assets/builds/.keep
 
 /public/assets/*
+/public/fonts/*
+/public/icons/*
 
 # Postgres dumps
 **/20*.tar.gz

--- a/.slugignore
+++ b/.slugignore
@@ -1,5 +1,5 @@
 spec
 docs
-tmp/cache
-node_modules
-.cache/yarn
+/tmp/cache
+/node_modules
+/.cache/yarn

--- a/.slugignore
+++ b/.slugignore
@@ -1,5 +1,5 @@
 spec
 docs
-/tmp/cache
-/node_modules
-/.cache/yarn
+tmp/cache
+node_modules
+.cache/yarn

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lapin",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts/ public/fonts; cp -r node_modules/@gouvfr/dsfr/dist/icons/ public/icons;"
+    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts/*.(woff|woff2) public/fonts; cp -r node_modules/@gouvfr/dsfr/dist/icons/**/*.svg public/icons;"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lapin",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts/ public/fonts; cp -r node_modules/@gouvfr/dsfr/dist/icons/ public/icons;"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lapin",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts/*.{woff,woff2} public/fonts; cp -r node_modules/@gouvfr/dsfr/dist/icons/**/*.svg public/icons;"
+    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts public; cp -r node_modules/@gouvfr/dsfr/dist/icons public;"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lapin",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts/*.(woff|woff2) public/fonts; cp -r node_modules/@gouvfr/dsfr/dist/icons/**/*.svg public/icons;"
+    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts/*.{woff,woff2} public/fonts; cp -r node_modules/@gouvfr/dsfr/dist/icons/**/*.svg public/icons;"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/public/fonts
+++ b/public/fonts
@@ -1,1 +1,0 @@
-../node_modules/@gouvfr/dsfr/dist/fonts/

--- a/public/icons
+++ b/public/icons
@@ -1,1 +1,0 @@
-../node_modules/@gouvfr/dsfr/dist/icons/


### PR DESCRIPTION
### Avant

<img width="1365" alt="Screenshot 2024-04-15 at 17 05 08" src="https://github.com/betagouv/rdv-service-public/assets/1840367/c307b9cd-b3cb-4da7-a561-23d331a4955c">
<img width="511" alt="Screenshot 2024-04-15 at 17 05 44" src="https://github.com/betagouv/rdv-service-public/assets/1840367/bd720495-4513-400e-bd60-a158d84799b3">

### Après

<img width="1327" alt="Screenshot 2024-04-15 at 17 05 19" src="https://github.com/betagouv/rdv-service-public/assets/1840367/19e09847-5dbb-4eef-bcee-116731cbca8a">
<img width="527" alt="Screenshot 2024-04-15 at 17 05 50" src="https://github.com/betagouv/rdv-service-public/assets/1840367/2c065613-deab-43f5-b4f6-3fb3b8a7c113">

### Le problème

Sur la page d'accueil de rdv mairie, on utilise les fiches de style minifiées du dsfr distribuées via le package node. Elles nécessitent que les polices soient disponibles via le path `/fonts` et les icônes via `/icons`.
A l'époque on avait résolu ça simplement en mettant en place des symlinks depuis `public/fonts` et `public/icons` vers `../node_modules/@gouvfr/dsfr/dist/fonts/` et `../node_modules/@gouvfr/dsfr/dist/icons/` (voir https://github.com/betagouv/rdv-service-public/pull/3551, l'avantage étant que ça permettait d'éviter de committer les fonts et les icônes)

Or, depuis https://github.com/betagouv/rdv-service-public/pull/4168, on n'inclus plus le dossier `node_modules` dans notre slug qui est déployé dans les containers scalingo, donc le symllink ne fonctionne pas, donc les polices ne se chargent pas (et on fallback sur Arial).

## La solution

Pour rappel, quand on lance `rails asset:precompile`, ça lance un ` yarn run build`, qui lance un `webpack --config webpack.config.js`, qui ensuite fait de la magie noire pour que les assets soient disponible dans `public/assets/` et que les `stylesheet_link_tag` et `javascript_include_tag` pointent vers les bon path.

J'ai essayé un premier fix avec un plugin webpack (https://webpack.js.org/plugins/copy-webpack-plugin/), mais ça permettait uniquement de copier les fonts et icônes vers le path des assets webpack (avec la clé de cache webpack dans le path), et pas vers les path statiques `/fonts` et `/icons`.

Du coup je suis revenu vers un fix beaucoup plus simple : ajouter un bête `cp` unix équivalent aux symlinks.

### Un fix plus durable

Pour limiter la différence entre la production et notre CI, je serais tenté de simuler la construction du slug scalingo en ajoutant une étape `cat .slugignore | xargs rm -r` à notre build de CI. En l'occurrence, ça aurait permis de voir cette erreur au moment du build et pas en production.
(Et contrairement à ce qu'on espérait dans la discussion mattermost, une gem de diff de screenshot n'aurait pas attrappé cette erreur, parce qu'on a encore les node_modules dans la CI).
C'est un peu plus complexe, donc je préfère garder ça dans un deuxième temps (et en priorité corriger la prod)