### PR TITLE
Stocker uniquement les headers HTTP (upcase) en base pour les logs API

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -124,7 +124,8 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       method: request.method,
       path: request.fullpath,
       host: request.host,
-      headers: request.headers.to_h.transform_values { |value| value.is_a?(String) ? value : value.inspect },
+      # We only keep headers that are uppercase (convention for HTTP headers)
+      headers: request.headers.select { |key, _| key == key.upcase }.to_h.transform_values { |value| value.is_a?(String) ? value : value.inspect },
     }
 
     ApiCall.create!(

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
           )
           expect(ApiCall.first.raw_http["method"]).to eq("GET")
           expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
+          expect(ApiCall.first.raw_http["headers"]).not_to include("rack.session.options")
           expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
         end
 


### PR DESCRIPTION
Fix suite à https://sentry.incubateur.net/organizations/betagouv/issues/96505/?project=74&referrer=webhooks_plugin
En l'état on stocke trop de choses qui n'ont rien à voir avec les headers (middleware rack, config puma...) dont des informations qui ne proviennent même pas de la session actuelle (dans `rack.session.options` par exemple) ce qui donne lieu à des remontée dans sentry qui peuvent induire en erreur.
On part du principe que les headers sont upcase, on filtre donc la dessus. Cela réduit considérablement la taille des valeurs `raw_http["headers"]` des `ApiCall` et évite les erreurs et la surcharge d'infos inutiles.
