### PR TITLE
Ne plus permettre aux super-admins de se propager

### DIFF
--- a/app/dashboards/super_admin_dashboard.rb
+++ b/app/dashboards/super_admin_dashboard.rb
@@ -34,25 +34,12 @@ class SuperAdminDashboard < Administrate::BaseDashboard
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
-  SHOW_PAGE_ATTRIBUTES = %i[
-    id
-    email
-    role
-    first_name
-    last_name
-    created_at
-    updated_at
-  ].freeze
+  SHOW_PAGE_ATTRIBUTES = %i[].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = %i[
-    email
-    role
-    first_name
-    last_name
-  ].freeze
+  FORM_ATTRIBUTES = %i[].freeze
 
   # Overwrite this method to customize how super admins are displayed
   # across all pages of the super_admin dashboard.

--- a/app/policies/super_admin/super_admin_policy.rb
+++ b/app/policies/super_admin/super_admin_policy.rb
@@ -1,13 +1,5 @@
 class SuperAdmin::SuperAdminPolicy < DefaultSuperAdminPolicy
-  def privileges_for_record?
-    legacy_admin_member? || (record.support_member? && support_member?)
-  end
 
   alias index? team_member?
-  alias show? team_member?
-  alias new? team_member?
-  alias create? privileges_for_record?
-  alias edit? privileges_for_record?
-  alias update? privileges_for_record?
-  alias destroy? privileges_for_record?
+  alias destroy? team_member?
 end

--- a/app/policies/super_admin/super_admin_policy.rb
+++ b/app/policies/super_admin/super_admin_policy.rb
@@ -1,5 +1,4 @@
 class SuperAdmin::SuperAdminPolicy < DefaultSuperAdminPolicy
-
   alias index? team_member?
   alias destroy? team_member?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     resources :agent_roles, only: %i[show edit update destroy]
     resources :agent_services, only: %i[show destroy]
     resources :user_profiles, only: %i[destroy]
-    resources :super_admins
+    resources :super_admins, only: %i[index destroy]
     resources :organisations
     resources :services
     resources :motifs

--- a/spec/policies/super_admin/super_admin_policy_spec.rb
+++ b/spec/policies/super_admin/super_admin_policy_spec.rb
@@ -6,20 +6,19 @@ RSpec.describe SuperAdmin::SuperAdminPolicy, type: :policy do
   let!(:new_legacy_admin_member) { build(:super_admin) }
 
   context "Permitted actions for super_admin" do
-    it_behaves_like "permit actions", :new_legacy_admin_member, :index?, :show?, :new?, :create?, :edit?, :update?, :destroy?
+    it_behaves_like "permit actions", :new_legacy_admin_member, :index?, :destroy?
   end
 
   context "permitted actions for support on super_admin role" do
     let!(:pundit_context) { create(:super_admin, :support) }
 
-    it_behaves_like "permit actions", :new_legacy_admin_member, :index?, :show?, :new?
-    it_behaves_like "not permit actions", :new_legacy_admin_member, :create?, :edit?, :update?, :destroy?
+    it_behaves_like "permit actions", :new_legacy_admin_member, :index?, :destroy?
   end
 
   context "permitted actions for support on support role" do
     let!(:pundit_context) { create(:super_admin, :support) }
     let!(:new_support_member) { build(:super_admin, :support) }
 
-    it_behaves_like "permit actions", :new_support_member, :index?, :show?, :new?, :create?, :edit?, :update?, :destroy?
+    it_behaves_like "permit actions", :new_support_member, :index?, :destroy?
   end
 end


### PR DESCRIPTION
Dans le contexte de l'audit de sécurité, nous avons décidé de ne plus laisser un⋅e super-admin la possibilité de créer ou modifier un⋅e autre super-admin (ou elle-même).

Cette opération est peu fréquente, et pourra être fait par une  nombre plus restreint de personnes : les devs (qui ont activé le 2FA sur leur Scalingo).

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
