### PR TITLE
Lien incitant à la prescription interne peut renvoyer vers des 404

### DIFF
--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -1,4 +1,6 @@
 module FeatureHelper
+  # Prescription
+
   def show_agent_prescription_feature?(user_provided:)
     # TODO: faire sauter ce return une fois que nous avons implémenté la saisie d'adresse
     return false if current_organisation.territory.sectorized? && !user_provided
@@ -9,5 +11,13 @@ module FeatureHelper
 
   def show_agent_prescription_incitation?
     current_agent.present? && current_agent.territories.any?(&:any_motifs_opened_for_prescription?)
+  end
+
+  def current_agent_can_prescribe_in_territory?(territory)
+    current_agent.territories.include?(territory) && territory.any_motifs_opened_for_prescription?
+  end
+
+  def current_agent_first_organisation_in_territory(territory)
+    current_agent.organisations.find_by(territory: territory)
   end
 end

--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -8,6 +8,6 @@ module FeatureHelper
   end
 
   def show_agent_prescription_incitation?
-    current_agent.present? && current_agent.territories.any?(&:any_motifs_opened_for_prescription?)
+    current_agent.present? && current_agent.territories_through_organisations.any?(&:any_motifs_opened_for_prescription?)
   end
 end

--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -12,12 +12,4 @@ module FeatureHelper
   def show_agent_prescription_incitation?
     current_agent.present? && current_agent.territories.any?(&:any_motifs_opened_for_prescription?)
   end
-
-  def current_agent_can_prescribe_in_territory?(territory)
-    current_agent.territories.include?(territory) && territory.any_motifs_opened_for_prescription?
-  end
-
-  def current_agent_first_organisation_in_territory(territory)
-    current_agent.organisations.find_by(territory: territory)
-  end
 end

--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -1,6 +1,4 @@
 module FeatureHelper
-  # Prescription
-
   def show_agent_prescription_feature?(user_provided:)
     # TODO: faire sauter ce return une fois que nous avons implémenté la saisie d'adresse
     return false if current_organisation.territory.sectorized? && !user_provided

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -84,6 +84,7 @@ class Agent < ApplicationRecord
   # and we need to destroy to trigger the callbacks on the model
   has_many :users, through: :referent_assignations, dependent: :destroy
   has_many :organisations, through: :roles, dependent: :destroy
+  has_many :territories_through_organisations, source: :territory, through: :organisations
   has_many :webhook_endpoints, through: :organisations
 
   attr_accessor :allow_blank_name

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -8,7 +8,7 @@ main.container
         .card-body
           h3 Vos coordonnées de prescripteur
           - territory = @rdv_wizard.motif.organisation.territory
-          - if current_agent_can_prescribe_in_territory?(territory)
+          - if current_agent.territories.include?(territory)
             .alert.alert-success
               p.mb-0
                 i.fas.fa-lightbulb>
@@ -16,7 +16,7 @@ main.container
                 - unless territory.sectorized?
                   / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
                   = link_to user_selection_admin_organisation_prescription_path( \
-                      current_agent_first_organisation_in_territory(territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
+                      current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
                     ) do
                     span> en cliquant ici.
 

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -7,15 +7,16 @@ main.container
         = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
         .card-body
           h3 Vos coordonnées de prescripteur
-          - if show_agent_prescription_incitation?
+          - territory = @rdv_wizard.motif.organisation.territory
+          - if current_agent_can_prescribe_in_territory?(territory)
             .alert.alert-success
               p.mb-0
                 i.fas.fa-lightbulb>
                 span> Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
-                - unless @rdv_wizard.motif.organisation.territory.sectorized?
+                - unless territory.sectorized?
                   / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
                   = link_to user_selection_admin_organisation_prescription_path( \
-                      @rdv_wizard.motif.organisation, session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
+                      current_agent_first_organisation_in_territory(territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
                     ) do
                     span> en cliquant ici.
 

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -7,24 +7,29 @@ main.container
         = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
         .card-body
           h3 Vos coordonnées de prescripteur
-          - territory = @rdv_wizard.motif.organisation.territory
-          - if current_agent.present? && current_agent.territories.include?(territory)
-            .alert.alert-success
-              p.mb-0
-                i.fas.fa-lightbulb>
-                span> Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
-                - unless territory.sectorized?
+          / Incitation à l'utilisation de la prescription interne
+          - if @rdv_wizard.present?
+            - territory = @rdv_wizard.motif.organisation.territory
+            - if current_agent.present? && current_agent.territories_through_organisations.include?(territory)
+              .alert.alert-success
+                p.mb-0
+                  i.fas.fa-lightbulb>
+                  | Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
                   / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
-                  = link_to user_selection_admin_organisation_prescription_path( \
-                      current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
-                    ) do
-                    span> en cliquant ici.
+                  - unless territory.sectorized?
+                    / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire
+                    = link_to user_selection_admin_organisation_prescription_path( \
+                        current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
+                      ) do
+                      | &nbsp;en cliquant ici.
+                  - else
+                    | .
 
-              p.mb-0
-              span> Pour en savoir plus consultez
-              = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
-                span> la documentation
-                i.fa.fa-external-link-alt>
+                p.mb-0
+                span> Pour en savoir plus consultez
+                = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
+                  span> la documentation
+                  i.fa.fa-external-link-alt>
 
           p
             = "Ces informations permettront à l'agent qui assure le rendez-vous de savoir qui l'a planifié, "

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -16,7 +16,7 @@ main.container
                   i.fas.fa-lightbulb>
                   | Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
                   / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
-                  - unless territory.sectorized?
+                  - if !territory.sectorized?
                     / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire
                     = link_to user_selection_admin_organisation_prescription_path( \
                         current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -8,28 +8,27 @@ main.container
         .card-body
           h3 Vos coordonnées de prescripteur
           / Incitation à l'utilisation de la prescription interne
-          - if @rdv_wizard.present?
+          - if @rdv_wizard.present? && show_agent_prescription_incitation?
             - territory = @rdv_wizard.motif.organisation.territory
-            - if current_agent.present? && current_agent.territories_through_organisations.include?(territory)
-              .alert.alert-success
-                p.mb-0
-                  i.fas.fa-lightbulb>
-                  | Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
-                  / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
-                  - if !territory.sectorized?
-                    / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire
-                    = link_to user_selection_admin_organisation_prescription_path( \
-                        current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
-                      ) do
-                      | &nbsp;en cliquant ici.
-                  - else
-                    | .
+            .alert.alert-success
+              p.mb-0
+                i.fas.fa-lightbulb>
+                | Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
+                / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
+                - if !territory.sectorized?
+                  / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire
+                  = link_to user_selection_admin_organisation_prescription_path( \
+                      current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
+                    ) do
+                    | &nbsp;en cliquant ici.
+                - else
+                  | .
 
-                p.mb-0
-                span> Pour en savoir plus consultez
-                = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
-                  span> la documentation
-                  i.fa.fa-external-link-alt>
+              p.mb-0
+              span> Pour en savoir plus consultez
+              = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
+                span> la documentation
+                i.fa.fa-external-link-alt>
 
           p
             = "Ces informations permettront à l'agent qui assure le rendez-vous de savoir qui l'a planifié, "

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -8,7 +8,7 @@ main.container
         .card-body
           h3 Vos coordonnées de prescripteur
           - territory = @rdv_wizard.motif.organisation.territory
-          - if current_agent.territories.include?(territory)
+          - if current_agent.present? && current_agent.territories.include?(territory)
             .alert.alert-success
               p.mb-0
                 i.fas.fa-lightbulb>

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -244,13 +244,13 @@ RSpec.describe "prescripteur can create RDV for a user" do
                                    " nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent")
       expect(page).to have_link("en cliquant ici")
       click_on "en cliquant ici"
-      expect(page).to have_current_path("/admin/organisations/2/prescription/user_selection", ignore_query: true)
+      expect(page).to have_current_path("/admin/organisations/#{agent_prescripteur.organisations.find_by(territory: territory).id}/prescription/user_selection", ignore_query: true)
       expect(page).to have_content(lieu.name)
       expect(page).to have_content("08h00")
       expect(page).to have_content(motif.name)
     end
 
-    it "doesn't display internal prescription incitation when the agent doesn't belongs to a territory with opened motifs", js: true do
+    it "doesn't display internal prescription incitation when the agent doesn't belongs to a territory with opened motifs" do
       organisation.motifs.destroy_all
       visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
       expect(page).not_to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
@@ -267,7 +267,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
         click_on "Prochaine disponibilité le", match: :first
         click_on "08:00"
         expect(page).to have_content("Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque" \
-                                     " nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent")
+                                     " nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent.")
         expect(page).not_to have_link("en cliquant ici")
       end
     end

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -3,7 +3,8 @@ RSpec.describe "prescripteur can create RDV for a user" do
     travel_to(Time.zone.parse("2022-11-07 15:00"))
   end
 
-  let!(:organisation) { create(:organisation) }
+  let!(:territory) { create(:territory, departement_number: "75") }
+  let!(:organisation) { create(:organisation, territory: territory) }
   let!(:agent) { create(:agent, :cnfs, admin_role_in_organisations: [organisation], rdv_notifications_level: "all") }
   let(:bookable_by) { "everyone" }
   let!(:motif) do
@@ -140,6 +141,8 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
     it "doesn't create a new one but adds the user to the organisation" do
       visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
+      # On vérifie que le message d'incitation à la prescription interne ne s'affiche pas (l'agent n'est pas connecté)
+      expect(page).not_to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
 
       fill_address_form
 
@@ -215,6 +218,58 @@ RSpec.describe "prescripteur can create RDV for a user" do
       click_on "08:00" # choix du créneau
 
       expect(page).to have_content("Vos coordonnées de prescripteur")
+    end
+  end
+
+  context "when using the prescripteur route for a logged agent" do
+    let!(:agent_prescripteur) { create(:agent, admin_role_in_organisations: [organisation2]) }
+    let(:sector) { build(:sector, territory: territory) }
+    let!(:organisation2) { create(:organisation, territory: territory) }
+
+    before do
+      login_as(agent_prescripteur, scope: :agent)
+    end
+
+    it "display internal prescription incitation and correctly redirect to the feature", js: true do
+      visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
+      expect(page).to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
+
+      fill_address_form
+
+      click_on "Prochaine disponibilité le", match: :first
+      click_on "08:00"
+
+      expect(page).to have_content("Vos coordonnées de prescripteur")
+      expect(page).to have_content("Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque" \
+                                   " nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent")
+      expect(page).to have_link("en cliquant ici")
+      click_on "en cliquant ici"
+      expect(page).to have_current_path("/admin/organisations/2/prescription/user_selection", ignore_query: true)
+      expect(page).to have_content(lieu.name)
+      expect(page).to have_content("08h00")
+      expect(page).to have_content(motif.name)
+    end
+
+    it "doesn't display internal prescription incitation when the agent doesn't belongs to a territory with opened motifs", js: true do
+      organisation.motifs.destroy_all
+      visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
+      expect(page).not_to have_content("Nouvelle fonctionnalité :\nla prescription dans l'espace agent")
+    end
+
+    context "when the agent belongs to a sectorized territory" do
+      before do
+        allow_any_instance_of(Territory).to receive(:sectorized?).and_return(true) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it "doesn't display internal prescription incitation link when territory is sectorized", js: true do
+        visit "http://www.rdv-solidarites-test.localhost/prendre_rdv_prescripteur"
+        fill_address_form
+        click_on "Prochaine disponibilité le", match: :first
+        click_on "08:00"
+        expect(page).to have_content("Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque" \
+                                     " nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent")
+        expect(page).not_to have_link("en cliquant ici")
+      end
     end
   end
 


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-service-public/pull/4217
Plusieurs problèmes sont résolus ici :
- Le lien pré-rempli incitant à l'utilisation de la prescription interne pouvait mener vers des erreurs 404 si l'agent n'était pas membre de l'organisation sur laquelle il essai de prescrire, ce qui est contraire à l'objectif de la prescription.
Désormais on se base sur l'appartenance de l'agent au territoire de l'organisation du motif sélectionné pour afficher ou non le message d'incitation.
On renvoie vers la première organisation du territoire dont fait parti l'agent pour la suite du tunnel de prescription interne.
- On vérifiait que l'agent faisait parti du territoire en utilisant `current_agent.territories`, hors cette association correspond aux admin de territoires. J'ajoute donc une nouvelle association à cet usage : `agent.territories_through_organisations`
- Je met en place des tests pour les différentes conditions de la feature.
