### PR TITLE
Bugfix: Utilisateur bloqué si il saisit le numéro ANTS en minuscule

### DIFF
--- a/app/models/concerns/user/ants.rb
+++ b/app/models/concerns/user/ants.rb
@@ -4,7 +4,9 @@ module User::Ants
   def self.validate_ants_pre_demande_number(user:, ants_pre_demande_number:, ignore_benign_errors:)
     return if ants_pre_demande_number.blank?
 
-    unless ants_pre_demande_number.match?(/\A[A-Za-z0-9]{10}\z/)
+    ants_pre_demande_number = ants_pre_demande_number.upcase
+
+    unless ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)
       user.errors.add(:ants_pre_demande_number, :invalid_format)
       return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,8 +71,6 @@ class User < ApplicationRecord
 
   # Hooks
   before_save :set_email_to_null_if_blank
-  # voir Ants::AppointmentSerializerAndListener pour d'autres callbacks
-  before_validation -> { ants_pre_demande_number.upcase! }, if: -> { ants_pre_demande_number.present? }
 
   # Scopes
   default_scope { where(deleted_at: nil) }
@@ -226,6 +224,10 @@ class User < ApplicationRecord
 
   def assign_rdv_invitation_token
     self.rdv_invitation_token = generate_rdv_invitation_token
+  end
+
+  def ants_pre_demande_number=(value)
+    super(value&.upcase)
   end
 
   protected

--- a/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe "Agent can create user" do
     end
   end
 
+  context "when using a pre-demande number in lowercase" do
+    let!(:call_to_status_with_upcased_number) { stub_ants_status("ABCD1234EF", appointments: []) }
+
+    it "considers it as uppercase when calling ANTS API and saving it in user" do
+      fill_in :user_first_name, with: "Marco"
+      fill_in :user_last_name, with: "Lebreton"
+      fill_in :user_ants_pre_demande_number, with: "abcd1234ef"
+      expect { click_button "Créer" }.to change(User, :count).by(1)
+      expect(User.last.ants_pre_demande_number).to eq("ABCD1234EF")
+      expect(call_to_status_with_upcased_number).to have_been_requested.at_least_once
+    end
+  end
+
   context "ants_pre_demander number is validated but already has appointments" do
     before do
       stub_ants_status(

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe "prescripteur can create RDV for a user" do
     end
   end
 
+  context "when using a pre-demande number in lowercase" do
+    let(:ants_pre_demande_number) { "abcd1234ef" }
+    let!(:call_to_status_with_upcased_number) { stub_ants_status("ABCD1234EF", appointments: []) }
+
+    it "considers it as uppercase when calling ANTS API and saving it in user" do
+      visit creneaux_url
+      click_on "Je suis un prescripteur qui oriente un bénéficiaire"
+
+      fill_up_prescripteur_and_user
+      expect { click_on "Confirmer le rendez-vous" }.to change(User, :count).by(1)
+      expect(User.last.ants_pre_demande_number).to eq("ABCD1234EF")
+      expect(call_to_status_with_upcased_number).to have_been_requested.at_least_once
+    end
+  end
+
   context "ants_pre_demander number is validated but already has appointments" do
     before do
       stub_ants_status(


### PR DESCRIPTION
On continue d'avoir des erreurs de l'API ANST `string does not match regex \"^([A-Z0-9]{10}[,;:\\-/.\\s])*[A-Z0-9]{10}$\""`.

C'est parce qu'on appel `/status` en passant le code brut, et non la version majuscule. L'opération de mise en majuscule n'est faite que lorsqu'on valide un `User`.

Pour faire les choses proprement on pourrait soit :

- ovrerride `#ants_pre_demande_number=` sur `Admin::UserForm`, `BeneficiaireForm` et `UserRdvWizard::Step1`
- wrapper la valeur dans un objet de type `AntsPreDemandeNumber` qui s'occuperait de faire le `upcase`

Je suis allé au plus simple : j'ajoute un `upcase` dans `.validate_ants_pre_demande_number` quand on appelle `/status`. J'aurais aimé avoir un traitement généralisé du numéro de pré-demande. 

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
