### PR TITLE
CI fix: update selenium-webdriver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,8 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
-    selenium-webdriver (4.11.0)
+    selenium-webdriver (4.19.0)
+      base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)


### PR DESCRIPTION
J'ai eu des specs JS qui crashent sur ma machine et un update de chromedriver a fait la job, et donc je pense qu'en mettant à jour la gem on va pouvoir [débloquer la CI](https://github.com/betagouv/rdv-service-public/actions/runs/8817138063/job/24202809866).

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
