### PR TITLE
Correctif pour des flaky specs

### DIFF
--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe "User can search for rdvs" do
     expect_page_h1("Prenez rendez-vous en ligne\navec votre département")
     fill_in("search_where", with: "79 Rue de Plaisance, 92250 La Garenne-Colombes")
 
-    # fake algolia autocomplete to pass on Circle ci
+    find("#search_departement", visible: :all) # permet d'attendre que l'élément soit dans le DOM
     page.execute_script("document.querySelector('#search_departement').value = '92'")
     page.execute_script("document.querySelector('#search_submit').disabled = false")
 


### PR DESCRIPTION
On a eu récemment des flaky specs (voir https://github.com/betagouv/rdv-service-public/actions/runs/8829213276/job/24239751699) avec le message d'erreur suivant : 
```
   Selenium::WebDriver::Error::UnknownError:
       unknown error: unhandled inspector error: {"code":-32000,"message":"Node with given id does not belong to the document"}
         (Session info: chrome-headless-shell=124.0.6367.60)
```

Ce `Node with given id does not belong to the document` semble être levé par `page.execute_script("document.querySelector('#search_departement').value = '92'")`, dans le cas d'une race condition où l'élément `#search_departement` n'est pas encore dans la page (peut-être parce que le turbolink est encore en train de changer le contenu de la page).
En ajoutant un `find` Capybara, on attend que cet élément soit disponible avant de continuer d'exécuter le script (voir https://rubydoc.info/github/jnicklas/capybara/Capybara/Node/Finders:find)