### PR TITLE
Suppression de la gem inutilisée `sib-api-v3-sdk`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,8 +124,6 @@ gem "dsfr-view-components"
 
 # Easily create styled HTML emails in Rails.
 gem "premailer-rails" # Mail formatting
-# SendinBlue API V3 Ruby Gem
-gem "sib-api-v3-sdk" # SendInBlue (SMS)
 # The Spreadsheet Library is designed to read and write Spreadsheet Documents
 gem "spreadsheet" # Excel export
 # If string, numeric, symbol and nil values wanna be a boolean value, they can with the new #to_b method (and more).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,6 @@ GEM
       thor (>= 0.14, < 2.0)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
-    json (2.6.3)
     json-jwt (1.16.6)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -541,10 +540,6 @@ GEM
       sentry-ruby (~> 5.16.1)
     sentry-ruby (5.16.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sib-api-v3-sdk (9.0.0)
-      addressable (~> 2.3, >= 2.3.0)
-      json (~> 2.1, >= 2.1.0)
-      typhoeus (~> 1.0, >= 1.0.1)
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -707,7 +702,6 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
-  sib-api-v3-sdk
   simple_form (~> 5.0)
   skylight
   slim


### PR DESCRIPTION
Pendant le point tech on a parlé de Brevo (ex SendInBlue) et j'ai réalisé qu'on avait toujours leur gem alors qu'on n'utilise pas leur API.

# Checklist

Avant la revue :
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
