### PR TITLE
Éviter les warnings qui parlent des default gems de ruby 3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,6 +145,11 @@ gem "lograge"
 # TODO: retirer cette ligne quand une nouvelle version de httpclient est released
 gem "httpclient", git: "https://github.com/nahi/httpclient.git", ref: "d57cc6d"
 
+# gems qui vont être intégrées à ruy 3.4.0, à supprimer quand on upgrade depuis 3.3.1
+gem "csv"
+gem "drb"
+gem "observer"
+
 group :development do
   #  Hot reload
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
     crass (1.0.6)
     css_parser (1.16.0)
       addressable
+    csv (3.3.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.0.1)
@@ -197,6 +198,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    drb (2.2.1)
     dsfr-view-components (0.5.0)
       html-attributes-utils (~> 1)
       pagy (~> 6)
@@ -332,6 +334,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    observer (0.1.2)
     omniauth (2.1.2)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -648,12 +651,14 @@ DEPENDENCIES
   chartkick (~> 5.0.1)
   common_french_passwords
   connection_pool
+  csv
   database_cleaner
   devise
   devise-async
   devise_invitable
   devise_token_auth
   dotenv-rails
+  drb
   dsfr-view-components
   factory_bot
   faker
@@ -669,6 +674,7 @@ DEPENDENCIES
   lograge
   mail
   montrose
+  observer
   omniauth-github
   omniauth-microsoft_graph
   omniauth-rails_csrf_protection

--- a/spec/factories/team.rb
+++ b/spec/factories/team.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :team do
     territory { association(:territory) }
-    name { "#{Faker::Team.name} #{id}" }
+    name { "#{Faker::Team.name} #{SecureRandom.hex(4)}" }
   end
 end

--- a/spec/features/agents/account/agent_can_login_spec.rb
+++ b/spec/features/agents/account/agent_can_login_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe "Agent can login" do
     visit new_agent_session_path
     fill_in "Email", with: agent.email
     fill_in "password", with: "correcthorse"
-    expect { click_on "Se connecter" }.to change { agent.reload.last_sign_in_at }.from(be_within(1.second).of(2.weeks.ago)).to(be_within(1.second).of(Time.zone.now))
+
+    # On utilise 10 secondes car la spec est parfois lente en CI et devient flaky
+    expect { click_on "Se connecter" }.to change { agent.reload.last_sign_in_at }
+      .from(be_within(10.seconds).of(2.weeks.ago))
+      .to(be_within(10.seconds).of(Time.zone.now))
   end
 end


### PR DESCRIPTION
```
/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.3.0/gems/bootsnap-1.17.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32: warning: /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of skylight-6.0.1 to add csv into its gemspec.

/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.3.0/gems/bootsnap-1.17.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32: warning: /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/drb.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add drb to your Gemfile or gemspec. Also contact author of skylight-6.0.1 to add drb into its gemspec.

/home/runner/work/rdv-service-public/rdv-service-public/vendor/bundle/ruby/3.3.0/gems/bootsnap-1.17.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32: warning: /opt/hostedtoolcache/Ruby/3.3.1/x64/lib/ruby/3.3.0/observer.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add observer to your Gemfile or gemspec. Also contact author of skylight-6.0.1 to add observer into its gemspec.
```

Il parle de la gem Skylight mais j'ai l'impression que les require viennent d'ailleurs car je ne trouve aucun usage dans cette gem Skylight.

# Checklist

Avant la revue :
- [ ] Préparer des captures de l’interface avant et après
- [ ] Nettoyer les commits pour faciliter la relecture
- [ ] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
