### PR TITLE
Correctif pour le yarn build en dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lapin",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js; cp -r node_modules/@gouvfr/dsfr/dist/fonts public; cp -r node_modules/@gouvfr/dsfr/dist/icons public;"
+    "build": "cp -r node_modules/@gouvfr/dsfr/dist/fonts public; cp -r node_modules/@gouvfr/dsfr/dist/icons public; webpack --config webpack.config.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",


### PR DESCRIPTION
On remet la commande webpack à la fin du yarn build pour pouvoir lui passer des arguments supplémentaires, notamment pour `yarn build --mode=development --watch --progress`