### PR TITLE
Correctifs sur le formulaire de motif

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,7 +42,7 @@ module ApplicationHelper
   end
 
   def fake_required_label(label)
-    %(#{label} <abbr title="obligatoire">*</abbr>).html_safe # rubocop:disable Rails/OutputSafety
+    sanitize("#{label} <abbr title=\"obligatoire\">*</abbr>")
   end
 
   def agents_or_users_body_class

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -7,7 +7,6 @@
 @import "~bootstrap/scss/bootstrap";
 @import "~select2/dist/css/select2";
 @import "~select2-bootstrap4-theme/dist/select2-bootstrap4.min";
-@import "structure/bootstrap_overrides";
 
 // Plugins
 @import '@fullcalendar/core/main';

--- a/app/javascript/stylesheets/components/_cards.scss
+++ b/app/javascript/stylesheets/components/_cards.scss
@@ -1,7 +1,11 @@
 .card {
-  border: none;
-  box-shadow: $shadow;
+  border: 1px solid $card-border-color;
+  box-shadow: none;
   margin-bottom: $grid-gutter-width;
+}
+
+.disabled-card * {
+  color: $gray-600 !important;
 }
 
 // Card title / Card Header

--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -1,8 +1,0 @@
-.card {
-  box-shadow: none !important;
-  border: 1px solid $card-border-color !important;
-}
-
-.disabled-card * {
-  color: $gray-600 !important;
-}

--- a/app/views/admin/motifs/_visibility.html.slim
+++ b/app/views/admin/motifs/_visibility.html.slim
@@ -3,7 +3,7 @@ h6.mb-2
   span.mr-1= t(".default_html", motif: link_to(motif.name, admin_organisation_motif_path(current_organisation, motif), target: "_blank"))
 .ml-3
   = boolean_tag(motif.visible_and_notified?) do
-    = motif.human_attribute_value(:visibility_type)
+    = sanitize(motif.human_attribute_value(:visibility_type, context: :html))
     p.mb-0
       span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint)
       - if current_organisation.rdv_insertion?

--- a/app/views/admin/motifs/form/_notifs_et_instructions.html.slim
+++ b/app/views/admin/motifs/form/_notifs_et_instructions.html.slim
@@ -18,7 +18,7 @@
     .mt-3
       = f.input :restriction_for_rdv,
               label: sanitize("Instructions à accepter <strong>avant</strong> la prise du RDV"),
-              placeholder: "Laisser vide si vous ne souhaitez pas donner d’instruction.",
+              placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
               input_html: { rows: 5 },
               wrapper_html: { class: "mb-1" }
       = link_to image_path("motif_form/restriction_for_rdv.png"), target: "_blank" do
@@ -27,7 +27,7 @@
     .mt-3
       = f.input :instruction_for_rdv,
               label: sanitize("Instructions affichées <strong>après</strong> la prise du RDV"),
-              placeholder: "Laisser vide si vous ne souhaitez pas donner d’instruction.",
+              placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
               input_html: { rows: 5 },
               wrapper_html: { class: "mb-1" }
       = link_to image_path("motif_form/instruction_for_rdv.png"), target: "_blank" do
@@ -36,7 +36,7 @@
     .mt-3
       = f.input :custom_cancel_warning_message,
               label: sanitize("Message d’avertissement </strong>en cas d’annulation</strong>"),
-              placeholder: "Laisser vide si vous ne souhaitez pas afficher de messager d’avertissement.",
+              placeholder: "Laissez vide si vous ne souhaitez pas afficher de messager d’avertissement.",
               input_html: { rows: 5 },
               wrapper_html: { class: "mb-1" }
       = link_to image_path("motif_form/custom_cancel_warning_message.png"), target: "_blank" do

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -65,7 +65,8 @@
         hr
 
         = motif_attribute_row(Motif.human_attribute_name(:visibility_type)) do
-          div= @motif.human_attribute_value(:visibility_type)
+          div= sanitize(@motif.human_attribute_value(:visibility_type, context: :html))
+
           div.text-muted
             = @motif.human_attribute_value(:visibility_type, context: :hint)
             - if current_organisation.rdv_insertion?


### PR DESCRIPTION
Cette PR corrige plusieurs problèmes introduits par https://github.com/betagouv/rdv-service-public/pull/4135/files, découpés en commits individuels :
- le style des cards était modifié dans un nouveau fichier avec des important plutôt que de modifier le fichier de composant existant, ce qui posait plusieurs problèmes :
  - les `important` nuisent à la maintenabilité du code (c'est bien de les éviter autant que possible)
  - on ajoute un niveau d'indirection inutile
  - le fichier d'overrides était ajouté uniquement au style de l'espace agent, donc les cards ont un aspect différent dans les préférentes agents (et du côté usagers)
- l'affichage du niveau de visibilité sur le show du motif était cassé (ça a été remonté dans la pr d'origine mais pas corrigé)
- Eva de rdv insertion m'a fait remonter des fautes de frappe dans les placeholders des instructions
- On s'était mis d'accord en review pour utiliser un sanitize plutôt qu'un html_safe