### PR TITLE
Ajout d'une durée minimum de session

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,9 +58,10 @@ module Lapin
 
     config.x.redis_namespace = "app"
 
-    # Avec cette configuration, on crée un cookie sans date d'expiration.
+    # Avec cette configuration, on crée un cookie qvec une expiration dans 8 heures
+    # Cette date d'expiration est mise à jour à chaque requête.
     # L'expiration est gérée avec le module Timeoutable de Devise.
-    config.session_store :cookie_store, key: "_rdv_sp_session"
+    config.session_store :cookie_store, key: "_rdv_sp_session", expire_after: 8.hours
 
     # Devise layout
     config.to_prepare do

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,9 +58,10 @@ module Lapin
 
     config.x.redis_namespace = "app"
 
-    # Avec cette configuration, on crée un cookie qvec une expiration dans 8 heures
+    # Avec cette configuration, on crée un cookie qui expire au bout de 8 heures
     # Cette date d'expiration est mise à jour à chaque requête.
-    # L'expiration est gérée avec le module Timeoutable de Devise.
+    # L'expiration est aussi gérée avec le module Timeoutable de Devise, qui indique le temps entre le login et la déconnexion.
+    # L'utilisateur peut être obligé à se reconnecter par Devise::Timeoutable même si le cookie n'a pas expiré.
     config.session_store :cookie_store, key: "_rdv_sp_session", expire_after: 8.hours
 
     # Devise layout

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -84,4 +84,10 @@ Rails.application.configure do
   config.active_record.encryption.primary_key = "test"
   config.active_record.encryption.deterministic_key = "test"
   config.active_record.encryption.key_derivation_salt = "test"
+
+  # Dans l'environnement de test on ne met pas de date d'expiration des cookies, car l'heure du
+  # serveur de test et celle du navigateur sont différentes quand on utilise une spec d'intégration en
+  # js: true avec un travel_to.
+  # Quand le travel_to est dans le passé, cela fait expirer le cookie immédiatement et rend le test impossible.
+  config.session_store :cookie_store, key: "_rdv_sp_session"
 end

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "User can search rdv on rdv service public" do
                                              end_time: Tod::TimeOfDay.new(10))
   end
 
-  it "allows booking a rdv", js: true do
+  it "allows booking a rdv" do
     visit "http://www.rdv-mairie-test.localhost/org/#{organisation.id}"
     click_on("Clarification du dossier")
     click_on("Prochaine disponibilité le") # choix du lieu


### PR DESCRIPTION
Cette PR ajoute une date d'expiration explicite aux cookies de session pour éviter de déconnecter trop souvent les agents.
Voir https://github.com/betagouv/rdv-service-public/pull/4241#issuecomment-2096283436 et https://zammad10.ethibox.fr/#ticket/zoom/13651