### PR TITLE
Eviter la duplication de la version de ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.1
+          ruby-version: .ruby-version
           bundler-cache: true
       - run: bundle exec rubocop --parallel
   slim-lint:
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.1
+          ruby-version: .ruby-version
           bundler-cache: true
       - run: bundle exec slim-lint app/views/
   brakeman:
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.1
+          ruby-version: .ruby-version
           bundler-cache: true
       - run: bundle exec brakeman
   active_record_doctor:
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.1
+          ruby-version: .ruby-version
           bundler-cache: true
       - name: Run active_record_doctor:missing_foreign_keys
         run: bundle exec rails active_record_doctor:missing_foreign_keys
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.1
+          ruby-version: .ruby-version
           bundler-cache: true
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.1
+          ruby-version: .ruby-version
           bundler-cache: true
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0


### PR DESCRIPTION
Une toute petite PR pour éviter de répéter la version de ruby dans toute la CI : en passant l'option `.ruby-version` plutôt qu'un numéro de version explicite, notre CI utilise automatiquement le numéro de version contenu dans le fichier `.ruby-version`.
C'est vraiment un tout petit nettoyage pour limiter les opérations manuelles pendant la mise à jour de version de ruby, et limiter le risque d'oubli.