### PR TITLE
Correctif sur la duplication motif pour les admin mono-orga

### DIFF
--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -4,7 +4,7 @@ p
 
 = f.hidden_field :duplicated_from_motif_id
 - organisations_i_can_manage = Agent::MotifPolicy.organisations_i_can_manage(current_agent)
-- if motif.duplicated_from_motif && motif.new_record? && organisations_i_can_manage.any?
+- if motif.duplicated_from_motif && motif.new_record? && organisations_i_can_manage.count > 1
   .card
     .card-body
       = f.association :organisation, label: "Créer le motif dans cette organisation", collection: organisations_i_can_manage, input_html: { class: "select2-input" }

--- a/spec/features/agents/agent_can_duplicate_motif_spec.rb
+++ b/spec/features/agents/agent_can_duplicate_motif_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe "agent can duplicate motif" do
     login_as(agent, scope: :agent)
     visit admin_organisation_motif_path(organisation, existing_motif)
     click_on "Dupliquer"
+
+    expect(page).not_to have_content("Créer le motif dans cette organisation")
     choose :motif_location_type_home # Je veux créer le même motif mais en version à domicile
     expect { click_on "Créer le motif" }.to change(Motif, :count).by(1)
 


### PR DESCRIPTION
Contrairement à ce qui était annoncé dans la description de la PR (https://github.com/betagouv/rdv-service-public/pull/4185), le select d'orga apparaissait tout le temps, et pas uniquement pour les admins de plusieurs orgas (c'était peut-être le sens de ce commentaire resté sans réponse : https://github.com/betagouv/rdv-service-public/pull/4185#issuecomment-2009646977)

Je me demande s'il n'y a pas le même bug sur l'affichage du cta "Dupliquer" sur le `show` et sur l'affichage de l'icône dans l'index, mais j'aurais besoin de confirmation du trio pour être sûr. (et le choix d'avoir deux ctas primaires côte à côte est assez étonnant aussi)