### PR TITLE
On enléve du code déprécié dans l'api (rdvs_users)

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -20,8 +20,6 @@ class RdvBlueprint < Blueprinter::Base
   association :motif, blueprint: MotifBlueprint
   # DEPRECATED : Nous laissons l'association `:users` le temps que le 92, 26, 62, 64, et data-insertion mettent à jours leur système.
   association :users, blueprint: UserBlueprint
-  # DEPRECATED : On garde l'ancien nom des participations le temps que le 92, 26, 62, 64, et data-insertion mettent à jours leur système.
-  association :participations, blueprint: ParticipationBlueprint, name: :rdvs_users
   association :participations, blueprint: ParticipationBlueprint
   association :agents, blueprint: AgentBlueprint
   association :lieu, blueprint: LieuBlueprint

--- a/docs/api/v1/description_api.md
+++ b/docs/api/v1/description_api.md
@@ -4,10 +4,7 @@ Toutes les fonctionnalités de RDV-Solidarités ne sont pas encore disponibles v
 
 # Dépréciations
 
-**ATTENTION l'association `rdvs_users` des `rdvs` est dépréciée au profit de l'association `participations`.**
-
 **ATTENTION le champ `created_by` des `rdvs` et des `participations` est déprécié au profit du champ `created_by_type`.**
-
 
 # Requêtes
 

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -34,17 +34,6 @@ RSpec.describe RdvBlueprint do
     end
   end
 
-  describe "rdvs_users contains user (DEPRECATED)" do
-    let(:user) { build(:user, first_name: "Jean") }
-    let(:rdv) { build(:rdv, participations: [participation]) }
-    let(:participation) { build(:participation, status: "seen", user: user) }
-
-    it do
-      expect(json.dig("rdv", "rdvs_users").first["status"]).to eq "seen"
-      expect(json.dig("rdv", "rdvs_users").first["user"]["first_name"]).to eq "Jean"
-    end
-  end
-
   describe "participations contains user" do
     let(:user) { build(:user, first_name: "Jean") }
     let(:rdv) { build(:rdv, participations: [participation]) }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -76,10 +76,6 @@ RSpec.configure do |config|
                 type: "array",
                 items: { "$ref" => "#/components/schemas/participation" },
               },
-              rdvs_users: {
-                type: "array",
-                items: { "$ref" => "#/components/schemas/rdvs_user" },
-              },
               starts_at: { type: "string" },
               status: { type: "string", enum: %w[unknown seen excused revoked noshow] },
               users: {
@@ -90,7 +86,7 @@ RSpec.configure do |config|
               uuid: { type: "string" },
             },
             required: %w[id address agents cancelled_at collectif context created_by_type duration_in_min lieu max_participants_count motif
-                         name organisation rdvs_users participations starts_at status users users_count uuid],
+                         name organisation participations starts_at status users users_count uuid],
           },
           agents: {
             type: "object",
@@ -385,19 +381,6 @@ RSpec.configure do |config|
               territory: { "$ref" => "#/components/schemas/territory" },
             },
             required: %w[territory],
-          },
-          rdvs_user: {
-            type: "object",
-            properties: {
-              send_lifecycle_notifications: { type: "boolean" },
-              send_reminder_notification: { type: "boolean" },
-              status: { type: "string", enum: %w[unknown seen excused revoked noshow] },
-              user: { "$ref" => "#/components/schemas/user" },
-              created_by: { type: "string", enum: %w[agent user prescripteur] },
-              created_by_type: { type: "string", enum: %w[Agent User Prescripteur] },
-              created_by_id: { type: "integer" },
-            },
-            required: %w[send_lifecycle_notifications send_reminder_notification status user],
           },
           participation: {
             type: "object",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "API RDV Solidarités",
     "version": "v1",
-    "description": "L'API de RDV-Solidarités vous permet de lire des données dans notre base depuis votre logiciel.\n\nToutes les fonctionnalités de RDV-Solidarités ne sont pas encore disponibles via l’API. Contactez-nous si vous avez besoin de fonctionnalités qui ne sont pas encore présentes.\n\n# Dépréciations\n\n**ATTENTION l'association `rdvs_users` des `rdvs` est dépréciée au profit de l'association `participations`.**\n\n**ATTENTION le champ `created_by` des `rdvs` et des `participations` est déprécié au profit du champ `created_by_type`.**\n\n\n# Requêtes\n\nL'API adhère aux principes REST :\n\n- requêtes `GET` : lecture sans modification\n- requêtes `POST` : création de nouvelle ressource\n- requêtes `PATCH` : mise à jour d'une ressource existante\n- requêtes `DELETE` : suppression d'une ressource\n\nLes paramètres des requêtes `GET` doivent être envoyés via les query string de la requête.\n\nLes paramètres des requêtes `POST` doivent être transmis dans le corps de la requête sous un format JSON valide, et doivent contenir le header `Content-Type: application/json`.\n\nLes paramètres doivent respecter les formats suivants :\n- `DATE` : \"YYYY-MM-DD\" par exemple : \"2021-10-21\"\n- `TIME` : H:m[:s], par exemple : \"10:30\"\n\n# Versionnage\n\nL'API est versionnée. La version actuelle est 1.0 (référencée comme v1 dans les points de terminaison).\n\n# Routes\n\nLes points de terminaison de l'API sont accessibles par une route de la forme : `https://<domain>/api/<version>/<endpoint>`.\n\nAvec :\n\n- `version` est la version de l'API\n- `endpoint` est le nom du point de terminaison\n\nPar exemple, on aura : `https://<domain>/api/v1/absences`\n\nPour la version production, les requêtes doivent être adressées à https://www.rdv-solidarites.fr et non à https://rdv-solidarites.fr.\n\nPour la version démo, les requêtes doivent être adressées à https://demo.rdv-solidarites.fr.\n\n# Authentification\n\nCertains points de terminaison sont réservés aux agents authentifiés, dans la limite de leur rôle au sein de l'application.\n\n## Headers d'authentification\n\nTous les agents peuvent utiliser l'API. Les requêtes faites sur l'API sont authentifiées grace à des tokens d'accès associés à chaque agent. Chaque action faite via l'API est donc attribuable à un agent.\n\nPour récupérer le token d'accès d'un agent il faut faire une première requête `POST` à l'url `https://www.rdv-solidarites.fr/api/v1/auth/sign_in` en passant en paramètres JSON l'email et le mot de passe de l'agent. Par exemple (avec HTTPie) :\n\n```httpie\nhttp --json POST 'https://www.rdv-solidarites.fr/api/v1/auth/sign_in' \\\n  email='martine@demo.rdv-solidarites.fr' password='123456'\n```\n\nEn cas de succès d'authentification, la réponse à cette requête contiendra dans le corps le détail de l'agent, et dans les headers les token d'accès à l'API. Par exemple :\n\n```http\nHTTP/1.1 200 OK\nX-Frame-Options: SAMEORIGIN\nX-XSS-Protection: 1; mode=block\nX-Content-Type-Options: nosniff\nX-Download-Options: noopen\nX-Permitted-Cross-Domain-Policies: none\nReferrer-Policy: strict-origin-when-cross-origin\nContent-Type: application/json; charset=utf-8\naccess-token: SFYBngO55ImjD1HOcv-ivQ< token-type: Bearer\nclient: Z6EihQAY9NWsZByfZ47i_Q< expiry: 1605600758\nuid: martine@demo.rdv-solidarites.fr\nETag: W/\"0fe52663d6745c922160384e13afe1e1\"\nCache-Control: max-age=0, private, must-revalidate\nX-Meta-Request-Version: 0.7.2\nX-Request-Id: 291fab6a-043b-4b9c-b4b9-3c7fc9c9453a\nX-Runtime: 0.194743< Transfer-Encoding: chunked\n* Connection #0 to host rdv-solidarites.fr left intact\n{\n  \"data\": {\n    \"id\":1,\n    \"deleted_at\":null,\n    \"email\":\"martine@demo.rdv-solidarites.fr\",\n    \"provider\":\"email\",\n    \"service_id\":1,\n    \"role\":\"admin\",\n    \"last_name\":\"VALIDAY\",\n    \"first_name\":\"Martine\",\n    \"uid\":\"martine@demo.rdv-solidarites.fr\",\n    \"allow_password_change\":false\n  }\n}\n* Closing connection 0\n```\n\nLes 3 headers essentiels pour l'authentification sont les suivants :\n\n```http\naccess-token: SFYBngO55ImjD1HOcv-ivQ\nclient: Z6EihQAY9NWsZByfZ47i_Q\nuid: martine@demo.rdv-solidarites.fr\n```\n\n- `access-token` : c'est le jeton d'accès qui vous a été attribué. Il a une durée de vie de 24h, après ça il vous faudra reproduire cette procédure pour en récupérer un nouveau.\n- `client` : un identifiant unique associé à l'appareil depuis lequel vous avez effectué la requête\n- `uid` : l'identifiant de l'agent dans l'API, égal à l'email de l'agent.\n\n**Ces 3 headers doivent être transmis avec chacune de vos requêtes successives à l'API**, peu importe la méthode HTTP.\n\n## Permissions\n\nLes rôles et permissions des agents sont les mêmes via l'API que depuis l'interface web.\n\nC'est à dire que les agents classiques ont accès à leur service uniquement, les agents du service secrétariat peuvent accéder aux agendas des agents des autres services, les agents admin ont accès à toute l'organisation, etc.\n\nPar défaut, les requêtes en lecture n'appliquent aucun filtre et retourneront toutes les ressources auxquelles a accès l'agent connecté. Par exemple si un agent admin fait une requête pour accéder à la liste des absences sans filtre, l'API retournera toutes les absences de tous les agents appartenant aux organisations dont fait partie cet agent admin, ce qui peut faire beaucoup.\n\n\n\n# Sérialisation\n\nL'API supporte uniquement le format JSON. Toutes les réponses envoyées par l'API contiendront le header `Content-Type: application/json` et leur contenu est présent dans le body dans un format JSON à désérialiser.\n\n# Pagination des réponses par listes\n\nTous les points de terminaison qui retournent des listes sont paginés. De manière générale, tout point de terminaison qui retourne une liste peut retourner une liste vide.\n\n## Paramètres\n\nLe paramètre (optionnel) `page` permet d'accéder à une page donnée. Sauf précision contraire dans la documentation d'un point de terminaison donné, on retrouve 100 éléments par page.\n\n## Résultats\n\nLa réponse contient en outre un objet meta qui indique le nombre total de pages et d’items, par exemple :\n\n```rb\n{\n  […],\n  \"meta\": {\n      \"current_page\": 1,\n      \"total_count\": 112,\n      \"total_pages\": 2\n  }\n}\n```\n\n# Rate limiting\n\nL'utilisation de l'API est limitée pour les points de terminaison sans authentification. Vous pouvez effectuer au maximum 50 appels par minutes. Si vous dépassez cette limite, une erreur 429 vous sera renvoyée et vous trouverez le temps que vous devez attendre avant de relancer une requête dans le header (`Retry-After`).\n\n# Codes de retour\n\nL'API est susceptible de retourner les codes suivants :\n\n| Code  | Nom                   | Description                                                                   |\n| ----  | --------              | --------                                                                      |\n| `200` | Success               | Succès                                                                        |\n| `204` | No Content            | Succès mais la réponse ne contient pas de données (exemple : suppression)     |\n| `400` | Bad Request           | La requête est invalide                                                       |\n| `401` | Unauthorized          | L'authentification a échoué                                                   |\n| `403` | Forbidden             | Droits insuffisants pour réaliser l'action demandée                           |\n| `404` | Not Found             | La ressource est introuvable                                                  |\n| `422` | Unprocessable Entity  | La donnée transmise est mal formattée                                         |\n| `429` | Too Many Requests     | Trop de requêtes ont été effectuées                                           |\n| `500` | Internal Server Error | Une erreur serveur produite (l'équipe technique est notifiée automatiquement) |\n\n# Erreurs\n\nEn cas d'erreur reconnue par le système (par exemple erreur 422), les champs suivants seront présents dans la réponse pour vous informer sur les problèmes :\n\n- `errors` : [ERREUR] : liste d'erreurs groupées par attribut problèmatique au format machine\n- `error_messages` : [ERREUR] : idem mais dans un format plus facilement lisible.\n\n# Principes fonctionnels\n\n- Les statuts des RDV et des participants.\n\nLe statut du RDV (status) est un statut général. **Il n'est pas représentatif des statuts individuels des usagers.**\n\n**Chaque participant au RDV a son propre statut de participation porté par l'association `participations` du RDV.**\n\nPour les RDV avec l'attribut collectif à false les statuts du/des participants et du RDV seront tous identiques. (dans l'exemple suivant : `seen`)\n\nIl est conseillé malgrés tout d'utiliser les statuts des participants (dans `participations`) quelque soit le type de rdv.\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": false,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n\nPour les RDV avec l'attribut collectif à true les statuts du/des participants peuvent être différents.\n\nIci, le RDV a un status `seen` mais les 3 participants ont des status de participation différents.\n- Tristan Leroux s'est présenté au RDV collectif : `seen`\n- Roger Lapin ne s'est pas présenté et n'a pas annulé : `noshow`\n- Marie Dupont a annulé sa venue : `excused`\n\n`users_count` représente le nombre d'inscrits au RDV en temps réél (Tous les statuts hors `revoked` et `excused`)\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": true,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n"
+    "description": "L'API de RDV-Solidarités vous permet de lire des données dans notre base depuis votre logiciel.\n\nToutes les fonctionnalités de RDV-Solidarités ne sont pas encore disponibles via l’API. Contactez-nous si vous avez besoin de fonctionnalités qui ne sont pas encore présentes.\n\n# Dépréciations\n\n**ATTENTION le champ `created_by` des `rdvs` et des `participations` est déprécié au profit du champ `created_by_type`.**\n\n# Requêtes\n\nL'API adhère aux principes REST :\n\n- requêtes `GET` : lecture sans modification\n- requêtes `POST` : création de nouvelle ressource\n- requêtes `PATCH` : mise à jour d'une ressource existante\n- requêtes `DELETE` : suppression d'une ressource\n\nLes paramètres des requêtes `GET` doivent être envoyés via les query string de la requête.\n\nLes paramètres des requêtes `POST` doivent être transmis dans le corps de la requête sous un format JSON valide, et doivent contenir le header `Content-Type: application/json`.\n\nLes paramètres doivent respecter les formats suivants :\n- `DATE` : \"YYYY-MM-DD\" par exemple : \"2021-10-21\"\n- `TIME` : H:m[:s], par exemple : \"10:30\"\n\n# Versionnage\n\nL'API est versionnée. La version actuelle est 1.0 (référencée comme v1 dans les points de terminaison).\n\n# Routes\n\nLes points de terminaison de l'API sont accessibles par une route de la forme : `https://<domain>/api/<version>/<endpoint>`.\n\nAvec :\n\n- `version` est la version de l'API\n- `endpoint` est le nom du point de terminaison\n\nPar exemple, on aura : `https://<domain>/api/v1/absences`\n\nPour la version production, les requêtes doivent être adressées à https://www.rdv-solidarites.fr et non à https://rdv-solidarites.fr.\n\nPour la version démo, les requêtes doivent être adressées à https://demo.rdv-solidarites.fr.\n\n# Authentification\n\nCertains points de terminaison sont réservés aux agents authentifiés, dans la limite de leur rôle au sein de l'application.\n\n## Headers d'authentification\n\nTous les agents peuvent utiliser l'API. Les requêtes faites sur l'API sont authentifiées grace à des tokens d'accès associés à chaque agent. Chaque action faite via l'API est donc attribuable à un agent.\n\nPour récupérer le token d'accès d'un agent il faut faire une première requête `POST` à l'url `https://www.rdv-solidarites.fr/api/v1/auth/sign_in` en passant en paramètres JSON l'email et le mot de passe de l'agent. Par exemple (avec HTTPie) :\n\n```httpie\nhttp --json POST 'https://www.rdv-solidarites.fr/api/v1/auth/sign_in' \\\n  email='martine@demo.rdv-solidarites.fr' password='123456'\n```\n\nEn cas de succès d'authentification, la réponse à cette requête contiendra dans le corps le détail de l'agent, et dans les headers les token d'accès à l'API. Par exemple :\n\n```http\nHTTP/1.1 200 OK\nX-Frame-Options: SAMEORIGIN\nX-XSS-Protection: 1; mode=block\nX-Content-Type-Options: nosniff\nX-Download-Options: noopen\nX-Permitted-Cross-Domain-Policies: none\nReferrer-Policy: strict-origin-when-cross-origin\nContent-Type: application/json; charset=utf-8\naccess-token: SFYBngO55ImjD1HOcv-ivQ< token-type: Bearer\nclient: Z6EihQAY9NWsZByfZ47i_Q< expiry: 1605600758\nuid: martine@demo.rdv-solidarites.fr\nETag: W/\"0fe52663d6745c922160384e13afe1e1\"\nCache-Control: max-age=0, private, must-revalidate\nX-Meta-Request-Version: 0.7.2\nX-Request-Id: 291fab6a-043b-4b9c-b4b9-3c7fc9c9453a\nX-Runtime: 0.194743< Transfer-Encoding: chunked\n* Connection #0 to host rdv-solidarites.fr left intact\n{\n  \"data\": {\n    \"id\":1,\n    \"deleted_at\":null,\n    \"email\":\"martine@demo.rdv-solidarites.fr\",\n    \"provider\":\"email\",\n    \"service_id\":1,\n    \"role\":\"admin\",\n    \"last_name\":\"VALIDAY\",\n    \"first_name\":\"Martine\",\n    \"uid\":\"martine@demo.rdv-solidarites.fr\",\n    \"allow_password_change\":false\n  }\n}\n* Closing connection 0\n```\n\nLes 3 headers essentiels pour l'authentification sont les suivants :\n\n```http\naccess-token: SFYBngO55ImjD1HOcv-ivQ\nclient: Z6EihQAY9NWsZByfZ47i_Q\nuid: martine@demo.rdv-solidarites.fr\n```\n\n- `access-token` : c'est le jeton d'accès qui vous a été attribué. Il a une durée de vie de 24h, après ça il vous faudra reproduire cette procédure pour en récupérer un nouveau.\n- `client` : un identifiant unique associé à l'appareil depuis lequel vous avez effectué la requête\n- `uid` : l'identifiant de l'agent dans l'API, égal à l'email de l'agent.\n\n**Ces 3 headers doivent être transmis avec chacune de vos requêtes successives à l'API**, peu importe la méthode HTTP.\n\n## Permissions\n\nLes rôles et permissions des agents sont les mêmes via l'API que depuis l'interface web.\n\nC'est à dire que les agents classiques ont accès à leur service uniquement, les agents du service secrétariat peuvent accéder aux agendas des agents des autres services, les agents admin ont accès à toute l'organisation, etc.\n\nPar défaut, les requêtes en lecture n'appliquent aucun filtre et retourneront toutes les ressources auxquelles a accès l'agent connecté. Par exemple si un agent admin fait une requête pour accéder à la liste des absences sans filtre, l'API retournera toutes les absences de tous les agents appartenant aux organisations dont fait partie cet agent admin, ce qui peut faire beaucoup.\n\n\n\n# Sérialisation\n\nL'API supporte uniquement le format JSON. Toutes les réponses envoyées par l'API contiendront le header `Content-Type: application/json` et leur contenu est présent dans le body dans un format JSON à désérialiser.\n\n# Pagination des réponses par listes\n\nTous les points de terminaison qui retournent des listes sont paginés. De manière générale, tout point de terminaison qui retourne une liste peut retourner une liste vide.\n\n## Paramètres\n\nLe paramètre (optionnel) `page` permet d'accéder à une page donnée. Sauf précision contraire dans la documentation d'un point de terminaison donné, on retrouve 100 éléments par page.\n\n## Résultats\n\nLa réponse contient en outre un objet meta qui indique le nombre total de pages et d’items, par exemple :\n\n```rb\n{\n  […],\n  \"meta\": {\n      \"current_page\": 1,\n      \"total_count\": 112,\n      \"total_pages\": 2\n  }\n}\n```\n\n# Rate limiting\n\nL'utilisation de l'API est limitée pour les points de terminaison sans authentification. Vous pouvez effectuer au maximum 50 appels par minutes. Si vous dépassez cette limite, une erreur 429 vous sera renvoyée et vous trouverez le temps que vous devez attendre avant de relancer une requête dans le header (`Retry-After`).\n\n# Codes de retour\n\nL'API est susceptible de retourner les codes suivants :\n\n| Code  | Nom                   | Description                                                                   |\n| ----  | --------              | --------                                                                      |\n| `200` | Success               | Succès                                                                        |\n| `204` | No Content            | Succès mais la réponse ne contient pas de données (exemple : suppression)     |\n| `400` | Bad Request           | La requête est invalide                                                       |\n| `401` | Unauthorized          | L'authentification a échoué                                                   |\n| `403` | Forbidden             | Droits insuffisants pour réaliser l'action demandée                           |\n| `404` | Not Found             | La ressource est introuvable                                                  |\n| `422` | Unprocessable Entity  | La donnée transmise est mal formattée                                         |\n| `429` | Too Many Requests     | Trop de requêtes ont été effectuées                                           |\n| `500` | Internal Server Error | Une erreur serveur produite (l'équipe technique est notifiée automatiquement) |\n\n# Erreurs\n\nEn cas d'erreur reconnue par le système (par exemple erreur 422), les champs suivants seront présents dans la réponse pour vous informer sur les problèmes :\n\n- `errors` : [ERREUR] : liste d'erreurs groupées par attribut problèmatique au format machine\n- `error_messages` : [ERREUR] : idem mais dans un format plus facilement lisible.\n\n# Principes fonctionnels\n\n- Les statuts des RDV et des participants.\n\nLe statut du RDV (status) est un statut général. **Il n'est pas représentatif des statuts individuels des usagers.**\n\n**Chaque participant au RDV a son propre statut de participation porté par l'association `participations` du RDV.**\n\nPour les RDV avec l'attribut collectif à false les statuts du/des participants et du RDV seront tous identiques. (dans l'exemple suivant : `seen`)\n\nIl est conseillé malgrés tout d'utiliser les statuts des participants (dans `participations`) quelque soit le type de rdv.\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": false,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n\nPour les RDV avec l'attribut collectif à true les statuts du/des participants peuvent être différents.\n\nIci, le RDV a un status `seen` mais les 3 participants ont des status de participation différents.\n- Tristan Leroux s'est présenté au RDV collectif : `seen`\n- Roger Lapin ne s'est pas présenté et n'a pas annulé : `noshow`\n- Marie Dupont a annulé sa venue : `excused`\n\n`users_count` représente le nombre d'inscrits au RDV en temps réél (Tous les statuts hors `revoked` et `excused`)\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": true,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n"
   },
   "components": {
     "securitySchemes": {
@@ -118,12 +118,6 @@
               "$ref": "#/components/schemas/participation"
             }
           },
-          "rdvs_users": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/rdvs_user"
-            }
-          },
           "starts_at": {
             "type": "string"
           },
@@ -164,7 +158,6 @@
           "motif",
           "name",
           "organisation",
-          "rdvs_users",
           "participations",
           "starts_at",
           "status",
@@ -828,55 +821,6 @@
           "territory"
         ]
       },
-      "rdvs_user": {
-        "type": "object",
-        "properties": {
-          "send_lifecycle_notifications": {
-            "type": "boolean"
-          },
-          "send_reminder_notification": {
-            "type": "boolean"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "unknown",
-              "seen",
-              "excused",
-              "revoked",
-              "noshow"
-            ]
-          },
-          "user": {
-            "$ref": "#/components/schemas/user"
-          },
-          "created_by": {
-            "type": "string",
-            "enum": [
-              "agent",
-              "user",
-              "prescripteur"
-            ]
-          },
-          "created_by_type": {
-            "type": "string",
-            "enum": [
-              "Agent",
-              "User",
-              "Prescripteur"
-            ]
-          },
-          "created_by_id": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "send_lifecycle_notifications",
-          "send_reminder_notification",
-          "status",
-          "user"
-        ]
-      },
       "participation": {
         "type": "object",
         "properties": {
@@ -1412,7 +1356,7 @@
                   "example": {
                     "value": {
                       "motif_category": {
-                        "id": 64,
+                        "id": 71,
                         "name": "RSA Orientation",
                         "short_name": "rsa_orientation"
                       }
@@ -1512,11 +1456,11 @@
                   "example": {
                     "value": {
                       "territory": {
-                        "id": 46,
+                        "id": 51,
                         "departement_number": "01",
                         "motif_categories": [
                           {
-                            "id": 69,
+                            "id": 77,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           }
@@ -1981,21 +1925,21 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 17,
+                        "id": 18,
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Narcisse",
+                          "first_name": "Timoléon",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Rousseau"
+                          "last_name": "Meyer"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20240314T105708Z\r\nUID:absence_17@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_17@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20240514T080825Z\r\nUID:absence_18@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_18@RDV Solidarités",
                         "organisation": {
-                          "id": 119,
+                          "id": 132,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2173,21 +2117,21 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 26,
+                        "id": 27,
                         "agent": {
-                          "id": 139,
+                          "id": 153,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "André",
+                          "first_name": "Primerose",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Jean"
+                          "last_name": "Noel"
                         },
-                        "end_day": "2024-03-15",
+                        "end_day": "2024-05-15",
                         "end_time": "15:30:00",
-                        "first_day": "2024-03-15",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20240314T105709Z\r\nUID:absence_26@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20240315T100000\r\nDTEND;TZID=Europe/Paris:20240315T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_26@RDV Solidarités",
+                        "first_day": "2024-05-15",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20240514T080827Z\r\nUID:absence_27@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20240515T100000\r\nDTEND;TZID=Europe/Paris:20240515T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_27@RDV Solidarités",
                         "organisation": {
-                          "id": 133,
+                          "id": 146,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2386,21 +2330,21 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 38,
+                        "id": 39,
                         "agent": {
-                          "id": 151,
+                          "id": 165,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Aliénor",
+                          "first_name": "Albérade",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Boyer"
+                          "last_name": "Dvnis"
                         },
-                        "end_day": "2024-03-15",
+                        "end_day": "2024-05-15",
                         "end_time": "15:30:00",
-                        "first_day": "2024-03-15",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20240314T105709Z\r\nUID:absence_38@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20240315T100000\r\nDTEND;TZID=Europe/Paris:20240315T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_38@RDV Solidarités",
+                        "first_day": "2024-05-15",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20240514T080827Z\r\nUID:absence_39@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20240515T100000\r\nDTEND;TZID=Europe/Paris:20240515T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_39@RDV Solidarités",
                         "organisation": {
-                          "id": 145,
+                          "id": 158,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2696,11 +2640,11 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 172,
+                          "id": 189,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Thibault",
+                          "first_name": "Olivier",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Joly"
+                          "last_name": "Paul"
                         }
                       ],
                       "meta": {
@@ -2849,7 +2793,7 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 86,
+                          "id": 99,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2858,16 +2802,16 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 76,
+                            "id": 85,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 182,
-                          "service_id": 279
+                          "organisation_id": 199,
+                          "service_id": 310
                         },
                         {
-                          "id": 87,
+                          "id": 100,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2876,13 +2820,13 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 77,
+                            "id": 86,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 182,
-                          "service_id": 279
+                          "organisation_id": 199,
+                          "service_id": 310
                         }
                       ],
                       "meta": {
@@ -3013,35 +2957,35 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 209,
+                          "id": 232,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 210,
+                          "id": 233,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 211,
+                          "id": 234,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 212,
+                          "id": 235,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 213,
+                          "id": 236,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -3165,7 +3109,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 220,
+                        "id": 243,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -3280,7 +3224,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 224,
+                        "id": 247,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -3371,15 +3315,15 @@
                       "public_links": [
                         {
                           "external_id": "ext_id_A",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/263"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/295"
                         },
                         {
                           "external_id": "ext_id_B",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/264"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/296"
                         },
                         {
                           "external_id": "ext_id_C",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/265"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/297"
                         }
                       ]
                     }
@@ -3537,36 +3481,36 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 8,
-                          "address": "1 rue de l'adresse 12345 Ville",
+                          "id": 10,
+                          "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 245,
+                              "id": 272,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Pierre",
+                              "first_name": "Adonise",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Gilbert"
+                              "last_name": "Lévêque"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
                           "created_by": "agent",
-                          "created_by_id": 245,
+                          "created_by_id": 272,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 82,
-                            "address": "1 rue de l'adresse 12345 Ville",
+                            "id": 95,
+                            "address": "1 rue de l'adresse, Ville, 12345",
                             "name": "Lieu n°1",
-                            "organisation_id": 275,
+                            "organisation_id": 307,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 134,
+                            "id": 154,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3575,17 +3519,17 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 124,
+                              "id": 140,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 277,
-                            "service_id": 354
+                            "organisation_id": 309,
+                            "service_id": 401
                           },
                           "name": null,
                           "organisation": {
-                            "id": 275,
+                            "id": 307,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3593,76 +3537,37 @@
                           },
                           "participations": [
                             {
-                              "id": 10,
+                              "id": 13,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 245,
+                              "created_by_id": 272,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 59,
-                                "address": "20 avenue de Ségur, Paris",
+                                "id": 68,
+                                "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
                                 "caisse_affiliation": "caf",
                                 "case_number": null,
-                                "created_at": "2024-03-14 11:57:15 +0100",
+                                "created_at": "2024-05-14 10:08:36 +0200",
                                 "email": "usager_1@lapin.fr",
                                 "family_situation": "divorced",
-                                "first_name": "Alix",
+                                "first_name": "Armide",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "SIMON",
+                                "last_name": "MULLER",
                                 "logement": "locataire",
                                 "notes": "Super note",
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
                                 "number_of_children": 12,
-                                "phone_number": "0779661935",
-                                "phone_number_formatted": "+33779661935",
-                                "responsible": null,
-                                "responsible_id": null,
-                                "user_profiles": null
-                              }
-                            }
-                          ],
-                          "rdvs_users": [
-                            {
-                              "id": 10,
-                              "created_by": "agent",
-                              "created_by_agent_prescripteur": false,
-                              "created_by_id": 245,
-                              "created_by_type": "Agent",
-                              "send_lifecycle_notifications": true,
-                              "send_reminder_notification": true,
-                              "status": "unknown",
-                              "user": {
-                                "id": 59,
-                                "address": "20 avenue de Ségur, Paris",
-                                "address_details": null,
-                                "affiliation_number": "39012093812038",
-                                "birth_date": "1985-07-20",
-                                "birth_name": null,
-                                "caisse_affiliation": "caf",
-                                "case_number": null,
-                                "created_at": "2024-03-14 11:57:15 +0100",
-                                "email": "usager_1@lapin.fr",
-                                "family_situation": "divorced",
-                                "first_name": "Alix",
-                                "invitation_accepted_at": null,
-                                "invitation_created_at": null,
-                                "last_name": "SIMON",
-                                "logement": "locataire",
-                                "notes": "Super note",
-                                "notify_by_email": true,
-                                "notify_by_sms": true,
-                                "number_of_children": 12,
-                                "phone_number": "0779661935",
-                                "phone_number_formatted": "+33779661935",
+                                "phone_number": "0619411509",
+                                "phone_number_formatted": "+33619411509",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3673,35 +3578,35 @@
                           "status": "unknown",
                           "users": [
                             {
-                              "id": 59,
-                              "address": "20 avenue de Ségur, Paris",
+                              "id": 68,
+                              "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
                               "caisse_affiliation": "caf",
                               "case_number": null,
-                              "created_at": "2024-03-14 11:57:15 +0100",
+                              "created_at": "2024-05-14 10:08:36 +0200",
                               "email": "usager_1@lapin.fr",
                               "family_situation": "divorced",
-                              "first_name": "Alix",
+                              "first_name": "Armide",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "SIMON",
+                              "last_name": "MULLER",
                               "logement": "locataire",
                               "notes": "Super note",
                               "notify_by_email": true,
                               "notify_by_sms": true,
                               "number_of_children": 12,
-                              "phone_number": "0779661935",
-                              "phone_number_formatted": "+33779661935",
+                              "phone_number": "0619411509",
+                              "phone_number_formatted": "+33619411509",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "d1cc9b13-2161-46f8-b1a8-69f3a6d8d0f8"
+                          "uuid": "90a5de17-6341-48d2-81d3-9e647cdfca40"
                         }
                       ],
                       "meta": {
@@ -3820,35 +3725,35 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 340,
+                          "id": 373,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Avigaëlle",
+                          "first_name": "Timoléon",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Giraud"
+                          "last_name": "Gerard"
                         },
                         "user": {
-                          "id": 131,
-                          "address": "20 avenue de Ségur, Paris",
+                          "id": 144,
+                          "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-03-14 11:57:21 +0100",
+                          "created_at": "2024-05-14 10:08:48 +0200",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Primerose",
+                          "first_name": "Léonard",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LAPORTE",
+                          "last_name": "JACQUET",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 58 73 79 23",
-                          "phone_number_formatted": "+33658737923",
+                          "phone_number": "7 51 16 53 80",
+                          "phone_number_formatted": "+33751165380",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4129,35 +4034,35 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 362,
+                          "id": 400,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         "user": {
-                          "id": 146,
-                          "address": "20 avenue de Ségur, Paris",
+                          "id": 160,
+                          "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-03-14 11:57:22 +0100",
+                          "created_at": "2024-05-14 10:08:50 +0200",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Alverède",
+                          "first_name": "Manassé",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PICHON",
+                          "last_name": "RÉMY",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "7 56 83 57 99",
-                          "phone_number_formatted": "+33756835799",
+                          "phone_number": "6 47 35 86 15",
+                          "phone_number_formatted": "+33647358615",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4456,15 +4361,15 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 162,
-                        "address": "20 avenue de Ségur, Paris",
+                        "id": 177,
+                        "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-03-14 11:57:24 +0100",
+                        "created_at": "2024-05-14 10:08:52 +0200",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -4476,14 +4381,14 @@
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "0741520069",
-                        "phone_number_formatted": "+33741520069",
+                        "phone_number": "07 52 91 30 12",
+                        "phone_number_formatted": "+33752913012",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 382,
+                              "id": 421,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -4676,7 +4581,7 @@
             "name": "address",
             "in": "query",
             "description": "Adresse",
-            "example": "10 rue du Havre, Paris",
+            "example": "10 rue du Havre, Paris, 75016",
             "required": false,
             "schema": {
               "type": "string"
@@ -4795,15 +4700,15 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 201,
-                        "address": "10 rue du Havre, Paris",
+                        "id": 216,
+                        "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-03-14 11:57:25 +0100",
+                        "created_at": "2024-05-14 10:08:54 +0200",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Alain",
@@ -4818,33 +4723,33 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 200,
-                          "address": "20 avenue de Ségur, Paris",
+                          "id": 215,
+                          "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-03-14 11:57:25 +0100",
+                          "created_at": "2024-05-14 10:08:54 +0200",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Lucille",
+                          "first_name": "Nicole",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LECLERC",
+                          "last_name": "ROBERT",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "648146314",
-                          "phone_number_formatted": "+33648146314",
+                          "phone_number": "07 50 01 24 67",
+                          "phone_number_formatted": "+33750012467",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 200,
+                        "responsible_id": 215,
                         "user_profiles": null
                       }
                     }
@@ -4980,7 +4885,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "BHIT5S1I"
+                      "invitation_token": "DH387SSO"
                     }
                   }
                 },
@@ -5119,28 +5024,28 @@
                     "value": {
                       "users": [
                         {
-                          "id": 219,
-                          "address": "20 avenue de Ségur, Paris",
+                          "id": 234,
+                          "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-03-14 11:57:26 +0100",
+                          "created_at": "2024-05-14 10:08:56 +0200",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Euphrasie",
+                          "first_name": "Thérèse",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEROUX",
+                          "last_name": "BAILLY",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "790407854",
-                          "phone_number_formatted": "+33790407854",
+                          "phone_number": "07 42 52 87 42",
+                          "phone_number_formatted": "+33742528742",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5312,7 +5217,7 @@
             "name": "address",
             "in": "query",
             "description": "Adresse",
-            "example": "10 rue du Havre, Paris",
+            "example": "10 rue du Havre, Paris, 75016",
             "required": false,
             "schema": {
               "type": "string"
@@ -5403,15 +5308,15 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 230,
-                        "address": "10 rue du Havre, Paris",
+                        "id": 245,
+                        "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-03-14 11:57:27 +0100",
+                        "created_at": "2024-05-14 10:08:57 +0200",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Johnny",
@@ -5426,33 +5331,33 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 229,
-                          "address": "20 avenue de Ségur, Paris",
+                          "id": 244,
+                          "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-03-14 11:57:27 +0100",
+                          "created_at": "2024-05-14 10:08:57 +0200",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Aurèle",
+                          "first_name": "Maguelone",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "FABRE",
+                          "last_name": "COLIN",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "0613148523",
-                          "phone_number_formatted": "+33613148523",
+                          "phone_number": "0769814993",
+                          "phone_number_formatted": "+33769814993",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 229,
+                        "responsible_id": 244,
                         "user_profiles": null
                       }
                     }
@@ -5599,28 +5504,28 @@
                     "value": {
                       "users": [
                         {
-                          "id": 239,
-                          "address": "20 avenue de Ségur, Paris",
+                          "id": 254,
+                          "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-03-14 11:57:27 +0100",
+                          "created_at": "2024-05-14 10:08:58 +0200",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Archange",
+                          "first_name": "Macaire",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ROUX",
+                          "last_name": "CARPENTIER",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "6 17 97 40 30",
-                          "phone_number_formatted": "+33617974030",
+                          "phone_number": "699258714",
+                          "phone_number_formatted": "+33699258714",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5743,15 +5648,15 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 244,
-                        "address": "20 avenue de Ségur, Paris",
+                        "id": 259,
+                        "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-03-14 11:57:28 +0100",
+                        "created_at": "2024-05-14 10:08:58 +0200",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -5763,14 +5668,14 @@
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "7 68 42 86 91",
-                        "phone_number_formatted": "+33768428691",
+                        "phone_number": "06 54 66 64 27",
+                        "phone_number_formatted": "+33654666427",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 454,
+                              "id": 493,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -6090,8 +5995,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 25,
-                        "organisation_id": 477,
+                        "id": 30,
+                        "organisation_id": 517,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -6294,8 +6199,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 30,
-                        "organisation_id": 490,
+                        "id": 35,
+                        "organisation_id": 530,
                         "subscriptions": [
                           "rdv",
                           "user",


### PR DESCRIPTION
Byebye `rdvs_users`
Depuis 1 mois on log les accés à notre api dans une table dédiée.
On a eu un seul utilisateur unique de l'api pour l'index des rdvs (qui contient l'association dépréciée) en 1 mois et il a déjà migré : 
https://mattermost.incubateur.net/betagouv/pl/wf7j5855ff8qmpsw447k3s77mr
On peut donc enlever ce code inutile et terminer cette migration.