### PR TITLE
Correctif sur les policies dans la sectorisation

### DIFF
--- a/app/views/admin/territories/sectors/show.html.slim
+++ b/app/views/admin/territories/sectors/show.html.slim
@@ -60,7 +60,7 @@
                 - else
                   td.text-muted Commune entière
                 td
-                  - if policy([:agent, zone]).destroy?
+                  - if policy([:configuration, zone]).destroy?
                     = link_to "retirer", admin_territory_sector_zone_path(current_territory, @sector, zone), method: :delete
         div= paginate @zones
         .mb-2.text-center


### PR DESCRIPTION
Similaire à https://github.com/betagouv/rdv-service-public/pull/4254
Corrige https://sentry.incubateur.net/organizations/betagouv/issues/99234/?project=74&referrer=webhooks_plugin suite à https://github.com/betagouv/rdv-service-public/pull/4249

J'ai fait une recherche des autres occurrences de `policy.*agent` dans `app/views/admin/territories`, et c'était la dernière.