### PR TITLE
Désactivation temporaire de france connect pour l'anct

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -75,7 +75,7 @@ class Domain
       can_sync_to_outlook: false,
       sms_sender_name: "RDV S.P.",
       documentation_url: "https://rdvs.notion.site/RDV-Service-Public-ab27fed1634741e0a1537fcb0d1d5a24",
-      france_connect_enabled: true,
+      france_connect_enabled: false,
       support_email: "support@rdv-service-public.fr",
       verticale: :rdv_mairie,
       secretariat_email: "secretariat-auto@rdv-service-public.fr"

--- a/app/views/common/_franceconnect_button.html.slim
+++ b/app/views/common/_franceconnect_button.html.slim
@@ -1,4 +1,4 @@
-- if current_domain.france_connect_enabled
+- if current_domain.france_connect_enabled || params[:force_franceconnect].present?
   .text-center.mb-3
     p FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne
     = link_to "/omniauth/franceconnect", class: "france-connect-link", method: :post do


### PR DESCRIPTION
Suite à une expiration d'un dns non utilisé (mais qui était utilisé pour une redirection dans france connect) en début de semaine france connect ne fonctionne plus pour rdv-mairie tant que l'équipe du support france connect ne fait pas les changements.
On désactive france connect temporairement pour rdv-mairie et on affiche le bouton avec un params dédié pour pouvoir continuer à tester (après la résolution on gardera ce fonctionnement au cas ou pour plus tard).