### PR TITLE
Demander aux agents de mettre à jour leur mot de passe s'il est trop faible

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -1,6 +1,16 @@
 class Agents::SessionsController < Devise::SessionsController
   before_action :exclude_signed_in_users, only: [:new]
 
+  def create
+    checker = PasswordChecker.new(params[:agent][:password]) # voir aussi app/controllers/users/sessions_controller.rb
+    if checker.too_weak?
+      flash[:error] =
+        "Votre mot de passe est trop faible, vous devez le mettre à jour pour continuer d'utiliser #{current_domain.name}. <a href=\"#{edit_agent_mot_de_passes_path}\">Changer de mot de passe</a>"
+    end
+
+    super
+  end
+
   private
 
   def exclude_signed_in_users

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -2,13 +2,13 @@ class Agents::SessionsController < Devise::SessionsController
   before_action :exclude_signed_in_users, only: [:new]
 
   def create
+    super
+
     checker = PasswordChecker.new(params[:agent][:password]) # voir aussi app/controllers/users/sessions_controller.rb
     if checker.too_weak?
-      flash[:error] =
-        "Votre mot de passe est trop faible, vous devez le mettre à jour pour continuer d'utiliser #{current_domain.name}. <a href=\"#{edit_agent_mot_de_passes_path}\">Changer de mot de passe</a>"
+      flash[:notice] = nil
+      flash[:alert] = checker.error_message(current_domain.name)
     end
-
-    super
   end
 
   private

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,8 +13,8 @@ class Users::SessionsController < Devise::SessionsController
 
       checker = PasswordChecker.new(params[:user][:password]) # voir aussi app/controllers/agents/sessions_controller.rb
       if checker.too_weak?
-        flash[:error] =
-          "Votre mot de passe est trop faible, vous devez le mettre à jour pour continuer d'utiliser #{current_domain.name}. <a href=\"#{edit_agent_mot_de_passes_path}\">Changer de mot de passe</a>"
+        flash[:notice] = nil
+        flash[:alert] = checker.error_message(current_domain.name)
       end
 
       yield resource if block_given?

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,6 +10,13 @@ class Users::SessionsController < Devise::SessionsController
     if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])
       set_flash_message!(:notice, :signed_in)
       sign_in(:agent, resource)
+
+      checker = PasswordChecker.new(params[:user][:password]) # voir aussi app/controllers/agents/sessions_controller.rb
+      if checker.too_weak?
+        flash[:error] =
+          "Votre mot de passe est trop faible, vous devez le mettre à jour pour continuer d'utiliser #{current_domain.name}. <a href=\"#{edit_agent_mot_de_passes_path}\">Changer de mot de passe</a>"
+      end
+
       yield resource if block_given?
       respond_with resource, location: after_sign_in_path_for(resource)
     else

--- a/app/services/password_checker.rb
+++ b/app/services/password_checker.rb
@@ -7,4 +7,12 @@ class PasswordChecker
   def too_weak?
     @agent_for_validation.errors[:password].any?
   end
+
+  def error_message(app_name)
+    <<~MESSAGE
+      <div class="fa fa-exclamation-triangle mr-1" />
+      Votre mot de passe est trop faible, vous devez le mettre à jour pour continuer d'utiliser #{app_name}.
+      <a href="#{Rails.application.routes.url_helpers.edit_agent_mot_de_passes_path}">Changer de mot de passe</a>
+    MESSAGE
+  end
 end

--- a/app/services/password_checker.rb
+++ b/app/services/password_checker.rb
@@ -1,0 +1,13 @@
+class PasswordChecker
+  def initialize(password)
+    @agent_for_validation = Agent.new(password: password) # ne sera pas persisté
+    @agent_for_validation.validate
+  end
+
+  def too_weak?
+    # Si l'agent se connecte par oauth, on ne fait pas de vérification sur le mot de passe
+    return false if @agent_for_validation.password.blank?
+
+    @agent_for_validation.errors[:password].any?
+  end
+end

--- a/app/services/password_checker.rb
+++ b/app/services/password_checker.rb
@@ -5,9 +5,6 @@ class PasswordChecker
   end
 
   def too_weak?
-    # Si l'agent se connecte par oauth, on ne fait pas de vérification sur le mot de passe
-    return false if @agent_for_validation.password.blank?
-
     @agent_for_validation.errors[:password].any?
   end
 end

--- a/spec/features/agents/account/agent_can_login_spec.rb
+++ b/spec/features/agents/account/agent_can_login_spec.rb
@@ -10,4 +10,20 @@ RSpec.describe "Agent can login" do
       .from(be_within(10.seconds).of(2.weeks.ago))
       .to(be_within(10.seconds).of(Time.zone.now))
   end
+
+  context "when the agent's password is too weak" do
+    let(:agent) do
+      build(:agent, password: "tropfaible").tap do |a|
+        a.save(validate: false)
+      end
+    end
+
+    it "shows a warning and advises to change the password" do
+      visit new_agent_session_path
+      fill_in "Email", with: agent.email
+      fill_in "password", with: "tropfaible"
+      click_on "Se connecter"
+      expect(page).to have_content("Votre mot de passe est trop faible")
+    end
+  end
 end

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe "User signs up and signs in" do
       end
       expect(page).to have_current_path(admin_organisation_agent_agenda_path(agent.organisations.first, agent), ignore_query: true)
     end
+
+    context "when the agent's password is too weak" do
+      let(:agent) do
+        build(:agent, password: "tropfaible").tap do |a|
+          a.save(validate: false)
+        end
+      end
+
+      it "shows a warning and advises to change the password" do
+        visit new_agent_session_path
+        fill_in "Email", with: agent.email
+        fill_in "password", with: "tropfaible"
+        click_on "Se connecter"
+        expect(page).to have_content("Votre mot de passe est trop faible")
+      end
+    end
   end
 
   def expect_flash_info(message)

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "User signs up and signs in" do
       end
 
       it "shows a warning and advises to change the password" do
-        visit new_agent_session_path
+        visit new_user_session_path
         fill_in "Email", with: agent.email
         fill_in "password", with: "tropfaible"
         click_on "Se connecter"


### PR DESCRIPTION
pour https://github.com/betagouv/rdv-service-public/issues/4278

On ajoute un avertissement pour demander aux agents de changer leur mot de passe s'il est trop faible.
C'est une première version pour qu'ils commencent à faire les mises à jour, et on sera plus ferme la semaine prochaine.


<img width="1422" alt="Screenshot 2024-05-21 at 17 47 22" src="https://github.com/betagouv/rdv-service-public/assets/1840367/180f9884-c9a1-4ba9-bce2-fbabafd4cdf1">

(UI validée avec Téo)