### PR TITLE
Update GitHub actions/cache from v3 (deprecated) to v4 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
       - name: Cache js dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
@@ -122,7 +122,7 @@ jobs:
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test unit spec runtime log
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: unit-spec-runtime-log-${{ hashFiles('tmp/spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log
@@ -169,7 +169,7 @@ jobs:
       - name: Set up Redis
         uses: zhulik/redis-action@1.1.0
       - name: Cache js dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: node_modules-${{ hashFiles('yarn.lock') }}
           path: node_modules
@@ -180,7 +180,7 @@ jobs:
       - name: Prepare runtime log cache key
         run: ls spec/features/**/*.rb > tmp/feature_spec_files.txt
       - name: Cache parallel test feature spec runtime log
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: feature-spec-runtime-log-${{ hashFiles('tmp/feature_spec_files.txt') }}
           path: tmp/parallel_runtime_rspec.log


### PR DESCRIPTION
On a ce warning dans notre CI :

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Visiblement un passage en v4 règle le problème.

# Checklist

Avant la revue :
- [x] Nettoyer les commits pour faciliter la relecture
- [x] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
