### PR TITLE
Expliciter les nouvelles contraintes sur les mots de passe lors d'un reset de mot de passe par les agents 

### DIFF
--- a/app/views/agents/mot_de_passes/_new_password_hints.html.slim
+++ b/app/views/agents/mot_de_passes/_new_password_hints.html.slim
@@ -1,0 +1,10 @@
+.form-text.text-muted.mb-2
+  p
+    = "Votre mot de passe doit contenir :"
+    ul
+      li= "#{Devise.password_length.first} caractères minimum"
+      li= "1 chiffre minimum"
+      li= "1 majuscule minimum"
+      li= "1 caractère spécial minimum"
+
+  | Si possible, nous vous recommandons d'utiliser un gestionnaire de mots de passe.

--- a/app/views/agents/mot_de_passes/edit.html.slim
+++ b/app/views/agents/mot_de_passes/edit.html.slim
@@ -4,16 +4,8 @@
   = render "devise/shared/error_messages", resource: current_agent
   = f.input :password, label: "Nouveau mot de passe", autocomplete: "new-password"
   = f.input :password_confirmation, label: "Confirmation du mot de passe", autocomplete: "new-password"
-  .form-text.text-muted.mb-2
-    p
-      = "Votre mot de passe doit contenir :"
-      ul
-        li= "#{Devise.password_length.first} caractères minimum"
-        li= "1 chiffre minimum"
-        li= "1 majuscule minimum"
-        li= "1 caractère spécial minimum"
+  = render "agents/mot_de_passes/new_password_hints"
 
-    | Si possible, nous vous recommandons d'utiliser un gestionnaire de mots de passe.
   = f.input :current_password, hint: "Votre mot de passe actuel", required: true, autocomplete: "off"
   .d-flex.justify-content-between
     = link_to("Retour à votre compte", edit_agent_registration_path, class: "mb-2")

--- a/app/views/devise/passwords/edit.html.slim
+++ b/app/views/devise/passwords/edit.html.slim
@@ -8,12 +8,11 @@
   = render "devise/shared/error_messages", resource: resource
   = f.input :reset_password_token, as: :hidden
   .form-group
-    = f.password_field :password, as: :password, label: "Mot de passe", class: "form-control", autocomplete: "off", required: true, id: "password"
+    = f.password_field :password, as: :password, label: "Mot de passe", class: "form-control", autocomplete: "new-password", required: true, id: "password"
     span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
 
-  - if @minimum_password_length
-    .form-text.text-muted.mb-2
-      | #{@minimum_password_length} caractères minimum
+    = render "agents/mot_de_passes/new_password_hints"
+
   .text-center
     = f.submit "Enregistrer", class: "btn btn btn-primary"
 


### PR DESCRIPTION
Un petit détail qui avait été oublié dans https://github.com/betagouv/rdv-service-public/pull/4265
On avait bien les validations en back, mais elle n'étaient pas expliquées en front.


# Avant 

<img width="1067" alt="Screenshot 2024-05-23 at 12 08 19" src="https://github.com/betagouv/rdv-service-public/assets/1840367/e0cc038b-6fcb-4a90-b228-bf50a9beafd6">

# Après 

<img width="1108" alt="Screenshot 2024-05-23 at 12 08 06" src="https://github.com/betagouv/rdv-service-public/assets/1840367/61910733-9cc3-4545-813d-878b9dcf0b52">


