### PR TITLE
Création des bases de données pour les tests en parallèle dans le setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -26,6 +26,9 @@ FileUtils.chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 
+  puts "\n== Preparing parallel test databases =="
+  system! "RAILS_ENV=test rake parallel:create"
+
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 


### PR DESCRIPTION
Sans cet appel préalable à `rake parallel:create`, les lancements de tests échouent, par exemple avec `make test` : 

```
ActiveRecord::NoDatabaseError:
  We could not find your database: lapin_test2.
```