### PR TITLE
[Rdv Mairie] Ne pas exiger le numéro ANTS, lorsque le motif du RDV ne le requiert pas

### DIFF
--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -13,7 +13,7 @@ ruby:
     - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
       .col-md-6= f.input :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
       .col-md-6= date_input(f, :birth_date, disabled: user.logged_once_with_franceconnect?)
-  - if rdv_wizard&.rdv&.requires_ants_predemande_number? || current_user.rdvs.requires_ants_predemande_number.any?
+  - if rdv_wizard&.rdv&.requires_ants_predemande_number?
     = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   - if user.logged_once_with_franceconnect?
     .alert.alert-info.d-flex.align-items-center


### PR DESCRIPTION
La mairie de Gattières nous a signalé un bug selon lequel, les usagers en voulant prendre RDV pour le motif _Retrait_, sont bloqués, car le formulaire exige le numéro ANTS. 
Ce numéro ayant déjà été consommé lors de la prise de RDV, il est signalé comme invalide et la prise de RDV est bloquée. (Voire capture d'écran, ci-dessous).

Cette PR reproduit le bug à l'aide d'un feature test (`spec/features/users/online_booking/on_rdv_mairie_spec.rb:243`) et propose un correctif.

## Screenshot du bug

![IMG_6368](https://github.com/betagouv/rdv-service-public/assets/11911945/d1e150d1-ec78-4c04-aad1-e8c9a76b541f)

## Détails sur l'origine du bug
L'affichage du champ pour le numéro ANTS est conditionné au motif du Rdv courant, mais aussi à l'existence de Rdvs précédents avec numéro ANTS pour l'usager courant. Cette deuxième condition est erronée et crée des faux positifs.

# Checklist

Avant la revue :
- [X] Nettoyer les commits pour faciliter la relecture
- [X] Supprimer les éventuels logs de test et le code mort

Revue :
- [ ] Relecture du code
- [ ] Test sur la review app / en local
