### PR TITLE
Nouveau template de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
-Pour tester : <`mettre ici l'url de la review app une fois déployé`>
+Closes #XXXX
+
+Review app : https://demo-rdv-solidarites-prXXXX.osc-secnum-fr1.scalingo.io/
+
+# Contexte
 
 Décrire le pourquoi des modifications
 
-Closes #issue_number
+# Solution
+
+Expliquer les choix techniques
 
 # Checklist
 
-Avant la revue :
+- [ ] Extraire dans d'autres PRs les changements indépendants
 - [ ] Préparer des captures de l’interface avant et après
-- [ ] Nettoyer les commits pour faciliter la relecture
-- [ ] Supprimer les éventuels logs de test et le code mort
-
-Revue :
-- [ ] Relecture du code
-- [ ] Test sur la review app / en local

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,5 +12,5 @@ Expliquer les choix techniques
 
 # Checklist
 
-- [ ] Extraire dans d'autres PRs les changements indépendants
+- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
 - [ ] Préparer des captures de l’interface avant et après


### PR DESCRIPTION
# Contexte

Au point tech du 23 mai 2024, nous avons abordé le sujet des templates de PR. OIl en est ressorti que :
- la section "Revue" n'était jamais utilisée
- le point "Supprimer les éventuels logs de test et le code mort" n'avait pas pour effet d'améliorer les réflexes de l'équipe sur ce point, car ces réflexes sont déjà très bons
- la pratique "Nettoyer les commits pour faciliter la relecture" n'était pas respectée car trop chronophage, malgré des préférences hétérogènes dans l'équipe

L'équipe tech a aussi pour ambition de faire de plus petites PRs pour fluidifier les reviews et les déploiements.

Pour l'URL de review app, j'ai trouvé plus pratique de la pré-remplir, au lieu de devoir la retrouver à chaque fois.

# Checklist

- [ ] Séparer les changements indépendants en plusieurs PRs si nécessaire
- [ ] Préparer des captures de l’interface avant et après
