### PR TITLE
[BUG] Fix formulaire des webhook

### DIFF
--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -30,7 +30,7 @@ class WebhookEndpoint < ApplicationRecord
   end
 
   def partially_hidden_secret
-    secret.gsub(/.(?=.{3})/, "*")
+    secret&.gsub(/.(?=.{3})/, "*")
   end
 
   private


### PR DESCRIPTION
Suite à cette PR : https://github.com/betagouv/rdv-service-public/pull/4296
Le formulaire de création des webhook cherchait à appliquer gsub à un secret initialisé à nil.
Ce fix régle le problème.
Pour mettre en place une spec de non regression il faudrait créer un feature test.
Je peux m'en occuper si vous estimez que c'est nécessaire.