### PR TITLE
Afficher le lien de visio aux secrétaires

### DIFF
--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -13,7 +13,7 @@
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv, agent: local_assigns[:agent], remote: true
   hr.my-0.mx-3
   .card-body.py-3.row
-    .col-md-6.col-sm-12
+    .col-md-8.col-sm-12
       .d-flex.justify-content-between.flex-wrap.mb-1
         p.card-text
           i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
@@ -23,7 +23,7 @@
             = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
       = render "admin/rdvs/rdv_details", rdv: rdv
 
-    .col-md-6.col-sm-12
+    .col-md-4.col-sm-12
       div.d-flex.justify-content-end.mt-1
         = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "btn btn-outline-primary btn-sm mr-2"
         - if rdv.individuel?

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -25,7 +25,7 @@
   p.card-text
     i.fa.fa-video-camera.text-primary-blue>
     = "Par visioconférence "
-    - if current_agent.in?(rdv.agents)
+    - if current_agent.in?(rdv.agents) || current_agent.secretaire?
       = link_to(rdv.visio_url, target: :_blank) do
         = "démarrer la visioconférence "
         i.fa.fa-external-link[aria-hidden="true"]

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -30,7 +30,7 @@
       = link_to(rdv.visio_url, target: :_blank) do
         = "démarrer la visioconférence "
         i.fa.fa-external-link[aria-hidden="true"]
-    - if !should_display_link
+    - else
       br
       small.text-muted = "Le lien de visioconférence s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."
 

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -22,13 +22,18 @@
     i.fa.fa-fw.fa-phone.text-primary-blue>
     | RDV téléphonique
 - elsif rdv.motif.visio?
-  p.card-text
+  p.card-text.pb-0
+    /- should_display_link = current_agent.in?(rdv.agents) || current_agent.secretaire?
+    - should_display_link = false
     i.fa.fa-video-camera.text-primary-blue>
     = "Par visioconférence "
-    - if current_agent.in?(rdv.agents) || current_agent.secretaire?
+    - if should_display_link
       = link_to(rdv.visio_url, target: :_blank) do
         = "démarrer la visioconférence "
         i.fa.fa-external-link[aria-hidden="true"]
+
+  - if !should_display_link
+    small.text-muted = "Le lien de visio s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."
 - else
   .d-flex.card-text.mb-1
     div.mr-1

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -22,18 +22,18 @@
     i.fa.fa-fw.fa-phone.text-primary-blue>
     | RDV téléphonique
 - elsif rdv.motif.visio?
-  p.card-text.pb-0
-    /- should_display_link = current_agent.in?(rdv.agents) || current_agent.secretaire?
-    - should_display_link = false
+  p.card-text.mb-0
+    - should_display_link = current_agent.in?(rdv.agents) || current_agent.secretaire?
     i.fa.fa-video-camera.text-primary-blue>
     = "Par visioconférence "
     - if should_display_link
       = link_to(rdv.visio_url, target: :_blank) do
         = "démarrer la visioconférence "
         i.fa.fa-external-link[aria-hidden="true"]
+    - if !should_display_link
+      br
+      small.text-muted = "Le lien de visioconférence s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."
 
-  - if !should_display_link
-    small.text-muted = "Le lien de visio s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."
 - else
   .d-flex.card-text.mb-1
     div.mr-1


### PR DESCRIPTION
On a eu des premiers retours du CDAD sur la visio, et ça leur serait utile que les secrétaires puissent accéder au lien de visio, surtout pour le cas des intervenants (des agents qui n'ont pas de compte, mais qui assurent des rdv). On avait caché ce lien aux agents qui ne font pas partie du rdv pour limiter le risque qu'il soit partagé à n'importe qui.
