### PR TITLE
MàJ de l’URL du budget vers le nouveau pad numerique.gouv

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,7 +252,7 @@ Rails.application.routes.draw do
   end
   get "/.well-known/microsoft-identity-association" => "static_pages#microsoft_domain_verification", format: :json
 
-  get "/budget", to: redirect("https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#RDV-Services-Publics", status: 302)
+  get "/budget", to: redirect("https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#RDV-Service-Public", status: 302)
 
   ## Shorten urls for SMS
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,7 +252,7 @@ Rails.application.routes.draw do
   end
   get "/.well-known/microsoft-identity-association" => "static_pages#microsoft_domain_verification", format: :json
 
-  get "/budget", to: redirect("https://pad.incubateur.net/3hxhbOuaSyapxRUg_PnA5g#ANCT-L%E2%80%99Incubateur-des-Territoires", status: 302)
+  get "/budget", to: redirect("https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#RDV-Services-Publics", status: 302)
 
   ## Shorten urls for SMS
   get "r", to: redirect("users/rdvs", status: 301), as: "rdvs_short"


### PR DESCRIPTION
L’[url actuelle](https://pad.incubateur.net/3hxhbOuaSyapxRUg_PnA5g#ANCT-L%E2%80%99Incubateur-des-Territoires) pointe vers ça  : 

![Screen Shot 2024-05-29 at 11 37 53](https://github.com/betagouv/rdv-service-public/assets/883348/c9617ff9-0b2b-46bb-825c-4d8413a23053)

et on perd l’anchor post-redirection