### PR TITLE
Correction du GITHUB_APP_ID dans .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@ SKYLIGHT_DISABLE_DEV_WARNING=true
 
 # Third-party authentication services
 ## Github (SuperAdmins)
-GITHUB_APP_ID=1069209
+GITHUB_APP_ID=bcc6effe435bfcb0388f
 GITHUB_APP_SECRET="créer un nouveau secret sur https://github.com/organizations/rdv-solidarites/settings/applications/1069209"
 ## FranceConnect (Users)
 FRANCECONNECT_APP_ID=change_me


### PR DESCRIPTION
1069209 est l’identifiant interne de l’app github mais l’identifiant à utiliser pour oauth est le CLIENT ID bcc6effe435bfcb0388f visible sur https://github.com/organizations/rdv-solidarites/settings/applications/1069209

Ce client ID de l’appli est bien un identifiant public