### PR TITLE
Mise en place d'erreurs standardisées pour l'API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ test_unit:  ## Run unit tests in parallel
 test_features:  ## Run feature tests
 	bundle exec spring rspec spec/features
 
+test_api: # Run API tests
+	bundle exec spring rspec spec/requests/api
+
 autocorrect: ## Fix autocorrectable lint issues
 	bundle exec rubocop --auto-correct-all
 

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -3,8 +3,6 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
 
   def creneau_availability
     render json: { creneau_availability: creneau_available? }
-  rescue StandardError => e
-    render json: { error: e.message }, status: :internal_server_error
   end
 
   private

--- a/app/controllers/api/rdvinsertion/referent_assignations_controller.rb
+++ b/app/controllers/api/rdvinsertion/referent_assignations_controller.rb
@@ -15,8 +15,6 @@ class Api::Rdvinsertion::ReferentAssignationsController < Api::Rdvinsertion::Age
 
   def set_user
     @user = User.find(referent_assignations_params[:user_id])
-  rescue ActiveRecord::RecordNotFound
-    render_error :not_found, not_found: :user
   end
 
   def referent_assignations_params

--- a/app/controllers/api/rdvinsertion/user_profiles_controller.rb
+++ b/app/controllers/api/rdvinsertion/user_profiles_controller.rb
@@ -14,8 +14,6 @@ class Api::Rdvinsertion::UserProfilesController < Api::Rdvinsertion::AgentAuthBa
 
   def set_user
     @user = User.find(user_profiles_params[:user_id])
-  rescue ActiveRecord::RecordNotFound
-    render_error :not_found, not_found: :user
   end
 
   def user_profiles_params

--- a/app/controllers/api/v1/absences_controller.rb
+++ b/app/controllers/api/v1/absences_controller.rb
@@ -10,50 +10,35 @@ class Api::V1::AbsencesController < Api::V1::AgentAuthBaseController
     authorize(absence) if absence.valid?
     absence.save!
     render_record absence
-  rescue ActiveRecord::RecordNotFound
-    render_error :not_found, not_found: :agent
   end
 
   def show
-    if @absence
-      authorize(@absence)
-      render_record @absence
-    else
-      render_error :not_found, not_found: :absence
-    end
+    authorize(@absence)
+    render_record @absence
   end
 
   def update
-    if @absence
-      authorize(@absence)
-      @absence.update!(update_params)
-      render_record @absence
-    else
-      render_error :not_found, not_found: :absence
-    end
+    authorize(@absence)
+    @absence.update!(update_params)
+    render_record @absence
   end
 
   def destroy
-    if @absence
-      authorize(@absence)
-      @absence.destroy!
-      head :no_content
-    else
-      render_error :not_found, not_found: :absence
-    end
+    authorize(@absence)
+    @absence.destroy!
+    head :no_content
   end
 
   private
 
   def retrieve_absence
-    @absence = Absence.find_by(id: params[:id])
+    @absence = Absence.find(params[:id])
   end
 
   def create_params
     # Allow creating an absence for an agent identified by their email.
     if params[:agent_id].blank? && params[:agent_email].present?
       agent = Agent.find_by!(email: params[:agent_email])
-      render_error :not_found, not_found: :agent unless agent
       params[:agent_id] = agent.id
       params.delete(:agent_email)
     end

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -25,42 +25,17 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   # Rescuable exceptions
 
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
-  rescue_from ActionController::ParameterMissing, with: :parameter_missing
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-  rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
 
   def not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
+    # Je ne peux pas faire ca ici
+    # raise ApiException::Forbidden, t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default)
     render(
       status: :forbidden,
       json: {
-        errors: [{ base: :forbidden }],
-        error_messages: [t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default)],
-      }
-    )
-  end
-
-  def parameter_missing(exception)
-    render(
-      status: :unprocessable_entity,
-      json: { success: false, errors: [exception.to_s] }
-    )
-  end
-
-  def record_not_found(exception)
-    render(
-      status: :not_found,
-      json: { success: false, errors: [exception.to_s] }
-    )
-  end
-
-  def record_invalid(exception)
-    render(
-      status: :unprocessable_entity,
-      json: {
         success: false,
-        errors: exception.record.errors.details,
-        error_messages: exception.record.errors.map { "#{_1.attribute} #{_1.message}" },
+        message: "Unauthorized",
+        detail: t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default),
       }
     )
   end

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -1,6 +1,8 @@
 class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   include Pundit::Authorization
   include DeviseTokenAuth::Concerns::SetUserByToken
+  # le Json d'erreur de DeviseTokenAuth n'est pas compliant avec le module ApiException::Handler
+  # Il faudrait trouver une solution pour formatter les erreurs de DeviseTokenAuth
 
   skip_before_action :verify_authenticity_token
   before_action :authenticate_agent, :log_api_call_in_database
@@ -28,7 +30,7 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   def not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
-    # Je ne peux pas faire ca ici
+    # Je ne peux pas faire ca ici, investiguer pourquoi ?
     # raise ApiException::Forbidden, t("#{policy_name}.#{exception.query}", scope: "pundit", default: :default)
     render(
       status: :forbidden,

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,17 +1,15 @@
 class Api::V1::BaseController < ActionController::Base
   respond_to :json
 
+  include ApiException::Handler
+
   PAGINATE_PER = 100
 
   protected
 
   def check_parameters_presence(*parameters)
     missing_parameters = parameters.select { |param| params[param].blank? }
-    render_error :bad_request, missing: missing_parameters.to_sentence if missing_parameters.any?
-  end
-
-  def render_error(status, error = { error: :unknown })
-    render json: error, status: status
+    raise ActionController::ParameterMissing, missing_parameters.to_sentence if missing_parameters.any?
   end
 
   def render_record(record, **options)

--- a/app/controllers/api/v1/public_links_controller.rb
+++ b/app/controllers/api/v1/public_links_controller.rb
@@ -41,7 +41,6 @@ class Api::V1::PublicLinksController < Api::V1::BaseController
   end
 
   def set_territory
-    @territory = Territory.find_by(departement_number: params[:territory])
-    render_error :not_found, not_found: :territory unless @territory
+    @territory = Territory.find_by!(departement_number: params[:territory])
   end
 end

--- a/app/controllers/api/v1/user_profiles_controller.rb
+++ b/app/controllers/api/v1/user_profiles_controller.rb
@@ -4,8 +4,6 @@ class Api::V1::UserProfilesController < Api::V1::AgentAuthBaseController
     authorize(user_profile)
     user_profile.save!
     render_record user_profile
-  rescue ArgumentError => e
-    render_error :unprocessable_entity, { success: false, errors: {}, error_messages: [e] }
   end
 
   def destroy
@@ -19,10 +17,7 @@ class Api::V1::UserProfilesController < Api::V1::AgentAuthBaseController
       user.soft_delete(organisation)
       head :no_content
     else
-      render_error :unprocessable_entity, {
-        success: false, errors: {},
-        error_messages: [I18n.t("users.can_not_delete_because_has_future_rdvs")],
-      }
+      raise ApiException::UnprocessableEntity, I18n.t("users.can_not_delete_because_has_future_rdvs")
     end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -49,8 +49,6 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   def set_user
     @user = @organisation.present? ? @organisation.users.find(params[:id]) : User.find(params[:id])
     authorize(@user)
-  rescue ActiveRecord::RecordNotFound
-    render_error :not_found, not_found: :user
   end
 
   def user_params

--- a/app/controllers/concerns/api_exception.rb
+++ b/app/controllers/concerns/api_exception.rb
@@ -1,0 +1,47 @@
+module ApiException
+  EXCEPTIONS = {
+    # 400
+    "ActionController::ParameterMissing" => { status: 400, message: "Missing Parameter" },
+
+    # 401
+    # "Unauthorized" => { status: 401, message: "Unauthorized" },
+
+    # 403
+    # "Forbidden" => { status: 403, message: "Forbidden" },
+
+    # 404
+    "ActiveRecord::RecordNotFound" => { status: 404, message: "Record Not Found" },
+
+    # 422
+    "UnprocessableEntity" => { status: 422, message: "Unprocessable Entity" },
+    "ActiveRecord::RecordInvalid" => { status: 422, message: "Unprocessable Entity" },
+  }.freeze
+
+  class BaseError < StandardError
+    def initialize(msg = nil)
+      super
+      @message = msg
+    end
+
+    def message
+      @message || nil
+    end
+  end
+
+  module Handler
+    def self.included(klass)
+      klass.class_eval do
+        EXCEPTIONS.each do |exception_name, context|
+          unless ApiException.const_defined?(exception_name)
+            ApiException.const_set(exception_name, Class.new(BaseError))
+            exception_name = "ApiException::#{exception_name}"
+          end
+
+          rescue_from exception_name do |exception|
+            render status: context[:status], json: { success: false, message: context[:message], detail: exception.message }.compact
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -138,7 +138,8 @@ RSpec.describe "Available Creneaux Count for Invitation", swagger_doc: "v1/api.j
 
           it do
             expect(parsed_response_body["creneau_availability"]).to be_falsey
-            expect(parsed_response_body["error"]).to eq("Couldn't find Lieu with 'id'=666")
+            expect(parsed_response_body["detail"]).to eq("Couldn't find Lieu with 'id'=666")
+            expect(parsed_response_body["success"]).to eq(false)
           end
         end
 

--- a/spec/requests/api/v1/public_links_request_spec.rb
+++ b/spec/requests/api/v1/public_links_request_spec.rb
@@ -71,14 +71,9 @@ RSpec.describe "Public links API", swagger_doc: "v1/api.json" do
         it { expect(ApiCall.count).to eq(0) }
       end
 
-      response 400, "Retourne 'bad_request' quand le territory est manquant" do
+
+      it_behaves_like "an endpoint that returns 400 - missing", "le paramêtre est manquant" do
         let(:territory) { nil }
-
-        schema "$ref" => "#/components/schemas/error_missing"
-
-        run_test!
-
-        it { expect(parsed_response_body).to match(missing: "territory") }
       end
 
       it_behaves_like "an endpoint that returns 404 - not found", "le territory ne peut pas être trouvé" do

--- a/spec/requests/api/v1/public_links_request_spec.rb
+++ b/spec/requests/api/v1/public_links_request_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "Public links API", swagger_doc: "v1/api.json" do
         it { expect(ApiCall.count).to eq(0) }
       end
 
-
       it_behaves_like "an endpoint that returns 400 - missing", "le paramêtre est manquant" do
         let(:territory) { nil }
       end

--- a/spec/support/api_spec_shared_examples.rb
+++ b/spec/support/api_spec_shared_examples.rb
@@ -9,9 +9,17 @@ module ApiSpecSharedExamples
     end
   end
 
+  RSpec.shared_context "an endpoint that returns 400 - missing" do |details|
+    response 400, "Renvoie 'missing' quand #{details}" do
+      schema "$ref" => "#/components/schemas/standard_error"
+
+      run_test!
+    end
+  end
+
   RSpec.shared_context "an endpoint that returns 403 - forbidden" do |details|
     response 403, "Renvoie 'forbidden' quand #{details}" do
-      schema "$ref" => "#/components/schemas/error_forbidden"
+      schema "$ref" => "#/components/schemas/standard_error"
 
       run_test!
     end
@@ -19,7 +27,7 @@ module ApiSpecSharedExamples
 
   RSpec.shared_context "an endpoint that returns 404 - not found" do |details|
     response 404, "Renvoie 'not_found' quand #{details}" do
-      schema "$ref" => "#/components/schemas/error_not_found"
+      schema "$ref" => "#/components/schemas/standard_error"
 
       run_test!
     end
@@ -27,7 +35,7 @@ module ApiSpecSharedExamples
 
   RSpec.shared_context "an endpoint that returns 422 - unprocessable_entity" do |details, document|
     response 422, "Renvoie 'unprocessable_entity' quand #{details}", document: document do
-      schema "$ref" => "#/components/schemas/error_unprocessable_entity"
+      schema "$ref" => "#/components/schemas/standard_error"
 
       run_test!
     end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -425,18 +425,14 @@ RSpec.configure do |config|
             },
             required: %w[current_page next_page prev_page total_pages total_count],
           },
-          errors_unprocessable_entity: {
+          standard_error: {
             type: "object",
             properties: {
-              errors: {
-                type: "object",
-              },
-              error_messages: {
-                type: "array",
-                items: { type: "string" },
-              },
+              success: { type: "boolean" },
+              message: { type: "string" },
+              detail: { type: "string" },
             },
-            required: %w[errors],
+            required: %w[success message],
           },
           error_too_many_request: {
             type: "object",
@@ -457,50 +453,6 @@ RSpec.configure do |config|
               },
             },
             required: %w[errors],
-          },
-          error_forbidden: {
-            type: "object",
-            properties: {
-              errors: {
-                type: "array",
-                items: {
-                  type: "object",
-                  properties: {
-                    base: { type: "string" },
-                  },
-                  required: %w[base],
-                },
-              },
-            },
-            required: %w[errors],
-          },
-          error_missing: {
-            type: "object",
-            properties: {
-              missing: { type: "string" },
-            },
-            required: %w[missing],
-          },
-          error_not_found: {
-            type: "object",
-            properties: {
-              not_found: { type: "string" },
-            },
-            required: %w[not_found],
-          },
-          error_unprocessable_entity: {
-            type: "object",
-            properties: {
-              success: { type: "boolean" },
-              errors: {
-                type: "object",
-              },
-              error_messages: {
-                type: "array",
-                items: { type: "string" },
-              },
-            },
-            required: %w[success errors error_messages],
           },
         },
       },


### PR DESCRIPTION
Work in progress.

Le but est de standardiser les modèles d'erreur que l'on utilise dans notre API (il suffit de regarder dans `swagger_helper.rb` le code que j'enlève pour se rendre compte de l'hétérogénéité des erreurs actuellement).
Je met en place un module `ApiException` qui va rescue les erreurs définie et render le format standard proposé.

```
          standard_error: {
            type: "object",
            properties: {
              success: { type: "boolean" },
              message: { type: "string" },
              detail: { type: "string" },
            },
            required: %w[success message],
```

La mise en place de ce système évite de s'embêter avec des `rescue` ou des `render_error` dans les contrôleurs de l'api.

J'aimerai bien également normaliser les erreurs de l'authentification faites avec `DeviseTokenAuth` mais il semble que cela soit assez complexe à faire et nécessiterai beaucoup de code (monkeypatching dans les controlleurs devise) pour cela.
https://medium.com/the-kickstarter/customizing-error-response-json-from-devisetokenauth-35e64ee5ce6b
https://devise-token-auth.gitbook.io/devise-token-auth/usage/overrides