### PR TITLE
[Chore] Reparer l'usage du SuperAdmin en local

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,10 @@ SAFE_DOMAIN_LIST=
 # This is used to provide redirections to rdv-insertion.fr website
 RDV_INSERTION_HOST=http://localhost:8000
 
+# SuperAdmin
+## HTTP Basic authentication in local
+ADMIN_BASIC_AUTH_PASSWORD=change_me
+
 # Third-party tools
 ## Performance
 SKYLIGHT_AUTHENTICATION=change_me

--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -43,8 +43,6 @@ module SuperAdmins
     end
 
     def user_for_paper_trail
-      return "Local SuperAdmin" if current_super_admin.nil?
-
       current_super_admin.name_for_paper_trail
     end
 
@@ -60,6 +58,14 @@ module SuperAdmins
 
     def set_sentry_context
       Sentry.set_user({ email: current_super_admin.email }) if super_admin_signed_in?
+    end
+
+    def current_super_admin
+      if ENV["ADMIN_BASIC_AUTH_PASSWORD"].present?
+        return SuperAdmin.new(first_name: "Local", last_name: "SuperAdmin", role: :legacy_admin)
+      end
+
+      super
     end
   end
 end


### PR DESCRIPTION
## Réparer l'usage du SuperAdmin en local

Lorsque l'on essaie d'utiliser le SuperAdmin en local, nous avons plusieurs erreurs, du fait que `current_super_admin` est `nil`. Cela est dû au fait qu'on effectue une authentification basique HTTP hors du circuit de Devise, qui ne parvient donc pas à attribuer la bonne valeur à `current_super_admin`.

Cette PR propose un correctif, qui consiste à `overload` la méthode `current_super_admin` de sorte à fournir une valeur valide lors d'une connexion en environnement local.

### Captures d'écran des erreurs 
![Screenshot 2024-06-03 at 12 24 04](https://github.com/betagouv/rdv-service-public/assets/11911945/5a4f52a6-68af-4e75-813f-c20c45575d43)

### Tests

Testé en Démo: Cette modification n'affecte pas le fonctionnement correct du SuperAdmin, et le logging au niveau de Papertrail fonctionne bien.

![Screenshot 2024-06-03 at 12 27 45](https://github.com/betagouv/rdv-service-public/assets/11911945/637bc4c6-3b12-4ffb-af63-4af40f760a54)
