### PR TITLE
hardcode la version de la gem parser pour correspondre à celle de Ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -169,6 +169,9 @@ group :development do
   gem "brakeman", require: false
   # Automatic Ruby code style checking tool.
   gem "rubocop", "1.24.1", require: false
+  # Rubocop depends on parser
+  # cf https://github.com/whitequark/parser#compatibility-with-ruby-mri
+  gem "parser", "3.3.1.0", require: false
   # Code style checking for RSpec files
   gem "rubocop-rspec", "2.7.0"
   # Automatic Rails code style checking tool.

--- a/Gemfile
+++ b/Gemfile
@@ -169,8 +169,8 @@ group :development do
   gem "brakeman", require: false
   # Automatic Ruby code style checking tool.
   gem "rubocop", "1.24.1", require: false
-  # Rubocop depends on parser
-  # cf https://github.com/whitequark/parser#compatibility-with-ruby-mri
+  # Rubocop depends on parser. https://github.com/whitequark/parser#compatibility-with-ruby-mri
+  # Mettre à jour la version de cette gem lorsqu'on met à jour Ruby (version actuelle : 3.3.1)
   gem "parser", "3.3.1.0", require: false
   # Code style checking for RSpec files
   gem "rubocop-rspec", "2.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
     parallel (1.22.1)
     parallel_tests (4.5.1)
       parallel
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     pg (1.4.6)
@@ -687,6 +687,7 @@ DEPENDENCIES
   omniauth_openid_connect
   paper_trail (< 13.0)
   parallel_tests
+  parser (= 3.3.1.0)
   pg
   pg_search
   phonelib

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -101,3 +101,13 @@ Pour le moment, il y a un système d'invitation avancé qui est utilisé par RDV
 - récupérer le token dans le mail d‘invitation de letter_opener
 - aller sur l’url du rdv en rajoutant le token en paramètre, ça donne quelque chose comme http://localhost:5000/users/rdvs/1234?invitation_token=MON_TOKEN
 
+## Montée en version des dépendances
+
+### Version de Ruby
+Pas de politique très clairement décidée mais la pratique est d’essayer de coller à la version la plus récente. Lors de la mise à jour de Ruby, il faut penser à mettre à jour la version cible de la gem `parser` dans le `Gemfile`, cf [le README de parser](https://github.com/whitequark/parser#compatibility-with-ruby-mri).
+
+### Version de Rails
+Pas de politique très clairement décidée mais la pratique est d’essayer de coller à la version la plus récente.
+
+### Versions des gems et des node modules
+Une politique de mise à jour prudente a été décidée cf [l’ADR 2023-04-24](https://github.com/betagouv/rdv-service-public/blob/production/docs/decisions/2023-04-24-politique-maj-gems.md)


### PR DESCRIPTION
## Problème

Actuellement lorsqu’on lance par exemple `bundle exec slim-lint app/views`, on reçoit des erreurs comme celle-ci : 
`warning: parser/current is loading parser/ruby33, which recognizes 3.3.0-compliant syntax, but you are running 3.3.1.`

La gem `parser` est une dépendance de `rubocop`.

Le [README de la gem `parser`](https://github.com/whitequark/parser#compatibility-with-ruby-mri) indique qu’il est nécessaire d’écrire en dur la version cible de ruby.

## Changements

Cette PR corrige ce problème en fixant la version de la gem `parser` dans le `Gemfile`

Je rajoute aussi un bout de documentation sur la politique de montée en version des dépendances.

