### PR TITLE
Bugfix : SSL_read: shutdown while in init (OpenSSL::SSL::SSLError)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "paper_trail", "< 13.0"
 # Integrate PostgreSQL's enum data type into ActiveRecord's schema and migrations.
 gem "activerecord-postgres_enum"
 # A Ruby client library for Redis
-gem "redis", "< 5.0"
+gem "redis"
 # Adds a Redis::Namespace class which can be used to namespace calls to Redis.
 gem "redis-namespace"
 # Generic connection pooling for Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,7 +464,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
     regexp_parser (2.8.2)
@@ -701,7 +704,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   rails_autolink
-  redis (< 5.0)
+  redis
   redis-namespace
   rspec-rails
   rspec_junit_formatter

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,10 +1,13 @@
 raise "Prevent monkey patch chaos" if Redis.respond_to?(:with_connection)
 
 class Redis
-  raise "Prevent monkey patch chaos" if const_defined?(:CONNECTION_POOL)
+  raise "Prevent monkey patch chaos" if const_defined?(:CONNECTION_POOL) || const_defined?(:POOL_TIMEOUT) || const_defined?(:REDIS_TIMEOUT)
 
-  CONNECTION_POOL = ConnectionPool.new(size: ENV.fetch("RAILS_MAX_THREADS", 5), timeout: 5) do
-    redis_connection = new(url: Rails.configuration.x.redis_url)
+  POOL_TIMEOUT = 5 # amount of time to wait for a connection if none currently available in the pool
+  REDIS_TIMEOUT = 5 # timeout for each individual connection, see https://github.com/redis/redis-rb?tab=readme-ov-file#timeouts
+
+  CONNECTION_POOL = ConnectionPool.new(size: ENV.fetch("RAILS_MAX_THREADS", 5), timeout: POOL_TIMEOUT) do
+    redis_connection = new(url: Rails.configuration.x.redis_url, timeout: REDIS_TIMEOUT)
     Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
   end
 


### PR DESCRIPTION
Closes #4321

Review app : https://demo-rdv-solidarites-pr4324.osc-secnum-fr1.scalingo.io/

Note : la branche est mal nommée, on ne fix pas de timeout, on fix l'erreur décrite dans l'issue.

# Contexte

Tout est décrit dans #4321.

# Solution

1. Mise à jour de la gem `redis` en v5, ce qui introduit une dépendance sur `redis-client` (comme expliqué dans l'issue).
2. Je passe explicitement `5` comme valeur de timeout dans notre méthode de helper d'appels à Redis. Cette valeur diffère de notre config pour le cache (voir `application.rb`), mais reste bien la même que notre valeur actuelle (5 seconde par défaut). Si on veut l'ajuster plus tard, on pourra.

Note : on voit que `redis-client` (la gem base niveau utilisée par la gem `redis` haut niveau) propose une pool de connection, mais pas encore `redis`, qui conseille toujours de passer par la gem `connection_pool`. Donc on continue à utilise `connection_pool` qui fonctionne très bien.

# Checklist

- [ ] ~~Extraire dans d'autres PRs les changements indépendants, si nécessaire~~
- [ ] ~~Préparer des captures de l’interface avant et après~~
