### PR TITLE
Lien vers le vaultwarden pour certaines variables d'env en local

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,9 +31,10 @@ GITHUB_APP_SECRET="créer un nouveau secret sur https://github.com/organizations
 FRANCECONNECT_APP_ID=change_me
 FRANCECONNECT_APP_SECRET=change_me
 FRANCECONNECT_HOST=change_me
+
 ## Microsoft Graph (Users for Calendar)
-AZURE_APPLICATION_CLIENT_ID=change_me
-AZURE_APPLICATION_CLIENT_SECRET=change_me
+AZURE_APPLICATION_CLIENT_ID=c8bdd6de-569d-434a-a39f-f369e32276af
+AZURE_APPLICATION_CLIENT_SECRET="voir https://coffre.incubateur.anct.gouv.fr/#/vault?folderId=577313a3-40e2-48e9-b043-273019afc22f&itemId=48247d0e-fc14-47b4-b3bb-11c78f77d1a7"
 
 # Third-party services
 ## SMS provider (fallback if not setup in the Departement)
@@ -70,5 +71,5 @@ POSTGRES_PASSWORD=
 # Shared Secrets for external services
 SHARED_SECRET_FOR_AGENTS_AUTH=123456
 ANTS_API_AUTH_TOKEN=fake_ants_api_auth_token
-ANTS_RDV_OPT_AUTH_TOKEN=""
+ANTS_RDV_OPT_AUTH_TOKEN="voir https://coffre.incubateur.anct.gouv.fr/#/vault?folderId=577313a3-40e2-48e9-b043-273019afc22f&itemId=48247d0e-fc14-47b4-b3bb-11c78f77d1a7"
 ANTS_RDV_API_URL="https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api"


### PR DESCRIPTION
Pour simplifier la configuration des variables d'env pour le développement en local qu'on ne veut pas committer (typiquement les secrets des différents services d'oauth), j'ai ajouté une note dans le vaultwarden de l'anct qui récapitule ces valeurs dans un format de fichier .env

Il se peut qu'il manque certaines valeurs, on peut les ajouter au fur et à mesure.
