### PR TITLE
[Simplification des plages d'ouvertures] Amélioration du formulaire

### DIFF
--- a/app/javascript/application_agent.js
+++ b/app/javascript/application_agent.js
@@ -26,6 +26,7 @@ import { ParticipationSelect } from './components/rdv-user-select'
 import { DestroyButton } from './components/destroy-button'
 import { Tooltips } from './components/tooltips'
 import { HeaderTooltip } from './components/header_tooltip'
+import { PlageOuverture } from './components/plage_ouverture.js'
 import './components/calendar'
 import './components/browser-detection'
 import './components/clear-field-on-focus.js'
@@ -105,6 +106,8 @@ $(document).on('turbolinks:load', function() {
   new ParticipationSelect()
 
   new DestroyButton()
+
+  new PlageOuverture()
 
   Tooltips()
   HeaderTooltip()

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,4 +1,3 @@
-
 class PlageOuverture {
   constructor() {
     this.toggleLieuSelectionField();

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,18 +1,18 @@
 class PlageOuverture {
   constructor() {
-    this.toggleLieuSelectionField();
-
+    this.toggleLieuSelectionField(true);
     $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("change", () => { this.toggleLieuSelectionField(); })
   }
 
-  toggleLieuSelectionField() {
+  toggleLieuSelectionField(noTransition = false) {
     const selectedMotifsPublicOffice = $(".plage-ouverture-form .form-check-input.public_office[name='plage_ouverture[motif_ids][]']:checked");
+    const lieuSelectionField = $(".plage-ouverture-form .collapse.js-lieu-field").toggleClass("no-transition", noTransition);
 
     if (selectedMotifsPublicOffice.length > 0) {
-      $(".plage-ouverture-form .collapse.js-lieu-field").collapse("show");
+      lieuSelectionField.collapse("show");
     } else {
-      $(".plage-ouverture-form .collapse.js-lieu-field .select2-input").val(null).trigger('change');
-      $(".plage-ouverture-form .collapse.js-lieu-field").collapse("hide");
+      $(lieuSelectionField).find(".select2-input").val(null).trigger('change');
+      lieuSelectionField.collapse("hide");
     }
   }
 }

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,0 +1,22 @@
+
+class PlageOuverture {
+  constructor() {
+    this.toggleLieuSelectionField();
+
+    let that = this;
+    $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("change", () => { that.toggleLieuSelectionField(); })
+  }
+
+  toggleLieuSelectionField() {
+    let selectedMotifsPublicOffice = $(".plage-ouverture-form .form-check-input.public_office[name='plage_ouverture[motif_ids][]']:checked");
+
+    if (selectedMotifsPublicOffice.length > 0) {
+      $(".plage-ouverture-form .collapse.lieu-field").collapse("show");
+    } else {
+      $(".plage-ouverture-form .collapse.lieu-field .select2-input").val(null).trigger('change');
+      $(".plage-ouverture-form .collapse.lieu-field").collapse("hide");
+    }
+  }
+}
+
+export { PlageOuverture };

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -2,18 +2,17 @@ class PlageOuverture {
   constructor() {
     this.toggleLieuSelectionField();
 
-    let that = this;
-    $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("change", () => { that.toggleLieuSelectionField(); })
+    $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("change", () => { this.toggleLieuSelectionField(); })
   }
 
   toggleLieuSelectionField() {
-    let selectedMotifsPublicOffice = $(".plage-ouverture-form .form-check-input.public_office[name='plage_ouverture[motif_ids][]']:checked");
+    const selectedMotifsPublicOffice = $(".plage-ouverture-form .form-check-input.public_office[name='plage_ouverture[motif_ids][]']:checked");
 
     if (selectedMotifsPublicOffice.length > 0) {
-      $(".plage-ouverture-form .collapse.lieu-field").collapse("show");
+      $(".plage-ouverture-form .collapse.js-lieu-field").collapse("show");
     } else {
-      $(".plage-ouverture-form .collapse.lieu-field .select2-input").val(null).trigger('change');
-      $(".plage-ouverture-form .collapse.lieu-field").collapse("hide");
+      $(".plage-ouverture-form .collapse.js-lieu-field .select2-input").val(null).trigger('change');
+      $(".plage-ouverture-form .collapse.js-lieu-field").collapse("hide");
     }
   }
 }

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -1,36 +1,49 @@
 - if plage_ouverture.available_motifs.any?
-  = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture] do |f|
+  = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture], html: { class: "plage-ouverture-form" } do |f|
     = render("model_errors", model: plage_ouverture, f: f)
     = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
       = f.input :title, placeholder: "Saisissez le nom de la plage d'ouverture"
-      = f.association :lieu,
-        collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
-        label_method: :full_name,
-        input_html: { \
-            class: "select2-input", \
-            data: { \
-              placeholder: "Sélectionnez un lieu", \
-              "select-options": { disableSearch: true }, \
-              "allow-clear": true, \
-            }, \
-          }
       - motifs_by_services = plage_ouverture.available_motifs.group_by(&:service)
       - motifs_by_services.each do |service, motifs|
-        - extra_options = motifs_by_services.size > 1 ? { label: "Motifs de #{service.name}", required: false } : {}
-        / Le "required: false" permet de ne pas afficher la petite astérisque, mais le champ reste obligatoire
-        = f.association(:motifs, collection: motifs, label_method: -> { motif_name_with_location_type_and_badges(_1) }, as: :check_boxes, **extra_options)
-
+        .form-group
+          p Motifs de #{service.name}
+          - motifs.each do |motif|
+            .pl-3
+              = f.check_box :motif_ids, { multiple: true, class: "form-check-input #{motif.location_type}" }, motif.id, false
+              = f.label "motif_ids_#{motif.id}", motif_name_with_location_type_and_badges(motif), class: "form-check-label"
+      .collapse.lieu-field
+        = f.association :lieu,
+          collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
+          label_method: :full_name,
+          input_html: { \
+              class: "select2-input", \
+              data: { \
+                placeholder: "Sélectionnez un lieu", \
+                "select-options": { disableSearch: true }, \
+                "allow-clear": true, \
+              }, \
+            }
       hr
 
       = render partial: "common/recurrence", locals: { f: f, model: plage_ouverture }
 
-      .row
-        .col.text-left
-          = link_to "Annuler", \
-            plage_ouverture.persisted? ? admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture) : admin_organisation_agent_plage_ouvertures_path(current_organisation, current_agent), \
-            class: "btn btn-link"
-        .col.text-right
-          = f.button :submit
+    .row.justify-content-center
+      .col-md-6
+        .row
+          - if plage_ouverture.persisted?
+            .col.text-left
+              = link_to "Annuler", \
+                admin_organisation_plage_ouverture_path(current_organisation, plage_ouverture), \
+                class: "btn btn-link"
+            .col.text-right
+              = f.button :submit, "Enregistrer"
+          -else
+            .col.text-left
+              = link_to "Annuler", \
+                admin_organisation_agent_plage_ouvertures_path(current_organisation, current_agent), \
+                class: "btn btn-link"
+            .col.text-right
+              = f.button :submit, "Créer la palge d'ouverture"
 - else
   | Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -1,32 +1,38 @@
 - if plage_ouverture.available_motifs.any?
   = simple_form_for [:admin, plage_ouverture.organisation, plage_ouverture], html: { class: "plage-ouverture-form" } do |f|
-    = render("model_errors", model: plage_ouverture, f: f)
-    = collapsible_form_fields_for_warnings(plage_ouverture) do
-      = f.hidden_field :agent_id
-      = f.input :title, placeholder: "Saisissez le nom de la plage d'ouverture"
-      - motifs_by_services = plage_ouverture.available_motifs.group_by(&:service)
-      - motifs_by_services.each do |service, motifs|
-        .form-group
-          p Motifs de #{service.name}
-          - motifs.each do |motif|
-            .pl-3
-              = f.check_box :motif_ids, { multiple: true, class: "form-check-input #{motif.location_type}" }, motif.id, false
-              = f.label "motif_ids_#{motif.id}", motif_name_with_location_type_and_badges(motif), class: "form-check-label"
-      .collapse.lieu-field
-        = f.association :lieu,
-          collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
-          label_method: :full_name,
-          input_html: { \
-              class: "select2-input", \
-              data: { \
-                placeholder: "Sélectionnez un lieu", \
-                "select-options": { disableSearch: true }, \
-                "allow-clear": true, \
-              }, \
-            }
-      hr
-
-      = render partial: "common/recurrence", locals: { f: f, model: plage_ouverture }
+    .row.justify-content-center
+      .col-md-6
+        .card
+          .card-body
+            = render("model_errors", model: plage_ouverture, f: f)
+            = collapsible_form_fields_for_warnings(plage_ouverture) do
+              = f.hidden_field :agent_id
+              = f.input :title, placeholder: "Saisissez le nom de la plage d'ouverture"
+              - motifs_by_services = plage_ouverture.available_motifs.group_by(&:service)
+              - motifs_by_services.each do |service, motifs|
+                .form-group
+                  p Motifs de #{service.name}
+                  - motifs.each do |motif|
+                    .pl-3
+                      = f.check_box :motif_ids, { multiple: true, class: "form-check-input #{motif.location_type}" }, motif.id, false
+                      = f.label "motif_ids_#{motif.id}", motif_name_with_location_type_and_badges(motif), class: "form-check-label"
+              .collapse.lieu-field
+                = f.association :lieu,
+                  collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
+                  label_method: :full_name,
+                  input_html: { \
+                      class: "select2-input", \
+                      data: { \
+                        placeholder: "Sélectionnez un lieu", \
+                        "select-options": { disableSearch: true }, \
+                        "allow-clear": true, \
+                      }, \
+                    }
+    .row.justify-content-center
+      .col-md-6
+        .card
+          .card-body
+            = render partial: "common/recurrence", locals: { f: f, model: plage_ouverture }
 
     .row.justify-content-center
       .col-md-6

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -50,6 +50,6 @@
                 admin_organisation_agent_plage_ouvertures_path(current_organisation, current_agent), \
                 class: "btn btn-link"
             .col.text-right
-              = f.button :submit, "Créer la palge d'ouverture"
+              = f.button :submit, "Créer la plage d'ouverture"
 - else
   | Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -16,7 +16,7 @@
                     .pl-3
                       = f.check_box :motif_ids, { multiple: true, class: "form-check-input #{motif.location_type}" }, motif.id, false
                       = f.label "motif_ids_#{motif.id}", motif_name_with_location_type_and_badges(motif), class: "form-check-label"
-              .collapse.lieu-field
+              .collapse.js-lieu-field
                 = f.association :lieu,
                   collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
                   label_method: :full_name,

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -3,7 +3,7 @@
     = render("model_errors", model: plage_ouverture, f: f)
     = collapsible_form_fields_for_warnings(plage_ouverture) do
       = f.hidden_field :agent_id
-      = f.input :title, hint: "Uniquement visible en interne", placeholder: "Ex: Permanence PMI exceptionnelle"
+      = f.input :title, placeholder: "Saisissez le nom de la plage d'ouverture"
       = f.association :lieu,
         collection: Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name,
         label_method: :full_name,

--- a/app/views/admin/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/plage_ouvertures/edit.html.slim
@@ -17,8 +17,4 @@
     li.breadcrumb-item.active
       = link_to truncate(@plage_ouverture.title, length: 20), admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
 
-.row.justify-content-center
-  .col-md-6
-    .card
-      .card-body
-        = render "form", plage_ouverture: @plage_ouverture, agent: @agent
+= render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/new.html.slim
+++ b/app/views/admin/plage_ouvertures/new.html.slim
@@ -7,4 +7,15 @@
   - else
     | Nouvelle plage d'ouverture pour #{@plage_ouverture.agent.full_name}
 
+- content_for :breadcrumb do
+  ol.breadcrumb.m-0
+    li.breadcrumb-item
+      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
+        - if @plage_ouverture.agent == current_agent
+          | Vos plages d'ouverture
+        - else
+          | Plages d'ouverture de #{@plage_ouverture.agent.full_name}
+    li.breadcrumb-item.active
+      | Nouvelle plage
+
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/new.html.slim
+++ b/app/views/admin/plage_ouvertures/new.html.slim
@@ -7,19 +7,4 @@
   - else
     | Nouvelle plage d'ouverture pour #{@plage_ouverture.agent.full_name}
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0
-    li.breadcrumb-item
-      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
-      - if @plage_ouverture.agent == current_agent
-        | Vos plages d'ouverture
-      - else
-        | Plages d'ouverture de #{@plage_ouverture.agent.full_name}
-    li.breadcrumb-item.active
-      | Nouvelle plage
-
-.row.justify-content-center
-  .col-md-6
-    .card
-      .card-body
-        = render "form", plage_ouverture: @plage_ouverture, agent: @agent
+= render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -26,9 +26,10 @@
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Agent :
           span= @plage_ouverture.agent.full_name
-        div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Lieu :
-          = lieu_tag(@plage_ouverture.lieu)
+        - if @plage_ouverture.lieu
+          div.mt-2.d-flex
+            .flex-shrink-0.mr-1.font-weight-bold Lieu :
+            = lieu_tag(@plage_ouverture.lieu)
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Motifs :
           ul.pl-3.mb-0

--- a/config/locales/models/plage_ouverture.fr.yml
+++ b/config/locales/models/plage_ouverture.fr.yml
@@ -4,7 +4,7 @@ fr:
       plage_ouverture: Plage d'ouverture
     attributes:
       plage_ouverture:
-        title: Description
+        title: Nom de la plage d'ouverture
         first_day: Premier jour
         start_time: Commence à
         end_time: Termine à

--- a/config/locales/views/plage_ouvertures.fr.yml
+++ b/config/locales/views/plage_ouvertures.fr.yml
@@ -14,7 +14,7 @@ fr:
         not_yet_created_plage_ouverture: Vous n'avez pas encore créé de plage d'ouverture.
         this_agent_not_yet_created_plage_ouverture: "%{full_name} n'a pas encore créé de plage d'ouverture."
         explanation_plage_ouverture: Les plages d'ouvertures affichent votre disponibilité à la prise de RDV, qu'elle soit faite par l'usager lui même (en ligne) ou par un autre agent de votre organisation. Chaque agent a ses propres plages d'ouvertures et peut y associer des motifs et un lieu. Les plages peuvent être récurrentes.
-        description: Description
+        description: Nom de la plage d'ouverture
         motifs: Motifs
         place: Lieu
         dates: Dates

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_link "Modifier"
 
       expect_page_title("Modifier votre plage d'ouverture")
-      fill_in "Description", with: "La belle plage"
+      fill_in "Nom de la plage d'ouverture", with: "La belle plage"
       click_button("Enregistrer")
 
       expect_page_title("La belle plage")
@@ -39,7 +39,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_link "Créer une plage d'ouverture", match: :first
       expect_page_title("Nouvelle plage d'ouverture")
 
-      fill_in "Description", with: "Accueil"
+      fill_in "Nom de la plage d'ouverture", with: "Accueil"
       select(lieu.full_name, from: "plage_ouverture_lieu_id") if lieu
       check "Suivi bonjour"
       click_button "Enregistrer"
@@ -104,7 +104,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_link "Modifier"
 
       expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
-      fill_in "Description", with: "La belle plage"
+      fill_in "Nom de la plage d'ouverture", with: "La belle plage"
       click_button("Enregistrer")
 
       expect_page_title("La belle plage")
@@ -116,7 +116,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
 
       expect_page_title("Nouvelle plage d'ouverture")
-      fill_in "Description", with: "Accueil"
+      fill_in "Nom de la plage d'ouverture", with: "Accueil"
       select(lieu.full_name, from: "plage_ouverture_lieu_id")
       check "Suivi bonjour"
       click_button "Enregistrer"
@@ -139,7 +139,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         click_link "Modifier"
 
         expect_page_title("Modifier la plage d'ouverture de Jane FAROU")
-        fill_in "Description", with: "La belle plage"
+        fill_in "Nom de la plage d'ouverture", with: "La belle plage"
         click_button("Enregistrer")
 
         expect_page_title("La belle plage")
@@ -151,7 +151,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
 
         expect_page_title("Nouvelle plage d'ouverture")
-        fill_in "Description", with: "Accueil"
+        fill_in "Nom de la plage d'ouverture", with: "Accueil"
         check "Suivi bonjour"
         click_button "Enregistrer"
 

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Nom de la plage d'ouverture", with: "Accueil"
       select(lieu.full_name, from: "plage_ouverture_lieu_id") if lieu
       check "Suivi bonjour"
-      click_button "Enregistrer"
+      click_button "Créer la plage d'ouverture"
 
       expect_page_title("Accueil")
       click_link "Modifier"
@@ -119,7 +119,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Nom de la plage d'ouverture", with: "Accueil"
       select(lieu.full_name, from: "plage_ouverture_lieu_id")
       check "Suivi bonjour"
-      click_button "Enregistrer"
+      click_button "Créer la plage d'ouverture"
 
       expect_page_title("Accueil")
       click_link "Modifier"
@@ -153,7 +153,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         expect_page_title("Nouvelle plage d'ouverture")
         fill_in "Nom de la plage d'ouverture", with: "Accueil"
         check "Suivi bonjour"
-        click_button "Enregistrer"
+        click_button "Créer la plage d'ouverture"
 
         expect_page_title("Accueil")
         click_link "Modifier"

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
-  let!(:motif) { create(:motif, name: "Suivi bonjour", organisation: organisation, service: service) }
+  let!(:motif) { create(:motif, name: "Suivi bonjour", organisation: organisation, service: service, location_type: :phone) }
   let!(:plage_ouverture) { create(:plage_ouverture, agent: agent, organisation: organisation, first_day: Time.zone.local(2019, 12, 3)) }
 
   before do


### PR DESCRIPTION
# Simplification des plages d'ouverture
## Amélioration du formulaire
Cette PR propose une première itération du projet des plages d'ouverture. 
Les changements ici, se focalisent uniquement sur quelques améliorations sur le formulaire de création des plages d'ouverture, notamment:
- Remplacer "Description" par "Nom de la plage d'ouverture", avec un nouveau placeholder et suppression du hint
- Afficher le champ Lieu, uniquement quand un motif _sur place_, est sélectionné
- Séparer en 2 _cards_, les sections haute (informations de base) et basse du formulaire (informations de récurrence)
- Changer le nom du bouton de soumission du formulaire, de "Enregistrer" à "Créer la plage d'ouverture

## Screenshots
### Description
Avant | Après
:-------------------------:|:-------------------------:
![1 - before](https://github.com/betagouv/rdv-service-public/assets/11911945/8c52ff77-0255-4dde-afa5-94e4ca2849e1)|![1 - after](https://github.com/betagouv/rdv-service-public/assets/11911945/f92cd532-f033-4f1b-82e1-365c788cf8e7)|

### Lieu
Désormais, le champ de sélection du Lieu ne s'affiche que quand on coche un motif sur place
Avant | Après
:-------------------------:|:-------------------------:
![2 - before](https://github.com/betagouv/rdv-service-public/assets/11911945/f4ed7dcf-a6f4-4f0d-9504-c97d08ea19f2)|![2 - after](https://github.com/betagouv/rdv-service-public/assets/11911945/2d54faf9-d722-4733-b168-f1820ed8898d)
### Sections du formulaire
Le formulaire est séparé en 2 sections (ou cards)
Avant | Après
:-------------------------:|:-------------------------:
![4 - before](https://github.com/betagouv/rdv-service-public/assets/11911945/51006c30-8145-4c8d-accf-a6d46bceea4b)|![4 - after](https://github.com/betagouv/rdv-service-public/assets/11911945/f93857c7-f6fc-4224-aeae-3d0932ba3108)

### Bouton de soumission
"Enregistrer" devient "Créer la plage d'ouverture
Avant | Après
:-------------------------:|:-------------------------:
![3 - before](https://github.com/betagouv/rdv-service-public/assets/11911945/0535b9b2-b859-4b43-a9a9-2699d0edbabc)|![3 - after](https://github.com/betagouv/rdv-service-public/assets/11911945/5faa3f5c-501d-493e-93cd-d737b6dbb927)

## Pour plus d'informations : 
- [Figma](https://www.figma.com/design/1K04Z2rNDvJJ3ZjY7epsas/Motifs-%2F-Plages-d'ouverture?node-id=508-8687&t=zsxvTJEGS5fdjuUj-0)
- [Notion](https://www.notion.so/rdvs/Les-plages-d-ouvertures-b7376db041a3487bbd8d5d1786ecb246)