### PR TITLE
Augmenter le timeout des matchers Capybara

### DIFF
--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -24,6 +24,12 @@ end
 
 Capybara.javascript_driver = :selenium
 
+# Voir https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends
+# Par défaut, les matchers Capybara attendent jusqu'à 2 secondes pour trouver le changement attendu.
+# Parfois ce temps d'attente est trop court et nous avons des flaky specs.
+# Passer ce timeout à 5 permettra peut-être de limiter ces échecs.
+Capybara.default_max_wait_time = 5
+
 Capybara.configure do |config|
   port = 9887 + ENV["TEST_ENV_NUMBER"].to_i
   config.app_host = "http://www.rdv-solidarites-test.localhost:#{port}"


### PR DESCRIPTION
Nous avons eu une [flaky spec](https://github.com/betagouv/rdv-service-public/actions/runs/9367776323/job/25788199305) qui échouaient sur la ligne suivante : 

https://github.com/betagouv/rdv-service-public/blob/1569efb3aff03bd8b4148426573b164e0f0ac4ef/spec/features/users/online_booking/default_spec.rb#L431

La première tentative ici semble avoir échoué : #4237

Si j'ai bien compris, il y a deux catégories de flaky specs :
1. usage d'un matcher qui n'attend pas du tout : la solution est d'utiliser un matcher qui attend
2. le temps d'attente d'un matcher n'est pas suffisant (cas supposé ici) : la solution est augmenter le temps d'attente

Si j'ai bien compris la doc[^1], le matcher `have_content` attend 2 secondes (valeur par défaut de `Capybara.default_max_wait_time`). Je suppose donc que les 2 secondes n'ont pas suffit dans le cas de cette flaky spec.

Augment la valeur à 5 seconde devrait :
- être sans impact sur nos perfs de spec, puisque c'est une valeur maximale
- éviter cette catégorie de flaky spec

[^1]: https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après
