### PR TITLE
Ajout de doc sur la mise à jour de Metabase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean: ## Clean temporary files (including weppacks) and logs
 generate_db_diagram: ## Generate docs/domain_model.svg from Rails models
 	bundle exec erd
 
-rswag:
+rswag: ## Re-generate swagger/v1/api.json by running API specs
 	SWAGGER_DRY_RUN=0 RAILS_ENV=test rake rswag:specs:swaggerize PATTERN="spec/requests/api/**/*_spec.rb"
 
 help: ## Display available commands
@@ -41,5 +41,5 @@ help: ## Display available commands
 .PHONY: install run lint lint_rubocop lint_brakeman test test_unit test_features autocorrect clean generate_db_diagram help
 .DEFAULT_GOAL := help
 
-review_app:
+review_app: ## Create Scalingo review app for the PR linked to the current branch
 	scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites integration-link-manual-review-app `gh pr view --json number --jq '.number'`

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ generate_db_diagram: ## Generate docs/domain_model.svg from Rails models
 rswag: ## Re-generate swagger/v1/api.json by running API specs
 	SWAGGER_DRY_RUN=0 RAILS_ENV=test rake rswag:specs:swaggerize PATTERN="spec/requests/api/**/*_spec.rb"
 
-help: ## Display available commands
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
-
 .PHONY: install run lint lint_rubocop lint_brakeman test test_unit test_features autocorrect clean generate_db_diagram help
 .DEFAULT_GOAL := help
 
 review_app: ## Create Scalingo review app for the PR linked to the current branch
 	scalingo --region osc-secnum-fr1 --app demo-rdv-solidarites integration-link-manual-review-app `gh pr view --json number --jq '.number'`
+
+help: ## Display available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -163,3 +163,25 @@ classDiagram
     + filter_motifs()
   }
 ```
+
+## Metabase
+
+Nous utilisons Metabase pour donner à l'ensemble de l'équipe une visibilité sur nos données.
+
+Notre dossier d'architecture technique fournit une description haut niveau de notre usage de Metabase :
+[architecture-technique.md](architecture-technique.md)
+
+Le script [scripts/etl.sh](scripts/etl.sh) permet de lancer la procédure de copie du dernier backup de la prod vers la base de donnée de l'app `rdv-service-public-etl`.
+
+### Mettre à jour Metabase
+
+Nous avons utilisé le déploiement en un clic décrit dans cette doc de Scalingo :
+https://doc.scalingo.com/platform/getting-started/getting-started-with-metabase
+
+Pour mettre à jour Metabase il faut déclencher un deploy en utilisant la commande ci-dessous. 
+
+⚠️ Attention, une mise à jour de Metabase peut mal se passer et rendre notre Metabase indisponible.
+
+```bash
+scalingo --app rdv-service-public-metabase deploy https://github.com/Scalingo/metabase-scalingo/archive/refs/heads/master.tar.gz
+```


### PR DESCRIPTION
Aujourd'hui nous avons découvert comment mettre à jour Metabase, j'ajoute donc un bout de doc pratique, à destination de l'équipe dev, pour noter ce qu'on a découvert.

J'en profite pour initier une section sur comment utiliser `etl.sh`, à compléter quand @victormours m'aura fait un tour de de ce process.