### PR TITLE
Refactos et harmonisations des layouts application

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,6 @@
 class SearchController < ApplicationController
+  layout "application_base"
+
   include TokenInvitable
 
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,7 @@
 class StaticPagesController < ApplicationController
   def mds
     redirect_to root_path unless current_domain == Domain::RDV_SOLIDARITES
+    render layout: "application_base"
   end
 
   def accessibility; end

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -1,6 +1,8 @@
 class Users::ParticipationsController < UserAuthController
   before_action :set_rdv, :set_user
 
+  layout "application_narrow"
+
   include TokenInvitable
 
   def index

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -6,7 +6,7 @@ class Users::RdvsController < UserAuthController
   before_action :build_creneau, :redirect_if_creneau_not_available, only: %i[edit update]
   after_action :allow_iframe
 
-  layout "application_narrow", only: %i[show edit]
+  layout "application_narrow", only: %i[show]
 
   include TokenInvitable
 

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -6,6 +6,8 @@ class Users::RdvsController < UserAuthController
   before_action :build_creneau, :redirect_if_creneau_not_available, only: %i[edit update]
   after_action :allow_iframe
 
+  layout "application_narrow", only: %i[show edit]
+
   include TokenInvitable
 
   def index

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,11 +1,11 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   include CanHaveRdvWizardContext
 
-  before_action :set_rdv_insertion_organisations, only: %i[edit destroy]
+  before_action :set_rdv_insertion_organisations, only: %i[edit destroy] # rubocop:disable Rails/LexicallyScopedActionFilter
   after_action :allow_iframe
 
   layout "application"
-  layout "application_narrow", only: %i[new edit]
+  layout "application_narrow", only: %i[new edit pending]
 
   def create
     return invite_and_redirect(existing_unconfirmed_user) if existing_unconfirmed_user
@@ -30,7 +30,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def pending
     @email_tld = params[:email_tld]
-    render layout: "application_narrow"
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,10 +1,11 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  layout :user_devise_layout
-
   include CanHaveRdvWizardContext
 
-  before_action :set_rdv_insertion_organisations, only: %i[edit destroy] # rubocop:disable Rails/LexicallyScopedActionFilter
+  before_action :set_rdv_insertion_organisations, only: %i[edit destroy]
   after_action :allow_iframe
+
+  layout "application"
+  layout "application_narrow", only: %i[new edit]
 
   def create
     return invite_and_redirect(existing_unconfirmed_user) if existing_unconfirmed_user
@@ -29,6 +30,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def pending
     @email_tld = params[:email_tld]
+    render layout: "application_narrow"
   end
 
   private
@@ -45,10 +47,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     form = Users::RegistrationForm.new(hash)
     form.user.sign_up_domain = current_domain
     self.resource = form
-  end
-
-  def user_devise_layout
-    user_signed_in? ? "application" : "application_narrow"
   end
 
   def after_inactive_sign_up_path_for(resource)

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -1,4 +1,6 @@
 class Users::RelativesController < UserAuthController
+  layout "application_narrow"
+
   respond_to :html
 
   before_action :set_user, only: %i[edit update destroy]

--- a/app/controllers/users/user_name_initials_verification_controller.rb
+++ b/app/controllers/users/user_name_initials_verification_controller.rb
@@ -1,4 +1,6 @@
 class Users::UserNameInitialsVerificationController < UserAuthController
+  layout "application_narrow"
+
   skip_after_action :verify_authorized
 
   include TokenInvitable

--- a/app/views/lapin/sms_preview/index.html.slim
+++ b/app/views/lapin/sms_preview/index.html.slim
@@ -1,10 +1,9 @@
-.container.mt-3
-  .row.justify-content-center
-    .col-md-8
-      - @actions.each do |group, action_names|
-        .card
-          .card-body
-            h5.card-title= group
-            ul
-              - action_names.each do |name|
-                li= link_to name, lapin_sms_preview_preview_path(group.to_s.parameterize, name)
+.row.justify-content-center
+  .col-md-8
+    - @actions.each do |group, action_names|
+      .card
+        .card-body
+          h5.card-title= group
+          ul
+            - action_names.each do |name|
+              li= link_to name, lapin_sms_preview_preview_path(group.to_s.parameterize, name)

--- a/app/views/lapin/sms_preview/preview.html.slim
+++ b/app/views/lapin/sms_preview/preview.html.slim
@@ -1,32 +1,31 @@
-.container.mt-3
-  .row.justify-content-center
-    .col-md-8
-      .card
-        .card-header
-          = link_to t("helpers.back"), lapin_sms_preview_index_path
-          hr
-          = form_with url: lapin_sms_preview_preview_path, method: :get do |f|
-            .form-row
-              .col.form-group
-                = f.label :location_type, Motif.human_attribute_name(:location_type)
-                = f.select :location_type, Motif.human_attribute_values(:location_type), { selected: @mock_params[:location_type] }, { class: "form-control", onchange: "this.form.submit()" }
-              .col.form-group
-                = f.label :phone_number, "Numéro du lieu"
-                = f.text_field :phone_number, value: @mock_params[:phone_number], class: "form-control"
-            .form-row
-              .col
-                .form-check.form-check-inline
-                  = f.check_box :show_relatives, checked: @mock_params[:show_relatives], class: "form-check-input", onchange: "this.form.submit()"
-                  = f.label :show_relatives, "Pour un(e) proche", class: "form-check-label"
-            .form-row
-              .col
-                .form-check.form-check-inline
-                  = f.check_box :show_agent, checked: @mock_params[:show_agent], class: "form-check-input", onchange: "this.form.submit()"
-                  = f.label :show_agent, "Suivi", class: "form-check-label"
-        .card-body
-          h5.card-title= @title
-          p= @sms.phone_number
-          .bg-light.p-1
-            code= @sms.content
-        .card-footer
-          p="#{@sms.content.length} caractères"
+.row.justify-content-center
+  .col-md-8
+    .card
+      .card-header
+        = link_to t("helpers.back"), lapin_sms_preview_index_path
+        hr
+        = form_with url: lapin_sms_preview_preview_path, method: :get do |f|
+          .form-row
+            .col.form-group
+              = f.label :location_type, Motif.human_attribute_name(:location_type)
+              = f.select :location_type, Motif.human_attribute_values(:location_type), { selected: @mock_params[:location_type] }, { class: "form-control", onchange: "this.form.submit()" }
+            .col.form-group
+              = f.label :phone_number, "Numéro du lieu"
+              = f.text_field :phone_number, value: @mock_params[:phone_number], class: "form-control"
+          .form-row
+            .col
+              .form-check.form-check-inline
+                = f.check_box :show_relatives, checked: @mock_params[:show_relatives], class: "form-check-input", onchange: "this.form.submit()"
+                = f.label :show_relatives, "Pour un(e) proche", class: "form-check-label"
+          .form-row
+            .col
+              .form-check.form-check-inline
+                = f.check_box :show_agent, checked: @mock_params[:show_agent], class: "form-check-input", onchange: "this.form.submit()"
+                = f.label :show_agent, "Suivi", class: "form-check-label"
+      .card-body
+        h5.card-title= @title
+        p= @sms.phone_number
+        .bg-light.p-1
+          code= @sms.content
+      .card-footer
+        p="#{@sms.content.length} caractères"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,94 +1,11 @@
-doctype html
-html lang="fr"
-  head
-    = render "common/meta"
-    = stylesheet_link_tag "@gouvfr/dsfr/dist/dsfr.min.css", "data-turbo-track": "reload"
-    = stylesheet_link_tag "@gouvfr/dsfr/dist/utility/icons/icons.min.css", "data-turbo-track": "reload"
-    = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
-    = javascript_include_tag "application", "data-turbolinks-track": "reload"
-    = javascript_include_tag "@gouvfr/dsfr/dist/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
-    = javascript_include_tag "@gouvfr/dsfr/dist/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
-    = content_for(:charts_script)
+- content_for :main_content do
+  .container.pt-3
+    - if content_for :container_content
+      = yield :container_content
+    - else
+      - if content_for :title
+        h1= yield :title
+      = render "layouts/flash"
+      = yield
 
-  body
-    = render "layouts/rdv_solidarites_instance_name"
-    = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
-    .header-wrapper
-      = dsfr_header logo_text: "République<br>Française".html_safe, html_attributes: { class: "container" } do |header|
-        - header.with_operator_image title: "Accueil - RDV #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: "RDV #{current_domain.name}"
-        - if current_user.present? && !current_user.only_invited?
-          ruby:
-            header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, classes: "fr-icon-calendar-fill"
-            header.with_tool_link title: "Vos informations", path: users_informations_path
-            header.with_tool_link title: "Votre compte", path: edit_user_registration_path
-            header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, classes: "fr-icon-lock-fill", html_attributes: { "data-method": "delete" }
-        - elsif !stats_path?
-          - header.with_tool_link title: "Espace Agent", path: new_agent_session_path
-          - header.with_tool_link title: "Se connecter", path: new_user_session_path, classes: "fr-fi-account-fill"
-
-    main class="#{ "container" if params[:controller].include?("users/") }"
-      - if content_for :main_content
-        = yield :main_content
-      - else
-        = render "layouts/flash"
-        = yield
-
-    #modal-holder
-
-    footer.main-footer
-      .container
-        .row
-          .col-12.col-md
-            div
-              = link_to image_tag(current_domain.dark_logo_path, size: "250x80", alt: current_domain.name), root_path, title: "aller à l'accueil #{current_domain.name}"
-              ul.list-unstyled
-                li.mb-2
-                  - if current_domain.default?
-                    span> #{current_domain.name} est fourni par
-                    = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
-                    = " et un consortium de départements"
-                  - else
-                    span
-                    = "#{current_domain.name} est géré par #{Domain::RDV_MAIRIE.name}, un service fourni par "
-                    = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
-                    = ". "
-                    = link_to "En savoir plus", domaines_path
-                li.mb-2
-                  = image_tag "logos/republique-francaise-logo.svg", size: "105x90", alt:""
-          .col-6.col-md
-            h2 À propos
-            ul.list-unstyled
-              li.mb-1 = link_to "Contact", contact_path
-              - if current_domain == Domain::RDV_SOLIDARITES
-                li.mb-1 = link_to "Les solidarités dans votre département", mds_path
-              li.mb-1 = link_to "Espace professionnel", presentation_agent_path
-              li.mb-1 = link_to "Statistiques", stats_path
-              li.mb-1 = link_to "Budget", budget_path
-          .col-6.col-md
-            h2 Produit
-            ul.list-unstyled
-              li.mb-1 = link_to "Accessibilité : non conforme", accessibility_path
-              li.mb-1 = link_to current_domain.documentation_url do
-                span> Documentation utilisateur
-              li.mb-1 = link_to "Documentation technique", "https://github.com/betagouv/rdv-service-public#documentation-externe"
-              li.mb-1 = link_to "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
-                span>= ENV["RDV_SOLIDARITES_VERSION"]
-                i.fa.fa-external-link-alt
-              li.mb-1 = link_to "https://github.com/betagouv/rdv-service-public/" do
-                span> Code Source sur GitHub
-                i.fa.fa-external-link-alt
-          .col-6.col-md
-            h2 Informations légales
-            ul.list-unstyled
-              li.mb-1 = link_to mentions_legales_path do
-                span> Mentions Légales
-              li.mb-1 = link_to cgu_path do
-                span> C.G.U.
-              li.mb-1 = link_to politique_de_confidentialite_path do
-                span> Politique de confidentialité
-        .fr-footer__partners
-          h3.fr-footer__partners-title Nos partenaires
-          .fr-footer__partners-logos
-            .fr-footer__partners-main
-              = link_to(image_tag("logos/logo_dinum.svg", alt: "Logo de la Dinum", style: "height: 5.625rem"), "https://www.numerique.gouv.fr/dinum/", class: "fr-footer__partners-link" )
-              = link_to(image_tag("logos/logo_anct.png", alt: "Logo de l'ANCT", style: "height: 5.625rem"), "https://agence-cohesion-territoires.gouv.fr/", class: "fr-footer__partners-link" )
+= render template: "layouts/application_base"

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -1,0 +1,94 @@
+doctype html
+html lang="fr"
+  head
+    = render "common/meta"
+    = stylesheet_link_tag "@gouvfr/dsfr/dist/dsfr.min.css", "data-turbo-track": "reload"
+    = stylesheet_link_tag "@gouvfr/dsfr/dist/utility/icons/icons.min.css", "data-turbo-track": "reload"
+    = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
+    = javascript_include_tag "application", "data-turbolinks-track": "reload"
+    = javascript_include_tag "@gouvfr/dsfr/dist/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
+    = javascript_include_tag "@gouvfr/dsfr/dist/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
+    = content_for(:charts_script)
+
+  body
+    = render "layouts/rdv_solidarites_instance_name"
+    = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
+    .header-wrapper
+      = dsfr_header logo_text: "République<br>Française".html_safe, html_attributes: { class: "container" } do |header|
+        - header.with_operator_image title: "Accueil - RDV #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: "RDV #{current_domain.name}"
+        - if current_user.present? && !current_user.only_invited?
+          ruby:
+            header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, classes: "fr-icon-calendar-fill"
+            header.with_tool_link title: "Vos informations", path: users_informations_path
+            header.with_tool_link title: "Votre compte", path: edit_user_registration_path
+            header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, classes: "fr-icon-lock-fill", html_attributes: { "data-method": "delete" }
+        - elsif !stats_path?
+          - header.with_tool_link title: "Espace Agent", path: new_agent_session_path
+          - header.with_tool_link title: "Se connecter", path: new_user_session_path, classes: "fr-fi-account-fill"
+
+    main
+      - if content_for :main_content
+        = yield :main_content
+      - else
+        = render "layouts/flash"
+        = yield
+
+    #modal-holder
+
+    footer.main-footer
+      .container
+        .row
+          .col-12.col-md
+            div
+              = link_to image_tag(current_domain.dark_logo_path, size: "250x80", alt: current_domain.name), root_path, title: "aller à l'accueil #{current_domain.name}"
+              ul.list-unstyled
+                li.mb-2
+                  - if current_domain.default?
+                    span> #{current_domain.name} est fourni par
+                    = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
+                    = " et un consortium de départements"
+                  - else
+                    span
+                    = "#{current_domain.name} est géré par #{Domain::RDV_MAIRIE.name}, un service fourni par "
+                    = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
+                    = ". "
+                    = link_to "En savoir plus", domaines_path
+                li.mb-2
+                  = image_tag "logos/republique-francaise-logo.svg", size: "105x90", alt:""
+          .col-6.col-md
+            h2 À propos
+            ul.list-unstyled
+              li.mb-1 = link_to "Contact", contact_path
+              - if current_domain == Domain::RDV_SOLIDARITES
+                li.mb-1 = link_to "Les solidarités dans votre département", mds_path
+              li.mb-1 = link_to "Espace professionnel", presentation_agent_path
+              li.mb-1 = link_to "Statistiques", stats_path
+              li.mb-1 = link_to "Budget", budget_path
+          .col-6.col-md
+            h2 Produit
+            ul.list-unstyled
+              li.mb-1 = link_to "Accessibilité : non conforme", accessibility_path
+              li.mb-1 = link_to current_domain.documentation_url do
+                span> Documentation utilisateur
+              li.mb-1 = link_to "Documentation technique", "https://github.com/betagouv/rdv-service-public#documentation-externe"
+              li.mb-1 = link_to "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
+                span>= ENV["RDV_SOLIDARITES_VERSION"]
+                i.fa.fa-external-link-alt
+              li.mb-1 = link_to "https://github.com/betagouv/rdv-service-public/" do
+                span> Code Source sur GitHub
+                i.fa.fa-external-link-alt
+          .col-6.col-md
+            h2 Informations légales
+            ul.list-unstyled
+              li.mb-1 = link_to mentions_legales_path do
+                span> Mentions Légales
+              li.mb-1 = link_to cgu_path do
+                span> C.G.U.
+              li.mb-1 = link_to politique_de_confidentialite_path do
+                span> Politique de confidentialité
+        .fr-footer__partners
+          h3.fr-footer__partners-title Nos partenaires
+          .fr-footer__partners-logos
+            .fr-footer__partners-main
+              = link_to(image_tag("logos/logo_dinum.svg", alt: "Logo de la Dinum", style: "height: 5.625rem"), "https://www.numerique.gouv.fr/dinum/", class: "fr-footer__partners-link" )
+              = link_to(image_tag("logos/logo_anct.png", alt: "Logo de l'ANCT", style: "height: 5.625rem"), "https://agence-cohesion-territoires.gouv.fr/", class: "fr-footer__partners-link" )

--- a/app/views/layouts/application_narrow.html.slim
+++ b/app/views/layouts/application_narrow.html.slim
@@ -1,11 +1,9 @@
-- content_for :main_content do
+- content_for :container_content do
   .row
-    .col-md-8.m-auto.pt-3
+    .col-md-8.m-auto
       - if content_for :title
         h1= yield :title
-
       = render "layouts/flash"
-
       = yield
 
 = render template: "layouts/application"

--- a/app/views/static_pages/accessibility.html.slim
+++ b/app/views/static_pages/accessibility.html.slim
@@ -1,66 +1,64 @@
 - content_for :title, "Déclaration d'accessibilité"
 
-.container.mt-3
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      h1.text-dark.mb-3 Déclaration d'accessibilité
-      p
-        b> Agence Nationale de la Cohésion des Territoires
-        | s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
-      p
-        | Cette déclaration d’accessibilité s’applique à
-        b< RDV-Solidarités.
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    p
+      b> Agence Nationale de la Cohésion des Territoires
+      | s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
+    p
+      | Cette déclaration d’accessibilité s’applique à
+      b< RDV-Solidarités.
 
-      h2 État de conformité
+    h2 État de conformité
 
-      p
-        b> RDV-Solidarités
-        span> est
-        b
-          span> non conforme
-        span> avec le
-        b> RGAA 4.1
-        | Le site n'a encore pas été audité.
+    p
+      b> RDV-Solidarités
+      span> est
+      b
+        span> non conforme
+      span> avec le
+      b> RGAA 4.1
+      | Le site n'a encore pas été audité.
 
-      h2 Établissement de cette déclaration d'accessibilité
+    h2 Établissement de cette déclaration d'accessibilité
 
-      p
-        span> Cette déclaration a été établie le
-        b 12 juin 2021
-        |.
+    p
+      span> Cette déclaration a été établie le
+      b 12 juin 2021
+      |.
 
-      h2 Amélioration et contact
+    h2 Amélioration et contact
 
-      p
-        span> Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de
-        b> RDV-Solidarités
-        | pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+    p
+      span> Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de
+      b> RDV-Solidarités
+      | pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
 
+    ul
+      li E-mail : <a href="mailto:contact@beta.gouv.fr">contact@beta.gouv.fr</a>
+    p
+      span> Nous essayons de répondre dans les
+      b 2 jours ouvrés.
+
+    h2 Voie de recours
+
+    p Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
+
+    p
+      | Vous pouvez :
       ul
-        li E-mail : <a href="mailto:contact@beta.gouv.fr">contact@beta.gouv.fr</a>
-      p
-        span> Nous essayons de répondre dans les
-        b 2 jours ouvrés.
+        li Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a>
+        li Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits dans votre région</a>
+        li
+          | Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) :
+          br
+          | Défenseur des droits
+          br
+          | Libre réponse 71120 75342 Paris CEDEX 07
 
-      h2 Voie de recours
+    hr
 
-      p Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
-
-      p
-        | Vous pouvez :
-        ul
-          li Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a>
-          li Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits dans votre région</a>
-          li
-            | Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) :
-            br
-            | Défenseur des droits
-            br
-            | Libre réponse 71120 75342 Paris CEDEX 07
-
-      hr
-
-      p
-        span> Cette déclaration d'accessibilité a été créé le
-        b> 12 juin 2021
-        | grâce au <a href="https://betagouv.github.io/a11y-generateur-declaration/#create">Générateur de Déclaration d'Accessibilité de BetaGouv</a>.
+    p
+      span> Cette déclaration d'accessibilité a été créé le
+      b> 12 juin 2021
+      | grâce au <a href="https://betagouv.github.io/a11y-generateur-declaration/#create">Générateur de Déclaration d'Accessibilité de BetaGouv</a>.

--- a/app/views/static_pages/cgu.html.slim
+++ b/app/views/static_pages/cgu.html.slim
@@ -1,121 +1,119 @@
-- content_for :title, "Conditions d’utilisation de la plateforme"
+- content_for :title, "Conditions d’utilisation de la plateforme #{current_domain.name}"
 
-.container.mt-3
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      h1.text-dark.mb-3 Conditions d’utilisation de la plateforme #{current_domain.name}
-      p Les présentes conditions générales d’utilisation (dites « CGU ») encadrent les différents usages de la Plateforme "#{current_domain.name}" et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
-      h2 Article 1 - Champ d'application
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    p Les présentes conditions générales d’utilisation (dites « CGU ») encadrent les différents usages de la Plateforme "#{current_domain.name}" et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
+    h2 Article 1 - Champ d'application
 
-      p La plateforme "#{current_domain.name} " est à l'initiative de l’ Agence Nationale de la Cohésion des Territoires (ANCT).
-      p Cette plateforme inclut le site principal RDV Solidarités, disponible à l'adresse www.rdv-solidarites.fr, ainsi que le site RDV Aide Numérique, disponible à l'adresse www.rdv-aide-numerique.fr.
-      h2 Article 2 - Objet
+    p La plateforme "#{current_domain.name} " est à l'initiative de l’ Agence Nationale de la Cohésion des Territoires (ANCT).
+    p Cette plateforme inclut le site principal RDV Solidarités, disponible à l'adresse www.rdv-solidarites.fr, ainsi que le site RDV Aide Numérique, disponible à l'adresse www.rdv-aide-numerique.fr.
+    h2 Article 2 - Objet
 
-      p #{current_domain.name} est un outil permettant d'organiser et de fluidifier la prise de rendez-vous médico-sociaux ou de formation numérique pour les services publics.
+    p #{current_domain.name} est un outil permettant d'organiser et de fluidifier la prise de rendez-vous médico-sociaux ou de formation numérique pour les services publics.
 
-      h2 Article 3 - Définitions
+    h2 Article 3 - Définitions
 
-      ul
-        li « L'Utilisateur » est toute personne utilisant la plateforme "#{current_domain.name}".
-        li « L'Usager » est tout administré utilisant la plateforme "#{current_domain.name}".
-        li « L'Agent » est tout agent public utilisant la plateforme "#{current_domain.name}".
-        li Les « Services » sont les fonctionnalités offertes par la plateforme.
+    ul
+      li « L'Utilisateur » est toute personne utilisant la plateforme "#{current_domain.name}".
+      li « L'Usager » est tout administré utilisant la plateforme "#{current_domain.name}".
+      li « L'Agent » est tout agent public utilisant la plateforme "#{current_domain.name}".
+      li Les « Services » sont les fonctionnalités offertes par la plateforme.
 
-      h2 Article 4 - Fonctionnalités
+    h2 Article 4 - Fonctionnalités
 
-      h3 4.1 Fonctionnalités ouvertes aux Usagers
+    h3 4.1 Fonctionnalités ouvertes aux Usagers
 
-      p #{current_domain.name} permet à tout Usager qui le souhaite de :
-      ul
-        li
-          p se créer un compte lui permettant de prendre un rendez-vous avec un service public.
-          p A cet effet, il lui suffira de se créer un compte sur le site de la plateforme en fournissant les informations suivantes : nom, prénom, adresse e-mail et numéro de téléphone. Il pourra également remplir une fiche d'information dans laquelle il devra renseigner des informations relatives à sa situation sociale et familiale : adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants.
+    p #{current_domain.name} permet à tout Usager qui le souhaite de :
+    ul
+      li
+        p se créer un compte lui permettant de prendre un rendez-vous avec un service public.
+        p A cet effet, il lui suffira de se créer un compte sur le site de la plateforme en fournissant les informations suivantes : nom, prénom, adresse e-mail et numéro de téléphone. Il pourra également remplir une fiche d'information dans laquelle il devra renseigner des informations relatives à sa situation sociale et familiale : adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants.
 
-        li
-          p vérifier s'il est possible de prendre rendez-vous via la plateforme en fonction de son adresse.
-          p En effet, en entrant l'adresse dans la barre de recherche, l'usager reçoit un message lui indiquant les services publics utilisant le dispositif à proximité de chez lui. Si de tels services n'existent pas, il recevra un message lui indiquant que la prise en charge n'est pas encore établie.
+      li
+        p vérifier s'il est possible de prendre rendez-vous via la plateforme en fonction de son adresse.
+        p En effet, en entrant l'adresse dans la barre de recherche, l'usager reçoit un message lui indiquant les services publics utilisant le dispositif à proximité de chez lui. Si de tels services n'existent pas, il recevra un message lui indiquant que la prise en charge n'est pas encore établie.
 
-        li
-          p renseigner des informations relatives à un "Proche".
-          p A cet effet, il pourra remplir une "fiche" pour simplifier les démarches futures d'un proche. Il lui revient d'informer le proche par tous moyens et dans un délai d'1 mois, de la transmission de ces informations à la Plateforme #{current_domain.name}.
+      li
+        p renseigner des informations relatives à un "Proche".
+        p A cet effet, il pourra remplir une "fiche" pour simplifier les démarches futures d'un proche. Il lui revient d'informer le proche par tous moyens et dans un délai d'1 mois, de la transmission de ces informations à la Plateforme #{current_domain.name}.
 
-      h3 4.2 Fonctionnalités ouvertes aux Agents
+    h3 4.2 Fonctionnalités ouvertes aux Agents
 
-      p #{current_domain.name} permet à tout agent réalisant une mission de service public de :
-      ul
-        li Regrouper les actions relatives à la prise de rendez-vous en ligne ;
-        li Organiser directement la configuration générale de la prise de rendez-vous ;
-        li Etablir des plages d'ouverture relatives au rendez-vous ;
-        li Créer une fiche "Nouvel usager" ;
-        li Gérer les statistiques relatives à la prise de rendez-vous.
+    p #{current_domain.name} permet à tout agent réalisant une mission de service public de :
+    ul
+      li Regrouper les actions relatives à la prise de rendez-vous en ligne ;
+      li Organiser directement la configuration générale de la prise de rendez-vous ;
+      li Etablir des plages d'ouverture relatives au rendez-vous ;
+      li Créer une fiche "Nouvel usager" ;
+      li Gérer les statistiques relatives à la prise de rendez-vous.
 
-      h4 A) Regrouper les actions relatives à la prise de rendez-vous
+    h4 A) Regrouper les actions relatives à la prise de rendez-vous
 
-      p Cette fonctionnalité permet de faciliter la prise de rendez-vous en ligne des usagers, en choisissant certaines modalités relatives à l'interface. Ainsi, la structure pourra :
-      ul
-        li Déterminer le service avec lequel l'usager prendra rendez-vous ;
-        li Préciser le lieu du rendez-vous ;
-        li Ajouter les Agents susceptibles de procéder aux rendez-vous et consultations ;
-        li Établir un délai minimum et maximum de réservation.
+    p Cette fonctionnalité permet de faciliter la prise de rendez-vous en ligne des usagers, en choisissant certaines modalités relatives à l'interface. Ainsi, la structure pourra :
+    ul
+      li Déterminer le service avec lequel l'usager prendra rendez-vous ;
+      li Préciser le lieu du rendez-vous ;
+      li Ajouter les Agents susceptibles de procéder aux rendez-vous et consultations ;
+      li Établir un délai minimum et maximum de réservation.
 
-      p Ces fonctionnalités permettent aux agents et structures de simplifier le processus de choix des usagers et l'organisation interne de la structure liée à la prise de rendez-vous.
+    p Ces fonctionnalités permettent aux agents et structures de simplifier le processus de choix des usagers et l'organisation interne de la structure liée à la prise de rendez-vous.
 
-      h4 B) Organiser directement la configuration générale de la prise de rendez-vous
+    h4 B) Organiser directement la configuration générale de la prise de rendez-vous
 
-      p Cette fonctionnalité permet aux structures de déterminer et préciser les modalités des rendez-vous. Ces modalités sont déterminantes pour l'organisation générale des structures et des prises de rendez-vous. En effet, chaque structure pourra :
-      ul
-        li Choisir la durée moyenne de rendez-vous ;
-        li Choisir le type de rendez-vous (sur place, téléphone, à domicile) ;
-        li Établir ou organiser un rendez-vous de suivi ;
-        li Permettre la notification par SMS aux usagers.
+    p Cette fonctionnalité permet aux structures de déterminer et préciser les modalités des rendez-vous. Ces modalités sont déterminantes pour l'organisation générale des structures et des prises de rendez-vous. En effet, chaque structure pourra :
+    ul
+      li Choisir la durée moyenne de rendez-vous ;
+      li Choisir le type de rendez-vous (sur place, téléphone, à domicile) ;
+      li Établir ou organiser un rendez-vous de suivi ;
+      li Permettre la notification par SMS aux usagers.
 
-      h4 C) Établir des plages d'ouvertures
+    h4 C) Établir des plages d'ouvertures
 
-      p Cette fonctionnalité permet aux structures de mieux intégrer les rendez-vous pris ou à prendre dans les plages d'ouverture de la structure. En effet, chaque structure pourra :
-      ul
-        li Déterminer un "nom" pour la plage d'ouverture uniquement visible en interne ;
-        li Déterminer un lieu d'ouverture ;
-        li Déterminer la plage horaire.
+    p Cette fonctionnalité permet aux structures de mieux intégrer les rendez-vous pris ou à prendre dans les plages d'ouverture de la structure. En effet, chaque structure pourra :
+    ul
+      li Déterminer un "nom" pour la plage d'ouverture uniquement visible en interne ;
+      li Déterminer un lieu d'ouverture ;
+      li Déterminer la plage horaire.
 
-      p Après avoir déterminé ces éléments, la structure devra "créer sa plage". Cette plage préviendra toute prise de rendez-vous en dehors d'horaires ou de moments prévus par la structure. Elle pourra les modifier à tout moment.
+    p Après avoir déterminé ces éléments, la structure devra "créer sa plage". Cette plage préviendra toute prise de rendez-vous en dehors d'horaires ou de moments prévus par la structure. Elle pourra les modifier à tout moment.
 
-      p A ces possibilités, s'ajoutent celles permettant d'intégrer les RDV prévus dans le futur, en :
-      ul
-        li ajoutant directement un rendez-vous dans l'agenda de la structure ou d'un Agent de manière spécifique ;
-        li en précisant les créneaux pour lesquels un Agent n'est pas présent et ne peut donc prendre de rendez-vous.
+    p A ces possibilités, s'ajoutent celles permettant d'intégrer les RDV prévus dans le futur, en :
+    ul
+      li ajoutant directement un rendez-vous dans l'agenda de la structure ou d'un Agent de manière spécifique ;
+      li en précisant les créneaux pour lesquels un Agent n'est pas présent et ne peut donc prendre de rendez-vous.
 
-      h4 D) Créer une fiche "Nouvel Usager"
+    h4 D) Créer une fiche "Nouvel Usager"
 
-      p Cette fonctionnalité est ouverte aux Agents, qui peuvent créer une fiche pour un usager ou pour un proche de l'usager. Cette fonctionnalité permet une meilleure visibilité et organisation aux structures. Ainsi, il est possible de remplir une fiche d'Usager et de proposer à l'usager de se créer un compte #{current_domain.name}. Lorsque l'usager est un "proche", alors l'Agent devra remplir la fiche du Nouvel usager "Responsable", c'est-à-dire celui avec lequel il est en relation directe. Il reviendra à l'Usager d'informer le proche par tous moyens et dans un délai d'1 mois, de la transmission de ces informations à la Plateforme #{current_domain.name}.
+    p Cette fonctionnalité est ouverte aux Agents, qui peuvent créer une fiche pour un usager ou pour un proche de l'usager. Cette fonctionnalité permet une meilleure visibilité et organisation aux structures. Ainsi, il est possible de remplir une fiche d'Usager et de proposer à l'usager de se créer un compte #{current_domain.name}. Lorsque l'usager est un "proche", alors l'Agent devra remplir la fiche du Nouvel usager "Responsable", c'est-à-dire celui avec lequel il est en relation directe. Il reviendra à l'Usager d'informer le proche par tous moyens et dans un délai d'1 mois, de la transmission de ces informations à la Plateforme #{current_domain.name}.
 
-      h4 E) Gérer les statistiques de la structure.
+    h4 E) Gérer les statistiques de la structure.
 
-      p Chaque Agent peut télécharger un export de ses Rendez-vous, et ainsi voir la progression relative aux Rendez-vous manqués (excusés ou non). Les informations suivantes sont disponibles :
+    p Chaque Agent peut télécharger un export de ses Rendez-vous, et ainsi voir la progression relative aux Rendez-vous manqués (excusés ou non). Les informations suivantes sont disponibles :
 
-      ul
-        li Nombre de Rendez-vous ;
-        li Nombre de personnes vues ;
-        li Nombre d'absences excusées à des rendez-vous ;
-        li Nombre d'absences non excusées à des rendez-vous.
+    ul
+      li Nombre de Rendez-vous ;
+      li Nombre de personnes vues ;
+      li Nombre d'absences excusées à des rendez-vous ;
+      li Nombre d'absences non excusées à des rendez-vous.
 
-      h2 Article 5 – Responsabilités
+    h2 Article 5 – Responsabilités
 
-      h3 5.1 L’éditeur de la « Plateforme #{current_domain.name} »
+    h3 5.1 L’éditeur de la « Plateforme #{current_domain.name} »
 
-      p Les sources des informations diffusées sur la Plateforme sont réputées fiables mais le site ne garantit pas qu’il soit exempt de défauts, d’erreurs ou d’omissions.
+    p Les sources des informations diffusées sur la Plateforme sont réputées fiables mais le site ne garantit pas qu’il soit exempt de défauts, d’erreurs ou d’omissions.
 
-      p L’éditeur s’autorise à suspendre ou révoquer n'importe quel compte et toutes les actions réalisées par ce biais, s’il estime que l’usage réalisé du service porte préjudice à son image ou ne correspond pas aux exigences de sécurité.
+    p L’éditeur s’autorise à suspendre ou révoquer n'importe quel compte et toutes les actions réalisées par ce biais, s’il estime que l’usage réalisé du service porte préjudice à son image ou ne correspond pas aux exigences de sécurité.
 
-      p L’éditeur s’engage à la sécurisation de la Plateforme, notamment en prenant toutes les mesures nécessaires permettant de garantir la sécurité et la confidentialité des informations fournies.
+    p L’éditeur s’engage à la sécurisation de la Plateforme, notamment en prenant toutes les mesures nécessaires permettant de garantir la sécurité et la confidentialité des informations fournies.
 
-      p L’éditeur fournit les moyens nécessaires et raisonnables pour assurer un accès continu, sans contrepartie financière, à la Plateforme. Il se réserve la liberté de faire évoluer, de modifier ou de suspendre, sans préavis, la plateforme pour des raisons de maintenance ou pour tout autre motif jugé nécessaire.
+    p L’éditeur fournit les moyens nécessaires et raisonnables pour assurer un accès continu, sans contrepartie financière, à la Plateforme. Il se réserve la liberté de faire évoluer, de modifier ou de suspendre, sans préavis, la plateforme pour des raisons de maintenance ou pour tout autre motif jugé nécessaire.
 
-      h3 5.2 L’Utilisateur
+    h3 5.2 L’Utilisateur
 
-      p L'Utilisateur s'assure de garder son mot de passe secret. Toute divulgation du mot de passe, quelle que soit sa forme, est interdite. Il assume les risques liés à l'utilisation de son identifiant et mot de passe.
+    p L'Utilisateur s'assure de garder son mot de passe secret. Toute divulgation du mot de passe, quelle que soit sa forme, est interdite. Il assume les risques liés à l'utilisation de son identifiant et mot de passe.
 
-      p Toute information transmise par l'Utilisateur est de sa seule responsabilité. Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour autrui s’expose, notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des peines pouvant aller jusqu’à trois ans d’emprisonnement et 45 000 euros d’amende.
+    p Toute information transmise par l'Utilisateur est de sa seule responsabilité. Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour autrui s’expose, notamment, aux sanctions prévues à l’article 441-1 du code pénal, prévoyant des peines pouvant aller jusqu’à trois ans d’emprisonnement et 45 000 euros d’amende.
 
-      h2 Article 6 - Mise à jour des conditions d’utilisation
+    h2 Article 6 - Mise à jour des conditions d’utilisation
 
-      p Les termes des présentes conditions d’utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
+    p Les termes des présentes conditions d’utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -1,30 +1,28 @@
 - content_for :title, "Contact"
 
-.container.mt-3
-  h1.text-dark.mb-3 Contact
-  h2 Votre département
-  ul.list-group.mb-2
-    - Territory.all.where.not(phone_number: nil).each do |territory|
-      li
-        span> #{territory}
-        = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
+h2 Votre département
+ul.list-group.mb-2
+  - Territory.all.where.not(phone_number: nil).each do |territory|
     li
-      span> Autres départements, voir
-      = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
+      span> #{territory}
+      = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
+  li
+    span> Autres départements, voir
+    = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
 
-  .row#tech-support
-    .col-md-6
-      h3.mt-4
-        = mail_to current_domain.support_email,
-          subject: "[Problème Usager]",
-          body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "btn btn-primary" do
-          span>
-            i.fa.fa-envelope
-          | Contacter l'équipe technique
+.row#tech-support
+  .col-md-6
+    h3.mt-4
+      = mail_to current_domain.support_email,
+        subject: "[Problème Usager]",
+        body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "btn btn-primary" do
+        span>
+          i.fa.fa-envelope
+        | Contacter l'équipe technique
 
-      .alert.alert-warning.my-4.d-flex.align-items-center
-        i.fa.fa-exclamation-triangle>
-        .ml-2
-          b> Nous ne sommes pas travailleurs médico-sociaux,
-          span> et nous ne pouvons pas débloquer d'autres créneaux que ceux affichés,
-          | nous pouvons seulement aider avec les sujets techniques
+    .alert.alert-warning.my-4.d-flex.align-items-center
+      i.fa.fa-exclamation-triangle>
+      .ml-2
+        b> Nous ne sommes pas travailleurs médico-sociaux,
+        span> et nous ne pouvons pas débloquer d'autres créneaux que ceux affichés,
+        | nous pouvons seulement aider avec les sujets techniques

--- a/app/views/static_pages/domaines.html.slim
+++ b/app/views/static_pages/domaines.html.slim
@@ -1,20 +1,18 @@
 - content_for :title, "RDV Solidarités et #{Domain::RDV_AIDE_NUMERIQUE.name}"
 
-.container.mt-3
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      h1.text-dark.mb-3 RDV Solidarités et #{Domain::RDV_AIDE_NUMERIQUE.name}
-      p Le site #{Domain::RDV_AIDE_NUMERIQUE.name} a été créé par l’équipe de RDV Solidarités pour permettre la prise de rendez-vous avec les Conseillers Numériques France Service et d’autres acteurs de l’inclusion numérique. C’est le même logiciel que RDV Solidarités, sous un autre nom afin d’être plus compréhensible par les usagers.
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    p Le site #{Domain::RDV_AIDE_NUMERIQUE.name} a été créé par l’équipe de RDV Solidarités pour permettre la prise de rendez-vous avec les Conseillers Numériques France Service et d’autres acteurs de l’inclusion numérique. C’est le même logiciel que RDV Solidarités, sous un autre nom afin d’être plus compréhensible par les usagers.
 
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      p Les usagers qui ont un compte sur #{Domain::RDV_SOLIDARITES.name} peuvent s’en servir pour se connecter à #{Domain::RDV_AIDE_NUMERIQUE.name}, et vice-versa. Leurs rendez-vous avec les services médico-sociaux sont visibles uniquement sur RDV Solidarités, et leurs rendez-vous liés à l'aide au numérique sont visibles uniquement sur #{Domain::RDV_AIDE_NUMERIQUE.name}
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    p Les usagers qui ont un compte sur #{Domain::RDV_SOLIDARITES.name} peuvent s’en servir pour se connecter à #{Domain::RDV_AIDE_NUMERIQUE.name}, et vice-versa. Leurs rendez-vous avec les services médico-sociaux sont visibles uniquement sur RDV Solidarités, et leurs rendez-vous liés à l'aide au numérique sont visibles uniquement sur #{Domain::RDV_AIDE_NUMERIQUE.name}
 
-  .row
-    .col-lg-8
-      - Domain::ALL.each do |domain|
-        p> #{domain.name} est accessible à l'adresse #{link_to(domain.host_name, "https://#{domain.host_name}")}
+.row
+  .col-lg-8
+    - Domain::ALL.each do |domain|
+      p> #{domain.name} est accessible à l'adresse #{link_to(domain.host_name, "https://#{domain.host_name}")}
 
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      p Les agents peuvent accéder à leur compte et toutes leur données indifféremment sur les deux sites.
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    p Les agents peuvent accéder à leur compte et toutes leur données indifféremment sur les deux sites.

--- a/app/views/static_pages/mentions_legales.html.slim
+++ b/app/views/static_pages/mentions_legales.html.slim
@@ -1,48 +1,46 @@
 - content_for :title, "Mentions légales"
 
-.container.mt-3
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      h1.text-dark.mb-3 Mentions légales
-      h2 Éditeur de la plateforme
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    h2 Éditeur de la plateforme
 
-      p
-        | La plateforme est éditée par :
-        br
-        b> Agence nationale de la cohésion des territoires
-        br
-        | 20, avenue de Ségur
-        br
-        | TSA 10717
-        br
-        | 75 334 Paris Cedex 07
-        br
-        | Téléphone : +33 1 85 58 60 00
-        br
-        | Mail :
-        = mail_to "info@anct.gouv.fr"
+    p
+      | La plateforme est éditée par :
+      br
+      b> Agence nationale de la cohésion des territoires
+      br
+      | 20, avenue de Ségur
+      br
+      | TSA 10717
+      br
+      | 75 334 Paris Cedex 07
+      br
+      | Téléphone : +33 1 85 58 60 00
+      br
+      | Mail :
+      = mail_to "info@anct.gouv.fr"
 
-      h2 Directeur de la publication
+    h2 Directeur de la publication
 
-      p Monsieur Stanislas Bourron, Directeur général de l’Agence Nationale de la Cohésion des Territoires
+    p Monsieur Stanislas Bourron, Directeur général de l’Agence Nationale de la Cohésion des Territoires
 
-      h2 Hébergement de la plateforme
+    h2 Hébergement de la plateforme
 
-      p
-        | Ce site est hébergé par
-        br
-        | Outscale SASU
-        br
-        |1 rue Royale - 319 Bureaux de la Colline
-        br
-        | 92210 Saint-Cloud
+    p
+      | Ce site est hébergé par
+      br
+      | Outscale SASU
+      br
+      |1 rue Royale - 319 Bureaux de la Colline
+      br
+      | 92210 Saint-Cloud
 
-      h2 Accessibilité
+    h2 Accessibilité
 
-      p La conformité aux normes d’accessibilité numérique est un objectif ultérieur mais nous tâchons de rendre ce site accessible à toutes et à tous.
+    p La conformité aux normes d’accessibilité numérique est un objectif ultérieur mais nous tâchons de rendre ce site accessible à toutes et à tous.
 
-      p Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part. Si vous n'obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Pour en savoir plus sur la politique d'accessibilité numérique de l'État :
+    p Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part. Si vous n'obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Pour en savoir plus sur la politique d'accessibilité numérique de l'État :
 
-      h2 Sécurité
+    h2 Sécurité
 
-      p Le site est protégé par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges, mais permet aussi aux usagers de s’assurer de l’authenticité du site. En aucun cas les services associés à la plateforme ne seront à l’origine d’envoi de courriels pour demander la saisie d’informations personnelles, en particulier, le mot de passe qui reste sous le contrôle exclusif des usagers.
+    p Le site est protégé par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges, mais permet aussi aux usagers de s’assurer de l’authenticité du site. En aucun cas les services associés à la plateforme ne seront à l’origine d’envoi de courriels pour demander la saisie d’informations personnelles, en particulier, le mot de passe qui reste sous le contrôle exclusif des usagers.

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -1,214 +1,212 @@
 - content_for :title, "Politique de confidentialité"
 
-.container.mt-3
-  .row.align-items-center.mb-4.content
-    .col-lg-8
-      h1.text-dark.mb-3 Politique de confidentialité
-      h2 Traitement des données à caractère personnel
+.row.align-items-center.mb-4.content
+  .col-lg-8
+    h2 Traitement des données à caractère personnel
 
-      p La plateforme "RDV-Solidarités" est à l'initiative de l'Agence Nationale de la Cohésion des Territoires (ANCT), placé sous la tutelle des ministres chargés de l'aménagement du territoire, des collectivités territoriales et de la politique de la ville.
+    p La plateforme "RDV-Solidarités" est à l'initiative de l'Agence Nationale de la Cohésion des Territoires (ANCT), placé sous la tutelle des ministres chargés de l'aménagement du territoire, des collectivités territoriales et de la politique de la ville.
 
-      h3 Finalité
+    h3 Finalité
 
-      p La plateforme sert à collecter des données à caractère personnel pour organiser et fluidifier la prise de rendez-vous médico-sociaux pour les services publics.
+    p La plateforme sert à collecter des données à caractère personnel pour organiser et fluidifier la prise de rendez-vous médico-sociaux pour les services publics.
 
-      h3 Données à caractère personnel traitées
+    h3 Données à caractère personnel traitées
 
-      p La plateforme peut traiter les données à caractère personnel suivantes :
+    p La plateforme peut traiter les données à caractère personnel suivantes :
+
+    ul
+      li
+        strong Données relatives au compte Agent :
+        span> Nom, prénom, adresse mail professionnelle de manière obligatoire, et le rôle de manière facultative ;
+      li
+        strong Données relatives au compte Usager :
+        span> Nom, prénom, adresse e-mail, numéro de téléphone, adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants ;
+      li
+        strong Données relatives à la fiche "Nouvel Usager" - Responsable :
+        span> Nom, prénom, nom de naissance, date de naissance, adresse e-mail, numéro de téléphone, adresse, champ "remarques", caisse d'affiliation, numéro d'allocataire, situation familiale, nombre d'enfants, modalités de logement (SDS, propriétaire, hébergé, locataire, en accession à la propriété) ;
+      li
+        strong Données relatives à la fiche "Nouvel Usager" - Proche :
+        span> Nom, prénom, date de naissance, champ "remarques", informations relatives à l'Usager "Type Responsable" ;
+      li
+        strong Données de localisation :
+        span> Adresse ;
+      li
+        strong Données d'hébergeur :
+        span> Identifiant de connexion ; Nature des opérations ;
+      li
+        strong Cookies.
+
+      p La création du compte professionnel n'est ouverte qu'aux seuls agents et professionnels exerçant une mission de service public à vocation médico-sociale.
+
+      h3 Base juridique des traitements de données
+
+      p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques :
 
       ul
-        li
-          strong Données relatives au compte Agent :
-          span> Nom, prénom, adresse mail professionnelle de manière obligatoire, et le rôle de manière facultative ;
-        li
-          strong Données relatives au compte Usager :
-          span> Nom, prénom, adresse e-mail, numéro de téléphone, adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants ;
-        li
-          strong Données relatives à la fiche "Nouvel Usager" - Responsable :
-          span> Nom, prénom, nom de naissance, date de naissance, adresse e-mail, numéro de téléphone, adresse, champ "remarques", caisse d'affiliation, numéro d'allocataire, situation familiale, nombre d'enfants, modalités de logement (SDS, propriétaire, hébergé, locataire, en accession à la propriété) ;
-        li
-          strong Données relatives à la fiche "Nouvel Usager" - Proche :
-          span> Nom, prénom, date de naissance, champ "remarques", informations relatives à l'Usager "Type Responsable" ;
-        li
-          strong Données de localisation :
-          span> Adresse ;
-        li
-          strong Données d'hébergeur :
-          span> Identifiant de connexion ; Nature des opérations ;
-        li
-          strong Cookies.
+        li l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD ;
+        li la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD.
 
-        p La création du compte professionnel n'est ouverte qu'aux seuls agents et professionnels exerçant une mission de service public à vocation médico-sociale.
+      p Ces fondements sont précisés ci-dessous :
 
-        h3 Base juridique des traitements de données
+      h4 a) Les données relatives au compte professionnel
+      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-        p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques :
+      h4 b) Les données relatives au compte usager
+      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-        ul
-          li l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD ;
-          li la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD.
+      h4 c) Les données relatives à la fiche "Nouvel Usager" - Responsable
+      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-        p Ces fondements sont précisés ci-dessous :
+      h4 d) Les données relatives à la fiche "Nouvel Usager" - Proche
+      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-        h4 a) Les données relatives au compte professionnel
-        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+      h4 e) Les données de localisation
+      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-        h4 b) Les données relatives au compte usager
-        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+      h4 f) Données d'hébergeur
+      p Ce traitement de données est nécessaire au respect d’une obligation légale à laquelle le responsable du traitement est soumis au sens de l’article 6-c du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-        h4 c) Les données relatives à la fiche "Nouvel Usager" - Responsable
-        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+      p L’obligation légale est posée par :
+      ul
+        li = link_to "la loi LCEN n°2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique ;", "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000801164/2020-10-26/"
+        li = link_to "les articles 1 et 3 du décret n°2021-1362 du 20 octobre 2021.", "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044228912"
 
-        h4 d) Les données relatives à la fiche "Nouvel Usager" - Proche
-        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+      h4 g) Cookies
 
-        h4 e) Les données de localisation
-        p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+      p Voir la partie sur les cookies ci-après.
 
-        h4 f) Données d'hébergeur
-        p Ce traitement de données est nécessaire au respect d’une obligation légale à laquelle le responsable du traitement est soumis au sens de l’article 6-c du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+      h2 Durée de conservation
 
-        p L’obligation légale est posée par :
-        ul
-          li = link_to "la loi LCEN n°2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique ;", "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000801164/2020-10-26/"
-          li = link_to "les articles 1 et 3 du décret n°2021-1362 du 20 octobre 2021.", "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044228912"
+      p Les données à caractère personnel sont conservées :
 
-        h4 g) Cookies
+      table.table
+        thead
+          tr
+            th Types de données
+            th Durées de conservation
+        tbody
+          tr
+            td Données relatives au compte Agent
+            td Les données sont conservées jusqu'à la suppression du compte professionnel, ou 2 ans après l’inactivité du compte.
+          tr
+            td Données relatives au compte Usager
+            td Les données sont conservées jusqu'à la suppression du compte usager, ou 2 ans après l’inactivité du compte.
+          tr
+            td Données relatives à la fiche "Nouvel Usager" - Responsable
+            td Les données sont conservées jusqu'à la création d'un compte usager, dans un délai maximum de 2 ans à compter de la création de la fiche.
+          tr
+            td Données relatives à la fiche "Nouvel Usager" - Proche
+            td Les données sont conservées jusqu'à la création d'un compte usager, dans un délai de 2 ans à compter de la création de la fiche.
+          tr
+            td Données de localisation
+            td Les données sont supprimées à compter de la prise de rendez-vous.
+          tr
+            td Données d'hébergeur
+            td 1 an.
+          tr
+            td Cookies
+            td 13 mois.
 
-        p Voir la partie sur les cookies ci-après.
+      p L'inactivité d'un usager se mesure sur la date du dernier RDV pris.
 
-        h2 Durée de conservation
+      h3 Droit des personnes concernées
 
-        p Les données à caractère personnel sont conservées :
+      p Vous disposez des droits suivants concernant vos données à caractère personnel :
 
-        table.table
-          thead
-            tr
-              th Types de données
-              th Durées de conservation
-          tbody
-            tr
-              td Données relatives au compte Agent
-              td Les données sont conservées jusqu'à la suppression du compte professionnel, ou 2 ans après l’inactivité du compte.
-            tr
-              td Données relatives au compte Usager
-              td Les données sont conservées jusqu'à la suppression du compte usager, ou 2 ans après l’inactivité du compte.
-            tr
-              td Données relatives à la fiche "Nouvel Usager" - Responsable
-              td Les données sont conservées jusqu'à la création d'un compte usager, dans un délai maximum de 2 ans à compter de la création de la fiche.
-            tr
-              td Données relatives à la fiche "Nouvel Usager" - Proche
-              td Les données sont conservées jusqu'à la création d'un compte usager, dans un délai de 2 ans à compter de la création de la fiche.
-            tr
-              td Données de localisation
-              td Les données sont supprimées à compter de la prise de rendez-vous.
-            tr
-              td Données d'hébergeur
-              td 1 an.
-            tr
-              td Cookies
-              td 13 mois.
+      ul
+        li Droit d’information ;
+        li Droit d’accès aux données ;
+        li Droit de rectification ;
+        li Droit de suppression des données.
 
-        p L'inactivité d'un usager se mesure sur la date du dernier RDV pris.
+      p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
 
-        h3 Droit des personnes concernées
+      strong = mail_to current_domain.support_email
 
-        p Vous disposez des droits suivants concernant vos données à caractère personnel :
+      p ou par voie postale :
 
-        ul
-          li Droit d’information ;
-          li Droit d’accès aux données ;
-          li Droit de rectification ;
-          li Droit de suppression des données.
+      p Agence nationale de la cohésion des territoires
+      br
+      | 20, avenue de Ségur
+      br
+      | TSA 10717
+      br
+      | 75 334 Paris Cedex 07
 
-        p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
+      p En raison de l’obligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici
+      = link_to "https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces"
+      span> , un modèle de courrier élaboré par la Cnil.
 
-        strong = mail_to current_domain.support_email
+      p Nous nous engageons à ne jamais céder ces informations à des tiers.
 
-        p ou par voie postale :
+      h3 Délais de réponse
 
-        p Agence nationale de la cohésion des territoires
-        br
-        | 20, avenue de Ségur
-        br
-        | TSA 10717
-        br
-        | 75 334 Paris Cedex 07
+      p Le responsable de traitement s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
 
-        p En raison de l’obligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici
-        = link_to "https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces"
-        span> , un modèle de courrier élaboré par la Cnil.
+      h3 Destinataires des données
 
-        p Nous nous engageons à ne jamais céder ces informations à des tiers.
+      p Le responsable de traitement s'engage à ce que les données à caractères personnels soient traitées par les seules personnes autorisées.
 
-        h3 Délais de réponse
+      h3 Sous-traitants
 
-        p Le responsable de traitement s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
+      p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
 
-        h3 Destinataires des données
+      table.table
+        thead
+          tr
+            th Partenaire
+            th Traitement réalisé
+            th Pays destinataire
+            th Garanties
+        tbody
+          tr
+            td Outscale SASU
+            td Hébergement
+            td France
+            td = link_to "​​​​https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf"
+          tr
+            td Sendinblue
+            td Envoi de mails
+            td France
+            td = link_to "https://fr.sendinblue.com/rgpd/"
+          tr
+            td LinkMobility
+            td Envoi de SMS
+            td France
+            td = link_to "https://linkmobility.fr/wp-content/uploads/sites/12/2021/05/Notice-dinformation-sur-la-protection-des-donnees-FR-31032021-1.pdf"
 
-        p Le responsable de traitement s'engage à ce que les données à caractères personnels soient traitées par les seules personnes autorisées.
+      h3 Sécurité et confidentialité des données
 
-        h3 Sous-traitants
+      p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment :
+      ul
+        li Pare feu système.
+        li Pare feu applicatif (WAF).
+        li Chiffrement des flux réseaux via certificat SSL.
+        li Disque dur chiffré.
+        li Services isolés dans des containers.
+        li Gestion des journaux.
+        li Administration et monitoring centralisés des accès.
+        li Accès aux ressources via clés SSH (pas de mot de passe post installation).
+        li Accès aux données réservé aux membres de l'entité (hors restitution applicative publique des données).
+        li Accès aux données uniquement via un outil d'édition sécurisé (SSL + mot de passe) avec utilisation de comptes nominatifs.
+        li Hébergeur de données de santé.
 
-        p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
+      h2#cookies Utilisation de témoins de connexion (« cookies »)
 
-        table.table
-          thead
-            tr
-              th Partenaire
-              th Traitement réalisé
-              th Pays destinataire
-              th Garanties
-          tbody
-            tr
-              td Outscale SASU
-              td Hébergement
-              td France
-              td = link_to "​​​​https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf"
-            tr
-              td Sendinblue
-              td Envoi de mails
-              td France
-              td = link_to "https://fr.sendinblue.com/rgpd/"
-            tr
-              td LinkMobility
-              td Envoi de SMS
-              td France
-              td = link_to "https://linkmobility.fr/wp-content/uploads/sites/12/2021/05/Notice-dinformation-sur-la-protection-des-donnees-FR-31032021-1.pdf"
+      p Les cookies utilisés sur RDV-Solidarités ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet.
+      p RDV-Solidarités utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
 
-        h3 Sécurité et confidentialité des données
+      p RDV-Solidarités n'utilise aucun cookies dits "tiers".
 
-        p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment :
-        ul
-          li Pare feu système.
-          li Pare feu applicatif (WAF).
-          li Chiffrement des flux réseaux via certificat SSL.
-          li Disque dur chiffré.
-          li Services isolés dans des containers.
-          li Gestion des journaux.
-          li Administration et monitoring centralisés des accès.
-          li Accès aux ressources via clés SSH (pas de mot de passe post installation).
-          li Accès aux données réservé aux membres de l'entité (hors restitution applicative publique des données).
-          li Accès aux données uniquement via un outil d'édition sécurisé (SSL + mot de passe) avec utilisation de comptes nominatifs.
-          li Hébergeur de données de santé.
+      p Il convient d'indiquer que :
+      ul
+        li Les données collectées ne sont pas recoupées avec d’autres traitements.
+        li Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
 
-        h2#cookies Utilisation de témoins de connexion (« cookies »)
+      p À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
 
-        p Les cookies utilisés sur RDV-Solidarités ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet.
-        p RDV-Solidarités utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
+      p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
 
-        p RDV-Solidarités n'utilise aucun cookies dits "tiers".
-
-        p Il convient d'indiquer que :
-        ul
-          li Les données collectées ne sont pas recoupées avec d’autres traitements.
-          li Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
-
-        p À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
-
-        p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
-
-        ul
-          li = link_to "Cookies & traceurs : que dit la loi ?", "https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
-          li = link_to "Cookies : les outils pour les maîtriser", "https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"
+      ul
+        li = link_to "Cookies & traceurs : que dit la loi ?", "https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
+        li = link_to "Cookies : les outils pour les maîtriser", "https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -2,203 +2,198 @@
 - content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for :title do
-  h1
-    | Statistiques
-    = " pour le #{@territory}" if @territory.present?
+  | Statistiques
+  = " pour le #{@territory}" if @territory.present?
 
 - cache([@territory, Time.zone.today], expires_in: 24.hours) do
-  .container.mt-3
-    h1.text-primary-blue
-      | Statistiques
-      = " pour le #{@territory}" if @territory.present?
-    - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
-      h3 Cette structure n'utilise pas #{current_domain.name}.
-    - else
-      .card.mb-5
-        .card-body
-          h2.card-title Nombre de RDV par statut
-          .row
-            .col-lg-4
-              .px-1
-                - %i[seen excused revoked noshow].each do |temporal_status|
-                  = render "stats/rdv_counter_without_link", \
-                    temporal_status: temporal_status, \
-                    element: "RDV".pluralize(@stats.rdvs.status(temporal_status).count), \
-                    count: @stats.rdvs.status(temporal_status).count
-            .col-lg-4
-              .px-1
+  - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
+    h3 Cette structure n'utilise pas #{current_domain.name}.
+  - else
+    .card.mb-5
+      .card-body
+        h2.card-title Nombre de RDV par statut
+        .row
+          .col-lg-4
+            .px-1
+              - %i[seen excused revoked noshow].each do |temporal_status|
                 = render "stats/rdv_counter_without_link", \
-                  temporal_status: :unknown_past, \
-                  element: "RDV", \
-                  count: @stats.rdvs.status(:unknown_past).count
-            .col-lg-4
-              .px-1
-                = render "stats/rdv_counter_without_link", \
-                  temporal_status: :unknown_future, \
-                  element: "RDV", \
-                  count: @stats.rdvs.status(:unknown_future).count
-          hr
-          .row
-            .col-lg-4
-              .px-1
-                = render "stats/rdv_counter_without_link", \
-                  element: "RDV", \
-                  label: "Tous", \
-                  count: @stats.rdvs.count
+                  temporal_status: temporal_status, \
+                  element: "RDV".pluralize(@stats.rdvs.status(temporal_status).count), \
+                  count: @stats.rdvs.status(temporal_status).count
+          .col-lg-4
+            .px-1
+              = render "stats/rdv_counter_without_link", \
+                temporal_status: :unknown_past, \
+                element: "RDV", \
+                count: @stats.rdvs.status(:unknown_past).count
+          .col-lg-4
+            .px-1
+              = render "stats/rdv_counter_without_link", \
+                temporal_status: :unknown_future, \
+                element: "RDV", \
+                count: @stats.rdvs.status(:unknown_future).count
+        hr
+        .row
+          .col-lg-4
+            .px-1
+              = render "stats/rdv_counter_without_link", \
+                element: "RDV", \
+                label: "Tous", \
+                count: @stats.rdvs.count
 
-      .card.mb-5
-        .card-body
-          h2.card-title Nombre de RDV par statut de participation
-          .row
-            .col-lg-4
-              .px-1
-                - %i[seen excused revoked noshow].each do |temporal_status|
-                  - count = Participation.where(rdv: @stats.rdvs).status(temporal_status).count
-                  = render "stats/rdv_counter_without_link", \
-                    temporal_status: temporal_status, \
-                    element: "Usager".pluralize(count), \
-                    count: count
-            .col-lg-4
-              .px-1
-                - count = Participation.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_past).count
+    .card.mb-5
+      .card-body
+        h2.card-title Nombre de RDV par statut de participation
+        .row
+          .col-lg-4
+            .px-1
+              - %i[seen excused revoked noshow].each do |temporal_status|
+                - count = Participation.where(rdv: @stats.rdvs).status(temporal_status).count
                 = render "stats/rdv_counter_without_link", \
-                  temporal_status: :unknown_past, \
+                  temporal_status: temporal_status, \
                   element: "Usager".pluralize(count), \
                   count: count
-            .col-lg-4
-              .px-1
-                - count = Participation.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_future).count
-                = render "stats/rdv_counter_without_link", \
-                  element: "Usager".pluralize(count), \
-                  temporal_status: :unknown_future, \
-                  count: count
-          hr
-          .row
-            .col-lg-4
-              .px-1
-                - count = Participation.where(rdv: @stats.rdvs).count
-                = render "stats/rdv_counter_without_link", \
-                  element: "Usager".pluralize(count), \
-                  label: "Tous", \
-                  count: count
+          .col-lg-4
+            .px-1
+              - count = Participation.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_past).count
+              = render "stats/rdv_counter_without_link", \
+                temporal_status: :unknown_past, \
+                element: "Usager".pluralize(count), \
+                count: count
+          .col-lg-4
+            .px-1
+              - count = Participation.where(rdv: @stats.rdvs).joins(:rdv).status(:unknown_future).count
+              = render "stats/rdv_counter_without_link", \
+                element: "Usager".pluralize(count), \
+                temporal_status: :unknown_future, \
+                count: count
+        hr
+        .row
+          .col-lg-4
+            .px-1
+              - count = Participation.where(rdv: @stats.rdvs).count
+              = render "stats/rdv_counter_without_link", \
+                element: "Usager".pluralize(count), \
+                label: "Tous", \
+                count: count
 
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs"
+          h2.card-title RDV créés (#{@stats.rdvs.count})
+        = column_chart rdvs_stats_path(territory: @territory), stacked: true
+
+    - unless @territory.present?
       .card.mb-5
         .card-body
-          = self_anchor "rdvs"
-            h2.card-title RDV créés (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(territory: @territory), stacked: true
+          = self_anchor "rdvs-territory"
+            h2.card-title RDV créés par structure (#{@stats.rdvs.count})
+          = column_chart rdvs_stats_path(by_territory: true), stacked: true
 
-      - unless @territory.present?
-        .card.mb-5
-          .card-body
-            = self_anchor "rdvs-territory"
-              h2.card-title RDV créés par structure (#{@stats.rdvs.count})
-            = column_chart rdvs_stats_path(by_territory: true), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-service"
+          h2.card-title RDV créés par service (#{@stats.rdvs.count})
+        = column_chart rdvs_stats_path(by_service: true, territory: @territory), stacked: true
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-service"
-            h2.card-title RDV créés par service (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(by_service: true, territory: @territory), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-type"
+          h2.card-title RDV par type (#{@stats.rdvs.count})
+        = column_chart rdvs_stats_path(by_location_type: true, territory: @territory), stacked: true
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-type"
-            h2.card-title RDV par type (#{@stats.rdvs.count})
-          = column_chart rdvs_stats_path(by_location_type: true, territory: @territory), stacked: true
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-status"
+          h2.card-title RDV par statut
+        /
+          Note: colors are synced manually with the status css and the order of the stats.
+          From stat.rb, Stat#rdvs_group_by_status:
+            * stats are in this order: unknown seen excused revoked noshow
+          From _rdv_status.scss, the colors are:
+            "unknown": $info, #ffbc00
+            "seen": $success, #0acf97
+            "excused": $info, #39afd1
+            "revoked": $teal, #02a8b5
+            "noshow": $danger, #fa5c7c
+        - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
+        = column_chart rdvs_stats_path(by_status: true, territory: @territory), stacked: :percent, max: 100, suffix: "%", colors: colors
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-status"
-            h2.card-title RDV par statut
-          /
-            Note: colors are synced manually with the status css and the order of the stats.
-            From stat.rb, Stat#rdvs_group_by_status:
-              * stats are in this order: unknown seen excused revoked noshow
-            From _rdv_status.scss, the colors are:
-              "unknown": $info, #ffbc00
-              "seen": $success, #0acf97
-              "excused": $info, #39afd1
-              "revoked": $teal, #02a8b5
-              "noshow": $danger, #fa5c7c
-          - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
-          = column_chart rdvs_stats_path(by_status: true, territory: @territory), stacked: :percent, max: 100, suffix: "%", colors: colors
+    .card.mb-5
+      .card-body
+        = self_anchor "rdvs-status"
+          h2.card-title RDV par statut de participation
+        - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
+        = column_chart rdvs_stats_path(by_participations_status: true, territory: @territory), stacked: :percent, max: 100, suffix: "%", colors: colors
 
-      .card.mb-5
-        .card-body
-          = self_anchor "rdvs-status"
-            h2.card-title RDV par statut de participation
-          - colors = %w[#fa5c7c #02a8b5 #39afd1 #0acf97 #ffbc00]
-          = column_chart rdvs_stats_path(by_participations_status: true, territory: @territory), stacked: :percent, max: 100, suffix: "%", colors: colors
+    .card.mb-5
+      .card-header
+        = self_anchor "notifications"
+          h2.card-title #{Receipt.model_name.human(count: 2)}
+      .card-body
+        = "Vous pouvez consulter les statistiques sur les notifications envoyées "
+        = link_to("ici", notifications_index_stats_path(params.permit(:territory)))
 
-      .card.mb-5
-        .card-header
-          = self_anchor "notifications"
-            h2.card-title #{Receipt.model_name.human(count: 2)}
-        .card-body
-          = "Vous pouvez consulter les statistiques sur les notifications envoyées "
-          = link_to("ici", notifications_index_stats_path(params.permit(:territory)))
+    .card.mb-5
+      .card-body
+        = self_anchor "activations"
+          h2.card-title Activité des agents
+        - active_agents = @agents.active
 
-      .card.mb-5
-        .card-body
-          = self_anchor "activations"
-            h2.card-title Activité des agents
-          - active_agents = @agents.active
+        h5 Aujourd'hui
 
-          h5 Aujourd'hui
+        p #{active_agents.count} agents ont été invités
 
-          p #{active_agents.count} agents ont été invités
+        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).count
+        p #{percent(accepted_count, active_agents.count)} ont accepté l'invitation (#{accepted_count})
 
-          - accepted_count = active_agents.where.not(invitation_accepted_at: nil).count
-          p #{percent(accepted_count, active_agents.count)} ont accepté l'invitation (#{accepted_count})
+        - first_rdv_count = active_agents.joins(:rdvs).distinct.count
+        p #{percent(first_rdv_count, active_agents.count)} ont participé à au moins un rdv (#{first_rdv_count})
 
-          - first_rdv_count = active_agents.joins(:rdvs).distinct.count
-          p #{percent(first_rdv_count, active_agents.count)} ont participé à au moins un rdv (#{first_rdv_count})
+        - active_count = active_agents.joins(:rdvs).where("rdvs.created_at > ?", 30.days.ago).distinct.count
+        p #{percent(active_count, active_agents.count)} ont participé à un rdv créé dans les 30 derniers jours (#{active_count})
 
-          - active_count = active_agents.joins(:rdvs).where("rdvs.created_at > ?", 30.days.ago).distinct.count
-          p #{percent(active_count, active_agents.count)} ont participé à un rdv créé dans les 30 derniers jours (#{active_count})
+        - agents_with_online_reservation = active_agents.with_online_reservations_at(Time.zone.now)
+        p #{agents_with_online_reservation.count} ont des créneaux ouverts au public
 
-          - agents_with_online_reservation = active_agents.with_online_reservations_at(Time.zone.now)
-          p #{agents_with_online_reservation.count} ont des créneaux ouverts au public
+        h5 Il y a 30 jours
 
-          h5 Il y a 30 jours
+        - active_agents = active_agents.where("agents.created_at < ?", 30.days.ago)
+        p #{active_agents.count} agents avaient été invités
 
-          - active_agents = active_agents.where("agents.created_at < ?", 30.days.ago)
-          p #{active_agents.count} agents avaient été invités
+        - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("agents.created_at < ?", 30.days.ago).count
+        p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
 
-          - accepted_count = active_agents.where.not(invitation_accepted_at: nil).where("agents.created_at < ?", 30.days.ago).count
-          p #{percent(accepted_count, active_agents.count)} avaient accepté l'invitation (#{accepted_count})
+        - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
+        p #{percent(first_rdv_count, active_agents.count)} avaient participé à au moins un rdv (#{first_rdv_count})
 
-          - first_rdv_count = active_agents.joins(:rdvs).where("rdvs.created_at < ?", 30.days.ago).distinct.count
-          p #{percent(first_rdv_count, active_agents.count)} avaient participé à au moins un rdv (#{first_rdv_count})
+        - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
+        p #{percent(active_count, active_agents.count)} avaient participé à un rdv créé un rdv les 30 derniers jours précédents (#{active_count})
 
-          - active_count = active_agents.joins(:rdvs).where(rdvs: {created_at: 60.days.ago..30.days.ago}).distinct.count
-          p #{percent(active_count, active_agents.count)} avaient participé à un rdv créé un rdv les 30 derniers jours précédents (#{active_count})
+        - agents_with_online_reservation = active_agents.with_online_reservations_at(30.days.ago)
+        p #{agents_with_online_reservation.count} avaient des créneaux ouverts au public
 
-          - agents_with_online_reservation = active_agents.with_online_reservations_at(30.days.ago)
-          p #{agents_with_online_reservation.count} avaient des créneaux ouverts au public
+        = self_anchor "active_agents"
+          h2.card-title Agents actifs par mois
+        p Nombre d'agents ayant participé à au moins un rdv chaque mois
+        = column_chart active_agents_stats_path(territory: @territory)
 
-          = self_anchor "active_agents"
-            h2.card-title Agents actifs par mois
-          p Nombre d'agents ayant participé à au moins un rdv chaque mois
-          = column_chart active_agents_stats_path(territory: @territory)
+    .card.mb-5
+      .card-header
+        = self_anchor "outlook_sync"
+          h2.card-title Synchronisation Outlook
+      .card-body
+        p #{@agents.where.not(microsoft_graph_token: nil).count} agents utilisent la synchronisation d'agenda avec Outlook
 
-      .card.mb-5
-        .card-header
-          = self_anchor "outlook_sync"
-            h2.card-title Synchronisation Outlook
-        .card-body
-          p #{@agents.where.not(microsoft_graph_token: nil).count} agents utilisent la synchronisation d'agenda avec Outlook
-
-      .card.mb-5
-        .card-header
-          = "#{@territories.count} structures utilisent RDV-Solidarités"
-        .card-body
-          ul
-            - @territories.order(:name).each do |territory|
-              li = link_to territory, stats_path(territory: territory)
-          .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
-          .alert.alert-info.d-flex.align-items-center
-            .mr-3
-              i.fa.fa-info
-            = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."
+    .card.mb-5
+      .card-header
+        = "#{@territories.count} structures utilisent RDV-Solidarités"
+      .card-body
+        ul
+          - @territories.order(:name).each do |territory|
+            li = link_to territory, stats_path(territory: territory)
+        .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
+        .alert.alert-info.d-flex.align-items-center
+          .mr-3
+            i.fa.fa-info
+          = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."

--- a/app/views/stats/notifications_index.html.slim
+++ b/app/views/stats/notifications_index.html.slim
@@ -2,35 +2,30 @@
 - content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for :title do
-  h1
-    | Statistiques de notifications
-    = " pour le #{@territory}" if @territory.present?
+  | Statistiques de notifications
+  = " pour le #{@territory}" if @territory.present?
 
 - cache([@territory, Time.zone.today], expires_in: 24.hours) do
-  .container.mt-3
-    - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
-      h3 Cette structure n'utilise pas #{current_domain.name}.
-    - else
-      .card.mb-5
-        .card-body
-          = self_anchor "notifications"
-            h1.text-primary-blue
-              | Statistiques de notifications
-              = " pour le #{@territory}" if @territory.present?
-            h2.card-title #{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})
-          - %i[event channel result].each do |attribute|
-            h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
-            = column_chart receipts_stats_path(group_by: attribute, departement: @departement, territory: @territory), stacked: true
+  - if @territory.present? && Organisation.joins(:territory).where(territories: [@territory]).empty?
+    h3 Cette structure n'utilise pas #{current_domain.name}.
+  - else
+    .card.mb-5
+      .card-body
+        = self_anchor "notifications"
+          h2.card-title #{Receipt.model_name.human(count: 2)} (#{@stats.receipts.count})
+        - %i[event channel result].each do |attribute|
+          h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
+          = column_chart receipts_stats_path(group_by: attribute, departement: @departement, territory: @territory), stacked: true
 
-      .card.mb-5
-        .card-header
-          = "#{@territories.count} structures utilisent RDV-Solidarités"
-        .card-body
-          ul
-            - @territories.order(:name).each do |territory|
-              li = link_to territory, stats_path(territory: territory)
-          .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
-          .alert.alert-info.d-flex.align-items-center
-            .mr-3
-              i.fa.fa-info
-            = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."
+    .card.mb-5
+      .card-header
+        = "#{@territories.count} structures utilisent RDV-Solidarités"
+      .card-body
+        ul
+          - @territories.order(:name).each do |territory|
+            li = link_to territory, stats_path(territory: territory)
+        .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
+        .alert.alert-info.d-flex.align-items-center
+          .mr-3
+            i.fa.fa-info
+          = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -1,56 +1,54 @@
-.row.mt-3.justify-content-center
-  .col-md-6
-    h1.text-dark.mb-3 Changer de participants
+- content_for :title, "Changer de participants"
 
-    ul.list-group.list-group-flush
-      li.list-group-item
-        i.fa.fa-info-circle>
-        = @rdv.motif_name
+ul.list-group
+  li.list-group-item
+    i.fa.fa-info-circle>
+    = @rdv.motif_name
 
-      li.list-group-item
-        .fa.fa-calendar>
-        = rdv_title(@rdv)
-        = rdv_tag(@rdv)
+  li.list-group-item
+    .fa.fa-calendar>
+    = rdv_title(@rdv)
+    = rdv_tag(@rdv)
 
-      - if @rdv.home?
-        li.list-group-item
-          .fa.fa-home>
-          | Ce RDV se déroulera à domicile
+  - if @rdv.home?
+    li.list-group-item
+      .fa.fa-home>
+      | Ce RDV se déroulera à domicile
 
-      - elsif @rdv.public_office?
-        li.list-group-item
-          .fa.fa-map-marker-alt>
-          = human_location(@rdv)
-          - if @rdv.lieu&.phone_number
-            span>
-            span.fa.fa-phone>
-            = link_to @rdv.lieu.phone_number, "tel:#{@rdv.lieu.phone_number_formatted}"
+  - elsif @rdv.public_office?
+    li.list-group-item
+      .fa.fa-map-marker-alt>
+      = human_location(@rdv)
+      - if @rdv.lieu&.phone_number
+        span>
+        span.fa.fa-phone>
+        = link_to @rdv.lieu.phone_number, "tel:#{@rdv.lieu.phone_number_formatted}"
 
-      - elsif @rdv.phone?
-        li.list-group-item
-          .fa.fa-phone>
-          | RDV Téléphonique
+  - elsif @rdv.phone?
+    li.list-group-item
+      .fa.fa-phone>
+      | RDV Téléphonique
 
-      - if @rdv.motif.instruction_for_rdv.present?
-        li.list-group-item
-          i.fa.fa-exclamation-triangle>
-          strong Informations supplémentaires :
-          .pl-3.pt-1
-            = instruction_for_rdv_to_html(@rdv.motif)
+  - if @rdv.motif.instruction_for_rdv.present?
+    li.list-group-item
+      i.fa.fa-exclamation-triangle>
+      strong Informations supplémentaires :
+      .pl-3.pt-1
+        = instruction_for_rdv_to_html(@rdv.motif)
 
-      li.list-group-item
-        i.fa.fa-users>
-        | Participant
+  li.list-group-item
+    i.fa.fa-users>
+    | Participant
 
-        = form_tag users_rdv_participations_path(@rdv) do
-          .form-group
-          - current_user.available_users_for_rdv.each do |possible_participant|
-            label
-              = radio_button_tag :user_id, possible_participant.id, @rdv.users.include?(possible_participant)
-              span>
-              = possible_participant.full_name
-            br
-          .form-group
-            = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?), data: { modal: true }
-          .form-group
-            = submit_tag "Enregistrer", class: "btn btn-primary"
+    = form_tag users_rdv_participations_path(@rdv) do
+      .form-group
+      - current_user.available_users_for_rdv.each do |possible_participant|
+        label
+          = radio_button_tag :user_id, possible_participant.id, @rdv.users.include?(possible_participant)
+          span>
+          = possible_participant.full_name
+        br
+      .form-group
+        = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?), data: { modal: true }
+      .form-group
+        = submit_tag "Enregistrer", class: "btn btn-primary"

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -1,6 +1,6 @@
 .row.mt-3.justify-content-center
   .col-md-6
-    h2.text-dark.mb-3 Vos rendez-vous
+    h1.text-dark.mb-3 Vos rendez-vous
     .mb-3.flex-direction-col-sm-row-reverse-md
       = render "prendre_rdv_button"
       - if params[:past].present?

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -1,6 +1,6 @@
 .row.mt-3.justify-content-center
   .col-md-6
-    h1.text-dark.mb-3 Vos rendez-vous
+    h2.text-dark.mb-3 Vos rendez-vous
     .mb-3.flex-direction-col-sm-row-reverse-md
       = render "prendre_rdv_button"
       - if params[:past].present?
@@ -27,7 +27,7 @@
               i.fa.fa-calendar.fa-stack-1x.text-white
             .text-center.mt-2
   .col-md-6
-    h1.text-dark.mb-3 Vos référents
+    h2.text-dark.mb-3 Vos référents
     - if current_user.referent_agents.any?
       - current_user.referent_agents.each do |agent|
         .card

--- a/app/views/users/rdvs/show.html.slim
+++ b/app/views/users/rdvs/show.html.slim
@@ -1,6 +1,5 @@
-.row.my-3.justify-content-center
-  .col-md-6.border-bottom
-    h2.text-dark.mb-3.text-center Votre RDV
-    .card
-      .card-body
-        = render "rdv", rdv: @rdv
+- content_for :title, "Votre RDV"
+
+.card
+  .card-body
+    = render "rdv", rdv: @rdv

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -1,28 +1,27 @@
-.row.justify-content-md-center
-  .col-md-6
-    h1.text-dark.my-3 Votre compte
-    .card.mt-3
-      .card-body
-        - if resource.logged_once_with_franceconnect?
-          .alert.alert-info.d-flex.align-items-center
-            .mr-3
-              .fa.fa-info
-            div Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
-        = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }) do |f|
-          = render "devise/shared/error_messages", resource: resource
-          = f.input :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "nom.prenom@email.com"
-          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-            .form-text.text-muted.mb-2
-              | En attente de confirmation pour #{resource.unconfirmed_email}
-          = f.input :password, label: "Nouveau mot de passe", autocomplete: "new-password"
-          = render "agents/mot_de_passes/new_password_hints"
-          .form-text.text-muted.mb-2
-            | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
-          = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
-          .form-text.text-muted.mb-2
-            | Renseignez votre mot de passe actuel pour tout changement.
-          .text-right= f.submit "Modifier", class: "btn btn-primary"
-          .mt-5.text-center
-            hr
-            p.font-13 Vous souhaitez supprimer votre compte ?
-            = link_to "Supprimer", user_registration_path, data:{ confirm: @rdv_insertion_organisations.blank? ? "Voulez-vous vraiment supprimer votre compte ?" : "Vous ne pourrez plus vous connecter à votre compte mais les données liées aux structures d'insertion ne seront pas supprimées. Vos données liées à d'autres structures seront bien supprimées." }, method: :delete, class: "btn btn-outline-danger btn-sm"
+- content_for :title, "Votre compte"
+
+.card
+  .card-body
+    - if resource.logged_once_with_franceconnect?
+      .alert.alert-info.d-flex.align-items-center
+        .mr-3
+          .fa.fa-info
+        div Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
+    = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      = f.input :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "nom.prenom@email.com"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        .form-text.text-muted.mb-2
+          | En attente de confirmation pour #{resource.unconfirmed_email}
+      = f.input :password, label: "Nouveau mot de passe", autocomplete: "new-password"
+      = render "agents/mot_de_passes/new_password_hints"
+      .form-text.text-muted.mb-2
+        | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
+      = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
+      .form-text.text-muted.mb-2
+        | Renseignez votre mot de passe actuel pour tout changement.
+      .text-right= f.submit "Modifier", class: "btn btn-primary"
+      .mt-5.text-center
+        hr
+        p.font-13 Vous souhaitez supprimer votre compte ?
+        = link_to "Supprimer", user_registration_path, data:{ confirm: @rdv_insertion_organisations.blank? ? "Voulez-vous vraiment supprimer votre compte ?" : "Vous ne pourrez plus vous connecter à votre compte mais les données liées aux structures d'insertion ne seront pas supprimées. Vos données liées à d'autres structures seront bien supprimées." }, method: :delete, class: "btn btn-outline-danger btn-sm"

--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -1,6 +1,7 @@
+- content_for :title, t("devise.invitations.invitation.title")
+
 .card
   .card-body
-    h1.card-title = t("devise.invitations.invitation.title")
     p = t("devise.invitations.invitation.click_on_link_sent")
     .text-center
       - unless email_tld_infos(@email_tld).blank?

--- a/app/views/users/relatives/edit.html.slim
+++ b/app/views/users/relatives/edit.html.slim
@@ -1,15 +1,13 @@
-.row.justify-content-md-center.pt-3
-  .col-md-6
-    .card
-      .card-header
-        h1.card-title Modifier un proche
-      .card-body
-        = simple_form_for @user, url: relative_path(@user) do |f|
-          = render "model_errors", model: @user
-          = render "form_fields", f: f
-          .d-flex.justify-content-between
-            = link_to "Supprimer", relative_path(@user), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce proche ?"}
+- content_for :title, "Modifier un proche"
 
-            .d-flex.justify-content-end
-              = link_to "Annuler", users_informations_path, class: "btn btn-link"
-              = f.button :submit, class: "btn"
+.card
+  .card-body
+    = simple_form_for @user, url: relative_path(@user) do |f|
+      = render "model_errors", model: @user
+      = render "form_fields", f: f
+      .d-flex.justify-content-between
+        = link_to "Supprimer", relative_path(@user), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce proche ?"}
+
+        .d-flex.justify-content-end
+          = link_to "Annuler", users_informations_path, class: "btn btn-link"
+          = f.button :submit, class: "btn"

--- a/app/views/users/user_name_initials_verification/new.html.slim
+++ b/app/views/users/user_name_initials_verification/new.html.slim
@@ -1,14 +1,12 @@
-.row.mt-3.justify-content-center
-  .container
-    .row.justify-content-center.my-3
-      .col-lg-7.col-md-10.col-sm-11
-        .card
-          .card-header.text-center
-            h4 = t(".title")
-          .card-body
-            = render "form", user: current_user
-          .car-footer.text-center
-            p Par exemple :
-            p.fw-lighter.fs-6 = t(".examples.first")
-            p.fw-lighter.fs-6 = t(".examples.second")
-            p.fw-lighter.fs-6 = t(".examples.third")
+- content_for :title, "Vérification"
+
+.card
+  .card-header.text-center
+    h4 = t(".title")
+  .card-body
+    = render "form", user: current_user
+  .car-footer.text-center
+    p Par exemple :
+    p.fw-lighter.fs-6 = t(".examples.first")
+    p.fw-lighter.fs-6 = t(".examples.second")
+    p.fw-lighter.fs-6 = t(".examples.third")

--- a/app/views/welcome/super_admin.html.slim
+++ b/app/views/welcome/super_admin.html.slim
@@ -1,16 +1,14 @@
-.container.py-5
-  .row.justify-content-center
-    .col-3
-      = link_to "Accéder à superadmin", "/omniauth/github", class: "btn btn-primary", method: :post
+.row.justify-content-center
+  .col-3
+    = link_to "Accéder à superadmin", "/omniauth/github", class: "btn btn-primary", method: :post
 
 - if Rails.env.development?
-  .container.py-5
-    .row.justify-content-center
-      .col-3
-        h5 Liens utiles
-        ul
-          li = link_to "Letter Opener", letter_opener_web_path
-          li = link_to "Mailer Previews", "/rails/mailers"
-          li = link_to "SMS Previews", "/lapin/sms_preview"
-          li = link_to "Routes", "/rails/info/routes"
-          li = link_to "Rails properties", "/rails/info/properties"
+  .row.justify-content-center.mt-5
+    .col-3
+      h5 Liens utiles
+      ul
+        li = link_to "Letter Opener", letter_opener_web_path
+        li = link_to "Mailer Previews", "/rails/mailers"
+        li = link_to "SMS Previews", "/lapin/sms_preview"
+        li = link_to "Routes", "/rails/info/routes"
+        li = link_to "Rails properties", "/rails/info/properties"


### PR DESCRIPTION
Refactors et harmonisation des pages utilisant le layout `application` 

> [!TIP]  
> je recommande d’activer l’option `Hide Whitespace` dans github pour relire ces changements pour ignorer les changements d’indentation

## Contexte

Avant de passer les pages utilisant le layout `application` aux containers et aux grilles du DSFR j’harmonise un peu les usages pour avoir moins de choses à changer dans un second temps

## Nouveau base layout 

- `application` est renommé `application_base` et inclut le contenu directement dans le `main`, sans container
- Le nouveau `application` hérite de `application_base` et rajoute simplement un wrapper `.container` avec un padding top

cela permet de supprimer tous les `.container` en début des fichiers de vues et d’harmoniser la marge haute utilisée

Le layout `base` est utile pour les pages dont le contenu _bleede_ c’est à dire qui dépasse sur les marges à gauche et à droite du main : les landing pages principalement.

Une manière alternative de faire serait de ne garder qu’un layout `application.html` et d’utiliser des variables d’instance par exemple `@wrap_main_in_container = false` et de brancher dans `application.html` pour wrapper ou non.

Je sui sun peu mitigé sur la bonne direction : 
- je trouve que c’est un peu bizarre de devoir définir le layout `application_base` dans le controlleur alors que c’est un "détail" de la vue à ce niveau
- en revanche je trouve ça très vilain quand on fait des conditions sur des variables d’instance dans les layouts, on encore plus sur les routes comme c’était le cas jusqu’ici `class = 'container' if controller starts with /users` 😥 

si vous avez des suggestions d’amélioration je suis preneur !

## harmonisation des layout narrow

Il y avait pas mal de pages qui utilisait des structures comme :

```slim
.container
  .row.justify-content-center
    .col-md-6
```

Je supprime tout ça et je le remplace par l’utilisation du layout `application_narrow` qui hérite de `application`. Les grands changements d’indentation de cette PR proviennent de ce changement

`application_narrow` est en `col-md-8` donc ça agrandit un peu le wrapper sur ces pages. je ne me suis pas concerté avec Téo car :
- à mon avis ce n’est pas spécialement volontaire qu’il y ait deux narrows différents
- sur mobile ça ne change rien et c’est largement le plus important

si vous pensez qu’il faut que je valide avec elle faites moi signe ! 

## harmonisation des titres

J’ai déplacé pour la plupart des pages les titres en dur 

`h1 Le Titre` ->  `content_for :title, "Le Titre"`

et ce sont les layouts qui sont en charge d’afficher le titre de la page

Là encore cela permet d’harmoniser les marges et les styles

par ex : 
|avant|après|
|-|-|
| ![Screenshot 2024-06-13 at 13 31 42](https://github.com/betagouv/rdv-service-public/assets/883348/471804d5-9b96-4f22-8e1c-a570dafee487) | ![Screenshot 2024-06-13 at 13 31 05](https://github.com/betagouv/rdv-service-public/assets/883348/a674fe4a-0e7e-4bbc-9b0c-01ea4e8fc1c3) |
| ![Screenshot 2024-06-13 at 13 33 25](https://github.com/betagouv/rdv-service-public/assets/883348/ec7824f3-4f03-41cf-878a-786188ca3f22) | ![Screenshot 2024-06-13 at 13 33 32](https://github.com/betagouv/rdv-service-public/assets/883348/3ded0b57-2a71-4e09-9d10-0c87335f1883) |

## Review app et screenshots

Review app : https://demo-rdv-solidarites-pr4345.osc-secnum-fr1.scalingo.io/

Jeu de screenshots mobile et desktop sur : 
https://rdv-2024-06-13-layouts.surge.sh