### PR TITLE
Uploader les artefacts Capybara pour débugger les specs JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: artifacts-capybara
           path: tmp/capybara

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,3 +194,7 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-capybara
+          path: tmp/capybara

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "agents can prescribe rdvs" do
         find(".select2-search__field").send_keys("francis")
         expect(page).to have_content("FACTICE Francis")
         first(".select2-results ul.select2-results__options li").click
-        click_on "Continuerr"
+        click_on "Continuer"
         # Display Récapitulatif
         expect(page).to have_content("Motif : #{motif_collectif.name}")
         expect(page).to have_content("Lieu : #{mds_paris_nord.name}")

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe "agents can prescribe rdvs" do
         find(".select2-search__field").send_keys("francis")
         expect(page).to have_content("FACTICE Francis")
         first(".select2-results ul.select2-results__options li").click
-        click_on "Continuer"
+        click_on "Continuerr"
         # Display Récapitulatif
         expect(page).to have_content("Motif : #{motif_collectif.name}")
         expect(page).to have_content("Lieu : #{mds_paris_nord.name}")

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -33,6 +33,7 @@ Capybara.configure do |config|
   config.javascript_driver = :selenium
   config.server = :puma, { Silent: true }
   config.disable_animation = true
+  config.save_path = Rails.root.join("tmp/capybara")
 
   # This is necessary when using Selenium + custom .localhost domain.
   # See: https://stackoverflow.com/a/63973323/2864020


### PR DESCRIPTION
# Contexte

Nous avons des soucis de flaky specs en ce moment (comme souvent), toujours sur des specs Capybara Selenium (JS).

Lorsqu'une spec Capybara échoue, Capybara fournit :
- une copie du HTML de la page à ce moment là
- une capture d'écran si on utilise Selenium

Mais ces artéfacts ne sont pas disponibles par défaut sur GitHub Actions, ils sont simplement stockés sur le disque du runner de l'action :

```
HTML screenshot: /home/runner/work/rdv-service-public/rdv-service-public/tmp/capybara/screenshot_2021-12-13-08-00-00.000.html
Image screenshot: /home/runner/work/rdv-service-public/rdv-service-public/tmp/capybara/screenshot_2021-12-13-08-00-00.000.png
```

# Solution

L'action `actions/upload-artifact` permet d'uploader des fichiers du runner vers un stockage de GitHub pour pouvoir les télécharger.

Le résultat en bas du run qui a échoué : 

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/9f7159b4-c94a-408d-9781-7ce501911fc0)

Et aussi dispo dans les logs du run :

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/f3742fc8-9b95-401c-80ca-6a61b049de89)


# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [X] Préparer des captures de l’interface avant et après
