### PR TITLE
Éviter d'envoyer une notif de rappel pour un RDV passé

### DIFF
--- a/app/jobs/rdv_upcoming_reminder_job.rb
+++ b/app/jobs/rdv_upcoming_reminder_job.rb
@@ -1,7 +1,14 @@
 class RdvUpcomingReminderJob < ApplicationJob
   queue_as :reminders
 
+  class TooLateError < StandardError; end
+  discard_on(TooLateError) { |_job, error| Sentry.capture_exception(error) }
+
   def perform(rdv)
+    if rdv.ends_at < Time.zone.now
+      raise TooLateError, "Reminder not sent: RDV in the past"
+    end
+
     Notifiers::RdvUpcomingReminder.perform_with(rdv, nil)
   end
 end

--- a/spec/jobs/rdv_upcoming_reminder_job_spec.rb
+++ b/spec/jobs/rdv_upcoming_reminder_job_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe RdvUpcomingReminderJob do
+  it "runs a Notifiers::RdvUpcomingReminder job" do
+    rdv = build(:rdv, starts_at: 6.hours.from_now)
+
+    expect(Notifiers::RdvUpcomingReminder).to receive(:perform_with).with(rdv, nil)
+    described_class.perform_now(rdv)
+    expect(sentry_events).to be_empty
+  end
+
+  context "when RDV already ended" do
+    it "discards the job and warns Sentry" do
+      past_rdv = build(:rdv, starts_at: 6.hours.ago)
+
+      expect(sentry_events).to be_empty
+      described_class.perform_now(past_rdv)
+      expect(sentry_events.last.exception.values.last.value).to eq("Reminder not sent: RDV in the past (RdvUpcomingReminderJob::TooLateError)")
+    end
+  end
+end


### PR DESCRIPTION
Closes #4351

Tout est dans l'issue (qui référence une autre issue).

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après
