### PR TITLE
correction d’un bug d’affichage au survol des boutons côté usagers

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -34,3 +34,4 @@
 @import "./structure/authentication";
 @import "./structure/left-menu";
 @import "./structure/misc";
+@import "./structure/bootstrap_overrides"

--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -1,0 +1,6 @@
+// Ces règles sont temporaires, on les supprimera une fois qu’on aura complètement remplacé
+// Bootstrap par le DSFR.
+
+.btn:hover {
+  color: inherit;
+}


### PR DESCRIPTION
En incluant le CSS du DSFR dans le layout application, j’ai introduit un bug d’affichage au hover des boutons sur desktop. 
Il doit y avoir un conflit sur les règles CSS entre bootstrap et le DSFR. Je n’ai pas investigué plus que ça et j’ai fait un fix rapide, en me disant qu’on va très rapidement utiliser les classes `.fr-btn` en lieu et place de `.btn` de bootstrap. 

avant | après 
-|-
<img width="197" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/883348/5d8078ba-9c7c-49c0-8a77-98340f19f857"> | <img width="199" alt="SCR-20240617-otdu-2" src="https://github.com/betagouv/rdv-service-public/assets/883348/000ad637-de22-414b-adc5-c227b0d32ba2"> 
<img width="126" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/883348/4c3ee0b0-d164-4fe3-b614-5266e56ea5c4"> |  <img width="115" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/883348/52461c06-957c-4a3e-b26d-a11845c8665d">

bouton primaire visible sur review app : https://demo-rdv-solidarites-pr4353.osc-secnum-fr1.scalingo.io/contact