### PR TITLE
[Correctif] Reparer souci de marge sur le formulaire des plages d'ouverture

### DIFF
--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -36,7 +36,7 @@
 
     .row.justify-content-center
       .col-md-6
-        .row
+        .row.mb-5
           - if plage_ouverture.persisted?
             .col.text-left
               = link_to "Annuler", \


### PR DESCRIPTION
https://github.com/betagouv/rdv-service-public/pull/4328 introduit un souci de marge au bas du formulaire de création/modification des plages d'ouverture.

Le bouton "Créer la plage d'ouverture" est coupé en 2 par la ligne horizontale du footer. Quand l'agent clique sur la partie supérieure, tout fonctionne bien mais quand il clique sur la partie inférieure , rien ne fonctionne.

Ici, nous faisons un fix plutôt rapide afin de rapidement _débloquer_ les agents impactés. Par la suite, nous aurons l'occasion de proper un fix plus propre/permanent dans https://github.com/betagouv/rdv-service-public/pull/4338.

Avant | Après
:-------------------------:|:-------------------------:
![1 - before](https://github.com/betagouv/rdv-service-public/assets/11911945/0b2bb486-9b7a-4065-b69d-395e09dbc9be)|![1 - after](https://github.com/betagouv/rdv-service-public/assets/11911945/7d9cdda3-69f4-4432-b8e1-a8f9641ddffd)|
