### PR TITLE
Empêcher de modifier "collectif / individuel" pour un motif déjà utilisé

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -68,7 +68,7 @@ class Motif < ApplicationRecord
   validate :not_associated_with_secretariat
   validates :color, css_hex_color: true
   validate :not_at_home_if_collectif
-  validate :unused_motif, if: :location_type_changed?
+  validate :cant_change_once_rdvs_exist
   validate :cant_be_for_secretariat_and_follow_up
 
   # Scopes
@@ -258,10 +258,11 @@ class Motif < ApplicationRecord
     errors.add(:base, :not_at_home_if_collectif)
   end
 
-  def unused_motif
-    return if rdvs.empty?
+  def cant_change_once_rdvs_exist
+    return unless rdvs.exists?
 
-    errors.add(:location_type, :cant_change_because_already_used)
+    errors.add(:collectif, :cant_change_because_already_used) if attribute_changed?(:collectif)
+    errors.add(:location_type, :cant_change_because_already_used) if attribute_changed?(:location_type)
   end
 
   def cant_be_for_secretariat_and_follow_up

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -41,15 +41,19 @@ p
 
 .card
   .card-body
+    - disabled = motif.rdvs.any?
     h5.card-title Nombre de participants
     p Choisissez le nombre de participants :
 
+    - if disabled
+      p.alert.alert-warning Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le nombre de participants
+
     = label_tag do
-      = f.radio_button(:collectif, false)
+      = f.radio_button(:collectif, false, disabled: disabled)
       span.ml-1= Motif.human_attribute_value(:collectif, false)
       p.text-muted.font-14.mt-1= Motif.human_attribute_value(:collectif, false, context: :hint)
 
     = label_tag do
-      = f.radio_button(:collectif, true)
+      = f.radio_button(:collectif, true, disabled: disabled)
       span.ml-1= Motif.human_attribute_value(:collectif, true)
       p.text-muted.font-14.mt-1= Motif.human_attribute_value(:collectif, true, context: :hint)

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -110,12 +110,11 @@ fr:
     errors:
       models:
         motif:
+          cant_change_because_already_used: ne peut être modifié car le motif est utilisé pour un RDV
           attributes:
             base:
               not_at_home_if_collectif: Les RDV collectifs doivent avoir lieu sur place.
             name:
               taken: est déjà utilisé pour un motif avec le même type de RDV.
-            location_type:
-              cant_change_because_already_used: ne peut être modifié car le motif est utilisé pour un RDV
             for_secretariat:
               cant_be_enabled_if_follow_up: ne peut être activé si "RDV de suivi" est activé


### PR DESCRIPTION
# Contexte

J'ai remarqué qu'il était possible de changer la config "collectif / individuel" d'un motif existant, même si il existe déjà des RDVs pour ce motif.

Il me semble pertinent de bloquer cette modification car les RDVs collectifs et individuels sont des notions métier assez différentes ("atelier" vs. "entretien").

# Solution

J'ai fusionné au sein d'une même méthode de validation les deux cas de blocages quand des RDVs existent : 
- interdit de changer le `location_type`
- interdit de changer le `collectif` (ajouté dans cette PR)

# Capture d'écran

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/1ab3f2e2-ddcb-44c4-881f-24554ca6978a)

# Checklist

- [ ] ~~Extraire dans d'autres PRs les changements indépendants, si nécessaire~~
- [X] Préparer des captures de l’interface avant et après
