### PR TITLE
Améliorer les erreurs d’authentification Oauth remontées à Sentry

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -22,22 +22,17 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   on_failure do |env|
     http_host = env["HTTP_HOST"]
     provider = env["omniauth.error.strategy"].class.name.demodulize
-    error_type = env["omniauth.error.type"]
-    error = env["omniauth.error"]
 
-    crumb = Sentry::Breadcrumb.new(
-      message: "Omniauth env values",
-      data: {
+    Sentry.set_context(
+      "omniauth_env",
+      {
         http_host: http_host,
         provider: provider,
-        error: error,
-        error_type: error_type,
         full_env: env.transform_values { |value| value.is_a?(String) ? value : value.inspect },
       }
     )
-    Sentry.add_breadcrumb(crumb)
 
-    Sentry.capture_message("Omniauth for #{provider} failed on #{http_host}: #{error}", fingerprint: [provider, http_host])
+    Sentry.capture_exception(env['omniauth.error'])
 
     OmniauthCallbacksController.action(:failure).call(env)
   end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -32,7 +32,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       }
     )
 
-    Sentry.capture_exception(env['omniauth.error'])
+    Sentry.capture_exception(env["omniauth.error"])
 
     OmniauthCallbacksController.action(:failure).call(env)
   end


### PR DESCRIPTION
## Contexte

ces [erreurs sur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/17938/?project=74&query=is%3Aunresolved+is%3Aunlinked&referrer=issue-stream&sort=priority&statsPeriod=14d) sont difficiles à investiguer :

```
Omniauth for Franceconnect failed on www.rdv-solidarites.fr: undefined method `to_sym' for nil
```

## Solution proposée

Remplacer le `capture_message` par un `capture_exception` qui devrait nous permettre d’avoir la stack trace de l’erreur et comprendre de quel `to_sym` on parle. 

J’ai réussi à tester en local en : 
- définissant les credentials SENTRY_DSN et FRANCECONNECT dans mon .env
- supprimant le wrapper `devise_scope :user` dans `routes.rb` autour du callback FC

on a la stacktrace et on peut voir d’où vient ce `nil.to_sym` (teaser : il vient de omniauth_openid_connect on dirait)

## TODO

- [x] Tester en local une fois les credentials France Connect dev récupérés
- [x] valider avec @francois-ferrandis qu’il n’y avait pas une raison précise de faire `capture_message`, peut-être pour grouper les erreurs. J’ai creusé les git blames mais je n’ai jamais vu de `capture_exception`