### PR TITLE
Ne plus exclure `config/**/*` du check Rubocop sur les double quotes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -218,8 +218,6 @@ Naming/BlockForwarding:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-  Exclude:
-    - "config/**/*"
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   # Voir health_check_spec.rb pour les infos de contexte
-  config.ssl_options = { redirect: { exclude: proc { |env| env&.path&.start_with?('/health_check') } } }
+  config.ssl_options = { redirect: { exclude: proc { |env| env&.path&.start_with?("/health_check") } } }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -22,7 +22,7 @@ Devise.setup do |config|
   config.mailer = "CustomDeviseMailer"
 
   # Configure the parent class responsible to send e-mails.
-  config.parent_mailer = 'ApplicationMailer'
+  config.parent_mailer = "ApplicationMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.cleanup_preserved_jobs_before_seconds_ago = 604_800 # 1 semaine
   config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) }
   config.good_job.execution_mode = :external
-  config.good_job.queues = '*'
+  config.good_job.queues = "*"
   config.good_job.max_threads = 5
   config.good_job.shutdown_timeout = 25 # seconds
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -5,14 +5,14 @@ class Rack::Attack
   end
 
   self.throttled_responder = lambda do |request|
-    match_data = request.env['rack.attack.match_data']
+    match_data = request.env["rack.attack.match_data"]
     now = match_data[:epoch_time]
 
     headers = {
-      'Content-Type' => 'application/json',
-      'RateLimit-Limit' => match_data[:limit].to_s,
-      'RateLimit-Remaining' => '0',
-      'Retry-After' => (match_data[:period] - (now % match_data[:period])).to_s,
+      "Content-Type" => "application/json",
+      "RateLimit-Limit" => match_data[:limit].to_s,
+      "RateLimit-Remaining" => "0",
+      "Retry-After" => (match_data[:period] - (now % match_data[:period])).to_s,
     }
 
     [429, headers, [{ errors: ["Limite d'appels API atteinte. Merci de patienter.\n"] }.to_json]]

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -3,7 +3,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.join('swagger')
+  c.openapi_root = Rails.root.join("swagger")
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -7,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.openapi_endpoint '/api-docs/v1/api.json', 'API V1 Docs'
+  c.openapi_endpoint "/api-docs/v1/api.json", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  mount Rswag::Ui::Engine => '/api-docs'
-  mount Rswag::Api::Engine => '/api-docs'
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
   ## OAUTH ##
   devise_scope :user do
     get "omniauth/franceconnect/callback" => "omniauth_callbacks#franceconnect"
@@ -284,7 +284,7 @@ Rails.application.routes.draw do
     # we rename the short parameter tkn
     params[:invitation_token] ||= params.delete(:tkn) if params[:tkn]
     params.delete(:id) # id is passed through path_params
-    params.values.any? ? "?#{params.to_query}" : ''
+    params.values.any? ? "?#{params.to_query}" : ""
   end
 
   # short public link
@@ -310,7 +310,7 @@ Rails.application.routes.draw do
 
   # rubocop:disable Style/FormatStringToken
   # temporary route after admin namespace introduction
-  get "/organisations/*rest", to: redirect('admin/organisations/%{rest}')
+  get "/organisations/*rest", to: redirect("admin/organisations/%{rest}")
   # old agenda rule was bookmarked by some agents
   get "admin/organisations/:organisation_id/agents/:agent_id", to: redirect("/admin/organisations/%{organisation_id}/agent_agendas/%{agent_id}")
   # rubocop:enable Style/FormatStringToken
@@ -319,7 +319,7 @@ Rails.application.routes.draw do
 
   # This route redirects invitations to rdv-insertion so that rdv-insertion
   # can use rdvs domain name in their emails
-  get '/i/r/:uuid', to: redirect { |path_params, _|
+  get "/i/r/:uuid", to: redirect { |path_params, _|
     "#{ENV['RDV_INSERTION_HOST']}/r/#{path_params[:uuid]}"
   }
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -5,7 +5,7 @@ namespace :api do
     resources :absences, except: %i[new edit]
     resources :agents, only: %i[index]
     resources :users, only: %i[create index show update] do
-      post :rdv_invitation_token, to: 'users#rdv_invitation_token', on: :member
+      post :rdv_invitation_token, to: "users#rdv_invitation_token", on: :member
     end
     resource :user_profiles, only: %i[create destroy]
     resource :referent_assignations, only: %i[create destroy]
@@ -28,7 +28,7 @@ namespace :api do
 
   namespace :rdvinsertion do
     resources :invitations, only: [] do
-      get 'creneau_availability', to: 'invitations#creneau_availability', on: :collection
+      get "creneau_availability", to: "invitations#creneau_availability", on: :collection
     end
     resource :user_profiles, only: [] do
       post :create_many, on: :collection


### PR DESCRIPTION
On remarque que dans certains fichiers du répertoire `config/`, on utilise des single quotes et Rubocop ne dit rien mais je me gratte la tête à chaque fois que j'en vois passer.

Visiblement cette exception avait été ajoutée à l'époque où les fichiers de config Rails étaient générés avec des single quotes : b1e9111c

Cette époque est révolue, on peut donc rétablir la cohérence entre ces fichiers et le reste du code.