### PR TITLE
generize search/address_selection partials between RDVS and RDV ANCT

### DIFF
--- a/app/views/search/address_selection/_rdv_mairie.html.slim
+++ b/app/views/search/address_selection/_rdv_mairie.html.slim
@@ -1,48 +1,5 @@
-section.bg-primary.p-4
-  .container.mb-4
-    #search_form
-      = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
-        = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
-        - if context.prescripteur?
-          = f.input :prescripteur, as: :hidden, input_html: { name: "prescripteur", value: 1 }
-        = f.input :city_code, as: :hidden, input_html: { name: "city_code", value: context.city_code }
-        = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }
-        = f.input :latitude, as: :hidden, input_html: { name: "latitude", value: context.latitude }
-        = f.input :longitude, as: :hidden, input_html: { name: "longitude", value: context.longitude }
-        .form-row.d-flex.justify-content-md-center
-          / TODO: change input name to address and change whereInput in application.js
-          .col-lg-9= f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
-          .col-lg-3.align-self-end
-            = f.button :button, id: "search_submit", class: "btn-white btn-lg w-100 text-center", disabled: true do
-              i.fa.fa-search>
-              | Rechercher
-
-section
-  .container
-    .row.mt-4
-      .col-lg-12
-        h2.text-center  Comment ça marche ?
-    .row.mt-5
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/location.svg", class: "img-circle mb-3", alt: "premièrement"
-          span.text-primary.mt-3 Choisir votre adresse
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/service.svg", class: "img-circle mb-3", alt: "deuxièmement"
-          span.text-primary.mt-3 Choisir un service
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/motif.svg", class: "img-circle mb-3", alt: "troisièmement"
-          span.text-primary.mt-3 Choisir un motif
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/creneau.svg", class: "img-circle mb-3", alt: "et quatrièmement"
-          span.text-primary.mt-3 Choisir un créneau
+= render "search/address_selection/search_form_section", context: context
+= render "search/address_selection/steps_section"
 
 section.bg-lightturquoise.p-5
   .container

--- a/app/views/search/address_selection/_rdv_solidarites.html.slim
+++ b/app/views/search/address_selection/_rdv_solidarites.html.slim
@@ -1,48 +1,5 @@
-section.bg-primary.p-4
-  .container.mb-4
-    #search_form
-      = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
-        = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
-        - if context.prescripteur?
-          = f.input :prescripteur, as: :hidden, input_html: { name: "prescripteur", value: 1 }
-        = f.input :city_code,  as: :hidden, input_html: { name: "city_code", value: context.city_code }
-        = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }
-        = f.input :latitude, as: :hidden, input_html: { name: "latitude", value: context.latitude }
-        = f.input :longitude, as: :hidden, input_html: { name: "longitude" , value: context.longitude }
-        .form-row.d-flex.justify-content-md-center
-            / TODO: change input name to address and change whereInput in application.js
-            .col-lg-9= f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
-            .col-lg-3.align-self-end
-              = f.button :button, id: "search_submit", class: "btn-white btn-lg w-100 text-center", disabled: true do
-                i.fa.fa-search>
-                | Rechercher
-
-section
-  .container
-    .row.mt-4
-      .col-lg-12
-        h2.text-center  Comment ça marche ?
-    .row.mt-5
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/location.svg", class: "img-circle mb-3", alt: "premièrement"
-          span.text-primary.mt-3 Choisir votre adresse
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/service.svg", class: "img-circle mb-3", alt: "deuxièmement"
-          span.text-primary.mt-3 Choisir un service
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/motif.svg", class: "img-circle mb-3", alt: "troisièmement"
-          span.text-primary.mt-3 Choisir un motif
-      .col-lg-3
-        .text-center.mb-3
-          .d-flex.justify-content-center
-            = image_tag "welcome/creneau.svg", class: "img-circle mb-3", alt: "et quatrièmement"
-          span.text-primary.mt-3 Choisir un créneau
+= render "search/address_selection/search_form_section", context: context
+= render "search/address_selection/steps_section"
 
 section.bg-lightturquoise.p-5
   .container

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -1,0 +1,18 @@
+section.bg-primary.p-4
+  .container.mb-4
+    #search_form
+      = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
+        = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
+        - if context.prescripteur?
+          = f.input :prescripteur, as: :hidden, input_html: { name: "prescripteur", value: 1 }
+        = f.input :city_code, as: :hidden, input_html: { name: "city_code", value: context.city_code }
+        = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }
+        = f.input :latitude, as: :hidden, input_html: { name: "latitude", value: context.latitude }
+        = f.input :longitude, as: :hidden, input_html: { name: "longitude", value: context.longitude }
+        .form-row.d-flex.justify-content-md-center
+          / TODO: change input name to address and change whereInput in application.js
+          .col-lg-9= f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
+          .col-lg-3.align-self-end
+            = f.button :button, id: "search_submit", class: "btn-white btn-lg w-100 text-center", disabled: true do
+              i.fa.fa-search>
+              | Rechercher

--- a/app/views/search/address_selection/_steps_section.html.slim
+++ b/app/views/search/address_selection/_steps_section.html.slim
@@ -1,0 +1,26 @@
+section
+  .container
+    .row.mt-4
+      .col-lg-12
+        h2.text-center  Comment ça marche ?
+    .row.mt-5
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/location.svg", class: "img-circle mb-3", alt: "premièrement"
+          span.text-primary.mt-3 Choisir votre adresse
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/service.svg", class: "img-circle mb-3", alt: "deuxièmement"
+          span.text-primary.mt-3 Choisir un service
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/motif.svg", class: "img-circle mb-3", alt: "troisièmement"
+          span.text-primary.mt-3 Choisir un motif
+      .col-lg-3
+        .text-center.mb-3
+          .d-flex.justify-content-center
+            = image_tag "welcome/creneau.svg", class: "img-circle mb-3", alt: "et quatrièmement"
+          span.text-primary.mt-3 Choisir un créneau


### PR DESCRIPTION
## Contexte

Je m’apprête à harmoniser les containers et grilles de la partie usager pour utiliser le DSFR. 

J’ai remarqué qu’un endroit relativement central du code des vues va être impacté et que ce code est aujourd’hui dupliqué entre les vues pour RDVS et pour RDV ANCT. Il s’agit de ce qu’on voit au dessus du fold pour les homepages de ces deux sites, dont le formulaire de recherche

Cette PR n’est pas nécessaire, je peux très bien dupliquer ma migration aux grilles et containers dans les deux fichiers mais je trouve ça quand même un peu mieux en refactorant. 

N’hésitez pas à me dire si je m’éparpille.

## description de la PR 

petite PR de refacto qui générise les 40 lignes dupliquées entre 

- app/views/search/address_selection/_rdv_mairie.html.slim
- app/views/search/address_selection/_rdv_solidarites.html.slim

J’ai vérifié qu’il n’y avait aucune diff entre ces 40l avec 

`diff -w app/views/search/address_selection/_rdv_solidarites.html.slim app/views/search/address_selection/_rdv_mairie.html.slim`

J’ai déplacé ces 40l dans deux nouveaux partials 

- app/views/search/address_selection/_search_form_section.html.slim
- app/views/search/address_selection/_steps_section.html.slim
