### PR TITLE
Appli usagers : migration du footer au DSFR

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -29,7 +29,7 @@
 // Structure
 @import "./structure/general";
 @import "./structure/header";
-@import "./structure/footer";
+@import "./structure/footer_dsfr";
 @import "./structure/page-head";
 @import "./structure/authentication";
 @import "./structure/left-menu";

--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -4,3 +4,21 @@
 .btn:hover {
   color: inherit;
 }
+
+footer {
+  background-color: var(--background-default-grey); // this should go on the body
+
+  a, a:hover {
+    color: inherit;
+  }
+  [href]:not(.fr-footer__brand-link):not(.fr-footer__partners-link) {
+    background-image: var(--underline-img), var(--underline-img);
+  }
+  .fr-footer__partners-link {
+    border: 1px solid transparent;
+
+    &:hover {
+      border-color: #ccc;
+    }
+  }
+}

--- a/app/javascript/stylesheets/structure/_footer.scss
+++ b/app/javascript/stylesheets/structure/_footer.scss
@@ -7,22 +7,6 @@ footer {
   }
 }
 
-// only used for users
-footer.main-footer {
-  padding: 3rem 0 0;
-  .brand {
-    font-weight: 800;
-    font-size: 1.7rem;
-    color: #222;
-    margin-bottom: 20px;
-  }
-}
-@media (max-width: 991px) {
-  footer.main-footer {
-    padding: 100px 0 0;
-  }
-}
-
 // only used for agents
 .footer {
   border-top: 1px solid rgba($gray-600, 0.2);
@@ -42,13 +26,15 @@ footer.main-footer {
 
 // DSFR overrides
 
-.fr-footer__partners-title {
-  font-size: 1.5rem;
-}
-
 .fr-footer__partners-main {
   // this avoids footer to overflow on the right and thus increasing the viewport width which breaks DSFR modals
   flex-wrap: wrap;
   gap: 1rem;
   background: $white;
+}
+
+.main-footer {
+  h2, h3 {
+    text-align: left;
+  }
 }

--- a/app/javascript/stylesheets/structure/_footer.scss
+++ b/app/javascript/stylesheets/structure/_footer.scss
@@ -7,6 +7,22 @@ footer {
   }
 }
 
+// only used for users
+footer.main-footer {
+  padding: 3rem 0 0;
+  .brand {
+    font-weight: 800;
+    font-size: 1.7rem;
+    color: #222;
+    margin-bottom: 20px;
+  }
+}
+@media (max-width: 991px) {
+  footer.main-footer {
+    padding: 100px 0 0;
+  }
+}
+
 // only used for agents
 .footer {
   border-top: 1px solid rgba($gray-600, 0.2);
@@ -26,16 +42,13 @@ footer {
 
 // DSFR overrides
 
+.fr-footer__partners-title {
+  font-size: 1.5rem;
+}
+
 .fr-footer__partners-main {
   // this avoids footer to overflow on the right and thus increasing the viewport width which breaks DSFR modals
   flex-wrap: wrap;
   gap: 1rem;
   background: $white;
-}
-
-.main-footer {
-  h2, h3 {
-    text-align: left;
-    padding-bottom: 0;
-  }
 }

--- a/app/javascript/stylesheets/structure/_footer.scss
+++ b/app/javascript/stylesheets/structure/_footer.scss
@@ -36,5 +36,6 @@ footer {
 .main-footer {
   h2, h3 {
     text-align: left;
+    padding-bottom: 0;
   }
 }

--- a/app/javascript/stylesheets/structure/_footer_dsfr.scss
+++ b/app/javascript/stylesheets/structure/_footer_dsfr.scss
@@ -1,0 +1,15 @@
+footer {
+  color: $blue;
+  h2, h3 {
+    text-align: left;
+    padding-bottom: 0;
+  }
+}
+
+.fr-footer__partners-main {
+  // this avoids footer to overflow on the right and thus increasing the viewport width which breaks DSFR modals
+  flex-wrap: wrap;
+  gap: 1rem;
+  background: $white;
+  padding: 1rem;
+}

--- a/app/javascript/stylesheets/structure/_footer_dsfr.scss
+++ b/app/javascript/stylesheets/structure/_footer_dsfr.scss
@@ -1,15 +1,8 @@
 footer {
-  color: $blue;
+  overflow-x: hidden; // pour éviter le débordement horizontal qui agrandit le viewport
+
   h2, h3 {
     text-align: left;
     padding-bottom: 0;
   }
-}
-
-.fr-footer__partners-main {
-  // this avoids footer to overflow on the right and thus increasing the viewport width which breaks DSFR modals
-  flex-wrap: wrap;
-  gap: 1rem;
-  background: $white;
-  padding: 1rem;
 }

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -35,60 +35,65 @@ html lang="fr"
 
     #modal-holder
 
-    footer.main-footer
-      .container
-        .row
-          .col-12.col-md
-            div
-              = link_to image_tag(current_domain.dark_logo_path, size: "250x80", alt: current_domain.name), root_path, title: "aller à l'accueil #{current_domain.name}"
-              ul.list-unstyled
-                li.mb-2
-                  - if current_domain.default?
-                    span> #{current_domain.name} est fourni par
-                    = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
-                    = " et un consortium de départements"
-                  - else
-                    span
-                    = "#{current_domain.name} est géré par #{Domain::RDV_MAIRIE.name}, un service fourni par "
-                    = link_to("l'Agence Nationale de la Cohésion des Territoires", "https://agence-cohesion-territoires.gouv.fr", class: "inline")
-                    = ". "
-                    = link_to "En savoir plus", domaines_path
-                li.mb-2
-                  = image_tag "logos/republique-francaise-logo.svg", size: "105x90", alt:""
-          .col-6.col-md
-            h2 À propos
-            ul.list-unstyled
-              li.mb-1 = link_to "Contact", contact_path
-              - if current_domain == Domain::RDV_SOLIDARITES
-                li.mb-1 = link_to "Les solidarités dans votre département", mds_path
-              li.mb-1 = link_to "Espace professionnel", presentation_agent_path
-              li.mb-1 = link_to "Statistiques", stats_path
-              li.mb-1 = link_to "Budget", budget_path
-          .col-6.col-md
-            h2 Produit
-            ul.list-unstyled
-              li.mb-1 = link_to "Accessibilité : non conforme", accessibility_path
-              li.mb-1 = link_to current_domain.documentation_url do
-                span> Documentation utilisateur
-              li.mb-1 = link_to "Documentation technique", "https://github.com/betagouv/rdv-service-public#documentation-externe"
-              li.mb-1 = link_to "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
-                span>= ENV["RDV_SOLIDARITES_VERSION"]
-                i.fa.fa-external-link-alt
-              li.mb-1 = link_to "https://github.com/betagouv/rdv-service-public/" do
-                span> Code Source sur GitHub
-                i.fa.fa-external-link-alt
-          .col-6.col-md
-            h2 Informations légales
-            ul.list-unstyled
-              li.mb-1 = link_to mentions_legales_path do
-                span> Mentions Légales
-              li.mb-1 = link_to cgu_path do
-                span> C.G.U.
-              li.mb-1 = link_to politique_de_confidentialite_path do
-                span> Politique de confidentialité
+    footer.fr-footer.main-footer.fr-pb-12w
+      .fr-footer__top
+        .fr-container
+          .fr-grid-row.fr-grid-row--gutters.fr-grid-row--start
+            .fr-col-12.fr-col-sm-3.fr-col-md-3
+              h3.fr-footer__top-cat À propos
+              ul.fr-footer__top-list
+                li= link_to "Contact", contact_path, class: "fr-footer__top-link"
+                - if current_domain == Domain::RDV_SOLIDARITES
+                  li= link_to "Les solidarités dans votre département", mds_path, class: "fr-footer__top-link"
+            .fr-col-12.fr-col-sm-3.fr-col-md-3
+              h3.fr-footer__top-cat Agents
+              ul.fr-footer__top-list
+                li= link_to "Espace professionnel", presentation_agent_path, class: "fr-footer__top-link"
+            .fr-col-12.fr-col-sm-3.fr-col-md-3
+              h3.fr-footer__top-cat Le Service #{current_domain.name}
+              ul.fr-footer__top-list
+                li= link_to "Statistiques", stats_path, class: "fr-footer__top-link"
+                li= link_to "Budget", budget_path, class: "fr-footer__top-link", target: "_blank", rel: "noopener"
+            .fr-col-12.fr-col-sm-3.fr-col-md-3
+              h3.fr-footer__top-cat Documentation
+              ul.fr-footer__top-list
+                li= link_to "Documentation utilisateur", current_domain.documentation_url, class: "fr-footer__top-link", target: "_blank", rel: "noopener"
+                li= link_to "Documentation technique", "https://github.com/betagouv/rdv-service-public#documentation-externe", class: "fr-footer__top-link", target: "_blank", rel: "noopener"
+
+      .fr-container
+        .fr-footer__body
+          .fr-footer__brand.fr-enlarge-link
+            = link_to image_tag(current_domain.dark_logo_path, size: "250x80", alt: current_domain.name), root_path, title: "aller à l'accueil #{current_domain.name}"
+          .fr-footer__content
+            p.fr-footer__content-desc
+              - if current_domain.default?
+                = "#{current_domain.name} est fourni par l'Agence Nationale de la Cohésion des Territoires et un consortium de départements"
+              - else
+                span>= "#{current_domain.name} est géré par #{Domain::RDV_MAIRIE.name}, un service fourni par l'Agence Nationale de la Cohésion des Territoires."
+                = link_to "En savoir plus", domaines_path
+            ul.fr-footer__content-list
+              li.fr-footer__content-item
+                = link_to "anct.gouv.fr", "https://agence-cohesion-territoires.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener"
+
+
         .fr-footer__partners
           h3.fr-footer__partners-title Nos partenaires
           .fr-footer__partners-logos
             .fr-footer__partners-main
               = link_to(image_tag("logos/logo_dinum.svg", alt: "Logo de la Dinum", style: "height: 5.625rem"), "https://www.numerique.gouv.fr/dinum/", class: "fr-footer__partners-link" )
               = link_to(image_tag("logos/logo_anct.png", alt: "Logo de l'ANCT", style: "height: 5.625rem"), "https://agence-cohesion-territoires.gouv.fr/", class: "fr-footer__partners-link" )
+
+        .fr-footer__bottom
+          ul.fr-footer__bottom-list
+            li.fr-footer__bottom-item
+              = link_to "Accessibilité : non conforme", accessibility_path, class: "fr-footer__bottom-link"
+            li.fr-footer__bottom-item
+                = link_to "Mentions Légales", mentions_legales_path, class: "fr-footer__bottom-link"
+            li.fr-footer__bottom-item
+              = link_to "Données personnelles", politique_de_confidentialite_path, class: "fr-footer__bottom-link"
+            li.fr-footer__bottom-item
+              = link_to "C.G.U", cgu_path, class: "fr-footer__bottom-link"
+            li.fr-footer__bottom-item
+              = link_to "Code Source sur GitHub", "https://github.com/betagouv/rdv-service-public", class: "fr-footer__bottom-link", target: "_blank", rel: "noopener"
+            li.fr-footer__bottom-item
+              = link_to ENV["RDV_SOLIDARITES_VERSION"], "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", class: "fr-footer__bottom-link", title: "Aller au code source de #{current_domain.name}", target: "_blank", rel: "noopener"

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -40,22 +40,22 @@ html lang="fr"
         .container
           .fr-grid-row.fr-grid-row--gutters.fr-grid-row--start
             .fr-col-12.fr-col-sm-3.fr-col-md-3
-              h3.fr-footer__top-cat À propos
+              h2.fr-footer__top-cat À propos
               ul.fr-footer__top-list
                 li= link_to "Contact", contact_path, class: "fr-footer__top-link"
                 - if current_domain == Domain::RDV_SOLIDARITES
                   li= link_to "Les solidarités dans votre département", mds_path, class: "fr-footer__top-link"
             .fr-col-12.fr-col-sm-3.fr-col-md-3
-              h3.fr-footer__top-cat Agents
+              h2.fr-footer__top-cat Agents
               ul.fr-footer__top-list
                 li= link_to "Espace professionnel", presentation_agent_path, class: "fr-footer__top-link"
             .fr-col-12.fr-col-sm-3.fr-col-md-3
-              h3.fr-footer__top-cat Le Service #{current_domain.name}
+              h2.fr-footer__top-cat Le Service #{current_domain.name}
               ul.fr-footer__top-list
                 li= link_to "Statistiques", stats_path, class: "fr-footer__top-link"
                 li= link_to "Budget", budget_path, class: "fr-footer__top-link", target: "_blank", rel: "noopener"
             .fr-col-12.fr-col-sm-3.fr-col-md-3
-              h3.fr-footer__top-cat Documentation
+              h2.fr-footer__top-cat Documentation
               ul.fr-footer__top-list
                 li= link_to "Documentation utilisateur", current_domain.documentation_url, class: "fr-footer__top-link", target: "_blank", rel: "noopener"
                 li= link_to "Documentation technique", "https://github.com/betagouv/rdv-service-public#documentation-externe", class: "fr-footer__top-link", target: "_blank", rel: "noopener"
@@ -89,9 +89,9 @@ html lang="fr"
             li.fr-footer__bottom-item
                 = link_to "Mentions Légales", mentions_legales_path, class: "fr-footer__bottom-link"
             li.fr-footer__bottom-item
-              = link_to "Données personnelles", politique_de_confidentialite_path, class: "fr-footer__bottom-link"
+              = link_to "Politique de confidentialité", politique_de_confidentialite_path, class: "fr-footer__bottom-link"
             li.fr-footer__bottom-item
-              = link_to "C.G.U", cgu_path, class: "fr-footer__bottom-link"
+              = link_to "Conditions d’utilisation", cgu_path, class: "fr-footer__bottom-link"
             li.fr-footer__bottom-item
               = link_to "Code Source sur GitHub", "https://github.com/betagouv/rdv-service-public", class: "fr-footer__bottom-link", target: "_blank", rel: "noopener"
             li.fr-footer__bottom-item

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -50,7 +50,7 @@ html lang="fr"
               ul.fr-footer__top-list
                 li= link_to "Espace professionnel", presentation_agent_path, class: "fr-footer__top-link"
             .fr-col-12.fr-col-sm-3.fr-col-md-3
-              h2.fr-footer__top-cat Le Service #{current_domain.name}
+              h2.fr-footer__top-cat Le service #{current_domain.name}
               ul.fr-footer__top-list
                 li= link_to "Statistiques", stats_path, class: "fr-footer__top-link"
                 li= link_to "Budget", budget_path, class: "fr-footer__top-link", target: "_blank", rel: "noopener"
@@ -63,7 +63,12 @@ html lang="fr"
       .container
         .fr-footer__body
           .fr-footer__brand.fr-enlarge-link
-            = link_to image_tag(current_domain.dark_logo_path, size: "250x80", alt: current_domain.name), root_path, title: "aller à l'accueil #{current_domain.name}"
+            p.fr-logo
+              | République
+              br
+              | Française
+            = link_to root_path, title: "aller à l'accueil #{current_domain.name}", class: "fr-footer__brand-link" do
+              = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "fr-footer__logo", width: "150"
           .fr-footer__content
             p.fr-footer__content-desc
               - if current_domain.default?
@@ -78,7 +83,7 @@ html lang="fr"
         .fr-footer__partners
           h3.fr-footer__partners-title Nos partenaires
           .fr-footer__partners-logos
-            .fr-footer__partners-main
+            .fr-footer__partners-sub
               = link_to(image_tag("logos/logo_dinum.svg", alt: "Logo de la Dinum", style: "height: 5.625rem"), "https://www.numerique.gouv.fr/dinum/", class: "fr-footer__partners-link" )
               = link_to(image_tag("logos/logo_anct.png", alt: "Logo de l'ANCT", style: "height: 5.625rem"), "https://agence-cohesion-territoires.gouv.fr/", class: "fr-footer__partners-link" )
 

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -37,7 +37,7 @@ html lang="fr"
 
     footer.fr-footer.main-footer.fr-pb-12w
       .fr-footer__top
-        .fr-container
+        .container
           .fr-grid-row.fr-grid-row--gutters.fr-grid-row--start
             .fr-col-12.fr-col-sm-3.fr-col-md-3
               h3.fr-footer__top-cat À propos
@@ -60,7 +60,7 @@ html lang="fr"
                 li= link_to "Documentation utilisateur", current_domain.documentation_url, class: "fr-footer__top-link", target: "_blank", rel: "noopener"
                 li= link_to "Documentation technique", "https://github.com/betagouv/rdv-service-public#documentation-externe", class: "fr-footer__top-link", target: "_blank", rel: "noopener"
 
-      .fr-container
+      .container
         .fr-footer__body
           .fr-footer__brand.fr-enlarge-link
             = link_to image_tag(current_domain.dark_logo_path, size: "250x80", alt: current_domain.name), root_path, title: "aller à l'accueil #{current_domain.name}"

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -75,7 +75,6 @@ html lang="fr"
               li.fr-footer__content-item
                 = link_to "anct.gouv.fr", "https://agence-cohesion-territoires.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener"
 
-
         .fr-footer__partners
           h3.fr-footer__partners-title Nos partenaires
           .fr-footer__partners-logos

--- a/spec/features/anybody/anybody_can_see_legal_pages_spec.rb
+++ b/spec/features/anybody/anybody_can_see_legal_pages_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Anybody can see legal pages" do
 
   it "displays CGU" do
     visit root_path
-    expect(page).to have_content("C.G.U.")
-    click_link "C.G.U."
+    expect(page).to have_content("Conditions d’utilisation")
+    click_link "Conditions d’utilisation"
     expect(page).to have_selector("h1", text: "Conditions d’utilisation de la plateforme RDV Solidarités")
   end
 


### PR DESCRIPTION
## Contexte

Je préfère finalement migrer le footer avant de migrer les containers et grilles, ça permettra de réduire la taille de la PR #4349

La gem [`dsfr-view-components`](https://betagouv.github.io/dsfr-view-components/) ne propose malheureusement pas le Footer.

## Description de la PR 

Le footer a aujourd’hui deux sections : 

1. une colonne avec notre logo et description + 3 colonnes liens internes
2. partenaires

On passe à 4 sections : 

1. 4 colonnes de liens internes
2. notre logo et description
3. partenaires
4. liens de bas de page (cgu, mentions légales etc)

Il me semble que c’est ce qui est recommandé par [la doc du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/pied-de-page) mais on peut aussi choisir de s’en extraire un peu et faire à notre sauce.

### Style

- l’apparition d’un liseré bleu en haut du footer
- le background gris sur la section des liens internes
- je garde volontairement temporairement la classe `.container` de bootstrap plutôt que `.fr-container` pour que ça soit cohérent avec le reste de la page

### Corrections

- les titres ne flottent plus au milieu de la page en vue mobile
- j’ai mis certaines flèches « liens externes » manquantes 

## Code

Le bundle `application.scss` n’inclut plus le fichier commun aux différents layouts `_footer.scss` mais plutôt un fichier spécifique `_footer_dsfr.scss`.

Je me dis que cette approche d’isolation permettra de réduire au fur et à mesure les dépendances sur des règles CSS inutiles pour le bundle application. 
On sera potentiellement en mesure de supprimer le fichier `_footer.scss` à un certain moment. 
En tout cas on sera sûr que le code contenu n’impactera pas la partie usager déjà migrée au DSFR.

### Contenus 

J’ai pris quelques libertés tout à fait discutables :

- une Marianne en moins, celle qui dit « République Française » à côté de notre logo. Je ne sais pas trop si c’était souhaité et je me disais que comme il y en a une en dessous avec Premier Ministre / DINUM peut-être que ça suffisait ? mais on peut tout à fait en remettre une à côté du logo, c’est prévu dans le footer DSFR 
- renommage de « CGU » en « Conditions d’utilisation »
- déplacement des liens vers github à côté des liens légaux
- extraction du lien vers anct.gouv.fr 
- modification des catégories de liens internes : passage de `A propos / Produit / Mentions légales` à `A propos / Agents / Le Service RDV / Documentation`

Ce dernier découpage est un peu artificiel mais c’était pour utiliser la largeur de l’écran en vue desktop sinon ça fait un peu bizarre. on peut tout à fait revenir à deux ou trois colonnes, ce qui compte le plus c’est la vue mobile dans tous les cas.

## Review app

testable sur https://demo-rdv-solidarites-pr4370.osc-secnum-fr1.scalingo.io/

## Captures d’écran

Avant|Après
-|-
![avant](https://github.com/betagouv/rdv-service-public/assets/883348/8126977f-b2af-4568-afc3-c02962b95268) | <img width="401" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/883348/ffb6f35e-71ff-41bd-b548-6e94e80898af">
![image](https://github.com/betagouv/rdv-service-public/assets/883348/52301501-52c8-4021-bcb7-775effa5a3f6) |![image](https://github.com/betagouv/rdv-service-public/assets/883348/3ba34835-8b5e-4efd-b6ce-561fbaca4dfa)
