### PR TITLE
Ajout d'index uniques manquants sur des tables de jointure

### DIFF
--- a/app/models/agent_team.rb
+++ b/app/models/agent_team.rb
@@ -4,4 +4,6 @@ class AgentTeam < ApplicationRecord
   # Relations
   belongs_to :agent
   belongs_to :team
+
+  validates :agent_id, uniqueness: { scope: :team_id }
 end

--- a/app/models/motifs_plage_ouverture.rb
+++ b/app/models/motifs_plage_ouverture.rb
@@ -1,4 +1,6 @@
 class MotifsPlageOuverture < ApplicationRecord
   belongs_to :motif
   belongs_to :plage_ouverture
+
+  validates :motif_id, uniqueness: { scope: :plage_ouverture_id }
 end

--- a/db/migrate/20240625102621_add_unique_indexes_on_join_tables.rb
+++ b/db/migrate/20240625102621_add_unique_indexes_on_join_tables.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexesOnJoinTables < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    add_index :agent_teams, %i[team_id agent_id], unique: true, name: :index_agent_teams_primary_keys, algorithm: :concurrently
+    add_index :motifs_plage_ouvertures, %i[motif_id plage_ouverture_id], unique: true, name: :index_motifs_plage_ouvertures_primary_keys, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_25_132948) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_25_102621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -169,6 +169,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_132948) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["agent_id"], name: "index_agent_teams_on_agent_id"
+    t.index ["team_id", "agent_id"], name: "index_agent_teams_primary_keys", unique: true
     t.index ["team_id"], name: "index_agent_teams_on_team_id"
   end
 
@@ -444,6 +445,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_132948) do
   create_table "motifs_plage_ouvertures", id: false, force: :cascade do |t|
     t.bigint "motif_id", null: false
     t.bigint "plage_ouverture_id", null: false
+    t.index ["motif_id", "plage_ouverture_id"], name: "index_motifs_plage_ouvertures_primary_keys", unique: true
     t.index ["motif_id"], name: "index_motifs_plage_ouvertures_on_motif_id"
     t.index ["plage_ouverture_id"], name: "index_motifs_plage_ouvertures_on_plage_ouverture_id"
   end


### PR DESCRIPTION
# Contexte

Nous avons deux tables de jointure qui n'ont aucune garantie d'unicité. Cela peut mener à des incohérence dans nos données.

# Solution

Pour garantir cette unicité, nous pouvons :
1. ajouter un index composite UNIQUE
2. déclarer une primary key : cela ajoute un index ainsi qu'un NOT NULL sur les colonnes impliquées

D'un point de vue logique, j'aurais aimé ajouter une primary key, mais actuellement nous n'en n'avons aucune sur nos tables de jointures, et nous utilisons plutôt la solution 1.

Côté perfs, un index sur `[col1, col2]` sera utilisé et efficace pour un `WHERE col1 = x` mais moins efficace pour `WHERE col2 = x` (voir doc [^1]). Je pense donc qu'on pourra supprimer les index sur nos `col1`, dans une prochaine PR.

# Déploiement

J'ai testé la migration sur un dump de prod en local (en activant transaction et `safety_assured`) et ça passe en une poignée de millisecondes, sûrement parce qu'il construit l'index composite à partir des deux index existants. :zap: 

# Checklist

- [ ] ~~Extraire dans d'autres PRs les changements indépendants, si nécessaire~~
- [ ] ~~Préparer des captures de l’interface avant et après~~

[^1]: https://www.postgresql.org/docs/current/indexes-multicolumn.html
