### PR TITLE
commentaire : un job met plus de 8 jours à être abandonné

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -26,6 +26,7 @@ module DefaultJobBehaviour
     # Exponential backoff is n^4, so wait times between retries will be as follows:
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
+    # it therefore takes more than 8 days for a job to be discarded
     retry_on(StandardError, wait: :exponentially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
 
     # Makes sure every failed attempt is logged to Sentry


### PR DESCRIPTION
```rb
irb(main):003> ActiveSupport::Duration.build((1..20).map { _1 ** 4 }.sum)
=> 1 week, 1 day, 8 hours, 44 minutes, and 26 seconds
```

