### PR TITLE
Nettoyer les pending specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -180,6 +180,10 @@ RSpec/MessageChain:
   Exclude:
     - "spec/jobs/outlook/mass_create_event_job_spec.rb"
 
+# Pending specs always rot, please create a GitHub issue so it can rot instead
+RSpec/Pending:
+  Enabled: true
+
 Style/AsciiComments:
   Enabled: false
 

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -41,17 +41,6 @@ RSpec.describe "agents page", js: true do
     expect_page_to_be_axe_clean(path)
   end
 
-  xit "admin organisation users path is accessible" do
-    territory = create(:territory, departement_number: "75")
-    organisation = create(:organisation, territory: territory)
-    create_list(:user, 3, organisations: [organisation])
-    agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as(agent, scope: :agent)
-
-    path = admin_organisation_users_path(organisation)
-    expect_page_to_be_axe_clean(path)
-  end
-
   it "admin organisation user path is accessible" do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
@@ -69,14 +58,5 @@ RSpec.describe "agents page", js: true do
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
     login_as(agent, scope: :agent)
     expect_page_to_be_axe_clean(agents_preferences_path)
-  end
-
-  xit "RDV list is accessible" do
-    territory = create(:territory, departement_number: "75")
-    organisation = create(:organisation, territory: territory)
-    agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    login_as(agent, scope: :agent)
-    create_list(:rdv, 3, agents: [agent])
-    expect_page_to_be_axe_clean(admin_organisation_rdvs_path(organisation))
   end
 end

--- a/spec/helpers/paper_trail_helper_spec.rb
+++ b/spec/helpers/paper_trail_helper_spec.rb
@@ -16,19 +16,6 @@ RSpec.describe PaperTrailHelper do
       expect(helper.paper_trail_change_value("status", "unknown")).to eq("État indéterminé")
     end
 
-    xit "returns rdv user ids when property user_ids for rdv resource" do
-      user1 = create(:user, first_name: "Jeanne", last_name: "Dupont")
-      user2 = create(:user, first_name: "Martine", last_name: "Lalou")
-      expect(helper.paper_trail_change_value("user_ids", [user1.id, user2.id])).to eq("Jeanne DUPONT, Martine LALOU")
-    end
-
-    xit "returns rdv agent ids when property agent_ids with rdv ressource" do
-      agent1 = create(:agent, first_name: "Patricia", last_name: "Allo")
-      agent2 = create(:agent, first_name: "Marco", last_name: "Labat")
-
-      expect(helper.paper_trail_change_value("agent_ids", [agent1.id, agent2.id])).to eq("Patricia ALLO, Marco LABAT")
-    end
-
     it "returns stringified value when passed an unknown property of arbitrary type" do
       expect(helper.paper_trail_change_value("some_value", :some_symbol)).to eq("some_symbol")
     end

--- a/spec/jobs/outlook/sync_event_job_spec.rb
+++ b/spec/jobs/outlook/sync_event_job_spec.rb
@@ -83,20 +83,6 @@ RSpec.describe Outlook::SyncEventJob do
         expect(client_double).to receive(:delete_event!).with("stubbed_outlook_event_id")
         perform_enqueued_jobs
       end
-
-      context "and it has already been deleted" do
-        xit "deletes it in the api" do
-          # Ce premier job pourrait être ajouté à la queue suite à une update sur le rdv
-          described_class.perform_later(agents_rdv.id, agents_rdv.outlook_id, agents_rdv.agent)
-          agents_rdv.delete
-          described_class.perform_later(agents_rdv.id, agents_rdv.outlook_id, agents_rdv.agent)
-
-          # Cette spec échoue : on aura ici une erreur de l'api puisque l'event n'est pas trouvé.
-          # Ce n'est peut-être pas bloquant pour une v1
-          expect(client_double).to receive(:delete_event!).with("stubbed_outlook_event_id")
-          perform_enqueued_jobs
-        end
-      end
     end
   end
 end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -75,23 +75,25 @@ RSpec.describe Agent, type: :model do
   end
 
   describe "password validations" do
-    let(:organisation) { create(:organisation) }
+    it "provide the agent with explanations" do
+      agent = build(:agent)
 
-    let(:agent) do
-      create(:agent, admin_role_in_organisations: [organisation]).reload # The reload makes sure the role is in memory
-    end
-
-    xit "has only one validation for password length" do
-      # Actuellement, ce test ne passe pas parce la validation est exécutée deux fois :
-      # - une fois sur agent.password
-      # - une fois sur agent.roles.agent.password
-      # La deuxième validation est causée par le fait qu'on a un cycle de accepts_nested_attributes_for de agent, vers roles, puis à nouveau vers l'agent.
-      # J'ai essayé d'ajouter un inverse_of sur le has_many, mais sans succès.
-      # Pour le moment, cette double validation est contournée en dupliquant les clés de traductions des erreurs de agent vers agents/roles/agent, puis en faisant un uniq
-      # sur les messages d'erreur.
       agent.password = "123"
       agent.validate
-      expect(agent.errors.count).to eq(1)
+      expected_error_messages = [
+        "Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins 12 caractères",
+        "Votre mot de passe doit comporter au moins une majuscule.",
+        "Votre mot de passe doit comporter au moins un caractère spécial, par exemple un signe de ponctuation.",
+      ]
+      expect(agent.errors).to match_array(expected_error_messages)
+
+      agent.password = "123!M"
+      agent.validate
+      expect(agent.errors).to match_array(["Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins 12 caractères"])
+
+      agent.password = "123!Merci c'est assez long"
+      agent.validate
+      expect(agent).to be_valid
     end
   end
 


### PR DESCRIPTION
# Contexte

Nous avons une poignée de pending specs, et visiblement nous ne prenons pas le temps de les investiguer. Nous avons donc la manifestation d'une dette technique / produit dans nos specs, qui crée une charge mentale mais n'est pas visible par l'ensemble de l'équipe.

Aussi, les pending specs sont rédigées pendant une PR ou tout le contexte est en tête, et donc on a tendance à ne pas donner de contexte au niveau de la spec. Le fait de passer par des issues GitHub qui expliquent ce qu'il reste incite à offrir plus de contexte. 

# Solution

Ça se lit très bien commit par commit. :wink: 

Lors de mon examen des specs qu'on avait en `xit`, j'ai distingué deux cas :
- j'ai compris le contexte le de la spec car il était simple, je l'ai transformé en issues : 
  - https://github.com/betagouv/rdv-service-public/issues/4379
  - https://github.com/betagouv/rdv-service-public/issues/4375
- je n'ai pas compris les subtilités du contexte de la spec, je l'ai supprimée et je laisse le créateur de la spec (@victormours dans tous les cas) décider si il veut en faire quelque chose.
