### PR TITLE
[WIP] ne plus lever d’erreurs Sentry lors des retries de jobs, uniquement au fail final

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -5,21 +5,6 @@ module DefaultJobBehaviour
   PRIORITY_OF_RETRIES = 20
 
   included do
-    # Include job metadata in Sentry context
-    around_perform do |_job, block|
-      Sentry.with_scope do |scope|
-        scope.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
-        block.call
-      rescue StandardError => e
-        # Setting the fingerprint after the error occurs, allow us to capture failure responses and error codes
-        scope.set_fingerprint(sentry_fingerprint) if sentry_fingerprint.present?
-        Sentry.capture_exception(e) if log_failure_to_sentry?(e)
-        raise # will be caught by the retry mechanism
-      end
-    end
-
-    # https://github.com/bensheldon/good_job#timeouts
-
     # This retry_on means:
     # "retry 20 times with an exponential backoff, then mark job as discarded"
     #
@@ -28,18 +13,11 @@ module DefaultJobBehaviour
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
     # it therefore takes more than 8 days for a job to be discarded
     retry_on(StandardError, wait: :exponentially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
-
-    # Makes sure every failed attempt is logged to Sentry
-    # (see: https://github.com/bensheldon/good_job#retries)
   end
 
-  private
+  # private
 
-  def log_failure_to_sentry?(_exception)
-    true
-  end
-
-  def sentry_fingerprint
-    []
-  end
+  # def sentry_fingerprint
+  #   []
+  # end
 end

--- a/app/jobs/fail_on_purpose_job.rb
+++ b/app/jobs/fail_on_purpose_job.rb
@@ -1,0 +1,8 @@
+class OnPurposeError < StandardError
+end
+
+class FailOnPurposeJob < ApplicationJob
+  def perform
+    raise OnPurposeError, "Test adrien - I failed on purpose"
+  end
+end

--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -11,10 +11,4 @@ class SmsJob < ApplicationJob
 
     SmsSender.perform_with(sender_name, phone_number, content, provider, api_key, receipt_params)
   end
-
-  # Don't log first failures to Sentry, to prevent noise
-  # on temporary unavailability of an external service.
-  def log_failure_to_sentry?(_exception)
-    executions > 2
-  end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -48,14 +48,6 @@ class WebhookJob < ApplicationJob
     request.run
   end
 
-  def log_failure_to_sentry?(_exception)
-    # Pour limiter le bruit dans Sentry, on ne veut pas avoir de notification pour chaque retry.
-    # On veut seulement :
-    # - un premier avertissement assez rapide s'il y a un problème (4e essai)
-    # - une notification pour le dernier essai, avant que le job passe en "abandonnés"
-    executions == 4 || executions >= 10 || executions == MAX_ATTEMPTS
-  end
-
   def sentry_fingerprint
     @sentry_event_fingerprint
   end

--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -12,10 +12,4 @@ class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
       retry_job
     end
   end
-
-  # Don't log first failures to Sentry, to prevent noise
-  # on temporary unavailability of an external service.
-  def log_failure_to_sentry?(_exception)
-    executions > 2
-  end
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -3,7 +3,11 @@ Rails.application.configure do
 
   config.good_job.preserve_job_records = true
   config.cleanup_preserved_jobs_before_seconds_ago = 604_800 # 1 semaine
-  config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) }
+  config.good_job.on_thread_error = lambda { |exception|
+    # Sentry.set_context(:job, { job_id: job_id, queue_name: queue_name, arguments: arguments })
+    # Sentry.set_fingerprint(sentry_fingerprint) if sentry_fingerprint.present?
+    Sentry.capture_exception(exception)
+  }
   config.good_job.execution_mode = :external
   config.good_job.queues = "*"
   config.good_job.max_threads = 5


### PR DESCRIPTION
absolutely not ready for review

cf discussion https://pad.numerique.gouv.fr/C7MjFXXCR_aO0UH3XoWZqw?view#est-il-n%C3%A9cessaire-d%E2%80%99avoir-un-event-Sentry-pour-chaque-retry-de-job- 