### PR TITLE
Lever des exceptions pundit plutôt qu’AR lorsqu’un agent essaie d’accéder à une orga étrangère

### DIFF
--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -47,9 +47,8 @@ class AgentAuthController < ApplicationController
   end
 
   def authorize_organisation
-    # on ne peut pas utiliser authorize car le pundit_user défini plus haut a comme contexte
+    # on n’utilise pas le helper authorize directement car le pundit_user défini plus haut a comme contexte
     # l’organisation elle même, ici on veut un contexte d’agent sans organisation
-    policy = Agent::OrganisationPolicy.new(AgentContext.new(current_agent), current_organisation)
-    raise Pundit::NotAuthorizedError unless policy.link_to_organisation?
+    Pundit.authorize(AgentContext.new(current_agent), [:agent, current_organisation], :show?)
   end
 end

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -3,6 +3,7 @@ class AgentAuthController < ApplicationController
 
   layout "application_agent"
 
+  before_action :authorize_organisation
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 
@@ -34,7 +35,7 @@ class AgentAuthController < ApplicationController
   end
 
   def current_organisation
-    @current_organisation ||= current_agent.organisations.find(params[:organisation_id])
+    @current_organisation ||= Organisation.find(params[:organisation_id])
   end
 
   def current_territory
@@ -43,5 +44,10 @@ class AgentAuthController < ApplicationController
 
   def from_modal?
     params[:modal].present?
+  end
+
+  def authorize_organisation
+    policy = Agent::OrganisationPolicy.new(AgentContext.new(current_agent), current_organisation)
+    raise Pundit::NotAuthorizedError unless policy.link_to_organisation?
   end
 end

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -47,6 +47,8 @@ class AgentAuthController < ApplicationController
   end
 
   def authorize_organisation
+    # on ne peut pas utiliser authorize car le pundit_user défini plus haut a comme contexte
+    # l’organisation elle même, ici on veut un contexte d’agent sans organisation
     policy = Agent::OrganisationPolicy.new(AgentContext.new(current_agent), current_organisation)
     raise Pundit::NotAuthorizedError unless policy.link_to_organisation?
   end

--- a/app/controllers/agent_auth_controller.rb
+++ b/app/controllers/agent_auth_controller.rb
@@ -3,7 +3,7 @@ class AgentAuthController < ApplicationController
 
   layout "application_agent"
 
-  before_action :authorize_organisation
+  before_action :authorize_organisation, if: -> { params[:organisation_id].present? }
   after_action :verify_authorized, except: :index
   after_action :verify_policy_scoped, only: :index
 

--- a/app/controllers/agents/users_controller.rb
+++ b/app/controllers/agents/users_controller.rb
@@ -6,11 +6,7 @@ class Agents::UsersController < AgentAuthController
   def search
     skip_authorization # On scope les usagers par organisation puis par territoire via de la logique métier plutôt qu'une policy Pundit
     # Dans cette recherche, on autorise un périmètre plus grand que la policy de base, puisqu'on est en train d'ajouter un usager à l'organisation en créant un rdv
-
-    # On vérifie quand même que l'organisation demandée fait partie des organisations de l'agent
-    if current_agent.organisations.find_by(id: params[:organisation_id]).nil?
-      return head :forbidden
-    end
+    # ce skip_authorization ne skippe pas le AgentAuthController#authorize_organisation
 
     territory_scope = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.all).resolve
     current_org_scope = Agent::UserPolicy::Scope.new(pundit_user, User.all).resolve

--- a/config/locales/pundit.fr.yml
+++ b/config/locales/pundit.fr.yml
@@ -1,3 +1,5 @@
 fr:
- pundit:
-   default: 'Vous ne pouvez pas effectuer cette action.'
+  pundit:
+    default: 'Vous ne pouvez pas effectuer cette action.'
+    agent/organisation_policy:
+      show?: Vous ne pouvez pas accéder à cette organisation

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -97,10 +97,10 @@ RSpec.describe Admin::AgentsController, type: :controller do
         }
       end
 
-      it "rejects the change" do
+      it "rejects the change and redirects" do
         subject
         expect(response.status).to eq 302
-        expect(flash[:error]).to eq "Vous ne pouvez pas effectuer cette action."
+        expect(flash[:error]).to eq "Vous ne pouvez pas accéder à cette organisation"
         expect(Agent.last.email).not_to eq "hacker@renard.com"
       end
     end

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -98,7 +98,9 @@ RSpec.describe Admin::AgentsController, type: :controller do
       end
 
       it "rejects the change" do
-        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        subject
+        expect(response.status).to eq 302
+        expect(flash[:error]).to eq "Vous ne pouvez pas effectuer cette action."
         expect(Agent.last.email).not_to eq "hacker@renard.com"
       end
     end

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "agents can prescribe rdvs" do
     create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_insertion], lieu: mission_locale_paris_sud, organisation: org_insertion, agent: agent_insertion)
     create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_insertion], lieu: mission_locale_paris_nord, organisation: org_insertion)
     create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_autre_service], lieu: mission_locale_paris_sud, organisation: org_insertion)
+    current_agent.reload # needed to populate agent.organisations :/
+    agent_insertion.reload
   end
 
   def go_to_prescription_page

--- a/spec/requests/agents/users_controller_search_spec.rb
+++ b/spec/requests/agents/users_controller_search_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Agents::UsersController, "#search" do
     it "returns a 403 error and an empty body" do
       sign_in agent
       get search_agents_users_path(organisation_id: other_organisation)
-      expect(response).to have_http_status(:forbidden)
-      expect(response.body).to be_empty
+      expect(response).to have_http_status(:found) # 302 redirects
+      expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.")
     end
   end
 end

--- a/spec/requests/agents/users_controller_search_spec.rb
+++ b/spec/requests/agents/users_controller_search_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Agents::UsersController, "#search" do
       sign_in agent
       get search_agents_users_path(organisation_id: other_organisation)
       expect(response).to have_http_status(:found) # 302 redirects
-      expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.")
+      expect(flash[:error]).to eq("Vous ne pouvez pas accéder à cette organisation")
     end
   end
 end

--- a/spec/requests/agents/users_controller_search_spec.rb
+++ b/spec/requests/agents/users_controller_search_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Agents::UsersController, "#search" do
   context "when passing an organisation_id the agent doesn't belong to" do
     let(:other_organisation) { create(:organisation, territory: territory) }
 
-    it "returns a 403 error and an empty body" do
+    it "redirects with a flash message" do
       sign_in agent
       get search_agents_users_path(organisation_id: other_organisation)
       expect(response).to have_http_status(:found) # 302 redirects


### PR DESCRIPTION
corrige #4383

Lorsqu’un agent accède à une URL d’une orga à laquelle il n’a pas accès : 
1. on lève une exception `ActiveRecord::RecordNotFound`
2. l’agent voit une 404
3. on notifie Sentry

Cette PR propose de changer tout ce comportement : 
1. lever une exception `Pundit::NotAuthorizedError`
2. rediriger vers la page précédente ou la home de l’agent avec un flash d’erreur "vous n’avez pas le droit"
3. ne pas notifier sentry

Il me semble que c’est un meilleur comportement pour les agents et que cela nous fera moins de bruit dans Sentry

<img width="1263" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/883348/a309ace7-0f4c-4c97-ae89-1c588eade07d">


## Followup

- [ ] une autre PR similaire pour les contrôleurs agent de la partie "admin" 