### PR TITLE
Ajout d’un tag sentry lorsqu’un RDV ANTS est supprimé dans le job de synchro

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -42,7 +42,7 @@ module Ants
         application_id: @rdv_attributes[:obsolete_application_id],
         management_url: @appointment_data[:management_url]
       )
-      Sentry.set_tags("ants_appointment_deleted", res.present?)
+      Sentry.set_tags(ants_appointment_deleted: res.present?)
     end
 
     def rdv_cancelled_or_deleted?

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -38,10 +38,11 @@ module Ants
     def delete_obsolete_appointment
       return if @rdv_attributes[:obsolete_application_id].blank?
 
-      AntsApi.find_and_delete(
+      res = AntsApi.find_and_delete(
         application_id: @rdv_attributes[:obsolete_application_id],
         management_url: @appointment_data[:management_url]
       )
+      Sentry.set_tags("ants_appointment_deleted", res.present?)
     end
 
     def rdv_cancelled_or_deleted?


### PR DESCRIPTION
cf #4318

Le tag permettra de filtrer les issues et events pour comprendre si le problème se produit uniquement / majoritairement / de temps en temps lors d’un delete - recreate. 
Ça devrait nous donner des infos pour la piste à suivre 🔍 

Les breadcrumbs paraitraient plus sémantiquement adaptés mais si je comprends bien on ne peut pas filtrer les issues et events dessus.


Je n’ai pas testé en local en revanche il y a un test qui passe par ce bout de code. 
Je l’avais cassé dans un premier commit en appelant mal `set_tags`. 

Ça me parait à peu près suffisant comme niveau de confiance pour déployer ce petit tooling facilement annulable. Mais c’est discutable ! 
