### PR TITLE
Ne plus lever d’erreurs sentry pour les 404 venant de l’exterieur

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -21,8 +21,9 @@ Sentry.init do |config|
   config.excluded_exceptions += ["GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError"]
 
   config.before_send = lambda do |event, hint|
-    return if hint[:exception].is_a?(ActiveRecord::RecordNotFound) &&
-              event.request&.headers&.fetch("Referer", "")&.exclude?("rdv-")
+    referer = event.request&.headers&.fetch("Referer", "")
+    internal_referer = Domain::ALL.map(&:host_name).any? { referer&.include?(_1) }
+    return if hint[:exception].is_a?(ActiveRecord::RecordNotFound) && !internal_referer
 
     event
   end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,18 +7,9 @@ Sentry.init do |config|
   # Cf https://docs.sentry.io/platforms/ruby/configuration/options/#optional-settings
   # config.excluded_exceptions += []
 
-  # Par défault, Sentry ignore les erreurs ActiveRecord::RecordNotFound pour éviter de faire remonter
-  # des erreurs en cas de visite de page obsolètes
-  # par exemple pour des ids non trouvés.
-  # Dans le contexte des jobs, on a besoin de savoir s'il y a cette erreur
-  # Par ailleurs, on préfère mettre une règle dans Sentry pour ignorer ces erreurs en dessous d'un
-  # certain volume plutôt que de les rendre complètement invisibles.
+  # cf docs/5-role-de-vigie.md
+  # et https://docs.sentry.io/platforms/ruby/guides/rails/configuration/filtering/
   config.excluded_exceptions -= ["ActiveRecord::RecordNotFound"]
-
-  # Ces erreurs déclenchent un retry :
-  # https://github.com/bensheldon/good_job?tab=readme-ov-file#how-concurrency-controls-work
-  # Il ne nous est pas utile de les voir dans Sentry puisqu'elles ont un rôle de contrôle de flux.
-  config.excluded_exceptions += ["GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError"]
 
   config.before_send = lambda do |event, hint|
     referer = event.request&.headers&.fetch("Referer", "")
@@ -27,4 +18,9 @@ Sentry.init do |config|
 
     event
   end
+
+  # Ces erreurs déclenchent un retry :
+  # https://github.com/bensheldon/good_job?tab=readme-ov-file#how-concurrency-controls-work
+  # Il ne nous est pas utile de les voir dans Sentry puisqu'elles ont un rôle de contrôle de flux.
+  config.excluded_exceptions += ["GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError"]
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -19,4 +19,11 @@ Sentry.init do |config|
   # https://github.com/bensheldon/good_job?tab=readme-ov-file#how-concurrency-controls-work
   # Il ne nous est pas utile de les voir dans Sentry puisqu'elles ont un rôle de contrôle de flux.
   config.excluded_exceptions += ["GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError"]
+
+  config.before_send = lambda do |event, hint|
+    return if hint[:exception].is_a?(ActiveRecord::RecordNotFound) &&
+              event.request&.headers&.fetch("Referer", "")&.exclude?("rdv-")
+
+    event
+  end
 end

--- a/docs/5-role-de-vigie.md
+++ b/docs/5-role-de-vigie.md
@@ -28,11 +28,15 @@ L'un des rôles de la vigie est donc de qualifier les issues Sentry :
 
 Il y a un volume d'erreur important lié à des ActiveRecord::NotFound, qui se traduisent souvent par des erreurs 404 pour les usagers.
 
-Ces erreurs sont normalement ignorées au niveau du client Sentry (dans l'appli Rails), mais on a eu des cas où cela rendait des bugs invisibles (des mails qui ne s'envoyaient pas parce qu'on ne trouvait pas de lieux de rdv). On a donc réactivé ces erreurs sur le client Sentry, pour faire le tri au niveau du serveur Sentry (via l'appli web Sentry).
+Ces erreurs sont normalement ignorées au niveau du client Sentry (dans l'appli Rails).
+On a eu des cas où cela rendait des bugs invisibles, par exemple des mails qui ne s'envoyaient pas parce qu'on ne trouvait pas le lieu.
+On ne veut en effet pas ignorer ces erreurs lorsqu’elles émanent d’un job.
 
-Ce qui nous intéresse, ce sont les erreur ActiveRecord::NotFound qui sont liée à un vrai bug et pas juste un lien obsolète. On peut donc trier sur la base de la présence du header http referer : les liens obsolètes qui sont partagés par mail ou conservés dans les favoris n'auront pas de valeur pour ce header, alors que les vraies erreurs, comme un lien cassé sur l'appli, auront notre nom de domaine dans le referer. On a ajouté la recherche sauvegardée "RecordNotFound with internal referer" dans Sentry pour chercher ce type d'erreurs.
+Côté web, on est aussi intéressés par les erreurs 404 qui sont liées à des liens cassés dans l’application.
+En revanche, les liens venant de l’extérieur qui mènent vers des 404 sont beaucoup moins intéressantes.
+Il peut s’agir de liens obsolètes qui ont été partagés par mail, ou qui sont dans les favoris de l’utilisateur.
 
-Les erreurs liées à des liens obsolètes peuvent être ignorées avec des règles du type "Ignore until this occurs again 100 times per week". Le nombre exact d'occurrences par semaine est à trouver au cas par cas. Il vaut mieux commencer avec un nombre assez bas, et augmenter au fur et à mesure, ce qui nous permettra de voir s'il y a soudainement un pic d'erreurs de ce type (ce qui pourrait révéler un vrai bug, et pas juste un bruit de fond d'erreurs liées à des liens obsolètes).
+On a configuré [sentry](https://github.com/betagouv/rdv-service-public/blob/production/config/initializers/sentry.rb) pour ignorer les erreurs `ActiveRecord::RecordNotFound` de requêtes web venant de l’extérieur.
 
 ## GoodJob
 


### PR DESCRIPTION
Cette PR tente de configurer sentry pour ignorer les `RecordNotFound` lorsqu’elles n’ont pas de Referer interne.

Cela correspond à ce qu’il est indiqué de faire dans la [doc vigie](https://github.com/betagouv/rdv-service-public/blob/production/docs/5-role-de-vigie.md#les-erreurs-activerecordnotfound) 

C’est difficile à tester manuellement ou automatiquement.

En local à la main j’ai fait les tests suivants : 

- ajouter le sentry dsn à mon .env
- depuis la partie agent connecté casser un lien depuis l’inspecteur web de mon navigateur pour voir que la 404 avec referer est bien levée vers sentry
- vérifier que lorsque j’accède à une URL 404 depuis l’extérieur ça ne lève pas d’erreur sentry
- lancer un job qui faile on purpose pour vérifier que mon lambda n’explose pas et que l’erreur est bien remontée à Sentry