### PR TITLE
Indiquer que le rdv est par visio dans les sms

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -55,7 +55,7 @@ class Rdv < ApplicationRecord
   has_one :territory, through: :organisation
 
   # Delegates
-  delegate :home?, :phone?, :public_office?, :bookable_by_everyone?,
+  delegate :home?, :phone?, :public_office?, :visio?, :bookable_by_everyone?,
            :bookable_by_everyone_or_bookable_by_invited_users?, :service_social?, :follow_up?, :service, :collectif?, :collectif, :individuel?, :requires_ants_predemande_number?, to: :motif
 
   # Validations

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -77,6 +77,8 @@ class Users::RdvSms < Users::BaseSms
       "RDV téléphonique"
     elsif rdv.home?
       "RDV à votre domicile"
+    elsif rdv.visio?
+      "RDV par visioconférence"
     else
       rdv.address_complete
     end

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -73,14 +73,17 @@ class Users::RdvSms < Users::BaseSms
   end
 
   def rdv_location(rdv)
-    if rdv.phone?
+    case rdv.motif.location_type
+    when "public_office"
+      rdv.address_complete
+    when "phone"
       "RDV téléphonique"
-    elsif rdv.home?
+    when "home"
       "RDV à votre domicile"
-    elsif rdv.visio?
+    when "visio"
       "RDV par visioconférence"
     else
-      rdv.address_complete
+      raise "Il manque un texte de rdv_location pour #{rdv.motif.location_type}"
     end
   end
 end

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -198,7 +198,17 @@ RSpec.describe Users::RdvSms, type: :service do
           expect(subject).to include("RDV par visioconférence")
           expect(subject).to include(rdv.address)
         end
+      end
 
+      context "if we add a new location type without adding the location text" do
+        it "would raise an error in this block" do
+          Motif.location_types.each_value do |location_type|
+            motif = build(:motif, location_type: location_type)
+            rdv = build(:rdv, motif: motif, users: [user], starts_at: 5.days.from_now, id: 1)
+
+            described_class.rdv_created(rdv, user, token).content
+          end
+        end
       end
     end
 

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -190,6 +190,16 @@ RSpec.describe Users::RdvSms, type: :service do
           expect(subject).to include(rdv.address)
         end
       end
+
+      context "when rdv is by visio" do
+        let(:motif) { build(:motif, location_type: :visio) }
+
+        it do
+          expect(subject).to include("RDV par visioconférence")
+          expect(subject).to include(rdv.address)
+        end
+
+      end
     end
 
     describe "depending on phone" do


### PR DESCRIPTION
Message de Matis sur notre Mattermost :
> Une utilisatrice nous fait remarquer que les SMS envoyés pour des rendez-vous "visioconférence" ne mentionnent pas le type de rendez-vous "visioconférence", comme pourrait le faire les SMS envoyés pour les rendez-vous téléphoniques 

> Ça pourrait être un plus pour l'usager de bien comprendre que c'est un rendez-vous visio, plutôt que de ne pas l'informer et laisser du doute ?

C'est effectivement un oubli lors de la mise en place de la fonctionnalité : pour les trois autres location type, on indique soit l'adresse du lieu du rdv, soit le location type ("RDV téléphonique" ou "RDV à votre domicile").

Cette Pr fait donc la même chose pour les rdv en visio : on met "RDV par visioconférence" dans le sms là où on aurait mis "RDV téléphonique".