### PR TITLE
empêcher jobs simultanés de synchro ANTS pour le même RDV

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -1,6 +1,7 @@
 module Ants
   class SyncAppointmentJob < ApplicationJob
     # prevent concurrent jobs for the same RDV
+    include GoodJob::ActiveJobExtensions::Concurrency
     good_job_control_concurrency_with(
       perform_limit: 1,
       key: -> { "#{self.class.name}-rdv-#{arguments.last[:rdv_attributes][:id]}" }

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -3,7 +3,7 @@ module Ants
     # prevent concurrent jobs for the same RDV
     good_job_control_concurrency_with(
       perform_limit: 1,
-      key: "#{self.class.name}-rdv-#{arguments.last[:rdv_attributes][:id]}"
+      key: -> { "#{self.class.name}-rdv-#{arguments.last[:rdv_attributes][:id]}" }
     )
 
     class << self

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -1,5 +1,11 @@
 module Ants
   class SyncAppointmentJob < ApplicationJob
+    # prevent concurrent jobs for the same RDV
+    good_job_control_concurrency_with(
+      perform_limit: 1,
+      key: "#{self.class.name}-rdv-#{arguments.last[:rdv_attributes][:id]}"
+    )
+
     class << self
       def perform_later_for(rdv)
         # On passe les attributes du RDV au lieu de l'objet active record, au cas où ce dernier serait supprimé


### PR DESCRIPTION
cf #4318 

Cette PR rajoute un lock au niveau du job de synchro ANTS. 
C’est une tentative un peu aveugle de voir si le problème de ces nombreuses erreurs vient de jobs quasi simultanés.