### PR TITLE
Show error message when no available creneau when invited with lieu preselected

### DIFF
--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -89,6 +89,10 @@ module Users::CreneauxWizardConcern
     @next_availability ||= creneaux.empty? ? creneaux_search.next_availability : nil
   end
 
+  def no_availability?
+    creneaux.empty? && next_availability.nil?
+  end
+
   def max_public_booking_delay
     matching_motifs.maximum("max_public_booking_delay")
   end

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,39 +1,42 @@
 .container
-  = render "search/selected_motif_recap", context: context
-  - if context.lieu.present?
-    .card.card-hoverable
-      .card-body
-        = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
-          .row
-            .col-auto.align-self-center
-              i.fa.fa-chevron-left
-            .col
-              h2.pb-1.mb-1.card-title= context.lieu.name
-              .card-subtitle= context.lieu.address
-  - elsif context.user_selected_organisation.present?
+  - if context.no_availability?
+    = render "search/nothing_to_show", context: context
+  - else
+    = render "search/selected_motif_recap", context: context
+    - if context.lieu.present?
       .card.card-hoverable
         .card-body
-          = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
+          = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
             .row
               .col-auto.align-self-center
                 i.fa.fa-chevron-left
               .col
-                h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
-                = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
-  - if context.first_matching_motif.collectif?
-    h3.font-weight-bold = "Inscrivez-vous à l'atelier de votre choix :"
-  - else
-    h3.font-weight-bold = "Sélectionnez un créneau :"
-  .card.mb-3
-    .card-body
-      - if context.first_matching_motif.collectif?
-        - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
-          = render "search/rdv_collectif", rdv: rdv
-      - elsif context.unique_motifs_by_name_and_location_type.present?
-        = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
-      - else
-        .alert.alert-warning
-          = "Le motif "
-          b= context.first_matching_motif.name
-          = " n'est plus disponible à la réservation à "
-          b= context.lieu.name
+                h2.pb-1.mb-1.card-title= context.lieu.name
+                .card-subtitle= context.lieu.address
+    - elsif context.user_selected_organisation.present?
+        .card.card-hoverable
+          .card-body
+            = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
+              .row
+                .col-auto.align-self-center
+                  i.fa.fa-chevron-left
+                .col
+                  h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
+                  = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
+    - if context.first_matching_motif.collectif?
+      h3.font-weight-bold = "Inscrivez-vous à l'atelier de votre choix :"
+    - else
+      h3.font-weight-bold = "Sélectionnez un créneau :"
+    .card.mb-3
+      .card-body
+        - if context.first_matching_motif.collectif?
+          - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
+            = render "search/rdv_collectif", rdv: rdv
+        - elsif context.unique_motifs_by_name_and_location_type.present?
+          = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
+        - else
+          .alert.alert-warning
+            = "Le motif "
+            b= context.first_matching_motif.name
+            = " n'est plus disponible à la réservation à "
+            b= context.lieu.name

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,28 +1,28 @@
 .container
-  - if context.no_availability?
-    = render "search/nothing_to_show", context: context
-  - else
-    = render "search/selected_motif_recap", context: context
-    - if context.lieu.present?
+  = render "search/selected_motif_recap", context: context
+  - if context.lieu.present?
+    .card.card-hoverable
+      .card-body
+        = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+          .row
+            .col-auto.align-self-center
+              i.fa.fa-chevron-left
+            .col
+              h2.pb-1.mb-1.card-title= context.lieu.name
+              .card-subtitle= context.lieu.address
+  - elsif context.user_selected_organisation.present?
       .card.card-hoverable
         .card-body
-          = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+          = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
             .row
               .col-auto.align-self-center
                 i.fa.fa-chevron-left
               .col
-                h2.pb-1.mb-1.card-title= context.lieu.name
-                .card-subtitle= context.lieu.address
-    - elsif context.user_selected_organisation.present?
-        .card.card-hoverable
-          .card-body
-            = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
-              .row
-                .col-auto.align-self-center
-                  i.fa.fa-chevron-left
-                .col
-                  h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
-                  = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
+                h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
+                = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
+  - if context.no_availability?
+    = render "search/nothing_to_show", context: context
+  - else
     - if context.first_matching_motif.collectif?
       h3.font-weight-bold = "Inscrivez-vous à l'atelier de votre choix :"
     - else

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "User can select a creneau" do
     it "does not show duplicate creneaux" do
       visit public_link_to_org_path(organisation_id: organisation.id)
 
-      click_on("Vaccination") # choix du motif
+      click_on("RSA Orientation") # choix du motif
       click_on("Prochaine disponibilité le") # choix du lieu
       displayed_creneaux = page.all("a", text: "08:00")
       expect(displayed_creneaux.size).to eq(1)


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-insertion/issues/2169

J'ai ouvert l'issue côté rdv-insertion parce qu'elles concernent les usagers ayant reçu une invitation, n'hésitez pas à me dire si vous voulez que j'en ouvre une côté rdv-service-public.

# Contexte

Lorsque l'on invite un usager à prendre rdv via l'API de rdv-insertion (c'est le cas notamment pour le département des Bouches-du-Rhône), on laisse la possibilité lors de l'appel API de renseigner l'id du lieu vers lequel on veut inviter la personne. En effet dans les Bouches-du-Rhône le SI du conseil départemental qui gère les invitations sur toutes les structures du département a son propre système de sectorisation et préfère diriger chaque usager vers un lieu précis.

Le problème est que lorsqu'aucun créneau n'est disponible dans ce cas-là, aucun message d'erreur n'est affiché. À la place l'usager voit la page de sélection de créneau sans pouvoir choisir de créneau

# Solution

Le problème vient du fait qu'à la sélection du créneau, on affiche la page de sélection sans vérifier s'il existe des créneaux disponibles au préalable. Or dans le cas mentionné au-dessus, l'usager arrive directement à la sélection du créneau.
J'ajoute donc une condition pour vérifier s'il y a des créneaux de disponibles, et s'il y en a pas faire pareil que sur les autres étapes de la prise de rdv par l'usager: afficher un message expliquant qu'il n'y a plus de créneaux avec les informations de l'organisation en question si disponibles.

# Previews 

* Avant 📸 

<img width="1167" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/7602809/5f601098-f3b9-4952-b1cc-c6a6ac52b793">

* Après 📸 

![image](https://github.com/betagouv/rdv-service-public/assets/7602809/d14cdbdf-71bb-4825-83aa-6b1eb34d31d7)
