### PR TITLE
Bugfix: le hint est collé à droite du label

### DIFF
--- a/app/views/admin/motifs/form/_resa_en_ligne.html.slim
+++ b/app/views/admin/motifs/form/_resa_en_ligne.html.slim
@@ -45,8 +45,8 @@
       .col-md-6= f.input :min_public_booking_delay, label: "Délai minimum avant le RDV", collection: min_max_delay_options
       .col-md-6= f.input :max_public_booking_delay, label: "Délai maximum avant le RDV", collection: min_max_delay_options
 
-    .form-row.mt-2
-      = f.input(:rdvs_editable_by_user, input_html: { class: "js-check-on-section-enable js-uncheck-on-section-disable" })
+    .mt-2
+      = f.input(:rdvs_editable_by_user, input_html: { class: "js-check-on-section-enable js-uncheck-on-section-disable" }, wrapper_html: { class: "mb-1" })
       .text-muted.font-14= Motif.human_attribute_name("rdvs_editable_by_user_hint")
 
     .alert.alert-warning.mt-2.js-reasons-for-disabled-section

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -45,7 +45,7 @@ fr:
         instruction_for_rdv_hint: Indications affichées après la confirmation du rendez-vous
         instruction_for_rdv_short: Indications après
         rdvs_editable_by_user: RDVs modifiables
-        rdvs_editable_by_user_hint: L’horaire et la date du rendez-vous peut être changé par l’usager au plus tard 48h avant le rendez-vous.
+        rdvs_editable_by_user_hint: L’horaire et la date du rendez-vous peuvent être changés par l’usager au plus tard 48h avant le rendez-vous.
       motif/collectifs:
         true: RDV collectif
         false: RDV individuel


### PR DESCRIPTION
# Avant

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/2e395b8f-a7e2-4d7f-b536-ad765e93d949)

# Après

![image](https://github.com/betagouv/rdv-service-public/assets/6357692/6fcb8caa-0491-46eb-a9e2-f9d92843c07b)
