### PR TITLE
Ajout d'une doc pour générer un lien d'invitation depuis RDVSP (sans RDVI)

### DIFF
--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -267,19 +267,23 @@ user2.save!
 
 # On reprend ci dessous les paramêtres que Rdvi utilise pour générer l'url d'invitation.
 # le code est ici https://github.com/betagouv/rdv-insertion/blob/9c03e5a6c720a88826e84ca854fd5ccb6135569a/app/services/invitations/compute_link.rb#L2
-# Si vous souhaitez tester avec d'autres données il suffit de remplacer les valeurs ci-dessous dans votre console.
-# L'organisation doit avoir un motif avec une catégorie de motif, la valeur de bookable_by doit être :agents_and_prescripteurs_and_invited_users
-# et des plages d'ouvertures doivent être créées pour le motif.
-# Le user doit avoir un rdv_invitation_token assigné via la méthode assign_rdv_invitation_token et sauvegardé.
 
 dataset = [{
   user: user1,
   organisation: org_drome1,
   motif: motif1_drome1,
+  city_code: "26362",
+  street_ban_id: "26362_1450",
+  longitude: "4.901427",
+  latitude: "44.931348",
 }, {
   user: user2,
   organisation: org_yonne,
   motif: motif_yonne_physique,
+  city_code: "89024",
+  street_ban_id: "89024_3940",
+  longitude: "3.572903",
+  latitude: "47.795585",
 },]
 
 dataset.each do |data|
@@ -287,9 +291,10 @@ dataset.each do |data|
   organisation = data[:organisation]
   motif = data[:motif]
 
-  city_code = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:city_code]
-  street_ban_id = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:street_ban_id]
-  longitude, latitude = GeoCoding.new.find_geo_coordinates(user.address)
+  city_code = data[:city_code]
+  street_ban_id = data[:street_ban_id]
+  longitude = data[:longitude]
+  latitude = data[:latitude]
   invitation_token = user.rdv_invitation_token
   organisation_id = organisation.id
   motif_category_short_name = motif.motif_category.short_name

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -236,3 +236,80 @@ WebhookEndpoint.create!(
   organisation_id: org_yonne.id,
   subscriptions: %w[rdv user user_profile organisation motif lieu agent agent_role referent_assignation]
 )
+
+# Users
+user1 = User.create!(
+  email: "jean.rsavalence@testinvitation.fr",
+  address: "60 avenue de Chabeuil 26000 Valence",
+  first_name: "Jean",
+  last_name: "RSAValence",
+  phone_number: "0601020304",
+  created_through: "agent_creation_api",
+  invited_through: "external",
+  birth_date: 30.years.ago,
+  organisations: [org_drome1, org_drome2]
+)
+user1.assign_rdv_invitation_token
+user1.save!
+
+user2 = User.create!(
+  email: "jean.rsaAuxerre@testinvitation.fr",
+  address: "12 Rue Joubert, Auxerre, 89000",
+  first_name: "Jean",
+  last_name: "RSAAuxerre",
+  created_through: "agent_creation_api",
+  invited_through: "external",
+  birth_date: 30.years.ago,
+  organisations: [org_yonne]
+)
+user2.assign_rdv_invitation_token
+user2.save!
+
+# On reprend ci dessous les paramêtres que Rdvi utilise pour générer l'url d'invitation.
+# le code est ici https://github.com/betagouv/rdv-insertion/blob/9c03e5a6c720a88826e84ca854fd5ccb6135569a/app/services/invitations/compute_link.rb#L2
+# Si vous souhaitez tester avec d'autres données il suffit de remplacer les valeurs ci-dessous dans votre console.
+# L'organisation doit avoir un motif avec une catégorie de motif, la valeur de bookable_by doit être :agents_and_prescripteurs_and_invited_users
+# et des plages d'ouvertures doivent être créées pour le motif.
+# Le user doit avoir un rdv_invitation_token assigné via la méthode assign_rdv_invitation_token et sauvegardé.
+
+dataset = [{
+  user: user1,
+  organisation: org_drome1,
+  motif: motif1_drome1,
+}, {
+  user: user2,
+  organisation: org_yonne,
+  motif: motif_yonne_physique,
+},]
+
+dataset.each do |data|
+  user = data[:user]
+  organisation = data[:organisation]
+  motif = data[:motif]
+
+  city_code = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:city_code]
+  street_ban_id = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:street_ban_id]
+  longitude, latitude = GeoCoding.new.find_geo_coordinates(user.address)
+  invitation_token = user.rdv_invitation_token
+  organisation_id = organisation.id
+  motif_category_short_name = motif.motif_category.short_name
+  address = user.address
+  departement = organisation.territory.departement_number
+
+  attributes = {
+    longitude: longitude,
+    latitude: latitude,
+    city_code: city_code,
+    street_ban_id: street_ban_id,
+    departement: departement,
+    address: address,
+    invitation_token: invitation_token,
+    organisation_ids: [organisation_id],
+    motif_category_short_name: motif_category_short_name
+  }
+  link = "#{ENV['HOST']}/prendre_rdv?#{attributes.to_query}"
+
+  # !!! Le lien d'invitation est disponible dans la note des users
+  # jean.rsavalence@testinvitation.fr et jean.rsaAuxerre@testinvitation.fr
+  user.update!(notes: link)
+end

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -305,7 +305,7 @@ dataset.each do |data|
     address: address,
     invitation_token: invitation_token,
     organisation_ids: [organisation_id],
-    motif_category_short_name: motif_category_short_name
+    motif_category_short_name: motif_category_short_name,
   }
   link = "#{ENV['HOST']}/prendre_rdv?#{attributes.to_query}"
 

--- a/docs/invitations.md
+++ b/docs/invitations.md
@@ -1,0 +1,35 @@
+# Tester les invitations depuis RDVSP
+
+Le code qui génére le lien d'invitation dans le service de RDVI `Invitations::ComputeLink` dédié est présent dans ce fichier https://github.com/betagouv/rdv-insertion/blob/9c03e5a6c720a88826e84ca854fd5ccb6135569a/app/services/invitations/compute_link.rb#L2
+
+Pour tester **depuis RDVSP** dans une console rails par exemple vous pouvez utiliser le code suivant.
+`user` doit avoir un `rdv_invitation_token` assigné via la méthode `assign_rdv_invitation_token` et être sauvegardé.
+Il doit faire parti de l'organisation.
+`organisation` doit avoir un `motif` avec une catégorie de motif, la valeur de `bookable_by` doit être `:agents_and_prescripteurs_and_invited_users` et des plages d'ouvertures doivent être créées pour le motif.
+
+```ruby
+city_code = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:city_code]
+street_ban_id = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:street_ban_id]
+longitude, latitude = GeoCoding.new.find_geo_coordinates(user.address)
+invitation_token = user.rdv_invitation_token
+organisation_id = organisation.id
+motif_category_short_name = motif.motif_category.short_name
+address = user.address
+departement = organisation.territory.departement_number
+
+attributes = {
+  longitude: longitude,
+  latitude: latitude,
+  city_code: city_code,
+  street_ban_id: street_ban_id,
+  departement: departement,
+  address: address,
+  invitation_token: invitation_token,
+  organisation_ids: [organisation_id],
+  motif_category_short_name: motif_category_short_name,
+  # Optionnel : lieu spécifique et referents
+  # lieu_id: 1
+  # referent_ids: [1, 2]
+}
+invitation_link = "#{ENV['HOST']}/prendre_rdv?#{attributes.to_query}"
+```


### PR DESCRIPTION
Suite à une demande d'Adrien j'ajoute cette petite documentation qui vous permettra de générer un lien d'invitation de facon autonome si vous en avez besoin.
