### PR TITLE
Mettre à jour le lien vers la cartographie des Conseillers Numériques

### DIFF
--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -3,7 +3,6 @@ section.bg-primary.p-4
     .d-flex.justify-content-center
       = link_to("https://cartographie.societenumerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
         | Consulter la carte des Conseillers numériques
-        .fa.fa-arrow-up-right-from-square.ml-1
 section
   .container
     .row.mt-4

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -2,7 +2,7 @@ section.bg-primary.p-4
   .container.mb-4
     .d-flex.justify-content-center
       = link_to("https://cartographie.societenumerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
-        | Consulter la carte des Conseillers numériques
+        | Consulter la carte des lieux d'inclusion numérique
 section
   .container
     .row.mt-4

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -1,7 +1,7 @@
 section.bg-primary.p-4
   .container.mb-4
     .d-flex.justify-content-center
-      = link_to("https://carte.conseiller-numerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
+      = link_to("https://cartographie.societenumerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
         | Consulter la carte des Conseillers numériques
         .fa.fa-arrow-up-right-from-square.ml-1
 section


### PR DESCRIPTION
Je viens de remarquer que le lien existant ne pointe vers aucun serveur web : 

https://carte.conseiller-numerique.gouv.fr/

Il semble que tout le domaine `conseiller-numerique.gouv.fr` soit down :

![2024-07-04_10-55](https://github.com/betagouv/rdv-service-public/assets/6357692/0b7cc56d-47e6-4fb7-8d12-db8cc7675ff7)

La carte et le parcours d'orientation semble désormais dispo ici : https://cartographie.societenumerique.gouv.fr/

Je mets donc à jour le lien. Faut-il aussi changer le texte du bouton ?