### PR TITLE
correction de la vue calendrier des plages d’ouvertures

### DIFF
--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -39,7 +39,7 @@
         data-agent-id="#{@agent.id}"
         data-organisation-id="#{@current_organisation.id}"
         data-display-saturdays="#{current_agent.display_saturdays}"
-        data-event-sources-json="#{[admin_agenda_plage_ouvertures_path(@agent, organisation_id: current_organisation.id, plages_ids: @plage_ouvertures.pluck(:id)), OffDays.to_full_calendar_array].to_json}"
+        data-event-sources-json="#{[admin_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, plages_ids: @plage_ouvertures.pluck(:id)), OffDays.to_full_calendar_array].to_json}"
       ]
     - else
       table.table


### PR DESCRIPTION
Closes #4407

# Contexte

L’erreur Sentry semblait pointer vers une `ActiveRecord::RecordNotFound` mais en fait il ne s’agit pas d’une 404.
Le chargement de la vue calendrier des plages d’ouvertures agents est complètement cassé. 

# Solution

Le problème vient d’un lien incorrect, le helper de route utilise le `@agent.id` comme paramètre positionnel alors que c’est un kwarg.

Avant de corriger ce problème j’introduis un test qui faile ce qui n’est pas si simple 😅 

- je passe un des tests E2E sur les plages d’ouvertures en `js: true`, puisqu’on a besoin de charger le calendrier fullcalendar pour voir l’erreur
- je suis obligé d’introduire une validation de contenu suite au clic sur le lien pour m’assurer que le chargement turbo de la page est effectivement fait, sinon la spec passe super vite sans charger le calendrier et voir l’erreur
- je dois aussi rajouter un wrapper `accept_confirm` autour du clic de suppression car sans JS pas de dialogue d’alerte
- enfin je dois inverser l’ordre de la sélection du motif et du lieu suite aux améliorations d’UX de ce formulaire : le select de lieu n’apparaît pas tant qu’un motif sur place n’est pas sélectionné

moralité : faire les tests E2E sans JS cache quand même pas mal d’erreurs qu’on peut rater :/ 
