### PR TITLE
Diminuer le bruit dans Sentry en évitant de logger les exceptions pour certains retry de jobs

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -38,7 +38,7 @@ module DefaultJobBehaviour
   private
 
   def log_failure_to_sentry?(_exception)
-    true
+    executions >= 4 || executions == MAX_ATTEMPTS
   end
 
   def sentry_fingerprint

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -38,7 +38,7 @@ module DefaultJobBehaviour
   private
 
   def log_failure_to_sentry?(_exception)
-    executions >= 4 || executions == MAX_ATTEMPTS
+    executions <= 4 || executions == MAX_ATTEMPTS
   end
 
   def sentry_fingerprint

--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -15,6 +15,6 @@ class SmsJob < ApplicationJob
   # Don't log first failures to Sentry, to prevent noise
   # on temporary unavailability of an external service.
   def log_failure_to_sentry?(_exception)
-    executions > 2
+    super && executions > 2
   end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -53,7 +53,7 @@ class WebhookJob < ApplicationJob
     # On veut seulement :
     # - un premier avertissement assez rapide s'il y a un problème (4e essai)
     # - une notification pour le dernier essai, avant que le job passe en "abandonnés"
-    executions == 4 || executions >= 10 || executions == MAX_ATTEMPTS
+    executions == 4 || executions == MAX_ATTEMPTS
   end
 
   def sentry_fingerprint

--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -16,6 +16,6 @@ class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
   # Don't log first failures to Sentry, to prevent noise
   # on temporary unavailability of an external service.
   def log_failure_to_sentry?(_exception)
-    executions > 2
+    super && executions > 2
   end
 end


### PR DESCRIPTION
C'est pas parfait, mais c'est mieux.

Suite à https://github.com/betagouv/rdv-service-public/pull/4382, @adipasquale fait remarquer à très juste titre qu'on a trop de bruit dans Sentry.
Tout le monde dans l'équipe technique est d'accord que c'est un problème, mais il semble qu'on n'a pas encore trouvé de réponse qui fait l'unanimité sur au moins deux questions :
- Est-ce que notre politique de retry n'est pas trop intense ? Il faudrait peut-être moins de retry, pendant moins longtemps, ou est-ce que au contraire c'est une manière pratique d'automatiser le retour à la normale quand un service externe est en panne pendant longtemps.
- Est-ce qu'il faut notifier Sentry dès la première exception, ou s'autoriser quelques exceptions en cas de timeout ou d'interruption de service très brève chez un partenaire ?

Pour ne pas répondre à toutes ces questions mais quand même diminuer le bruit, on commence dans cette PR par déjà se débarasser de toutes les notifications Sentry inutiles.

Autrement dit, au lieu de notifier Sentry à chaque retry, on notifie uniquement aux premiers retry, puis on arrête jusqu'au moment où le job est définitivement abandonné.
