### PR TITLE
Supprimer les colonnes inutilisées dans les versions PaperTrail : Étape 1

### DIFF
--- a/config/initializers/versions_tmp.rb
+++ b/config/initializers/versions_tmp.rb
@@ -1,0 +1,3 @@
+class PaperTrail::Version < ::ActiveRecord::Base
+  self.ignored_columns = %i[old_object old_object_changes]
+end


### PR DESCRIPTION
Ces colonnes TEXT contiennent les données historiques qui ont été migrées vers des colonnes JSON dans #3943.

Leur suppression permettra de gagner pas mal de place dans les dumps je pense. 

Ici la première étape d'une migration safe telle que décrite ici :
https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column