### PR TITLE
Suppression des colonnes `remember_created_at`

### DIFF
--- a/db/migrate/20240704145418_remove_user_and_agents_remember_created_at.rb
+++ b/db/migrate/20240704145418_remove_user_and_agents_remember_created_at.rb
@@ -1,0 +1,8 @@
+class RemoveUserAndAgentsRememberCreatedAt < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :users, :remember_created_at, :datetime
+      remove_column :agents, :remember_created_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_04_122706) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_04_145418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -199,7 +199,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_04_122706) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "confirmation_token"
@@ -695,7 +694,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_04_122706) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
Depuis #4241 nous n'utilisons plus le module `rememberable` de Devise, et ces colonnes ne sont donc plus utilisées.

Je prépare une PR pour supprimer les `self.ignored_columns` qui restent des migrations passées.