### PR TITLE
Supprimer les ignored_columns restant des migrations passées

### DIFF
--- a/app/lib/anonymizer/rules/rdv_service_public.rb
+++ b/app/lib/anonymizer/rules/rdv_service_public.rb
@@ -162,7 +162,7 @@ class Anonymizer::Rules::RdvServicePublic
     agent_roles: { non_anonymized_column_names: %w[access_level] },
     agents_rdvs: { non_anonymized_column_names: %w[outlook_id outlook_create_in_progress] },
     agent_territorial_access_rights: {
-      non_anonymized_column_names: %w[allow_to_manage_teams created_at updated_at allow_to_manage_access_rights allow_to_invite_agents allow_to_download_metrics],
+      non_anonymized_column_names: %w[allow_to_manage_teams created_at updated_at allow_to_manage_access_rights allow_to_invite_agents],
     },
     teams: { non_anonymized_column_names: %w[name created_at updated_at] },
     motifs: {

--- a/app/lib/anonymizer/rules/rdv_service_public.rb
+++ b/app/lib/anonymizer/rules/rdv_service_public.rb
@@ -31,7 +31,6 @@ class Anonymizer::Rules::RdvServicePublic
         confirmation_token
         reset_password_token
         invitation_token
-        remember_created_at
         rdv_invitation_token
       ],
       non_anonymized_column_names: %w[
@@ -60,7 +59,6 @@ class Anonymizer::Rules::RdvServicePublic
         tokens
         microsoft_graph_token
         refresh_microsoft_graph_token
-        remember_created_at
         inclusion_connect_open_id_sub
       ],
       non_anonymized_column_names: %w[

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,8 +1,6 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  self.ignored_columns = [:remember_created_at]
-
   # Mixins
   has_paper_trail(
     only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at]

--- a/app/models/agent_territorial_access_right.rb
+++ b/app/models/agent_territorial_access_right.rb
@@ -1,6 +1,4 @@
 class AgentTerritorialAccessRight < ApplicationRecord
-  self.ignored_columns = ["allow_to_download_metrics"]
-
   # Mixins
   has_paper_trail
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  self.ignored_columns = [:remember_created_at]
-
   # Mixins
   has_paper_trail(
     only: %w[

--- a/config/initializers/versions_tmp.rb
+++ b/config/initializers/versions_tmp.rb
@@ -1,3 +1,0 @@
-class PaperTrail::Version < ::ActiveRecord::Base
-  self.ignored_columns = %i[old_object old_object_changes]
-end


### PR DESCRIPTION
Ces colonnes sont maintenant supprimées de la base, on peut cesser de les ignorer explicitement au niveau des modèles. 

Pour rappel, il s'agit de la dernière étape de la procédure de suppression de colonne décrite ici : 
https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column

Au passage, j'ai supprimé ces colonnes de `app/lib/anonymizer/rules/rdv_service_public.rb`.