### PR TITLE
correction du layout des pages de présentation agents

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -15,7 +15,7 @@ class StaticPagesController < ApplicationController
   end
 
   def presentation_for_agents
-    render current_domain.presentation_for_agents_template_name
+    render current_domain.presentation_for_agents_template_name, layout: "application_base"
   end
 
   def microsoft_domain_verification

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -4,7 +4,7 @@ section.py-5.bg-primary
       .col-md-9.m-auto
         h1.text-white.mb-3 Faciliter la gestion des rendez-vous avec vos apprenants
         .mt-4= link_to "Connectez-vous", new_agent_session_path, class: "btn text-white btn-outline-white bg-primary"
-        p.mt-4
+        p.mt-4.text-white
           | RDV Aide Numérique est un outil de prise de rendez-vous en ligne,
             simplifiant votre organisation et rappelant aux usagers leurs rendez-vous.
 section.bg-white.py-5

--- a/app/views/static_pages/presentation_for_mairie.html.slim
+++ b/app/views/static_pages/presentation_for_mairie.html.slim
@@ -4,8 +4,8 @@ section.py-5.bg-primary
       .col-md-9.m-auto
         h1.text-white.mb-3 Faciliter la gestion des rendez-vous
         .mt-4= link_to "Connectez-vous", new_agent_session_path, class: "btn text-white btn-outline-white bg-primary"
-        p.mt-4
-            | RDV Mairie est un outil de prise de rendez-vous en ligne,
+        p.mt-4.text-white
+          | RDV Mairie est un outil de prise de rendez-vous en ligne,
                 simplifiant votre organisation et rappelant aux usagers leurs rendez-vous.
 section.bg-white.py-5
   .container

--- a/app/views/welcome/super_admin.html.slim
+++ b/app/views/welcome/super_admin.html.slim
@@ -1,14 +1,15 @@
-.row.justify-content-center
-  .col-3
-    = link_to "Accéder à superadmin", "/omniauth/github", class: "btn btn-primary", method: :post
-
-- if Rails.env.development?
-  .row.justify-content-center.mt-5
+.mb-3
+  .row.justify-content-center.pt-6
     .col-3
-      h5 Liens utiles
-      ul
-        li = link_to "Letter Opener", letter_opener_web_path
-        li = link_to "Mailer Previews", "/rails/mailers"
-        li = link_to "SMS Previews", "/lapin/sms_preview"
-        li = link_to "Routes", "/rails/info/routes"
-        li = link_to "Rails properties", "/rails/info/properties"
+      = link_to "Accéder à superadmin", "/omniauth/github", class: "btn btn-primary", method: :post
+
+  - if Rails.env.development?
+    .row.justify-content-center.mt-3
+      .col-3
+        h5 Liens utiles
+        ul
+          li = link_to "Letter Opener", letter_opener_web_path
+          li = link_to "Mailer Previews", "/rails/mailers"
+          li = link_to "SMS Previews", "/lapin/sms_preview"
+          li = link_to "Routes", "/rails/info/routes"
+          li = link_to "Rails properties", "/rails/info/properties"


### PR DESCRIPTION
J’avais raté la page presentation agents lors de l’introduction du nouveau layout 🤦 

je l’ai rajouté dans mon script pour faire des screenshots automatique.
Au passage j’ai commité ce script dans un gist, je ne sais pas trop où le mettre  https://gist.github.com/adipasquale/73a48555cbf0f023e8b834296a8d168f

avant|après
-|-
![image](https://github.com/betagouv/rdv-service-public/assets/883348/807c499a-c017-489f-b7e6-19e8b190c027) | ![image](https://github.com/betagouv/rdv-service-public/assets/883348/82bc372e-1a17-40a1-a9e5-15dddb233a34)


Jeu de screenshots complet : http://rdv-prod-2024-07-08.surge.sh/