### PR TITLE
Simplifier le code de fingerprinting Sentry dans les jobs

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -13,8 +13,6 @@ module DefaultJobBehaviour
         scope.set_context(:job, job_context)
         block.call
       rescue StandardError => e
-        # Setting the fingerprint after the error occurs, allow us to capture failure responses and error codes
-        scope.set_fingerprint(sentry_fingerprint) if sentry_fingerprint.present?
         Sentry.capture_exception(e) if log_failure_to_sentry?(e)
         raise # will be caught by the retry mechanism
       end
@@ -39,9 +37,5 @@ module DefaultJobBehaviour
 
   def log_failure_to_sentry?(_exception)
     executions <= 4 || executions == MAX_ATTEMPTS
-  end
-
-  def sentry_fingerprint
-    []
   end
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -27,7 +27,7 @@ class WebhookJob < ApplicationJob
 
     request.on_failure do |response|
       # Cela permet d'identifier singulièrement l'erreur selon l'URL et le code HTTP de la réponse
-      @sentry_event_fingerprint = ["OutgoingWebhookError", webhook_endpoint.target_url, response.code.to_s]
+      Sentry.get_current_scope.set_fingerprint(["OutgoingWebhookError", webhook_endpoint.target_url, response.code.to_s])
 
       if response.timed_out?
         raise OutgoingWebhookError, "HTTP Timeout, URL: #{webhook_endpoint.target_url}"
@@ -54,10 +54,6 @@ class WebhookJob < ApplicationJob
     # - un premier avertissement assez rapide s'il y a un problème (4e essai)
     # - une notification pour le dernier essai, avant que le job passe en "abandonnés"
     executions == 4 || executions == MAX_ATTEMPTS
-  end
-
-  def sentry_fingerprint
-    @sentry_event_fingerprint
   end
 
   # La réponse de la Drôme est en JSON


### PR DESCRIPTION
Pas besoin de stocker le fingerprint en variable d'instance du job pour y avoir accès à la fin de l'exécution : nous pouvons appeler directement `Sentry.get_current_scope.set_fingerprint(...)` qui stocke la valeur dans la `current_scope` Sentry qui est la même durant toute l'exécution du job, voir #4424.