### PR TITLE
Réparation du tableau sur la page "Politique de confidentialité"

### DIFF
--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -44,6 +44,10 @@ a[disabled] {
   text-align: right;
 }
 
+.rdv-white-space-nowrap {
+  white-space: nowrap;
+}
+
 // GRID
 
 .d-grid {
@@ -103,18 +107,6 @@ ul.horizontal-border-between-items {
   &:last-child {
     border-bottom: none;
   }
-}
-
-.text-bold {
-  font-weight: bold;
-}
-
-.text-underline {
-  text-decoration: underline;
-}
-
-.co-white-space-nowrap {
-  white-space: nowrap;
 }
 
 .hover-bg-light:hover {

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -105,6 +105,18 @@ ul.horizontal-border-between-items {
   }
 }
 
+.text-bold {
+  font-weight: bold;
+}
+
+.text-underline {
+  text-decoration: underline;
+}
+
+.co-white-space-nowrap {
+  white-space: nowrap;
+}
+
 .hover-bg-light:hover {
   background-color: $gray-200;
 }

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -152,7 +152,7 @@
 
     p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
 
-    .fr-table.fr-table--layout-fixed
+    .fr-table.co-white-space-nowrap
       table
         thead
           tr

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -152,7 +152,7 @@
 
     p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
 
-    .fr-table.co-white-space-nowrap
+    .fr-table.rdv-white-space-nowrap
       table
         thead
           tr

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -175,7 +175,7 @@
             td LinkMobility
             td Envoi de SMS
             td France
-            td = link_to "Protection des données Link Mobility", "https://linkmobility.fr/wp-content/uploads/sites/12/2021/05/Notice-dinformation-sur-la-protection-des-donnees-FR-31032021-1.pdf", target: "_blank", rel: "noopener"
+            td = link_to "Politique de confidentialité Link Mobility", "https://www.linkmobility.com/fr/legal/politique-de-confidentialite", target: "_blank", rel: "noopener"
 
     h3 Sécurité et confidentialité des données
 

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -165,17 +165,17 @@
             td Outscale SASU
             td Hébergement
             td France
-            td = link_to "CGV Outscale", "https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf", target: "_blank", rel: "noopener"
+            td = link_to "CGV Outscale", "https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf", target: "_blank"
           tr
             td Sendinblue
             td Envoi de mails
             td France
-            td = link_to "RGPD Brevo", "https://fr.sendinblue.com/rgpd/", target: "_blank", rel: "noopener"
+            td = link_to "RGPD Brevo", "https://fr.sendinblue.com/rgpd/", target: "_blank"
           tr
             td LinkMobility
             td Envoi de SMS
             td France
-            td = link_to "Politique de confidentialité Link Mobility", "https://www.linkmobility.com/fr/legal/politique-de-confidentialite", target: "_blank", rel: "noopener"
+            td = link_to "Politique de confidentialité Link Mobility", "https://www.linkmobility.com/fr/legal/politique-de-confidentialite", target: "_blank"
 
     h3 Sécurité et confidentialité des données
 

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -1,7 +1,7 @@
 - content_for :title, "Politique de confidentialité"
 
 .fr-grid-row
-  .fr-col-md-8
+  .fr-col-12.fr-col-md-8
     h2 Traitement des données à caractère personnel
 
     p La plateforme "RDV-Solidarités" est à l'initiative de l'Agence Nationale de la Cohésion des Territoires (ANCT), placé sous la tutelle des ministres chargés de l'aménagement du territoire, des collectivités territoriales et de la politique de la ville.

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -36,50 +36,51 @@
       li
         strong Cookies.
 
-      p La création du compte professionnel n'est ouverte qu'aux seuls agents et professionnels exerçant une mission de service public à vocation médico-sociale.
+    p La création du compte professionnel n'est ouverte qu'aux seuls agents et professionnels exerçant une mission de service public à vocation médico-sociale.
 
-      h3 Base juridique des traitements de données
+    h3 Base juridique des traitements de données
 
-      p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques :
+    p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques :
 
-      ul
-        li l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD ;
-        li la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD.
+    ul
+      li l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD ;
+      li la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD.
 
-      p Ces fondements sont précisés ci-dessous :
+    p Ces fondements sont précisés ci-dessous :
 
-      h4 a) Les données relatives au compte professionnel
-      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+    h4 a) Les données relatives au compte professionnel
+    p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-      h4 b) Les données relatives au compte usager
-      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+    h4 b) Les données relatives au compte usager
+    p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-      h4 c) Les données relatives à la fiche "Nouvel Usager" - Responsable
-      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+    h4 c) Les données relatives à la fiche "Nouvel Usager" - Responsable
+    p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-      h4 d) Les données relatives à la fiche "Nouvel Usager" - Proche
-      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+    h4 d) Les données relatives à la fiche "Nouvel Usager" - Proche
+    p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-      h4 e) Les données de localisation
-      p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+    h4 e) Les données de localisation
+    p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-      h4 f) Données d'hébergeur
-      p Ce traitement de données est nécessaire au respect d’une obligation légale à laquelle le responsable du traitement est soumis au sens de l’article 6-c du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+    h4 f) Données d'hébergeur
+    p Ce traitement de données est nécessaire au respect d’une obligation légale à laquelle le responsable du traitement est soumis au sens de l’article 6-c du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-      p L’obligation légale est posée par :
-      ul
-        li = link_to "la loi LCEN n°2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique ;", "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000801164/2020-10-26/"
-        li = link_to "les articles 1 et 3 du décret n°2021-1362 du 20 octobre 2021.", "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044228912"
+    p L’obligation légale est posée par :
+    ul
+      li = link_to "la loi LCEN n°2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique ;", "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000801164/2020-10-26/"
+      li = link_to "les articles 1 et 3 du décret n°2021-1362 du 20 octobre 2021.", "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044228912"
 
-      h4 g) Cookies
+    h4 g) Cookies
 
-      p Voir la partie sur les cookies ci-après.
+    p Voir la partie sur les cookies ci-après.
 
-      h2 Durée de conservation
+    h2 Durée de conservation
 
-      p Les données à caractère personnel sont conservées :
+    p Les données à caractère personnel sont conservées :
 
-      table.table
+    .fr-table
+      table
         thead
           tr
             th Types de données
@@ -107,51 +108,52 @@
             td Cookies
             td 13 mois.
 
-      p L'inactivité d'un usager se mesure sur la date du dernier RDV pris.
+    p L'inactivité d'un usager se mesure sur la date du dernier RDV pris.
 
-      h3 Droit des personnes concernées
+    h3 Droit des personnes concernées
 
-      p Vous disposez des droits suivants concernant vos données à caractère personnel :
+    p Vous disposez des droits suivants concernant vos données à caractère personnel :
 
-      ul
-        li Droit d’information ;
-        li Droit d’accès aux données ;
-        li Droit de rectification ;
-        li Droit de suppression des données.
+    ul
+      li Droit d’information ;
+      li Droit d’accès aux données ;
+      li Droit de rectification ;
+      li Droit de suppression des données.
 
-      p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
+    p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
 
-      strong = mail_to current_domain.support_email
+    strong = mail_to current_domain.support_email
 
-      p ou par voie postale :
+    p ou par voie postale :
 
-      p Agence nationale de la cohésion des territoires
-      br
-      | 20, avenue de Ségur
-      br
-      | TSA 10717
-      br
-      | 75 334 Paris Cedex 07
+    p Agence nationale de la cohésion des territoires
+    br
+    | 20, avenue de Ségur
+    br
+    | TSA 10717
+    br
+    | 75 334 Paris Cedex 07
 
-      p En raison de l’obligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici
-      = link_to "https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces"
-      span> , un modèle de courrier élaboré par la Cnil.
+    p En raison de l’obligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici
+    = link_to "https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces"
+    span> , un modèle de courrier élaboré par la Cnil.
 
-      p Nous nous engageons à ne jamais céder ces informations à des tiers.
+    p Nous nous engageons à ne jamais céder ces informations à des tiers.
 
-      h3 Délais de réponse
+    h3 Délais de réponse
 
-      p Le responsable de traitement s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
+    p Le responsable de traitement s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
 
-      h3 Destinataires des données
+    h3 Destinataires des données
 
-      p Le responsable de traitement s'engage à ce que les données à caractères personnels soient traitées par les seules personnes autorisées.
+    p Le responsable de traitement s'engage à ce que les données à caractères personnels soient traitées par les seules personnes autorisées.
 
-      h3 Sous-traitants
+    h3 Sous-traitants
 
-      p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
+    p Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, d’usage et de protection des données.
 
-      table.table
+    .fr-table.fr-table--layout-fixed
+      table
         thead
           tr
             th Partenaire
@@ -163,50 +165,50 @@
             td Outscale SASU
             td Hébergement
             td France
-            td = link_to "​​​​https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf"
+            td = link_to "CGV Outscale", "https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf", target: "_blank", rel: "noopener"
           tr
             td Sendinblue
             td Envoi de mails
             td France
-            td = link_to "https://fr.sendinblue.com/rgpd/"
+            td = link_to "RGPD Brevo", "https://fr.sendinblue.com/rgpd/", target: "_blank", rel: "noopener"
           tr
             td LinkMobility
             td Envoi de SMS
             td France
-            td = link_to "https://linkmobility.fr/wp-content/uploads/sites/12/2021/05/Notice-dinformation-sur-la-protection-des-donnees-FR-31032021-1.pdf"
+            td = link_to "Protection des données Link Mobility", "https://linkmobility.fr/wp-content/uploads/sites/12/2021/05/Notice-dinformation-sur-la-protection-des-donnees-FR-31032021-1.pdf", target: "_blank", rel: "noopener"
 
-      h3 Sécurité et confidentialité des données
+    h3 Sécurité et confidentialité des données
 
-      p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment :
-      ul
-        li Pare feu système.
-        li Pare feu applicatif (WAF).
-        li Chiffrement des flux réseaux via certificat SSL.
-        li Disque dur chiffré.
-        li Services isolés dans des containers.
-        li Gestion des journaux.
-        li Administration et monitoring centralisés des accès.
-        li Accès aux ressources via clés SSH (pas de mot de passe post installation).
-        li Accès aux données réservé aux membres de l'entité (hors restitution applicative publique des données).
-        li Accès aux données uniquement via un outil d'édition sécurisé (SSL + mot de passe) avec utilisation de comptes nominatifs.
-        li Hébergeur de données de santé.
+    p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment :
+    ul
+      li Pare feu système.
+      li Pare feu applicatif (WAF).
+      li Chiffrement des flux réseaux via certificat SSL.
+      li Disque dur chiffré.
+      li Services isolés dans des containers.
+      li Gestion des journaux.
+      li Administration et monitoring centralisés des accès.
+      li Accès aux ressources via clés SSH (pas de mot de passe post installation).
+      li Accès aux données réservé aux membres de l'entité (hors restitution applicative publique des données).
+      li Accès aux données uniquement via un outil d'édition sécurisé (SSL + mot de passe) avec utilisation de comptes nominatifs.
+      li Hébergeur de données de santé.
 
-      h2#cookies Utilisation de témoins de connexion (« cookies »)
+    h2#cookies Utilisation de témoins de connexion (« cookies »)
 
-      p Les cookies utilisés sur RDV-Solidarités ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet.
-      p RDV-Solidarités utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
+    p Les cookies utilisés sur RDV-Solidarités ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet.
+    p RDV-Solidarités utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
 
-      p RDV-Solidarités n'utilise aucun cookies dits "tiers".
+    p RDV-Solidarités n'utilise aucun cookies dits "tiers".
 
-      p Il convient d'indiquer que :
-      ul
-        li Les données collectées ne sont pas recoupées avec d’autres traitements.
-        li Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
+    p Il convient d'indiquer que :
+    ul
+      li Les données collectées ne sont pas recoupées avec d’autres traitements.
+      li Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
 
-      p À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+    p À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
 
-      p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
+    p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
 
-      ul
-        li = link_to "Cookies & traceurs : que dit la loi ?", "https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
-        li = link_to "Cookies : les outils pour les maîtriser", "https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"
+    ul
+      li = link_to "Cookies & traceurs : que dit la loi ?", "https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
+      li = link_to "Cookies : les outils pour les maîtriser", "https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"


### PR DESCRIPTION
> [!TIP]
> je recommande d’activer l’option « Hide Whitespace » sur GH pour relire la PR, il y a un changement d’indentation

## Contexte

Le tableau des sous-traitants sur la page Politique de confidentialité fait déborder le viewport horizontalement


Aussi les liens n’ont pas de description textuelle, ce qui les rend durs à lire

enfin le lien vers Link Mobility renvoie maintenant vers la home

## Solution

J’ai d’abord corrigé l’indentation du contenu de la page

Puis j’ai utilisé les classes `.fr-table` du DSFR :

avant|après
-|-
![Screen Shot 2024-07-22 at 16 23 09](https://github.com/user-attachments/assets/ca993c8e-5fe7-440a-bbe1-05dd07019da4) | ![Screen Shot 2024-07-22 at 16 23 14](https://github.com/user-attachments/assets/293e92bf-42f5-4fe2-9ff7-4fc1dba6d334)




Le tableau est scrollable horizontalement vers la droite.
J’ai du réparer la classe manquante au niveau le plus haut pour atteindre le bon comportement : `.fr-col-md-8` ne marche pas bien tout seul, il faut faire`.fr-col-12.fr-col-md-8`·
Je ferai une autre PR où j’essaierai de corriger la plupart des usages des classes responsive sans le défaut.

Je me demande si on ne devrait pas tout simplement écrire ça textuellement en listes, ça n’est pas super utilisable ces tableaux.

J’ai utilisé une nouvelle claasse utility pour éviter que le texte ne wrappe sinon le rendu était encore plus bizarre.

J’ai corrigé le lien de Link Mobility vers leur page [Politique de confidentialité](https://www.linkmobility.com/fr/legal/politique-de-confidentialite)

## Review App

https://demo-rdv-solidarites-pr4425.osc-secnum-fr1.scalingo.io/politique_de_confidentialite
