### PR TITLE
[Vigie] Fournir un lien vers la page GoodJob d'un job depuis Sentry

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -39,11 +39,9 @@ module DefaultJobBehaviour
   end
 
   def job_link
-    @job_link ||= GoodJob::Engine.routes.url_helpers.job_url(id: job_id, host: Domain::RDV_SOLIDARITES.host_name)
-  end
-
-  def domain
     server_name = Sentry::Configuration.new.server_name
-    server_name.match?(/rdv-mairie/) ? Domain::RDV_MAIRIE : Domain::RDV_SOLIDARITES
+    good_job_domain = server_name.match?(/rdv-mairie/) ? Domain::RDV_MAIRIE : Domain::RDV_SOLIDARITES
+
+    GoodJob::Engine.routes.url_helpers.job_url(id: job_id, host: good_job_domain.host_name)
   end
 end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -39,8 +39,7 @@ module DefaultJobBehaviour
   end
 
   def job_link
-    server_name = Sentry::Configuration.new.server_name
-    good_job_domain = server_name.match?(/rdv-mairie/) ? Domain::RDV_MAIRIE : Domain::RDV_SOLIDARITES
+    good_job_domain = ENV["APP"]&.match?(/rdv-mairie/) ? Domain::RDV_MAIRIE : Domain::RDV_SOLIDARITES
 
     GoodJob::Engine.routes.url_helpers.job_url(id: job_id, host: good_job_domain.host_name)
   end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -39,7 +39,7 @@ module DefaultJobBehaviour
   end
 
   def job_link
-    @job_link ||= "https://#{domain.host_name}/super_admins/good_job/jobs/#{job_id}"
+    @job_link ||= GoodJob::Engine.routes.url_helpers.job_url(id: job_id, host: Domain::RDV_SOLIDARITES.host_name)
   end
 
   def domain

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe ApplicationJob, type: :job do
       expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
       expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
       expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { _some_kw_arg: 456 }])
+      expect(sentry_events.last.contexts[:job][:job_link]).to match("/super_admins/good_job/jobs/#{enqueued_job_id}")
+      expect(sentry_events.last.tags[:job_link]).to match("/super_admins/good_job/jobs/#{enqueued_job_id}")
 
       expect(sentry_events.last.exception.values.first.value).to match("Something unexpected happened (RuntimeError)")
       expect(sentry_events.last.exception.values.first.type).to eq("RuntimeError")


### PR DESCRIPTION
# Fournir un lien vers la page GoodJob d'un job, depuis une page d'erreur Sentry

## Contexte
Cette PR fait suite à une proposition lors du point tech du 27 Juillet dernier.
Le but est de faciliter la vigie, notamment l'investigation des erreurs de jobs qui échouent ; en réduisant le temps d'aller-retour Sentry -> GoodJob.

Le processus actuel est: 
- Copier l'ID du job depuis Sentry
- Se rendre sur GoodJob
- Effectuer une recherche à l'aide de l'ID du job ou manuellement composer l'URL directe pour la page du job

Ces 3 étapes se résument désormais en un seul clic.

## Solution
Erreur de test: https://sentry.incubateur.net/organizations/betagouv/issues/110078/events/741382f894694ef1870e07e82c58462d/
### Tag Sentry
Le Tag nous permet d'avoir le lien en début de page:

<img width="851" alt="Screenshot 2024-07-10 at 07 43 11" src="https://github.com/betagouv/rdv-service-public/assets/11911945/814baa16-7809-40bc-93e2-42b99133c94d">

### Contexte Sentry
Le contexte nous permet d'avoir une version un peu plus structurée:

<img width="853" alt="Screenshot 2024-07-10 at 07 46 02" src="https://github.com/betagouv/rdv-service-public/assets/11911945/8ddf59e6-c81a-44f8-b0e6-5f60a050431c">

PS: Il faut cliquer sur la flèche tout à droite, pour être redirigé.


# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [X] Préparer des captures de l’interface avant et après
