### PR TITLE
Devtools perfs - Ne pas require les linters au chargement de l'app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,9 +173,9 @@ group :development do
   # Mettre à jour la version de cette gem lorsqu'on met à jour Ruby (version actuelle : 3.3.3)
   gem "parser", "3.3.3.0", require: false
   # Code style checking for RSpec files
-  gem "rubocop-rspec", "2.7.0"
+  gem "rubocop-rspec", "2.7.0", require: false
   # Automatic Rails code style checking tool.
-  gem "rubocop-rails", "2.13.1"
+  gem "rubocop-rails", "2.13.1", require: false
   # Slim template linting tool
   gem "slim_lint", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -195,7 +195,7 @@ group :development do
   # Other
 
   # Manage Procfile-based applications
-  gem "foreman"
+  gem "foreman", require: false
   # Gives letter_opener an interface for browsing sent emails
   gem "letter_opener_web" # Saves sent emails and serves them on /letter_opener
   # Entity-relationship diagram for your Rails models.

--- a/Gemfile
+++ b/Gemfile
@@ -199,7 +199,7 @@ group :development do
   # Gives letter_opener an interface for browsing sent emails
   gem "letter_opener_web" # Saves sent emails and serves them on /letter_opener
   # Entity-relationship diagram for your Rails models.
-  gem "rails-erd" # Keeps docs/domain_model.svg up-to-date. See .erdconfig
+  gem "rails-erd", require: false # Keeps docs/domain_model.svg up-to-date. See .erdconfig
 end
 
 group :test do

--- a/docs/4-notes-techniques.md
+++ b/docs/4-notes-techniques.md
@@ -50,7 +50,7 @@ Pour tester les migrations avec les données de prod, il faut récupérer un bac
 
 Il est recommandé de lancer le serveur local sans le worker sinon il y aura beaucoup de jobs de reminders et de simulations d'envois de mails :
 
-`foreman start -f Procfile.dev  web=1,webpack=1`
+`foreman start -f Procfile.dev  web=1,js=1`
 
 ## Export Excel sectorisation
 


### PR DESCRIPTION
Je regardais [ce talk](https://www.youtube.com/watch?v=9-PWz9nbrT8) de Ben Sheldon[^1] (auteur de GoodJob et ingénieur à GitHub), et il y parle des outils mis à disposition par Rails pour charger uniquement le code nécessaire et pas plus. Il y évoque les méthodes pour permettre de ne charger au démarrage que la configuration mais pas les comportements. En effet, lancer le serveur rapidement permet d'avoir une boucle de feedback plus rapide et un meilleur confort de dev.

Cela m'a incité à lancer un flamegraph sur notre boot d'app, et j'ai remarqué que l'on chargeait rubocop, ce qui est inutile (on appelle jamais rubocop depuis notre appli) et ralentit le chargement de l'app.

On passe sur ma machine de ~1500-1700 ms à ~1100-1200 ms pour lancer

```
time rails runner "puts 'coucou'"
```

C'est pas si énorme mais ça ne coûtait pas cher.

[^1]: https://github.com/bensheldon