### PR TITLE
nettoyage des utility classes CSS 

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -25,6 +25,7 @@
 @import "./components/lieux";
 @import "./components/alert";
 @import "./components/select2";
+@import "./components/button_group_before_card";
 
 // Structure
 @import "./structure/general";

--- a/app/javascript/stylesheets/application_agent_config.scss
+++ b/app/javascript/stylesheets/application_agent_config.scss
@@ -19,7 +19,6 @@
 @import "./components/forms";
 @import "./components/cards";
 @import "./components/utilities";
-@import "./components/steps";
 @import "./components/autocomplete";
 @import "./components/rdv_status";
 @import "./components/rdv_solidarites_instance_name";

--- a/app/javascript/stylesheets/components/_backgrounds.scss
+++ b/app/javascript/stylesheets/components/_backgrounds.scss
@@ -10,19 +10,6 @@
   background-color: #F4F6FE;
 }
 
-.bg-dark {
-  color: white;
-  button {
-    color: white;
-  }
-}
-@include media-breakpoint-down(sm) {
-  .bg-dark {
-    background: $bg-leftbar !important;
-  }
-}
-
-
 .bg-primary {
   background-color: $primary !important;
 }

--- a/app/javascript/stylesheets/components/_button_group_before_card.scss
+++ b/app/javascript/stylesheets/components/_button_group_before_card.scss
@@ -1,0 +1,10 @@
+.rdv-button-group-before-card {
+  display: flex;
+  flex-wrap: wrap-reverse;
+  justify-content: center;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    justify-content: space-between;
+  }
+}

--- a/app/javascript/stylesheets/components/_steps.scss
+++ b/app/javascript/stylesheets/components/_steps.scss
@@ -91,16 +91,3 @@
         opacity: 0;
     }
 }
-
-@include media-breakpoint-down(sm) {
-    .horizontal-steps {
-
-        .horizontal-steps-content {
-            .step-item {
-                span {
-                    white-space: inherit;
-                }
-            }
-        }
-    }
-}

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -2,14 +2,22 @@
   background: rgba(255, 255, 255, .9);
 }
 
+// DISPLAY & VISIBILITY
+
+.hidden {
+  display: none;
+}
+
+.inline {
+  display: inline;
+}
+
 .translucent {
   opacity: 0.5;
   pointer-events: none;
 }
 
-.hidden {
-  display: none;
-}
+// TEXT
 
 .strikethrough {
   text-decoration: line-through;
@@ -24,6 +32,16 @@ a[disabled] {
   word-break: break-all;
 }
 
+.text-bold {
+  font-weight: bold;
+}
+
+.text-underline {
+  text-decoration: underline;
+}
+
+// GRID
+
 .d-grid {
   display: grid;
 }
@@ -37,6 +55,8 @@ a[disabled] {
   grid-column-start: 2;
 }
 
+// FLEX
+
 .flex-gap-1em {
   gap: 0 1em;
 }
@@ -44,6 +64,15 @@ a[disabled] {
 .flex-v-gap-1em {
   gap: 1em 0;
 }
+
+.flex-row-aligned {
+  display: flex;
+  flex-direction: row;
+  align-items: first baseline;
+  gap: 0.5em;
+}
+
+// OTHER
 
 ul.horizontal-border-between-items {
   li {
@@ -62,47 +91,10 @@ ul.horizontal-border-between-items {
   }
 }
 
-.text-bold {
-  font-weight: bold;
-}
-
-.text-underline {
-  text-decoration: underline;
-}
-
 .hover-bg-light:hover {
   background-color: $gray-200;
 }
 
 .no-transition {
   transition: none !important;
-}
-
-.flex-row-aligned {
-  display: flex;
-  flex-direction: row;
-  align-items: first baseline;
-  gap: 0.5em;
-}
-
-.inline {
-  display: inline;
-}
-
-.flex-direction-col-sm-row-reverse-md {
-  display: flex;
-  flex-direction: column;
-  @include media-breakpoint-up(md) {
-    flex-direction: row-reverse;
-  }
-  justify-content: space-between;
-  align-items: center;
-
-  a:last-child {
-    margin-top: 1rem;
-    @include media-breakpoint-up(md) {
-      margin-top: 0;
-      margin-right: 1rem;
-    }
-  }
 }

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -1,12 +1,12 @@
 .row.mt-3.justify-content-center
   .col-md-6
     h1.text-dark.mb-3 Vos rendez-vous
-    .mb-3.flex-direction-col-sm-row-reverse-md
-      = render "prendre_rdv_button"
+    .rdv-button-group-before-card.mb-3
       - if params[:past].present?
         = link_to "Voir vos prochains RDV", users_rdvs_path, class: "btn btn-outline-primary"
       - else
         = link_to "Voir vos RDV passés", users_rdvs_path(past: true), class: "btn btn-outline-primary"
+      = render "prendre_rdv_button"
 
     - if @rdvs.any?
           - @rdvs.each do |rdv|


### PR DESCRIPTION
## Contexte

PR extraite de #4349 

J’ai extrait ici quelques refactors sans impact visuels et nettoyage de code mort.

## Description des changements

Certains changements sont décrits avec des commentaires GitHub.

### Réorganisation du fichier `utilities.css`

Je mets un peu de propre et regroupe les utilities similaires dans ce fichier appelé à grossir un peu en vue de la sortie de bootstrap côté usagers.

### nouveau composant `rdv-button-group-before-card `

Aujourd’hui il y a une classe `flex-direction-col-sm-row-reverse-md` utilisée à un seul endroit pour avoir ce comportement : 

<img width="929" alt="SCR-20240710-nktn" src="https://github.com/betagouv/rdv-service-public/assets/883348/367c628a-5b30-4e1e-b05e-7200dfa5e869">

(à gauche desktop, à droite mobile)

J’ai décidé que ce n’était pas une utility class, donc je l’ai extraite et renommée.

J’ai aussi un peu simplifié son implémentation car je n’ai pas pu m’empêcher. 
Suite à mon changement d’implém j’ai du changer l’ordre initial dans le DOM.
