### PR TITLE
aligner à droite le bouton de confirmation RDV

### DIFF
--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -70,6 +70,10 @@ ul.horizontal-border-between-items {
   text-decoration: underline;
 }
 
+.rdv-text-align-right {
+  text-align: right;
+}
+
 .hover-bg-light:hover {
   background-color: $gray-200;
 }

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -5,8 +5,7 @@
     h3.text-center.mb-3 Confirmation
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
-      .card-body
-        .col.text-center
+      .card-body.rdv-text-align-right
         - if @rdv_wizard.rdv.collectif?
           = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary"
         - else


### PR DESCRIPTION
## Contexte

Le bouton confirmer mon RDV de l’étape finale de prise de RDV usagers est aligné à gauche alors que les boutons précédents sont alignés à droite.

## Solution

Aligner à droite ! 

<img width="1497" alt="image" src="https://github.com/betagouv/rdv-service-public/assets/883348/cab389f5-52a7-4bfe-bdf1-3e211c3da0b2">

dédicace à Téo ! 