### PR TITLE
Afficher le territoire sur la page d'orga du super-admin

### DIFF
--- a/app/dashboards/organisation_dashboard.rb
+++ b/app/dashboards/organisation_dashboard.rb
@@ -39,6 +39,7 @@ class OrganisationDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     name
+    territory
     horaires
     phone_number
     agent_roles

--- a/config/locales/models/organisation.fr.yml
+++ b/config/locales/models/organisation.fr.yml
@@ -8,3 +8,4 @@ fr:
         email: Email
         website: Site web
         horaires: Horaires
+        territory: Territoire


### PR DESCRIPTION
Demande simple : https://mattermost.incubateur.net/betagouv/pl/feq3fm5u5bdxdphuiuoxjtsz4r *

> Hello, 
> 
> Lors de notre investigation hier avec @francois.ferrandis , je trouvais utile d'avoir dans superadmin le nom du territoire sur la partie organisation. 
> 
> **JTBD : Lors d'une investigation, savoir rapidement le territoire auquel est rattaché l'orga que j'investigue.**
> 
> Aujourd'hui pour le voir, je dois cliquer sur éditer.
> 
> Si ca vous va et que ca ne pose pas d'autres implications.

et implémentation encore plus simple, merci Administrate.