### PR TITLE
Correction des credentials github dans .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,8 +25,8 @@ SKYLIGHT_DISABLE_DEV_WARNING=true
 
 # Third-party authentication services
 ## Github (SuperAdmins)
-GITHUB_APP_ID=bcc6effe435bfcb0388f
-GITHUB_APP_SECRET="créer un nouveau secret sur https://github.com/organizations/rdv-solidarites/settings/applications/1069209"
+GITHUB_APP_ID=Iv1.cc0b69b918187eb4
+GITHUB_APP_SECRET="créer un nouveau secret sur https://github.com/organizations/rdv-solidarites/settings/apps/demos-rdv-sp-superadmin-auth"
 ## FranceConnect (Users)
 FRANCECONNECT_APP_ID=change_me
 FRANCECONNECT_APP_SECRET=change_me


### PR DESCRIPTION
Lors du point tech d'hier, on a fait le ménage dans les anciennes oauth apps qui permettaient la connexion au super admin.
Cette PR met à jour le client ID utilisé en local et la consigne pour générer un nouveau secret pour un nouveau setup de dev.