### PR TITLE
Correctif du calcul de créneau s'il y a une absence pendant un rdv

### DIFF
--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -30,12 +30,11 @@ module SlotBuilder
 
     def calculate_free_times(plage_ouverture, datetime_range)
       ranges = ranges_for(plage_ouverture, datetime_range)
-      should_debug = datetime_range.first >= Date.new(2024, 8, 21) && plage_ouverture.id == 1008
       return [] if ranges.empty?
 
       ranges.flat_map do |range|
         busy_times = BusyTime.busy_times_for(range, plage_ouverture)
-        split_range_recursively(range, busy_times, debug: (range == ranges.second && should_debug))
+        split_range_recursively(range, busy_times)
       end
     end
 
@@ -50,32 +49,14 @@ module SlotBuilder
     end
 
     # On enlève les intervalles occupés d'un morceau de plage d'ouverture
-    def split_range_recursively(range, busy_times, debug: false)
+    def split_range_recursively(range, busy_times)
       return [] if range.nil?
       return [range] if busy_times.empty?
 
-      # raise "coucou" if debug
-      # require "byebug"
-      # byebug if debug
-
       busy_time = busy_times.first
-      #
-      # if debug
-      #   puts "BUSY TIMES : #{busy_times}"
-      #   puts "FIRST_RANGE: #{first_range(range, busy_time)}"
-      #
-      #   puts "RANGE: #{range}"
-      #   puts "BUSY TIME: #{busy_time}"
-      #   puts "REMAINING_RANGE: #{remaining_range(range, busy_time)}"
-      #
-      #   if range.first.to_date == Date.new(2024, 8, 27)
-      #     require "byebug"
-      #     byebug
-      #   end
-      # end
 
       first_range(range, busy_time) \
-        + split_range_recursively(remaining_range(range, busy_time), busy_times - [busy_time], debug: debug)
+        + split_range_recursively(remaining_range(range, busy_time), busy_times - [busy_time])
     end
 
     def first_range(range, busy_time)

--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -5,7 +5,6 @@ module SlotBuilder
       datetime_range = Lapin::Range.ensure_date_range_with_time(date_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)
       free_times_po = free_times_from(plage_ouvertures, datetime_range) # dépendances implicite à Rdv, Absence et OffDays
-
       slots_for(free_times_po, motif)
     end
 
@@ -24,7 +23,6 @@ module SlotBuilder
       plage_ouvertures.each do |plage_ouverture|
         free_times[plage_ouverture] = calculate_free_times(plage_ouverture, datetime_range)
       end
-
       free_times.select { |_, v| v&.any? }
     end
 


### PR DESCRIPTION
# Contexte

Ticket de vigie : https://www.notion.so/rdvs/Vigie-33a095eff8f24bdd8c23d54ac2cff659?p=fc31879ed91440149a7bdc2c57f0de2f&pm=s
zammad : https://zammad10.ethibox.fr/#ticket/zoom/14875

En résumé, notre calcul de créneau n'arrivait pas à trouver les créneaux de 15mn qui seraient normalement disponibles dans ce cas là : 

<img width="323" alt="Screenshot 2024-07-12 at 11 30 06" src="https://github.com/user-attachments/assets/45d4f199-f6e8-4e2e-b7d4-92c94c58048e">




# Diagnostic

Il y avait un bug sur le calcul de créneaux dans le cas où il y a une absence pendant un rdv : on ne traitait pas ce cas dans la méthode `SlotBuilder.remaining_range`, ce qui faisait qu'on renvoyait un remaining_range vide après avoir essayé d'enlever l'absence du temps restant, donc on ignorait tout le reste du range.

# Solution

On traite maintenant ce cas dans la méthode, et on renvoie tout le range s'il n'a pas d'intersection avec le busy_time

La spec se fait au niveau de la méthode publique de SlotBuilder.

On remarquera que c'est bizarre qu'il y ai une absence pendant un rdv, et je me demande si c'est pas un signe que les rallongement automatique de la durée des rdv pour les titres sécurisés pour plusieurs personnes n'a pas un bug. Ça me dit quelque chose, et c'est possible que ce bug ai été résolu depuis, mais qu'on a quand même eu des données invalides pendant qu'il existait.

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après
