### PR TITLE
Permettre aux secrétaires qui ont aussi un autre service d'assurer des rdv de leur service

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -93,11 +93,13 @@ class Motif < ApplicationRecord
   scope :available_motifs_for_organisation_and_agent, lambda { |organisation, agent|
     available_motifs = if agent.admin_in_organisation?(organisation)
                          all
-                       elsif agent.secretaire?
-                         for_secretariat
                        else
                          where(service: agent.services)
                        end
+
+    if agent.secretaire?
+      available_motifs = available_motifs.or(for_secretariat)
+    end
     available_motifs.where(organisation_id: organisation.id).active.ordered_by_name
   }
   # This should match the implementation of #name_with_location_type

--- a/spec/models/motif_spec.rb
+++ b/spec/models/motif_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Motif, type: :model do
       let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }
 
       it { is_expected.to contain_exactly(motif3) }
+
+      context "when the agent is also part of another service" do
+        before do
+          agent.services << service
+        end
+
+        it { is_expected.to contain_exactly(motif, motif2, motif3) }
+      end
     end
 
     describe "for other service" do


### PR DESCRIPTION
# Contexte

Maintenant qu'on permet aux agents d'avoir plusieurs services, on a des cas où des agents ont "Secrétariat" et un autre service. On peut imaginer par exemple quelqu'un qui travaille pour la PMI et qui fait un peu de travail de secrétariat en plus, et qui aura donc ces deux services.

Dans le cadre de ce ticket de vigie (https://www.notion.so/rdvs/Vigie-33a095eff8f24bdd8c23d54ac2cff659?p=48cfda00dd504c9eb2f7b7ea484caa82&pm=s), on a ce cas de figure, et un bug qui fait que la personne concernée ne peut pas ajouter de rdv de son service à son agenda.

# Solution

On corrige le bug en additionnant les rdv de secrétariat aux rdvs que peut faire l'agent, plutôt qu'en les remplaçant.
Au passage, je ne suis pas sûr que ça ai du sens métier d'autoriser les admins à assurer des rdv de n'importe quel autre service, mais c'est une question pour un autre jour.

