### PR TITLE
Revert "Correctif du calcul de créneau s'il y a une absence pendant un rdv"

### DIFF
--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -46,7 +46,6 @@ module SlotBuilder
       end.compact
     end
 
-    # On enlève les intervalles occupés d'un morceau de plage d'ouverture
     def split_range_recursively(range, busy_times)
       return [] if range.nil?
       return [range] if busy_times.empty?
@@ -67,8 +66,6 @@ module SlotBuilder
       return busy_time.ends_at..range.end if range.cover?(busy_time.range)
       return range.begin..busy_time.starts_at if range.cover?(busy_time.starts_at)
       return busy_time.ends_at..range.end if range.cover?(busy_time.ends_at)
-
-      return range if (busy_time.ends_at < range.begin) || (busy_time.starts_at > range.end) # Dans ce dernier cas il n'y a pas d'overlap du tout entre le range et le busy_time
     end
 
     def slots_for(plage_ouverture_free_times, motif)

--- a/spec/services/slot_builder_spec.rb
+++ b/spec/services/slot_builder_spec.rb
@@ -84,22 +84,6 @@ RSpec.describe SlotBuilder, type: :service do
                                                       ])
       end
     end
-
-    context "when there is an absence and a rdv overlapping at the beginning of the plage ouverture" do
-      # Une plage d'ouverture de 9h à 11h,
-      # Un rdv de 9h à 10h
-      # Une absence de 9h15 à 9h45 (par exemple une absence récurrente créée après le rdv, où on suppose que l'agent accepte de faire une exception)
-      before do
-        plage_ouverture = create(:plage_ouverture, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), lieu: lieu)
-        create(:rdv, agents: [plage_ouverture.agent], motif: motif, starts_at: Time.zone.local(2021, 5, 3, 9, 0, 0), duration_in_min: 60)
-        create(:absence, agent: plage_ouverture.agent, first_day: first_day, end_day: first_day, start_time: Tod::TimeOfDay.new(9, 15), end_time: Tod::TimeOfDay.new(9, 45))
-      end
-
-      it "returns the slots in the free part of the plage ouverture" do
-        slots = described_class.available_slots(motif, lieu, date_range)
-        expect(slots.map(&:starts_at).map(&:hour)).to eq([10])
-      end
-    end
   end
 
   describe "#plage_ouvertures_for" do


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#4441

Ce changement a entraîné un crash lorsqu'un usager essayer de déplacer un RDV : 
https://sentry.incubateur.net/organizations/betagouv/issues/110923