### PR TITLE
Mieux gérer les erreurs de Microsoft Graph Token

### DIFF
--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -73,5 +73,14 @@ module Outlook
     def api_client
       @api_client ||= Outlook::ApiClient.new(@agent)
     end
+
+    def log_failure_to_sentry?(exception)
+      # Cette erreur se produit parfois à la première exécution, puis le job passe au retry.
+      if exception.is_a?(Outlook::ApiClient::RefreshTokenError)
+        executions > 4
+      else
+        super
+      end
+    end
   end
 end

--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -3,6 +3,7 @@ module Outlook
     class ApiError < StandardError; end
     class NotFoundError < ApiError; end
     class AlreadyExistsError < ApiError; end
+    class RefreshTokenError < ApiError; end
 
     def initialize(agent)
       @agent = agent
@@ -89,7 +90,7 @@ module Outlook
       refresh_token_response = JSON.parse(refresh_token_query.response_body)
 
       if refresh_token_response["error"].present?
-        raise "Error refreshing Microsoft Graph Token"
+        raise RefreshTokenError, refresh_token_response["error"]
       elsif refresh_token_response["access_token"].present?
         @agent.update!(microsoft_graph_token: refresh_token_response["access_token"])
       end

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Outlook::ApiClient do
       end
 
       it "raises an error" do
-        expect { described_class.new(agent).create_event!(expected_body) }.to raise_error("Error refreshing Microsoft Graph Token")
+        expect { described_class.new(agent).create_event!(expected_body) }.to raise_error(Outlook::ApiClient::RefreshTokenError, "Unknwon error")
       end
     end
   end


### PR DESCRIPTION
Closes #4316

Nous avons plus 100 occurrences de cette erreur Sentry : 

https://sentry.incubateur.net/organizations/betagouv/issues/93325

# Contexte

1. Nous ne savons pas pourquoi l'erreur se produit.
2. Le job semble passer au premier retry (parfois au second ou troisième retry)
3. le message d'erreur précis est censuré par Sentry, on sait juste que Microsoft nous retourne une HTTP 400 (Bad Request)

# Solution

Je fais deux choses dans cette PR : 
- ne pas logger les 4 premiers essais
- remonter le message d'erreur précis dans le message de l'exception, pour qu'on puisse le voir

J'aurais pu séparer en 2 PRs mais je pense que c'est plus pratique de discuter sur la même PR des deux aspects car ils sont pas mal en lien.

