### PR TITLE
Bugfix: crash quand un usager veut prendre une RDV en visio 📷

### DIFF
--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -8,15 +8,21 @@ ul.list-group.list-group-flush
       - unless rdv_wizard.invitation?
         .col-auto
           = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
-  - if rdv_wizard.motif.phone?
+
+  - case rdv_wizard.motif.location_type
+  - when Motif.location_types[:phone]
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | RDV téléphonique
-  - elsif rdv_wizard.motif.home?
+  - when Motif.location_types[:home]
     li.list-group-item
       i.fa.fa-check.fa-fw.mr-1.text-success
       | RDV à domicile
-  - else
+  - when Motif.location_types[:visio]
+    li.list-group-item
+      i.fa.fa-check.fa-fw.mr-1.text-success
+      | RDV par visioconférence
+  - when Motif.location_types[:public_office]
     li.list-group-item
       .row
         .col
@@ -26,6 +32,9 @@ ul.list-group.list-group-flush
         - unless rdv_wizard.invitation?
           .col-auto
             = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
+  - else
+    = raise "unrecognized location_type: #{rdv_wizard.motif.location_type.inspect}"
+
   li.list-group-item
     .row
       .col

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -142,6 +142,33 @@ RSpec.describe "User can search for rdvs" do
         confirm_rdv(first_motif)
       end
     end
+
+    context "when the motif is visio (visioconférence)" do
+      before do
+        [first_motif, other_motif_with_po, motif_without_po].each { |m| m.update!(location_type: Motif.location_types[:visio]) }
+      end
+
+      it "can take a RDV in the available organisations", js: true do
+        visit root_path
+        execute_search
+
+        ## Motif selection
+        expect(page).to have_content(first_motif.name)
+        click_link(first_motif.name)
+
+        expect(page).not_to have_content(organisation_without_po.name)
+
+        find(".card-title", text: /#{first_organisation_with_po.name}/).ancestor(".card").find("a.stretched-link").click
+
+        choose_creneau
+        expect(page).to have_content("RDV par visioconférence")
+        sign_up
+        continue_to_rdv(first_motif, address: "03 Rue Lambert, Paris, 75016")
+        add_relative
+        confirm_rdv(first_motif)
+        expect(page).to have_content("RDV par visioconférence")
+      end
+    end
   end
 
   describe "follow up rdvs" do


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/108683

# Contexte

Nous avons des crash lorsqu'un usager (ou un agent prescripteur) clique sur un créneau pour une RDV en visio.

# Solution

Dans notre vue, nous avions :

```
if phone?
  # code qui gère un RDV par téléphone
elsif home?
  # code qui gère un RDV à domicile
else
  # code qui gère un RDV sur place
```

L'erreur est d'utiliser un `else` qui suppose que les valeurs possibles pour un `location_type` ne changeront pas, ce qui est faux car nous avons ajouté la visio. C'est exactement le même problème qu'ici : https://github.com/betagouv/rdv-service-public/pull/4387#discussion_r1660717674

J'ai utilisé un `case` avec un `else` qui gère le cas inattendu. 

Je n'ai pas trouvé de façon facile d'ajouter un test qui échouerait si on ajoute un nouveau `location_type`. J'ai essayé d'extraire le `case` de la vue dans une sous-partial, avec  un test de vue unitaire, mais en fait le `UserRdvWizard` a des dépendances sur des tas de choses, donc j'ai baissé les bras, je préfère déjà merger ce fix.

# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après
