### PR TITLE
Afficher la date et l'heure sur la page d'ajout de participant⋅e à un RDV collectif

### DIFF
--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -6,6 +6,7 @@
       .card
         .card-header
           h3.text-center #{@rdv.motif_name} (#{@rdv.motif.service.short_name})
+          .text-center= I18n.l(@rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
         .card-body.px-3
           .row.mt-3
             .col-md-6


### PR DESCRIPTION
# Contexte

Remonté par la référente des Hauts-de-Seine : https://zammad10.ethibox.fr/#ticket/zoom/15360

> Autre point dans nos tests, lorsque sur un RDV collectif, on souhaite ajouter un participant, je passe par la recherche de dispo, via le motif concerné, puis je choisi un RDV… jusqu’ici tout va bien… mais à l’étape suivante en cliquant sur « ajouter un participant », pas mal d’info intéressantes sont affichées, mais il manque la date et l’heure du RDV :

![image](https://github.com/user-attachments/assets/23c6e3ed-5316-479d-94a9-9be17ae97cf1)

# Solution

La plus petit PR possible : j'ajoute la date et l'heure en dessous du titre comme c'est fait sur la liste des RDVs collectifs.

![image](https://github.com/user-attachments/assets/463c4dbf-3cbd-4faf-8538-5b1e330366dc)

## Pour aller plus loin : cohérence avec l'affichage liste ?

J'observe que le recap affiché sur cette page est différente de celui fait dans la liste :

![image](https://github.com/user-attachments/assets/9c48d043-f5d2-438a-9381-78f37380649f)

Je remarque donc plusieurs incohérences : 
- inversion des colonnes d'info (visiblement c'était pas le cas initialement, voir #2315)
- titre ferré à gauche dans la liste mais centré dans l'affichage individuel

# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [X] Préparer des captures de l’interface avant et après
