### PR TITLE
Reapply "Correctif du calcul de créneau s'il y a une absence pendant un rdv"

### DIFF
--- a/app/services/slot_builder.rb
+++ b/app/services/slot_builder.rb
@@ -46,6 +46,7 @@ module SlotBuilder
       end.compact
     end
 
+    # On enlève les intervalles occupés d'un morceau de plage d'ouverture
     def split_range_recursively(range, busy_times)
       return [] if range.nil?
       return [range] if busy_times.empty?
@@ -66,6 +67,8 @@ module SlotBuilder
       return busy_time.ends_at..range.end if range.cover?(busy_time.range)
       return range.begin..busy_time.starts_at if range.cover?(busy_time.starts_at)
       return busy_time.ends_at..range.end if range.cover?(busy_time.ends_at)
+
+      return range if (busy_time.ends_at < range.begin) || (busy_time.starts_at > range.end) # Dans ce dernier cas il n'y a pas d'overlap du tout entre le range et le busy_time
     end
 
     def slots_for(plage_ouverture_free_times, motif)


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#4444

J'ai fait un revert de #4441 en pensant qu'elle était responsable [d'un crash](https://sentry.incubateur.net/organizations/betagouv/issues/110923/?project=74), mais en fait le crash est indépendant et traité dans #4466.

Je fais donc ici un revert de revert, aussi appelé "reapply" de la PR d'origine (#4441).