### PR TITLE
Homogénéiser nos usages de `ordered_by_name`

### DIFF
--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -10,7 +10,7 @@ class Admin::AgentsController < AgentAuthController
     @invited_agents_count = @agents.invitation_not_accepted.where.not(invitation_sent_at: nil).created_by_invite.count
 
     @agents.where("(invitation_sent_at IS NULL AND invitation_accepted_at is NULL) OR (invitation_sent_at IS NOT NULL AND invitation_accepted_at IS NULL)")
-    @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.order_by_last_name
+    @agents = index_params[:term].present? ? @agents.search_by_text(index_params[:term]) : @agents.ordered_by_last_name
     @agents = @agents.page(page_number)
   end
 

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -21,7 +21,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       @teams = current_organisation.territory.teams
       @agents = policy_scope(Agent)
         .joins(:organisations).where(organisations: { id: current_organisation.id })
-        .complete.active.order_by_last_name
+        .complete.active.ordered_by_last_name
       @lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name
     end
   end

--- a/app/controllers/admin/slots_controller.rb
+++ b/app/controllers/admin/slots_controller.rb
@@ -16,7 +16,7 @@ class Admin::SlotsController < AgentAuthController
     @form.service_id = @services.first.id if @services.count == 1
     @agents = policy_scope(Agent)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
-      .complete.active.order_by_last_name
+      .complete.active.ordered_by_last_name
     @lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name
   end
 

--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -15,7 +15,7 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
     if search_term.present?
       agents.search_by_text(search_term)
     else
-      agents.order_by_last_name
+      agents.ordered_by_last_name
     end
   end
 

--- a/app/controllers/admin/territories/sector_attributions_controller.rb
+++ b/app/controllers/admin/territories/sector_attributions_controller.rb
@@ -34,7 +34,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
     @available_organisations = Organisation
       .where(territory: current_territory)
       .where.not(id: excluded_organisation_ids)
-      .order_by_name
+      .ordered_by_name
     return if @sector_attribution.level_organisation? || @sector_attribution.organisation.blank?
 
     existing_agent_attributions = @sector

--- a/app/controllers/admin/territories/sectors_controller.rb
+++ b/app/controllers/admin/territories/sectors_controller.rb
@@ -6,7 +6,7 @@ class Admin::Territories::SectorsController < Admin::Territories::BaseController
     @sectors = policy_scope(Sector)
       .where(territory: current_territory)
       .includes(:attributions)
-      .order_by_name
+      .ordered_by_name
     @sectors = @sectors.where(attributions: { organisation: params[:organisation_id] }) if params[:organisation_id].present?
     @sectors = @sectors.page(page_number) unless params[:view] == "map"
     render :index_map if params[:view] == "map"

--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -5,7 +5,7 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
 
   def index
     @teams = policy_scope(Team).page(page_number)
-    @teams = params[:term].present? ? @teams.search_by_text(params[:term]) : @teams.order(:name)
+    @teams = params[:term].present? ? @teams.search_by_text(params[:term]) : @teams.ordered_by_name
   end
 
   def new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,7 +27,7 @@ class Admin::UsersController < AgentAuthController
     @users = @users.none if agent_id.blank? && search_params.blank?
     @users = @users.merge(Agent.find(agent_id).users) if agent_id.present?
     @users = @users.search_by_text(search_params) if search_params.present?
-    @users = @users.order_by_last_name.page(page_number)
+    @users = @users.ordered_by_last_name.page(page_number)
   end
 
   def search

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -106,7 +106,7 @@ class Agent < ApplicationRecord
     where("invitation_sent_at IS NULL OR invitation_accepted_at IS NOT NULL")
   }
   scope :active, -> { where(deleted_at: nil) }
-  scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
+  scope :order_by_last_name, -> { case_insensitive_order_by(:last_name) }
   scope :in_any_of_these_services, lambda { |services|
     joins(:agent_services).where(agent_services: { service_id: services.map(&:id) })
   }

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -106,7 +106,6 @@ class Agent < ApplicationRecord
     where("invitation_sent_at IS NULL OR invitation_accepted_at IS NOT NULL")
   }
   scope :active, -> { where(deleted_at: nil) }
-  scope :order_by_last_name, -> { case_insensitive_order_by(:last_name) }
   scope :in_any_of_these_services, lambda { |services|
     joins(:agent_services).where(agent_services: { service_id: services.map(&:id) })
   }

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,6 +4,8 @@ class ApplicationRecord < ActiveRecord::Base
   include HumanAttributeValue
   include BenignErrors
 
+  scope :case_insensitive_order_by, ->(column_name) { order(Arel.sql("unaccent(LOWER(#{table_name}.#{column_name}))")) }
+
   def new_and_blank?
     new_record? && attributes == self.class.new.attributes
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,7 +4,7 @@ class ApplicationRecord < ActiveRecord::Base
   include HumanAttributeValue
   include BenignErrors
 
-  scope :case_insensitive_order_by, ->(column_name) { order(Arel.sql("unaccent(LOWER(#{table_name}.#{column_name}))")) }
+  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(#{table_name}.name))")) }
 
   def new_and_blank?
     new_record? && attributes == self.class.new.attributes

--- a/app/models/concerns/full_name_concern.rb
+++ b/app/models/concerns/full_name_concern.rb
@@ -3,6 +3,10 @@ module FullNameConcern
   # Relies on the attributes of the receiver:
   # :first_name, :last_name, and :birth_name (optionally)
 
+  included do
+    scope :ordered_by_last_name, -> { order(Arel.sql("unaccent(LOWER(#{table_name}.last_name))")) }
+  end
+
   # Marie Curie (Skłodowska)
   def full_name
     names = [first_name,

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -51,8 +51,6 @@ class Lieu < ApplicationRecord
     where.not(availability: :disabled).where(id: plage_ouverture_lieu_ids + rdv_collectif_lieu_ids)
   }
 
-  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
-
   ## -
   alias enabled enabled?
   def enabled=(value)

--- a/app/models/lieu.rb
+++ b/app/models/lieu.rb
@@ -51,7 +51,7 @@ class Lieu < ApplicationRecord
     where.not(availability: :disabled).where(id: plage_ouverture_lieu_ids + rdv_collectif_lieu_ids)
   }
 
-  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(lieux.name))")) }
+  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
 
   ## -
   alias enabled enabled?

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -81,7 +81,6 @@ class Motif < ApplicationRecord
   scope :not_bookable_by_everyone_or_not_bookable_by_invited_users, -> { where.not(bookable_by: %i[everyone agents_and_prescripteurs_and_invited_users]) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
   scope :for_secretariat, -> { where(for_secretariat: true) }
-  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
   scope :available_for_booking, lambda {
     where_id_in_subqueries(
       [
@@ -145,7 +144,7 @@ class Motif < ApplicationRecord
       .includes(:services)
       .complete
       .active
-      .order_by_last_name
+      .ordered_by_last_name
   end
 
   def visible_and_notified?

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -81,7 +81,7 @@ class Motif < ApplicationRecord
   scope :not_bookable_by_everyone_or_not_bookable_by_invited_users, -> { where.not(bookable_by: %i[everyone agents_and_prescripteurs_and_invited_users]) }
   scope :by_phone, -> { Motif.phone } # default scope created by enum
   scope :for_secretariat, -> { where(for_secretariat: true) }
-  scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(motifs.name))")) }
+  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
   scope :available_for_booking, lambda {
     where_id_in_subqueries(
       [

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -60,7 +60,7 @@ class Organisation < ApplicationRecord
 
     where(id: attributions.pluck(:organisation_id))
   }
-  scope :order_by_name, -> { order(Arel.sql("unaccent(LOWER(name))")) }
+  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
   scope :contactable, lambda {
     where.not(phone_number: ["", nil])
       .or(where.not(website: ["", nil]))

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -60,7 +60,6 @@ class Organisation < ApplicationRecord
 
     where(id: attributions.pluck(:organisation_id))
   }
-  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
   scope :contactable, lambda {
     where.not(phone_number: ["", nil])
       .or(where.not(website: ["", nil]))

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -16,7 +16,7 @@ class Sector < ApplicationRecord
   validate :coherent_territory
 
   # Scopes
-  scope :order_by_name, -> { order(Arel.sql("LOWER(sectors.name)")) }
+  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
   scope :attributed_to_organisation, lambda { |organisation|
     joins(:attributions)
       .where(sector_attributions: { organisation_id: organisation.id, level: SectorAttribution::LEVEL_ORGANISATION })

--- a/app/models/sector.rb
+++ b/app/models/sector.rb
@@ -16,7 +16,6 @@ class Sector < ApplicationRecord
   validate :coherent_territory
 
   # Scopes
-  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
   scope :attributed_to_organisation, lambda { |organisation|
     joins(:attributions)
       .where(sector_attributions: { organisation_id: organisation.id, level: SectorAttribution::LEVEL_ORGANISATION })

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,7 +22,7 @@ class Service < ApplicationRecord
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
 
   # Scopes
-  default_scope { case_insensitive_order_by(:name) }
+  default_scope { ordered_by_name }
 
   ## -
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,7 +22,7 @@ class Service < ApplicationRecord
   validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
 
   # Scopes
-  default_scope { order(Arel.sql("unaccent(LOWER(name))")) }
+  default_scope { case_insensitive_order_by(:name) }
 
   ## -
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -32,9 +32,6 @@ class Team < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :territory }
   validate :agent_from_same_territory, if: -> { agents.any? }
 
-  # Scopes
-  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
-
   ## -
 
   def to_s

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -32,6 +32,9 @@ class Team < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :territory }
   validate :agent_from_same_territory, if: -> { agents.any? }
 
+  # Scopes
+  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
+
   ## -
 
   def to_s

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -55,7 +55,6 @@ class Territory < ApplicationRecord
   scope :with_upcoming_rdvs, lambda {
     where(id: Organisation.with_upcoming_rdvs.distinct.select(:territory_id))
   }
-  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
 
   ## -
 

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -55,6 +55,7 @@ class Territory < ApplicationRecord
   scope :with_upcoming_rdvs, lambda {
     where(id: Organisation.with_upcoming_rdvs.distinct.select(:territory_id))
   }
+  scope :ordered_by_name, -> { case_insensitive_order_by(:name) }
 
   ## -
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,7 +77,6 @@ class User < ApplicationRecord
   # Scopes
   default_scope { where(deleted_at: nil) }
 
-  scope :order_by_last_name, -> { case_insensitive_order_by(:last_name) }
   scope :responsible, -> { where(responsible_id: nil) }
   scope :relative, -> { where.not(responsible_id: nil) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,7 +77,7 @@ class User < ApplicationRecord
   # Scopes
   default_scope { where(deleted_at: nil) }
 
-  scope :order_by_last_name, -> { order(Arel.sql("LOWER(last_name)")) }
+  scope :order_by_last_name, -> { case_insensitive_order_by(:last_name) }
   scope :responsible, -> { where(responsible_id: nil) }
   scope :relative, -> { where.not(responsible_id: nil) }
 

--- a/app/views/admin/territories/invitations_devise/new.html.slim
+++ b/app/views/admin/territories/invitations_devise/new.html.slim
@@ -6,7 +6,7 @@
     = f.input :email, placeholder: t(".email_placeholder"), input_html: { autocomplete: "off"}
     = f.association :services, collection: @services, input_html: { class: "select2-input" }, hint: t(".services_hint")
 
-    = f.association :organisations, as: :check_boxes, collection: current_agent.organisations.where(territory: current_territory).order(:name), label: t(".organisations"), include_hidden: false
+    = f.association :organisations, as: :check_boxes, collection: current_agent.organisations.where(territory: current_territory).ordered_by_name, label: t(".organisations"), include_hidden: false
 
     .text-right
       = f.button :submit, t("devise.invitations.new.submit_button")

--- a/app/views/agents/exports/index.html.slim
+++ b/app/views/agents/exports/index.html.slim
@@ -7,7 +7,7 @@
         ' Vous trouverez ci-dessous les exports réalisés au cours de ces deux dernières semaines.
         => "Les liens de téléchargement ne sont valables que pour une durée de #{Export::EXPIRATION_DELAY.in_hours.to_i}h."
         ' Si le lien a expiré, vous pouvez générer un nouvel export à partir de la
-        = link_to("liste des RDV", admin_organisation_rdvs_path(organisation_id: current_agent.organisations.order(:name).first.id))
+        = link_to("liste des RDV", admin_organisation_rdvs_path(organisation_id: current_agent.organisations.ordered_by_name.first.id))
         | .
 
   table.table.table-sm

--- a/app/views/layouts/left_menu/_organisation_switcher.html.slim
+++ b/app/views/layouts/left_menu/_organisation_switcher.html.slim
@@ -3,6 +3,6 @@ ul.list-unstyled.left-submenu-account.collapse
     li
       = link_to "Changer d'organisation", admin_organisations_path, class: "side-menu__item side-menu__item--small pl-4"
   - else
-    - current_agent.organisations.order_by_name.each do |organisation|
+    - current_agent.organisations.ordered_by_name.each do |organisation|
       li
         = link_to organisation.name, admin_organisation_agent_agenda_path(organisation, current_agent), class: "side-menu__item side-menu__item--small #{'active' if organisation == current_organisation} pl-4 "

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -190,7 +190,7 @@
         = "#{@territories.count} structures utilisent RDV-Solidarités"
       .card-body
         ul
-          - @territories.order(:name).each do |territory|
+          - @territories.ordered_by_name.each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
         .alert.alert-info.d-flex.align-items-center

--- a/app/views/stats/notifications_index.html.slim
+++ b/app/views/stats/notifications_index.html.slim
@@ -22,7 +22,7 @@
         = "#{@territories.count} structures utilisent RDV-Solidarités"
       .card-body
         ul
-          - @territories.order(:name).each do |territory|
+          - @territories.ordered_by_name.each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
         .alert.alert-info.d-flex.align-items-center

--- a/scripts/split_territory.rb
+++ b/scripts/split_territory.rb
@@ -52,7 +52,7 @@ class SplitTerritory
     end
 
     puts "\nLes organisations suivantes restent dans le territoire actuel"
-    @old_territory.organisations.reload.order("name asc").each do |org|
+    @old_territory.organisations.reload.ordered_by_name.each do |org|
       puts "- #{org.name}"
     end
   end


### PR DESCRIPTION
À la base je voulais juste faire une PR pour appliquer la suggestion proposée [ici](https://github.com/betagouv/rdv-service-public/pull/4465/files#r1686485293), mais j'ai vu une opportunité d'homogénéiser notre pratiques.

------------

Je pourrai splitter en plusieurs PRs si certains ne font pas l'unanimité, mais je me permet de grouper pour donner une vision d'ensemble.

Les fixes proposés : 
- Nous avions des scopes `order_by_xxx` et `ordered_by_xxx` : j'ai préféré garder la seconde forme, bien plus fréquemment utilisée
- j'ai créé une méthode `ApplicationRecord#ordered_by_name` mais c'est assez moche, j’hésite à mettre dans un concern
- j'ai cherché et remplacé les `.order(:name)` par `.ordered_by_name`

Note : on peut voir que les services ont des index sur `"lower((name)::text)"` : ces index on été ajoutés pour s'assurer de l'unicité, mais je doute qu'ils soient utilisés pour des gains de performances étant donnée la taille de la table `services`.
