### PR TITLE
Ne plus centrer par défaut les titres h2 en vue mobile

### DIFF
--- a/app/javascript/stylesheets/application_agent_config.scss
+++ b/app/javascript/stylesheets/application_agent_config.scss
@@ -35,3 +35,4 @@
 @import "./structure/authentication";
 @import "./structure/left-menu";
 @import "./structure/misc";
+@import "./structure/misc_agent_config";

--- a/app/javascript/stylesheets/structure/_footer_dsfr.scss
+++ b/app/javascript/stylesheets/structure/_footer_dsfr.scss
@@ -3,7 +3,6 @@ footer {
 
   h2,
   h3 {
-    text-align: left;
     padding-bottom: 0;
   }
 }

--- a/app/javascript/stylesheets/structure/_misc.scss
+++ b/app/javascript/stylesheets/structure/_misc.scss
@@ -37,10 +37,6 @@ section header {
 
 /* General Media Query ---------------------------------- */
 @media (max-width: 991px) {
-  h2 {
-    text-align: center;
-  }
-
   .container {
     max-width: 90%;
   }

--- a/app/javascript/stylesheets/structure/_misc_agent_config.scss
+++ b/app/javascript/stylesheets/structure/_misc_agent_config.scss
@@ -1,0 +1,5 @@
+@media (max-width: 991px) {
+  h2 {
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Contexte

Une règle un peu surprenante fait que tous les h2 de notre appli sont alignés au centre par défaut sur mobile.
Cela cause plus de problèmes que de solutions à mon avis sur l’appli côté usagers.

## Solution

J’ai isolé cette règle CSS dans un nouveau fichier spécifique au layout agent_config, car c’est le seul autre bundle CSS qui l’utilisait. 
Cette règle n’est donc plus appliquée dans le bundle par défaut `application` qui est utilisé côté usagers.

J’ai fait un grep des h2 un peu rapide et j’ai fait un chemin classique de RDV avec inscription pour vérifier qu’il n’y avait pas de problème : pas de problème et c’est mieux qu’avant.
Je n’y passe pas trop de temps je me dis que si certains h2 se retrouvent alignés à gauche par erreur après cette PR on s’en rendra compte en temps voulu et ce n’est pas bien grave.

## Screenshots

avant|après
-|-
![Screen Shot 2024-07-22 at 16 40 52](https://github.com/user-attachments/assets/d8789b14-b4cc-4e49-b3ed-5b76970ffdc8) | ![Screen Shot 2024-07-22 at 16 41 04](https://github.com/user-attachments/assets/cccd89f4-faa6-4517-94b0-42c66b0d1022)
![Screen Shot 2024-07-22 at 16 41 59](https://github.com/user-attachments/assets/c792f100-46bc-4bff-9001-cab4186027cc) | ![Screen Shot 2024-07-22 at 16 42 07](https://github.com/user-attachments/assets/33749ffd-e630-43ab-bb8d-5ba6bd1a0607)
