### PR TITLE
Déplacement des définitions de variables SCSS pour la grille bootstrap

### DIFF
--- a/app/javascript/stylesheets/_variables_dsfr.scss
+++ b/app/javascript/stylesheets/_variables_dsfr.scss
@@ -1,0 +1,12 @@
+// override the default bootstrap grid breakpoints to match the DSFR ones
+// this is temporary while we still use responsive classes from bootstrap
+// cf https://www.systeme-de-design.gouv.fr/fondamentaux/grille-et-points-de-rupture
+
+$grid-breakpoints: (
+  xs: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1248px,
+  // xl is actually the only one that is different
+);

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -2,9 +2,8 @@
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 @import "./_variables";
+@import "./_variables_dsfr";
 @import "./fontawesome_imports";
-
-@import "./structure/bootstrap_overrides"; // needs to be before bootstrap import
 @import "~bootstrap/scss/bootstrap";
 
 @import "~select2/dist/css/select2";
@@ -39,3 +38,4 @@
 @import "./structure/authentication";
 @import "./structure/left-menu";
 @import "./structure/misc";
+@import "./structure/bootstrap_overrides";

--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -29,16 +29,3 @@ footer {
     }
   }
 }
-
-// override the default bootstrap grid breakpoints to match the DSFR ones
-// this is temporary while we still use responsive classes from bootstrap
-// cf https://www.systeme-de-design.gouv.fr/fondamentaux/grille-et-points-de-rupture
-
-$grid-breakpoints: (
-  xs: 0,
-  sm: 576px,
-  md: 768px,
-  lg: 992px,
-  xl: 1248px,
-  // xl is actually the only one that is different
-);


### PR DESCRIPTION
## Contexte

Dans la PR #4349 , on a rajouté dans le fichier `boostrap_overrides.scss` la définition des variables CSS de la taille des grilles bootstrap.
Il a donc fallu déplacer l’inclusion de ce fichier avant l’inclusion de bootstrap pour que ces variables soient prises en compte.

Malheureusement, cela a cassé le fonctionnement des autres règles de ce fichier qui sont des overrides de bootstrap et doivent donc se situer après l’inclusion de bootstrap.
@victormours me l’a fait remarquer car ça a re-cassé le hover sur les boutons.

## solution

Cette PR re-sépare les définitions de variables dans un autre fichier `_variables_dsfr.scss` qui reste inclus avant bootstrap. Les règles d’overrides bootstraps redescendent en dernier import.

J’ai choisi d’appeler le fichier `_variables_dsfr` plutôt que `_variables_bootstrap` pour garder la cohérence : on ne veut importer ce fichier que dans la version "dsfr" du site, même si en l’occurence cela contient pour l’instant des règles qui concernent bootstrap. 