### PR TITLE
Ajouter un template d'avant/après pour les captures d'écran dans les pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,5 @@ Expliquer les choix techniques
 ## Captures d'écran
 
 Avant | Après
-:-------------------------:|:-------------------------:
+:- | -:
 _mettre un screenshot ici_ | _et ici_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,9 @@ Expliquer les choix techniques
 
 - [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
 - [ ] Préparer des captures de l’interface avant et après
+
+## Captures d'écran
+
+Avant | Après
+:-------------------------:|:-------------------------:
+_mettre un screenshot ici_ | _et ici_


### PR DESCRIPTION
Je me suis retrouvé à aller chercher le bout de markdown pour faire des jolis tableaux d'avant/après dans une vieille pull request, et je me suis dit que ça pourrait être utile de toujours les avoir sous la main

Avant | Après
:-------------------------:|:-------------------------:
<img width="864" alt="Screenshot 2024-07-23 at 11 30 05" src="https://github.com/user-attachments/assets/86bffbf0-04d0-431b-81b2-134d7c3e765b"> | <img width="859" alt="Screenshot 2024-07-23 at 11 30 25" src="https://github.com/user-attachments/assets/41de2117-efc5-40cf-87e2-38fcd368cf55">