### PR TITLE
Tagger les erreurs Sentry d'un super-admin "loggé en tant que"

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,7 @@ class ApplicationController < ActionController::Base
 
   def set_sentry_context
     Sentry.set_user(sentry_user)
+    Sentry.set_tags({ impersonating: "true" }) if session[:impersonating]
   end
 
   def sentry_user

--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -6,6 +6,7 @@ module SuperAdmins
       if sign_in_as_allowed?
         sign_out(:user)
         bypass_sign_in(agent, scope: :agent)
+        session[:impersonating] = true
         redirect_to root_url
       else
         flash[:error] = "Fonctionnalité désactivée sur cet environnement."

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,7 +26,7 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   # Test env has the same config as the global one (defined in application.rb)
@@ -39,7 +39,7 @@ Rails.application.configure do
   config.x.redis_namespace = "test:app:#{ENV['TEST_ENV_NUMBER']}"
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/features/super_admin/impersonating_an_agent_spec.rb
+++ b/spec/features/super_admin/impersonating_an_agent_spec.rb
@@ -14,13 +14,6 @@ RSpec.describe "Impersonating an agent" do
   end
 
   describe "telling Sentry that the agent is impersonating" do
-    # Display 404 instead of letting the ActiveRecord::RecordNotFound bubble up to the spec
-    around do |example|
-      Rails.application.configure { config.action_dispatch.show_exceptions = true }
-      example.run
-      Rails.application.configure { config.action_dispatch.show_exceptions = false }
-    end
-
     let!(:other_organisation) { create(:organisation) }
 
     it "works" do

--- a/spec/features/super_admin/impersonating_an_agent_spec.rb
+++ b/spec/features/super_admin/impersonating_an_agent_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe "Impersonating an agent" do
+  stub_env_with(SIGN_IN_AS_ALLOWED: "true")
+
+  let!(:super_admin) { create(:super_admin) }
+  let!(:agent) { create(:agent, password: "Correcth0rse!") }
+  let!(:agent_organisation) { create(:organisation, agents: [agent]) }
+
+  it "works" do
+    login_as(super_admin, scope: :super_admin)
+    visit super_admins_agent_path(agent)
+    click_on "Se logger en tant que"
+    expect(page).to have_current_path("/admin/organisations/#{agent_organisation.id}/agent_agendas/#{agent.id}")
+    expect(page).to have_content(agent.full_name)
+  end
+
+  describe "telling Sentry that the agent is impersonating" do
+    # Display 404 instead of letting the ActiveRecord::RecordNotFound bubble up to the spec
+    around do |example|
+      Rails.application.configure { config.action_dispatch.show_exceptions = true }
+      example.run
+      Rails.application.configure { config.action_dispatch.show_exceptions = false }
+    end
+
+    let!(:other_organisation) { create(:organisation) }
+
+    it "works" do
+      login_as(super_admin, scope: :super_admin)
+      visit super_admins_agent_path(agent)
+      click_on "Se logger en tant que"
+
+      # Simulate clicking on a
+      Capybara.current_session.driver.header "Referer", "https://www.rdv-solidarites-test.localhost#{page.current_path}"
+      expect { visit "/admin/organisations/#{other_organisation.id}" }.to change(sentry_events, :size).by(1)
+      expect(page).to have_content("Page introuvable")
+      expect(sentry_events.last.tags[:impersonating]).to eq("true")
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Nous avons beaucoup de remontées Sentry pour des erreurs `ActiveRecord::RecordNotFound`, et nous supectons qu'une bonne partie d'entre elles soient causées par des personnes de l'équipe support qui :

1. se loggent en tant que l'agent A dans un onglet A et font leurs manipulations
2. commencent à travailler sur un nouveau sujet / ticket
3. se loggent en tant que l'agent B dans l'onglet B
4. retournent sur l'onglet A et cliquent sur un lien : l'agent A n'ayant pas accès à la ressource, ils voient une 404 et Sentry reçoit une notif pour une `ActiveRecord::RecordNotFound`

# Solution

À terme nous pourrons ignorer ces erreurs pour éviter d'avoir du bruit dans Sentry. Pour le moment nous pouvons tagger ces remontées pour évaluer leur proportion dans les remontées qu'on a. C'est ce que fait cette PR.

:warning: Il va falloir définir 

```ruby
config.consider_all_requests_local       = false
config.action_dispatch.show_exceptions = true
```
dans `test.rb` et corriger les specs, on fera ça dans une autre PR, je passe celle-ci en brouillon en attendant.