### PR TITLE
Afficher un tag pour les motifs réservables par "agents + prescripteurs"

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -21,7 +21,7 @@ module MotifsHelper
     tag.span(motif_name_and_location_type(motif)) + motif_badges(motif)
   end
 
-  def motif_badges(motif, only: %i[bookable_by_invited_users bookable_by_everyone for_secretariat follow_up collectif])
+  def motif_badges(motif, only: %i[bookable_by_invited_users bookable_by_everyone bookable_by_agents_and_prescripteurs for_secretariat follow_up collectif])
     safe_join(only.select { motif.send("#{_1}?") }.map { build_badge_tag_for(_1) })
   end
 

--- a/app/javascript/stylesheets/components/_motifs.scss
+++ b/app/javascript/stylesheets/components/_motifs.scss
@@ -1,8 +1,6 @@
-.badge-motif-bookable_by_everyone {
-  background-color: $yellow;
-  color: $dark;
-}
-
+.badge-motif-bookable_by_everyone,
+.badge-motif-bookable_by_invited_users,
+.badge-motif-bookable_by_agents_and_prescripteurs,
 .badge-motif-bookable_by_invited_users {
   background-color: $yellow;
   color: $dark;

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -222,6 +222,10 @@ class Motif < ApplicationRecord
     bookable_by == "everyone"
   end
 
+  def bookable_by_agents_and_prescripteurs?
+    bookable_by == "agents_and_prescripteurs"
+  end
+
   def bookable_by_invited_users?
     bookable_by == "agents_and_prescripteurs_and_invited_users"
   end

--- a/app/views/admin/motifs/_motif.html.slim
+++ b/app/views/admin/motifs/_motif.html.slim
@@ -5,7 +5,7 @@ tr
     = link_to motif.name, admin_organisation_motif_path(motif.organisation, motif)
     = motif_badges(motif, only: %i[for_secretariat follow_up collectif])
   td
-    = motif_badges(motif, only: %i[bookable_by_everyone bookable_by_invited_users])
+    = motif_badges(motif, only: %i[bookable_by_everyone bookable_by_agents_and_prescripteurs bookable_by_invited_users])
   - if @display_sectorisation_level
     td
       - if !motif.bookable_outside_of_organisation? || motif.follow_up?

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -3,6 +3,7 @@ fr:
     badges:
       collectif: "Collectif"
       bookable_by_everyone: "En ligne"
+      bookable_by_agents_and_prescripteurs: "Prescripteur"
       bookable_by_invited_users: "En ligne sur invitation"
       phone: "Par tél."
       home: "À domicile"

--- a/spec/helpers/motifs_helper_spec.rb
+++ b/spec/helpers/motifs_helper_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe MotifsHelper do
       expect(badges).to include("badge-motif-collectif")
     end
 
+    it "affiche le badge En ligne pour un motif bookable_by: :everyone" do
+      motif = build(:motif, bookable_by: :everyone)
+      badges = motif_badges(motif)
+      expect(badges).to eq(%(<span class="badge badge-motif-bookable_by_everyone">En ligne</span>))
+    end
+
+    it "affiche le badge Prescripteur pour un motif bookable_by: :agents_and_prescripteurs" do
+      motif = build(:motif, bookable_by: :agents_and_prescripteurs)
+      badges = motif_badges(motif)
+      expect(badges).to eq(%(<span class="badge badge-motif-bookable_by_agents_and_prescripteurs">Prescripteur</span>))
+    end
+
     it "affiche le badge secretariat ET followup pour un motif `for_secretariat` et `follow_up`" do
       motif = build(:motif, bookable_by: :agents, follow_up: true, for_secretariat: true)
       badges = motif_badges(motif)

--- a/spec/helpers/motifs_helper_spec.rb
+++ b/spec/helpers/motifs_helper_spec.rb
@@ -3,22 +3,19 @@ RSpec.describe MotifsHelper do
     it "affiche le badge Secrétariat pour un motif `secretariat`" do
       motif = build(:motif, bookable_by: :agents, for_secretariat: true)
       badges = motif_badges(motif)
-      expect(badges).to include("Secrétariat")
-      expect(badges).to include("badge-motif-for_secretariat")
+      expect(badges).to eq(%(<span class="badge badge-motif-for_secretariat">Secrétariat</span>))
     end
 
     it "affiche le badge Suivi pour un motif `follow_up`" do
       motif = build(:motif, bookable_by: :agents, follow_up: true)
       badges = motif_badges(motif)
-      expect(badges).to include("Suivi")
-      expect(badges).to include("badge-motif-follow_up")
+      expect(badges).to eq(%(<span class="badge badge-motif-follow_up">Suivi</span>))
     end
 
     it "affiche le badge Collectif pour un motif `collectif`" do
       motif = build(:motif, bookable_by: :agents, collectif: true)
       badges = motif_badges(motif)
-      expect(badges).to include("Collectif")
-      expect(badges).to include("badge-motif-collectif")
+      expect(badges).to eq(%(<span class="badge badge-motif-collectif">Collectif</span>))
     end
 
     it "affiche le badge En ligne pour un motif bookable_by: :everyone" do
@@ -36,19 +33,15 @@ RSpec.describe MotifsHelper do
     it "affiche le badge secretariat ET followup pour un motif `for_secretariat` et `follow_up`" do
       motif = build(:motif, bookable_by: :agents, follow_up: true, for_secretariat: true)
       badges = motif_badges(motif)
-      expect(badges).to include("Secrétariat")
-      expect(badges).to include("badge-motif-for_secretariat")
-      expect(badges).to include("Suivi")
-      expect(badges).to include("badge-motif-follow_up")
+      expect(badges).to include(%(<span class="badge badge-motif-for_secretariat">Secrétariat</span>))
+      expect(badges).to include(%(<span class="badge badge-motif-follow_up">Suivi</span>))
     end
 
     it "affiche le badge collectif ET followup pour un motif `collectif` et `follow_up`" do
       motif = build(:motif, bookable_by: :agents, follow_up: true, collectif: true)
       badges = motif_badges(motif)
-      expect(badges).to include("Collectif")
-      expect(badges).to include("badge-motif-collectif")
-      expect(badges).to include("Suivi")
-      expect(badges).to include("badge-motif-follow_up")
+      expect(badges).to include(%(<span class="badge badge-motif-collectif">Collectif</span>))
+      expect(badges).to include(%(<span class="badge badge-motif-follow_up">Suivi</span>))
     end
   end
 


### PR DESCRIPTION
# Contexte

Lorsque l'option "Réservable par les prescripteurs" a été introduite, nous avions omis d'afficher une pastille (un "tag") dans ce genre pour le signaler :

![image](https://github.com/user-attachments/assets/4eb35bc4-be8e-46f8-a0ab-60e34e40871f)

Peut-être par oubli, peut-être parce que la feature était trop neuve.

Aujourd'hui, afin de rendre la feature de prescription plus compréhensible et plus visible, nous ajoutons ce tag :

![image](https://github.com/user-attachments/assets/02db6d97-b9ce-4d40-aecd-bb72a3b7f140)


# Solution

Rien de compliqué, j'ai utilisé les mécanismes existants.

Côté tests j'ai ajouté des cas pour teste "En ligne" et "Prescripeur". J'en ai profité pour les rendre plus explicites et plus lisibles, car quand je suis arrivé sur les specs existantes je n'ai pas bien compris ce que ce helper génère. Maintenant c'est plus clair.

# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [X] Préparer des captures de l’interface avant et après

## Captures d'écran



Avant | Après
:- | -:
<img src="https://github.com/user-attachments/assets/adbdc031-fcc9-4e4e-b149-47f2746c31d6" width="864"> | <img width="864" src="https://github.com/user-attachments/assets/615ee29a-d283-4746-802d-37586329c274">
<img width="864" src="https://github.com/user-attachments/assets/d9d18063-7351-40f9-95be-fa7113118dee"> | <img width="864" src="https://github.com/user-attachments/assets/87fc74c1-5e25-4fcf-852d-179efbbb1f24">

