### PR TITLE
Renommer le tag de motif "En ligne sur invitation" en "Sur invitation"

### DIFF
--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -3,7 +3,7 @@ fr:
     badges:
       collectif: "Collectif"
       bookable_by_everyone: "En ligne"
-      bookable_by_invited_users: "En ligne sur invitation"
+      bookable_by_invited_users: "Sur invitation"
       phone: "Par tél."
       home: "À domicile"
       for_secretariat: "Secrétariat"


### PR DESCRIPTION
Dans le cadre de #4483, nous ajoutons un tag pour indiquer qu'un motif est réservable par un prescripteur. Ce tag a pour libellé "Prescripteur", pour rester concis. Nous avons donc pensé qu'il serais préférable d'adopter un libellé concis pour le cas de l'invitation.

À noter que tous les tags concernant la résa en ligne sont de la même couleur (jaune), ce qui indique implicitement qu'ils décrivent des valeurs différentes pour une même config.

Je tagge @NesserineZarouri et @Teodora-Stanki en co-équipières pour les inclure dans les discussions, et je poste cette PR sur la Mattermost RDV-I. :wink: 

Avant : 

![image](https://github.com/user-attachments/assets/b3028b55-b3a9-4322-af61-fac2a37c715f)

Après : 

![image](https://github.com/user-attachments/assets/f048ed12-ef36-4eb0-9b5b-a94348852d2b)

