### PR TITLE
Correction de flaky specs causées par des erreurs JS

### DIFF
--- a/app/javascript/components/destroy-button.js
+++ b/app/javascript/components/destroy-button.js
@@ -11,7 +11,7 @@ class DestroyButton {
 
   destroyItem = (event) => {
     event.preventDefault();
-    let id = event.target.dataset.target;
+    let id = event.target.closest(".js-destroy-button").dataset.target;
     document.getElementById(id).style.display = 'none';
     document.getElementById(id+"-destroy").value = true
   }

--- a/app/views/layouts/_headway_widget.html.erb
+++ b/app/views/layouts/_headway_widget.html.erb
@@ -13,7 +13,9 @@
       onWidgetReady: function(widget) {
         // Ne pas afficher le conteneur du badge avant que le widget soit chargé
         // pour éviter le mouvement bref de l'élément au chargement.
-        document.querySelector("#HW_badge_cont").style.display = "block"
+        const container = document.querySelector("#HW_badge_cont")
+        if(!container) return
+        container.style.display = "block"
       },
     },
   };

--- a/app/views/layouts/_headway_widget.html.erb
+++ b/app/views/layouts/_headway_widget.html.erb
@@ -14,8 +14,9 @@
         // Ne pas afficher le conteneur du badge avant que le widget soit chargé
         // pour éviter le mouvement bref de l'élément au chargement.
         const container = document.querySelector("#HW_badge_cont")
-        if(!container) return
-        container.style.display = "block"
+        if(container) {
+          container.style.display = "block"
+        }
       },
     },
   };


### PR DESCRIPTION
[Ce run de CI](https://github.com/betagouv/rdv-service-public/actions/runs/10094810385/job/27913490613?pr=4484) a échoué avec l'erreur suivante : 

```
     Failure/Error: expect(log.level).not_to eq("SEVERE"), log.message
       javascript 15:48 Uncaught TypeError: Cannot read properties of null (reading 'style')
```

J'ai donc cherché dans nos fichiers JS `.style`, et il y a deux cas où l'erreur peut en effet arriver :
- une fonction de callback de headway (je pense que c'est ce qui a fait échouer la spec)
- un petit bout de JS qui gère le bouton "Supprimer" qui retire une participation d'un RDV. Si on clique sur l'icône et pas le texte, on avait une erreur JS et rien ne se passait. J'ai corrigé ça, même si c'est pas la cause de l'échec de la spec.