### PR TITLE
Mise à jour de Devise

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       rails (>= 3.1)
     brakeman (6.1.2)
       racc
-    builder (3.2.4)
+    builder (3.3.0)
     bullet (7.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
@@ -161,7 +161,7 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     common_french_passwords (0.0.1)
-    concurrent-ruby (1.3.1)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crack (0.4.5)
       rexml
@@ -179,7 +179,7 @@ GEM
     debug_inspector (1.1.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.8.1)
+    devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0)
@@ -206,7 +206,7 @@ GEM
       pagy (~> 6)
       view_component (~> 2)
     dumb_delegator (1.0.0)
-    erubi (1.12.0)
+    erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
     ethon (0.16.0)
@@ -309,7 +309,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.23.1)
+    minitest (5.24.1)
     montrose (0.16.0)
       activesupport (>= 5.2, < 8)
     msgpack (1.7.2)
@@ -327,7 +327,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.5)
+    nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -474,9 +474,9 @@ GEM
     regexp_parser (2.8.2)
     request_store (1.5.1)
       rack (>= 1.4)
-    responders (3.0.1)
-      actionpack (>= 5.0)
-      railties (>= 5.0)
+    responders (3.1.1)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rexml (3.3.2)
       strscan
     rspec-core (3.12.3)
@@ -631,7 +631,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.14)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   ruby

--- a/app/controllers/modal_responder.rb
+++ b/app/controllers/modal_responder.rb
@@ -14,7 +14,7 @@ class ModalResponder < ActionController::Responder
 
   def redirect_to(options, response_options = {})
     if request.xhr?
-      head response_options[:status] || :ok, location: controller.url_for(options)
+      head :ok, location: controller.url_for(options)
     else
       controller.redirect_to(options, response_options)
     end

--- a/app/controllers/modal_responder.rb
+++ b/app/controllers/modal_responder.rb
@@ -12,11 +12,11 @@ class ModalResponder < ActionController::Responder
     render(*args)
   end
 
-  def redirect_to(options)
+  def redirect_to(options, response_options = {})
     if request.xhr?
-      head :ok, location: controller.url_for(options)
+      head response_options[:status] || :ok, location: controller.url_for(options)
     else
-      controller.redirect_to(options)
+      controller.redirect_to(options, response_options)
     end
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -348,6 +348,15 @@ Devise.setup do |config|
   #   include Turbolinks::Controller
   # end
 
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found` respectively, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
+
   # ==> Configuration for :registerable
 
   # When set to false, does not sign a user in automatically after their password is


### PR DESCRIPTION
En prévision d'une potentielle mise à jour de sécurité, c'est pratique d'être sur la version de Devise la plus à jour.

J'ai suivi les recommandations de la doc de Devise.