### PR TITLE
Ajouter les ids des organisations des usagers dans les webhooks

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -23,4 +23,8 @@ class RdvBlueprint < Blueprinter::Base
   association :participations, blueprint: ParticipationBlueprint
   association :agents, blueprint: AgentBlueprint
   association :lieu, blueprint: LieuBlueprint
+
+  view :rdv_insertion do 
+    association :users, blueprint: UserBlueprint, view: :rdv_insertion 
+  end
 end

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -24,7 +24,7 @@ class RdvBlueprint < Blueprinter::Base
   association :agents, blueprint: AgentBlueprint
   association :lieu, blueprint: LieuBlueprint
 
-  view :rdv_insertion do 
-    association :users, blueprint: UserBlueprint, view: :rdv_insertion 
+  view :rdv_insertion do
+    association :users, blueprint: UserBlueprint, view: :rdv_insertion
   end
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -4,7 +4,7 @@ class UserBlueprint < Blueprinter::Base
   fields  :first_name, :birth_name, :last_name, :email, :address, :phone_number, :phone_number_formatted, :birth_date,
           :responsible_id, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :notify_by_sms,
           :notify_by_email, :invitation_created_at, :invitation_accepted_at, :created_at, :case_number, :address_details,
-          :logement, :notes
+          :logement, :notes, :organisation_ids
 
   association :responsible, blueprint: UserBlueprint
 

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -14,7 +14,7 @@ class UserBlueprint < Blueprinter::Base
     Agent::UserProfilePolicy::Scope.new(options[:agent_context], user.user_profiles).resolve
   end
 
-  view :rdv_insertion do 
-    field :organisation_ids 
+  view :rdv_insertion do
+    field :organisation_ids
   end
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -4,7 +4,7 @@ class UserBlueprint < Blueprinter::Base
   fields  :first_name, :birth_name, :last_name, :email, :address, :phone_number, :phone_number_formatted, :birth_date,
           :responsible_id, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :notify_by_sms,
           :notify_by_email, :invitation_created_at, :invitation_accepted_at, :created_at, :case_number, :address_details,
-          :logement, :notes, :organisation_ids
+          :logement, :notes
 
   association :responsible, blueprint: UserBlueprint
 
@@ -12,5 +12,9 @@ class UserBlueprint < Blueprinter::Base
     next if options[:agent_context].blank?
 
     Agent::UserProfilePolicy::Scope.new(options[:agent_context], user.user_profiles).resolve
+  end
+
+  view :rdv_insertion do 
+    field :organisation_ids 
   end
 end

--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -4,7 +4,7 @@
 module WebhookDeliverable
   extend ActiveSupport::Concern
 
-  def generate_webhook_payload(action, destinated_to_rdvi = false)
+  def generate_webhook_payload(action, destinated_to_rdvi: false)
     # Reload attributes and associations from DB to ensure they are up to date.
     # We dont use #reload on self because some other parts
     # of the code rely on the state of the current object.
@@ -24,14 +24,14 @@ module WebhookDeliverable
 
   def generate_payload_and_send_webhook(action)
     subscribed_webhook_endpoints.each do |endpoint|
-      WebhookJob.perform_later(generate_webhook_payload(action, endpoint.rdv_insertion?), endpoint.id)
+      WebhookJob.perform_later(generate_webhook_payload(action, destinated_to_rdvi: endpoint.rdv_insertion?), endpoint.id)
     end
   end
 
   def generate_payload_and_send_webhook_for_destroy
     # Prépare les données à envoyer, avant de supprimer l'objet
     payloads = subscribed_webhook_endpoints.index_with do |endpoint|
-      generate_webhook_payload(:destroyed, endpoint.rdv_insertion?)
+      generate_webhook_payload(:destroyed, destinated_to_rdvi: endpoint.rdv_insertion?)
     end
     # Execute la suppression, après avoir construit les données à envoyer
     yield if block_given?

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -26,7 +26,7 @@ class WebhookEndpoint < ApplicationRecord
   end
 
   def trigger_for(record)
-    WebhookJob.perform_later(record.generate_webhook_payload(:created, rdv_insertion?), id)
+    WebhookJob.perform_later(record.generate_webhook_payload(:created, destinated_to_rdvi: rdv_insertion?), id)
   end
 
   def partially_hidden_secret
@@ -34,7 +34,7 @@ class WebhookEndpoint < ApplicationRecord
   end
 
   def rdv_insertion?
-    target_url.include?(ENV["RDV_INSERTION_HOST"])
+    rdv_insertion_host.present? && target_url.include?(rdv_insertion_host)
   end
 
   private
@@ -44,4 +44,6 @@ class WebhookEndpoint < ApplicationRecord
 
     errors.add(:base, "la liste des abonnements choisis contient une ou plusieurs valeurs incorrectes")
   end
+
+  def rdv_insertion_host = ENV["RDV_INSERTION_HOST"]
 end

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -26,11 +26,15 @@ class WebhookEndpoint < ApplicationRecord
   end
 
   def trigger_for(record)
-    WebhookJob.perform_later(record.generate_webhook_payload(:created), id)
+    WebhookJob.perform_later(record.generate_webhook_payload(:created, rdv_insertion?), id)
   end
 
   def partially_hidden_secret
     secret&.gsub(/.(?=.{3})/, "*")
+  end
+
+  def rdv_insertion?
+    target_url.include?(ENV["RDV_INSERTION_HOST"])
   end
 
   private


### PR DESCRIPTION
Lié à https://github.com/gip-inclusion/rdv-insertion/issues/2244

# Contexte

Je remets ce qui est écrit dans le ticket: 

Dans certains cas, lorsqu'un usager créé depuis rdvsp a un rdv placé sur une organisation présente dans rdv-insertion, pour une catégorie de motif gérée par l'organisation dans rdv-insertion, nous importons le rdv ainsi que l'usager sur rdv-insertion.
Cependant, lorsque l'on crée l'usager sur rdv-i, on le lie uniquement à l'organisation du rdv en question. 
Or cet usager peut potentiellement déjà appartenir à plusieurs organisations déjà présentes sur rdv-i. Ainsi il en résulte un problème de synchronisation: 
* on n'affiche pas toutes ses orgas sur rdvi
* on a la possibilité de l'ajouter sur ces orgas depuis rdv-i ce qui engendrera des erreurs

# Solution

La solution la plus simple et qui semblait acceptable en en discutant avec @victormours était d'ajouter les ids des organisations auxquelles l'usager appartient dans le webhook. 
Je fais donc en sorte de l'ajouter ici. 

N.B: le blueprint contient déjà un champ `user_profiles` mais il ne concerne que les usagers récupérés via l'API (car il faut qu'un agent soit connecté pour les render) et il contient plus d'informations sur les organisations (nom, numéro de tel, verticale) que les ids seulement. Pour info nous n'utilisons pas ce champ côté rdv-insertion. 