### PR TITLE
Bugfix : un admin de territoire ne peut pas lister les agents qui ne sont pas dans ses orgas

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -83,7 +83,7 @@ class Admin::AbsencesController < AgentAuthController
   end
 
   def set_agent
-    @agent = filter_params[:agent_id].present? ? policy_scope(Agent).find(filter_params[:agent_id]) : @absence.agent
+    @agent = filter_params[:agent_id].present? ? policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(filter_params[:agent_id]) : @absence.agent
   end
 
   def absence_params

--- a/app/controllers/admin/agent_agendas_controller.rb
+++ b/app/controllers/admin/agent_agendas_controller.rb
@@ -1,7 +1,7 @@
 class Admin::AgentAgendasController < AgentAuthController
   def show
     @hide_rdv_a_renseigner_in_main_layout = true
-    @agent = policy_scope(Agent).find(params[:id])
+    @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
     authorize(AgentAgenda.new(agent: @agent, organisation: current_organisation))
     @status = params[:status]
     @organisation = current_organisation

--- a/app/controllers/admin/agents_controller.rb
+++ b/app/controllers/admin/agents_controller.rb
@@ -2,7 +2,7 @@ class Admin::AgentsController < AgentAuthController
   respond_to :html, :json
 
   def index
-    @agents = policy_scope(Agent)
+    @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .includes(:services, :roles, :organisations)
       .active
 
@@ -71,7 +71,7 @@ class Admin::AgentsController < AgentAuthController
   end
 
   def destroy
-    @agent = policy_scope(Agent).find(params[:id])
+    @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
     authorize(@agent)
 
     agent_removal = AgentRemoval.new(@agent, current_organisation)

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -19,7 +19,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       @services = Service.where(id: @motifs.pluck(:service_id).uniq)
       @form.service_id = @services.first.id if @services.count == 1
       @teams = current_organisation.territory.teams
-      @agents = policy_scope(Agent)
+      @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
         .joins(:organisations).where(organisations: { id: current_organisation.id })
         .complete.active.ordered_by_last_name
       @lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -1,6 +1,6 @@
 class Admin::InvitationsController < AgentAuthController
   def index
-    @invited_agents = policy_scope(Agent)
+    @invited_agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .invitation_not_accepted.where.not(invitation_sent_at: nil)
       .created_by_invite
@@ -9,7 +9,7 @@ class Admin::InvitationsController < AgentAuthController
   end
 
   def reinvite
-    @agent = policy_scope(Agent).find(params[:id])
+    @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
     authorize(@agent)
     @agent.invite!(current_agent, validate: false)
     redirect_to admin_organisation_invitations_path(current_organisation), notice: "Une nouvelle invitation a été envoyée à l'agent #{@agent.email}."

--- a/app/controllers/admin/organisations/stats_controller.rb
+++ b/app/controllers/admin/organisations/stats_controller.rb
@@ -4,7 +4,7 @@ class Admin::Organisations::StatsController < AgentAuthController
   def index
     @stats = Stat.new(
       rdvs: rdv_scope,
-      agents: policy_scope(Agent)
+      agents: policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
         .joins(:organisations).where(organisations: { id: current_organisation.id }),
       users: policy_scope(User)
     )

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -84,7 +84,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   private
 
   def set_agent
-    @agent = filter_params[:agent_id].present? ? policy_scope(Agent).find(filter_params[:agent_id]) : @plage_ouverture.agent
+    @agent = filter_params[:agent_id].present? ? policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(filter_params[:agent_id]) : @plage_ouverture.agent
   end
 
   def set_plage_ouverture

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -144,7 +144,7 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def set_optional_agent
-    @agent = policy_scope(Agent).find(params[:agent_id]) if params[:agent_id].present?
+    @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:agent_id]) if params[:agent_id].present?
   end
 
   def parse_date_from_params(date_param)

--- a/app/controllers/admin/referent_assignations_controller.rb
+++ b/app/controllers/admin/referent_assignations_controller.rb
@@ -3,7 +3,7 @@ class Admin::ReferentAssignationsController < AgentAuthController
     @user = policy_scope(User).find(index_params[:user_id])
     authorize(@user, :update?)
     @referents = policy_scope(@user.referent_agents).distinct.order(:last_name)
-    @agents = policy_scope(Agent).merge(current_organisation.agents)
+    @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).merge(current_organisation.agents)
     @agents = @agents.search_by_text(index_params[:search]) if index_params[:search].present?
     @agents = @agents.page(page_number)
   end
@@ -23,8 +23,8 @@ class Admin::ReferentAssignationsController < AgentAuthController
   def find_agent_and_user_save_and_redirect_with(params)
     user = policy_scope(User).find(params[:user_id])
     authorize(user, :update?)
-    agent = policy_scope(Agent).find(params[:agent_id]) if params[:agent_id]
-    agent ||= policy_scope(Agent).find(params[:id])
+    agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:agent_id]) if params[:agent_id]
+    agent ||= policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
 
     yield(user, agent)
 

--- a/app/controllers/admin/slots_controller.rb
+++ b/app/controllers/admin/slots_controller.rb
@@ -14,7 +14,7 @@ class Admin::SlotsController < AgentAuthController
       .active.ordered_by_name
     @services = Service.where(id: @motifs.pluck(:service_id).uniq)
     @form.service_id = @services.first.id if @services.count == 1
-    @agents = policy_scope(Agent)
+    @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .complete.active.ordered_by_last_name
     @lieux = Agent::LieuPolicy::Scope.apply(current_agent, current_organisation.lieux).enabled.ordered_by_name

--- a/app/controllers/admin/territories/sector_attributions_controller.rb
+++ b/app/controllers/admin/territories/sector_attributions_controller.rb
@@ -41,7 +41,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
       .attributions
       .level_agent
       .where(organisation: @sector_attribution.organisation)
-    @available_agents = policy_scope(Agent)
+    @available_agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .merge(@sector_attribution.organisation.agents)
       .where.not(id: existing_agent_attributions.pluck(:agent_id))
       .includes(:services)

--- a/app/controllers/api/v1/agents_controller.rb
+++ b/app/controllers/api/v1/agents_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::AgentsController < Api::V1::AgentAuthBaseController
   def index
-    agents = policy_scope(Agent).distinct
+    agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).distinct
     agents = agents.joins(:organisations).where(organisations: { id: current_organisation.id }) if current_organisation.present?
     render_collection(agents.order(:created_at))
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -27,6 +27,6 @@ class ApplicationRecord < ActiveRecord::Base
   #     Agent.where_id_in_subqueries([agents_with_open_plage, agents_with_open_rdv_collectif])
   #
   def self.where_id_in_subqueries(subqueries)
-    subqueries.map { |scope| where(id: scope) }.reduce(:or)
+    subqueries.map { |subquery| where(id: subquery) }.reduce(:or)
   end
 end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -36,18 +36,16 @@ class Agent::AgentPolicy < ApplicationPolicy
     include CurrentAgentInPolicyConcern
 
     def resolve
-      if current_agent.secretaire?
-        scope.where(id: AgentRole.where(organisation_id: current_agent.organisations).select(:agent_id))
-      else
-        agents_of_territories_i_admin = scope.joins(:organisations).merge(current_agent.organisations_of_territorial_roles)
+      agents_i_can_see_as_secretaire = current_agent.secretaire? ? scope.where(id: AgentRole.where(organisation_id: current_agent.organisations).select(:agent_id)) : scope.none
 
-        agents_of_orgs_i_admin = scope.joins(:organisations).merge(current_agent.admin_orgs)
+      agents_of_territories_i_admin = scope.joins(:organisations).merge(current_agent.organisations_of_territorial_roles)
 
-        agents_of_orgs_i_basic_same_service = scope.joins(:organisations).merge(current_agent.basic_orgs)
-          .merge(current_agent.confreres)
+      agents_of_orgs_i_admin = scope.joins(:organisations).merge(current_agent.admin_orgs)
 
-        scope.where_id_in_subqueries([agents_of_territories_i_admin, agents_of_orgs_i_admin, agents_of_orgs_i_basic_same_service])
-      end
+      agents_of_orgs_i_basic_same_service = scope.joins(:organisations).merge(current_agent.basic_orgs)
+        .merge(current_agent.confreres)
+
+      scope.where_id_in_subqueries([agents_i_can_see_as_secretaire, agents_of_territories_i_admin, agents_of_orgs_i_admin, agents_of_orgs_i_basic_same_service])
     end
   end
 end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -36,14 +36,12 @@ class Agent::AgentPolicy < ApplicationPolicy
     include CurrentAgentInPolicyConcern
 
     def resolve
-      agents_i_can_see_as_secretaire = current_agent.secretaire? ? scope.where(id: AgentRole.where(organisation_id: current_agent.organisations).select(:agent_id)) : scope.none
+      scope = scope.joins(:organisations) # JOINing on :organisations allows us to #merge Organisation scopes
 
-      agents_of_territories_i_admin = scope.joins(:organisations).merge(current_agent.organisations_of_territorial_roles)
-
-      agents_of_orgs_i_admin = scope.joins(:organisations).merge(current_agent.admin_orgs)
-
-      agents_of_orgs_i_basic_same_service = scope.joins(:organisations).merge(current_agent.basic_orgs)
-        .merge(current_agent.confreres)
+      agents_i_can_see_as_secretaire = current_agent.secretaire? ? scope.merge(current_agent.organisations) : scope.none
+      agents_of_territories_i_admin = scope.merge(current_agent.organisations_of_territorial_roles)
+      agents_of_orgs_i_admin = scope.merge(current_agent.admin_orgs)
+      agents_of_orgs_i_basic_same_service = scope.merge(current_agent.basic_orgs).merge(current_agent.confreres)
 
       scope.where_id_in_subqueries([agents_i_can_see_as_secretaire, agents_of_territories_i_admin, agents_of_orgs_i_admin, agents_of_orgs_i_basic_same_service])
     end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -36,12 +36,14 @@ class Agent::AgentPolicy < ApplicationPolicy
     include CurrentAgentInPolicyConcern
 
     def resolve
-      scope = scope.joins(:organisations) # JOINing on :organisations allows us to #merge Organisation scopes
+      agents_i_can_see_as_secretaire = current_agent.secretaire? ? scope.where(id: AgentRole.where(organisation_id: current_agent.organisations).select(:agent_id)) : scope.none
 
-      agents_i_can_see_as_secretaire = current_agent.secretaire? ? scope.merge(current_agent.organisations) : scope.none
-      agents_of_territories_i_admin = scope.merge(current_agent.organisations_of_territorial_roles)
-      agents_of_orgs_i_admin = scope.merge(current_agent.admin_orgs)
-      agents_of_orgs_i_basic_same_service = scope.merge(current_agent.basic_orgs).merge(current_agent.confreres)
+      agents_of_territories_i_admin = scope.joins(:organisations).merge(current_agent.organisations_of_territorial_roles)
+
+      agents_of_orgs_i_admin = scope.joins(:organisations).merge(current_agent.admin_orgs)
+
+      agents_of_orgs_i_basic_same_service = scope.joins(:organisations).merge(current_agent.basic_orgs)
+        .merge(current_agent.confreres)
 
       scope.where_id_in_subqueries([agents_i_can_see_as_secretaire, agents_of_territories_i_admin, agents_of_orgs_i_admin, agents_of_orgs_i_basic_same_service])
     end

--- a/app/policies/agent/agent_policy.rb
+++ b/app/policies/agent/agent_policy.rb
@@ -36,12 +36,12 @@ class Agent::AgentPolicy < ApplicationPolicy
     include CurrentAgentInPolicyConcern
 
     def resolve
-      scope = scope.joins(:organisations) # JOINing on :organisations allows us to #merge Organisation scopes
+      agents = scope.joins(:organisations) # JOINing on :organisations allows us to #merge Organisation scopes
 
-      agents_i_can_see_as_secretaire = current_agent.secretaire? ? scope.merge(current_agent.organisations) : scope.none
-      agents_of_territories_i_admin = scope.merge(current_agent.organisations_of_territorial_roles)
-      agents_of_orgs_i_admin = scope.merge(current_agent.admin_orgs)
-      agents_of_orgs_i_basic_same_service = scope.merge(current_agent.basic_orgs).merge(current_agent.confreres)
+      agents_i_can_see_as_secretaire = current_agent.secretaire? ? agents.merge(current_agent.organisations) : scope.none
+      agents_of_territories_i_admin = agents.merge(current_agent.organisations_of_territorial_roles)
+      agents_of_orgs_i_admin = agents.merge(current_agent.admin_orgs)
+      agents_of_orgs_i_basic_same_service = agents.merge(current_agent.basic_orgs).merge(current_agent.confreres)
 
       scope.where_id_in_subqueries([agents_i_can_see_as_secretaire, agents_of_territories_i_admin, agents_of_orgs_i_admin, agents_of_orgs_i_basic_same_service])
     end

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
       let!(:other_agent_same_orgas) { create(:agent, basic_role_in_organisations: organisations, service: other_service) }
 
       it { is_expected.to match_array([agent, other_agent_same_orgas]) }
+
+      context "when agent is also territory admin" do
+        let!(:territory) { create(:territory) }
+        let!(:organisations) { create_list(:organisation, 2, territory: territory) }
+        let!(:other_organisation_in_territory) { create(:organisation, territory: territory) }
+        let!(:agent_in_other_org_in_territory) { create(:agent, organisations: [other_organisation_in_territory]) }
+
+        before { agent.territories << territory }
+
+        it { is_expected.to match_array([agent, other_agent_same_orgas, agent_in_other_org_in_territory]) }
+      end
     end
 
     context "admin agent, misc state" do

--- a/spec/policies/agent/agent_policy_spec.rb
+++ b/spec/policies/agent/agent_policy_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
       end
     end
 
-    context "agent is in secrétariat" do
+    context "when agent is secrétaire" do
       let!(:service_secretariat) { create(:service, :secretariat) }
       let!(:other_service) { create :service }
       let!(:services) { create_list(:service, 2) }
@@ -96,7 +96,7 @@ RSpec.describe Agent::AgentPolicy::Scope, type: :policy do
 
       it { is_expected.to match_array([agent, other_agent_same_orgas]) }
 
-      context "when agent is also territory admin" do
+      context "when secrétaire is also territory admin" do
         let!(:territory) { create(:territory) }
         let!(:organisations) { create_list(:organisation, 2, territory: territory) }
         let!(:other_organisation_in_territory) { create(:organisation, territory: territory) }


### PR DESCRIPTION
# Contexte

Dans #4494 nous faisons en sorte d'homogénéiser la liste des agents dont on peut connaître l'existence. Pour ce faire, nous faisons en sorte d'utiliser la scope existante `Agent::AgentPolicy::Scope` depuis la liste des agents. Cette scope a un petit défaut d'implémentation, car elle commence par cette condition :

```ruby
if current_agent.secretaire?
  # voir les agents de mes orgas
```

donc si l'agent est secrétaire **et** admin de territoire, iel ne pourra pas voir les agents des orgas donc elle ne fait pas partie.

Dans metabase je vois [84 secrétaires qui sont admin de territoire](https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQ3LCJqb2lucyI6W3sic3RyYXRlZ3kiOiJpbm5lci1qb2luIiwiYWxpYXMiOiJBZ2VudCBTZXJ2aWNlcyIsImNvbmRpdGlvbiI6WyI9IixbImZpZWxkIiwxMTMseyJiYXNlLXR5cGUiOiJ0eXBlL0JpZ0ludGVnZXIifV0sWyJmaWVsZCIsMTM2LHsiYmFzZS10eXBlIjoidHlwZS9CaWdJbnRlZ2VyIiwiam9pbi1hbGlhcyI6IkFnZW50IFNlcnZpY2VzIn1dXSwic291cmNlLXRhYmxlIjozNH0seyJmaWVsZHMiOiJhbGwiLCJzdHJhdGVneSI6ImlubmVyLWpvaW4iLCJhbGlhcyI6IkFnZW50IFRlcnJpdG9yaWFsIFJvbGVzIiwiY29uZGl0aW9uIjpbIj0iLFsiZmllbGQiLDExMyx7ImJhc2UtdHlwZSI6InR5cGUvQmlnSW50ZWdlciJ9XSxbImZpZWxkIiwxNTgseyJiYXNlLXR5cGUiOiJ0eXBlL0JpZ0ludGVnZXIiLCJqb2luLWFsaWFzIjoiQWdlbnQgVGVycml0b3JpYWwgUm9sZXMifV1dLCJzb3VyY2UtdGFibGUiOjIzfV0sImFnZ3JlZ2F0aW9uIjpbWyJjb3VudCJdXSwiZmlsdGVyIjpbImFuZCIsWyI9IixbImZpZWxkIiwxMzcseyJiYXNlLXR5cGUiOiJ0eXBlL0JpZ0ludGVnZXIiLCJqb2luLWFsaWFzIjoiQWdlbnQgU2VydmljZXMifV0sNV0sWyJpcy1udWxsIixbImZpZWxkIiwxMDAseyJiYXNlLXR5cGUiOiJ0eXBlL0RhdGVUaW1lIn1dXV19fSwiZGlzcGxheSI6InNjYWxhciIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9LCJ0eXBlIjoicXVlc3Rpb24ifQ==) et [66 qui ont le droit d'éditer des équipes](https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQ3LCJqb2lucyI6W3sic3RyYXRlZ3kiOiJpbm5lci1qb2luIiwiYWxpYXMiOiJBZ2VudCBTZXJ2aWNlcyIsImNvbmRpdGlvbiI6WyI9IixbImZpZWxkIiwxMTMseyJiYXNlLXR5cGUiOiJ0eXBlL0JpZ0ludGVnZXIifV0sWyJmaWVsZCIsMTM2LHsiYmFzZS10eXBlIjoidHlwZS9CaWdJbnRlZ2VyIiwiam9pbi1hbGlhcyI6IkFnZW50IFNlcnZpY2VzIn1dXSwic291cmNlLXRhYmxlIjozNH0seyJmaWVsZHMiOiJhbGwiLCJzdHJhdGVneSI6ImlubmVyLWpvaW4iLCJhbGlhcyI6IkFnZW50IFRlcnJpdG9yaWFsIEFjY2VzcyBSaWdodHMiLCJjb25kaXRpb24iOlsiPSIsWyJmaWVsZCIsMTEzLHsiYmFzZS10eXBlIjoidHlwZS9CaWdJbnRlZ2VyIn1dLFsiZmllbGQiLDE1MCx7ImJhc2UtdHlwZSI6InR5cGUvQmlnSW50ZWdlciIsImpvaW4tYWxpYXMiOiJBZ2VudCBUZXJyaXRvcmlhbCBBY2Nlc3MgUmlnaHRzIn1dXSwic291cmNlLXRhYmxlIjoyNH1dLCJhZ2dyZWdhdGlvbiI6W1siY291bnQiXV0sImZpbHRlciI6WyJhbmQiLFsiPSIsWyJmaWVsZCIsMTM3LHsiYmFzZS10eXBlIjoidHlwZS9CaWdJbnRlZ2VyIiwiam9pbi1hbGlhcyI6IkFnZW50IFNlcnZpY2VzIn1dLDVdLFsiaXMtbnVsbCIsWyJmaWVsZCIsMTAwLHsiYmFzZS10eXBlIjoidHlwZS9EYXRlVGltZSJ9XV0sWyI9IixbImZpZWxkIiwxNTIseyJiYXNlLXR5cGUiOiJ0eXBlL0Jvb2xlYW4iLCJqb2luLWFsaWFzIjoiQWdlbnQgVGVycml0b3JpYWwgQWNjZXNzIFJpZ2h0cyJ9XSx0cnVlXV19fSwiZGlzcGxheSI6InNjYWxhciIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9LCJ0eXBlIjoicXVlc3Rpb24ifQ==).

# Solution

Nous choisissons ici de faire en sorte que les droits d'accès soit cumulatifs. C'est à dire que :
- si je suis secrétaire, je peux voir les _agents de mes orgas_
- si je suis admin de territoire, je peux voir les _agents de mon territoire_
- si je suis secrétaire **et** admin de territoire, je peux voir les agents de mes orgas **et** les agents de mon territoire

Avant cette PR, le troisième point n'était pas géré.

Note : quand je dis "les agents de mon territoire", c'est une façon plus concise de dire "les agents des orgas du territoire dont je suis admin".

# Bug trouvé et corrigé du même coup

En cherchant les occurrences de `policy_scope(Agent)` dans le code, j'ai réalisé que celui présent dans `app/controllers/admin/territories/sector_attributions_controller.rb:44` faisait implicitement appel à `Configuration::AgentPolicy::Scope`, qui n'existe plus depuis #4494 (déployée ce matin). Donc la page suivante était inaccessible : 

![image](https://github.com/user-attachments/assets/9adce623-53f2-471c-b0c2-c3512f191f06)

car elle donnait cette erreur :

![image](https://github.com/user-attachments/assets/fc804042-ac25-47d7-9b11-040656552308)

J'ai donc préféré spécifier la scope explicitement : `policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)`

J'ai par la même occasion remplacé tous les usages de `policy_scope(Agent)` pour qu'ils mentionnent explicitement la scope, conformément à notre objectif d'usage plus explicite des policies.

# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [X] Préparer des captures de l’interface avant et après
