### PR TITLE
Correctifs mineurs sur l'ui de la page équipes dans l'espace Admin

### DIFF
--- a/app/views/admin/territories/teams/index.html.slim
+++ b/app/views/admin/territories/teams/index.html.slim
@@ -2,11 +2,11 @@
 
 = simple_form_for "", url: admin_territory_teams_path(current_territory), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
 
-  .container-fluid.bg-white.rounded.m-2.p-2
+  .container-fluid.bg-white.rounded.m-2.p-4
 
-    .text-right
+    .float-left
       = link_to t(".create_team"), new_admin_territory_team_path(current_territory), class:"btn btn-outline-primary"
-    .m-3.d-flex.justify-content-end
+    .d-flex.justify-content-end
       - term = params[:term].blank? ? "d-none" : ""
       div= link_to "Réinitialiser", admin_territory_teams_path(current_territory), class: "btn btn-link #{term}"
       = f.input :term, placeholder: "ex. Puericultrice", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
@@ -21,7 +21,7 @@
       tbody
         - @teams.each do |team|
           tr id="team_#{team.id}"
-            td = team.name
+            td = link_to team.name, edit_admin_territory_team_path(current_territory, team)
             td = team.agents.count
             td
               .d-flex
@@ -37,5 +37,4 @@
       = paginate @teams, theme: "twitter-bootstrap-4"
 
     .text-right
-      = link_to t(".back"), admin_territory_agents_path(current_territory), class: "btn btn-link"
       = link_to t(".create_team"), new_admin_territory_team_path(current_territory), class: "btn btn-outline-primary"


### PR DESCRIPTION
# Contexte

Dans le cadre du développement de https://github.com/betagouv/rdv-service-public/pull/4498, j'ai passé pas mal de temps à regarder l'index de la liste des équipes dans l'espace admin, et plusieurs petits problèmes m'ont un peu irrités :
- L'action la plus fréquente sur une équipe est d'aller voir l'édit pour consulter la liste des membres et éventuellement la modifier, or cette action n'est accessible que via le petit bouton d'édition à droite. On rend ici le nom de l'équipe cliquable pour améliorer l'ergonomie (plutôt qu'avoir une indirection vers le bouton à droite, qui en plus n'est pas pratique si on a plein d'équipes)
- un bouton "retour" qui ramène vers la liste des agents, mais sur laquelle il n'y a aucun lien vers la liste des équipes
- un cta pour ajouter une équipe qui ajoutait de la hauteur à la page plutôt qu'être sur la même ligne que la recherche. Au passage j'ai aussi uniformisé l'index des agents






## Captures d'écran

Avant | Après
:- | -:
<img width="1440" alt="Screenshot 2024-07-30 at 15 09 46" src="https://github.com/user-attachments/assets/61d2e879-50ea-4ca1-aafd-d05d852c0218"> | <img width="1438" alt="Screenshot 2024-07-30 at 15 09 37" src="https://github.com/user-attachments/assets/cedc8726-20a1-4a2a-870a-44acafaaf049">
<img width="1440" alt="Screenshot 2024-07-30 at 15 09 57" src="https://github.com/user-attachments/assets/e3cb697f-8ec8-4fa7-8cad-8f92cd1d1f7e">| <img width="1440" alt="Screenshot 2024-07-30 at 15 10 07" src="https://github.com/user-attachments/assets/e2279f25-d01a-48cd-b10f-cb622491e998">
