### PR TITLE
Correctif des droits d'accès aux territoire

### DIFF
--- a/app/controllers/admin/territories/base_controller.rb
+++ b/app/controllers/admin/territories/base_controller.rb
@@ -41,6 +41,6 @@ class Admin::Territories::BaseController < ApplicationController
   private
 
   def set_territory
-    @territory = Territory.find(params[:territory_id])
+    @territory = policy_scope(Territory).find(params[:territory_id])
   end
 end

--- a/app/controllers/admin/territories/base_controller.rb
+++ b/app/controllers/admin/territories/base_controller.rb
@@ -41,6 +41,13 @@ class Admin::Territories::BaseController < ApplicationController
   private
 
   def set_territory
-    @territory = policy_scope(Territory).find(params[:territory_id])
+    @territory = Territory.find(params[:territory_id])
+
+    context = AgentTerritorialContext.new(current_agent, @territory)
+
+    policy = ::Configuration::TerritoryPolicy.new(context, @territory)
+    raise ActiveRecord::RecordNotFound unless policy.show?
+
+    @territory
   end
 end

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -33,4 +33,19 @@ class Configuration::TerritoryPolicy
   alias edit? territorial_admin?
   alias display_rdv_fields_configuration? territorial_admin?
   alias display_motif_fields_configuration? territorial_admin?
+
+  class Scope < ApplicationPolicy::Scope
+    include CurrentAgentInPolicyConcern
+
+    def resolve
+      territories_with_at_least_partial_access_rights = Territory.joins(:agent_territorial_access_rights).where(
+        agent_territorial_access_rights: { agent_id: current_agent.id }
+      ).where("allow_to_manage_teams OR allow_to_invite_agents OR allow_to_manage_access_rights")
+
+      scope.where_id_in_subqueries([
+                                     current_agent.territories,
+                                     territories_with_at_least_partial_access_rights,
+                                   ])
+    end
+  end
 end

--- a/app/policies/configuration/territory_policy.rb
+++ b/app/policies/configuration/territory_policy.rb
@@ -33,19 +33,4 @@ class Configuration::TerritoryPolicy
   alias edit? territorial_admin?
   alias display_rdv_fields_configuration? territorial_admin?
   alias display_motif_fields_configuration? territorial_admin?
-
-  class Scope < ApplicationPolicy::Scope
-    include CurrentAgentInPolicyConcern
-
-    def resolve
-      territories_with_at_least_partial_access_rights = Territory.joins(:agent_territorial_access_rights).where(
-        agent_territorial_access_rights: { agent_id: current_agent.id }
-      ).where("allow_to_manage_teams OR allow_to_invite_agents OR allow_to_manage_access_rights")
-
-      scope.where_id_in_subqueries([
-                                     current_agent.territories,
-                                     territories_with_at_least_partial_access_rights,
-                                   ])
-    end
-  end
 end

--- a/spec/features/territory_admins/can_crud_webhook_spec.rb
+++ b/spec/features/territory_admins/can_crud_webhook_spec.rb
@@ -37,4 +37,11 @@ RSpec.describe "territory admin can crud webhooks endpoints" do
     expect(page).not_to have_content organisation.name
     expect(organisation.reload.webhook_endpoints.count).to eq(0)
   end
+
+  it "has correct permissions for other territories" do
+    other_territory = create(:territory)
+    expect do
+      visit admin_territory_webhook_endpoints_path(territory_id: other_territory.id)
+    end.to raise_error(ActiveRecord::RecordNotFound)
+  end
 end

--- a/spec/features/territory_admins/teams_spec.rb
+++ b/spec/features/territory_admins/teams_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe "Managing teams" do
     other_territory = create(:territory)
     create(:team, territory: other_territory, name: "Equipe d'un autre territoire")
 
-    visit admin_territory_teams_path(territory_id: other_territory.id)
-    expect(page).not_to have_content("Equipe d'un autre territoire")
+    expect do
+      visit admin_territory_teams_path(territory_id: other_territory.id)
+    end.to raise_error(ActiveRecord::RecordNotFound)
   end
 end


### PR DESCRIPTION
# Contexte

Dans le cadre de https://github.com/betagouv/rdv-service-public/pull/4498#discussion_r1696965505, François faisait remarque à très juste titre que même si on se mettait à filtrer les équipe qu'on affiche, il était quand même possible d'afficher un index vide, et qu'il y avait un problème fondamental sur la manière dont les permissions sont gérées dans les nested routes de l'espace admin.

En effet, le problème des équipes n'est qu'un cas particulier : on a le même bug sur la plupart des indexes de l'espace admin (par exemple pour les webhooks comme le montre la spec de cette PR).

Cette PR a pour objectif de fournir une première couche de sécurité sur ces appels.

# Solution

J'ai essayé une première implémentation en ajoutant un `Configuration::TerritoryPolicy::Scope` pour scoper le gros `Territory.find(params[:territory_id])`, mais cela avait deux inconvénients :
- on se mettait à avoir un `Configuration::TerritoryPolicy::Scope`  similaire à  `Agent::TerritoryPolicy::Scope`, mais avec une différence de comportement importante (la gestion des agents qui ont des permissions sans être admin de territoire)
- ça ne marchait pas avec le `Admin::Territories::MotifsController` qui a le bon goût d'avoir `current_agent` en tant que `pundit_user`

J'ai donc réutilisé  `Configuration::TerritoryPolicy#show?` à la place.

L'erreur raisée n'est pas forcément la plus élégante, mais vu l'importance de traiter rapidement ce fix, ça me semblait être une première solution acceptable.

Un relecteur attentif verra qu'il y a un problème similaire dans `Admin::Territories::InvitationsDeviseController`. Ça sera traité dans une pr que je suis en train de préparer.

