### PR TITLE
Suppression des appels ajax à l'index des équipes

### DIFF
--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -2,8 +2,8 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
   before_action :set_team, only: %i[edit update destroy]
 
   def index
-    @teams = policy_scope(current_territory.teams, policy_scope_class: Agent::TeamPolicy::Scope)
-      .page(page_number).ordered_by_name
+    @teams = policy_scope(current_territory.teams, policy_scope_class: Agent::TeamPolicy::Scope).page(page_number)
+    @teams = params[:term].present? ? @teams.search_by_text(params[:term]) : @teams.ordered_by_name
   end
 
   def new

--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -1,11 +1,9 @@
 class Admin::Territories::TeamsController < Admin::Territories::BaseController
   before_action :set_team, only: %i[edit update destroy]
 
-  respond_to :html, :json
-
   def index
-    @teams = policy_scope(current_territory.teams, policy_scope_class: Agent::TeamPolicy::Scope).page(page_number)
-    @teams = params[:term].present? ? @teams.search_by_text(params[:term]) : @teams.ordered_by_name
+    @teams = policy_scope(current_territory.teams, policy_scope_class: Agent::TeamPolicy::Scope)
+      .page(page_number).ordered_by_name
   end
 
   def new

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,19 +5,6 @@ class Team < ApplicationRecord
     meta: { virtual_attributes: :virtual_attributes_for_paper_trail }
   )
 
-  include TextSearch
-  def self.search_options
-    {
-      against:
-        {
-          name: "A",
-          id: "D",
-        },
-      ignoring: :accents,
-      using: { tsearch: { prefix: true, any_word: true } },
-    }
-  end
-
   # Attributes
   auto_strip_attributes :name
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,6 +5,19 @@ class Team < ApplicationRecord
     meta: { virtual_attributes: :virtual_attributes_for_paper_trail }
   )
 
+  include TextSearch
+  def self.search_options
+    {
+      against:
+        {
+          name: "A",
+          id: "D",
+        },
+      ignoring: :accents,
+      using: { tsearch: { prefix: true, any_word: true } },
+    }
+  end
+
   # Attributes
   auto_strip_attributes :name
 

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -60,21 +60,12 @@ h1
         = t(".agent_teams_legend")
       = simple_form_for @agent, url: admin_territory_agent_path(current_territory, @agent) do |f|
         .card-body
-          = f.input :team_ids, collection: @agent.teams,
+          = f.input :team_ids, collection: current_territory.teams,
                 label: t(".teams"),
                 label_method: :name,
                 input_html: { \
                   multiple: true, \
                   class: "select2-input",\
-                  data: {\
-                    "select-options": {\
-                      ajax: {\
-                        url: admin_territory_teams_path(current_territory),
-                        dataType: "json",
-                        delay: 250,\
-                      },\
-                    },\
-                  },\
                 }
         .card-footer
           .row

--- a/app/views/admin/territories/teams/index.json.jbuilder
+++ b/app/views/admin/territories/teams/index.json.jbuilder
@@ -1,4 +1,0 @@
-json.results @teams do |team|
-  json.id team.id
-  json.text team.name
-end

--- a/app/views/admin/territories/teams/search.json.jbuilder
+++ b/app/views/admin/territories/teams/search.json.jbuilder
@@ -1,4 +1,0 @@
-json.results @teams do |team|
-  json.id team.id
-  json.text team.name
-end

--- a/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
+++ b/spec/requests/admin/territories/cruds_teams_configuration_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "CRUDS teams configuration", type: :request do
-  include Rails.application.routes.url_helpers
-
   describe "GET admin/territories/:territory_id/teams" do
     it "returns all teams" do
       territory = create(:territory)
@@ -28,22 +26,6 @@ RSpec.describe "CRUDS teams configuration", type: :request do
       matching_team = create(:team, territory: territory, name: "First Groupe")
 
       get admin_territory_teams_path(territory, term: "first")
-
-      expect(response).to be_successful
-      expect(assigns(:teams)).to eq([matching_team])
-    end
-
-    it "returns searched teams with json format" do
-      territory = create(:territory)
-      agent = create(:agent)
-      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent, territory: territory)
-
-      sign_in agent
-
-      create(:team, territory: territory, name: "other name")
-      matching_team = create(:team, territory: territory, name: "First Groupe")
-
-      get admin_territory_teams_path(territory, term: "first", format: :json)
 
       expect(response).to be_successful
       expect(assigns(:teams)).to eq([matching_team])


### PR DESCRIPTION
Dans la lignée de ce qui a été fait pour https://github.com/betagouv/rdv-service-public/pull/4501, on peut charger en mémoire la liste des équipes lors de l'édition d'un agent dans l'espace admin.

Ça permet au passage de simplifier le code.

J'ai été agréablement surpris par la recherche de select2 quand les objets sont chargés en mémoire : les accents sont traités correctement (par exemple quand je tape "équipe", les équipes avec le nom "equipe" sans accent apparaissent). Par ailleurs c'est plus rapide d'avoir une recherche en mémoire que via un appel ajax donc c'est une ux légèrement plus agréable.