### PR TITLE
Correctif sur la Configuration::AgentRolePolicy

### DIFF
--- a/app/policies/configuration/agent_role_policy.rb
+++ b/app/policies/configuration/agent_role_policy.rb
@@ -1,12 +1,12 @@
 class Configuration::AgentRolePolicy
-  def initialize(context, _agent)
+  def initialize(context, agent_role)
     @current_agent = context.agent
-    @current_territory = context.territory
-    @access_rights = @current_agent.access_rights_for_territory(@current_territory)
+    @agent_role = agent_role
+    @access_rights = @current_agent.access_rights_for_territory(agent_role.organisation.territory)
   end
 
   def territorial_admin?
-    @current_agent.territorial_admin_in?(@current_territory) ||
+    @current_agent.territorial_admin_in?(@agent_role.organisation.territory) ||
       @access_rights&.allow_to_invite_agents?
   end
 

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Admin::Territories::AgentRolesController, type: :controller do
     it "redirect to territorial agent edit on success" do
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-      agent_role = create(:agent_role, agent: agent, access_level: "basic")
+      organisation = create(:organisation, territory: territory)
+      agent_role = create(:agent_role, agent: agent, access_level: "basic", organisation: organisation)
       sign_in agent
 
       post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { access_level: "admin" } }
@@ -16,6 +17,7 @@ RSpec.describe Admin::Territories::AgentRolesController, type: :controller do
     it "changes role" do
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
+      organisation = create(:organisation, territory: territory)
       agent_role = create(:agent_role, agent: agent, access_level: "basic")
       sign_in agent
 

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -3,18 +3,7 @@ RSpec.describe Admin::Territories::AgentRolesController, type: :controller do
   let!(:territory) { create(:territory).tap { |t| t.roles.create!(agent: create(:agent)) } }
 
   describe "POST #update" do
-    it "redirect to territorial agent edit on success" do
-      agent = create(:agent, role_in_territories: [territory])
-      create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
-      organisation = create(:organisation, territory: territory)
-      agent_role = create(:agent_role, agent: agent, access_level: "basic", organisation: organisation)
-      sign_in agent
-
-      post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { access_level: "admin" } }
-      expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
-    end
-
-    it "changes role" do
+    it "changes role and redirect to territorial agent edit" do
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
       organisation = create(:organisation, territory: territory)
@@ -24,6 +13,8 @@ RSpec.describe Admin::Territories::AgentRolesController, type: :controller do
       expect do
         post :update, params: { territory_id: territory.id, id: agent_role.id, agent_role: { access_level: "admin" } }
       end.to change { agent_role.reload.access_level }.from(AgentRole::ACCESS_LEVEL_BASIC).to(AgentRole::ACCESS_LEVEL_ADMIN)
+
+      expect(response).to redirect_to(edit_admin_territory_agent_path(territory, agent))
     end
   end
 

--- a/spec/controllers/admin/territories/agent_roles_controller_spec.rb
+++ b/spec/controllers/admin/territories/agent_roles_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Admin::Territories::AgentRolesController, type: :controller do
       agent = create(:agent, role_in_territories: [territory])
       create(:agent_territorial_access_right, allow_to_manage_teams: true, agent: agent)
       organisation = create(:organisation, territory: territory)
-      agent_role = create(:agent_role, agent: agent, access_level: "basic")
+      agent_role = create(:agent_role, agent: agent, access_level: "basic", organisation: organisation)
       sign_in agent
 
       expect do


### PR DESCRIPTION
Correctif de sécurité, voir le diff pour comprendre le bug. L'implémentation précédente était très surprenante.

Ça serait bien de merger les deux AgentRolePolicy, mais je garde ça pour plus tard.