### PR TITLE
Nettoyage de code devise obsolete

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,8 +67,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     if resource_class == Agent
-      devise_parameter_sanitizer.permit(:invite, keys: [:email, :service_id, { organisation_ids: [] },
-                                                        { agent_territorial_access_rights_attributes: :territory_id }, { roles_attributes: %i[access_level organisation_id] },])
       devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name])
       devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name service_id])
     elsif resource_class == User


### PR DESCRIPTION
Ces deux lignes sont inutiles depuis qu'on a mergé https://github.com/betagouv/rdv-service-public/pull/4505, mais je ne les avait pas vues à l'époque de cette pr.