### PR TITLE
Empêcher les créations d'invitation par défaut de devise_invitable

### DIFF
--- a/app/controllers/admin/territories/invitations_devise_controller.rb
+++ b/app/controllers/admin/territories/invitations_devise_controller.rb
@@ -2,7 +2,7 @@ class Admin::Territories::InvitationsDeviseController < Devise::InvitationsContr
   # Ce controller est uniquement utilisé pour permettre aux agents d'accepter les invitations
   layout "application_dsfr"
 
-  # Bloque l'accès aux méthodes du controller parent
+  # Bloque l'accès aux méthodes du controller parent pour éviter de permettre d'envoyer des invitations n'importe comment
   before_action :block_controller_action, except: %i[edit update] # rubocop:disable Rails/LexicallyScopedActionFilter
 
   def block_controller_action

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -4,6 +4,13 @@ class Users::InvitationsController < Devise::InvitationsController
   before_action :delete_token_from_session, only: [:update]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
+  # Bloque l'accès aux méthodes du controller parent pour éviter de permettre d'envoyer des invitations n'importe comment
+  before_action :block_controller_action, except: %i[edit update invitation] # rubocop:disable Rails/LexicallyScopedActionFilter
+
+  def block_controller_action
+    raise Pundit::NotAuthorizedError, "not authorized"
+  end
+
   include CanHaveRdvWizardContext
 
   def invitation; end


### PR DESCRIPTION
Les routes créées par devise_invitable via la méthode `devise_for` ont le comportement par défaut de devise_invitable, c'est à dire un formulaire basique qui permet d'envoyer une invitation.

Si c'était utilisé, ça aboutirait probablement à des comptes usagers invalides, donc on préfère éviter ça.