### PR TITLE
Correction Configuration::ZonePolicy

### DIFF
--- a/app/controllers/admin/territories/zones_controller.rb
+++ b/app/controllers/admin/territories/zones_controller.rb
@@ -3,6 +3,7 @@ class Admin::Territories::ZonesController < Admin::Territories::BaseController
 
   def index
     zones = policy_scope(Zone)
+      .joins(:sector).where(sectors: { territory_id: current_territory.id })
       .where(params[:sector_id].present? ? { sector: params[:sector_id] } : {})
     respond_to do |format|
       format.xls do

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -9,6 +9,7 @@ class Zone < ApplicationRecord
 
   # Relations
   belongs_to :sector
+  delegate :territory, to: :sector
 
   # Validations
   validates :level, :city_name, :city_code, presence: true

--- a/app/policies/configuration/zone_policy.rb
+++ b/app/policies/configuration/zone_policy.rb
@@ -13,12 +13,15 @@ class Configuration::ZonePolicy
   alias destroy? territorial_admin?
 
   class Scope
-    def initialize(context, _scope)
-      @current_territory = context.territory
+    def initialize(context, scope)
+      @current_agent = context.agent
+      @scope = scope
     end
 
     def resolve
-      @current_territory.zones
+      @scope
+        .joins(:sector)
+        .where(sectors: { territory_id: @current_agent.territorial_roles.pluck(:territory_id) })
     end
   end
 end

--- a/app/policies/configuration/zone_policy.rb
+++ b/app/policies/configuration/zone_policy.rb
@@ -1,12 +1,11 @@
 class Configuration::ZonePolicy
-  def initialize(context, agent)
+  def initialize(context, zone)
     @current_agent = context.agent
-    @current_territory = context.territory
-    @agent = agent
+    @zone = zone
   end
 
   def territorial_admin?
-    @current_agent.territorial_admin_in?(@current_territory)
+    @current_agent.territorial_admin_in?(@zone.territory)
   end
 
   alias new? territorial_admin?

--- a/app/services/zone_import_row.rb
+++ b/app/services/zone_import_row.rb
@@ -68,7 +68,7 @@ class ZoneImportRow
   def authorized?
     return true if !fields_present? || !sector_found? || !valid_zone?
 
-    policy = Configuration::ZonePolicy.new(AgentTerritorialContext.new(@agent, zone.sector.territory), @agent)
+    policy = Configuration::ZonePolicy.new(AgentTerritorialContext.new(@agent, zone.sector.territory), zone)
     return true if policy.create?
 
     @errors << {

--- a/spec/policies/configuration/zone_policy_spec.rb
+++ b/spec/policies/configuration/zone_policy_spec.rb
@@ -1,53 +1,59 @@
 RSpec.describe Configuration::ZonePolicy, type: :policy do
-  %i[new? create? destroy?].each do |action|
-    describe "##{action}" do
-      context "agent does not have any territorial role" do
-        let(:territory) { create(:territory) }
-        let(:sector) { create(:sector, territory:) }
-        let(:zone) { create(:zone, sector:) }
-        let(:agent) { create(:agent) }
-        let(:agent_territorial_context) { AgentTerritorialContext.new(agent, territory) }
+  subject { described_class }
 
-        it "does not permit #{action}" do
-          expect(described_class.new(agent_territorial_context, zone).send(action)).to eq false
-        end
-      end
+  context "agent does not have any territorial role" do
+    let(:territory) { create(:territory) }
+    let(:sector) { create(:sector, territory:) }
+    let(:zone) { create(:zone, sector:) }
+    let(:agent) { create(:agent) }
+    let(:pundit_context) { AgentTerritorialContext.new(agent, territory) }
 
-      context "agent has territorial role in zone territory" do
-        let(:territory) { create(:territory) }
-        let(:sector) { create(:sector, territory:) }
-        let(:zone) { create(:zone, sector:) }
-        let(:agent) { create(:agent, role_in_territories: [territory]) }
-        let(:agent_territorial_context) { AgentTerritorialContext.new(agent, territory) }
+    it_behaves_like "not permit actions",
+                    :zone,
+                    :new?,
+                    :create?,
+                    :destroy?
+  end
 
-        it "permits #{action}" do
-          expect(described_class.new(agent_territorial_context, zone).send(action)).to eq true
-        end
-      end
+  context "agent has territorial role in zone territory" do
+    let(:territory) { create(:territory) }
+    let(:sector) { create(:sector, territory:) }
+    let(:zone) { create(:zone, sector:) }
+    let(:agent) { create(:agent, role_in_territories: [territory]) }
+    let(:pundit_context) { AgentTerritorialContext.new(agent, territory) }
 
-      context "agent has territorial role in other territory" do
-        let(:territory_zone) { create(:territory) }
-        let(:territory_agent) { create(:territory) }
-        let(:sector) { create(:sector, territory: territory_zone) }
-        let(:zone) { create(:zone, sector:) }
-        let(:agent) { create(:agent, role_in_territories: [territory_agent]) }
+    it_behaves_like "permit actions",
+                    :zone,
+                    :new?,
+                    :create?,
+                    :destroy?
+  end
 
-        context "context uses agent's territory" do
-          let(:agent_territorial_context) { AgentTerritorialContext.new(agent, territory_agent) }
+  context "agent has territorial role in other territory" do
+    let(:territory_zone) { create(:territory) }
+    let(:territory_agent) { create(:territory) }
+    let(:sector) { create(:sector, territory: territory_zone) }
+    let(:zone) { create(:zone, sector:) }
+    let(:agent) { create(:agent, role_in_territories: [territory_agent]) }
 
-          it "does not permit #{action}" do
-            expect(described_class.new(agent_territorial_context, zone).send(action)).to eq false
-          end
-        end
+    context "context uses agent’s territory" do
+      let(:pundit_context) { AgentTerritorialContext.new(agent, territory_agent) }
 
-        context "context uses zone's territory" do
-          let(:agent_territorial_context) { AgentTerritorialContext.new(agent, territory_zone) }
+      it_behaves_like "not permit actions",
+                      :zone,
+                      :new?,
+                      :create?,
+                      :destroy?
+    end
 
-          it "does not permit #{action}" do
-            expect(described_class.new(agent_territorial_context, zone).send(action)).to eq false
-          end
-        end
-      end
+    context "context uses zone's territory" do
+      let(:pundit_context) { AgentTerritorialContext.new(agent, territory_zone) }
+
+      it_behaves_like "not permit actions",
+                      :zone,
+                      :new?,
+                      :create?,
+                      :destroy?
     end
   end
 end

--- a/spec/policies/configuration/zone_policy_spec.rb
+++ b/spec/policies/configuration/zone_policy_spec.rb
@@ -56,4 +56,120 @@ RSpec.describe Configuration::ZonePolicy, type: :policy do
                       :destroy?
     end
   end
+
+  describe Configuration::ZonePolicy::Scope, type: :policy do
+    let!(:territory_paris) { create(:territory) }
+    let!(:sector_montparnasse) { create(:sector, territory: territory_paris) }
+    let!(:zone_montparnasse) { create(:zone, city_name: "Paris", sector: sector_montparnasse) }
+    let!(:sector_vautgirard) { create(:sector, territory: territory_paris) }
+    let!(:zone_vaugirard) { create(:zone, city_name: "Paris", sector: sector_vautgirard) }
+
+    let!(:territory_marseille) { create(:territory) }
+    let!(:sector_timone) { create(:sector, territory: territory_marseille) }
+    let!(:zone_timone) { create(:zone, city_name: "Marseille", sector: sector_timone) }
+    let!(:sector_baille) { create(:sector, territory: territory_marseille) }
+    let!(:zone_baille) { create(:zone, city_name: "Marseille", sector: sector_baille) }
+
+    let!(:territory_lyon) { create(:territory) }
+    let!(:sector_perrache) { create(:sector, territory: territory_lyon) }
+    let!(:zone_perrache) { create(:zone, city_name: "Lyon", sector: sector_perrache) }
+    let!(:sector_partdieu) { create(:sector, territory: territory_lyon) }
+    let!(:zone_partdieu) { create(:zone, city_name: "Lyon", sector: sector_partdieu) }
+
+    context "agent has territorial roles in Paris and Marseille" do
+      let(:agent) { create(:agent, role_in_territories: [territory_paris, territory_marseille]) }
+
+      context "scope all zones using Paris as context territory" do
+        subject { described_class.new(AgentTerritorialContext.new(agent, territory_paris), Zone.all).resolve }
+
+        it { is_expected.to contain_exactly(zone_montparnasse, zone_vaugirard, zone_timone, zone_baille) }
+      end
+
+      context "scope Paris zones using Paris as context territory" do
+        subject do
+          described_class.new(
+            AgentTerritorialContext.new(agent, territory_paris),
+            Zone.joins(:sector).where(sectors: { territory_id: territory_paris.id })
+          ).resolve
+        end
+
+        it { is_expected.to contain_exactly(zone_montparnasse, zone_vaugirard) }
+      end
+
+      context "scope Marseille zones using Paris as context territory" do
+        subject do
+          described_class.new(
+            AgentTerritorialContext.new(agent, territory_paris),
+            Zone.joins(:sector).where(sectors: { territory_id: territory_marseille.id })
+          ).resolve
+        end
+
+        it { is_expected.to contain_exactly(zone_timone, zone_baille) }
+      end
+
+      context "scope Lyon zones using Paris as context territory" do
+        subject do
+          described_class.new(
+            AgentTerritorialContext.new(agent, territory_paris),
+            Zone.joins(:sector).where(sectors: { territory_id: territory_lyon.id })
+          ).resolve
+        end
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context "agent has single territorial role in Paris" do
+      let(:agent) { create(:agent, role_in_territories: [territory_paris]) }
+
+      context "scope all zones using Paris as context territory" do
+        subject { described_class.new(AgentTerritorialContext.new(agent, territory_paris), Zone.all).resolve }
+
+        it { is_expected.to contain_exactly(zone_montparnasse, zone_vaugirard) }
+      end
+
+      context "scope Paris zones using Paris as context territory" do
+        subject do
+          described_class.new(
+            AgentTerritorialContext.new(agent, territory_paris),
+            Zone.joins(:sector).where(sectors: { territory_id: territory_paris.id })
+          ).resolve
+        end
+
+        it { is_expected.to contain_exactly(zone_montparnasse, zone_vaugirard) }
+      end
+
+      context "scope Marseille zones using Paris as context territory" do
+        subject do
+          described_class.new(
+            AgentTerritorialContext.new(agent, territory_paris),
+            Zone.joins(:sector).where(sectors: { territory_id: territory_marseille.id })
+          ).resolve
+        end
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    context "agent has no territorial roles at all" do
+      let(:agent) { create(:agent, role_in_territories: []) }
+
+      context "scope all zones using Paris as context territory" do
+        subject { described_class.new(AgentTerritorialContext.new(agent, territory_paris), Zone.all).resolve }
+
+        it { is_expected.to be_empty }
+      end
+
+      context "scope Paris zones using Paris as context territory" do
+        subject do
+          described_class.new(
+            AgentTerritorialContext.new(agent, territory_paris),
+            Zone.joins(:sector).where(sectors: { territory_id: territory_paris.id })
+          ).resolve
+        end
+
+        it { is_expected.to be_empty }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Voir le doc notion pour plus de contexte

cette PR se lit bien commit par commit

On pourra réduire le nombre de specs lorsqu’on supprimera le `context.territory` complètement pour revenir à une policy avec pour seul contexte l’agent. Là j’en ai écrit beaucoup pour avoir des failing specs volontairement, mais elles n’ont plus beaucoup de sens une fois le code de la policy corrigé.