### PR TITLE
correction erreur lors de la création d’un agent depuis l’admin de territoire

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -57,8 +57,7 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
       flash[:alert] = create_agent.warning_message
       redirect_to admin_territory_agents_path(current_territory)
     else
-      flash[:error] = agent.errors.full_messages.to_sentence
-      render_new
+      render :new
     end
   end
 


### PR DESCRIPTION
Cette PR devrait corriger https://sentry.incubateur.net/organizations/betagouv/issues/113856/?project=74

C’est un relicat d’une PR de fix récente, `agent` n’existe plus ici, il aurait fallu utiliser `@agent`.

Cependant j’ai remarqué que ça faisait doublon d’afficher les erreurs dans un flash d’erreur. Les erreurs sont en effet déjà affichées de manière plus classique dans le formulaire : 

<img width="612" alt="image" src="https://github.com/user-attachments/assets/d15d75d7-0acb-40b7-a069-9966b4905df8">

Au passage je corrige le `render_new` en `render :new`, ce `render_new` a été copié depuis le controleur d’agents non-scopé à la configuration mais il n’existe pas ici

Pour reproduire, une manière simple est de remplacer dans le html le type du champ email par string et de mettre un mauvais email.