### PR TITLE
Correctif de la AgentPolicy

### DIFF
--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -20,7 +20,7 @@ class Configuration::AgentPolicy
   alias display? territorial_admin_or_allowed_to_manage_agent_part?
   alias edit? territorial_admin_or_allowed_to_manage_agent_part?
   alias update? territorial_admin_or_allowed_to_manage_agent_part?
-  alias territory_admin? territorial_admin_or_allowed_to_manage_agent_part?
+  alias territory_admin? territorial_admin?
   alias update_services? territorial_admin_or_allowed_to_manage_agent_part?
 
   def create?

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -36,7 +36,7 @@ h1
             .col.text-right
               = f.submit class: "btn btn-primary", value: "Enregistrer les droits d'accès"
 
-  - if Agent::TerritoryPolicy.new(current_agent, current_territory).allow_to_manage_access_rights?
+  - if Configuration::AgentPolicy.new(AgentTerritorialContext.new(current_agent, current_territory), current_territory).territorial_admin?
     .card.m-2.rounded.agent-territorial
       h2.card-header
         = t(".agent_territorial_role_caption")

--- a/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_agents_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "territory admin can manage agents", type: :feature do
     it "works" do
       team_a = create(:team, name: "A", territory: territory)
       team_b = create(:team, name: "B", territory: territory)
-      current_agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory], teams: [team_a])
-      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [territory], teams: [team_a, team_b])
+      current_agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [], teams: [team_a])
+      agent = create(:agent, admin_role_in_organisations: [organisation], role_in_territories: [], teams: [team_a, team_b])
       create(:agent_territorial_access_right, agent: current_agent, territory: territory, allow_to_manage_teams: true)
       create(:agent_territorial_access_right, agent: agent, territory: territory)
       login_as(current_agent, scope: :agent)

--- a/spec/requests/admin/territories/update_territory_admin_spec.rb
+++ b/spec/requests/admin/territories/update_territory_admin_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "Update territory admin" do
+  let(:territory) { create(:territory) }
+  let(:current_agent) { create(:agent, role_in_territories: []) }
+  let(:other_agent) { create(:agent) }
+  let(:organisation) { create(:organisation, territory: territory) }
+
+  before do
+    create(:agent_territorial_access_right, agent: other_agent)
+  end
+
+  before { sign_in current_agent }
+
+  context "when the agent can only manage teams in the current territory" do
+    before do
+      create(:agent_territorial_access_right, agent: current_agent, territory: territory, allow_to_manage_teams: true)
+    end
+
+    it "doesn't allow making an agent a territorial admin" do
+      put territory_admin_admin_territory_agent_path(territory_id: territory.id, id: other_agent.id), params: { territorial_admin: "1" }
+      expect(other_agent.reload.territorial_roles).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
voir fiche notion et la spec pour plus de détails

Le fix est assez restrictif : pour éviter les escalades de privilèges, on autorise uniquement les admins, et pas les agents qui ont les droits d'accès (contrairement à l'implémentation précédente)