### PR TITLE
renommage de la route pour mettre à jour les équipes d’un agent depuis l’admin de territoire

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -29,7 +29,7 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
 
   def update_teams
     # ATTENTION: ce update peut supprimer des team_ids d’autres territoires.
-    # C’est un bug consciemment laissé pour l’instant.
+    # C’est un bug consciemment laissé pour l’instant puisqu'on a pas ou peu d'agents multi-territoire et que les équipes ne sont pas utilisées par la plupart des territoires
     # cf PR https://github.com/betagouv/rdv-service-public/pull/4525 qui tentait de résoudre ça.
     team_ids = params[:agent][:team_ids].compact_blank
     if @agent.update(team_ids:)

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -19,7 +19,7 @@ class Configuration::AgentPolicy
 
   alias display? territorial_admin_or_allowed_to_manage_agent_part?
   alias edit? territorial_admin_or_allowed_to_manage_agent_part?
-  alias update? territorial_admin_or_allowed_to_manage_agent_part?
+  alias update_teams? territorial_admin_or_allowed_to_manage_agent_part?
   alias territory_admin? territorial_admin?
   alias update_services? territorial_admin_or_allowed_to_manage_agent_part?
 

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -58,7 +58,7 @@ h1
     .card.m-2.rounded
       h2.card-header
         = t(".agent_teams_legend")
-      = simple_form_for @agent, url: admin_territory_agent_path(current_territory, @agent) do |f|
+      = simple_form_for @agent, url: update_teams_admin_territory_agent_path(current_territory, @agent) do |f|
         .card-body
           = f.input :team_ids, collection: current_territory.teams,
                 label: t(".teams"),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,10 +126,11 @@ Rails.application.routes.draw do
           resources :agent_roles, only: %i[update create destroy]
           resources :agent_territorial_access_rights, only: %i[update]
           resources :webhook_endpoints, except: %i[show]
-          resources :agents, only: %i[index new create update edit] do
+          resources :agents, only: %i[index new create edit] do
             member do
               put :territory_admin
               patch :update_services
+              patch :update_teams
             end
           end
           resources :teams, except: :show

--- a/spec/policies/configuration/agent_policy_spec.rb
+++ b/spec/policies/configuration/agent_policy_spec.rb
@@ -9,35 +9,35 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory) }
 
-      it_behaves_like "not permit actions", :agent, :display?, :edit?, :create?, :update?
+      it_behaves_like "not permit actions", :agent, :display?, :edit?, :create?, :update_teams?
     end
 
     context "admin access to this territory" do
       let(:agent) { create(:agent, role_in_territories: [territory]) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory) }
 
-      it_behaves_like "permit actions", :agent, :display?, :edit?, :create?, :update?
+      it_behaves_like "permit actions", :agent, :display?, :edit?, :create?, :update_teams?
     end
 
     context "allowed to manage teams agent" do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_manage_teams: true) }
 
-      it_behaves_like "permit actions", :agent, :display?, :edit?, :update?
+      it_behaves_like "permit actions", :agent, :display?, :edit?, :update_teams?
     end
 
     context "allowed to invite agents agent" do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_invite_agents: true) }
 
-      it_behaves_like "permit actions", :agent, :display?, :edit?, :create?, :update?
+      it_behaves_like "permit actions", :agent, :display?, :edit?, :create?, :update_teams?
     end
 
     context "allowed to manage access rights agent" do
       let(:agent) { create(:agent, role_in_territories: []) }
       let!(:access_rights) { create(:agent_territorial_access_right, agent: agent, territory: territory, allow_to_manage_access_rights: true) }
 
-      it_behaves_like "permit actions", :agent, :display?, :edit?, :update?
+      it_behaves_like "permit actions", :agent, :display?, :edit?, :update_teams?
     end
   end
 end


### PR DESCRIPTION
## Contexte

Actuellement la route `PATCH territories/:territory_id/agents/:agent_id` met à jour les équipes de l’agent
De plus il s’y glisse un bug dur à voir.

## Solution

On renomme la route en `update_teams` et on rajoute un commentaire pour expliciter ce bug.

On aurait aussi pu raiser si on s’apprête à écraser des team_ids sans le savoir, @victormours qu’en penses-tu ?