### PR TITLE
Simplification des méthodes pundit_user, authorize et policy_scope pour les controllers de l'espace admin

### DIFF
--- a/app/controllers/admin/territories/agent_roles_controller.rb
+++ b/app/controllers/admin/territories/agent_roles_controller.rb
@@ -45,10 +45,6 @@ class Admin::Territories::AgentRolesController < Admin::Territories::BaseControl
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def agent_role_params
     params.require(:agent_role).permit(:access_level, :organisation_id, :agent_id)
   end

--- a/app/controllers/admin/territories/agent_territorial_access_rights_controller.rb
+++ b/app/controllers/admin/territories/agent_territorial_access_rights_controller.rb
@@ -13,10 +13,4 @@ class Admin::Territories::AgentTerritorialAccessRightsController < Admin::Territ
   def agent_territorial_access_right_params
     params.require(:agent_territorial_access_right).permit(:allow_to_manage_teams, :allow_to_manage_access_rights, :allow_to_invite_agents)
   end
-
-  private
-
-  def pundit_user
-    current_agent
-  end
 end

--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -93,6 +93,16 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
 
   private
 
+  def pundit_user
+    AgentTerritorialContext.new(current_agent, current_territory)
+  end
+
+  def authorize_with_legacy_configuration_scope(record, *args, **kwargs)
+    # L'utilisation de configuration est un legacy qui a l'inconvénient de distinguer les permissions en fonction de la page sur laquelle on est en train de naviguer
+    # On préfère que le controller applique le filtre pertinent, et que les policy indiquent les permissions dans l'absolu, indépendamment de la page courante.
+    authorize([:configuration, record], *args, **kwargs)
+  end
+
   def set_agent
     @agent = Agent.active.find(params[:id])
   end

--- a/app/controllers/admin/territories/base_controller.rb
+++ b/app/controllers/admin/territories/base_controller.rb
@@ -16,26 +16,13 @@ class Admin::Territories::BaseController < ApplicationController
   helper_method :current_territory
 
   def pundit_user
-    AgentTerritorialContext.new(current_agent, current_territory)
+    current_agent
   end
   helper_method :pundit_user
 
-  def authorize_with_legacy_configuration_scope(record, *args, **kwargs)
-    # L'utilisation de configuration est un legacy qui a l'inconvénient de distinguer les permissions en fonction de la page sur laquelle on est en train de naviguer
-    # On préfère que le controller applique le filtre pertinent, et que les policy indiquent les permissions dans l'absolu, indépendamment de la page courante.
-    authorize([:configuration, record], *args, **kwargs)
-  end
-
   # L'usage recommandé est de passer explicitement une policy_scope_class pour savoir quelle policy est utilisé
-  # A terme, on voudra forcer l'argument policy_scope_class
-  def policy_scope(scope, policy_scope_class: nil)
-    if policy_scope_class
-      super(scope, policy_scope_class: policy_scope_class)
-    else
-      # L'utilisation de configuration est un legacy qui a l'inconvénient de distinguer les permissions en fonction de la page sur laquelle on est en train de naviguer
-      # On préfère que le controller applique le filtre pertinent, et que les policy indiquent les permissions dans l'absolu, indépendamment de la page courante.
-      super([:configuration, scope])
-    end
+  def policy_scope(scope, policy_scope_class:)
+    super(scope, policy_scope_class: policy_scope_class)
   end
 
   private

--- a/app/controllers/admin/territories/motif_categories_controller.rb
+++ b/app/controllers/admin/territories/motif_categories_controller.rb
@@ -8,10 +8,6 @@ class Admin::Territories::MotifCategoriesController < Admin::Territories::BaseCo
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def motif_categories_params
     params.require(:territory).permit(motif_category_ids: [])
   end

--- a/app/controllers/admin/territories/motif_fields_controller.rb
+++ b/app/controllers/admin/territories/motif_fields_controller.rb
@@ -2,10 +2,4 @@ class Admin::Territories::MotifFieldsController < Admin::Territories::BaseContro
   def edit
     authorize_agent current_territory
   end
-
-  private
-
-  def pundit_user
-    current_agent
-  end
 end

--- a/app/controllers/admin/territories/motifs_controller.rb
+++ b/app/controllers/admin/territories/motifs_controller.rb
@@ -20,7 +20,7 @@ class Admin::Territories::MotifsController < Admin::Territories::BaseController
 
   def destroy
     motif = Motif.active.find(params[:id])
-    authorize_with_legacy_configuration_scope(motif, policy_class: Agent::MotifPolicy)
+    authorize_agent motif
     if motif.soft_delete
       flash[:notice] = "Le motif a été supprimé."
     else
@@ -39,9 +39,5 @@ class Admin::Territories::MotifsController < Admin::Territories::BaseController
     motifs = motifs.where(collectif: params[:collectif].to_b) if params[:collectif].present?
     motifs = motifs.where(bookable_by: params[:bookable_by]) if params[:bookable_by].present?
     motifs
-  end
-
-  def pundit_user
-    current_agent
   end
 end

--- a/app/controllers/admin/territories/rdv_fields_controller.rb
+++ b/app/controllers/admin/territories/rdv_fields_controller.rb
@@ -12,10 +12,6 @@ class Admin::Territories::RdvFieldsController < Admin::Territories::BaseControll
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def rdv_fields_params
     params.require(:territory).permit(Territory::OPTIONAL_RDV_FIELD_TOGGLES.keys + Territory::OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.keys)
   end

--- a/app/controllers/admin/territories/sector_attributions_controller.rb
+++ b/app/controllers/admin/territories/sector_attributions_controller.rb
@@ -30,10 +30,6 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def prepare_available_organisations_and_agents
     @available_organisations = Organisation
       .where(territory: current_territory)

--- a/app/controllers/admin/territories/sectors_controller.rb
+++ b/app/controllers/admin/territories/sectors_controller.rb
@@ -55,10 +55,6 @@ class Admin::Territories::SectorsController < Admin::Territories::BaseController
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def set_sector
     @sector = Sector.find(params[:id])
     authorize_agent @sector

--- a/app/controllers/admin/territories/services_controller.rb
+++ b/app/controllers/admin/territories/services_controller.rb
@@ -22,10 +22,6 @@ class Admin::Territories::ServicesController < Admin::Territories::BaseControlle
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def services_params
     params.require(:territory).permit(service_ids: [])
   end

--- a/app/controllers/admin/territories/teams_controller.rb
+++ b/app/controllers/admin/territories/teams_controller.rb
@@ -41,11 +41,6 @@ class Admin::Territories::TeamsController < Admin::Territories::BaseController
     redirect_to admin_territory_teams_path(current_territory)
   end
 
-  # On est obligé de redéfinir cette méthode ici tant que le controller parent utilise les AgentTerritorialContext
-  def pundit_user
-    current_agent
-  end
-
   private
 
   def team_params

--- a/app/controllers/admin/territories/user_fields_controller.rb
+++ b/app/controllers/admin/territories/user_fields_controller.rb
@@ -13,10 +13,6 @@ class Admin::Territories::UserFieldsController < Admin::Territories::BaseControl
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def user_fields_params
     params.require(:territory).permit(Territory::OPTIONAL_FIELD_TOGGLES.keys)
   end

--- a/app/controllers/admin/territories/webhook_endpoints_controller.rb
+++ b/app/controllers/admin/territories/webhook_endpoints_controller.rb
@@ -40,11 +40,6 @@ class Admin::Territories::WebhookEndpointsController < Admin::Territories::BaseC
 
   private
 
-  # On est obligé de redéfinir cette méthode ici tant que le controller parent utilise les AgentTerritorialContext
-  def pundit_user
-    current_agent
-  end
-
   def webhook_endpoint_params
     params.require(:webhook_endpoint).permit(
       :target_url, :secret, :organisation_id, subscriptions: []

--- a/app/controllers/admin/territories/zone_imports_controller.rb
+++ b/app/controllers/admin/territories/zone_imports_controller.rb
@@ -24,10 +24,6 @@ class Admin::Territories::ZoneImportsController < Admin::Territories::BaseContro
 
   private
 
-  def pundit_user
-    agent
-  end
-
   def import_params
     params
       .require(:zone_import)

--- a/app/controllers/admin/territories/zones_controller.rb
+++ b/app/controllers/admin/territories/zones_controller.rb
@@ -61,10 +61,6 @@ class Admin::Territories::ZonesController < Admin::Territories::BaseController
 
   private
 
-  def pundit_user
-    current_agent
-  end
-
   def set_sector
     @sector = sector_policy.resolve.find(params[:sector_id])
   end

--- a/app/controllers/admin/territories_controller.rb
+++ b/app/controllers/admin/territories_controller.rb
@@ -25,8 +25,4 @@ class Admin::TerritoriesController < Admin::Territories::BaseController
     @territory = Territory.find(params[:id])
     authorize_agent @territory
   end
-
-  def pundit_user
-    current_agent
-  end
 end


### PR DESCRIPTION
Cette PR finit le travail commencé dans : https://github.com/betagouv/rdv-service-public/pull/4498

Il nous reste juste le cas de la AgentPolicy à gérer, mais il risque d'être plus compliqué que les autres.