### PR TITLE
suppression AgentTerritorialContext

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -82,10 +82,6 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
 
   private
 
-  def pundit_user
-    AgentTerritorialContext.new(current_agent, current_territory)
-  end
-
   def set_agent
     @agent = Agent.active.find(params[:id])
     authorize [:configuration, @agent]

--- a/app/policies/agent/agent_territorial_role_policy.rb
+++ b/app/policies/agent/agent_territorial_role_policy.rb
@@ -15,8 +15,6 @@ class Agent::AgentTerritorialRolePolicy
   end
 
   def visible_agent?
-    context = AgentTerritorialContext.new(@current_agent, @agent_territorial_role.territory)
-
-    Agent::AgentPolicy::Scope.new(context, Agent).resolve.find_by(id: @agent_territorial_role.agent_id)
+    Agent::AgentPolicy::Scope.new(@current_agent, Agent).resolve.find_by(id: @agent_territorial_role.agent_id)
   end
 end

--- a/app/policies/agent_territorial_context.rb
+++ b/app/policies/agent_territorial_context.rb
@@ -1,9 +1,0 @@
-# TODO: supprimer ce context, nous devrions pouvoir utiliser le territoire de l'objet sur lequel on vérifier l'accès
-class AgentTerritorialContext
-  attr_reader :agent, :territory
-
-  def initialize(agent, territory)
-    @agent = agent
-    @territory = territory
-  end
-end

--- a/app/policies/concerns/current_agent_in_policy_concern.rb
+++ b/app/policies/concerns/current_agent_in_policy_concern.rb
@@ -5,6 +5,8 @@ module CurrentAgentInPolicyConcern
     alias_method :context, :pundit_user
 
     def current_agent
+      # on veut peu à peu supprimer les usages des contextes mais c’est compliqué de tout faire d’un coup
+      # cette méthode permet de simplifier la transition : on accepte des context.agent ou des agents directement
       if context.is_a? Agent
         context
       else

--- a/app/policies/concerns/current_agent_in_policy_concern.rb
+++ b/app/policies/concerns/current_agent_in_policy_concern.rb
@@ -3,6 +3,13 @@ module CurrentAgentInPolicyConcern
 
   included do
     alias_method :context, :pundit_user
-    delegate :agent, to: :context, prefix: :current # defines current_agent
+
+    def current_agent
+      if context.is_a? Agent
+        context
+      else
+        context.agent
+      end
+    end
   end
 end

--- a/app/policies/configuration/agent_policy.rb
+++ b/app/policies/configuration/agent_policy.rb
@@ -1,6 +1,6 @@
 class Configuration::AgentPolicy
-  def initialize(context, agent)
-    @current_agent = context.agent
+  def initialize(current_agent, agent)
+    @current_agent = current_agent
     @agent = agent
   end
 

--- a/spec/policies/configuration/agent_policy_spec.rb
+++ b/spec/policies/configuration/agent_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let(:territory) { create(:territory) }
     let(:current_agent) { create(:agent, role_in_territories: []) }
     let(:target_agent) { create(:agent) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "not permit actions", :target_agent, :edit?, :update_teams?, :update_services?, :create?
   end
@@ -18,7 +18,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let(:current_agent) { create(:agent, role_in_territories: [territory]) }
     let(:organisation) { create(:organisation, territory:) }
     let(:target_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "permit actions", :target_agent, :edit?, :update_services?, :create?
     it_behaves_like "not permit actions", :target_agent, :update_teams?
@@ -30,7 +30,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let(:other_territory) { create(:territory) }
     let(:organisation) { create(:organisation, territory: other_territory) }
     let(:target_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "not permit actions", :target_agent, :edit?, :update_services?, :create?
     it_behaves_like "not permit actions", :target_agent, :update_teams?
@@ -40,7 +40,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let(:territory) { create(:territory) }
     let(:current_agent) { create(:agent, role_in_territories: [territory]) }
     let(:target_agent) { create(:agent, role_in_territories: [territory]) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "permit actions", :target_agent, :edit?, :update_services?, :create?
     it_behaves_like "not permit actions", :target_agent, :update_teams?
@@ -49,7 +49,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
   context "current_agent has allow_to_manage_access_rights in a territory, target_agent has a basic role in this territory" do
     let(:territory) { create(:territory) }
     let(:current_agent) { create(:agent, role_in_territories: []) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
     let(:organisation) { create(:organisation, territory:) }
     let(:target_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
@@ -62,7 +62,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
   context "current_agent has allow_to_manage_teams access right in a territory, target_agent has a basic role in this territory" do
     let(:territory) { create(:territory) }
     let(:current_agent) { create(:agent, role_in_territories: []) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
     let(:organisation) { create(:organisation, territory:) }
     let(:target_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
@@ -75,7 +75,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
   context "current_agent has allow_to_invite_agents access right in a territory, target_agent has a basic role in this territory" do
     let(:territory) { create(:territory) }
     let(:current_agent) { create(:agent, role_in_territories: []) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
     let(:organisation) { create(:organisation, territory:) }
     let(:target_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
 
@@ -89,7 +89,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let(:territory) { create(:territory) }
     let(:current_agent) { create(:agent, role_in_territories: [territory]) }
     let(:target_agent) { build(:agent) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "not permit actions", :target_agent, :create?
   end
@@ -100,7 +100,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let!(:organisation) { create(:organisation, territory:) }
     # we cannot use the factory trait basic_roles_in_organisations because it works only with create, not build
     let(:target_agent) { build(:agent, organisation_ids: [organisation.id]) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "permit actions", :target_agent, :create?
   end
@@ -112,7 +112,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let!(:organisation) { create(:organisation, territory: other_territory) }
     # we cannot use the factory trait basic_roles_in_organisations because it works only with create, not build
     let(:target_agent) { build(:agent, organisation_ids: [organisation.id]) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "not permit actions", :target_agent, :create?
   end
@@ -125,7 +125,7 @@ RSpec.describe Configuration::AgentPolicy, type: :policy do
     let!(:organisation2) { create(:organisation, territory: other_territory) }
     # we cannot use the factory trait basic_roles_in_organisations because it works only with create, not build
     let(:target_agent) { build(:agent, organisation_ids: [organisation1.id, organisation2.id]) }
-    let(:pundit_context) { AgentTerritorialContext.new(current_agent, territory) }
+    let(:pundit_context) { current_agent }
 
     it_behaves_like "not permit actions", :target_agent, :create?
   end


### PR DESCRIPTION
# Contexte

Suite aux nombreuses modifications des policies de la partie admin de territoire, on peut maintenant supprimer `AgentTerritorialContext`. 
La direction globale est que les policies ne dépendent plus d’aucun contexte, comme recommandé par Pundit.

# Solution

Je remplace les usages de `AgentTerritorialContext` par `current_agent`. 

On modifie le comportement de la méthode `pundit_user` à l’échelle du controller `admin/territories/agents`.
Cela a un impact sur l’appel à `policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)` 

Pour résoudre ça, j’ai choisi ici de génériser le `CurrentAgentInPolicyConcern` pour qu’il accepte des `pundit_user` de type agent et de type contexte. 

On pourra peu à peu supprimer les usages inutiles de `AgentContext` et les remplacer par `current_agent` directement, puis on pourra simplifier ou inliner tout le CurrentAgentInPolicyConcern.
