### PR TITLE
Permettre d'utiliser Agent Connect même si le bouton est caché

### DIFF
--- a/config/initializers/agent_connect.rb
+++ b/config/initializers/agent_connect.rb
@@ -2,7 +2,7 @@ require_relative "sentry"
 
 Rails.configuration.x.agent_connect_unreachable_at_boot_time = false
 
-if ENV["AGENT_CONNECT_BASE_URL"].present? && !ENV["AGENT_CONNECT_DISABLED"]
+if ENV["AGENT_CONNECT_BASE_URL"].present?
   begin
     # la méthode .discover! fait un appel à l'api d'Agent Connect
     Rails.configuration.x.agent_connect_config = OpenIDConnect::Discovery::Provider::Config.discover!(ENV["AGENT_CONNECT_BASE_URL"])


### PR DESCRIPTION
Dans #4309, on avait prévu un mécanisme pour pouvoir cacher le bouton agent connect en activant la variable d'environnement `AGENT_CONNECT_DISABLED`.
On prévoit aussi un paramètre get pour pouvoir forcer l'affichage du bouton. C'est utile pour tester que agent connect marche avant de l'ouvrir au public (que ça soit pour l'ouverture initiale ou suite à une panne temporaire).

Le problème, c'est que si on activait cette variable d'environnement, on n'allait pas chercher la config agent connect, et on ne pouvait pas tester le bouton avec le paramètre get.

Cette PR corrige donc ça pour qu'on puisse faire des premiers tests sur la démo.