### PR TITLE
passage au DSFR du bouton de recherche adresse sur la home

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,7 @@ class SearchController < ApplicationController
   layout "application_base"
 
   include TokenInvitable
+  include SimpleFormDsfrConcern
 
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social
   after_action :allow_iframe

--- a/app/javascript/stylesheets/components/_search_form.scss
+++ b/app/javascript/stylesheets/components/_search_form.scss
@@ -7,11 +7,18 @@
     border: 0;
   }
 
-  .btn {
-    color: $gray-900;
-  }
-
   label {
     color: white;
+  }
+
+  .fr-btn[type="submit"] {
+    background-color: white;
+    color: #313131;
+    &:hover {
+      opacity: 0.9;
+    }
+    &[disabled] {
+      opacity: 0.65;
+    }
   }
 }

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -98,6 +98,16 @@ a[disabled] {
   }
 }
 
+.rdv-align-self-end {
+  align-self: end;
+}
+
+// DIMENSIONS
+
+.rdv-width-100 {
+  width: 100%;
+}
+
 // OTHER
 
 ul.horizontal-border-between-items {

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -14,5 +14,5 @@ section.rdv-background-color-flat-blue-ecume.fr-pt-4w.fr-pb-8w
           .fr-col-12.fr-col-lg-9
             = f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
           .fr-col-12.fr-col-lg-3.rdv-align-self-end
-            button#search_submit.fr-btn.fr-btn--lg.fr-btn--icon-left.fr-icon-search-line.rdv-width-100 disabled="true" type="submit"
+            = f.button :button, id: "search_submit", class: "fr-btn--lg fr-btn--icon-left fr-icon-search-line rdv-width-100", disabled: true do
               | Rechercher

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -9,10 +9,10 @@ section.rdv-background-color-flat-blue-ecume.fr-pt-4w.fr-pb-8w
         = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }
         = f.input :latitude, as: :hidden, input_html: { name: "latitude", value: context.latitude }
         = f.input :longitude, as: :hidden, input_html: { name: "longitude", value: context.longitude }
-        .form-row.d-flex.justify-content-md-center
+        .fr-grid-row.fr-grid-row--gutters
           / TODO: change input name to address and change whereInput in application.js
-          .col-lg-9= f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
-          .col-lg-3.align-self-end
-            = f.button :button, id: "search_submit", class: "btn-white btn-lg w-100 text-center", disabled: true do
-              i.fa.fa-search>
+          .fr-col-12.fr-col-lg-9
+            = f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
+          .fr-col-12.fr-col-lg-3.rdv-align-self-end
+            button#search_submit.fr-btn.fr-btn--lg.fr-btn--icon-left.fr-icon-search-line.rdv-width-100 disabled="true" type="submit"
               | Rechercher

--- a/config/initializers/simple_form_dsfr.rb
+++ b/config/initializers/simple_form_dsfr.rb
@@ -17,8 +17,8 @@ end
 
 # L’initializer simple_form_bootstrap.rb est lu par défaut pour toutes les parties de l’application
 # Or, nous souhaitons migrer pas à pas une partie de l’application vers le DSFR
-# Ce concern peut être inclus dans un controller et overrider la configuration spécifique bootstrap
-# uniquement pour les actions de ce controlleur.
+# Ce concern peut être inclus dans un contrôleur et overrider la configuration spécifique bootstrap
+# uniquement pour les actions de ce contrôleur.
 
 module SimpleFormDsfrConcern
   extend ActiveSupport::Concern
@@ -29,9 +29,9 @@ module SimpleFormDsfrConcern
 
   def override_simple_form_config
     button_class_before = SimpleForm.button_class
-    SimpleForm.setup { _1.button_class = "fr-btn" }
+    SimpleForm.button_class = "fr-btn"
     yield
   ensure
-    SimpleForm.setup { _1.button_class = button_class_before }
+    SimpleForm.button_class = button_class_before
   end
 end

--- a/config/initializers/simple_form_dsfr.rb
+++ b/config/initializers/simple_form_dsfr.rb
@@ -14,3 +14,24 @@ SimpleForm.setup do |config|
     b.use :hint
   end
 end
+
+# L’initializer simple_form_bootstrap.rb est lu par défaut pour toutes les parties de l’application
+# Or, nous souhaitons migrer pas à pas une partie de l’application vers le DSFR
+# Ce concern peut être inclus dans un controller et overrider la configuration spécifique bootstrap
+# uniquement pour les actions de ce controlleur.
+
+module SimpleFormDsfrConcern
+  extend ActiveSupport::Concern
+
+  included do
+    around_action :override_simple_form_config
+  end
+
+  def override_simple_form_config
+    button_class_before = SimpleForm.button_class
+    SimpleForm.setup { _1.button_class = "fr-btn" }
+    yield
+  ensure
+    SimpleForm.setup { _1.button_class = button_class_before }
+  end
+end


### PR DESCRIPTION
Review app : https://demo-rdv-solidarites-pr4539.osc-secnum-fr1.scalingo.io/

# Contexte

Dans le cadre de la migration au DSFR, on souhaite migrer les boutons pour pouvoir supprimer le composant associé bootstrap et éviter ses effets de bords.

Le bouton de recherche de la homepage est important et assez différent de ce que propose le DSFR. 
On décide donc de le migrer dans cette PR indépendante.

# Solution

J’essaie de rester proche de l’implémentation actuelle : je reprends les couleurs de fond et de texte actuelles.

En revanche je n’ai pas reproduit l’alignement centré du texte de ce bouton car ce n’est pas facile avec le DSFR. 

## SimpleForm

Dans un initializer, on configure `SimpleForm.button_class=" btn btn-primary"`.
C’est problématique car c’est fait au niveau le plus haut, on ne peut pas le désactiver simplement. 

J’ai mis en place un nouveau `SimpleFormDsfrConcern` qui permet d’overrider cette configuration pour le DSFR via un `around_action` de contrôleur.

J’ai envisagé et testé plusieurs alternatives
1. Descendre cette top-level config `button_class` vers les configs de wrappers. Ça ne fonctionne malheureusement pas. [L’implém de simple_form](https://github.com/heartcombo/simple_form/blob/c2c7faf3e532072e1ef511a97d677ae0e7c38957/lib/simple_form/form_builder.rb#L239) dépend vraiment de la top level config uniquement.
2. Ne pas utiliser SimpleForm pour ce bouton. Cela fonctionne mais je ne pense pas que nous allons vouloir sortir de SimpleForm pour tous les formulaires de la partie usagers. Ou alors il faut qu’on en parle, perso je suis pas fan de la couche de complexité supplémentaire SimpleForm 😬 et j’avais repéré des [form builders dsfr](https://github.com/etalab/data_pass/blob/8e7cda3868955ed1ef706fd3b379bfd2d25f2aba/app/form_builders/dsfr_form_builder.rb)
3. Laisser ces classes `.btn` mais faire en sorte qu’elles soient inopérantes en n’incluant plus le code correspondant de bootstrap sur les pages migrées. Cela fonctionne mais ça ne nous permet pas de définir `button_class = "fr-btn"`, il faut le faire sur chaque bouton. Cela rajoute aussi un peu de complexité 
4. peut-être que mon around_action est inutile et qu’on peut faire `SimpleForm.button_class = "fr-btn"` au niveau d’une action sans s’inquiéter que ça fuite mais j’en doute. 

Mobile
version | avant | après
-|-|-
désactivé | ![Screen Shot 2024-08-07 at 14 05 47](https://github.com/user-attachments/assets/347c64ca-ee14-43b5-a62a-e9bd5c7d4252) | ![Screen Shot 2024-08-07 at 14 04 10](https://github.com/user-attachments/assets/75b7d7e7-27cc-4f5b-bc42-3d5d0cb996fe)
activé | ![Screen Shot 2024-08-07 at 14 06 16](https://github.com/user-attachments/assets/c8b25eb6-15c4-4bff-880e-3fa49dedf7a3) | ![Screen Shot 2024-08-07 at 14 05 15](https://github.com/user-attachments/assets/31963521-a7bb-4663-81c5-ce048fc03875)


Desktop Désactivé

version |  
-|-
Avant | <img width="1125" alt="image" src="https://github.com/user-attachments/assets/88b76b95-abd0-4e4c-8ee9-395d6402c77a"> 
Après | <img width="1118" alt="image" src="https://github.com/user-attachments/assets/ca32e22a-a9ab-44c4-bc56-ff55dabb41c2">


Desktop Activé

version |  
-|-
Avant | <img width="1129" alt="image" src="https://github.com/user-attachments/assets/f314cc4d-aac8-4d4c-acda-d06f93033e58"> 
Après | <img width="1125" alt="image" src="https://github.com/user-attachments/assets/3b241958-4304-4f31-8730-8c6cced9f359"> 

Desktop Activé & hover

version |  
-|-
Avant | <img width="1128" alt="image" src="https://github.com/user-attachments/assets/1a95e4ea-c110-4b23-a6c1-80dc988f1cd8">
Après | <img width="1115" alt="image" src="https://github.com/user-attachments/assets/6da5fba7-a427-4aeb-93c4-b423cc278846">

