### PR TITLE
Utiliser les couleurs de textes du DSFR - remplacer les règles bootstrap

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -38,7 +38,25 @@
 @import "~bootstrap/scss/popover";
 @import "~bootstrap/scss/carousel";
 @import "~bootstrap/scss/spinners";
-@import "~bootstrap/scss/utilities";
+@import "~bootstrap/scss/utilities/align";
+@import "~bootstrap/scss/utilities/background";
+@import "~bootstrap/scss/utilities/borders";
+@import "~bootstrap/scss/utilities/clearfix";
+@import "~bootstrap/scss/utilities/display";
+@import "~bootstrap/scss/utilities/embed";
+@import "~bootstrap/scss/utilities/flex";
+@import "~bootstrap/scss/utilities/float";
+@import "~bootstrap/scss/utilities/interactions";
+@import "~bootstrap/scss/utilities/overflow";
+@import "~bootstrap/scss/utilities/position";
+@import "~bootstrap/scss/utilities/screenreaders";
+@import "~bootstrap/scss/utilities/shadows";
+@import "~bootstrap/scss/utilities/sizing";
+@import "~bootstrap/scss/utilities/spacing";
+@import "~bootstrap/scss/utilities/stretched-link";
+//@import "~bootstrap/scss/utilities/text";
+@import "~bootstrap/scss/utilities/visibility";
+
 @import "~bootstrap/scss/print";
 
 @import "vendor/inclusion_connect_button";

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -36,6 +36,10 @@ a[disabled] {
   font-weight: bold;
 }
 
+.rdv-font-weight-700 {
+  font-weight: 700;
+}
+
 .text-underline {
   text-decoration: underline;
 }
@@ -46,6 +50,10 @@ a[disabled] {
 
 .rdv-white-space-nowrap {
   white-space: nowrap;
+}
+
+.rdv-color-white {
+  color: white;
 }
 
 // GRID

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -10,6 +10,18 @@
   }
 }
 
+.rdv-color-text-action-high-blue-ecume {
+  color: var(--text-action-high-blue-ecume);
+}
+
+.rdv-color-text-mention-grey {
+  color: var(--text-mention-grey);
+}
+
+.rdv-color-text-default-success {
+  color: var(--text-default-success);
+}
+
 // FLEX
 
 .rdv-flex-wrap-wrap-reverse {

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -32,7 +32,7 @@
 
   - else
     .row.justify-content-md-center.p-2.mt-3
-      .col-md-6.text-center.mb-2
+      .col-md-6.rdv-text-align-center.mb-2
         p.mb-2.lead
           - if current_agent == @agent
             = t(".you_not_yet_create_busy_time")
@@ -42,7 +42,7 @@
         span.fa-stack.fa-4x
           i.fa.fa-circle.fa-stack-2x.text-primary
           i.far.fa-calendar.fa-stack-1x.text-white
-  .text-center.py-2
+  .rdv-text-align-center.py-2
     = link_to new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-primary" do
       - if @agent == current_agent
         = t(".create_busy_time")

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -24,12 +24,12 @@
       tbody
         = render partial: "agent", collection: @agents
     - if @agents.empty?
-      .mb-4.p.text-center Aucun agent trouvé
+      .mb-4.p.rdv-text-align-center Aucun agent trouvé
     - elsif @agents.total_pages > 1
       .m-3
         .d-flex.justify-content-center
           = paginate @agents, theme: "twitter-bootstrap-4"
-        .text-center= page_entries_info @agents
+        .rdv-text-align-center= page_entries_info @agents
 
     - if current_agent_can?(:create, Agent)
       .m-3.d-flex.justify-content-center.align-items-center

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -66,7 +66,7 @@
         = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
 
 #creneaux
-  .text-center
+  .rdv-text-align-center
     - if @search_results&.any?
       .container
         h3.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)

--- a/app/views/admin/invitations/index.html.slim
+++ b/app/views/admin/invitations/index.html.slim
@@ -25,12 +25,12 @@
       tbody
         = render partial: "admin/agents/agent", collection: @invited_agents
     - if @invited_agents.empty?
-      .mb-4.p.text-center Aucune invitation en attente
+      .mb-4.p.rdv-text-align-center Aucune invitation en attente
     - elsif @invited_agents.total_pages > 1
       .m-3
         .d-flex.justify-content-center
           = paginate @invited_agents, theme: "twitter-bootstrap-4"
-        .text-center= page_entries_info @invited_agents
+        .rdv-text-align-center= page_entries_info @invited_agents
 
     - if current_agent_can?(:create, Agent)
       .m-3.d-flex.justify-content-center

--- a/app/views/admin/lieux/index.html.slim
+++ b/app/views/admin/lieux/index.html.slim
@@ -23,7 +23,7 @@
       .d-flex.justify-content-center= paginate @lieux, theme: "twitter-bootstrap-4"
     - else
       .row.justify-content-md-center
-        .col-md-6.text-center.my-5
+        .col-md-6.rdv-text-align-center.my-5
           p.mb-2.lead Vous n'avez pas encore ajouté de lieu de consultation.
           p Les lieux sont les endroits où sont réalisés les RDV. L'adresse du lieu est contenue dans les notifications envoyées à l'usager.
           span.fa-stack.fa-4x
@@ -31,5 +31,5 @@
             i.fa.fa-building.fa-stack-1x.text-white
 
     - if @lieux_policy.create?
-      .text-center
+      .rdv-text-align-center
         = link_to "Ajouter un lieu", new_admin_organisation_lieu_path(current_organisation), class: "btn btn-primary"

--- a/app/views/admin/merge_users/new.html.slim
+++ b/app/views/admin/merge_users/new.html.slim
@@ -13,7 +13,7 @@
   = render "model_errors", model: @merge_users_form
   .card
     table.table.table-bordered.merge-users-table[style="table-layout:fixed"]
-      tr.text-center
+      tr.rdv-text-align-center
         th[style="width:20%"]
         th[style="width:40%"]
           i.fa.fa-user>
@@ -21,7 +21,7 @@
         th[style="width:40%"]
           i.fa.fa-user>
           | Usager B
-      tr.text-center
+      tr.rdv-text-align-center
         td
         td= render "user_selection", user: @merge_users_form.user1, attribute: "user1_id", f: f, other_user_id: @merge_users_form.user2&.id
         td= render "user_selection", user: @merge_users_form.user2, attribute: "user2_id", f: f, other_user_id: @merge_users_form.user1&.id

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -53,7 +53,7 @@
           tr
             td(colspan=6)
               .row.justify-content-md-center
-                .col-md-6.text-center.my-5
+                .col-md-6.rdv-text-align-center.my-5
                   - if @unfiltered_motifs.any?
                     p.mb-2.lead Aucun motif ne correspond à votre filtre
                   - else
@@ -63,12 +63,12 @@
                     i.fa.fa-circle.fa-stack-2x.text-primary
                     i.far.fa-calendar.fa-stack-1x.text-white
                   - if @motif_policy.create?
-                    .text-center.m-3
+                    .rdv-text-align-center.m-3
                       = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"
 
     - if @motifs.any?
       .d-flex.justify-content-center
         = paginate @motifs, theme: "twitter-bootstrap-4"
       - if @motif_policy.create?
-        .text-center.m-3
+        .rdv-text-align-center.m-3
           = link_to "Créer un motif", new_admin_organisation_motif_path(current_organisation), class: "btn btn-primary"

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -4,7 +4,7 @@
   .col-md-12.col-lg-8
     .card.mt-2
       .card-header
-        h3.text-center Motif #{@motif.name} (#{@motif.service.short_name})
+        h3.rdv-text-align-center Motif #{@motif.name} (#{@motif.service.short_name})
       .card-body
         = motif_attribute_row(Motif.human_attribute_name(:name), @motif.name)
         = motif_attribute_row(Motif.human_attribute_name(:service), @motif.service.name)

--- a/app/views/admin/organisations/index.html.slim
+++ b/app/views/admin/organisations/index.html.slim
@@ -17,5 +17,5 @@
             - if current_agent.admin_in_organisation?(organisation)
               i.fa.fa-user-cog.text-muted[title="Vous administrez cette organisation"]
       - if policy([:agent, Organisation.new(territory: territory)]).new?
-        .text-center.mt-4
+        .rdv-text-align-center.mt-4
           = link_to "Ajouter une organisation", new_admin_organisation_path(territory_id: territory.id), class: "btn btn-primary"

--- a/app/views/admin/organisations/new.html.slim
+++ b/app/views/admin/organisations/new.html.slim
@@ -1,5 +1,5 @@
-.text-center.m-auto
-  h4.text-dark-50.text-center.mt-0.font-weight-bold.mb-4 Ajouter une organisation
+.rdv-text-align-center.m-auto
+  h4.text-dark-50.rdv-text-align-center.mt-0.font-weight-bold.mb-4 Ajouter une organisation
 
   = render "model_errors", model: @organisation
 

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -56,7 +56,7 @@
         = paginate @plage_ouvertures, theme: "twitter-bootstrap-4"
   - else
     .row.justify-content-md-center.p-2.mt-3
-      .col-md-6.text-center.mb-2
+      .col-md-6.rdv-text-align-center.mb-2
         p.mb-2.lead
           - if params[:search].present?
             = t(".no_results_for_your_search")
@@ -70,7 +70,7 @@
               i.fa.fa-circle.fa-stack-2x.text-primary
               i.far.fa-calendar.fa-stack-1x.text-white
 
-  .text-center.py-2
+  .rdv-text-align-center.py-2
     = link_to new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-primary" do
       - if current_agent == @agent
         = t(".create_plage_ouverture")

--- a/app/views/admin/prescription/confirmation.html.slim
+++ b/app/views/admin/prescription/confirmation.html.slim
@@ -44,4 +44,4 @@ main.container
             li.list-group-item
               = "Besoin de déplacer le rendez-vous ou de corriger un détail ? "
               =< mail_to(current_domain.support_email, "Contactez-nous", target: "_blank")
-          .mt-4.text-center= link_to "Retour à l'accueil", admin_organisation_agent_agenda_path(current_organisation, current_agent)
+          .mt-4.rdv-text-align-center= link_to "Retour à l'accueil", admin_organisation_agent_agenda_path(current_organisation, current_agent)

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -34,7 +34,7 @@
   .mx-3
   - if rdv.users.any?
     div class=("users-details collapse p-3 pt-0")
-      h5.text-center.strong.mb-3> Participants :
+      h5.rdv-text-align-center.strong.mb-3> Participants :
       .row
         - rdv.users.sort_by { _1.last_name.downcase }.each do |user|
           .col-4

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -70,7 +70,7 @@
         .card
           .card-body
             .row.justify-content-md-center
-              .col-md-6.text-center.my-5
+              .col-md-6.rdv-text-align-center.my-5
                 p.mb-2.lead
                   | Aucun RDV
                 span.fa-stack.fa-4x

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -5,8 +5,8 @@
     = simple_form_for(@rdv, url: admin_organisation_rdvs_collectif_path(current_organisation), method: :put) do |f|
       .card
         .card-header
-          h3.text-center #{@rdv.motif_name} (#{@rdv.motif.service.short_name})
-          .text-center= I18n.l(@rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
+          h3.rdv-text-align-center #{@rdv.motif_name} (#{@rdv.motif.service.short_name})
+          .rdv-text-align-center= I18n.l(@rdv.starts_at, format: "%A %d %B à %H:%M").capitalize
         .card-body.px-3
           .row.mt-3
             .col-md-6

--- a/app/views/admin/rdvs_collectifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/index.html.slim
@@ -37,7 +37,7 @@
       .card
         .card-body
           .row.justify-content-md-center
-            .col-md-6.text-center.my-5
+            .col-md-6.rdv-text-align-center.my-5
               p.mb-2.lead
                 | Aucun RDV
               span.fa-stack.fa-4x

--- a/app/views/admin/rdvs_collectifs/motifs/index.html.slim
+++ b/app/views/admin/rdvs_collectifs/motifs/index.html.slim
@@ -10,7 +10,7 @@
   .col-md-12.col-lg-8
     .card
       .card-header
-        h3.text-center Choisissez un motif
+        h3.rdv-text-align-center Choisissez un motif
 
       .card-body
         - if @motifs.empty?

--- a/app/views/admin/rdvs_collectifs/new.html.slim
+++ b/app/views/admin/rdvs_collectifs/new.html.slim
@@ -11,7 +11,7 @@
     = simple_form_for(@rdv, url: admin_organisation_rdvs_collectifs_path(current_organisation), method: :post) do |f|
       .card
         .card-header
-          h3.text-center #{@rdv.motif_name} (#{@rdv.motif.service.short_name})
+          h3.rdv-text-align-center #{@rdv.motif_name} (#{@rdv.motif.service.short_name})
         .card-body.px-3
           = render "model_errors", model: @rdv, f: f
 

--- a/app/views/admin/referent_assignations/index.html.slim
+++ b/app/views/admin/referent_assignations/index.html.slim
@@ -47,7 +47,7 @@
     .m-3
       .d-flex.justify-content-center
         = paginate @agents, theme: "twitter-bootstrap-4"
-      .text-center= page_entries_info @agents
+      .rdv-text-align-center= page_entries_info @agents
 
   .m-3
     = link_to "Fiche #{@user.full_name}", admin_organisation_user_path(current_organisation, @user, anchor: "agents-referents"), class: "btn btn-outline-primary"

--- a/app/views/admin/slots/_no_slot_available.html.slim
+++ b/app/views/admin/slots/_no_slot_available.html.slim
@@ -1,3 +1,3 @@
-.text-center.mt-2
+.rdv-text-align-center.mt-2
   p= "Aucun créneau disponible dans l'organisation #{@form.organisation.name} pour les filtres sélectionnés."
   = render "admin/slots/prescription_cta"

--- a/app/views/admin/slots/_prescription_cta.html.slim
+++ b/app/views/admin/slots/_prescription_cta.html.slim
@@ -1,5 +1,5 @@
 - if show_agent_prescription_feature?(user_provided: @form.user_ids.any?)
-  .text-center.mt-2.mb-4
+  .rdv-text-align-center.mt-2.mb-4
     p
       | Vous pouvez aussi élargir votre recherche aux créneaux ouverts à la prescription dans d'autres organisations.
       span  Plus d'informations dans

--- a/app/views/admin/slots/_slots.html.slim
+++ b/app/views/admin/slots/_slots.html.slim
@@ -11,13 +11,13 @@ div id="creneaux-lieu-#{lieu&.id}"
       .row.no-gutters.creneaux-row.lieu-creneaux-card
         - form.date_range.each do |date|
           .col.position-relative
-            p.text-center.sticky-top.bg-white
+            p.rdv-text-align-center.sticky-top.bg-white
               strong= l(date, format: "%A")
               br
               = l(date, format: "%d %b")
 
             - if creneaux.empty?
-              p.text-center
+              p.rdv-text-align-center
                 small aucune disponibilité
             - else
               - agents = creneaux.map(&:agent).uniq

--- a/app/views/admin/territories/motifs/index.html.slim
+++ b/app/views/admin/territories/motifs/index.html.slim
@@ -96,6 +96,6 @@
       .mt-2 = paginate @motifs, theme: "twitter-bootstrap-4"
 
     - else
-      .text-center
+      .rdv-text-align-center
         p.mb-2.lead
           | Aucun résultat

--- a/app/views/admin/territories/sectors/index.html.slim
+++ b/app/views/admin/territories/sectors/index.html.slim
@@ -4,7 +4,7 @@
   .col-md-10
     = simple_form_for "", url: admin_territory_sectors_path(current_territory), html: { method: :get, class: "card" } do |f|
       .p-2.d-grid.grid-three-columns.grid-first-column-empty.grid-align-center
-        .text-center= page_entries_info @sectors
+        .rdv-text-align-center= page_entries_info @sectors
         div.text-right
           = link_to admin_territory_sectors_path(current_territory, view: "map"), class: "btn btn-light" do
             span> Voir la carte
@@ -61,7 +61,7 @@
                       i.fa.fa-trash-alt
       .pb-3.pr-3.pl-3
         div= paginate @sectors
-        .text-center
+        .rdv-text-align-center
           .mb-2= page_entries_info @sectors
           .mb-2= link_to new_admin_territory_sector_path(current_territory), class: "btn btn-primary" do
             i.fa.fa-plus>

--- a/app/views/admin/territories/sectors/index_map.html.slim
+++ b/app/views/admin/territories/sectors/index_map.html.slim
@@ -9,7 +9,7 @@
 .row
   .col-md-12
     .card
-      .alert.alert-warning.text-center
+      .alert.alert-warning.rdv-text-align-center
         | ⚠️ Cette carte n'affiche pas correctement les secteurs qui se chevauchent ni les rues dans le détail
       div.position-relative
         #zones-map[

--- a/app/views/admin/territories/sectors/show.html.slim
+++ b/app/views/admin/territories/sectors/show.html.slim
@@ -38,7 +38,7 @@
             span> Ajouter une commune ou une rue
       - else
         .p-2.d-flex.align-items-center
-          div.flex-grow-1.text-center= page_entries_info @zones
+          div.flex-grow-1.rdv-text-align-center= page_entries_info @zones
           div= link_to new_admin_territory_sector_zone_path(current_territory, @sector), class: "btn btn-primary" do
             i.fa.fa-plus>
             span> Ajouter une commune ou une rue
@@ -65,7 +65,7 @@
                   - if policy.destroy?
                     = link_to "retirer", admin_territory_sector_zone_path(current_territory, @sector, zone), method: :delete
         div= paginate @zones
-        .mb-2.text-center
+        .mb-2.rdv-text-align-center
           .mb-2= page_entries_info @zones
           - if @zones.count > 5
             .mb-2= link_to( \

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -2,7 +2,7 @@
   i.fa.fa-arrow-left
   = " Retour à l'accueil"
 
-h1.m-2.text-center.border-bottom.pb-2 Espace Admin - #{current_territory.name}
+h1.m-2.rdv-text-align-center.border-bottom.pb-2 Espace Admin - #{current_territory.name}
 .row.mb-3
   - if Agent::TerritoryPolicy.new(pundit_user, current_territory).edit?
     .col.col-md-4.p-2.rounded.settings-box

--- a/app/views/admin/territories/zone_imports/new.html.slim
+++ b/app/views/admin/territories/zone_imports/new.html.slim
@@ -59,8 +59,8 @@
           td Rue des casernes
           td 62080_0180
         tr
-          td.text-center[colspan=3] ...
-    .text-center
+          td.rdv-text-align-center[colspan=3] ...
+    .rdv-text-align-center
       .mb-1.w-75.m-auto.text-muted 3 premières lignes: communes entières, 2 dernières lignes: 2 rues spécifiques
       ul.list-inline
         li.list-inline-item= link_to "/zones_example.xls", class: "btn btn-link", download: "zones_example.xls" do

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -41,20 +41,20 @@
               = render partial: "admin/users/user", locals: { user: user }
 
     - if @users.empty?
-      .mb-4.p.text-center Aucun usager trouvé pour ces critères
+      .mb-4.p.rdv-text-align-center Aucun usager trouvé pour ces critères
     - elsif @users.total_pages > 1
       .m-3
         .d-flex.justify-content-center id="users-pagination"
           = paginate @users, theme: "twitter-bootstrap-4"
-          .text-center= page_entries_info @users
+          .rdv-text-align-center= page_entries_info @users
   - else
     .card-body
       .row.justify-content-md-center
-        .col-md-6.text-center.my-5
+        .col-md-6.rdv-text-align-center.my-5
           p.mb-2.lead Utilisez le champ de recherche pour trouver&nbsp;un&nbsp;usager
           span.fa-stack.fa-4x
             i.fa.fa-circle.fa-stack-2x.text-primary
             i.fa.fa-users.fa-stack-1x.text-white
 
-  .m-3.text-center
+  .m-3.rdv-text-align-center
     = link_to "Créer un usager", new_admin_organisation_user_path(current_organisation), class: "btn btn-primary"

--- a/app/views/agents/calendar_sync/show.html.slim
+++ b/app/views/agents/calendar_sync/show.html.slim
@@ -8,17 +8,17 @@ div.d-flex.justify-content-center.align-items-center.flex-wrap
       div.card-body
         h5.card-title Connexion Outlook
         p Vos rendez-vous seront synchronisés automatiquement et en temps réel dans votre agenda Outlook.
-        div.text-center
+        div.rdv-text-align-center
           = link_to "Connecter mon compte Outlook", agents_calendar_sync_outlook_sync_path, class: "btn btn-primary m-2"
 
   div.card.w-100
     div.card-body
       h5.card-title Lien Webcal
       p Vous pouvez synchroniser votre agenda externe grâce à un lien Webcal. Vos rendez-vous seront visibles sur votre agenda externe, mais parfois avec quelques heures de retard.
-      div.text-center
+      div.rdv-text-align-center
         = link_to "Synchronisation par lien Webcal", agents_calendar_sync_webcal_sync_path, class: "btn btn-primary m-2"
 
   p.lead.font-weight-bold.mt-4 Notifications par email
   p Vous pouvez aussi recevoir un email avec une invitation ics pour chaque rendez-vous, absence et plage d'ouverture.
-  div.text-center
+  div.rdv-text-align-center
     = link_to t("agents.preferences.show.title"), agents_preferences_path, class: "btn btn-tertiary m-2"

--- a/app/views/agents/exports/index.html.slim
+++ b/app/views/agents/exports/index.html.slim
@@ -29,4 +29,4 @@
                 .d-block= render partial: "agents/exports/export_badge", locals: { export: export }
 
 - else
-  .text-center.py-2 Vous n'avez aucun export
+  .rdv-text-align-center.py-2 Vous n'avez aucun export

--- a/app/views/agents/mot_de_passes/_new_password_hints.html.slim
+++ b/app/views/agents/mot_de_passes/_new_password_hints.html.slim
@@ -1,4 +1,4 @@
-.form-text.text-muted.mb-2
+.form-text.text-muted.mb-2.rdv-color-text-mention-grey
   p
     = "Votre mot de passe doit contenir :"
     ul

--- a/app/views/agents/outlook_sync/show.html.slim
+++ b/app/views/agents/outlook_sync/show.html.slim
@@ -4,14 +4,14 @@
   p Votre compte est déjà connecté à outlook et vos rendez-vous y sont donc synchronisés. Vous pouvez vous deconnecter si vous le souhaitez en cliquant sur le bouton ci-dessous.
   p Attention, cela aura pour effect de supprimer tous vos rendez-vous #{current_domain.name} de votre agenda Outlook.
 
-  div.text-center
+  div.rdv-text-align-center
     = link_to "Déconnecter votre compte Outlook", agents_calendar_sync_outlook_sync_path, class: "btn btn-primary m-2 #{'disabled' if current_agent.outlook_disconnect_in_progress?}", method: :delete
 
 - else
 
   p Vous pouvez envoyer automatiquement vos rendez-vous dans Outlook en vous connectant à votre compte grâce au bouton ci-dessous.
 
-  div.text-center
+  div.rdv-text-align-center
     = link_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", class: "mb-4", method: :post do
       = image_tag("sign_in_with_microsoft.svg", alt: "S'identifier avec Microsoft")
 

--- a/app/views/agents/registrations/edit.html.slim
+++ b/app/views/agents/registrations/edit.html.slim
@@ -6,7 +6,7 @@
   = render "form", resource: resource, resource_name: resource_name, devise_mapping: devise_mapping
 
 - if policy([:agent, resource]).destroy?
-  .mt-5.text-center
+  .mt-5.rdv-text-align-center
     hr
     p.font-13 Vous souhaitez supprimer votre compte ?
     = link_to "Supprimer", \

--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,4 +1,4 @@
-.text-center.m-auto
+.rdv-text-align-center.m-auto
   h1.text-dark.mt-0.font-weight-bold.mb-4 Connexion à #{current_domain.name}
 
   - if display_agent_connect_button? || display_inclusion_connect_button?
@@ -17,6 +17,6 @@
       .col
         hr
 
-.text-center.w-75.m-auto
+.rdv-text-align-center.w-75.m-auto
   p.text-muted.mb-2 Entrez votre email et votre mot de passe.
 = render "common/session_form", resource: resource, resource_name: resource_name

--- a/app/views/agents/webcal_sync/show.html.slim
+++ b/app/views/agents/webcal_sync/show.html.slim
@@ -16,7 +16,7 @@ p Pour plus d'informations sur cette fonctionnalité, #{link_to("consultez la do
 
 p Si jamais votre lien de synchronisation a été partagé par erreur et qu’il y a un risque que quelqu’un d’autre accède à votre liste de rendez-vous, vous pouvez le réinitialiser immédiatement.
 
-div.text-center
+div.rdv-text-align-center
   = simple_form_for(current_agent, url: agents_calendar_sync_webcal_sync_path) do |f|
     = f.submit "Réinitialiser mon lien de synchronisation", class: "btn btn-secondary", data: { confirm: "Attention, si vous réinitialisez votre lien de synchronisation, vous devrez entrer le nouveau lien dans votre agenda externe" }
 

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -9,7 +9,7 @@
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
-      small.form-text.text-muted.mb-3 Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
+      small.form-text.rdv-color-text-mention-grey.mb-3 Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant
       = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
       .d-flex.justify-content-between
         div

--- a/app/views/common/_creneaux.html.slim
+++ b/app/views/common/_creneaux.html.slim
@@ -17,7 +17,7 @@ div id="creneaux-lieu-#{lieu.id}"
       .row
         - date_range.each do |date|
           .col-6.col-md-3.col-lg
-            p.text-center
+            p.rdv-text-align-center
               strong= l(date, format: "%A")
               br
               = l(date, format: "%d %b")
@@ -41,11 +41,11 @@ div id="creneaux-lieu-#{lieu.id}"
                     =  render "/common/modal", id: "js-rdv-restriction-motif#{creneau.starts_at.to_i}" , title: "À lire avant de prendre un rendez-vous", confirm_path: new_users_rdv_wizard_step_path(@query.merge(motif_id: creneau.motif.id, starts_at: creneau.starts_at)) do
                       = restriction_for_rdv_to_html(creneau.motif)
             - elsif date >= (Time.now + max_public_booking_delay.seconds).to_date
-              p.text-center.text-muted
+              p.rdv-text-align-center.rdv-color-text-mention-grey
                 | Date fermée à la reservation
             - elsif creneaux.any?
-              p.text-center
-                i.fa.fa-minus.text-muted
+              p.rdv-text-align-center
+                i.fa.fa-minus.rdv-color-text-mention-grey
 
         - if @next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center

--- a/app/views/common/_franceconnect_button.html.slim
+++ b/app/views/common/_franceconnect_button.html.slim
@@ -1,5 +1,5 @@
 - if current_domain.france_connect_enabled || params[:force_franceconnect].present?
-  .text-center.mb-3
+  .rdv-text-align-center.mb-3
     p FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne
     = link_to "/omniauth/franceconnect", class: "france-connect-link", method: :post do
       .normal = image_tag("franceconnect-bouton.svg", alt: "S'identifier avec FranceConnect")
@@ -7,5 +7,5 @@
     .france-connect-details= link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/"
 
   hr.fr-my-2w
-  .text-center.w-75.m-auto
-    .text-dark-50.text-center.mt-0.font-weight-bold OU
+  .rdv-text-align-center.w-75.m-auto
+    .rdv-text-align-center.mt-0.rdv-font-weight-700 OU

--- a/app/views/common/_session_form.html.slim
+++ b/app/views/common/_session_form.html.slim
@@ -10,5 +10,5 @@
 
     .mt-1.mb-3= link_to "Mot de passe oublié ?", new_password_path(resource_name)
 
-  .form-group.mb-0.text-center
+  .form-group.mb-0.rdv-text-align-center
     = f.submit "Se connecter", class: "btn btn-primary"

--- a/app/views/layouts/_degraded_service.html.slim
+++ b/app/views/layouts/_degraded_service.html.slim
@@ -1,6 +1,6 @@
 - if message.present?
   .row
     .col-md-12
-      .d-print-none.alert.fade.show.main-alert.alert-warning.m-0.text-center
+      .d-print-none.alert.fade.show.main-alert.alert-warning.m-0.rdv-text-align-center
         span> ⚠️
         = message

--- a/app/views/layouts/modal.html.slim
+++ b/app/views/layouts/modal.html.slim
@@ -2,8 +2,8 @@
   .modal-dialog class=(content_for(:modal_class) || "modal-md")
     .modal-content
       .modal-header.modal-colored-header.bg-primary
-        #mainModalLabel.modal-title.m-0.text-white.text-center.w-100
+        #mainModalLabel.modal-title.m-0.rdv-color-white.rdv-text-align-center.w-100
           = yield :title if content_for? :title
-        button.close.text-white aria-hidden="true" data-dismiss="modal" type="button"  ×
+        button.close.rdv-color-white aria-hidden="true" data-dismiss="modal" type="button"  ×
       .modal-body
         = yield

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -49,4 +49,4 @@ main.container
               = "Vous pouvez aussi "
               = mail_to(current_domain.support_email, "nous écrire",target: "_blank")
               = " pour nous donner votre avis sur la prise de rendez-vous."
-          .mt-4.text-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)
+          .mt-4.rdv-text-align-center= link_to "Retour à l'accueil", prendre_rdv_prescripteur_path(rdv.territory.departement_number)

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -28,5 +28,5 @@ main.container
 
             = render("model_errors", model: @beneficiaire, f: f)
 
-            .form-group.mb-0.text-center
+            .form-group.mb-0.rdv-text-align-center
               = f.submit "Confirmer le rendez-vous", class: "btn btn-primary"

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -51,5 +51,5 @@ main.container
                 .col-12
                   = f.input :phone_number, as: :tel, placeholder: "0122334455", label: "Votre numéro de téléphone professionnel", hint: ""
 
-            .form-group.mb-0.text-center
+            .form-group.mb-0.rdv-text-align-center
               = f.submit "Continuer", class: "btn btn-primary"

--- a/app/views/search/_banner.html.slim
+++ b/app/views/search/_banner.html.slim
@@ -1,4 +1,4 @@
 section.py-2.bg-primary
   .fr-container
-    h1.mb-3.text-white
+    h1.mb-3.rdv-color-white
       = render(current_domain.search_banner_template_name, context: context)

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -24,9 +24,9 @@
     = render "search/nothing_to_show", context: context
   - else
     - if context.first_matching_motif.collectif?
-      h3.font-weight-bold = "Inscrivez-vous à l'atelier de votre choix :"
+      h3.rdv-font-weight-700 = "Inscrivez-vous à l'atelier de votre choix :"
     - else
-      h3.font-weight-bold = "Sélectionnez un créneau :"
+      h3.rdv-font-weight-700 = "Sélectionnez un créneau :"
     .card.mb-3
       .card-body
         - if context.first_matching_motif.collectif?

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -12,7 +12,7 @@ div id="creneaux-lieu-#{lieu&.id}"
       .row
         - date_range.each do |date|
           .col-6.col-md-3.col-lg
-            p.text-center
+            p.rdv-text-align-center
               strong= l(date, format: "%A")
               br
               = l(date, format: "%d %b")
@@ -27,11 +27,11 @@ div id="creneaux-lieu-#{lieu&.id}"
                       br
                       small= creneau.agent.short_name
             - elsif date >= (Time.now + max_public_booking_delay.seconds).to_date
-              p.text-center.text-muted
+              p.rdv-text-align-center.rdv-color-text-mention-grey
                 | Date fermée à la reservation
             - elsif creneaux.any?
-              p.text-center
-                i.fa.fa-minus.text-muted
+              p.rdv-text-align-center
+                i.fa.fa-minus.rdv-color-text-mention-grey
 
         - if next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -3,15 +3,15 @@
   - if context.shown_lieux.empty?
     = render "search/nothing_to_show", context: context
   - else
-    h3.font-weight-bold = t(".select_lieu")
+    h3.rdv-font-weight-700 = t(".select_lieu")
     p = t(".lieu_available", count: context.shown_lieux.count)
     - context.next_availability_by_lieux.each do |lieu, next_availability|
       .card.mb-3 class=("card-hoverable" if next_availability)
         .card-body
           .row
             .col-md
-              h4.card-title.mb-0.mt-0.text-success.font-weight-bold= lieu.name
-              .mb-3.mt-0.text-success.font-weight-bold.larger=lieu.organisation.name
+              h4.card-title.mb-0.mt-0.rdv-color-text-default-success.rdv-font-weight-700= lieu.name
+              .mb-3.mt-0.rdv-color-text-default-success.rdv-font-weight-700.larger=lieu.organisation.name
               .card-subtitle= lieu.address
               .card-subtitle= context.service.name
             .col-md.align-self-center.pt-3.pt-md-0.position-static

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -11,7 +11,7 @@
   - if context.unique_motifs_by_name_and_location_type.empty?
     = render "search/nothing_to_show", context: context
   - else
-    h2.font-weight-bold Sélectionnez le motif de votre RDV :
+    h2.rdv-font-weight-700 Sélectionnez le motif de votre RDV :
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       .card.mb-3
         = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do

--- a/app/views/search/_motif_selection_card.html.slim
+++ b/app/views/search/_motif_selection_card.html.slim
@@ -1,7 +1,7 @@
 .card-body
   .row
     .col-md
-      h3.card-title.mb-3.mt-0.text-success.font-weight-bold
+      h3.card-title.mb-3.mt-0.rdv-color-text-default-success.rdv-font-weight-700
         - if motif.collectif?
           i.fa.fa-users>
         = motif.name

--- a/app/views/search/_nothing_to_show.html.slim
+++ b/app/views/search/_nothing_to_show.html.slim
@@ -2,14 +2,14 @@
   .card-body
     - if context.follow_up?
       - if context.referent_agents.empty?
-        .font-weight-bold L'agent avec qui vous voulez prendre rendez-vous ne vous est pas assigné comme référent.
+        .rdv-font-weight-700 L'agent avec qui vous voulez prendre rendez-vous ne vous est pas assigné comme référent.
       - else
-        .mb-3.font-weight-bold Votre référent n'a pas de créneaux disponibles. Voulez-vous prendre rendez-vous avec un autre agent ?
+        .mb-3.rdv-font-weight-700 Votre référent n'a pas de créneaux disponibles. Voulez-vous prendre rendez-vous avec un autre agent ?
         .float-left
           = render "users/rdvs/prendre_rdv_button"
     - elsif context.invitation?
-      .font-weight-bold Malheureusement, aucun créneau correspondant à votre invitation n'a été trouvé.
-      .font-weight-bold.mb-2 Toutes nos excuses pour cela.
+      .rdv-font-weight-700 Malheureusement, aucun créneau correspondant à votre invitation n'a été trouvé.
+      .rdv-font-weight-700.mb-2 Toutes nos excuses pour cela.
       = render "search/nothing_to_show_invitation", context: context
     - else
-      .font-weight-bold Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.
+      .rdv-font-weight-700 Malheureusement, aucun créneau correspondant à votre recherche n'a été trouvé.

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -3,13 +3,13 @@
   - if context.next_availability_by_motifs_organisations.empty?
     = render "search/nothing_to_show", context: context
   - else
-    h3.font-weight-bold Sélectionnez la structure avec laquelle prendre RDV:
+    h3.rdv-font-weight-700 Sélectionnez la structure avec laquelle prendre RDV:
     - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
       .card.mb-3 class="card-hoverable"
         .card-body
           .row
             .col-md
-              h3.card-title.mb-3.mt-0.text-success.font-weight-bold= organisation.name
+              h3.card-title.mb-3.mt-0.rdv-color-text-default-success.rdv-font-weight-700= organisation.name
               = render "search/organisation_card_subtitles", organisation: organisation
             .col-md.align-self-center.pt-3.pt-md-0.position-static
               = link_to prendre_rdv_path(context.query_params.merge(user_selected_organisation_id: organisation.id, date: next_availability.starts_at)), class: "d-block stretched-link" do

--- a/app/views/search/_prescription_banner.html.slim
+++ b/app/views/search/_prescription_banner.html.slim
@@ -9,7 +9,7 @@
               h2.text-header-blue.mb-2.pb-0  la prescription dans l'espace agent
 
               .
-              p.mb-0.font-weight-bold Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
+              p.mb-0.rdv-font-weight-700 Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
               p.mb-0 Désormais, vous pouvez directement trouver un rendez-vous dans votre espace  #{current_domain.name}, en élargissant la recherche d’un créneau.
               p
                 span> Pour en savoir plus, connectez-vous ou consultez

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -19,7 +19,7 @@
 
   .card-footer
     - if current_user&.participation_for(rdv)&.not_cancelled?
-      .text-muted Vous êtes déjà inscrit pour cet atelier.
+      .rdv-color-text-mention-grey Vous êtes déjà inscrit pour cet atelier.
     - else
       = link_to @context.wizard_after_creneau_selection_path(rdv_collectif_id: rdv.id), class: "d-flex card-text mb-2" do
         i.fa.fa-fw.fa-user-plus>

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -2,7 +2,7 @@
   - if context.unique_motifs_by_name_and_location_type.empty?
     = render "search/nothing_to_show", context: context
   - else
-    h2.font-weight-bold Sélectionnez le service avec qui vous voulez prendre un RDV :
+    h2.rdv-font-weight-700 Sélectionnez le service avec qui vous voulez prendre un RDV :
     - unless context.invitation?
     - context.services.each do |service|
       .card.mb-3
@@ -10,5 +10,5 @@
           .card-body
             .row
               .col-md
-                h3.card-title.mb-3.mt-0.text-success.font-weight-bold= service.name
+                h3.card-title.mb-3.mt-0.rdv-color-text-default-success.rdv-font-weight-700= service.name
   = render "search/referent_booking_card", context: context

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -5,28 +5,28 @@ section.bg-primary.fr-py-4w
         | Consulter la carte des lieux d'inclusion numérique
 section.fr-py-4w
   .fr-container
-    h2.text-center  Comment ça marche ?
+    h2.rdv-text-align-center  Comment ça marche ?
     .fr-grid-row.fr-grid-row--gutters.fr-mt-10w
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/location.svg", class: "img-circle mb-3", alt: "premièrement"
-          span.text-primary.mt-3 Zoomez près de chez vous
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Zoomez près de chez vous
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/service.svg", class: "img-circle mb-3", alt: "deuxièmement"
-          span.text-primary.mt-3 Choisissez un acteur présent près de chez vous
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Choisissez un acteur présent près de chez vous
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/motif.svg", class: "img-circle mb-3", alt: "troisièmement"
-          span.text-primary.mt-3 Appelez la structure au numéro indiqué
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Appelez la structure au numéro indiqué
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/creneau.svg", class: "img-circle mb-3", alt: "et quatrièmement"
-          span.text-primary.mt-3 ou planifiez directement un RDV si ses disponibilités sont indiquées !
+          span.rdv-color-text-action-high-blue-ecume.mt-3 ou planifiez directement un RDV si ses disponibilités sont indiquées !
 
 section.bg-lightturquoise.fr-py-8w
   .fr-container
@@ -34,6 +34,6 @@ section.bg-lightturquoise.fr-py-8w
       .fr-col-12.fr-col-md-3.align-items-center
         = image_tag "welcome/agent.svg", class: "mx-auto d-block", alt: ""
       .fr-col-12.fr-col-md-9
-        .fr-text--xl.mb-2.text-primary Vous êtes Conseiller numérique ?
+        .fr-text--xl.mb-2.rdv-color-text-action-high-blue-ecume Vous êtes Conseiller numérique ?
         p Faciliter la prise de rendez-vous avec vos apprenants.
         = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"

--- a/app/views/search/address_selection/_rdv_mairie.html.slim
+++ b/app/views/search/address_selection/_rdv_mairie.html.slim
@@ -7,6 +7,6 @@ section.bg-lightturquoise.fr-py-8w.rdv-text-align-center.rdv-text-align-md-left
       .fr-col-12.fr-col-md-3.align-items-center
         = image_tag "welcome/agent.svg", class: "mx-auto d-block", alt: ""
       .fr-col-12.fr-col-md-9
-        .fr-text--xl.mb-2.text-primary Vous êtes employé⋅e de mairie ?
+        .fr-text--xl.mb-2.rdv-color-text-action-high-blue-ecume Vous êtes employé⋅e de mairie ?
         p Faciliter la prise de rendez-vous avec les citoyens.
         = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"

--- a/app/views/search/address_selection/_rdv_solidarites.html.slim
+++ b/app/views/search/address_selection/_rdv_solidarites.html.slim
@@ -7,6 +7,6 @@ section.bg-lightturquoise.fr-py-4w.rdv-text-align-center.rdv-text-align-md-left
       .fr-col-12.fr-col-md-3.align-items-center
         = image_tag "welcome/agent.svg", class: "mx-auto d-block", alt: ""
       .fr-col-12.fr-col-md-9
-        .fr-text--lg.mb-2.text-primary Vous êtes un agent ?
+        .fr-text--lg.mb-2.rdv-color-text-action-high-blue-ecume Vous êtes un agent ?
         p Nous nous engageons à réduire le nombre de rendez-vous manqués dans les services sociaux départementaux.
         = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"

--- a/app/views/search/address_selection/_steps_section.html.slim
+++ b/app/views/search/address_selection/_steps_section.html.slim
@@ -1,24 +1,24 @@
 section.fr-py-4w
   .fr-container
-    h2.text-center  Comment ça marche ?
+    h2.rdv-text-align-center  Comment ça marche ?
     .fr-grid-row.fr-grid-row--gutters.mt-5
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/location.svg", class: "img-circle mb-3", alt: "premièrement"
-          span.text-primary.mt-3 Choisir votre adresse
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Choisir votre adresse
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/service.svg", class: "img-circle mb-3", alt: "deuxièmement"
-          span.text-primary.mt-3 Choisir un service
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Choisir un service
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/motif.svg", class: "img-circle mb-3", alt: "troisièmement"
-          span.text-primary.mt-3 Choisir un motif
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Choisir un motif
       .fr-col-12.fr-col-lg-3
-        .text-center.mb-3
+        .rdv-text-align-center.mb-3
           .d-flex.justify-content-center
             = image_tag "welcome/creneau.svg", class: "img-circle mb-3", alt: "et quatrièmement"
-          span.text-primary.mt-3 Choisir un créneau
+          span.rdv-color-text-action-high-blue-ecume.mt-3 Choisir un créneau

--- a/app/views/static_pages/mds.html.slim
+++ b/app/views/static_pages/mds.html.slim
@@ -4,18 +4,18 @@
   .fr-container
     .fr-grid-row
       .fr-col-md-12.m-auto
-        h1.text-white.mb-3 Les solidarités dans votre département
+        h1.rdv-color-white.mb-3 Les solidarités dans votre département
 .fr-container.mt-3
   .fr-grid-row.align-items-center.mb-4.rdv-flex-wrap-wrap-reverse
     .fr-col-12.fr-col-lg-8
       h2 L'insertion sociale
       .small-divider
       p.lead Les professionnels des MDS aident les publics en difficulté (bénéficiaires de minima sociaux, demandeurs d'emploi) dans leurs démarches administratives ou la constitution de dossiers. En cas de gros problèmes financiers ou de difficultés à se loger, ils peuvent vous aider dans la recherche de solutions d'urgence provisoires : hébergement d'urgence, démarches auprès des banques...
-    .fr-col-12.fr-col-lg-4.text-center
+    .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/social.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
 
   .fr-grid-row.align-items-center.mb-4
-    .fr-col-12.fr-col-lg-4.text-center
+    .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/mere.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
     .fr-col-12.fr-col-lg-8
       h2 L'accompagnement des futures et jeunes mères
@@ -27,11 +27,11 @@
       h2 La prévention et la protection de l'enfance
       .small-divider
       p.lead Dans le cadre de l'aide sociale à l'enfance (ASE), les travailleurs sociaux et médico-sociaux des MDS offrent un soutien matériel, éducatif et psychologique aux familles qui rencontrent des difficultés dans l'éducation de leurs enfants : aides éducatives à domicile, accueil des jeunes. Des activités de soutien à la parentalité sont également organisées pour permettre aux parents d'exprimer leurs difficultés et rompre leur isolement.
-    .fr-col-12.fr-col-lg-4.text-center
+    .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/enfance.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
 
   .fr-grid-row.align-items-center.mb-4
-    .fr-col-12.fr-col-lg-4.text-center
+    .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/handicape.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
     .fr-col-12.fr-col-lg-8
       h2 La prise en charge des personnes âgées et handicapées

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -2,14 +2,14 @@ section.py-5.bg-primary
   .fr-container
     .fr-grid-row
       .fr-col-md-9.m-auto
-        h1.text-white.mb-3 Faciliter la gestion des rendez-vous avec vos apprenants
+        h1.rdv-color-white.mb-3 Faciliter la gestion des rendez-vous avec vos apprenants
         .mt-4= link_to "Connectez-vous", new_agent_session_path, class: "btn text-white btn-outline-white bg-primary"
-        p.mt-4.text-white
+        p.mt-4.rdv-color-white
           | RDV Aide Numérique est un outil de prise de rendez-vous en ligne,
             simplifiant votre organisation et rappelant aux usagers leurs rendez-vous.
 section.bg-white.py-5
   .fr-container
-    .text-center.m-auto
+    .rdv-text-align-center.m-auto
       h2.mb-4 RDV Aide Numérique offre des fonctionnalités adaptées à vos besoins&nbsp;:
     .divider
     .fr-grid-row
@@ -80,12 +80,12 @@ section.bg-white.py-5
 section.bg-lightturquoise.py-5
   .fr-container
     .fr-grid-row
-      .fr-col-12.fr-col-md-8.mx-auto.text-center.m-auto
+      .fr-col-12.fr-col-md-8.mx-auto.rdv-text-align-center.m-auto
         h2.mb-2 Ça vous intéresse&nbsp;?
         p.m-auto Vous souhaitez intégrer RDV Aide Numérique dans votre quotidien et simplifier le parcours des usagers&nbsp;?
         .mt-4= link_to "Connectez-vous", new_agent_session_path, class: "btn btn-primary "
     .fr-grid-row.mt-4
-      .fr-col-12.fr-col-md-8.mx-auto.text-center.m-auto
+      .fr-col-12.fr-col-md-8.mx-auto.rdv-text-align-center.m-auto
         p
           ' Si vous n'avez jamais utilisé votre compte, vous pouvez réinitialiser votre mot de passe en indiquant votre adresse
           em
@@ -99,23 +99,23 @@ section.bg-lightturquoise.py-5
 section.bg-white.py-5
   .fr-container
     .fr-grid-row
-      .text-center.m-auto
+      .rdv-text-align-center.m-auto
         h2.mb-2 Aide Numérique en quelques chiffres c’est :
     .fr-grid-row.mt-4.d-flex.justify-content-around.flex-sm-column.flex-md-row.flex-md-nowrap
       .d-flex.flex-column.align-items-center.flex-v-gap-1em
-        .bubble.bg-lightturquoise.text-primary
+        .bubble.bg-lightturquoise.rdv-color-text-action-high-blue-ecume
           | 78
           span.small %
-        .text-center des conseillers numériques qui utilisent l’outil le recommande
+        .rdv-text-align-center des conseillers numériques qui utilisent l’outil le recommande
       .d-flex.flex-column.align-items-center.flex-v-gap-1em
-        .bubble.bg-lightturquoise.text-primary
+        .bubble.bg-lightturquoise.rdv-color-text-action-high-blue-ecume
           | 27018
-        .text-center RDVs créés par des conseillers numériques
+        .rdv-text-align-center RDVs créés par des conseillers numériques
       .d-flex.flex-column.align-items-center.flex-v-gap-1em
-        .bubble.bg-lightturquoise.text-primary
+        .bubble.bg-lightturquoise.rdv-color-text-action-high-blue-ecume
           | 47
           span.small %
-        .text-center de conseillers numériques ont intégrés l’outil dans le quotidien
+        .rdv-text-align-center de conseillers numériques ont intégrés l’outil dans le quotidien
 
 section.bg-lightturquoise.py-5
   .fr-container
@@ -143,5 +143,5 @@ section.bg-lightturquoise.py-5
               | Numérique et moi-même sommes ravis de cette plateforme. »
           figcaption
             p.fr-quote__author Témoignage recueilli via sondage
-      .fr-col-3.text-center.d-none.d-lg-flex
+      .fr-col-3.rdv-text-align-center.d-none.d-lg-flex
         = image_tag "static_pages/social.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: "Une agente travaille sur son ordinateur"

--- a/app/views/static_pages/presentation_for_mairie.html.slim
+++ b/app/views/static_pages/presentation_for_mairie.html.slim
@@ -2,14 +2,14 @@ section.py-5.bg-primary
   .fr-container
     .row
       .col-md-9.m-auto
-        h1.text-white.mb-3 Faciliter la gestion des rendez-vous
+        h1.rdv-color-white.mb-3 Faciliter la gestion des rendez-vous
         .mt-4= link_to "Connectez-vous", new_agent_session_path, class: "btn text-white btn-outline-white bg-primary"
-        p.mt-4.text-white
+        p.mt-4.rdv-color-white
           | RDV Mairie est un outil de prise de rendez-vous en ligne,
                 simplifiant votre organisation et rappelant aux usagers leurs rendez-vous.
 section.bg-white.py-5
   .fr-container
-    .text-center.m-auto
+    .rdv-text-align-center.m-auto
       h2.mb-4 RDV Mairie offre des fonctionnalités adaptées à vos besoins&nbsp;:
     .divider
     .row

--- a/app/views/static_pages/rdv_solidarites_presentation_for_agents.html.slim
+++ b/app/views/static_pages/rdv_solidarites_presentation_for_agents.html.slim
@@ -3,16 +3,16 @@ section.py-5.bg-primary
   .fr-container
     .row
       .col-md-9.m-auto
-        h1.text-white.mb-3
+        h1.rdv-color-white.mb-3
           span> Gérez les rendez-vous de votre département
         .mt-5= link_to "Se connecter en tant qu'agent", new_agent_session_path, class: "btn text-white btn-outline-white bg-primary"
-section.py-5.bg-lightturquoise.text-primary
+section.py-5.bg-lightturquoise
   .fr-container
     .row
       .col-md-9.m-auto
         h2.pb-0 Notre mission
         .fr-text--xl.mb-5
-          span.text-dark> Réduire le nombre de rendez-vous manqués
+          ' Réduire le nombre de rendez-vous manqués
           | dans les services sociaux départementaux
         .divider
 
@@ -36,14 +36,14 @@ section.py-5.bg-lightturquoise.text-primary
               .col-md-9.d-flex.align-items-center
                 .fr-text--xl.m-0 moins d'attente pour l'usager
 
-        .text-dark.text-center.mt-5
+        .rdv-text-align-center.mt-5
           p.lead Vous souhaitez en savoir plus ?
           .p-2.px-3.p-md-0
             = link_to "Contactez-nous", generic_team_meeting_url, class: "btn btn-primary"
 
 section.bg-white.py-5
   .fr-container
-    .text-center.w-75.m-auto
+    .rdv-text-align-center.w-75.m-auto
       h2.mb-5 Comment ça marche ?
     .divider
     .row
@@ -70,7 +70,7 @@ section.bg-white.py-5
 
 section.bg-lightturquoise.py-5
   .fr-container
-    .text-center.w-75.m-auto
+    .rdv-text-align-center.w-75.m-auto
       h2.mb-4 Quelles fonctionnalités ?
     .divider
     .row
@@ -93,7 +93,7 @@ section.bg-lightturquoise.py-5
             li Notifications vers des systèmes d'informations externes
 
     .row
-      .col-md-12.text-center.mt-5
+      .col-md-12.rdv-text-align-center.mt-5
         p Vous y pensez pour votre Maison des Solidarités ?
         .p-2.px-3.p-md-0
           = link_to "Contactez-nous", generic_team_meeting_url, class: "btn btn-primary"

--- a/app/views/stats/_rdv_counter_with_link.html.slim
+++ b/app/views/stats/_rdv_counter_with_link.html.slim
@@ -4,7 +4,7 @@
       = label
     - elsif local_assigns[:temporal_status]
       = t("stats.rdv_counters.#{temporal_status}", count: count)
-  .flex-grow-1.text-right
+  .flex-grow-1.rdv-text-align-right
     span.text-bold>= count
     span RDV
     span.pl-2

--- a/app/views/stats/_rdv_counter_without_link.html.slim
+++ b/app/views/stats/_rdv_counter_without_link.html.slim
@@ -4,7 +4,7 @@
       = label
     - elsif local_assigns[:temporal_status]
       = t("stats.rdv_counters.#{temporal_status}", count: count)
-  .flex-grow-1.text-right
+  .flex-grow-1.rdv-text-align-right
     span.text-bold>= count
     span
       = element

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -5,7 +5,7 @@
 
   .card-body
     = simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f|
-      .text-center.w-75.m-auto
+      .rdv-text-align-center.w-75.m-auto
       = render "devise/shared/error_messages", resource: resource
       = f.hidden_field :invitation_token
       .form-row
@@ -22,8 +22,8 @@
         = f.label :password
         = f.password_field :password, required: true, class: "form-control", id: "password", autocomplete: "new-password"
         span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
-        .form-text.small.text-muted.mb-2
+        .form-text.small.rdv-color-text-mention-grey.mb-2
           | Choisissez votre mot de passe
 
         = render "agents/mot_de_passes/new_password_hints"
-      .text-center= f.button :submit, t("devise.invitations.edit.submit_button")
+      .rdv-text-align-center= f.button :submit, t("devise.invitations.edit.submit_button")

--- a/app/views/users/invitations/invitation.html.slim
+++ b/app/views/users/invitations/invitation.html.slim
@@ -3,11 +3,11 @@
 .card
   .card-body
     = form_with url: :accept_user_invitation, method: :get, local: true do |f|
-      .text-center.w-75.m-auto
+      .rdv-text-align-center.w-75.m-auto
       .form-row
         .col-md-12
           .form-group
             = f.label :invitation_token, t("devise.invitations.invitation.invitation_token"), class: "form-control-label"
             = f.text_field :invitation_token, placeholder: "e5a36F74", class: "form-control"
-      .text-center
+      .rdv-text-align-center
         = f.button t("devise.invitations.invitation.submit_button"), class: "btn btn-primary"

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -3,7 +3,7 @@
 .card
   .card-body
     - if @from_confirmation
-      p.text-muted Pour finaliser votre inscription, veuillez définir un mot de passe.
+      p.rdv-color-text-mention-grey Pour finaliser votre inscription, veuillez définir un mot de passe.
 
     = simple_form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put } do |f|
       = render "devise/shared/error_messages", resource: resource
@@ -14,5 +14,5 @@
 
         = render "agents/mot_de_passes/new_password_hints"
 
-      .text-center
+      .rdv-text-align-center
         = f.submit "Enregistrer", class: "btn btn btn-primary"

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -3,21 +3,21 @@
 .card
   .card-body
     = form_for resource, as: resource_name, url: password_path(resource_name) do |f|
-      .text-center.w-75.m-auto
+      .rdv-text-align-center.w-75.m-auto
       = render "devise/shared/error_messages", resource: resource
       .form-group
         = f.email_field :email, autofocus: true, required: true, placeholder: "nom.prenom@email.com", class: "form-control"
-      .form-group.mb-0.text-center
+      .form-group.mb-0.rdv-text-align-center
         = f.submit "Envoyer", class: "btn btn btn-primary"
 
     hr
-    .text-center
-      p.text-muted
+    .rdv-text-align-center
+      p.rdv-color-text-mention-grey
         | Vous avez un compte ?&nbsp;
         = link_to new_session_path(resource_name) do
           b Se connecter
 
-      p.text-muted
+      p.rdv-color-text-mention-grey
         | Vous n'avez pas de compte ?&nbsp;
         = link_to new_registration_path(resource_name) do
           b Je m'inscris

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -2,7 +2,7 @@ ul.list-group.list-group-flush
   li.list-group-item
     .row
       .col
-        i.fa.fa-check.fa-fw.mr-1.text-success
+        i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
         | Motif :&nbsp;
         = rdv_wizard.motif.name
       - unless rdv_wizard.invitation?
@@ -12,21 +12,21 @@ ul.list-group.list-group-flush
   - case rdv_wizard.motif.location_type
   - when Motif.location_types[:phone]
     li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.text-success
+      i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
       | RDV téléphonique
   - when Motif.location_types[:home]
     li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.text-success
+      i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
       | RDV à domicile
   - when Motif.location_types[:visio]
     li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.text-success
+      i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
       | RDV par visioconférence
   - when Motif.location_types[:public_office]
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.text-success
+          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
           | Lieu :&nbsp;
           = rdv_wizard.creneau.lieu.full_name
         - unless rdv_wizard.invitation?
@@ -38,7 +38,7 @@ ul.list-group.list-group-flush
   li.list-group-item
     .row
       .col
-        i.fa.fa-check.fa-fw.mr-1.text-success
+        i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
         | Date du rendez-vous :&nbsp;
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
       - unless rdv_wizard.invitation?
@@ -48,7 +48,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.text-success
+          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
           | Usager :&nbsp;
           - if !rdv_wizard.invitation?
             = users_to_sentence(rdv_wizard.users)
@@ -60,7 +60,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.text-success
+          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
           | Informations de contact :&nbsp;
       .row
         .col.ml-3
@@ -77,7 +77,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.text-success
+          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
           | Prescripteur :&nbsp;
           = @rdv_wizard.prescripteur.full_name
         .col-auto

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -2,7 +2,7 @@
 
 .row.justify-content-center
   .col-lg-7.col-md-10.col-sm-11
-    h3.text-center.mb-3 Vos informations
+    h3.rdv-text-align-center.mb-3 Vos informations
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -2,7 +2,7 @@
 
 .row.justify-content-center
   .col-lg-7.col-md-10.col-sm-11
-    h3.text-center.mb-3 Choix de l'usager
+    h3.rdv-text-align-center.mb-3 Choix de l'usager
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
@@ -36,5 +36,5 @@
           .row
             .col
               = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "btn btn-link"
-            .col.text-right
+            .col
               = f.button :submit, "Continuer"

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -2,7 +2,7 @@
 
 .row.justify-content-center
   .col-lg-7.col-md-10.col-sm-11
-    h3.text-center.mb-3 Confirmation
+    h3.rdv-text-align-center.mb-3 Confirmation
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body.rdv-text-align-right

--- a/app/views/users/rdvs/_creneaux.html.slim
+++ b/app/views/users/rdvs/_creneaux.html.slim
@@ -1,6 +1,6 @@
 - if @all_creneaux.blank?
-  .bg-info.text-white.p-2.mb-3 Malheureusement, tous les créneaux sont pris. Vous recevrez d'autres propositions si un créneau se libère. La date de votre RDV reste le #{I18n.l(@rdv.starts_at, format: :human)}.
-  .py-4.border-bottom.text-center
+  .bg-info.rdv-color-white.p-2.mb-3 Malheureusement, tous les créneaux sont pris. Vous recevrez d'autres propositions si un créneau se libère. La date de votre RDV reste le #{I18n.l(@rdv.starts_at, format: :human)}.
+  .py-4.border-bottom.rdv-text-align-center
       = link_to "Retour au RDV", users_rdv_path(@rdv), class: "btn btn-primary"
 - else
   .card
@@ -18,7 +18,7 @@
           .row
             - @date_range.each do |date|
               .col-6.col-md-3.col-lg
-                p.text-center
+                p.rdv-text-align-center
                   strong= l(date, format: "%A")
                   br
                   = l(date, format: "%d %b")

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -69,10 +69,10 @@ ul.list-group.list-group-flush
       | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
 
 .py-2.d-flex.justify-content-between.align-items-center
-  .text-left.mt-2
+  .mt-2
     - if policy([:user, rdv]).edit?
        = link_to "Déplacer le RDV", creneaux_users_rdv_path(rdv), class: "btn btn-outline-primary"
-  .text-right.mt-2
+  .mt-2
     - if policy([:user, rdv]).cancel?
         = link_to "Annuler le RDV", "#", data: { toggle: "modal", target: "#js-cancel-rdv-modal-#{rdv.id}" }, class: "btn btn-outline-danger"
     - if policy([:user, current_user.participation_for(rdv)]).cancel?

--- a/app/views/users/rdvs/edit.html.slim
+++ b/app/views/users/rdvs/edit.html.slim
@@ -3,7 +3,7 @@
 .card
   .card-body
     p= t(".recap_message", motif_name_and_service: (@can_see_rdv_motif ? motif_name_and_service(@rdv.motif) : nil), rdv_human_date: I18n.l(@rdv.starts_at, format: :human))
-    .my-5.text-center
+    .my-5.rdv-text-align-center
       h4 Nouveau créneau selectionné
 
       p= l(@starts_at, format: :human).capitalize
@@ -11,5 +11,5 @@
     .row
       .col
         = link_to "Retour à la liste des créneaux", creneaux_users_rdv_path(@rdv)
-      .col.text-right
-        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class:"btn btn-primary", method: :put
+      .col.rdv-text-align-right
+        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :put

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -1,6 +1,6 @@
 .row.mt-3.justify-content-center
   .col-md-6
-    h1.text-dark.mb-3 Vos rendez-vous
+    h1.mb-3 Vos rendez-vous
     .rdv-button-group-before-card.mb-3
       - if params[:past].present?
         = link_to "Voir vos prochains RDV", users_rdvs_path, class: "btn btn-outline-primary"
@@ -14,31 +14,31 @@
               .card-body
                 = render "rdv", rdv: rdv
           .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
-          .text-center
+          .rdv-text-align-center
             = render "prendre_rdv_button", text: "Prendre un autre RDV"
 
     - else
       .card
         .card-body
-          .text-center.my-5
+          .rdv-text-align-center.my-5
             p.mb-2.lead= no_rdv_for_users
             span.fa-stack.fa-4x
-              i.fa.fa-circle.fa-stack-2x.text-primary
-              i.fa.fa-calendar.fa-stack-1x.text-white
-            .text-center.mt-2
+              i.fa.fa-circle.fa-stack-2x.rdv-color-text-action-high-blue-ecume
+              i.fa.fa-calendar.fa-stack-1x.rdv-color-white
+            .rdv-text-align-center.mt-2
   .col-md-6
-    h2.text-dark.mb-3 Vos référents
+    h2.mb-3 Vos référents
     - if current_user.referent_agents.any?
       - current_user.referent_agents.each do |agent|
         .card
           .card-body
             = agent.full_name_and_service
-          .card-footer.text-right
+          .card-footer.rdv-text-align-right
             = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
     - else
       | Vous n'avez pas de référents
 
 .row.mt-3.justify-content-center
-  .text-center.my-5
+  .rdv-text-align-center.my-5
     = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
       img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -11,17 +11,17 @@
       = render "devise/shared/error_messages", resource: resource
       = f.input :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "nom.prenom@email.com"
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-        .form-text.text-muted.mb-2
+        .form-text.rdv-color-text-mention-grey.mb-2
           | En attente de confirmation pour #{resource.unconfirmed_email}
       = f.input :password, label: "Nouveau mot de passe", autocomplete: "new-password"
       = render "agents/mot_de_passes/new_password_hints"
-      .form-text.text-muted.mb-2
+      .form-text.rdv-color-text-mention-grey.mb-2
         | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
       = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
-      .form-text.text-muted.mb-2
+      .form-text.rdv-color-text-mention-grey.mb-2
         | Renseignez votre mot de passe actuel pour tout changement.
-      .text-right= f.submit "Modifier", class: "btn btn-primary"
-      .mt-5.text-center
+      .rdv-text-align-right= f.submit "Modifier", class: "btn btn-primary"
+      .mt-5.rdv-text-align-center
         hr
         p.font-13 Vous souhaitez supprimer votre compte ?
         = link_to "Supprimer", user_registration_path, data:{ confirm: @rdv_insertion_organisations.blank? ? "Voulez-vous vraiment supprimer votre compte ?" : "Vous ne pourrez plus vous connecter à votre compte mais les données liées aux structures d'insertion ne seront pas supprimées. Vos données liées à d'autres structures seront bien supprimées." }, method: :delete, class: "btn btn-outline-danger btn-sm"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -20,12 +20,12 @@
         span> En vous inscrivant, vous acceptez les
         = link_to("conditions générales d'utilisation", cgu_path)
 
-      .form-group.mb-0.text-center
+      .form-group.mb-0.rdv-text-align-center
         = f.button :submit, "Je m'inscris"
 
     hr.fr-my-2w
-    .text-center
-      p.text-muted
+    .rdv-text-align-center
+      p.rdv-color-text-mention-grey
         | Vous avez un compte ?&nbsp;
         = link_to new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)) do
           b Se connecter

--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -3,7 +3,7 @@
 .card
   .card-body
     p = t("devise.invitations.invitation.click_on_link_sent")
-    .text-center
+    .rdv-text-align-center
       - unless email_tld_infos(@email_tld).blank?
         = link_to email_tld_infos(@email_tld)[:url], target: "blank", class: "btn btn-link" do
           span.mr-2 #{email_tld_infos(@email_tld)[:name]}

--- a/app/views/users/relatives/new.html.slim
+++ b/app/views/users/relatives/new.html.slim
@@ -1,10 +1,10 @@
 - content_for(:title) do
-  h1.text-white Ajouter un proche
+  h1.rdv-color-white Ajouter un proche
 
 = simple_form_for @user, url: relatives_path, remote: true, data: { modal: true } do |f|
   = render "model_errors", model: @user
   = render "form_fields", f: f
   .row
-    .col.text-right
+    .col.rdv-text-align-right
       button.btn.btn-link data-dismiss="modal" type="button" Annuler
       = f.button :submit

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -5,20 +5,20 @@
 
   .card-body
     = render "common/franceconnect_button"
-    .text-center.w-75.m-auto
-      p.text-muted.mb-4 Entrez votre email et votre mot de passe
+    .rdv-text-align-center.w-75.m-auto
+      p.rdv-color-text-mention-grey.mb-4 Entrez votre email et votre mot de passe
 
     = render "common/session_form", resource: resource, resource_name: resource_name
 
     hr.fr-my-2w
-    .text-center
-      p.text-muted
+    .rdv-text-align-center
+      p.rdv-color-text-mention-grey
         | Vous n'avez pas de compte ?&nbsp;
         = link_to new_registration_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)) do
           b Je m'inscris
 
     - if @rdv_wizard
       hr.fr-my-2w
-        .text-center.text-muted
+        .rdv-text-align-center.rdv-color-text-mention-grey
           = link_to prescripteur_start_path(@rdv_wizard.to_query) do
             b Je suis un prescripteur qui oriente un bénéficiaire

--- a/app/views/users/user_name_initials_verification/new.html.slim
+++ b/app/views/users/user_name_initials_verification/new.html.slim
@@ -1,11 +1,11 @@
 - content_for :title, "Vérification"
 
 .card
-  .card-header.text-center
+  .card-header.rdv-text-align-center
     h4 = t(".title")
   .card-body
     = render "form", user: current_user
-  .car-footer.text-center
+  .car-footer.rdv-text-align-center
     p Par exemple :
     p.fw-lighter.fs-6 = t(".examples.first")
     p.fw-lighter.fs-6 = t(".examples.second")

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -66,5 +66,5 @@ ruby:
     - rdv_wizard.to_query.each do |wizard_key, wizard_value|
       = hidden_field_tag "rdv[#{wizard_key}]", wizard_value
 
-  .text-right
+  .rdv-text-align-right
     = f.button :submit, (rdv_wizard.present? ? "Continuer" : "Modifier")

--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -18,7 +18,7 @@
                 .col
                   => relative.full_name
                   = "(#{age(relative)})" if relative.birth_date
-                .col-auto.text-right
+                .col-auto.rdv-text-align-right
                   = link_to t("admin.rdvs.show.update"), edit_relative_path(relative)
-        .text-right
+        .rdv-text-align-right
           = link_to t(".add_relative"), new_relative_path, class: "btn btn-outline-primary", data: { modal: true }


### PR DESCRIPTION
Review app : https://demo-rdv-solidarites-pr4541.osc-secnum-fr1.scalingo.io/

# Contexte

Dans le cadre du passage au DSFR de la partie usagers, on souhaite appliquer les couleurs du DSFR aux textes plutôt que celles de bootstrap.

# Solution

Les textes impactés par des changements de couleurs sont ceux utilisant les classes bootstrap comme `.text-primary`, `.text-muted`, `.text-light` etc... Ces classes sont définies dans `bootstrap/scss/utilities/text`. 

J’inline donc l’import de tous les `bootstrap/scss/utilities` et je commente l’import du utility `text`.

Cela a pour effet de bord de supprimer certaines classes utilitaires qui ne concernent pas les couleurs comme `.text-right` ou `.font-weight-bold` ... Dans cette PR je supprime celles inutiles, et remplace celles à conserver par de nouvelles classes custom CSS.

## Convention de nommage des classes CSS

Pour les classes de remplacement de bootstrap je respecte la convention suivante `.rdv-{css-property}-[{responsive-modifier}]-{value}`. Par exemple `.text-right` devient `.rdv-text-align-right`. 

Cette convention est inspirée du DSFR, par exemple `.fr-mr-md-2v` : margin-right à partir du breakpoint md de valeur `2v` , une unité custom du DSFR.

C’est plus verbeux mais ça devrait éviter les surprises. Le préfixe `rdv-` permettra de détecter facilement ce qui est des classes custom de RDV versus des classes non préfixées de bootstrap.

J’ai aussi décidé d’inclure ces nouvelles classes dans `_utilities.scss` plutôt que `_utilities_dsfr.scss`. Je me dis en effet qu’elles pourront être adoptées peu à peu dans d’autre parties de l’application. Je pense finalement réserver l’usage de `utilities_dsfr.scss` aux règles qui dépendent directement de variables du DSFR, par exemple celles introduites dans #4477 

## Utilisation des variables CSS

Le DSFR ne fournit pas de classes utilitaires pour utiliser les couleurs simplement. Par exemple il n’y a pas de classe équivalente à `.text-primary`. 

J’introduis des classes sous cette forme : 

```css
.rdv-color-text-mention-grey {
  color: var(--text-mention-grey);
}
```

Je suis allé chercher les noms des variables CSS de couleurs dans le fichier compilé [`main.css`](https://unpkg.com/@gouvfr/dsfr@1.12.1/dist/dsfr.main.css) du DSFR. J’ai aussi utilisé [la documentation du DSFR au sujet des couleurs]( https://www.systeme-de-design.gouv.fr/fondamentaux/couleurs-utilisation-dans-le-dsfr) qui fait référence à ces mêmes noms de variables pour choisir les couleurs recommandées.

Plutôt que de recopier en dur les valeurs des variables du DSFR, j’ai fait le choix d’utiliser les variables CSS. Les navigateurs principaux supportent cette fonctionnalité [depuis 2017](https://developer.mozilla.org/en-US/docs/Web/CSS/var#browser_compatibility). J’ai testé sur browserstack un navigateur antérieur et c’est effectivement cassé. Nous n’incluons pas de polyfill pour cette fonctionnalité. On pourrait le faire si on pense que certains usagers utilisent des navigateurs très vieux. 

## Liste des remplacements de classes

couleurs
avant - bootstrap | après - DSFR ou custom | détails
-|-|-
`text-muted` | `rdv-color-text-mention-grey`
`text-primary` | `rdv-color-text-action-high-blue-ecume`
`text-white` | `rdv-text-white`
`text-success` | `rdv-color-text-default-success`
`text-dark` | supprimée | usages quasi invisibles
`text-dark-50` | supprimée | classe dépréciée jamais définie


alignement et autres
avant - bootstrap | après - DSFR ou custom | détails
-|-|-
`text-center` | `rdv-text-align-center`
`text-left` | supprimée | usages superflus
`text-right` | `rdv-text-align-right`
`font-weight-bold` | `rdv-font-weight-700`
`text-bold` | _inchangée_ | déjà custom dans notre `_utilities.scss`

## Solution alternative

Une solution alternative envisagée était d’overrider les variables de couleur de bootstrap définies [dans _variables.scss](https://github.com/betagouv/rdv-service-public/blob/production/app/javascript/stylesheets/_variables.scss). J’ai testé cette voie mais elle me paraît moins pérenne. Supprimer peu à peu les dépendances à bootstrap permet d’éviter de superposer des règles CSS concurrentes entre bootstrap et le DSFR. Je n’aimais pas trop l’idée de recopier en dur les valeurs de couleurs du DSFR, ce qu’on aurait été obligé de faire puisqu’on ne peut pas lire les valeurs des variables CSS du fichier `dsfr.main.css` dans SASS. 

## Captures d'écran

Jeu de screenshots avant-après quasi exhaustif : https://2024-08-12-remove-bootstrap-text.surge.sh/

Les différences sont minimes et dures à voir à l’oeil nu. Je me suis permis quelques différences qui me paraissaient plus être des corrections de couleurs bleues par erreur par exemples sur la page de présentation agents (qui est appelée à disparaitre de surcroit) : 

![image](https://github.com/user-attachments/assets/4b37982e-0898-419a-8983-8f6142189340)

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/0560fbee-fe80-4d8b-acdf-25c700ab06ac">
