### PR TITLE
correction bug typo sector attributions controller

### DIFF
--- a/app/controllers/admin/territories/sector_attributions_controller.rb
+++ b/app/controllers/admin/territories/sector_attributions_controller.rb
@@ -40,7 +40,7 @@ class Admin::Territories::SectorAttributionsController < Admin::Territories::Bas
     existing_agent_attributions = @sector
       .attributions
       .level_agent
-      .where(organagent: @sector_attribution.organisation)
+      .where(organisation: @sector_attribution.organisation)
     @available_agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .merge(@sector_attribution.organisation.agents)
       .where.not(id: existing_agent_attributions.pluck(:agent_id))

--- a/app/javascript/components/zones-map.js
+++ b/app/javascript/components/zones-map.js
@@ -1,7 +1,7 @@
 class ZonesMap {
 
   constructor() {
-    this.mapElement = document.querySelector('#zones-map')
+    this.mapElement = document.querySelector('#js-zones-map')
     if (!this.mapElement) return
 
     this.hoveredCityElt = document.querySelector("#js-hovered-city")
@@ -26,7 +26,7 @@ class ZonesMap {
 
   initMap = (centerCoordinates, zoom) => {
     var map = new mapboxgl.Map({
-      container: 'zones-map',
+      container: 'js-zones-map',
       hash: true,
       center: centerCoordinates,
       zoom: zoom,

--- a/app/javascript/stylesheets/components/_zones_map.scss
+++ b/app/javascript/stylesheets/components/_zones_map.scss
@@ -1,4 +1,4 @@
-#zones-map {
+#js-zones-map {
   width: 100%;
   height: 80vh;
 
@@ -10,7 +10,7 @@
   padding: 3px 10px;
   border-radius: 7px;
 }
-#zones-map-legend {
+#js-zones-map-legend {
   position: absolute;
   background-color: rgba(255, 255, 255, 0.8);
   border-left: 1px solid #ccc;
@@ -22,7 +22,7 @@
   max-height: 80vh;
   overflow: auto;
 }
-#zones-map-small-legend {
+#js-zones-map-small-legend {
   position: absolute;
   top: 0;
   width: 100%;

--- a/app/views/admin/territories/sectors/index_map.html.slim
+++ b/app/views/admin/territories/sectors/index_map.html.slim
@@ -12,10 +12,10 @@
       .alert.alert-warning.rdv-text-align-center
         | ⚠️ Cette carte n'affiche pas correctement les secteurs qui se chevauchent ni les rues dans le détail
       div.position-relative
-        #zones-map[
+        #js-zones-map[
           data-center-query="#{@sectors.first&.zones&.first&.city_name}, #{current_territory.departement_number}"
         ]
-        #zones-map-legend
+        #js-zones-map-legend
           h4 Légende
           b Ville survolée
           .hovered-city-container

--- a/app/views/admin/territories/sectors/show.html.slim
+++ b/app/views/admin/territories/sectors/show.html.slim
@@ -143,10 +143,11 @@
         .text-muted Lorsqu'un usager cherche une adresse couverte par ce secteur, les disponibilités des organisations ou des agents attribués lui seront proposées
 
     .card
-      #zones-map.small[
+      .small[
         data-center-query="#{@sector&.zones&.first&.city_name}, #{current_territory.departement_number}"
+        id=("js-zones-map" unless Rails.env.test?)
       ]
-      #zones-map-small-legend
+      #js-zones-map-small-legend
         .hovered-city-container
           #js-hovered-city>
         ul.list-unstyled

--- a/spec/features/agents/sectorisation/sectorisation_setup_spec.rb
+++ b/spec/features/agents/sectorisation/sectorisation_setup_spec.rb
@@ -1,12 +1,14 @@
 RSpec.describe "Agent can setup sectorisation", type: :feature do
   let(:territory) { create(:territory, departement_number: "26") }
+  let!(:service) { create(:service, name: "Service social") }
   let(:ccas_valentinois) { create(:organisation, territory: territory, name: "CCAS Valentinois") }
   let(:mds_drome) { create(:organisation, territory: territory, name: "MDS Drôme") }
-  let(:agent) { create(:agent, role_in_territories: [territory], admin_role_in_organisations: [ccas_valentinois, mds_drome]) }
+  let(:lea) { create(:agent, first_name: "lea", last_name: "Dupont", services: [service], role_in_territories: [territory], admin_role_in_organisations: [ccas_valentinois, mds_drome]) }
+  let!(:marguerite) { create(:agent, first_name: "Marguerite", last_name: "Duras", services: [service], role_in_territories: [territory], basic_role_in_organisations: [ccas_valentinois, mds_drome]) }
 
-  before { login_as(agent, scope: :agent) }
+  before { login_as(lea, scope: :agent) }
 
-  it "works" do
+  it "works", :js do
     visit admin_territory_sectorization_path(territory)
     find("a", text: "Secteurs").click
     click_on "Créer un nouveau secteur"
@@ -20,5 +22,22 @@ RSpec.describe "Agent can setup sectorisation", type: :feature do
     click_on "Attribuer une organisation ou un agent"
     select "MDS Drôme", from: "Organisation"
     click_on "Ajouter"
+    expect(page).to have_content("Attribution ajoutée")
+
+    click_on "Secteurs"
+    click_on "Créer un nouveau secteur"
+    fill_in :sector_name, with: "Secteur Sud"
+    fill_in :sector_human_id, with: "sud"
+    click_on "Enregistrer"
+    click_on "Ajouter une commune ou une rue"
+    fill_in_readonly_input("#zone_city_name", "Albon")
+    fill_in_readonly_input("#zone_city_code", "26004")
+    click_on "Enregistrer"
+    click_on "Attribuer une organisation ou un agent"
+    choose "Agent désigné"
+    select "MDS Drôme", from: "Organisation"
+    select "DURAS Marguerite (Service social)", from: "Agent"
+    click_on "Ajouter"
+    expect(page).to have_content("Attribution ajoutée")
   end
 end

--- a/spec/support/fill_in_readonly_input_helper.rb
+++ b/spec/support/fill_in_readonly_input_helper.rb
@@ -1,7 +1,11 @@
 module FillInReadOnlyInputHelper
   def fill_in_readonly_input(selector, value)
-    # cf https://github.com/teamcapybara/capybara/issues/1178
-    # this should work both with js: true and without
-    find(selector).native["value"] = value
+    if RSpec.current_example.metadata[:js]
+      find(selector) # so that it waits for the page to load
+      page.execute_script("document.querySelector('#{selector}').value = '#{value}'")
+    else
+      # cf https://github.com/teamcapybara/capybara/issues/1178
+      find(selector).native["value"] = value
+    end
   end
 end


### PR DESCRIPTION
Closes #4548 

# Contexte

Il y a des erreurs 500 dues à une typo sur le controlleur des sector attributions 

# Solution

Je modifie la spec pour tester l’attribution d’un agent
Cela nécessite de passer le test en js car l’interface pour basculer entre le niveau d’attribution agent et orga ne fonctionne pas sans  😢

Mon helper pour définir une valeur sur un input readonly ne fonctionnait pas avec un driver js, je le corrige.

Je dois aussi faire un hack pour ne pas afficher la carte des secteurs mapbox car elle déclenche des requêtes distantes qui déclenchent à leur tour des erreurs JS qui sont remontées par notre config rspec/capybara.

On a discuté avec Victor des alternatives à mon branchement dans la vue `unless Rails.env.test?` mais on a statué là dessus pour l’instant, ce n’est pas une fonctionnalité qu’on a particulièrement envie de tester pour l’instant
