### PR TITLE
Authentification et début de la documentation de l'api pour Visioplainte

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -81,3 +81,5 @@ AGENT_CONNECT_CLIENT_SECRET="voir https://vaultwarden.incubateur.net/#/vault?org
 # Décommenter s'il y a besoin de désactiver le bouton Agent Connect ou Inclusion Connect
 # AGENT_CONNECT_DISABLED=true
 # INCLUSIONCONNECT_DISABLED=true
+
+VISIOPLAINTE_API_KEY="visioplainte-api-test-key-123456"

--- a/app/controllers/api/visioplainte/base_controller.rb
+++ b/app/controllers/api/visioplainte/base_controller.rb
@@ -1,9 +1,9 @@
 class Api::Visioplainte::BaseController < ActionController::Base # rubocop:disable Rails/ApplicationController
   respond_to :json
 
-  before_action :authenticate_with_api_token
+  before_action :authenticate_with_api_key
 
-  def authenticate_with_api_token
+  def authenticate_with_api_key
     authorized = ActiveSupport::SecurityUtils.secure_compare(
       request.headers["X-VISIOPLAINTE-API-KEY"] || "",
       ENV.fetch("VISIOPLAINTE_API_KEY")

--- a/app/controllers/api/visioplainte/base_controller.rb
+++ b/app/controllers/api/visioplainte/base_controller.rb
@@ -1,0 +1,21 @@
+class Api::Visioplainte::BaseController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  respond_to :json
+
+  before_action :authenticate_with_api_token
+
+  def authenticate_with_api_token
+    authorized = ActiveSupport::SecurityUtils.secure_compare(
+      request.headers["X-VISIOPLAINTE-API-KEY"] || "",
+      ENV.fetch("VISIOPLAINTE_API_KEY")
+    )
+
+    unless authorized
+      render(
+        status: :unauthorized,
+        json: {
+          errors: ["Authentification invalide"],
+        }
+      )
+    end
+  end
+end

--- a/app/controllers/api/visioplainte/creneaux_controller.rb
+++ b/app/controllers/api/visioplainte/creneaux_controller.rb
@@ -1,0 +1,20 @@
+class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
+  def index
+    render json: {
+      creneaux: [
+        {
+          starts_at: "2024-12-22T10:00:00+02:00",
+          duration_in_min: 30,
+        },
+        {
+          starts_at: "2024-12-22T10:30:00+02:00",
+          duration_in_min: 30,
+        },
+        {
+          starts_at: "2024-12-22T11:00:00+02:00",
+          duration_in_min: 30,
+        },
+      ],
+    }
+  end
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -8,6 +8,7 @@ Rswag::Ui.configure do |c|
   # correspond to the relative paths for those endpoints.
 
   c.openapi_endpoint "/api-docs/v1/api.json", "API V1 Docs"
+  c.openapi_endpoint "/api-docs/visioplainte/api.json", "Documentation API pour Visioplainte"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -39,6 +39,10 @@ namespace :api do
     resources :motif_categories, only: %i[create]
     resources :motif_category_territories, only: %i[create]
   end
+
+  namespace :visioplainte do
+    resources :creneaux, only: %i[index]
+  end
 end
 
 # This one has been published before versioning the public API and unification with auth API:

--- a/docs/api/visioplainte/description.md
+++ b/docs/api/visioplainte/description.md
@@ -1,0 +1,8 @@
+# Authentification
+
+L'authentification à l'api se fait en passant la clé d'api dans le header `X-VISIOPLAINTE-API-KEY`.
+
+Par exemple:
+```
+curl --request GET --url "https://demo.rdv.anct.gouv.fr/api/visioplainte/creneaux" --header "X-VISIOPLAINTE-API-KEY: LA_CLE_D_API"
+```

--- a/spec/requests/api/v1/paginated_request_spec.rb
+++ b/spec/requests/api/v1/paginated_request_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "paginated requests", type: :request do
+RSpec.describe "paginated requests", type: :request, swagger_doc: "v1/api.json" do
   let(:agent) { create(:agent) }
   let(:auth_headers) { api_auth_headers_for_agent(agent) }
   let(:"access-token") { auth_headers["access-token"].to_s }

--- a/spec/requests/api/visioplainte/authentication_spec.rb
+++ b/spec/requests/api/visioplainte/authentication_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe "Authentification" do
+  context "when the api key is configured properly" do
+    stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
+
+    context "without the api key header" do
+      before do
+        get "/api/visioplainte/creneaux"
+      end
+
+      it "returns a 401 response" do
+        expect(response.status).to eq 401
+        expect(JSON.parse(response.body)).to eq({ "errors" => ["Authentification invalide"] })
+      end
+    end
+
+    context "with the wrong api key" do
+      before do
+        get "/api/visioplainte/creneaux", headers: { "X-VISIOPLAINTE-API-KEY": "wrong key" }
+      end
+
+      it "returns a 401 response" do
+        expect(response.status).to eq 401
+        expect(JSON.parse(response.body)).to eq({ "errors" => ["Authentification invalide"] })
+      end
+    end
+
+    context "with the correct api key" do
+      before do
+        get "/api/visioplainte/creneaux", headers: { "X-VISIOPLAINTE-API-KEY": "visioplainte-api-test-key-123456" }
+      end
+
+      it "returns a 200 response" do
+        expect(response.status).to eq 200
+        expect(JSON.parse(response.body).keys).to eq ["creneaux"]
+      end
+    end
+  end
+
+  context "when the api key is not configured" do
+    stub_env_with(VISIOPLAINTE_API_KEY: nil)
+
+    it "raises an error" do
+      expect do
+        get "/api/visioplainte/creneaux", headers: { "X-VISIOPLAINTE-API-KEY": "test-api-key" }
+      end.to raise_error(KeyError)
+
+      expect(response).to be_nil
+    end
+  end
+end

--- a/spec/requests/api/visioplainte/creneaux_spec.rb
+++ b/spec/requests/api/visioplainte/creneaux_spec.rb
@@ -1,0 +1,61 @@
+require "swagger_helper"
+
+RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
+  stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
+
+  path "/api/visioplainte/creneaux" do
+    get "Lister les créneaux disponibles" do
+      produces "application/json"
+
+      description "Renvoie les créneaux disponibles"
+      with_examples
+      with_visioplainte_authentication
+
+      let(:"X-VISIOPLAINTE-API-KEY") do # rubocop:disable RSpec/VariableName
+        "visioplainte-api-test-key-123456"
+      end
+      let(:date_debut) { "2024-12-22" }
+      let(:date_fin) { "2024-12-28" }
+
+      response 200, "Renvoie les créneaux" do
+        run_test!
+        parameter name: :service, in: :query, type: :string,
+                  description: "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. " \
+                               "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
+                  example: "Police", required: true
+
+        parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra", example: "2024-12-22"
+        parameter name: "date_fin", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
+                  example: "2024-12-28"
+
+        schema type: :object,
+               properties: {
+                 creneaux: { type: :array },
+               },
+               required: ["creneaux"]
+
+        let(:service) { "Police" }
+        specify do
+          expect(parsed_response_body).to eq(
+            {
+              creneaux: [
+                {
+                  starts_at: "2024-12-22T10:00:00+02:00",
+                  duration_in_min: 30,
+                },
+                {
+                  starts_at: "2024-12-22T10:30:00+02:00",
+                  duration_in_min: 30,
+                },
+                {
+                  starts_at: "2024-12-22T11:00:00+02:00",
+                  duration_in_min: 30,
+                },
+              ],
+            }.deep_stringify_keys
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -23,6 +23,11 @@ module ApiSpecMacros
     parameter name: "uid", in: :header, type: :string, description: "Identifiant d'accès (authentification)", example: "martine@demo.rdv-solidarites.fr"
   end
 
+  def with_visioplainte_authentication
+    security [{ "X-VISIOPLAINTE-API-KEY": [] }]
+    parameter name: "X-VISIOPLAINTE-API-KEY", in: :header, type: :string, description: "Clé d'API", example: "visioplainte-api-test-key-123456"
+  end
+
   def with_shared_secret_authentication
     security [{ uid: [], "X-Agent-Auth-Signature": [] }]
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -13,6 +13,15 @@ RSpec.configure do |config|
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.openapi_specs = {
+    "visioplainte/api.json" => {
+      openapi: "3.0.1",
+      info: {
+        title: "API RDV Service Public pour Visioplainte",
+        version: "v1",
+        description: File.read(Rails.root.join("docs/api/visioplainte/description.md")),
+      },
+    },
+
     "v1/api.json" => {
       openapi: "3.0.1",
       info: {

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -1,0 +1,102 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "API RDV Service Public pour Visioplainte",
+    "version": "v1",
+    "description": "# Authentification\n\nL'authentification à l'api se fait en passant la clé d'api dans le header `X-VISIOPLAINTE-API-KEY`.\n\nPar exemple:\n```\ncurl --request GET --url \"https://demo.rdv.anct.gouv.fr/api/visioplainte/creneaux\" --header \"X-VISIOPLAINTE-API-KEY: LA_CLE_D_API\"\n```\n"
+  },
+  "paths": {
+    "/api/visioplainte/creneaux": {
+      "get": {
+        "summary": "Lister les créneaux disponibles",
+        "description": "Renvoie les créneaux disponibles",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "service",
+            "in": "query",
+            "description": "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
+            "example": "Police",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_debut",
+            "in": "query",
+            "description": "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra",
+            "example": "2024-12-22",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_fin",
+            "in": "query",
+            "description": "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
+            "example": "2024-12-28",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Renvoie les créneaux",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "creneaux": [
+                        {
+                          "starts_at": "2024-12-22T10:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-12-22T10:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-12-22T11:00:00+02:00",
+                          "duration_in_min": 30
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "creneaux": {
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "creneaux"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fiche notion : https://www.notion.so/rdvs/Minist-re-de-l-Int-rieur-VisioPlainte-baaf80deb8624d1fa06e64df143213b9

# Contexte

On a commencé à dessiner l'api pour le projet visioplainte dans le pad disponible sur la fiche notion. Suite aux différentes réunions technique, la prochaine étape est donc de formaliser et préciser la définition de l'api dans un swagger pour que l'équipe technique de visioplainte puisse commencer à travailler.

Le but de cette PR est donc seulement de poser les bases de la documentation de l'api, et de préciser le mode d'authentification.

L'authentification est implémentée, et le premier endpoint de l'api est documenté mais pas encore implémenté.

La nouvelle doc est disponible à l'url : http://www.rdv-solidarites.localhost:3000/api-docs/index.html?urls.primaryName=Documentation%20API%20pour%20Visioplainte
# Solution

Pour ce projet, on reprend les principes d'architectures qui ont bien marché pour l'api de l'ants : une api isolée mais qui s'appuira sur le code métier existant, ce qui permet d'itérer facilement, sans se poser trop de question sur l'usage de tous les clients de l'api.

Pour l'authentification, on fait au plus simple et on reprend une authentification par clé d'api (comme convenu avec l'équipe tech visioplainte).

On crée une nouvelle documentation Swagger pour le nouvel endpoint.

<img width="1430" alt="Screenshot 2024-08-13 at 13 40 48" src="https://github.com/user-attachments/assets/12621c75-34bd-4634-a00d-1eab75f74206">

J'ai réutilisé le comportement actuel qui consiste à commiter le fichier json généré par rswag, mais ça serait mieux de ne pas avoir besoin de faire ça et de le générer au moment du deploy. Ça peut être une amélioration pour plus tard.