### PR TITLE
Retirer les espaces lors des redirections vers RDV-I

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,8 +327,8 @@ Rails.application.routes.draw do
 
   # This route redirects invitations to rdv-insertion so that rdv-insertion
   # can use rdvs domain name in their emails
-  get "/i/r/:uuid", to: redirect { |path_params, _|
-    "#{ENV['RDV_INSERTION_HOST']}/r/#{path_params[:uuid]}"
+  get "/i/r/*uuid", to: redirect { |path_params, _|
+    "#{ENV['RDV_INSERTION_HOST']}/r/#{path_params[:uuid]&.strip}"
   }
 
   if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,7 +327,7 @@ Rails.application.routes.draw do
 
   # This route redirects invitations to rdv-insertion so that rdv-insertion
   # can use rdvs domain name in their emails
-  get "/i/r/*uuid", to: redirect { |path_params, _|
+  get "/i/r/:uuid", to: redirect { |path_params, _|
     "#{ENV['RDV_INSERTION_HOST']}/r/#{path_params[:uuid]&.strip}"
   }
 

--- a/spec/requests/users/redirect_to_rdv_insertion_spec.rb
+++ b/spec/requests/users/redirect_to_rdv_insertion_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "RedirectToRdvInsertionSpec", type: :request do
-  before { ENV["RDV_INSERTION_HOST"] = "https://rdv-insertion-host.fr" }
+  stub_env_with(RDV_INSERTION_HOST: "https://rdv-insertion-host.fr")
 
   context "URL is well formed" do
     it "works" do
@@ -8,11 +8,7 @@ RSpec.describe "RedirectToRdvInsertionSpec", type: :request do
     end
   end
 
-  context "URL has spaces before and after" do
-    it "does not raise an error" do
-      expect { get("/i/r/%2012345%20") }.not_to raise_error
-    end
-
+  context "URL has spaces before and after because the user typed it manually from a paper letter" do
     it "strips the spaces" do
       get "/i/r/%2012345"
       expect(response).to redirect_to("https://rdv-insertion-host.fr/r/12345")

--- a/spec/requests/users/redirect_to_rdv_insertion_spec.rb
+++ b/spec/requests/users/redirect_to_rdv_insertion_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "RedirectToRdvInsertionSpec", type: :request do
+  before { ENV["RDV_INSERTION_HOST"] = "https://rdv-insertion-host.fr" }
+
+  context "URL is well formed" do
+    it "works" do
+      get "/i/r/12345"
+      expect(response).to redirect_to("https://rdv-insertion-host.fr/r/12345")
+    end
+  end
+
+  context "URL has spaces before and after" do
+    it "does not raise an error" do
+      expect { get("/i/r/%2012345%20") }.not_to raise_error
+    end
+
+    it "strips the spaces" do
+      get "/i/r/%2012345"
+      expect(response).to redirect_to("https://rdv-insertion-host.fr/r/12345")
+    end
+  end
+
+  context "URL has no uuid" do
+    it "works" do
+      expect { get("/i/r/") }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end


### PR DESCRIPTION
Closes #4550

# Contexte

cf issue #4550 

# Solution

On est obligés d’utiliser un [wildcard segment](https://guides.rubyonrails.org/routing.html#route-globbing-and-wildcard-segments). 
Un segment dynamique classique renvoie toujours une erreur `URI::InvalidURIError` lorsqu’il y a un espace dedans. 

Je ne sais pas si ça pose des questions de sécurité ?