### PR TITLE
Documentation de l'api usager pour Visioplainte

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     bindata (2.5.0)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
-    blueprinter (0.25.3)
+    blueprinter (1.1.0)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     bootstrap4-kaminari-views (1.0.1)

--- a/app/blueprints/visioplainte/rdv_blueprint.rb
+++ b/app/blueprints/visioplainte/rdv_blueprint.rb
@@ -3,10 +3,8 @@ class Visioplainte::RdvBlueprint < Blueprinter::Base
 
   fields :starts_at, :created_at, :duration_in_min, :ends_at, :status
 
-  field :users do |rdv, _options|
-    rdv.users.map do |user|
-      { id: user.id }
-    end
+  field :user_id do |rdv, _options|
+    rdv.users.first.id
   end
 
   field :guichet do |rdv, _options|

--- a/app/blueprints/visioplainte/rdv_blueprint.rb
+++ b/app/blueprints/visioplainte/rdv_blueprint.rb
@@ -2,4 +2,18 @@ class Visioplainte::RdvBlueprint < Blueprinter::Base
   identifier :id
 
   fields :starts_at, :created_at, :duration_in_min, :ends_at
+
+  field :users do |rdv, _options|
+    rdv.users.map do |user|
+      { id: user.id }
+    end
+  end
+
+  field :guichet do |rdv, _options|
+    guichet = rdv.agents.first
+    {
+      id: guichet.id,
+      name: guichet.full_name,
+    }
+  end
 end

--- a/app/blueprints/visioplainte/rdv_blueprint.rb
+++ b/app/blueprints/visioplainte/rdv_blueprint.rb
@@ -1,7 +1,7 @@
 class Visioplainte::RdvBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :starts_at, :created_at, :duration_in_min, :ends_at
+  fields :starts_at, :created_at, :duration_in_min, :ends_at, :status
 
   field :users do |rdv, _options|
     rdv.users.map do |user|

--- a/app/blueprints/visioplainte/rdv_blueprint.rb
+++ b/app/blueprints/visioplainte/rdv_blueprint.rb
@@ -1,0 +1,5 @@
+class Visioplainte::RdvBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :starts_at, :created_at, :duration_in_min, :ends_at
+end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -13,7 +13,7 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
 
   def rdv(status)
     # Des données de test pour documenter l'api.
-    rdv = Rdv.new(
+    Rdv.new(
       id: 123,
       users: [User.new(id: 456)],
       agents: [Agent.new(id: 789, last_name: "Guichet 3")],

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -4,12 +4,16 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
     rdv = Rdv.new(
       id: 123,
       users: [User.new(id: 456)],
-      agents: [Agent.new(id: 789)],
+      agents: [Agent.new(id: 789, last_name: "Guichet 3")],
       created_at: Time.zone.now,
       starts_at: params[:starts_at],
       duration_in_min: 45
     )
 
     render json: Visioplainte::RdvBlueprint.render(rdv), status: :created
+  end
+
+  def destroy
+    head :no_content
   end
 end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,0 +1,5 @@
+class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
+  def create
+    render json: Visioplainte::RdvBlueprint.render(Rdv.new(id: 123)), status: :created
+  end
+end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,5 +1,15 @@
 class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   def create
-    render json: Visioplainte::RdvBlueprint.render(Rdv.new(id: 123)), status: :created
+    # Des données de test pour documenter l'api.
+    rdv = Rdv.new(
+      id: 123,
+      users: [User.new(id: 456)],
+      agents: [Agent.new(id: 789)],
+      created_at: Time.zone.now,
+      starts_at: params[:starts_at],
+      duration_in_min: 45
+    )
+
+    render json: Visioplainte::RdvBlueprint.render(rdv), status: :created
   end
 end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -11,6 +11,8 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
     render json: Visioplainte::RdvBlueprint.render(rdv(:excused)), status: :ok
   end
 
+  private
+
   def rdv(status)
     # Des données de test pour documenter l'api.
     Rdv.new(

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,5 +1,17 @@
 class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   def create
+    render json: Visioplainte::RdvBlueprint.render(rdv(:unknown)), status: :created
+  end
+
+  def destroy
+    head :no_content
+  end
+
+  def cancel
+    render json: Visioplainte::RdvBlueprint.render(rdv(:excused)), status: :ok
+  end
+
+  def rdv(status)
     # Des données de test pour documenter l'api.
     rdv = Rdv.new(
       id: 123,
@@ -7,13 +19,8 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
       agents: [Agent.new(id: 789, last_name: "Guichet 3")],
       created_at: Time.zone.now,
       starts_at: params[:starts_at],
-      duration_in_min: 45
+      duration_in_min: 45,
+      status: status
     )
-
-    render json: Visioplainte::RdvBlueprint.render(rdv), status: :created
-  end
-
-  def destroy
-    head :no_content
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -42,6 +42,7 @@ namespace :api do
 
   namespace :visioplainte do
     resources :creneaux, only: %i[index]
+    resources :rdvs, only: %i[create]
   end
 end
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -42,7 +42,11 @@ namespace :api do
 
   namespace :visioplainte do
     resources :creneaux, only: %i[index]
-    resources :rdvs, only: %i[create]
+    resources :rdvs, only: %i[create destroy] do
+      member do
+        put :cancel
+      end
+    end
   end
 end
 

--- a/spec/requests/api/visioplainte/creneaux_spec.rb
+++ b/spec/requests/api/visioplainte/creneaux_spec.rb
@@ -1,19 +1,12 @@
 require "swagger_helper"
 
 RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
-  stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
-
   path "/api/visioplainte/creneaux" do
     get "Lister les créneaux disponibles" do
-      produces "application/json"
-
-      description "Renvoie les créneaux disponibles"
-      with_examples
       with_visioplainte_authentication
 
-      let(:"X-VISIOPLAINTE-API-KEY") do # rubocop:disable RSpec/VariableName
-        "visioplainte-api-test-key-123456"
-      end
+      description "Renvoie les créneaux disponibles"
+
       let(:date_debut) { "2024-12-22" }
       let(:date_fin) { "2024-12-28" }
 

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -1,0 +1,58 @@
+require "swagger_helper"
+
+RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
+  stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
+  let(:"X-VISIOPLAINTE-API-KEY") do # rubocop:disable RSpec/VariableName
+    "visioplainte-api-test-key-123456"
+  end
+
+  path "/api/visioplainte/rdvs" do
+    post "Prendre un rdv" do
+      produces "application/json"
+
+      description "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence"
+      with_examples
+      with_visioplainte_authentication
+
+      response 201, "Prend le rdv" do
+        run_test!
+        parameter name: :service, in: :query, type: :string,
+                  description: "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. " \
+                               "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
+                  example: "Police", required: true
+
+        parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra", example: "2024-12-22"
+        parameter name: "date_fin", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
+                  example: "2024-12-28"
+
+        schema type: :object,
+               properties: {
+                 id: { type: :integer },
+               },
+               required: %w[id starts_at created_at duration_in_min users guichet]
+
+        let(:service) { "Police" }
+        specify do
+          expect(parsed_response_body).to eq(
+            {
+              creneaux: [
+                {
+                  starts_at: "2024-12-22T10:00:00+02:00",
+                  duration_in_min: 30,
+                },
+                {
+                  starts_at: "2024-12-22T10:30:00+02:00",
+                  duration_in_min: 30,
+                },
+                {
+                  starts_at: "2024-12-22T11:00:00+02:00",
+                  duration_in_min: 30,
+                },
+              ],
+            }.deep_stringify_keys
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -21,37 +21,16 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
                                "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
                   example: "Police", required: true
 
-        parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra", example: "2024-12-22"
-        parameter name: "date_fin", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
-                  example: "2024-12-28"
-
+        parameter name: "starts_at", in: :query, type: :string, description: "datetime au format iso8601 (YYYY-MM-DD)"
         schema type: :object,
                properties: {
                  id: { type: :integer },
-               },
-               required: %w[id starts_at created_at duration_in_min users guichet]
 
+               },
+               required: Visioplainte::RdvBlueprint.reflections[:default].fields.keys
+
+        let(:starts_at) { Time.zone.now.iso8601 }
         let(:service) { "Police" }
-        specify do
-          expect(parsed_response_body).to eq(
-            {
-              creneaux: [
-                {
-                  starts_at: "2024-12-22T10:00:00+02:00",
-                  duration_in_min: 30,
-                },
-                {
-                  starts_at: "2024-12-22T10:30:00+02:00",
-                  duration_in_min: 30,
-                },
-                {
-                  starts_at: "2024-12-22T11:00:00+02:00",
-                  duration_in_min: 30,
-                },
-              ],
-            }.deep_stringify_keys
-          )
-        end
       end
     end
   end

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
+RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rubocop:disable RSpec/EmptyExampleGroup
   path "/api/visioplainte/rdvs" do
     post "Prendre un rdv" do
       with_visioplainte_authentication

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     post "Prendre un rdv" do
       with_visioplainte_authentication
 
-      description "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence"
+      description "Crée un rdv et réserve le créneau correspondant."
 
       response 201, "Prend le rdv" do
         run_test!
@@ -16,6 +16,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
 
         parameter name: "starts_at", in: :query, type: :string,
                   description: "datetime au format iso8601 (YYYY-MM-DD). Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.", required: true
+
         schema type: :object,
                properties: {
                  id: { type: :integer },
@@ -23,6 +24,8 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
                  starts_at: { type: :string },
                  duration_in_min: { type: :integer },
                  ends_at: { type: :string },
+                 guichet: { type: :object, properties: { id: { type: :integer }, name: { type: :string } } },
+                 user_id: { type: :integer },
                },
                required: Visioplainte::RdvBlueprint.reflections[:default].fields.keys
 
@@ -39,7 +42,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     delete "Supprimer un rdv" do
       with_visioplainte_authentication
 
-      description "Supprime le rdv. Il n'apparaitra plus dans aucune requête de l'api"
+      description "Supprime le rdv. Il n'apparaîtra plus dans aucune requête de l'api"
 
       response 204, "Supprime le rdv" do
         run_test!
@@ -52,7 +55,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     put "Annuler un rdv" do
       with_visioplainte_authentication
 
-      description "Annule le rdv. Il apparaitra encore dans la liste des rdv du guichet."
+      description "Annule le rdv. Il apparaîtra encore dans la liste des rdv du guichet."
 
       response 200, "Annule le rdv" do
         run_test!

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
         schema type: :object,
                properties: {
                  id: { type: :integer },
-
+                 created_at: { type: :string },
+                 starts_at: { type: :string },
+                 duration_in_min: { type: :integer },
+                 ends_at: { type: :string },
                },
                required: Visioplainte::RdvBlueprint.reflections[:default].fields.keys
 

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -1,27 +1,21 @@
 require "swagger_helper"
 
 RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
-  stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
-  let(:"X-VISIOPLAINTE-API-KEY") do # rubocop:disable RSpec/VariableName
-    "visioplainte-api-test-key-123456"
-  end
-
   path "/api/visioplainte/rdvs" do
     post "Prendre un rdv" do
-      produces "application/json"
+      with_visioplainte_authentication
 
       description "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence"
-      with_examples
-      with_visioplainte_authentication
 
       response 201, "Prend le rdv" do
         run_test!
         parameter name: :service, in: :query, type: :string,
-                  description: "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. " \
+                  description: "Indique si on souhaite prendre rendez-vous avec la gendarmerie ou la police. " \
                                "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
                   example: "Police", required: true
 
-        parameter name: "starts_at", in: :query, type: :string, description: "datetime au format iso8601 (YYYY-MM-DD)"
+        parameter name: "starts_at", in: :query, type: :string,
+                  description: "datetime au format iso8601 (YYYY-MM-DD). Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.", required: true
         schema type: :object,
                properties: {
                  id: { type: :integer },
@@ -35,6 +29,30 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
         let(:starts_at) { Time.zone.now.iso8601 }
         let(:service) { "Police" }
       end
+    end
+  end
+
+  let(:id) { rdv.id }
+  let(:rdv) { create(:rdv) }
+
+  path "/api/visioplainte/rdvs/{id}" do
+    delete "Supprimer un rdv" do
+      with_visioplainte_authentication
+
+      description "Supprime le rdv"
+
+      response 204, "Supprime le rdv" do
+        run_test!
+        parameter name: :id, in: :path, type: :string
+      end
+    end
+  end
+
+  path "/api/visioplainte/rdvs/{id}/annuler" do
+    put "Annuler un rdv" do
+      with_visioplainte_authentication
+
+      response 
     end
   end
 end

--- a/spec/requests/api/visioplainte/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/rdv_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     delete "Supprimer un rdv" do
       with_visioplainte_authentication
 
-      description "Supprime le rdv"
+      description "Supprime le rdv. Il n'apparaitra plus dans aucune requête de l'api"
 
       response 204, "Supprime le rdv" do
         run_test!
@@ -48,11 +48,16 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
     end
   end
 
-  path "/api/visioplainte/rdvs/{id}/annuler" do
+  path "/api/visioplainte/rdvs/{id}/cancel" do
     put "Annuler un rdv" do
       with_visioplainte_authentication
 
-      response 
+      description "Annule le rdv. Il apparaitra encore dans la liste des rdv du guichet."
+
+      response 200, "Annule le rdv" do
+        run_test!
+        parameter name: :id, in: :path, type: :string
+      end
     end
   end
 end

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -31,7 +31,7 @@ module ApiSpecMacros
       "visioplainte-api-test-key-123456"
     end
     security [{ "X-VISIOPLAINTE-API-KEY": [] }]
-    parameter name: "X-VISIOPLAINTE-API-KEY", in: :header, type: :string, description: "Clé d'API", example: "visioplainte-api-test-key-123456"
+    parameter name: "X-VISIOPLAINTE-API-KEY", in: :header, type: :string, description: "Clé d'API", example: "visioplainte-api-test-key-123456", required: true
   end
 
   def with_shared_secret_authentication

--- a/spec/support/api_spec_macros.rb
+++ b/spec/support/api_spec_macros.rb
@@ -24,6 +24,12 @@ module ApiSpecMacros
   end
 
   def with_visioplainte_authentication
+    with_examples
+    produces "application/json"
+    stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
+    let(:"X-VISIOPLAINTE-API-KEY") do # rubocop:disable RSpec/VariableName
+      "visioplainte-api-test-key-123456"
+    end
     security [{ "X-VISIOPLAINTE-API-KEY": [] }]
     parameter name: "X-VISIOPLAINTE-API-KEY", in: :header, type: :string, description: "Clé d'API", example: "visioplainte-api-test-key-123456"
   end

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -22,6 +22,7 @@
             "in": "header",
             "description": "Clé d'API",
             "example": "visioplainte-api-test-key-123456",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -114,6 +115,7 @@
             "in": "header",
             "description": "Clé d'API",
             "example": "visioplainte-api-test-key-123456",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -138,7 +140,7 @@
             }
           }
         ],
-        "description": "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence",
+        "description": "Crée un rdv et réserve le créneau correspondant.",
         "responses": {
           "201": {
             "description": "Prend le rdv",
@@ -148,20 +150,16 @@
                   "example": {
                     "value": {
                       "id": 123,
-                      "created_at": "2024-08-13 15:40:46 +0200",
+                      "created_at": "2024-08-14 10:36:20 +0200",
                       "duration_in_min": 45,
-                      "ends_at": "2024-08-13 16:25:46 +0200",
+                      "ends_at": "2024-08-14 11:21:20 +0200",
                       "guichet": {
                         "id": 789,
                         "name": "GUICHET 3"
                       },
-                      "starts_at": "2024-08-13 15:40:46 +0200",
+                      "starts_at": "2024-08-14 10:36:20 +0200",
                       "status": "unknown",
-                      "users": [
-                        {
-                          "id": 456
-                        }
-                      ]
+                      "user_id": 456
                     }
                   }
                 },
@@ -182,6 +180,20 @@
                     },
                     "ends_at": {
                       "type": "string"
+                    },
+                    "guichet": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "user_id": {
+                      "type": "integer"
                     }
                   },
                   "required": [
@@ -192,7 +204,7 @@
                     "guichet",
                     "starts_at",
                     "status",
-                    "users"
+                    "user_id"
                   ]
                 }
               }
@@ -217,6 +229,7 @@
             "in": "header",
             "description": "Clé d'API",
             "example": "visioplainte-api-test-key-123456",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -230,7 +243,7 @@
             }
           }
         ],
-        "description": "Supprime le rdv. Il n'apparaitra plus dans aucune requête de l'api",
+        "description": "Supprime le rdv. Il n'apparaîtra plus dans aucune requête de l'api",
         "responses": {
           "204": {
             "description": "Supprime le rdv",
@@ -263,6 +276,7 @@
             "in": "header",
             "description": "Clé d'API",
             "example": "visioplainte-api-test-key-123456",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -276,7 +290,7 @@
             }
           }
         ],
-        "description": "Annule le rdv. Il apparaitra encore dans la liste des rdv du guichet.",
+        "description": "Annule le rdv. Il apparaîtra encore dans la liste des rdv du guichet.",
         "responses": {
           "200": {
             "description": "Annule le rdv",
@@ -286,7 +300,7 @@
                   "example": {
                     "value": {
                       "id": 123,
-                      "created_at": "2024-08-13 15:40:47 +0200",
+                      "created_at": "2024-08-14 10:36:21 +0200",
                       "duration_in_min": 45,
                       "ends_at": null,
                       "guichet": {
@@ -295,11 +309,7 @@
                       },
                       "starts_at": null,
                       "status": "excused",
-                      "users": [
-                        {
-                          "id": 456
-                        }
-                      ]
+                      "user_id": 456
                     }
                   }
                 }

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -97,6 +97,106 @@
           }
         }
       }
+    },
+    "/api/visioplainte/rdvs": {
+      "post": {
+        "summary": "Prendre un rdv",
+        "description": "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "service",
+            "in": "query",
+            "description": "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
+            "example": "Police",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "starts_at",
+            "in": "query",
+            "description": "datetime au format iso8601 (YYYY-MM-DD)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Prend le rdv",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "id": 123,
+                      "created_at": "2024-08-13 14:47:16 +0200",
+                      "duration_in_min": 45,
+                      "ends_at": "2024-08-13 15:32:16 +0200",
+                      "guichet": {
+                        "id": 789,
+                        "name": ""
+                      },
+                      "starts_at": "2024-08-13 14:47:16 +0200",
+                      "users": [
+                        {
+                          "id": 456
+                        }
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "created_at": {
+                      "type": "string"
+                    },
+                    "starts_at": {
+                      "type": "string"
+                    },
+                    "duration_in_min": {
+                      "type": "integer"
+                    },
+                    "ends_at": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "created_at",
+                    "duration_in_min",
+                    "ends_at",
+                    "guichet",
+                    "starts_at",
+                    "users"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -9,7 +9,6 @@
     "/api/visioplainte/creneaux": {
       "get": {
         "summary": "Lister les créneaux disponibles",
-        "description": "Renvoie les créneaux disponibles",
         "security": [
           {
             "X-VISIOPLAINTE-API-KEY": [
@@ -56,6 +55,7 @@
             }
           }
         ],
+        "description": "Renvoie les créneaux disponibles",
         "responses": {
           "200": {
             "description": "Renvoie les créneaux",
@@ -101,7 +101,6 @@
     "/api/visioplainte/rdvs": {
       "post": {
         "summary": "Prendre un rdv",
-        "description": "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence",
         "security": [
           {
             "X-VISIOPLAINTE-API-KEY": [
@@ -122,7 +121,7 @@
           {
             "name": "service",
             "in": "query",
-            "description": "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
+            "description": "Indique si on souhaite prendre rendez-vous avec la gendarmerie ou la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
             "example": "Police",
             "required": true,
             "schema": {
@@ -132,12 +131,14 @@
           {
             "name": "starts_at",
             "in": "query",
-            "description": "datetime au format iso8601 (YYYY-MM-DD)",
+            "description": "datetime au format iso8601 (YYYY-MM-DD). Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.",
+            "required": true,
             "schema": {
               "type": "string"
             }
           }
         ],
+        "description": "Crée un rdv et réserve le créneau correspondant. Le rdv pourra être supprimé si l'usager ne le confirme pas, ou annulé si l'usager prévient d'une absence",
         "responses": {
           "201": {
             "description": "Prend le rdv",
@@ -147,14 +148,15 @@
                   "example": {
                     "value": {
                       "id": 123,
-                      "created_at": "2024-08-13 14:47:16 +0200",
+                      "created_at": "2024-08-13 15:40:46 +0200",
                       "duration_in_min": 45,
-                      "ends_at": "2024-08-13 15:32:16 +0200",
+                      "ends_at": "2024-08-13 16:25:46 +0200",
                       "guichet": {
                         "id": 789,
-                        "name": ""
+                        "name": "GUICHET 3"
                       },
-                      "starts_at": "2024-08-13 14:47:16 +0200",
+                      "starts_at": "2024-08-13 15:40:46 +0200",
+                      "status": "unknown",
                       "users": [
                         {
                           "id": 456
@@ -189,8 +191,117 @@
                     "ends_at",
                     "guichet",
                     "starts_at",
+                    "status",
                     "users"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/visioplainte/rdvs/{id}": {
+      "delete": {
+        "summary": "Supprimer un rdv",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "description": "Supprime le rdv. Il n'apparaitra plus dans aucune requête de l'api",
+        "responses": {
+          "204": {
+            "description": "Supprime le rdv",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": ""
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/visioplainte/rdvs/{id}/cancel": {
+      "put": {
+        "summary": "Annuler un rdv",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "description": "Annule le rdv. Il apparaitra encore dans la liste des rdv du guichet.",
+        "responses": {
+          "200": {
+            "description": "Annule le rdv",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "id": 123,
+                      "created_at": "2024-08-13 15:40:47 +0200",
+                      "duration_in_min": 45,
+                      "ends_at": null,
+                      "guichet": {
+                        "id": 789,
+                        "name": "GUICHET 3"
+                      },
+                      "starts_at": null,
+                      "status": "excused",
+                      "users": [
+                        {
+                          "id": 456
+                        }
+                      ]
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
suite de https://github.com/betagouv/rdv-service-public/pull/4551

Cette PR documente les autres endpoints de l'api conformément au pad, en prévision de la réunion de vendredi.


On fait une mise à jour de Blueprinter pour pouvoir utiliser les `reflections`. J'ai vérifié leur changelog, et les seuls breaking changes sont qu'ils arrêtent de supporter des vieilles versions de ruby, et des changements sur les `transformers`, une fonctionnalité de la gem qu'on n'utilise pas.