### PR TITLE
amélioration de la bannière de prescription

### DIFF
--- a/app/javascript/stylesheets/components/_types.scss
+++ b/app/javascript/stylesheets/components/_types.scss
@@ -65,13 +65,3 @@ mark,
     content: "\2014 \00A0";
   }
 }
-
-// Font colors (Custom)
-
-.text-dsfr-grey-50 {
-  color: #161616;
-}
-
-.text-header-blue {
-  color: #2e4077;
-}

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -22,6 +22,10 @@
   color: var(--text-default-success);
 }
 
+.rdv-color-text-title-grey {
+  color: var(--text-title-grey);
+}
+
 // FLEX
 
 .rdv-flex-wrap-wrap-reverse {

--- a/app/views/search/_prescription_banner.html.slim
+++ b/app/views/search/_prescription_banner.html.slim
@@ -5,17 +5,17 @@
         .fr-col-lg-12.mt-4.mb-3
           .fr-grid-row
             .fr-col-lg-7
-              h2.text-dsfr-grey-50.mb-1.pb-0  Nouvelle fonctionnalité :
-              h2.text-header-blue.mb-2.pb-0  la prescription dans l'espace agent
-
-              .
-              p.mb-0.rdv-font-weight-700 Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
-              p.mb-0 Désormais, vous pouvez directement trouver un rendez-vous dans votre espace  #{current_domain.name}, en élargissant la recherche d’un créneau.
+              h2.rdv-color-text-title-grey.mb-1.pb-0  Nouvelle fonctionnalité :
+              h2.rdv-color-text-action-high-blue-ecume.mb-2.pb-0  la prescription dans l'espace agent
+              p.rdv-font-weight-700 Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
               p
-                span> Pour en savoir plus, connectez-vous ou consultez
+                ' Désormais, vous pouvez directement trouver un rendez-vous dans
+                = link_to "votre espace agent #{current_domain.name}", root_path
+                | , en élargissant la recherche d’un créneau.
+              p
+                span> Pour en savoir plus, consultez
                 = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
                   span> la documentation
-                  i.fa.fa-external-link-alt>
             .fr-col-lg-5
               .d-flex.justify-content-center
                 = image_tag "welcome/prescription_banner.svg", class: "rdv-max-width-60 rdv-max-width-md-100", alt: ""


### PR DESCRIPTION
# Contexte

La bannière de prescription indique aux agents faisant de la prescription par l’interface usagers qu’iels peuvent et devraient le faire depuis la partie agents.

Les agents accèdent à la partie usagers pour faire de la prescription via un lien comme `/prendre_rdv_prescripteur` qui leur a été donné par leurs référent·es, elleux-mêmes l’ayant reçu de nos chargé·es de déploiement. 

Cette bannière utilisait des classes DSFR custom pour les couleurs de textes qui ne collent pas aux nouvelles conventions de nommage que j’essaie d’introduire. 

Le contenu de la bannière avait aussi quelques problèmes (que j’ai en partie introduit dans mes migrations au DSFR) : 
- un icône lien externe en double
- un titre en noir au lieu d’être en bleu
- du texte qui suggère de se connecter alors que l’agent est déjà connecté

# Solution

Je réutilise les classes existantes et je créé de nouvelles classes pour celles qui n’existent pas encore.

J’en profite pour améliorer un peu le contenu de la bannière : 
- je rajoute un lien vers la partie agent connecté 
- je supprime l’incitation à se connecter

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/2843f8ff-0c83-4699-887f-67462ea19315) | ![image](https://github.com/user-attachments/assets/1556b705-67b7-492b-bee7-f64dd7904ec8)

