### PR TITLE
Ajout de détails dans la documentation swagger de l'api Visioplainte

### DIFF
--- a/spec/requests/api/visioplainte/creneaux_spec.rb
+++ b/spec/requests/api/visioplainte/creneaux_spec.rb
@@ -17,13 +17,16 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
                                "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
                   example: "Police", required: true
 
-        parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra", example: "2024-12-22"
+        parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra",
+                  example: "2024-12-22", required: true
         parameter name: "date_fin", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
-                  example: "2024-12-28"
+                  example: "2024-12-28", required: true
 
         schema type: :object,
                properties: {
-                 creneaux: { type: :array },
+                 creneaux: { type: :array, items: {
+                   type: :object, properties: { starts_at: { type: :string }, duration_in_min: { type: :integer } },
+                 }, },
                },
                required: ["creneaux"]
 

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -42,6 +42,7 @@
             "in": "query",
             "description": "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra",
             "example": "2024-12-22",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -51,6 +52,7 @@
             "in": "query",
             "description": "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
             "example": "2024-12-28",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -86,7 +88,18 @@
                   "type": "object",
                   "properties": {
                     "creneaux": {
-                      "type": "array"
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "starts_at": {
+                            "type": "string"
+                          },
+                          "duration_in_min": {
+                            "type": "integer"
+                          }
+                        }
+                      }
                     }
                   },
                   "required": [
@@ -150,14 +163,14 @@
                   "example": {
                     "value": {
                       "id": 123,
-                      "created_at": "2024-08-14 10:36:20 +0200",
+                      "created_at": "2024-08-14 11:01:05 +0200",
                       "duration_in_min": 45,
-                      "ends_at": "2024-08-14 11:21:20 +0200",
+                      "ends_at": "2024-08-14 11:46:05 +0200",
                       "guichet": {
                         "id": 789,
                         "name": "GUICHET 3"
                       },
-                      "starts_at": "2024-08-14 10:36:20 +0200",
+                      "starts_at": "2024-08-14 11:01:05 +0200",
                       "status": "unknown",
                       "user_id": 456
                     }
@@ -300,7 +313,7 @@
                   "example": {
                     "value": {
                       "id": 123,
-                      "created_at": "2024-08-14 10:36:21 +0200",
+                      "created_at": "2024-08-14 11:01:06 +0200",
                       "duration_in_min": 45,
                       "ends_at": null,
                       "guichet": {


### PR DESCRIPTION
En vérifiant le swagger sur la démo, j'ai vu qu'il y a un validateur qui n'est pas disponible en local et qui indiquait que certaines descriptions de champs manquaient : https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fdemo.rdv-solidarites.fr%2Fapi-docs%2Fvisioplainte%2Fapi.json
Il y a aussi certains paramètres qui sont requis mais qui n'étaient pas validés comme tels.