### PR TITLE
Verrouillage des noms de territoires spéciaux

### DIFF
--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -46,8 +46,8 @@ class Territory < ApplicationRecord
   validates :departement_number, length: { maximum: 3 }, if: -> { departement_number.present? }
   validates :name, presence: true, if: -> { persisted? }
   validate do
-    if name_changed? && name_was == MAIRIES_NAME
-      errors.add(:name, "Le nom de ce territoire permet de le brancher au moteur de recherche de l'ANTS et ne peut pas être changé")
+    if name_changed? && name_was.in?(SPECIAL_NAMES)
+      errors.add(:name, "Le nom de ce territoire lui donne des propriétés particulières et ne peut donc pas être changé")
     end
   end
   validate do

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -3,7 +3,8 @@ class Territory < ApplicationRecord
 
   SPECIAL_NAMES = [
     MAIRIES_NAME = "Mairies".freeze,
-  ]
+    CNFS_NAME = "Conseillers Numériques".freeze,
+  ].freeze
   CN_DEPARTEMENT_NUMBER = "CN".freeze
 
   # Mixins
@@ -98,7 +99,7 @@ class Territory < ApplicationRecord
   end
 
   def cn?
-    departement_number == CN_DEPARTEMENT_NUMBER
+    name == CNFS_NAME
   end
 
   def sectorized?

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -1,7 +1,9 @@
 class Territory < ApplicationRecord
   has_paper_trail
 
-  MAIRIES_NAME = "Mairies".freeze
+  SPECIAL_NAMES = [
+    MAIRIES_NAME = "Mairies".freeze,
+  ]
   CN_DEPARTEMENT_NUMBER = "CN".freeze
 
   # Mixins
@@ -45,6 +47,11 @@ class Territory < ApplicationRecord
   validate do
     if name_changed? && name_was == MAIRIES_NAME
       errors.add(:name, "Le nom de ce territoire permet de le brancher au moteur de recherche de l'ANTS et ne peut pas être changé")
+    end
+  end
+  validate do
+    if name_changed? && name.in?(SPECIAL_NAMES)
+      errors.add(:name, "Ce nom ne peut pas être utilisé")
     end
   end
 

--- a/db/seeds/cnfs.rb
+++ b/db/seeds/cnfs.rb
@@ -1,9 +1,10 @@
 territory_cnfs = Territory.create!(
   departement_number: Territory::CN_DEPARTEMENT_NUMBER,
-  name: "Conseillers Numériques",
   sms_provider: "netsize",
   sms_configuration: "login:pwd"
 )
+# Les contraintes de validations sur les noms spéciaux obligent à faire un update_columns ici
+territory_cnfs.update_columns(name: Territory::CNFS_NAME) # rubocop:disable Rails/SkipsModelValidations
 
 service_cnfs = Service.create!(name: Service::CONSEILLER_NUMERIQUE, short_name: Service::CONSEILLER_NUMERIQUE)
 territory_cnfs.services << service_cnfs

--- a/spec/factories/territory.rb
+++ b/spec/factories/territory.rb
@@ -10,6 +10,9 @@ FactoryBot.define do
   end
 
   trait :mairies do
-    name { Territory::MAIRIES_NAME }
+    after(:create) do |territory, _|
+      # Les contraintes de validations sur les noms spéciaux obligent à faire un update_columns ici
+      territory.update_columns(name: Territory::MAIRIES_NAME) # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 end

--- a/spec/factories/territory.rb
+++ b/spec/factories/territory.rb
@@ -15,4 +15,11 @@ FactoryBot.define do
       territory.update_columns(name: Territory::MAIRIES_NAME) # rubocop:disable Rails/SkipsModelValidations
     end
   end
+
+  trait :conseillers_numeriques do
+    after(:create) do |territory, _|
+      # Les contraintes de validations sur les noms spéciaux obligent à faire un update_columns ici
+      territory.update_columns(name: Territory::CNFS_NAME) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
 end

--- a/spec/factories/territory.rb
+++ b/spec/factories/territory.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
   end
 
   trait :conseillers_numeriques do
+    departement_number { Territory::CN_DEPARTEMENT_NUMBER }
     after(:create) do |territory, _|
       # Les contraintes de validations sur les noms spéciaux obligent à faire un update_columns ici
       territory.update_columns(name: Territory::CNFS_NAME) # rubocop:disable Rails/SkipsModelValidations

--- a/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
+++ b/spec/features/territory_admins/territory_admin_can_manage_services_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "territory admin can manage agents", type: :feature do
   # Le territoire doit avoir au moins un agent admin de territoire restant
-  let!(:territory) { create(:territory, name: Territory::MAIRIES_NAME).tap { |t| t.roles.create!(agent: create(:agent)) } }
+  let!(:territory) { create(:territory, :mairies).tap { |t| t.roles.create!(agent: create(:agent)) } }
   let!(:agent) { create(:agent, role_in_territories: [territory]) }
   let!(:service_a) { create(:service) }
   let!(:service_b) { create(:service) }

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -73,12 +73,23 @@ RSpec.describe Territory, type: :model do
     end
   end
 
-  describe "Mairies" do
-    let(:mairies_territory) { create(:territory, :mairies) }
+  describe "special names" do
+    let(:mairies_territory) do
+      create(:territory).tap do |t|
+        t.update_columns(name: Territory::MAIRIES_NAME)
+      end
+    end
 
-    it "doesn't allow changing the name of a territory with a specific meaning" do
+    it "doesn't allow changing the name of a territory with a special meaning" do
       expect(mairies_territory.update(name: "new name")).to be_falsey
       expect(mairies_territory.reload.name).to eq Territory::MAIRIES_NAME
+    end
+
+    it "doesn't allow changing to the name of a territory with a special meaning" do
+      normal_territory = create(:territory, name: "Ardennes")
+
+      expect(normal_territory.update(name: Territory::MAIRIES_NAME)).to be_falsey
+      expect(normal_territory.reload.name).to eq "Ardennes"
     end
   end
 end

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -75,9 +75,7 @@ RSpec.describe Territory, type: :model do
 
   describe "special names" do
     let(:mairies_territory) do
-      create(:territory).tap do |t|
-        t.update_columns(name: Territory::MAIRIES_NAME)
-      end
+      create(:territory, :mairies)
     end
 
     it "doesn't allow changing the name of a territory with a special meaning" do

--- a/spec/requests/agents/users_controller_search_spec.rb
+++ b/spec/requests/agents/users_controller_search_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Agents::UsersController, "#search" do
     end
 
     context "when in CN territory" do
-      let(:territory) { create(:territory, departement_number: Territory::CN_DEPARTEMENT_NUMBER) }
+      let(:territory) { create(:territory, :conseillers_numeriques) }
 
       it "does not include users from other orgs in the territory" do
         sign_in agent

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe AddConseillerNumerique do
-  let!(:territory) { create(:territory, name: "Conseillers Numériques") }
+  let!(:territory) { create(:territory, :conseillers_numeriques) }
   let(:params) do
     {
       external_id: "exemple@conseiller-numerique.fr",


### PR DESCRIPTION
Le but de cette PR est d'éviter qu'un admin de territoire change le nom de son territoire en un nom qui donne un comportement spécial au territoire.
On utilise une validation AR, car une contrainte d'unicité ça ne suffirait pas exactement : sur l'instance historique on n'a pas de territoire mairies, mais on ne veut pas pour autant qu'un autre territoire prenne ce nom.

Ça sera utile pour Visioplainte.