### PR TITLE
Correctif de la date de prochain créneau quand une semaine n'a pas de créneau.

### DIFF
--- a/app/services/users/creneaux_search.rb
+++ b/app/services/users/creneaux_search.rb
@@ -22,13 +22,12 @@ class Users::CreneauxSearch
   def next_availability
     return available_collective_rdvs.first if motif.collectif?
 
-    NextAvailabilityService.find(motif, @lieu, attributed_agents, from: start_booking_delay, to: end_booking_delay)
+    NextAvailabilityService.find(motif, @lieu, attributed_agents, from: reduced_date_range.first, to: @motif.end_booking_delay)
   end
 
   def creneaux
     return available_collective_rdvs if motif.collectif?
 
-    reduced_date_range = Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délay
     return [] if reduced_date_range.blank?
 
     SlotBuilder.available_slots(motif, @lieu, reduced_date_range, attributed_agents)
@@ -47,7 +46,9 @@ class Users::CreneauxSearch
 
   attr_reader :motif, :date_range
 
-  delegate :start_booking_delay, :end_booking_delay, to: :motif
+  def reduced_date_range
+    @reduced_date_range ||= Lapin::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délai min du motif
+  end
 
   def attributed_agents
     @attributed_agents ||= retrieve_attributed_agents

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -44,6 +44,27 @@ RSpec.describe "User can select a creneau" do
     end
   end
 
+  context "when there is a full week without any creneaux" do
+    let!(:motif) { create(:motif, name: "RSA Orientation", organisation: organisation, restriction_for_rdv: nil, service: service) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2021, 12, 13), motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:absence) do
+      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 12, 20), end_day: Date.new(2021, 12, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(18))
+    end
+
+    it "displays the correct date for the next availability" do
+      visit prendre_rdv_path(departement: 92)
+      click_on motif.name
+      expect(page).to have_content("Prochaine disponibilité")
+      expect(page).to have_content("mardi 14 décembre 2021 à 08h00")
+      click_on("Prochaine disponibilité")
+
+      click_on("sem. prochaine")
+
+      expect(page).to have_content("Prochaine disponibilité")
+      expect(page).to have_content("mardi 28 décembre 2021 à 08h00")
+    end
+  end
+
   context "when two agents are available for the given motif" do
     let!(:motif) { create(:motif, name: "RSA Orientation", organisation: organisation) }
     let!(:plage_ouverture1) { create(:plage_ouverture, first_day: Time.zone.tomorrow, motifs: [motif], lieu: lieu, organisation: organisation) }

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -10,7 +10,7 @@ Capybara.register_driver :selenium do |app|
   binary = chrome_bin if chrome_bin
   browser_options = Selenium::WebDriver::Chrome::Options.new(
     # these args seem to reduce test flakyness
-    args: %w[headless no-sandbox disable-gpu disable-dev-shm-usage window-size=1500,1000],
+    args: %w[headless no-sandbox disable-gpu disable-dev-shm-usage window-size=1500,1000 disable-search-engine-choice-screen],
     "goog:loggingPrefs": { browser: "ALL" },
     binary: binary
   )


### PR DESCRIPTION
# Contexte

En préparant l'endpoint de prochain créneaux pour l'api visioplainte, je suis tombé sur ce bug :
Dans la situation suivante :
- je suis un usager qui cherche des créneaux pour de la réservation en ligne
- il y a des créneaux cette semaine (la semaine du 26 aout)
- il n'y a aucun créneau la semaine suivante (la semaine du 2 septembre)
- il y a des créneaux la semaine d'après (la semaine du 9 septembre)

Quand je navigue dans l'interface pour voir la liste des créneaux de la semaine du 2 septembre, on m'affiche que la prochaine disponibilité est le 26 aout, alors qu'on devrait me dire qu'elle est le 9 septembre

# Solution

Le `Users::CreneauxSearch` ne prenait pas en compte le `date_range` passé à l'initialisation.
J'ai extrait l'appel à `Lapin::Range.reduce_range_to_delay` pour qu'il prenne ça en compte.

Je me demandais si ce bug était apparu dans le refacto récent de https://github.com/betagouv/rdv-service-public/pull/4559, mais il y était déjà.

Au passage j'ajoute un paramètre à Chromedriver qui semble être nécessaire depuis la version 127 de Chrome.
