### PR TITLE
Refactor sur la recherche de créneaux côté agent

### DIFF
--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -24,7 +24,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       skip_policy_scope # TODO: improve pundit checks for creneaux
       redirect_to admin_organisation_slots_path(current_organisation, creneaux_search_params)
     else
-      @prochaines_dispos = []
+      @next_availabilities = []
       prepare_form
     end
   end
@@ -63,7 +63,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   end
 
   def only_one_lieu?
-    requires_lieu? && @prochaines_dispos&.count == 1
+    requires_lieu? && @next_availabilities&.count == 1
   end
 
   def requires_lieu?
@@ -83,7 +83,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   def set_search_results
     if @form.valid?
       # Un RDV collectif peut-il avoir lieu à domicile ou au téléphone ?
-      @prochaines_dispos = if @form.motif.individuel?
+      @next_availabilities = if @form.motif.individuel?
                              SearchCreneauxForAgentsService.new(@form).next_availabilities
                            else
                              SearchRdvCollectifForAgentsService.new(@form).next_availabilities
@@ -94,7 +94,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   def creneaux_search_params
     creneaux_search_params = helpers.creneaux_search_params(@form)
     if only_one_lieu?
-      creneaux_search_params.merge(lieu_ids: [@prochaines_dispos.first.lieu.id])
+      creneaux_search_params.merge(lieu_ids: [@next_availabilities.first.lieu.id])
     else
       creneaux_search_params
     end

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -24,7 +24,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
       skip_policy_scope # TODO: improve pundit checks for creneaux
       redirect_to admin_organisation_slots_path(current_organisation, creneaux_search_params)
     else
-      @search_results = []
+      @prochaines_dispos = []
       prepare_form
     end
   end
@@ -63,7 +63,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   end
 
   def only_one_lieu?
-    requires_lieu? && @search_results&.count == 1
+    requires_lieu? && @prochaines_dispos&.count == 1
   end
 
   def requires_lieu?
@@ -83,18 +83,18 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
   def set_search_results
     if @form.valid?
       # Un RDV collectif peut-il avoir lieu à domicile ou au téléphone ?
-      @search_results = if @form.motif.individuel?
-                          SearchCreneauxForAgentsService.new(@form).next_availabilities
-                        else
-                          SearchRdvCollectifForAgentsService.new(@form).next_availabilities
-                        end
+      @prochaines_dispos = if @form.motif.individuel?
+                             SearchCreneauxForAgentsService.new(@form).next_availabilities
+                           else
+                             SearchRdvCollectifForAgentsService.new(@form).next_availabilities
+                           end
     end
   end
 
   def creneaux_search_params
     creneaux_search_params = helpers.creneaux_search_params(@form)
     if only_one_lieu?
-      creneaux_search_params.merge(lieu_ids: [@search_results.first.lieu.id])
+      creneaux_search_params.merge(lieu_ids: [@prochaines_dispos.first.lieu.id])
     else
       creneaux_search_params
     end

--- a/app/controllers/admin/creneaux/agent_searches_controller.rb
+++ b/app/controllers/admin/creneaux/agent_searches_controller.rb
@@ -35,7 +35,7 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     # motif public_office pour vérifier qu'il n'y
     # qu'un lieu
     set_search_results
-    if results_without_lieu? || only_one_lieu?
+    if only_one_lieu?
       skip_policy_scope # TODO: improve pundit checks for creneaux
       redirect_to admin_organisation_slots_path(current_organisation, creneaux_search_params)
     else
@@ -70,12 +70,6 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     @form.motif&.requires_lieu?
   end
 
-  def results_without_lieu?
-    return false if requires_lieu?
-
-    search_creneaux_service.present?
-  end
-
   def set_form
     @form = helpers.build_agent_creneaux_search_form(current_organisation, params)
   end
@@ -84,10 +78,10 @@ class Admin::Creneaux::AgentSearchesController < AgentAuthController
     if @form.valid?
       # Un RDV collectif peut-il avoir lieu à domicile ou au téléphone ?
       @next_availabilities = if @form.motif.individuel?
-                             SearchCreneauxForAgentsService.new(@form).next_availabilities
-                           else
-                             SearchRdvCollectifForAgentsService.new(@form).next_availabilities
-                           end
+                               SearchCreneauxForAgentsService.new(@form).next_availabilities
+                             else
+                               SearchRdvCollectifForAgentsService.new(@form).next_availabilities
+                             end
     end
   end
 

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -3,7 +3,7 @@ class SearchCreneauxForAgentsService
     @form = agent_creneaux_search_form
   end
 
-  def next_availability_by_lieu
+  def next_availabilities
     lieux.map do |lieu|
       availability = next_availability(lieu)
       if availability

--- a/app/services/search_creneaux_for_agents_service.rb
+++ b/app/services/search_creneaux_for_agents_service.rb
@@ -5,10 +5,7 @@ class SearchCreneauxForAgentsService
 
   def next_availabilities
     lieux.map do |lieu|
-      availability = next_availability(lieu)
-      if availability
-        OpenStruct.new(lieu: lieu, next_availability: availability)
-      end
+      next_availability(lieu)
     end.compact
   end
 

--- a/app/services/search_rdv_collectif_for_agents_service.rb
+++ b/app/services/search_rdv_collectif_for_agents_service.rb
@@ -5,10 +5,8 @@ class SearchRdvCollectifForAgentsService
 
   def next_availabilities
     lieux.map do |lieu|
-      OpenStruct.new(lieu: lieu, next_availability: rdvs.where(lieu: lieu).first)
-    end.sort_by do |result|
-      result.next_availability.starts_at
-    end
+      rdvs.where(lieu: lieu).first
+    end.sort_by(&:starts_at)
   end
 
   def slot_search

--- a/app/services/search_rdv_collectif_for_agents_service.rb
+++ b/app/services/search_rdv_collectif_for_agents_service.rb
@@ -3,7 +3,7 @@ class SearchRdvCollectifForAgentsService
     @form = agent_creneaux_search_form
   end
 
-  def lieu_search
+  def next_availabilities
     lieux.map do |lieu|
       OpenStruct.new(lieu: lieu, next_availability: rdvs.where(lieu: lieu).first)
     end.sort_by do |result|

--- a/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
@@ -2,16 +2,16 @@
   .card-body
     .row
       .col-md
-        h4.card-title.mb-3.mt-0.text-success.font-weight-bold= prochaine_dispo.lieu.name
+        h4.card-title.mb-3.mt-0.text-success.font-weight-bold= next_availability.lieu.name
         h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
-        h6.card-subtitle.text-black-50= prochaine_dispo.lieu.address
+        h6.card-subtitle.text-black-50= next_availability.lieu.address
       .col-md.align-self-center.pt-3.pt-md-0.position-static
-        = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [prochaine_dispo.lieu.id])),
+        = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [next_availability.lieu.id])),
                 class: "d-block stretched-link" do
           .row
             .col
               | Prochaine disponibilité le
               br
-              strong= l(prochaine_dispo.starts_at, format: :human)
+              strong= l(next_availability.starts_at, format: :human)
             .col-auto.align-self-center
               i.fa.fa-chevron-right

--- a/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
+++ b/app/views/admin/creneaux/agent_searches/_lieu_search_results.html.slim
@@ -2,16 +2,16 @@
   .card-body
     .row
       .col-md
-        h4.card-title.mb-3.mt-0.text-success.font-weight-bold= search_result.lieu.name
+        h4.card-title.mb-3.mt-0.text-success.font-weight-bold= prochaine_dispo.lieu.name
         h5.card-subtitle.text-black-50.mb-2 = @form.motif.service.name
-        h6.card-subtitle.text-black-50= search_result.lieu.address
+        h6.card-subtitle.text-black-50= prochaine_dispo.lieu.address
       .col-md.align-self-center.pt-3.pt-md-0.position-static
-        = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [search_result.lieu.id])),
+        = link_to admin_organisation_slots_path(current_organisation,creneaux_search_params(@form).merge(lieu_ids: [prochaine_dispo.lieu.id])),
                 class: "d-block stretched-link" do
           .row
             .col
               | Prochaine disponibilité le
               br
-              strong= l(search_result.next_availability.starts_at, format: :human)
+              strong= l(prochaine_dispo.starts_at, format: :human)
             .col-auto.align-self-center
               i.fa.fa-chevron-right

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -67,11 +67,11 @@
 
 #creneaux
   .rdv-text-align-center
-    - if @search_results&.any?
+    - if @prochaines_dispos&.any?
       .container
-        h3.font-weight-bold= t(".available_places_with_slots", count: @search_results.length)
-        - @search_results.each do |search_result|
-          = render "lieu_search_results", search_result: search_result
+        h3.font-weight-bold= t(".available_places_with_slots", count: @prochaines_dispos.length)
+        - @prochaines_dispos.each do |prochaine_dispo|
+          = render "lieu_search_results", prochaine_dispo: prochaine_dispo
         = render "admin/slots/prescription_cta"
     - elsif motif_selected? && params[:commit].present?
       = render partial: "admin/slots/no_slot_available"

--- a/app/views/admin/creneaux/agent_searches/index.html.slim
+++ b/app/views/admin/creneaux/agent_searches/index.html.slim
@@ -67,11 +67,11 @@
 
 #creneaux
   .rdv-text-align-center
-    - if @prochaines_dispos&.any?
+    - if @next_availabilities&.any?
       .container
-        h3.font-weight-bold= t(".available_places_with_slots", count: @prochaines_dispos.length)
-        - @prochaines_dispos.each do |prochaine_dispo|
-          = render "lieu_search_results", prochaine_dispo: prochaine_dispo
+        h3.font-weight-bold= t(".available_places_with_slots", count: @next_availabilities.length)
+        - @next_availabilities.each do |next_availability|
+          = render "lieu_search_results", next_availability: next_availability
         = render "admin/slots/prescription_cta"
     - elsif motif_selected? && params[:commit].present?
       = render partial: "admin/slots/no_slot_available"


### PR DESCRIPTION
# Contexte

En reviewant https://github.com/betagouv/rdv-service-public/pull/4565 avec François, on a essayé de voir si on pouvait mieux faire émerger les concepts métier dans notre code de recherche de créneaux, et ça nous a amené à relire et refactorer ce code.
Dans la continuité de https://github.com/betagouv/rdv-service-public/pull/4560, on s'appuie sur la spec d'intégration, et on essaye de simplifier le code côté agents.

Le comportement de l'appli reste le même.
