### PR TITLE
Visioplainte : implémentation de l'endpoint de suppression du rdv

### DIFF
--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -36,7 +36,14 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   end
 
   def destroy
-    head :no_content
+    rdv = find_rdv
+
+    if rdv.blank?
+      render(json: { errors: ["Pas de rdv pour cet id"] }, status: :not_found)
+    else
+      rdv.destroy
+      head :no_content
+    end
   end
 
   def cancel
@@ -59,18 +66,5 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
 
   def motif
     @motif ||= Api::Visioplainte::CreneauxController.find_motif(params[:service])
-  end
-
-  def rdv(status)
-    # Des données de test pour documenter l'api.
-    Rdv.new(
-      id: 123,
-      users: [User.new(id: 456)],
-      agents: [Agent.new(id: 789, last_name: "Guichet 3")],
-      created_at: Time.zone.now,
-      starts_at: params[:starts_at],
-      duration_in_min: 45,
-      status: status
-    )
   end
 end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -41,7 +41,7 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
     if rdv.blank?
       render(json: { errors: ["Pas de rdv pour cet id"] }, status: :not_found)
     else
-      rdv.destroy
+      rdv.destroy!
       head :no_content
     end
   end

--- a/spec/requests/api/visioplainte/swagger_doc/rdv_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdv_spec.rb
@@ -52,9 +52,6 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
     end
   end
 
-  let(:id) { rdv.id }
-  let(:rdv) { create(:rdv) }
-
   path "/api/visioplainte/rdvs/{id}" do
     delete "Supprimer un rdv" do
       with_visioplainte_authentication
@@ -64,6 +61,19 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
       response 204, "Supprime le rdv" do
         run_test!
         parameter name: :id, in: :path, type: :string
+
+        let(:id) do
+          post "/api/visioplainte/rdvs", params: {
+            starts_at: "2024-08-19T08:00:00+02:00",
+            service: "Police",
+          }, headers: auth_header
+
+          response.parsed_body["id"]
+        end
+
+        let(:auth_header) do
+          { "X-VISIOPLAINTE-API-KEY" => "visioplainte-api-test-key-123456" }
+        end
       end
     end
   end
@@ -79,15 +89,13 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
         parameter name: :id, in: :path, type: :string
         schema rdv_response_schema
 
-        before do
+        let(:id) do
           post "/api/visioplainte/rdvs", params: {
             starts_at: "2024-08-19T08:00:00+02:00",
             service: "Police",
           }, headers: auth_header
 
-          rdv_id = Rdv.last.id
-
-          put "/api/visioplainte/rdvs/#{rdv_id}/cancel", headers: auth_header
+          response.parsed_body["id"]
         end
 
         let(:auth_header) do

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -386,17 +386,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 4,
+                      "id": 6,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 72,
+                        "id": 81,
                         "name": "GUICHET 1"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "unknown",
-                      "user_id": 5
+                      "user_id": 7
                     }
                   }
                 },
@@ -566,17 +566,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 7,
+                      "id": 8,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 85,
+                        "id": 93,
                         "name": "GUICHET 1"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "excused",
-                      "user_id": 8
+                      "user_id": 9
                     }
                   }
                 },


### PR DESCRIPTION
La dernière pour l'api côté usagers ! 

Il faut qu'on merge https://github.com/betagouv/rdv-service-public/pull/4572 d'abord.

Suite de https://github.com/betagouv/rdv-service-public/pull/4554/files

Dans le même style que https://github.com/betagouv/rdv-service-public/pull/4570 et https://github.com/betagouv/rdv-service-public/pull/4569