### PR TITLE
Correctif pour l'ajout de proches à un RDV ANTS

### DIFF
--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -135,17 +135,17 @@ class Users::RdvsController < UserAuthController
   def build_rdv_from_creneau(creneau)
     rdv = creneau.build_rdv
     rdv.assign_attributes(
-      users: [user_for_rdv],
+      users: users_for_rdv,
       created_by: current_user
     )
     rdv
   end
 
-  def user_for_rdv
+  def users_for_rdv
     if rdv_params[:user_ids]
-      current_user.available_users_for_rdv.find(rdv_params[:user_ids]).first
+      current_user.available_users_for_rdv.find(rdv_params[:user_ids])
     else
-      current_user
+      [current_user]
     end
   end
 

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -136,12 +136,17 @@ RSpec.describe "User can search rdv on rdv mairie" do
       fill_in("user_ants_pre_demande_number", with: "5544332211")
       click_button("Enregistrer")
       expect(page).to have_content("Alain MAIRIE")
-      expect(User.exists?(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211")).to be(true)
+      alain = User.find_by(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211")
+      expect(alain).to be_present
 
+      check(user.full_name)
+      check(alain.full_name)
       click_button("Continuer")
 
       click_link("Confirmer mon RDV")
       expect(page).to have_content("Votre rendez vous a été confirmé.")
+      created_rdv = Rdv.last
+      expect(created_rdv.users).to contain_exactly(user, alain)
     end
   end
 


### PR DESCRIPTION
Ticket Notion : https://www.notion.so/rdvs/Vigie-33a095eff8f24bdd8c23d54ac2cff659?p=c364d1658f4b4c3089941f5790d982fc&pm=s

# Contexte

Lors d'une prise de RDV par un usager, la sélection des proches est inopérante : seul le responsable est ajouté au RDV.

Il semblerait que ça ait toujours été le cas. :scream: 

# Solution

Corriger le vilain code. :wink: 