### PR TITLE
Permettre la réservation en ligne quand il y a un délai minimum d'une semaine 

### DIFF
--- a/app/services/users/creneaux_search.rb
+++ b/app/services/users/creneaux_search.rb
@@ -21,9 +21,10 @@ class Users::CreneauxSearch
 
   def next_availability
     return available_collective_rdvs.first if motif.collectif?
-    return nil if reduced_date_range.blank?
 
-    NextAvailabilityService.find(motif, @lieu, attributed_agents, from: reduced_date_range.first, to: @motif.end_booking_delay)
+    from = [date_range.begin, @motif.start_booking_delay].max
+
+    NextAvailabilityService.find(motif, @lieu, attributed_agents, from: from, to: @motif.end_booking_delay)
   end
 
   def creneaux


### PR DESCRIPTION
Repéré par @aminedhobb :

> Il semblerait qu'[un changement récent](https://github.com/betagouv/rdv-service-public/pull/4565) sur le calculateur de créneau crée un problème important côté prise de rdv usager qui nous a été remonté par nos utilisateurs: 
Si le délai minimum de réservation est supérieur à une semaine, il lui est indiqué qu'aucun créneau n'est disponible. 

> Je pense que ça vient du fait que l'on cherche les créneaux par défaut sur la semaine en cours (voir [ici](https://github.com/betagouv/rdv-service-public/blob/214d0ac74bf583311008480c3554b567c84147e9/app/services/search_context.rb#L44)), mais que du coup si le délai minimum de réservation est supérieur à une semaine, on ne renvoie pas de prochaine disponibilité (voir [ici](https://github.com/betagouv/rdv-service-public/blob/214d0ac74bf583311008480c3554b567c84147e9/app/services/users/creneaux_search.rb#L24)).