### PR TITLE
Correctif pour le déclenchement des validations back end des numéros de pré-demande ANTS

### DIFF
--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -56,7 +56,7 @@ class PrescripteurRdvWizardController < ApplicationController
   def create_rdv
     beneficiaire_params = params.require(:beneficiaire_form).permit(*BeneficiaireForm::ATTRIBUTES)
 
-    @beneficiaire = BeneficiaireForm.new(beneficiaire_params.merge(motif_id: session[:rdv_wizard_attributes][:motif_id]))
+    @beneficiaire = BeneficiaireForm.new(beneficiaire_params.merge(motif_id: session[:rdv_wizard_attributes]["motif_id"]))
 
     if @beneficiaire.valid?
       session[:rdv_wizard_attributes][:user] = beneficiaire_params

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -56,7 +56,7 @@ class PrescripteurRdvWizardController < ApplicationController
   def create_rdv
     beneficiaire_params = params.require(:beneficiaire_form).permit(*BeneficiaireForm::ATTRIBUTES)
 
-    @beneficiaire = BeneficiaireForm.new(beneficiaire_params)
+    @beneficiaire = BeneficiaireForm.new(beneficiaire_params.merge(motif: session[:rdv_wizard_attributes][:motif_id]))
 
     if @beneficiaire.valid?
       session[:rdv_wizard_attributes][:user] = beneficiaire_params

--- a/app/controllers/prescripteur_rdv_wizard_controller.rb
+++ b/app/controllers/prescripteur_rdv_wizard_controller.rb
@@ -56,7 +56,7 @@ class PrescripteurRdvWizardController < ApplicationController
   def create_rdv
     beneficiaire_params = params.require(:beneficiaire_form).permit(*BeneficiaireForm::ATTRIBUTES)
 
-    @beneficiaire = BeneficiaireForm.new(beneficiaire_params.merge(motif: session[:rdv_wizard_attributes][:motif_id]))
+    @beneficiaire = BeneficiaireForm.new(beneficiaire_params.merge(motif_id: session[:rdv_wizard_attributes][:motif_id]))
 
     if @beneficiaire.valid?
       session[:rdv_wizard_attributes][:user] = beneficiaire_params

--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -8,13 +8,13 @@ class Admin::UserForm
   delegate :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :user
   validate :warn_duplicates
   validate do
-    return if ants_pre_demande_number.blank?
-
-    ValidateAntsPreDemandeNumber.perform(
-      user: @user,
-      ants_pre_demande_number: @user.ants_pre_demande_number,
-      ignore_benign_errors: ignore_benign_errors
-    )
+    if @user.ants_pre_demande_number.present?
+      ValidateAntsPreDemandeNumber.perform(
+        user: @user,
+        ants_pre_demande_number: @user.ants_pre_demande_number,
+        ignore_benign_errors: ignore_benign_errors
+      )
+    end
   end
 
   delegate :errors, to: :user

--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -10,7 +10,7 @@ class Admin::UserForm
   validate do
     return if ants_pre_demande_number.blank?
 
-    User::Ants.validate_ants_pre_demande_number(
+    ValidateAntsPreDemandeNumber.perform(
       user: @user,
       ants_pre_demande_number: @user.ants_pre_demande_number,
       ignore_benign_errors: ignore_benign_errors

--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -8,6 +8,8 @@ class Admin::UserForm
   delegate :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :user
   validate :warn_duplicates
   validate do
+    return if ants_pre_demande_number.blank?
+
     User::Ants.validate_ants_pre_demande_number(
       user: @user,
       ants_pre_demande_number: @user.ants_pre_demande_number,

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -18,7 +18,7 @@ class BeneficiaireForm
   validate do
     return if ants_pre_demande_number.blank?
 
-    User::Ants.validate_ants_pre_demande_number(
+    ValidateAntsPreDemandeNumber.perform(
       user: self,
       ants_pre_demande_number: ants_pre_demande_number,
       ignore_benign_errors: ignore_benign_errors

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -10,13 +10,13 @@ class BeneficiaireForm
     ants_pre_demande_number
   ].freeze
 
-  attr_accessor(*ATTRIBUTES)
+  attr_accessor(*ATTRIBUTES, :motif_id)
 
   validates_presence_of :first_name, :last_name
   validate :warn_no_contact_information
   validate :validate_phone_number
   validate do
-    if ants_pre_demande_number.present?
+    if Motif.find_by(id: motif_id)&.requires_ants_predemande_number?
       ValidateAntsPreDemandeNumber.perform(
         user: self,
         ants_pre_demande_number: ants_pre_demande_number,

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -16,6 +16,8 @@ class BeneficiaireForm
   validate :warn_no_contact_information
   validate :validate_phone_number
   validate do
+    return if ants_pre_demande_number.blank?
+
     User::Ants.validate_ants_pre_demande_number(
       user: self,
       ants_pre_demande_number: ants_pre_demande_number,

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -16,13 +16,13 @@ class BeneficiaireForm
   validate :warn_no_contact_information
   validate :validate_phone_number
   validate do
-    return if ants_pre_demande_number.blank?
-
-    ValidateAntsPreDemandeNumber.perform(
-      user: self,
-      ants_pre_demande_number: ants_pre_demande_number,
-      ignore_benign_errors: ignore_benign_errors
-    )
+    if ants_pre_demande_number.present?
+      ValidateAntsPreDemandeNumber.perform(
+        user: self,
+        ants_pre_demande_number: ants_pre_demande_number,
+        ignore_benign_errors: ignore_benign_errors
+      )
+    end
   end
 
   def warn_no_contact_information

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -89,7 +89,7 @@ module UserRdvWizard
     validate do
       return unless rdv.requires_ants_predemande_number?
 
-      User::Ants.validate_ants_pre_demande_number(
+      ValidateAntsPreDemandeNumber.perform(
         user: @user,
         ants_pre_demande_number: @user_attributes[:ants_pre_demande_number],
         ignore_benign_errors: @user_attributes[:ignore_benign_errors]

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -87,6 +87,8 @@ module UserRdvWizard
   class Step1 < Base
     validate :phone_number_present_for_motif_by_phone
     validate do
+      return unless rdv.requires_ants_predemande_number?
+
       User::Ants.validate_ants_pre_demande_number(
         user: @user,
         ants_pre_demande_number: @user_attributes[:ants_pre_demande_number],

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -87,14 +87,14 @@ module UserRdvWizard
   class Step1 < Base
     validate :phone_number_present_for_motif_by_phone
     validate do
-      return unless rdv.requires_ants_predemande_number?
-
-      ValidateAntsPreDemandeNumber.perform(
-        user: @user,
-        ants_pre_demande_number: @user_attributes[:ants_pre_demande_number],
-        ignore_benign_errors: @user_attributes[:ignore_benign_errors]
-      )
-      errors.merge!(@user)
+      if rdv.requires_ants_predemande_number?
+        ValidateAntsPreDemandeNumber.perform(
+          user: @user,
+          ants_pre_demande_number: @user_attributes[:ants_pre_demande_number],
+          ignore_benign_errors: @user_attributes[:ignore_benign_errors]
+        )
+        errors.merge!(@user)
+      end
     end
 
     def phone_number_present_for_motif_by_phone

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -86,7 +86,16 @@ module Ants
     end
 
     def users
-      @users ||= User.where(id: @rdv_attributes[:users_ids]).select(&:syncable_with_ants?)
+      @users ||= User.where(id: @rdv_attributes[:users_ids]).select do |user|
+        syncable_with_ants?(user)
+      end
+    end
+
+    def syncable_with_ants?(user)
+      return false if user.ants_pre_demande_number.blank?
+
+      status = AntsApi.status(application_id: user.ants_pre_demande_number, timeout: 4)["status"]
+      status == "validated"
     end
   end
 end

--- a/app/models/concerns/user/ants.rb
+++ b/app/models/concerns/user/ants.rb
@@ -2,7 +2,7 @@ module User::Ants
   extend ActionView::Helpers::TranslationHelper # allows getting a SafeBuffer instead of a String when using #translate (which a direct call to I18n.t doesn't do)
 
   def self.validate_ants_pre_demande_number(user:, ants_pre_demande_number:, ignore_benign_errors:)
-    return if ants_pre_demande_number.blank?
+    return unless ants_pre_demande_number.blank?
 
     ants_pre_demande_number = ants_pre_demande_number.upcase
 

--- a/app/models/concerns/user/ants.rb
+++ b/app/models/concerns/user/ants.rb
@@ -2,8 +2,6 @@ module User::Ants
   extend ActionView::Helpers::TranslationHelper # allows getting a SafeBuffer instead of a String when using #translate (which a direct call to I18n.t doesn't do)
 
   def self.validate_ants_pre_demande_number(user:, ants_pre_demande_number:, ignore_benign_errors:)
-    return unless ants_pre_demande_number.blank?
-
     ants_pre_demande_number = ants_pre_demande_number.upcase
 
     unless ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,6 @@ class User < ApplicationRecord
   include WebhookDeliverable
   include TextSearch
   include StrongPasswordConcern
-  include User::Ants
 
   def self.search_options
     {

--- a/app/services/validate_ants_pre_demande_number.rb
+++ b/app/services/validate_ants_pre_demande_number.rb
@@ -1,7 +1,7 @@
-module User::Ants
+module ValidateAntsPreDemandeNumber
   extend ActionView::Helpers::TranslationHelper # allows getting a SafeBuffer instead of a String when using #translate (which a direct call to I18n.t doesn't do)
 
-  def self.validate_ants_pre_demande_number(user:, ants_pre_demande_number:, ignore_benign_errors:)
+  def self.perform(user:, ants_pre_demande_number:, ignore_benign_errors:)
     ants_pre_demande_number = ants_pre_demande_number.upcase
 
     unless ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)
@@ -37,14 +37,4 @@ module User::Ants
       meeting_point: appointment.meeting_point
     )
   end
-
-  # rubocop:disable Style/ReturnNilInPredicateMethodDefinition
-  def syncable_with_ants?
-    return if ants_pre_demande_number.blank?
-
-    status = AntsApi.status(application_id: ants_pre_demande_number, timeout: 4)["status"]
-    status == "validated"
-  end
-
-  # rubocop:enable Style/ReturnNilInPredicateMethodDefinition
 end

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
     end
 
     context "when trying to bypass the front-end validation" do
-      it "considers it as uppercase when calling ANTS API and saving it in user" do
+      it "performs back-end validation and displays error" do
         time = Time.zone.now.change(hour: 9, min: 0)
         creneaux_url = creneaux_url(starts_at: time.strftime("%Y-%m-%d %H:%M"), lieu_id: lieu.id, motif_id: passport_motif.id, public_link_organisation_id: organisation.id, duration: 50)
         visit creneaux_url

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -187,6 +187,22 @@ RSpec.describe "User can search rdv on rdv mairie" do
       end
     end
 
+    context "when trying to bypass the front-end validation" do
+      it "considers it as uppercase when calling ANTS API and saving it in user" do
+        time = Time.zone.now.change(hour: 9, min: 0)
+        creneaux_url = creneaux_url(starts_at: time.strftime("%Y-%m-%d %H:%M"), lieu_id: lieu.id, motif_id: passport_motif.id, public_link_organisation_id: organisation.id, duration: 50)
+        visit creneaux_url
+
+        fill_in("user_email", with: user.email)
+        fill_in("password", with: user.password)
+        click_button("Se connecter")
+
+        fill_in("user_ants_pre_demande_number", with: "  ")
+        click_button("Continuer")
+        expect(page).to have_content("Numéro de pré-demande ANTS doit comporter 10 chiffres et lettres")
+      end
+    end
+
     context "ANTS responds with an unexpected error" do
       before do
         stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=5544332211").to_return(


### PR DESCRIPTION
# Description du problème 

Des usagers peuvent exploiter une faille pour prendre des rdvs pour des titres sécurisés sans numéros de pré-demande ANTS.
Le contournement se fait lors de la prise de rdv après le choix du créneau, sur cet écran :

<img width="1267" alt="Screenshot 2024-08-30 at 10 19 08" src="https://github.com/user-attachments/assets/836bc300-ea47-4a8d-ac2b-96d20af3c808">

Il y a plusieurs manières possibles de contourner la validation : 
- Mettre " " (juste un espace) comme numéro de prédemande ants
- Editer le html pour supprimer le champs


# Solution

On met une vrai validation back-end qui se base sur le changement du champs ou sur le type du motif.
