### PR TITLE
RuboCop: désactiver l’autosuggestion de cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - "scripts/screenshots/**/*"
   NewCops: enable
   TargetRubyVersion: 3.1.2
+  SuggestExtensions: false
 
 Bundler/OrderedGems:
   Exclude:


### PR DESCRIPTION
# Contexte

Lorsqu’on lance rubocop, en local ou en prod on a ce message de suggestion d’autres cops et gems : 

<img width="714" alt="image" src="https://github.com/user-attachments/assets/82cca91c-1391-4cae-bba0-d3a8b4c6bdfd">

Or on n’en fait rien depuis un moment et il est un peu distrayant.

# Solution

Désactiver la suggestion comme indiqué
