### PR TITLE
Rubocop: désactiver les cops de vérification de longueur

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,50 +42,23 @@ Lint/AssignmentInCondition:
 Metrics/AbcSize:
   Enabled: false
 
-Metrics/BlockLength:
-  Exclude:
-    - "Guardfile"
-    - "scripts/*"
-    - "spec/**/*"
-    - "config/initializers/*"
-    - "config/environments/*"
-    - "config/routes.rb"
-    - "config/routes/api.rb"
-
 Metrics/CyclomaticComplexity:
   Max: 8 # default is 7
 
-Metrics/ClassLength:
-  Max: 150
-  CountAsOne: ['array', 'hash', 'heredoc']
-  Exclude:
-    - 'app/models/rdv.rb'
-    - 'app/models/user.rb'
-    - 'app/models/agent.rb'
-    - 'app/models/motif.rb'
 
+# disable all Metrics Length cops. They don’t provide an explicit way to improve code.
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
 
 Metrics/ModuleLength:
-  Max: 150
-  CountAsOne: ['array', 'hash', 'heredoc']
+  Enabled: false
 
 Metrics/MethodLength:
-  CountAsOne: ['array', 'hash', 'heredoc']
-  Max: 20
-  Exclude:
-    - 'db/migrate/20210301135256_create_territories.rb'
-    - 'app/controllers/agents/users_controller.rb'
-    - 'app/controllers/inclusion_connect_controller.rb'
-    - 'app/controllers/lapin/sms_preview_controller.rb'
-    - 'app/controllers/super_admins/migrations_controller.rb'
-    - 'app/controllers/users/rdvs_controller.rb'
-    - 'app/helpers/configuration_helper.rb'
-    - 'app/jobs/webhook_job.rb'
-    - 'app/models/concerns/ical_helpers/ics.rb'
-    - 'app/services/sms_sender.rb'
-    - 'db/migrate/20231017125305_reunite_prod_schema.rb'
-    - 'spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb'
-    - 'spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb'
+  Enabled: false
 
 Rails/ApplicationController:
   Exclude:

--- a/db/migrate/20220629083453_add_not_null_to_various_foreign_key_columns.rb
+++ b/db/migrate/20220629083453_add_not_null_to_various_foreign_key_columns.rb
@@ -1,5 +1,4 @@
 class AddNotNullToVariousForeignKeyColumns < ActiveRecord::Migration[6.1]
-  # rubocop:disable Metrics/MethodLength
   def change
     change_column_null :absences, :agent_id, false
     change_column_null :absences, :organisation_id, false

--- a/db/migrate/20230413163145_add_foreign_keys.rb
+++ b/db/migrate/20230413163145_add_foreign_keys.rb
@@ -1,5 +1,4 @@
 class AddForeignKeys < ActiveRecord::Migration[7.0]
-  # rubocop:disable Metrics/MethodLength
   def change
     up_only do
       MotifsPlageOuverture.where.not(plage_ouverture_id: PlageOuverture.all.select(:id)).delete_all

--- a/db/migrate/20231219151419_add_comments_for_metabase.rb
+++ b/db/migrate/20231219151419_add_comments_for_metabase.rb
@@ -1,5 +1,5 @@
 class AddCommentsForMetabase < ActiveRecord::Migration[7.0]
-  def change # rubocop:disable Metrics/MethodLength
+  def change
     change_column_comment(
       :agents,
       :display_saturdays,

--- a/db/migrate/20240314101308_add_various_not_null_constraints.rb
+++ b/db/migrate/20240314101308_add_various_not_null_constraints.rb
@@ -1,5 +1,4 @@
 class AddVariousNotNullConstraints < ActiveRecord::Migration[7.0]
-  # rubocop:disable Metrics/MethodLength
   def change
     reversible do |direction|
       direction.up do


### PR DESCRIPTION
# Contexte

On a actuellement 4 cops de limites de longueurs :

- Metrics/BlockLength
- Metrics/ClassLength
- Metrics/ModuleLength
- Metrics/MethodLength

On a actuellement un nombre non-négligeable d’exceptions à ces règles, dans le fichier de config rubocop et en commentaires inline dans les fichiers ruby.

Aussi, ces règles sont assez discutables. Elles n’apportent pas de solution claire pour améliorer le code. Une méthode longue est parfois plus lisible et maintenable que son équivalent découpé en plusieurs petites méthodes « artificielles ». Une classe longue est parfois plus claire qu’une classe découpée en concerns, etc…

On peut aussi penser que notre process de review est largement suffisant et plus efficace pour nous aider à atteindre des tailles de blocks/classes/modules/méthodes dont nous sommes satifisaits.

D’autres projets ruby adoptent cette stratégie de désactiver ces règles, par exemple [mastodon](https://github.com/glitch-soc/mastodon/blob/main/.rubocop/metrics.yml).

# Solution

Cette PR désactive complètement ces 4 cops.