### PR TITLE
amélioration des alignements sur la page de connexion agent

### DIFF
--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,22 +1,27 @@
-.rdv-text-align-center.m-auto
-  h1.text-dark.mt-0.font-weight-bold.mb-4 Connexion à #{current_domain.name}
+h1.h2.text-dark.mt-0.font-weight-bold.mb-4 Connexion à #{current_domain.name}
+
+- if display_agent_connect_button? || display_inclusion_connect_button?
+  - if display_agent_connect_button?
+    = render "common/agent_connect_button"
+
+  - if display_agent_connect_button? && display_inclusion_connect_button?
+    .row.py-4
+      .col-2
+        hr
+      .col-auto.p-0.pt-1 OU
+      .col
+        hr
+
+  - if display_inclusion_connect_button?
+    = render "common/inclusionconnect_button", locals: {}
 
   - if display_agent_connect_button? || display_inclusion_connect_button?
-    .row
-      .col-12.d-flex.justify-content-center.pt-4.flex-direction-column.rdv-flex-direction-row-md
-        - if display_agent_connect_button?
-          = render "common/agent_connect_button"
-        - if display_inclusion_connect_button?
-          = render "common/inclusionconnect_button", locals: {}
-
-    .row.pt-2.pb-2
-      .col
+    .row.py-4
+      .col-2
         hr
-      .col-auto.p-0.pt-1
-        .text-uppercase ou
+      .col-auto.p-0.pt-1 OU
       .col
         hr
 
-.rdv-text-align-center.w-75.m-auto
-  p.text-muted.mb-2 Entrez votre email et votre mot de passe.
+p.text-muted.mb-2 Entrez votre email et votre mot de passe.
 = render "common/session_form", resource: resource, resource_name: resource_name

--- a/app/views/common/_agent_connect_button.html.slim
+++ b/app/views/common/_agent_connect_button.html.slim
@@ -1,6 +1,6 @@
 div.pr-4
   form[action="/agent_connect/auth" method="get"]
     button.agentconnect-button[aria-label="S'identifier avec Agent Connect"]
-  p
+  p.mb-0
     a[href="https://agentconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre"]
       |  Qu’est-ce que AgentConnect ?

--- a/app/views/common/_inclusionconnect_button.html.slim
+++ b/app/views/common/_inclusionconnect_button.html.slim
@@ -1,9 +1,8 @@
-.mb-3
-  - image_path = image_path("logo-inclusion-connect-bg.svg")
+- image_path = image_path("logo-inclusion-connect-bg.svg")
 
-  / Voir ici pourquoi on désactive Turbolinks : https://github.com/betagouv/rdv-service-public/pull/4070
-  a.btn-inclusion-connect href=inclusion_connect_auth_path(login_hint: locals[:login_hint]) data-turbolinks="false" style="background-image: url(#{image_path})"
-    = image_tag("logo-inclusion-connect-one-line.svg", alt: "Se connecter avec Inclusion Connect", height: 14)
+/ Voir ici pourquoi on désactive Turbolinks : https://github.com/betagouv/rdv-service-public/pull/4070
+a.btn-inclusion-connect href=inclusion_connect_auth_path(login_hint: locals[:login_hint]) data-turbolinks="false" style="background-image: url(#{image_path})"
+  = image_tag("logo-inclusion-connect-one-line.svg", alt: "Se connecter avec Inclusion Connect", height: 14)
 
-  p
-    = dsfr_link_to("Qu’est-ce que InclusionConnect ?", "https://connect.inclusion.beta.gouv.fr/", target: "_blank", rel: "noopener noreferrer", title: "Qu’est-ce que InclusionConnect ? - nouvelle fenêtre")
+p.mb-0
+  = dsfr_link_to("Qu’est-ce que InclusionConnect ?", "https://connect.inclusion.beta.gouv.fr/", target: "_blank", rel: "noopener noreferrer", title: "Qu’est-ce que InclusionConnect ? - nouvelle fenêtre")


### PR DESCRIPTION
## Contexte

Les alignements sont surprenants sur la page de connexion agents : 

![image](https://github.com/user-attachments/assets/ae5a477c-56f5-4f95-85d5-9c7800b55275)

## Solution

- J’aligne tout à gauche pour de vrai
- Je mets les différentes options de connexion à la ligne. S’il y a agents connect + inclusion connect ils s’affichent maintenant l’un au dessus de l’autre séparés par un OU
- Je réduis la taille d’affichage du titre qui est un peu démesuré sur desktop et cause un retour à la ligne sur un viewport raisonnable.

## Captures

Desktop agent connect + inclusion connect

avant|après
-|-
![image](https://github.com/user-attachments/assets/5f428fdc-f459-4cd0-9874-73af8386bc7f) | ![image](https://github.com/user-attachments/assets/3448d0b8-df3d-43a6-b39b-419da40c4533)


Desktop agent connect uniquement

avant|après
-|-
![image](https://github.com/user-attachments/assets/09d4f560-a807-493c-9241-d82d9540b949) | ![image](https://github.com/user-attachments/assets/fdcc7376-2e75-412d-88fb-e927fd76fdcd)
