### PR TITLE
Correction lancement webpacker en local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage/
 /public/assets/*
 /public/fonts/*
 /public/icons/*
+/public/favicon.ico
 
 # Postgres dumps
 **/20*.tar.gz

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lapin",
   "private": true,
   "scripts": {
-    "build": "cp -r node_modules/@gouvfr/dsfr/dist/fonts public; cp -r node_modules/@gouvfr/dsfr/dist/icons public; webpack --config webpack.config.js; cp app/assets/images/favicon/favicon.ico public/favicon.ico;"
+    "build": "cp -r node_modules/@gouvfr/dsfr/dist/fonts public; cp -r node_modules/@gouvfr/dsfr/dist/icons public; cp app/assets/images/favicon/favicon.ico public/favicon.ico; webpack --config webpack.config.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",


### PR DESCRIPTION
# Contexte

`make run` plante actuellement. 

Lors de mon [fix sur le favicon](https://github.com/betagouv/rdv-service-public/pull/4583) je n’avais pas réalisé que la dernière commande du script yarn `build` doit être webpacker.

# Solution

Je corrige simplement ici en déplaçant la commande de copie que j’avais introduite avant l’appel à webpack.

À mon avis on devrait probablement déplacer l’ensemble des `cp` vers un endroit plus approprié de l’asset pipeline.

J’en profite pour rajouter `public/favicon.ico` aux gitignore pour éviter les stagings intempestifs de ce fichier en local.