### PR TITLE
définition manquante de la classe CSS .rdv-text-align-center

### DIFF
--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -48,6 +48,10 @@ a[disabled] {
   text-align: right;
 }
 
+.rdv-text-align-center {
+  text-align: center;
+}
+
 .rdv-white-space-nowrap {
   white-space: nowrap;
 }


### PR DESCRIPTION
## Contexte

Il y a des alignements cassés dans la partie admin de l’appli depuis deux semaines. Exemple

![image](https://github.com/user-attachments/assets/9c018e33-eff4-493e-8f78-7c1261cbbc4a)

## Solution

Le problème vient de cette PR https://github.com/betagouv/rdv-service-public/pull/4541 dans laquelle j’ai par erreur : 

- changé des classes CSS dans la partie admin au lieu de me limiter à la partie usagers. j’ai probablement fait une erreur lors du scoping d’un find and replace 🤦 
- oublié de définir cette nouvelle classe CSS 🙄 

Petite 🎖️ à moi même donc, et merci à Victor de m’avoir alerté et pointé ce fix

## Captures

avant | après
-|-
![Vos indisponibilités - RDV Solidarités](https://github.com/user-attachments/assets/b4ad418d-68c8-4b54-9525-d83df487feee) | ![Vos indisponibilités - RDV Solidarités(1)](https://github.com/user-attachments/assets/579f4b23-d72c-4b23-8ba7-255de3895556)


