### PR TITLE
Bugfix: crash JS sur le formulaire de motif sur RDV Aide Numérique

### DIFF
--- a/app/javascript/controllers/motif_form_controller.js
+++ b/app/javascript/controllers/motif_form_controller.js
@@ -22,7 +22,9 @@ export default class extends Controller {
   refreshSections(event) {
     const resetCheckbox = !!event;
     this.refreshSection(this.bookingDelaySectionTarget, this.shouldDisableBookingDelay(), resetCheckbox)
-    this.refreshSection(this.sectoSectionTarget, this.shouldDisableSecto(), resetCheckbox)
+    if(this.hasSectoSectionTarget) {
+      this.refreshSection(this.sectoSectionTarget, this.shouldDisableSecto(), resetCheckbox)
+    }
     this.refreshSection(this.secretariatSectionTarget, this.shouldDisableSecretariat(), resetCheckbox)
   }
 


### PR DESCRIPTION
# Contexte

Remonté par @NesserineZarouri  : la section "RDV Secrétariat" n'apparaît plus sur le formulaire de motifs sur RDV Aide Numérique.

La console affiche cette erreur

```
Error: Missing target element "sectoSection" for "motif-form" controller
    at t.get (stimulus.js:2292:27)
    at t.refreshSections (motif_form_controller.js:25:30)
    at t.connect (motif_form_controller.js:14:10)
    at I.connect (stimulus.js:1498:29)
    [...]
```

# Solution

La raison du bug, c'est qu'on cherche à accéder à la target `sectoSection`, mais aucun élement n'est trouvé dans le DOM parce qu'on a ce if :

```slim
- unless current_domain.online_reservation_with_public_link
  .card.collapse [data-motif-form-target="sectoSection"]

```

Sur le domaine RDV Aide Numérique, on cache la section de secto parce que les conseillers numériques n'utilisent pas la secto, d'autant plus qu'ils sont tous sur le même territoire.

J'ai donc simplement modifié le JS pour qu'il vérifie que la section de secto est bien présente avant de tenter de la refresh.