### PR TITLE
ajout de doc sur les vars d’env scalingo pour les pages d’erreur

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -94,6 +94,7 @@ VISIOPLAINTE_API_KEY="visioplainte-api-test-key-123456"
 
 # Ces variables sont utiles uniquement sur les applis scalingo
 # cf https://doc.scalingo.com/platform/app/custom-error-page
+# githack.com permet d’exposer une page de notre repo github mais avec les bons headers Content-Type headers
 SCALINGO_APP_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html
 SCALINGO_NO_FRONT_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html
 SCALINGO_STOPPED_PAGE_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html

--- a/.env.sample
+++ b/.env.sample
@@ -91,3 +91,10 @@ AGENT_CONNECT_RDVAN_CLIENT_SECRET="voir https://vaultwarden.incubateur.net/#/vau
 # INCLUSIONCONNECT_DISABLED=true
 
 VISIOPLAINTE_API_KEY="visioplainte-api-test-key-123456"
+
+# Ces variables sont utiles uniquement sur les applis scalingo
+# cf https://doc.scalingo.com/platform/app/custom-error-page
+SCALINGO_APP_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html
+SCALINGO_NO_FRONT_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html
+SCALINGO_STOPPED_PAGE_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html
+SCALINGO_TIMEOUT_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-public/production/public/maintenance.html


### PR DESCRIPTION
On a défini des variables d’environnement sur Scalingo qu’on n’avait pas encore documenté, cette PR corrige ça

A priori pour l’instant la variable d’env ` SCALINGO_APP_ERROR_URL` ne fonctionne pas : /

>  if the application returns a 502 HTTP response, crashed or cut the connection unexpectedly. 

Pourtant on voit quand même dans pages d’erreurs Scalingo par défaut bleues en anglais.

J’écrirais à Scalingo pour leur poser la question demain ou plus tard après le rush d’aujourd’hui