### PR TITLE
Créer un receipts d'échec lors d'erreur Net::SMTPServerBusy avec SFR Mail2SMS

### DIFF
--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -128,6 +128,8 @@ class SmsSender < BaseService
     Admins::SfrMail2SmsMailer.send_sms(@api_key, @phone_number, @content).deliver_now
 
     save_receipt(result: :processed)
+  rescue Net::SMTPServerBusy => e
+    handle_failure(error_message: e.message)
   end
 
   # Clever Technologies


### PR DESCRIPTION
Nous avons actuellement des erreurs SMTP lors de l'envoi de sms via SFR Mail2SMS :
https://sentry.incubateur.net/organizations/betagouv/issues/118183/?project=74&referrer=webhooks_plugin

Ces erreurs lèvent une exception qui n'est pas rescued, et aucun receipt n'est créé. Les agents ne sont donc pas informés de l'échec de l'envoi du SMS.

J'ajoute ici un rescue et la création d'un receipt qui contient le message d'erreur SMTP.
