### PR TITLE
Améliorer les titres de la liste de création de motif

### DIFF
--- a/app/views/admin/motifs/edit.html.slim
+++ b/app/views/admin/motifs/edit.html.slim
@@ -8,7 +8,7 @@
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
-      = link_to "Vos motifs", admin_organisation_motifs_path(current_organisation)
+      = link_to "Motifs de l'organisation", admin_organisation_motifs_path(current_organisation)
     li.breadcrumb-item.active #{@motif.name_was}
 
 .row

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -1,7 +1,7 @@
 - content_for(:menu_item) { "menu-motifs" }
 
 - content_for :title do
-  | Vos motifs
+  | Motifs de l'organisation
 
 - if @motif_policy.create?
   - content_for :breadcrumb do

--- a/app/views/admin/motifs/new.html.slim
+++ b/app/views/admin/motifs/new.html.slim
@@ -1,13 +1,13 @@
 - content_for(:menu_item) { "menu-motifs" }
 
-- page_title = @motif.duplicated_from_motif ? %(Duplication du motif "#{@motif.duplicated_from_motif}") : "Création d’un nouveau motif"
+- page_title = @motif.duplicated_from_motif ? %(Duplication du motif "#{@motif.duplicated_from_motif}") : t("motifs.form.title.new")
 - content_for :title, page_title
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
-      = link_to "Vos motifs", admin_organisation_motifs_path(current_organisation)
-    li.breadcrumb-item.active Création d’un nouveau motif
+      = link_to t("motifs.index.title"), admin_organisation_motifs_path(current_organisation)
+    li.breadcrumb-item.active = page_title
 
 .row
   .col-md-12

--- a/app/views/admin/territories/motifs/new.html.slim
+++ b/app/views/admin/territories/motifs/new.html.slim
@@ -1,6 +1,6 @@
-= territory_navigation(t(".title"), [link_to("Liste des motifs", admin_territory_motifs_path(current_territory))])
+- content_for :title, t("motifs.form.title.new")
 
-- content_for :title, t(".title")
+= territory_navigation(content_for(:title), [link_to("Liste des motifs", admin_territory_motifs_path(current_territory))])
 
 .row
   .col-md-12

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -14,6 +14,8 @@ fr:
       sectorisation_level_departement: "Sectorisé au département"
     follow_up_need_signed_user: "Le RDV '%{motif_name}' est disponible uniquement pour les personnes déjà suivies. Veuillez vous connecter pour prendre ce type de RDV."
     form:
+      title:
+        new: Créer un motif
       sectorisation_level:
         sectors_attributed_to_orga:
           zero: "Aucun secteur n'est attribué à l'organisation %{organisation}, ce motif n'apparaîtra donc dans aucune recherche usager"
@@ -24,6 +26,7 @@ fr:
           one: "Un seul agent du service %{service} est attribué à %{sectors_count_human} : %{sectors}"
           other: "%{count} agents du service %{service} sont attribués à %{sectors_count_human} : %{sectors}"
     index:
+      title: Motifs de l'organisation
       sectorisation_level_organisation:
         zero: "⚠️ aucun secteur"
         one: "1 secteur"

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -111,8 +111,6 @@ fr:
       motifs:
         index:
           title: Motifs
-        new:
-          title: Création d’un nouveau motif
       motif_fields:
         edit:
           title: Champs des motifs

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Admin can configure the organisation" do
   it "CRUD on motifs", js: true do
     click_link "Paramètres"
     click_link "Motifs"
-    expect_page_title("Vos motifs")
+    expect_page_title("Motifs de l'organisation")
 
     click_link motif.name
     expect(page).to have_content("Motif 1")
@@ -92,11 +92,11 @@ RSpec.describe "Admin can configure the organisation" do
       retry
     end
 
-    expect_page_title("Vos motifs")
+    expect_page_title("Motifs de l'organisation")
     expect(page).to have_content("Vous n'avez pas encore créé de motif.")
 
     click_link "Créer un motif", match: :first
-    expect(page).to have_content("Création d’un nouveau motif")
+    expect(page).to have_content("Configuration générale")
     ## Check secretariat is unavailable
     expect(page.all("select#motif_service_id option").map(&:value)).to contain_exactly("", pmi.id.to_s, service_social.id.to_s)
     select(service_social.name, from: :motif_service_id)

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Agent can CRUD motifs" do
   it "works" do
     visit authenticated_agent_root_path
     click_link "Motifs"
-    expect_page_title("Vos motifs")
+    expect_page_title("Motifs de l'organisation")
     click_link motif.name
 
     expect(page).to have_content(motif.name)
@@ -24,17 +24,17 @@ RSpec.describe "Agent can CRUD motifs" do
     expect(page).to have_content("Suivi bonsoir")
     click_link("Supprimer")
 
-    expect_page_title("Vos motifs")
+    expect_page_title("Motifs de l'organisation")
     expect(page).to have_content("Vous n'avez pas encore créé de motif.")
     click_link "Créer un motif", match: :first
 
-    expect_page_title("Création d’un nouveau motif")
+    expect_page_title("Créer un motif")
     find("#motif_service_id").find(:option, service.name).select_option
     fill_in "Nom", with: "Suivi bonne nuit"
     fill_in "Couleur associée", with: "#000"
     click_button "Créer le motif"
 
-    expect_page_title("Vos motifs")
+    expect_page_title("Motifs de l'organisation")
     expect(page).to have_content("Suivi bonne nuit")
   end
 


### PR DESCRIPTION
"Vos motifs" devient "Motifs de l'organisation", pour clarifier que les motifs sont cloisonnés par organisation.

"Création d’un nouveau motif" de vient "Créer un motif" par souci de concision et simplicité.

# Avant

![image](https://github.com/user-attachments/assets/3850c6a6-0168-4d6f-8de5-84644c496084)

![image](https://github.com/user-attachments/assets/f7cf7079-ab7f-472c-99d1-f4f95def8533)

# Après

![image](https://github.com/user-attachments/assets/06590162-e240-4309-a958-1b81c2760adc)

![image](https://github.com/user-attachments/assets/10a83259-fefa-4ab5-a336-bddc422e0aa0)
