### PR TITLE
Utiliser le terme "Modifier" plutôt que "Éditer" (un motif)

### DIFF
--- a/app/views/admin/agenda/absences/index.json.jbuilder
+++ b/app/views/admin/agenda/absences/index.json.jbuilder
@@ -5,7 +5,7 @@ json.cache! [@absence_occurrences, :all_occurrences_for, date_range_params, @org
     json.end occurrence.ends_at.as_json
     json.backgroundColor "rgba(127, 140, 141, 0.7)"
 
-    # url pour éditer l'absence
+    # url pour modifier l'absence
     json.url edit_admin_organisation_absence_path(@organisation, absence)
   end
 end

--- a/app/views/admin/agenda/rdvs/index.json.jbuilder
+++ b/app/views/admin/agenda/rdvs/index.json.jbuilder
@@ -16,7 +16,7 @@ json.array! @rdvs do |rdv|
   json.start rdv.starts_at.as_json
   json.end rdv.ends_at.as_json
 
-  # url pour éditer le rendez-vous
+  # url pour modifier le rendez-vous
   # TODO trouver un meilleur nom à cet attribut pour en plus avoir besoin de ce commentaire
   json.url admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: params[:agent_id]) if rdv.organisation == @organisation
   if rdv.organisation == @organisation

--- a/app/views/admin/motifs/show.html.slim
+++ b/app/views/admin/motifs/show.html.slim
@@ -95,7 +95,7 @@
             - if @motif_policy.duplicate?
               div= link_to "Dupliquer", duplicate_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"
             - if @motif_policy.edit?
-              div= link_to "Éditer", edit_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"
+              div= link_to "Modifier", edit_admin_organisation_motif_path(current_organisation, @motif), class: "btn btn-primary w-100"
 
 .row.justify-content-center
   .col-md-12.col-lg-8

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -66,7 +66,7 @@ h1.m-2.rdv-text-align-center.border-bottom.pb-2 Espace Admin - #{current_territo
         h2.fw-bold.mb-0
           i.fa.fa-calendar>
           = t("admin.territories.motifs.index.title")
-        p Lister, éditer, supprimer les motifs de toutes vos organisations
+        p Lister, modifier, supprimer les motifs de toutes vos organisations
 
     .col.col-md-4.p-2.rounded.settings-box
       = link_to edit_admin_territory_motif_fields_path(current_territory) do

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Admin can configure the organisation" do
 
     click_link motif.name
     expect(page).to have_content("Motif 1")
-    click_link "Éditer"
+    click_link "Modifier"
     fill_in :motif_name, with: "Être appelé par"
     click_button("Enregistrer")
     expect(page).to have_content("Être appelé par")

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Agent can CRUD motifs" do
     click_link motif.name
 
     expect(page).to have_content(motif.name)
-    click_link "Éditer"
+    click_link "Modifier"
 
     expect_page_title("Modifier le motif")
     fill_in "Nom", with: "Suivi bonsoir"
@@ -65,7 +65,7 @@ RSpec.describe "Agent can CRUD motifs" do
       expect(motif.for_secretariat).to be_truthy
       expect(motif.follow_up).to be_falsey
 
-      click_on "Éditer"
+      click_on "Modifier"
       find("#tab_resa_en_ligne").click
       check "Autoriser ces rendez-vous seulement aux usagers bénéficiant d'un suivi par un référent"
       expect(find("#motif_for_secretariat", visible: false)).not_to be_checked
@@ -95,14 +95,14 @@ RSpec.describe "Agent can CRUD motifs" do
       expect { click_on "Enregistrer" }.to change { motif.reload.bookable_by }.to("everyone")
 
       # On décoche la case "RDVs modifiables" et on enregistre
-      click_on "Éditer"
+      click_on "Modifier"
       find("#tab_resa_en_ligne").click
       uncheck "motif_rdvs_editable_by_user"
       expect { click_on "Enregistrer" }.to change { motif.reload.rdvs_editable_by_user }.from(true).to(false)
 
       # On revient sur le formulaire, la case est bien décochée
       # et reste décochée lorsque l'on désactive la résa en ligne
-      click_on "Éditer"
+      click_on "Modifier"
       find("#tab_resa_en_ligne").click
       expect(editable_by_user_checkbox).not_to be_checked
       choose "Agents de l’organisation", id: "motif_bookable_by_agents"

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   it "allows changing the location type and adds validation when trying to create a rdv without email or phone number", js: true do
     visit admin_organisation_motifs_path(organisation)
     click_on motif.name
-    click_on "Éditer"
+    click_on "Modifier"
     expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
     choose "Par visioconférence"
     click_on "Enregistrer"


### PR DESCRIPTION
Nous utilisons "Modifier" dans toute l'appli sauf sur le bouton du show du motif et dans le sous-titre de la section Motifs de l'espace admin, où nous utilisons "Éditer". Nous souhaitons être cohérents donc je remplace ici "Éditer" par "Modifier".

# Avant

![image](https://github.com/user-attachments/assets/3820a772-bfaa-4463-90f6-7f96ee85ef9b)

# Après

![image](https://github.com/user-attachments/assets/3d582bd8-fda0-4dcb-b4db-b3d97c0a230c)

# Avant

![image](https://github.com/user-attachments/assets/5774e2cf-ca08-4c2f-9567-2012138427ff)

# Après

![image](https://github.com/user-attachments/assets/20901818-30a5-46a5-9123-7692b20fc78c)
