### PR TITLE
Désactiver l'option `any_word` du moteur de recherche

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -21,7 +21,7 @@ class Agent < ApplicationRecord
           id: "D",
         },
       ignoring: :accents,
-      using: { tsearch: { prefix: true, any_word: true } },
+      using: { tsearch: { prefix: true } },
     }
   end
 

--- a/app/models/concerns/text_search.rb
+++ b/app/models/concerns/text_search.rb
@@ -25,7 +25,7 @@ module TextSearch
 
     pg_search_scope :full_text_search, lambda { |query|
       {
-        using: { tsearch: { prefix: true, any_word: true } },
+        using: { tsearch: { prefix: true } },
         order_within_rank: "#{table_name}.updated_at desc",
         query: query,
       }.merge(search_options)

--- a/app/models/plage_ouverture.rb
+++ b/app/models/plage_ouverture.rb
@@ -18,7 +18,7 @@ class PlageOuverture < ApplicationRecord
           id: "D",
         },
       ignoring: :accents,
-      using: { tsearch: { prefix: true, any_word: true } },
+      using: { tsearch: { prefix: true } },
     }
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -14,7 +14,7 @@ class Team < ApplicationRecord
           id: "D",
         },
       ignoring: :accents,
-      using: { tsearch: { prefix: true, any_word: true } },
+      using: { tsearch: { prefix: true } },
     }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
 
   def self.search_options
     {
-      using: { tsearch: { prefix: true, any_word: true, tsvector_column: "text_search_terms" } },
+      using: { tsearch: { prefix: true, tsvector_column: "text_search_terms" } },
     }
   end
 

--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe TextSearch, type: :concern do
       expect(described_class.search_by_text("patricia")).to eq([patricia])
     end
 
-    it "returns users that match with second part of first name" do
-      michel = create(:user, first_name: "jean Michel")
-      patricia = create(:user, first_name: "patricia")
-      expect(described_class.search_by_text("michel")).to eq([michel])
-    end
-
     it "returns users that match with partial email" do
       create(:user, email: "jean@moustache.fr")
       patricia = create(:user, email: "patoche@duroy.fr")

--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -1,30 +1,25 @@
 RSpec.describe TextSearch, type: :concern do
-  # Tester les methods du concerns sans un objet des modèles...
-  # Peut-être difficile sans activerecord ?
-
-  shared_examples ".search_by_text" do
-    it "return findme objects" do
-      expect(described_class.search_by_text("findme")).to eq([object])
-    end
-  end
-
   describe(Team) do
     let(:other_object) { create(:team, name: "dont") }
     let(:object) { create(:team, name: "findme") }
     let(:object_to_save) { build(:team, name: "findme") }
 
-    include_examples ".search_by_text"
+    it "return findme objects" do
+      expect(described_class.search_by_text("findme")).to eq([object])
+    end
   end
 
   describe(User) do
-    let(:other_object) { create(:team, name: "dont") }
-    let(:object) { create(:team, name: "findme") }
-    let(:object_to_save) { build(:team, name: "findme") }
-
     it "returns users that match with first name" do
       create(:user, first_name: "jean")
       patricia = create(:user, first_name: "patricia")
       expect(described_class.search_by_text("patricia")).to eq([patricia])
+    end
+
+    it "returns users that match with second part of first name" do
+      michel = create(:user, first_name: "jean Michel")
+      patricia = create(:user, first_name: "patricia")
+      expect(described_class.search_by_text("michel")).to eq([michel])
     end
 
     it "returns users that match with partial email" do
@@ -45,39 +40,12 @@ RSpec.describe TextSearch, type: :concern do
       expect(described_class.search_by_text("+3313030")).to eq([jean])
     end
 
-    it "orders results by relevance" do
-      create(:user, first_name: "Marie", last_name: "Petit")
-      create(:user, first_name: "Gabrielle", last_name: "Petit")
-      create(:user, first_name: "Pauline", last_name: "Martin")
-      create(:user, first_name: "Jeanne", last_name: "Durand")
-      jean_paul = create(:user, first_name: "Jean-Paul", last_name: "Petit")
-      expect(described_class.search_by_text("Jean Paul Petit").count).to eq(5)
-      expect(described_class.search_by_text("Jean Paul Petit").first).to eq(jean_paul)
-    end
-
-    # Ce test a été introduit au moment de la mise en place de
-    # la pondération des colonnes lors de la recherche textuelle.
-    # Avant la pondération, les résultats pour "durand clem" étaient :
-    #   1. clement_berut_avec_email
-    #   2. clementine_dupond_ne_durand
-    #   3. clementine_durand
-    # ce qui est l'inverse de ce que l'on peut considérer comme pertinent.
-    it "orders results by relevance, weighing last name and first name above birth name and email" do
-      clementine_dupond_ne_durand = create(:user, first_name: "Clémentine", last_name: "DUPOND", birth_name: "DURAND")
-      clement_berut_avec_email = create(:user, first_name: "Clément", last_name: "BERUT", email: "clem.berut@example.com")
-      clementine_durand = create(:user, first_name: "Clémentine", last_name: "DURAND")
-      expected_order = [
-        clementine_durand,
-        clementine_dupond_ne_durand,
-        clement_berut_avec_email,
-      ]
-      expect(described_class.search_by_text("durand clem").to_a).to eq(expected_order)
-    end
-
     it "orders results by search terms" do
-      marie = create(:user, first_name: "Marie", last_name: "Petit")
-      frederic = create(:user, first_name: "Frédéric", last_name: "Petit")
-      expect(described_class.search_by_text("Pet")).to eq([frederic, marie])
+      match_in_last_name = create(:user, first_name: "Marie", last_name: "Nicolas")
+      match_in_first_name = create(:user, first_name: "Nicolas", last_name: "Marie")
+      match_in_email = create(:user, first_name: "Frédéric", last_name: "Petit", email: "nicolas@example.com")
+      expect(described_class.search_by_text("nicolas")).to include(match_in_birth_name)
+      expect(described_class.search_by_text("nicolas")).to eq([match_in_last_name, match_in_first_name, match_in_email])
     end
   end
 end

--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe TextSearch, type: :concern do
       match_in_last_name = create(:user, first_name: "Marie", last_name: "Nicolas")
       match_in_first_name = create(:user, first_name: "Nicolas", last_name: "Marie")
       match_in_email = create(:user, first_name: "Frédéric", last_name: "Petit", email: "nicolas@example.com")
-      expect(described_class.search_by_text("nicolas")).to include(match_in_birth_name)
       expect(described_class.search_by_text("nicolas")).to eq([match_in_last_name, match_in_first_name, match_in_email])
     end
   end


### PR DESCRIPTION
# Contexte

On nous remonte des comportement gênants du moteur de recherche d'usager (voir ticket qui contient des données personnelles) :
https://zammad10.ethibox.fr/#ticket/zoom/15360

Pour résumer le souci : lorsque l'on recherche un usager qui a un nom court, les premiers résultats affichés ne sont pas pertinents.

## Comment fonctionne le moteur de recherche

Actuellement nous avons activé 2 options de la librairie [pg_search](https://github.com/Casecommons/pg_search) : 
- `any_word` : "will return results matching any word in the search terms"
- `prefix` : "search for partial words"

L'option `any_word` nous semble non pertinente dans tous les cas : **lorsque l'on saisit des termes de recherche, on s'attend à ce que chaque terme saisi soit restrictif**, c'est à dire à ce que les résultats de la recherche soit l'intersection des résultats de chacun des termes pris séparément. 

L'option `prefix` est utile dans les contexte d'autocomplete, où l'utilisateur s'attend à ce que l'on lui propose des résultats avant qu'il ait fini de saisir la recherche. Nous prévoyons de désactiver cette option dans la recherche via la liste des usagers, mais de l'activer lors de la recherche d'usager Ajax, lors de la création d'un RDV par exemple. Ce sera fait dans une prochaine PR.

Note : Ces deux options avaient été activée dans #2791 sans trop y réfléchir, la technologie introduite était encore méconnue.

## Pourquoi ces options rendent les résultats non pertinents

Si l'on recherche une personne qui a dans son nom de famille une lettre toute seule, parexemple "Connor O Donnell" : 
1. le `o` de la recherche va être considéré avec la même importance que `connor` et `donnell`
2. la recherche va contenir :
  - tous les gens qui ont un nom qui commence par `o` 
  - tous les gens qui ont un nom qui commence par `connor`
  - tous les gens qui ont un nom qui commence par `donnell`

Or, beaucoup de gens ont des noms qui commencent par `o` ! Mais surtout lorsque j'ai tapé "Connor O Donnell", **je m'attendais à voir que des résultats de gens qui ont à la fois** "Connor" et "Donnell" dans leur nom, **pas les gens qui ont soit** "Connor", soit "Donnell".
 
# Solution

J'ai simplement supprimé les `any_word: true`, puisque l'option est `false` par défaut.

Côté tests, il y avait deux tests sur l'ordre des résultats, qui n'étaient pas très clairs et qui supposait qu'on avait `any_word: true`. Je les ai supprimés et j'en ai ajouté un plus clair.

# Checklist

- [X] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [X] Préparer des captures de l’interface avant et après

## Captures d'écran

# Avant

![image](https://github.com/user-attachments/assets/f775fa55-820a-4864-a0d0-c4997cd1a8e3)


# Après

![image](https://github.com/user-attachments/assets/198cad64-0383-42b5-9b71-2f3f75ba6022)

