### PR TITLE
Correctifs pour le calcul de créneaux quand une occurence a commencé et pour l'application du `min_booking_delay`

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -107,7 +107,7 @@ module RecurrenceConcern
     inclusive_datetime_range = (inclusive_date_range.begin)..(inclusive_date_range.end.end_of_day)
 
     if recurring?
-      min_from = only_future ? (earliest_future_occurrence_time || starts_at) : starts_at
+      min_from = only_future ? Time.zone.now : starts_at
       recurrence.starting(min_from).until(min_until).lazy.select do |occurrence_starts_at|
         event_in_range?(occurrence_starts_at, occurrence_starts_at + duration, inclusive_datetime_range)
       end.to_a

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -107,6 +107,7 @@ module RecurrenceConcern
     inclusive_datetime_range = (inclusive_date_range.begin)..(inclusive_date_range.end.end_of_day)
 
     if recurring?
+      # min_from = only_future ? (earliest_future_occurrence_time || starts_at) : starts_at
       min_from = only_future ? Time.zone.now : starts_at
       recurrence.starting(min_from).until(min_until).lazy.select do |occurrence_starts_at|
         event_in_range?(occurrence_starts_at, occurrence_starts_at + duration, inclusive_datetime_range)

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -5,7 +5,9 @@ module CreneauxSearch::Calculator
       datetime_range = CreneauxSearch::Range.ensure_date_range_with_time(date_range)
       plage_ouvertures = plage_ouvertures_for(motif, lieu, datetime_range, agents)
       free_times_po = free_times_from(plage_ouvertures, datetime_range) # dépendances implicite à Rdv, Absence et OffDays
-      slots_for(free_times_po, motif)
+      slots_for(free_times_po, motif).select do |slot|
+        slot.starts_at >= datetime_range.begin
+      end
     end
 
     def plage_ouvertures_for(motif, lieu, datetime_range, agents)

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "User can select a creneau" do
-  let(:now) { Time.zone.parse("2021-12-13 8:00") }
+  let(:now) { Time.zone.parse("2021-12-13 8:05") }
 
   let!(:territory92) { create(:territory, departement_number: "92") }
   let!(:organisation) { create(:organisation, territory: territory92) }

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "User can select a creneau" do
       visit prendre_rdv_path(departement: 92)
       click_on motif.name
       expect(page).to have_content("Prochaine disponibilité")
-      expect(page).to have_content("mardi 14 décembre 2021 à 08h00")
+      expect(page).to have_content("lundi 13 décembre 2021 à 08h50")
       click_on("Prochaine disponibilité")
 
       click_on("sem. prochaine")

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "User can select a creneau" do
     let!(:motif) { create(:motif, name: "RSA Orientation", organisation: organisation, restriction_for_rdv: nil, service: service) }
     let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: Date.new(2021, 12, 13), motifs: [motif], lieu: lieu, organisation: organisation) }
     let!(:absence) do
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 12, 20), end_day: Date.new(2021, 12, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(18))
+      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 12, 20), end_day: Date.new(2021, 12, 27), start_time: Tod::TimeOfDay.new(8), end_time: Tod::TimeOfDay.new(18))
     end
 
     it "displays the correct date for the next availability" do

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       let(:date_range) { friday..Date.new(2021, 5, 1) }
 
       it "returns the creneaux for the reste of the plage d'ouverture" do
-        create(:plage_ouverture, :daily, motifs: [motif], first_day: friday.to_date, start_time: Tod::TimeOfDay.new(7), end_time: Tod::TimeOfDay.new(11), lieu: lieu)
+        create(:plage_ouverture, :weekdays, motifs: [motif], first_day: friday.to_date, start_time: Tod::TimeOfDay.new(7), end_time: Tod::TimeOfDay.new(11), lieu: lieu)
         slots = described_class.available_slots(motif, lieu, date_range)
         expect(slots.first.starts_at.iso8601).to eq("2021-04-30T08:00:00+02:00")
       end

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       expect(slots.map(&:class).map(&:to_s).uniq).to eq(["Creneau"])
     end
 
+    context "when the plage d'ouverture has already started" do
+      let(:date_range) { friday..Date.new(2021, 5, 1) }
+
+      it "returns the creneaux for the reste of the plage d'ouverture" do
+        create(:plage_ouverture, :daily, motifs: [motif], first_day: friday.to_date, start_time: Tod::TimeOfDay.new(7), end_time: Tod::TimeOfDay.new(11), lieu: lieu)
+        slots = described_class.available_slots(motif, lieu, date_range)
+        expect(slots.first.starts_at.iso8601).to eq("2021-04-30T08:00:00+02:00")
+      end
+    end
+
     context "when date range starts before today" do
       let(:today) { Date.new(2022, 7, 13) }
       let(:yesterday) { today - 1.day }

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
     date_range = Time.zone.today..(Time.zone.today + 7.days)
     motif = create(:motif, organisation: organisation, min_public_booking_delay: 24.hours)
 
-    create(:plage_ouverture, :daily, motifs: [motif], first_day: 7.days.ago.to_date, start_time: Tod::TimeOfDay.new(10), end_time: Tod::TimeOfDay.new(18), lieu: lieu)
+    create(:plage_ouverture, :weekdays, motifs: [motif], first_day: 7.days.ago.to_date, start_time: Tod::TimeOfDay.new(10), end_time: Tod::TimeOfDay.new(18), lieu: lieu)
 
     service = described_class.new(motif: motif, lieu: lieu, date_range: date_range)
     expect(service.creneaux.map(&:starts_at).min.iso8601).to eq "2020-10-20T16:00:00+02:00"

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
     create(:plage_ouverture, :daily, motifs: [motif], first_day: 7.days.ago.to_date, start_time: Tod::TimeOfDay.new(10), end_time: Tod::TimeOfDay.new(18), lieu: lieu)
 
     service = described_class.new(motif: motif, lieu: lieu, date_range: date_range)
-    expect(service.creneaux.map(&:starts_at).first.iso8601).to eq "2020-10-20T16:00:00+02:00"
+    expect(service.creneaux.map(&:starts_at).min.iso8601).to eq "2020-10-20T16:00:00+02:00"
   end
 
   describe ".creneau_for" do

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
     end
   end
 
+  it "applies the motif's minimum and maximum booking delay restrictions" do
+    date_range = Time.zone.today..(Time.zone.today + 7.days)
+    motif = create(:motif, organisation: organisation, min_public_booking_delay: 24.hours)
+
+    create(:plage_ouverture, :daily, motifs: [motif], first_day: 7.days.ago.to_date, start_time: Tod::TimeOfDay.new(10), end_time: Tod::TimeOfDay.new(18), lieu: lieu)
+
+    service = described_class.new(motif: motif, lieu: lieu, date_range: date_range)
+    expect(service.creneaux.map(&:starts_at).first.iso8601).to eq "2020-10-20T16:00:00+02:00"
+  end
+
   describe ".creneau_for" do
     subject do
       described_class.creneau_for(


### PR DESCRIPTION
Cette PR corrige deux bugs distincts sur la recherche de créneaux.

### Premier bug : lors d'une recherche de créneaux, les créneaux de l'occurrence actuelle (qui a commencé) ne s'affichent pas

L'équipe technique de Visioplainte m'a fait remonter ce bug (ils s'intéressent beaucoup au cas des réservations le jour même).

#### Reproduction

- J'ai une plage d'ouverture qui va de 10h à 18h tous les jours de la semaine pour un motif de rdv qui dure 1h.
- Je fais une recherche de créneaux en tant qu'agent le lundi à 12h05
- Bug : le premier créneau que je vois est celui du mardi matin alors que je devrais voir celui du lundi à 13h

Il y a le même bug côté usager.

#### Correctif

Lors de l'appel à `RecurrenceConcern#occurrence_start_at_list_for`, on appelle `earliest_future_occurrence_time`, qui se base sur le début de la prochaine occurrence, et qui ne prend pas en compte le fait qu'une occurrence peut être en train d'avoir lieu en ce moment.
On modifie donc la logique de `earliest_future_occurrence_time` pour prendre ce cas en compte.
Je me demande s'il ne faudrait pas aussi changer le nom de cette méthode, parce que c'est discutable qu'il s'agisse d'une `future_occurrence` si elle est déjà commencée. Je suis chaud pour en discuter.

La spec ajoutée dans spec/services/creneaux_search/calculator_spec.rb permet une non-régression pour ce bug.

### Deuxième bug : le `min_booking_delay` n'était pas pris en compte dans la recherche de créneaux côté usagers

En testant le correctif du bug précédent, ça a révélé un autre problème : le `min_booking_delay` n'était pas pris en compte lors de la réservation par les usagers.

Ce bug devient beaucoup plus visible maintenant qu'on propose les créneaux de la plage d'ouverture en cours.

(Il y avait déjà eu un correctif pour une variante de ce bug : https://github.com/betagouv/rdv-service-public/pull/2390)

#### Correctif

De manière assez étonnante, le `CreneauxSearch::Calculator` pouvait renvoyer des créneaux qui commençaient avant le début de son date range.
J'ai ajouté le filtre dans la méthode la plus haute, mais il y a peut-être un autre fix plus élégant.


### Risques lors du déploiement du correctif

Finalement ces deux bugs ce compensaient, et en les corrigeant tous les deux, on change le fonctionnement du délai min de réservation.
Pour certaines organisations, il est possible que ça ouvre des réservation de dernière minute.
Par exemple, si on prend le cas d'une organisation qui a des plages d'ouverture 10h à 18h, et des motifs avec les délais min de réservation de 30 mn (la valeur par défaut), on a le fonctionnement suivant :
- avant le correctif, le délai min est en fonction de la plage d'ouverture en cours, donc généralement du jour pour le lendemain
- après le correctif, c'est possible de réserver 30 mn à l'avance.

On risque donc d'avoir pas mal de contact du support, donc je préfère mettre ce correctif en ligne lundi après avoir briefé notre équipe support et celle de rdv insertion.
