### PR TITLE
Suppression de points de suspensions inutilisés

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,7 +22,7 @@ fr:
         select_placeholder_single_use_lieu: Lieu ponctuel
       show:
         update: Modifier
-        duplicate: Dupliquer…
+        duplicate: Dupliquer
     rdvs_collectifs:
       new:
         single_use_lieu_hint_html: Ce rendez-vous aura lieu à une adresse inhabituelle ? <a href>Définir un lieu ponctuel.</a>


### PR DESCRIPTION
Discuté à l'instant avec Téo et Mehdi, ces points de suspension dans le bouton pour dupliquer un RDV ne servent à rien (dans la continuité du https://github.com/betagouv/rdv-service-public/pull/4602)