### PR TITLE
Incohérence dans la recherche de créneau agent pour des motifs sans lieux

### DIFF
--- a/app/services/creneaux_search/for_agent.rb
+++ b/app/services/creneaux_search/for_agent.rb
@@ -14,7 +14,7 @@ class CreneauxSearch::ForAgent
   end
 
   def build_result
-    lieu = lieux.first
+    lieu = @form.motif.requires_lieu? ? lieux.first : nil
     # utiliser les ids des agents pour ne pas faire de requêtes supplémentaire
     creneaux = CreneauxSearch::Calculator.available_slots(@form.motif, lieu, @form.date_range, all_agents)
     creneaux = creneaux.uniq { [_1.starts_at, _1.agent] }

--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
     it "has results" do
       expect(described_class.new(form).build_result.creneaux).to be_any
     end
+
+    describe "when there is concurrent PO with lieu" do
+      let(:lieu) { create(:lieu, organisation: organisation) }
+      let(:motif_with_lieu) { create :motif, organisation: organisation }
+      let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif, motif_with_lieu], first_day: Date.new(2022, 10, 20), lieu: lieu, organisation: organisation) }
+
+      it "give the good results with no conflict" do
+        expect(described_class.new(form).build_result.creneaux.first.starts_at).to eq(Time.zone.local(2022, 10, 25, 8, 0, 0))
+      end
+    end
   end
 
   describe "#all_agents" do


### PR DESCRIPTION
Remonté par @Evajuliab

Nous avons des incohérences entre les créneaux dans l'interface usager et la recherche de créneau pour le même motif dans l'interface agent pour des motifs téléphoniques.

Suite à [cette refacto](https://github.com/betagouv/rdv-service-public/pull/4560) il semblerai que l'on ai introduit un bug.

Je règle le soucis dans cette PR en prenant en compte le cas des motifs sans lieux dans la recherche de créneau agent.