### PR TITLE
DSFR partie usagers : activation du soulignement des liens

### DIFF
--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -42,3 +42,9 @@
     max-width: 100%;
   }
 }
+
+// OTHERS
+
+.rdv-background-image-none {
+  background-image: none;
+}

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -45,6 +45,7 @@
 
 // OTHERS
 
+// utile pour désactiver le soulignement des liens du DSFR
 .rdv-background-image-none {
   background-image: none;
 }

--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -5,8 +5,10 @@
   color: inherit;
 }
 
-a[href] {
-  background-image: none; // pour éviter le soulignement des liens
+a.btn[href],
+a.stretched-link[href] {
+  background-image: none;
+  // pour éviter le soulignement des boutons et liens bootstrap
 }
 
 footer {

--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -3,6 +3,6 @@
     .row.mt-2
       .col-md-12
         .d-print-none.alert.alert-dismissible.fade.show class=alert_class_for(type)
-          a.close(href="#" data-dismiss="alert" aria-label='Close')
+          a.close.rdv-background-image-none(href="#" data-dismiss="alert" aria-label='Close')
             i.fa.fa-times
           = sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune)

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -14,6 +14,6 @@
     h2.rdv-font-weight-700 Sélectionnez le motif de votre RDV :
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       .card.mb-3
-        = link_to(prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))) do
+        = link_to prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type)), class: "rdv-background-image-none" do
           = render "search/motif_selection_card", motif: motif
   = render "search/referent_booking_card", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -6,7 +6,7 @@
     - unless context.invitation?
     - context.services.each do |service|
       .card.mb-3
-        = link_to prendre_rdv_path(context.query_params.merge(service_id: service.id)) do
+        = link_to prendre_rdv_path(context.query_params.merge(service_id: service.id)), class: "rdv-background-image-none" do
           .card-body
             .row
               .col-md


### PR DESCRIPTION
Review app : https://demo-rdv-solidarites-pr4608.osc-secnum-fr1.scalingo.io/

> [!NOTE] 
> Cette PR ne concerne que la partie usagers de DSFR

# Contexte

Le soulignement des liens est désactivé sur RDV-Solidarités. C’est probablement une décision qui est venue par défaut avec les (4) premières versions de Bootstrap. 

Pourquoi est-ce utile de souligner les liens ?

- C’est le défaut d’internet, les navigateurs soulignent les liens, on a donc l’habitude ;
- La couleur n’est pas suffisante pour distinguer un lien, notamment pour les personnes ne distinguant pas les couleurs ;
- C’est ce qui est recommandé par le DSFR ;
- Même bootstrap a changé son défaut : en v5 les liens sont soulignés

# Solution

Le DSFR inclut déjà des règles de soulignement des liens via une `background-image`.

Lors de l’inclusion du CSS du DSFR j’avais volontairement désactivé cette règle partout pour éviter un gros changement d’un coup, et éviter des changements inattendus en conflit avec les composants bootstrap.

Dans cette PR, je rends notre règle de contournement du DSFR plus spécifique pour qu’elle ne désactive le soulignement des liens QUE sur les composants bootstrap qui ont un comportement inattendu avec ce soulignement.

Je rajoute aussi une nouvelle utility classe `.rdv-background-image-none` que j’applique à certains endroits pour reléguer à plus tard des réécritures de composants qui se comportent aujourd’hui mal avec des liens soulignés.

## Captures d'écran

Jeu de captures d’écran quasi exhaustif https://rdv-sp-2024-09-05-dsfr-links-underline.surge.sh/

ex : 

<img width="498" alt="image" src="https://github.com/user-attachments/assets/aa4f5310-6a75-46d4-8bf0-032e2b66149b">

Les changements sont assez mineurs, on n’utilise pas tant de liens que ça côté usagers.