### PR TITLE
Rename obsolete usages of term "busy time" to name an absence

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -41,7 +41,7 @@ class Admin::AbsencesController < AgentAuthController
     authorize(@absence)
     if @absence.save
       absence_mailer.absence_created.deliver_later if @agent.absence_notification_level == "all"
-      flash[:notice] = t(".busy_time_created")
+      flash[:notice] = t(".absence_created")
       redirect_to admin_organisation_agent_absences_path(current_organisation, @absence.agent_id)
     else
       render :new
@@ -52,7 +52,7 @@ class Admin::AbsencesController < AgentAuthController
     authorize(@absence)
     if @absence.update(absence_params)
       absence_mailer.absence_updated.deliver_later if @agent.absence_notification_level == "all"
-      flash[:notice] = t(".busy_time_updated")
+      flash[:notice] = t(".absence_updated")
       redirect_to admin_organisation_agent_absences_path(current_organisation, @absence.agent_id)
     else
       render :edit
@@ -64,7 +64,7 @@ class Admin::AbsencesController < AgentAuthController
     if @absence.destroy
       # NOTE: the destruction email is sent synchronously (not in a job) to ensure @absence still exists.
       absence_mailer.absence_destroyed.deliver_now if @agent.absence_notification_level == "all"
-      flash[:notice] = t(".busy_time_deleted")
+      flash[:notice] = t(".absence_deleted")
       redirect_to admin_organisation_agent_absences_path(current_organisation, @absence.agent_id)
     else
       render :edit

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -21,5 +21,5 @@ tr
       div.mr-3= link_to( admin_organisation_absence_path(current_organisation, absence),
               method: :delete,
               title: t("helpers.delete"),
-              data: { confirm: t(".confirm_delete_busy_time")} ) do
+              data: { confirm: t(".confirm_delete_absence")} ) do
         i.fa.fa-trash-alt

--- a/app/views/admin/absences/_form.html.slim
+++ b/app/views/admin/absences/_form.html.slim
@@ -2,7 +2,7 @@
   = render "model_errors", model: absence
   = f.hidden_field :agent_id
 
-  = f.input :title, hint:"Uniquement visible en interne", placeholder: t(".busy_time_example")
+  = f.input :title, hint:"Uniquement visible en interne", placeholder: t(".absence_example")
 
   hr
   = render partial: "common/recurrence", locals: { f: f, model: absence }
@@ -10,6 +10,6 @@
   .row
     - if absence.persisted?
       .col.text-left
-        = link_to "Supprimer", admin_organisation_absence_path(current_organisation, absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete_busy_time")}
+        = link_to "Supprimer", admin_organisation_absence_path(current_organisation, absence), method: :delete, class: "btn btn-outline-danger", data: { confirm: t(".confirm_delete_absence")}
     .col.text-right
       = f.button :submit

--- a/app/views/admin/absences/edit.html.slim
+++ b/app/views/admin/absences/edit.html.slim
@@ -2,18 +2,18 @@
 
 - content_for :title do
   - if @absence.agent == current_agent
-    = t(".update_your_busy_time")
+    = t(".update_your_absence")
   - else
-    = t(".update_busy_time_of", full_name: @absence.agent.full_name)
+    = t(".update_absences_of", full_name: @absence.agent.full_name)
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
       = link_to admin_organisation_agent_absences_path(current_organisation, @absence.agent) do
         - if @absence.agent == current_agent
-          = t(".your_busy_times")
+          = t(".your_absences")
         - else
-          = t(".busy_time_of", full_name: @absence.agent.full_name)
+          = t(".absences_of", full_name: @absence.agent.full_name)
     li.breadcrumb-item.active
       = truncate(@absence.title, length: 20)
 

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -3,12 +3,12 @@
 
 - content_for :title do
   - if current_agent == @agent
-    = t(".your_busy_times")
+    = t(".your_absences")
   - else
-    = t(".busy_time_of", full_name: @agent.full_name_and_service)
+    = t(".absences_of", full_name: @agent.full_name_and_service)
 
 - content_for :breadcrumb do
-  = link_to t(".create_busy_time"), new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-outline-primary align-bottom"
+  = link_to t(".create_absence"), new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-outline-primary align-bottom"
 
 .card.pb-3
   - if @display_tabs
@@ -35,9 +35,9 @@
       .col-md-6.rdv-text-align-center.mb-2
         p.mb-2.lead
           - if current_agent == @agent
-            = t(".you_not_yet_create_busy_time")
+            = t(".you_not_yet_create_absence")
           - else
-            = t(".has_no_busy_time_yet", full_name: @agent.full_name)
+            = t(".has_no_absence_yet", full_name: @agent.full_name)
         p = t(".explanation_html")
         span.fa-stack.fa-4x
           i.fa.fa-circle.fa-stack-2x.text-primary
@@ -45,6 +45,6 @@
   .rdv-text-align-center.py-2
     = link_to new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-primary" do
       - if @agent == current_agent
-        = t(".create_busy_time")
+        = t(".create_absence")
       - else
-        = t(".create_busy_time_for", full_name: @agent.full_name)
+        = t(".create_absence_for", full_name: @agent.full_name)

--- a/app/views/admin/absences/new.html.slim
+++ b/app/views/admin/absences/new.html.slim
@@ -3,20 +3,20 @@
 
 - content_for :title do
   - if @absence.agent == current_agent
-    = t(".new_busy_time")
+    = t(".new_absence")
   - else
-    = t(".new_busy_time_for", full_name: @absence.agent.full_name)
+    = t(".new_absence_for", full_name: @absence.agent.full_name)
 
 - content_for :breadcrumb do
   ol.breadcrumb.m-0
     li.breadcrumb-item
       = link_to admin_organisation_agent_absences_path(current_organisation, @absence.agent) do
         - if @absence.agent == current_agent
-          = t(".your_busy_times")
+          = t(".your_absences")
         - else
-          = t(".busy_time_of", full_name: @absence.agent.full_name)
+          = t(".absences_of", full_name: @absence.agent.full_name)
     li.breadcrumb-item.active
-      = t(".new_busy_time")
+      = t(".new_absence")
 
 .row.justify-content-center
   .col-md-6

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -52,7 +52,7 @@ nav.left-side-menu-wrapper
             li
               = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
-              = active_link_to "Absences", admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
+              = active_link_to "Indisponibilités", admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
               = active_link_to "RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__item side-menu__item--small"
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -52,7 +52,7 @@ nav.left-side-menu-wrapper
             li
               = active_link_to "Plages d'ouverture", admin_organisation_agent_plage_ouvertures_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
-              = active_link_to t(".busy_times"), admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
+              = active_link_to "Absences", admin_organisation_agent_absences_path(current_organisation, agent_for_left_menu), class: "side-menu__item side-menu__item--small"
             li
               = active_link_to "RDV collectifs", admin_organisation_rdvs_collectifs_path(current_organisation), class: "side-menu__item side-menu__item--small"
 
@@ -111,7 +111,7 @@ nav.left-side-menu-wrapper
               - if current_agent.territorial_admin_in?(current_organisation.territory)
                 = link_to admin_territory_path(current_organisation.territory), class: "side-menu__item side-menu__item--small" do
                   i.fa.fa-cog>
-                  = t(".configuration")
+                  ' Espace Admin
         li
           = active_link_to admin_organisation_support_path(current_organisation), class: "side-menu__item"
             i.fa.fa-question-circle>

--- a/config/locales/views/absence.fr.yml
+++ b/config/locales/views/absence.fr.yml
@@ -2,32 +2,32 @@ fr:
   admin:
     absences:
       common: &common
-        your_busy_times: Vos indisponibilités
-        confirm_delete_busy_time: Confirmez-vous la suppression de cette indisponibilité ?
-        busy_time_of: Indisponibilités de %{full_name}
+        your_absences: Vos indisponibilités
+        confirm_delete_absence: Confirmez-vous la suppression de cette indisponibilité ?
+        absences_of: Indisponibilités de %{full_name}
       index:
         <<: *common
-        create_busy_time: Créer une indisponibilité
-        create_busy_time_for: Créer une indisponibilité pour %{full_name}
-        you_not_yet_create_busy_time: Vous n'avez pas encore créé d'indisponibilité
-        has_no_busy_time_yet: "%{full_name} n'a pas encore créé d'indisponibilité."
+        create_absence: Créer une indisponibilité
+        create_absence_for: Créer une indisponibilité pour %{full_name}
+        you_not_yet_create_absence: Vous n'avez pas encore créé d'indisponibilité
+        has_no_absence_yet: "%{full_name} n'a pas encore créé d'indisponibilité."
         explanation_html: Les indisponibilités sont des exceptions aux <em>plages d'ouvertures</em>. Vous pouvez les utiliser pour les congés ou les fermetures. Les indisponibilités peuvent être récurrentes (par exemple pour les temps partiels).
       absence:
         <<: *common
       edit:
         <<: *common
-        update_your_busy_time: Modifier votre indisponibilité
-        update_busy_time_of: Modifier l'indisponibilité de %{full_name}
+        update_your_absence: Modifier votre indisponibilité
+        update_absences_of: Modifier l'indisponibilité de %{full_name}
       new:
         <<: *common
-        new_busy_time_for: Nouvelle indisponibilité pour %{full_name}
-        new_busy_time: Nouvelle indisponibilité
+        new_absence_for: Nouvelle indisponibilité pour %{full_name}
+        new_absence: Nouvelle indisponibilité
       form:
         <<: *common
-        busy_time_example: 'Ex: Indisponibilité pour formation premiers secours'
+        absence_example: 'Ex: Indisponibilité pour formation premiers secours'
       create:
-        busy_time_created: L'indisponibilité a été créée.
+        absence_created: L'indisponibilité a été créée.
       update:
-        busy_time_updated: L'indisponibilité a été modifiée.
+        absence_updated: L'indisponibilité a été modifiée.
       destroy:
-        busy_time_deleted: L'indisponibilité a été supprimée.
+        absence_deleted: L'indisponibilité a été supprimée.

--- a/config/locales/views/left_menu.fr.yml
+++ b/config/locales/views/left_menu.fr.yml
@@ -1,5 +1,0 @@
-fr:
-  layouts:
-    left_menu:
-      busy_times: Indisponibilités
-      configuration: Espace Admin


### PR DESCRIPTION
Nous avions des occurrences dans le code où les absences étaient appelées "busy times". Outre le souci de cohérence, cela venait créer de la confusion car la notion de "busy time" existe aussi dans le calculateur de créneau, pour représenter une période où l'agent n'est pas disponible (un RDV, une absence ou un jour férié).

J'ai donc renommé ces occurrences en "absence", car c'est le nom utilisé partout ailleurs dans le code.