### PR TITLE
Suppression d'absence / plage : supprimer et notifier dans le même job

### DIFF
--- a/app/controllers/admin/absences_controller.rb
+++ b/app/controllers/admin/absences_controller.rb
@@ -61,14 +61,9 @@ class Admin::AbsencesController < AgentAuthController
 
   def destroy
     authorize(@absence)
-    if @absence.destroy
-      # NOTE: the destruction email is sent synchronously (not in a job) to ensure @absence still exists.
-      absence_mailer.absence_destroyed.deliver_now if @agent.absence_notification_level == "all"
-      flash[:notice] = t(".busy_time_deleted")
-      redirect_to admin_organisation_agent_absences_path(current_organisation, @absence.agent_id)
-    else
-      render :edit
-    end
+    DestroyAbsenceJob.perform_later(@absence.id) if @agent.absence_notification_level == "all"
+    flash[:notice] = t(".busy_time_deleted")
+    redirect_to admin_organisation_agent_absences_path(current_organisation, @absence.agent_id)
   end
 
   private

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -71,14 +71,8 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def destroy
     authorize(@plage_ouverture)
-    # NOTE: the destruction email is sent synchronously (not in a job) to ensure @absence still exists.
-    mail = plage_ouverture_mailer.plage_ouverture_destroyed
-    if @plage_ouverture.destroy
-      mail.deliver_now if @agent.plage_ouverture_notification_level == "all"
-      redirect_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent), notice: "La plage d'ouverture a été supprimée."
-    else
-      render :edit
-    end
+    DestroyPlageOuvertureJob.perform_later(@plage_ouverture.id)
+    redirect_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent), notice: "La plage d'ouverture a été supprimée."
   end
 
   private

--- a/app/jobs/destroy_absence_job.rb
+++ b/app/jobs/destroy_absence_job.rb
@@ -1,0 +1,15 @@
+class DestroyAbsenceJob < ApplicationJob
+  def perform(absence_id)
+    absence = Absence.find_by(id: absence_id)
+    return unless absence
+
+    if absence.agent.absence_notification_level == "all"
+      Absence.transaction do
+        Agents::AbsenceMailer.with(absence: absence).absence_destroyed.deliver_now
+        absence.destroy!
+      end
+    else
+      absence.destroy!
+    end
+  end
+end

--- a/app/jobs/destroy_plage_ouverture_job.rb
+++ b/app/jobs/destroy_plage_ouverture_job.rb
@@ -1,0 +1,15 @@
+class DestroyPlageOuvertureJob < ApplicationJob
+  def perform(plage_ouverture_id)
+    plage_ouverture = PlageOuverture.find_by(id: plage_ouverture_id)
+    return unless plage_ouverture
+
+    if plage_ouverture.agent.plage_ouverture_notification_level == "all"
+      Absence.transaction do
+        Agents::PlageOuvertureMailer.with(plage_ouverture: plage_ouverture).plage_ouverture_destroyed.deliver_now
+        plage_ouverture.destroy!
+      end
+    else
+      plage_ouverture.destroy!
+    end
+  end
+end

--- a/spec/features/agents/agent_can_crud_absences_spec.rb
+++ b/spec/features/agents/agent_can_crud_absences_spec.rb
@@ -91,4 +91,19 @@ RSpec.describe "Agent can CRUD absences" do
       expect(page).not_to have_content(future_absence.title)
     end
   end
+
+  describe "sending an email notification upon deletion" do
+    let!(:absence) { create(:absence, agent: agent) }
+
+    it "works" do
+      click_link "Indisponibilités"
+      perform_enqueued_jobs do
+        expect { click_link("Supprimer") }.to change { emails_sent_to(absence.agent.email).size }.by(1)
+      end
+      open_email(absence.agent.email)
+      expect(current_email.subject).to eq("RDV Solidarités - Indisponibilité supprimée - #{absence.title}")
+      expect(current_email.body).to include(absence.title)
+      expect(current_email.body).to include(absence.agent.full_name)
+    end
+  end
 end

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -167,4 +167,17 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       end
     end
   end
+
+  describe "sending an email notification upon deletion" do
+    it "works" do
+      perform_enqueued_jobs do
+        expect { click_link("Supprimer") }.to change { emails_sent_to(plage_ouverture.agent.email).size }.by(1)
+      end
+      open_email(plage_ouverture.agent.email)
+      expect(current_email.subject).to eq("RDV Solidarités - Plage d’ouverture supprimée - #{plage_ouverture.title}")
+      expect(current_email.body).to include(plage_ouverture.title)
+      expect(current_email.body).to include(plage_ouverture.agent.full_name)
+      expect(current_email.body).to include(plage_ouverture.motifs.first.name)
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-service-public/issues/4388

Cette PR est une des deux solutions pour régler l'issue : 
- https://github.com/betagouv/rdv-service-public/pull/4612
- https://github.com/betagouv/rdv-service-public/pull/4613

**Edit : c'est l'autre solution qui a été choisie**

La solution employée ici : effectuer la suppression **et** la notification de façon asynchrone.

Avantages : 
- le mailer dispose encore de toutes les données en base lorsqu'il génère le mail

Inconvénients : 
- mauvaise UX pour l'agent : on lui dit "La plage d'ouverture va bientôt être supprimée" et la plage se trouve encore dans sa liste pendant quelques secondes