### PR TITLE
CreneauxSearch::Calculator#slots_for now sorts slots

### DIFF
--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -78,7 +78,7 @@ module CreneauxSearch::Calculator
           slots += calculate_slots(free_time, motif, plage_ouverture)
         end
       end
-      slots
+      slots.sort_by(&:starts_at)
     end
 
     def calculate_slots(free_time, motif, plage_ouverture)

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -374,6 +374,22 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       allow(described_class).to receive(:calculate_slots).with(free_times.first, motif, plage_ouverture).and_return([])
       described_class.slots_for(plage_ouverture_free_times, motif)
     end
+
+    it "sorts slots when there are multiple plage ouvertures" do
+      motif = build(:motif, default_duration_in_min: 60)
+      plage_ouverture1 = build(:plage_ouverture, motifs: [motif], first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+      free_times1 = [Time.zone.parse("20211027 9:00")..Time.zone.parse("20211027 11:00")]
+      plage_ouverture2 = build(:plage_ouverture, motifs: [motif], first_day: Date.new(2021, 10, 20), start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(16))
+      free_times2 = [Time.zone.parse("20211020 14:00")..Time.zone.parse("20211020 16:00")]
+      plage_ouverture_free_times = {
+        plage_ouverture1 => free_times1,
+        plage_ouverture2 => free_times2,
+      }
+
+      slots = described_class.slots_for(plage_ouverture_free_times, motif)
+      expect(slots.first.starts_at).to eq(Time.zone.parse("20211020 14:00"))
+      expect(slots.last.starts_at).to eq(Time.zone.parse("20211027 10:00"))
+    end
   end
 
   describe "#calculate_slots" do

--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
       let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif, motif_with_lieu], first_day: Date.new(2022, 10, 20), lieu: lieu, organisation: organisation) }
 
       it "give the good results with no conflict" do
-        expect(described_class.new(form).build_result.creneaux.first.starts_at).to eq(Time.zone.local(2022, 10, 25, 8, 0, 0))
+        expect(described_class.new(form).build_result.creneaux.first.starts_at).to eq(Time.zone.local(2022, 10, 20, 8, 0, 0))
       end
     end
   end


### PR DESCRIPTION
# Contexte

Il y a une flaky spec sur `spec/services/creneaux_search/for_agent_spec.rb` cf ce [run de GH Action](https://github.com/betagouv/rdv-service-public/actions/runs/10768721964/job/29858400832)

Après discussion avec Victor ici https://github.com/betagouv/rdv-service-public/commit/c79664daa0db34762667ddc6228898ff781d74ad#r146417161 on a compris que : 

- la spec est mal écrite et attend le mauvais résultat
- ce résultat erronné se produit souvent à cause de l’ordre non déterministe de retour des plages d’ouvertures de la db

# Solution

Dans cette PR je tente de corriger le problème au niveau le plus bas possible : je suis descendu jusqu’à `CreneauxSearch::Calculator#slots_for` où je rajoute un tri sur `starts_at`.

Il est possible que cette PR soit un peu dangereuse : 

- elle peut rajouter un peu de lenteur sur les endpoints de créneaux (même si je doute qu’un tri soit très lent)
- elle peut provoquer des changements de comportement inattendus si on s’appuyait sur le comportement actuel de `CreneauxSearch::Calculator#slots_for` qui renvoie des slots groupés par PO


Pour la lenteur, une optim simple serait de ne pas trier quand il n’y a qu’une PO car c’est déjà trié a priori