### PR TITLE
Trier les lieux par date de prochaine disponibilité dans la recherche côté agent

### DIFF
--- a/app/services/creneaux_search/for_agent.rb
+++ b/app/services/creneaux_search/for_agent.rb
@@ -6,7 +6,9 @@ class CreneauxSearch::ForAgent
   def next_availabilities
     lieux.map do |lieu|
       next_availability(lieu)
-    end.compact
+    end.compact.sort_by do |availability|
+      availability.starts_at
+    end
   end
 
   def next_availability(lieu = nil)
@@ -42,7 +44,6 @@ class CreneauxSearch::ForAgent
 
     @lieux = @lieux.where(id: PlageOuverture.where(agent_id: all_agents).select(:lieu_id)) if all_agents.present?
 
-    @lieux = @lieux.ordered_by_name
     @lieux
   end
 

--- a/app/services/creneaux_search/for_agent.rb
+++ b/app/services/creneaux_search/for_agent.rb
@@ -6,9 +6,7 @@ class CreneauxSearch::ForAgent
   def next_availabilities
     lieux.map do |lieu|
       next_availability(lieu)
-    end.compact.sort_by do |availability|
-      availability.starts_at
-    end
+    end.compact.sort_by(&:starts_at)
   end
 
   def next_availability(lieu = nil)

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -29,7 +29,7 @@
             collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
             as: :grouped_select, \
             group_method: :last,
-            label_method: -> { motif_name_and_location_type(_1) + " - #{_1.default_duration_in_min}mn" }, \
+            label_method: -> { motif_name_and_location_type(_1) }, \
             input_html: { \
               data: { placeholder: "Sélectionnez un motif" }, \
               class: "js-filtered-motifs", \

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -29,7 +29,7 @@
             collection: @motifs.includes(:service).to_a.group_by { _1.service.name }, \
             as: :grouped_select, \
             group_method: :last,
-            label_method: -> { motif_name_and_location_type(_1) }, \
+            label_method: -> { motif_name_and_location_type(_1) + " - #{_1.default_duration_in_min}mn" }, \
             input_html: { \
               data: { placeholder: "Sélectionnez un motif" }, \
               class: "js-filtered-motifs", \

--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
 
     before do
       create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu2, organisation: organisation, first_day: 2.weeks.from_now)
-      create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu1, organisation: organisation, first_day: 1.week.from_now)
+      create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu1, organisation: organisation, first_day: 1.week.from_now, recurrence_ends_at: 13.days.from_now)
     end
 
     it "sorts the results by the date of the next availability" do

--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -1,4 +1,37 @@
 RSpec.describe CreneauxSearch::ForAgent, type: :service do
+  let(:organisation) { create(:organisation) }
+  let(:motif) { create :motif, organisation: organisation }
+
+  describe "#next_availabilities" do
+    let(:form) do
+      instance_double(
+        AgentCreneauxSearchForm,
+        organisation: organisation,
+        motif: motif,
+        service: motif.service,
+        agent_ids: [],
+        team_ids: [],
+        lieu_ids: [],
+        date_range: Time.zone.today..(Time.zone.today + 6.days)
+      )
+    end
+    let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+    let(:lieu1) { create(:lieu, organisation: organisation, name: "MDS Valence") }
+    let(:lieu2) { create(:lieu, organisation: organisation, name: "MDS Arquest") }
+
+    before do
+      create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu2, organisation: organisation, first_day: 2.weeks.from_now)
+      create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu1, organisation: organisation, first_day: 1.week.from_now)
+    end
+
+    it "sorts the results by the date of the next availability" do
+      availabilities = described_class.new(form).next_availabilities
+      expect(availabilities.first.lieu).to eq lieu1
+      expect(availabilities.last.lieu).to eq lieu2
+    end
+  end
+
   describe "lieux" do
     subject { described_class.new(form).lieux }
 
@@ -14,9 +47,6 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
         date_range: Time.zone.today..(Time.zone.today + 6.days)
       )
     end
-
-    let(:organisation) { create(:organisation) }
-    let(:motif) { create :motif, organisation: organisation }
 
     let(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
     let(:lieu1) { create(:lieu, organisation: organisation) }
@@ -81,7 +111,6 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
         date_range: Date.new(2022, 10, 20)..Date.new(2022, 10, 30)
       )
     end
-    let(:organisation) { create(:organisation) }
     let(:motif) { create :motif, :by_phone, organisation: organisation }
     let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], first_day: Date.new(2022, 10, 25), lieu: nil, organisation: organisation) }
 
@@ -115,9 +144,6 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
         date_range: Time.zone.today..(Time.zone.today + 6.days)
       )
     end
-
-    let(:organisation) { create(:organisation) }
-    let(:motif) { create :motif, organisation: organisation }
 
     let(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
     let(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }


### PR DESCRIPTION
# Contexte

En me baladant dans la recherche de créneaux côté agents, je me rends compte que la liste des lieux qui proposent des dispos est triée par ordre alphabétique des noms des lieux plutôt que par disponibilité la plus proche (voir screenshot). Ça m'a même induit en erreur parce que je supposais que la dispo la plus proche remonterait en première. C'est assez trivial à changer, mais c'est comme ça depuis très longtemps (ça remonte à cette PR d'harmonisation de l'ordre des affichage en 2020 https://github.com/betagouv/rdv-service-public/pull/869).
Ça veut dire que les lieux s'affichent tout le temps dans le même ordre, donc ça peut légèrement changer les habitudes des secrétaires si on se met à les trier par date de prochaine dispo, mais je pense que ça peut être beaucoup plus pratique.

J'ai parcouru vite fait la liste des lieux triés par ordre alphabétique sur métabase, et j'ai pas vu de nom qui semblerait indiquer qu'ils sont utilisés pour apparaitre en premier (par exemple il y a pas de "AAA MDS de Valence").

Côté usager, on trie par distance si on a l'adresse de l'usager, et par date de prochaine disponibilité si c'est un rdv à distance (par téléphone ou visio). C'est pas évident de trier par distance ici vu qu'on n'a pas forcément d'adresse, et que ça ajouterait un appel supplémentaire au service de géoloc qui ralentirait la recherche.

Téo a validé ce changement (voir https://mattermost.incubateur.net/betagouv/pl/ebhjuomnjt8ff8mjn8mhfpoufe)

Attendre la validation de Nesserine avant de merger pour qu'elle puisse prévenir les agents.

# Solution

C'est assez simple, on change le tri et on ajoute la spec unitaire correspondante.


## Captures d'écran

Avant | Après
:- | -:
<img width="1175" alt="Screenshot 2024-09-10 at 11 19 50" src="https://github.com/user-attachments/assets/905bfe21-4954-4338-86e8-618e0e6ca246"> | <img width="1176" alt="Screenshot 2024-09-10 at 11 20 05" src="https://github.com/user-attachments/assets/d4d915be-70ff-4ce9-b822-7cc7730faf0f">


