### PR TITLE
Suppression des récurrences quotidiennes des données de test

### DIFF
--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe Users::RdvsController, type: :controller do
     context "creneaux available" do
       before do
         # Une plage quotidienne qui commence dans 3 jours, ouvertures de 10h00 à 12h00
-        create(:plage_ouverture, :daily,
+        create(:plage_ouverture, :weekdays,
                first_day: 3.days.from_now,
                start_time: Tod::TimeOfDay.new(10),
                end_time: Tod::TimeOfDay.new(12),

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -14,10 +14,6 @@ FactoryBot.define do
       recurrence { nil }
     end
 
-    trait :daily do
-      recurrence { Montrose.every(:day, starts: first_day) }
-    end
-
     trait :weekly do
       recurrence { Montrose.every(:week, starts: first_day) }
     end

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     trait :weekdays do
       recurrence do
         # Ce format de récurrence correspond à ce qu'on a en base
-        Montrose.every(:week, on: %i[monday tuesday wednesday thursday friday], day: [1, 2, 3, 4, 5], starts: first_day)
+        Montrose.every(:week, on: %i[monday tuesday wednesday thursday friday], day: [1, 2, 3, 4, 5], starts: first_day, interval: 1)
       end
     end
 

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -16,8 +16,11 @@ FactoryBot.define do
       recurrence { nil }
     end
 
-    trait :daily do
-      recurrence { Montrose.every(:day, starts: first_day) }
+    trait :weekdays do
+      recurrence do
+        # Ce format de récurrence correspond à ce qu'on a en base
+        Montrose.every(:week, on: %i[monday tuesday wednesday thursday friday], day: [1, 2, 3, 4, 5], starts: first_day)
+      end
     end
 
     trait :weekly do

--- a/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_creneau_search_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
 
   context "when there are multiple plage d'ouverture and lieux" do
     let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], agent: agent, organisation: organisation) }
-    let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], agent: agent, organisation: organisation) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, :weekdays, motifs: [motif], organisation: organisation) }
 
     it "displays lieux and allow filtering on lieux" do
       visit admin_organisation_creneaux_search_path(organisation)
@@ -33,7 +33,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
 
   context "when there is only one option for lieu, service and motif selector", js: true do
     let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], agent: agent, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], agent: agent, organisation: organisation) }
 
     it "automatically select the option" do
       visit admin_organisation_creneaux_search_path(organisation)
@@ -108,7 +108,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
 
   context "when the motif is bookable online and the next creneau is after the max booking delay" do
     let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, max_public_booking_delay: 7.days, service: agent.services.first) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: 8.days.since, motifs: [motif], organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: 8.days.since, motifs: [motif], organisation: organisation) }
 
     it "still allows the agent to book a rdv, because the booking delays should only apply to agents" do
       visit admin_organisation_creneaux_search_path(organisation)
@@ -123,7 +123,7 @@ RSpec.describe "Agent can create a Rdv with creneau search" do
   end
 
   context "when the motif doesn't require a lieu" do
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Time.zone.today, motifs: [motif], agent: agent, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: Time.zone.today, motifs: [motif], agent: agent, organisation: organisation) }
     let!(:plage_ouverture_without_lieu) { create(:plage_ouverture, motifs: [motif], lieu: nil, organisation: organisation) }
 
     shared_examples "book a rdv without a lieu" do

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
   context "for an other agent calendar" do
     let!(:other_agent) { create(:agent, first_name: "Jane", last_name: "FAROU", service: service, basic_role_in_organisations: [organisation]) }
     let!(:plage_ouverture) do
-      create(:plage_ouverture, :daily, first_day: Time.zone.today.prev_week(:monday), motifs: [motif], lieu: lieu, agent: other_agent, organisation: organisation, title: "Permanence")
+      create(:plage_ouverture, :weekdays, first_day: Time.zone.today.prev_week(:monday), motifs: [motif], lieu: lieu, agent: other_agent, organisation: organisation, title: "Permanence")
     end
 
     it "can crud a plage_ouverture", js: true do

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe "agents can prescribe rdvs" do
 
   before do
     next_month = (now + 1.month).to_date
-    create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_mds], lieu: mds_paris_nord, organisation: org_mds)
-    create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_insertion], lieu: mission_locale_paris_sud, organisation: org_insertion, agent: agent_insertion)
-    create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_insertion], lieu: mission_locale_paris_nord, organisation: org_insertion)
-    create(:plage_ouverture, :daily, first_day: next_month, motifs: [motif_autre_service], lieu: mission_locale_paris_sud, organisation: org_insertion)
+    create(:plage_ouverture, :weekdays, first_day: next_month, motifs: [motif_mds], lieu: mds_paris_nord, organisation: org_mds)
+    create(:plage_ouverture, :weekdays, first_day: next_month, motifs: [motif_insertion], lieu: mission_locale_paris_sud, organisation: org_insertion, agent: agent_insertion)
+    create(:plage_ouverture, :weekdays, first_day: next_month, motifs: [motif_insertion], lieu: mission_locale_paris_nord, organisation: org_insertion)
+    create(:plage_ouverture, :weekdays, first_day: next_month, motifs: [motif_autre_service], lieu: mission_locale_paris_sud, organisation: org_insertion)
     current_agent.reload # needed to populate agent.organisations :/
     agent_insertion.reload
   end

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "User can select a creneau" do
     # Avec un seul motif on passe par le choix d'un lieu.
     # Avec deux motifs, on affiche directement la disponibilité.
     let!(:autre_motif) { create(:motif, organisation: organisation, max_public_booking_delay: 7.days, service: service) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation) }
-    let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [autre_motif], lieu: lieu, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:autre_plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 8.days, motifs: [autre_motif], lieu: lieu, organisation: organisation) }
 
     it "shows that no creneau is available", js: true do
       visit root_path
@@ -46,7 +46,7 @@ RSpec.describe "User can select a creneau" do
 
   context "when there is a full week without any creneaux" do
     let!(:motif) { create(:motif, name: "RSA Orientation", organisation: organisation, restriction_for_rdv: nil, service: service) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: Date.new(2021, 12, 13), motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: Date.new(2021, 12, 13), motifs: [motif], lieu: lieu, organisation: organisation) }
     let!(:absence) do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 12, 20), end_day: Date.new(2021, 12, 27), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(18))
     end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe "User can search for rdvs" do
     let!(:autre_motif) { create(:motif, name: "Consultation", organisation: organisation, restriction_for_rdv: nil, service: service) }
     let!(:motif_autre_service) { create(:motif, :by_phone, name: "Télé consultation", organisation: organisation, restriction_for_rdv: nil, service: create(:service)) }
     let!(:lieu) { create(:lieu, organisation: organisation) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
-    let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [autre_motif], lieu: lieu, organisation: organisation) }
-    let!(:plage_ouverture_autre_service) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif_autre_service], lieu: lieu, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:autre_plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [autre_motif], lieu: lieu, organisation: organisation) }
+    let!(:plage_ouverture_autre_service) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif_autre_service], lieu: lieu, organisation: organisation) }
     let!(:lieu2) { create(:lieu, organisation: organisation) }
-    let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
+    let!(:plage_ouverture2) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
 
     it "default", js: true do
       visit root_path
@@ -214,7 +214,7 @@ RSpec.describe "User can search for rdvs" do
     ## POs
     let!(:plage_ouverture) do
       create(
-        :plage_ouverture, :daily,
+        :plage_ouverture, :weekdays,
         agent: agent, motifs: [motif1], organisation: organisation, first_day: Time.zone.parse("2021-12-15"), lieu: lieu,
         start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(12)
       )
@@ -228,7 +228,7 @@ RSpec.describe "User can search for rdvs" do
     end
     let!(:plage_ouverture3) do
       create(
-        :plage_ouverture, :daily,
+        :plage_ouverture, :weekdays,
         agent: agent, motifs: [motif3], organisation: organisation, first_day: Time.zone.parse("2021-12-15"), lieu: lieu,
         start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(17)
       )
@@ -236,7 +236,7 @@ RSpec.describe "User can search for rdvs" do
     # Available PO for selected motif on other agent
     let!(:plage_ouverture4) do
       create(
-        :plage_ouverture, :daily,
+        :plage_ouverture, :weekdays,
         agent: agent2, motifs: [motif1], organisation: organisation, first_day: Time.zone.parse("2021-12-15"), lieu: lieu,
         start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(15)
       )

--- a/spec/features/users/online_booking/motif_selection_spec.rb
+++ b/spec/features/users/online_booking/motif_selection_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Motif selection" do
     let(:organisation) { create(:organisation) }
     let(:autre_organisation) { create(:organisation, territory: organisation.territory) }
 
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
-    let!(:autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [autre_motif], lieu: autre_lieu, organisation: autre_organisation) }
-    let!(:encore_autre_plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [encore_autre_motif], lieu: encore_autre_lieu, organisation: autre_organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:autre_plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [autre_motif], lieu: autre_lieu, organisation: autre_organisation) }
+    let!(:encore_autre_plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [encore_autre_motif], lieu: encore_autre_lieu, organisation: autre_organisation) }
 
     let(:lieu) { create(:lieu, organisation: organisation, name: "Premier lieu") }
     let(:autre_lieu) { create(:lieu, organisation: autre_organisation, name: "Deuxième lieu") }
@@ -38,7 +38,7 @@ RSpec.describe "Motif selection" do
     let(:service) { create(:service) }
     let(:lieu) { create(:lieu, organisation: organisation, name: "MDS Centre") }
     let!(:motif) { create(:motif, name: "premier contact", organisation: organisation, service: service) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
 
     it "le choix de motif est quand même présenté et on peut revenir depuis l’étape suivante" do
       visit prendre_rdv_path(service_id: service.id, departement: organisation.territory.departement_number)

--- a/spec/features/users/online_booking/sectorisation_with_two_territories_spec.rb
+++ b/spec/features/users/online_booking/sectorisation_with_two_territories_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Prise de rdv avec sectorisations pour deux territoires dans le m
   let!(:lieu_insertion) { create(:lieu, name: "Pole Emploi Valence", organisation: orga_insertion) }
 
   before do
-    create(:plage_ouverture, :daily, first_day: 8.days.from_now, motifs: [motif_social], lieu: lieu_social, organisation: orga_social)
-    create(:plage_ouverture, :daily, first_day: 8.days.from_now, motifs: [motif_insertion], lieu: lieu_insertion, organisation: orga_insertion)
+    create(:plage_ouverture, :weekdays, first_day: 8.days.from_now, motifs: [motif_social], lieu: lieu_social, organisation: orga_social)
+    create(:plage_ouverture, :weekdays, first_day: 8.days.from_now, motifs: [motif_insertion], lieu: lieu_insertion, organisation: orga_insertion)
   end
 
   it "allows two territories in the same departement to use sectorisation and shows the organisations alongside one another", js: true do

--- a/spec/features/users/online_booking/with_invitation_spec.rb
+++ b/spec/features/users/online_booking/with_invitation_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "User can be invited" do
   end
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:lieu2) { create(:lieu, organisation: organisation) }
-  let!(:plage_ouverture) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
-  let!(:plage_ouverture2) { create(:plage_ouverture, :daily, first_day: now + 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
+  let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], lieu: lieu, organisation: organisation) }
+  let!(:plage_ouverture2) { create(:plage_ouverture, :weekdays, first_day: now + 1.month, motifs: [motif], lieu: lieu2, organisation: organisation) }
 
   let!(:organisation2) { create(:organisation) }
 
@@ -110,10 +110,10 @@ RSpec.describe "User can be invited" do
 
     context "when lieux do not have availability" do
       let!(:plage_ouverture) do
-        create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation)
+        create(:plage_ouverture, :weekdays, first_day: now + 8.days, motifs: [motif], lieu: lieu, organisation: organisation)
       end
       let!(:plage_ouverture2) do
-        create(:plage_ouverture, :daily, first_day: now + 8.days, motifs: [motif], lieu: lieu2, organisation: organisation)
+        create(:plage_ouverture, :weekdays, first_day: now + 8.days, motifs: [motif], lieu: lieu2, organisation: organisation)
       end
       let!(:motif) do
         create(

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "User can manage their rdvs" do
     let!(:user) { create(:user, organisations: [organisation]) }
     let!(:motif) { create(:motif, organisation: organisation) }
     let!(:rdv) { create(:rdv, users: [user], agents: [agent1], starts_at: 10.days.from_now, created_by: user, motif: motif, lieu: lieu) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, organisation: organisation, agent: agent2) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], lieu: lieu, organisation: organisation, agent: agent2) }
 
     before do
       stub_netsize_ok

--- a/spec/models/lieu_spec.rb
+++ b/spec/models/lieu_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Lieu, type: :model do
     describe ".for_motif" do
       subject { described_class.for_motif(motif) }
 
-      let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, organisation: organisation) }
+      let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], lieu: lieu, organisation: organisation) }
       let(:bookable_by) { :agents }
 
       before { freeze_time }
@@ -69,14 +69,14 @@ RSpec.describe Lieu, type: :model do
 
       context "with an other plage_ouverture" do
         let!(:lieu2) { create(:lieu) }
-        let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, :weekdays, motifs: [motif], lieu: lieu2) }
 
         it { expect(subject).to contain_exactly(lieu, lieu2) }
       end
 
       context "with a plage_ouverture not yet started" do
         let!(:lieu2) { create(:lieu) }
-        let!(:plage_ouverture2) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu2, first_day: 8.days.from_now) }
+        let!(:plage_ouverture2) { create(:plage_ouverture, :weekdays, motifs: [motif], lieu: lieu2, first_day: 8.days.from_now) }
 
         it { expect(subject).to contain_exactly(lieu, lieu2) }
       end
@@ -114,13 +114,13 @@ RSpec.describe Lieu, type: :model do
 
       context "for a motif individuel" do
         context "motif has current plage ouvertures" do
-          let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu) }
+          let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], lieu: lieu) }
 
           it { is_expected.to include(lieu) }
         end
 
         context "motif has finished plage ouverture" do
-          let!(:plage_ouverture) { create(:plage_ouverture, :daily, motifs: [motif], lieu: lieu, first_day: 2.days.ago, recurrence: nil) }
+          let!(:plage_ouverture) { create(:plage_ouverture, :weekdays, motifs: [motif], lieu: lieu, first_day: 2.days.ago, recurrence: nil) }
 
           it { is_expected.not_to include(lieu) }
         end

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -63,29 +63,6 @@ RSpec.shared_examples_for "recurrence" do
       end
     end
 
-    context "when there is a daily recurrence" do
-      let(:model_instance) { build(model_symbol, :daily, first_day: Date.new(2019, 7, 22)) }
-      let(:date_range) { Date.new(2019, 7, 22)..Date.new(2019, 7, 28) }
-
-      it do
-        expect(subject.size).to eq 7
-        expect(subject[0].starts_at).to eq(model_instance.starts_at)
-        expect(subject[0].ends_at).to eq(model_instance.first_occurrence_ends_at)
-        expect(subject[1].starts_at).to eq(model_instance.starts_at + 1.day)
-        expect(subject[1].ends_at).to eq(model_instance.first_occurrence_ends_at + 1.day)
-        expect(subject[2].starts_at).to eq(model_instance.starts_at + 2.days)
-        expect(subject[2].ends_at).to eq(model_instance.first_occurrence_ends_at + 2.days)
-        expect(subject[3].starts_at).to eq(model_instance.starts_at + 3.days)
-        expect(subject[3].ends_at).to eq(model_instance.first_occurrence_ends_at + 3.days)
-        expect(subject[4].starts_at).to eq(model_instance.starts_at + 4.days)
-        expect(subject[4].ends_at).to eq(model_instance.first_occurrence_ends_at + 4.days)
-        expect(subject[5].starts_at).to eq(model_instance.starts_at + 5.days)
-        expect(subject[5].ends_at).to eq(model_instance.first_occurrence_ends_at + 5.days)
-        expect(subject[6].starts_at).to eq(model_instance.starts_at + 6.days)
-        expect(subject[6].ends_at).to eq(model_instance.first_occurrence_ends_at + 6.days)
-      end
-    end
-
     context "when there is a weekly recurrence" do
       let(:model_instance) { build(model_symbol, :weekly, first_day: Date.new(2019, 7, 22)) }
       let(:date_range) { Date.new(2019, 7, 22)..Date.new(2019, 8, 7) }


### PR DESCRIPTION
# Contexte

Dans le cadre des recherches autour de https://github.com/betagouv/rdv-service-public/pull/4605 avec François, on s'est rendu compte que certaines de nos récurrences en test ne correspondent pas à nos données en production.

Plus précisément, les récurrences de type `:daily` ne sont jamais utilisées dans la réalité, puisque les seuls types de récurrence qu'on propose sont `:weekly` et `:monthly`, comme l'illustre notre formulaire de récurrence : 
<img width="860" alt="Screenshot 2024-09-10 at 09 51 04" src="https://github.com/user-attachments/assets/6d6b13d4-1ab0-4468-85c0-45e210d1064c">

J'ai aussi vérifié sur les données de prod qu'il n'y a pas de récurrence daily qui daterait d'une version plus ancienne du formulaire.

# Solution

On supprime donc les factories pour les récurrences daily, et on remplace leur usage par des récurrence hebdomadaire qui ont lieu les différent jours de la semaine (mais pas le weekend).
Pour toutes les specs concernées, ça permet un remplacement direct.