### PR TITLE
Correction spec erronée et flaky sur CreneauxSearch::ForAgent

### DIFF
--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
       let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif, motif_with_lieu], first_day: Date.new(2022, 10, 20), lieu: lieu, organisation: organisation) }
 
       it "give the good results with no conflict" do
-        expect(described_class.new(form).build_result.creneaux.first.starts_at).to eq(Time.zone.local(2022, 10, 25, 8, 0, 0))
+        # on utilise volontairement pas .first ici car les créneaux retournés ne sont pas triés
+        expect(described_class.new(form).build_result.creneaux.min_by(&:starts_at).starts_at).to eq(Time.zone.local(2022, 10, 20, 8, 0, 0))
       end
     end
   end


### PR DESCRIPTION
Cette PR fait suite à #4615

# Contexte

Il y a une flaky spec sur `spec/services/creneaux_search/for_agent_spec.rb` cf ce [run de GH Action](https://github.com/betagouv/rdv-service-public/actions/runs/10768721964/job/29858400832)

Après discussion avec Victor ici https://github.com/betagouv/rdv-service-public/commit/c79664daa0db34762667ddc6228898ff781d74ad#r146417161 on a compris que : 

- la spec est mal écrite et attend le mauvais résultat
- ce résultat erronné se produit souvent à cause de l’ordre non déterministe de retour des plages d’ouvertures de la db

# Solution

Dans cette PR je tente de corriger le problème d’une nouvelle manière suite aux retours de Victor : je corrige uniquement la spec.