### PR TITLE
Corriger la faute de frappe ".@" dans les adresses mail des usagers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,7 @@ class User < ApplicationRecord
   validates :number_of_children, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   validate :birth_date_validity
+  validate :email_looks_valid
 
   # Hooks
   before_save :set_email_to_null_if_blank
@@ -263,6 +264,12 @@ class User < ApplicationRecord
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
     errors.add(:birth_date, "est invalide")
+  end
+
+  def email_looks_valid
+    if email.to_s.include?(".@")
+      errors.add(:email, %(ne peut contenir ".@"))
+    end
   end
 
   def do_soft_delete(organisation)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,6 @@ class User < ApplicationRecord
   validates :number_of_children, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
   validate :birth_date_validity
-  validate :email_looks_valid
 
   # Hooks
   before_save :set_email_to_null_if_blank
@@ -84,6 +83,11 @@ class User < ApplicationRecord
 
   def to_s
     full_name
+  end
+
+  def email=(value)
+    # On corriger automatiquement cette faute de frappe courante
+    super(value&.gsub(".@", "@"))
   end
 
   def add_organisation(organisation)
@@ -264,12 +268,6 @@ class User < ApplicationRecord
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
     errors.add(:birth_date, "est invalide")
-  end
-
-  def email_looks_valid
-    if email.to_s.include?(".@")
-      errors.add(:email, :dot_at)
-    end
   end
 
   def do_soft_delete(organisation)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -268,7 +268,7 @@ class User < ApplicationRecord
 
   def email_looks_valid
     if email.to_s.include?(".@")
-      errors.add(:email, %(ne peut contenir ".@"))
+      errors.add(:email, :dot_at)
     end
   end
 

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -48,6 +48,9 @@ fr:
               franceconnect_frozen_field_cannot_change: Le nom de naissance ne peut-être changé car il a été certifié par FranceConnect
             birth_date:
               franceconnect_frozen_field_cannot_change: La date de naissance ne peut-être changée car elle a été certifiée par FranceConnect
+            email:
+              format: "%{message}"
+              dot_ata: "Attention, vous avez mis un point avant le @ dans l'adresse email."
             password:
               format: "%{message}"
               too_common: "Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés et ne permet donc pas d'assurer la sécurité de votre compte. Veuillez en choisir un autre."

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -48,9 +48,6 @@ fr:
               franceconnect_frozen_field_cannot_change: Le nom de naissance ne peut-être changé car il a été certifié par FranceConnect
             birth_date:
               franceconnect_frozen_field_cannot_change: La date de naissance ne peut-être changée car elle a été certifiée par FranceConnect
-            email:
-              format: "%{message}"
-              dot_ata: "Attention, vous avez mis un point avant le @ dans l'adresse email."
             password:
               format: "%{message}"
               too_common: "Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés et ne permet donc pas d'assurer la sécurité de votre compte. Veuillez en choisir un autre."

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,10 @@
 RSpec.describe User, type: :model do
+  describe "#email=" do
+    it %(automatically fixes ".@" typo) do
+      expect(described_class.new(email: "francis.@exemple.fr").email).to eq("francis@exemple.fr")
+    end
+  end
+
   describe "#add_organisation" do
     subject do
       user.add_organisation(organisation)


### PR DESCRIPTION
Closes #4317

# Edit du 27 septembre

J'ai tenté de lancer le script de correction ci-dessous, mais il se trouve qu'il existait déjà des User qui avaient la version sans erreur de l'email. J'ai choisi dans ce cas de mettre l'email en `.@` à NULL, puisque de toute façon il est inopérant et nous remonte des erreurs. 

Voici ce que j'ai lancé : 

```
User.where("email LIKE '%.@%'").each do |user|
  new_email = user.email.gsub(".@", "@")
  if User.find_by(email: new_email)
    user.update_columns(email: nil)
  else
    user.update_columns(email: new_email)
  end
end
```

# Edit du 11 sept 2024

Finalement cette PR corrige silencieusement la faute de frappe plutôt que d'ajouter une validation. Victor donne de bons arguments en faveur de ce comportement ici : https://github.com/betagouv/rdv-service-public/pull/4621#discussion_r1754019695

------------

Tout le contexte est dans l'issue. 

On a actuellement 25 cas en base (`User.where("email LIKE '%.@%'").count => 25`). Ces usagers seront corrigés en lançant ce petit script en console : 

```ruby
User.where("email LIKE '%.@%'").each do |user|
  user.update_columns(email: user.email.gsub(".@", "@"))
end
```

Côté implémentation, une validation sur le modèle permet de s'assurer que toutes les interfaces de création d'usager sont bien validées (voir screenshots).

Prochaine PR : détecter les emails qui ont des fautes de frappes flagrantes, voir #3406 ! :ok_hand: 

# Côté agent

![image](https://github.com/user-attachments/assets/6bfc453f-9287-4aa8-aff0-c03e3576650d)

# Côté usager

![image](https://github.com/user-attachments/assets/9b2e12e6-f966-4f03-ba07-1aac341f5f8a)
 