### PR TITLE
Harmoniser les récurrences de test avec celles des données de prod

### DIFF
--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
       let!(:plage_ouverture) do
         create(
           :plage_ouverture,
-          :weekly,
+          :weekly_on_monday,
           first_day: Date.new(2020, 11, 16),
           start_time: Tod::TimeOfDay(9),
           end_time: Tod::TimeOfDay(12),

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -14,8 +14,12 @@ FactoryBot.define do
       recurrence { nil }
     end
 
-    trait :weekly do
+    trait :weekly_on_monday do
       recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1) }
+    end
+
+    trait :once_a_week do
+      recurrence { Montrose.every(:week, starts: first_day, interval: 1) }
     end
 
     trait :monthly do

--- a/spec/factories/absence.rb
+++ b/spec/factories/absence.rb
@@ -15,15 +15,17 @@ FactoryBot.define do
     end
 
     trait :weekly do
-      recurrence { Montrose.every(:week, starts: first_day) }
+      recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1) }
     end
 
     trait :monthly do
-      recurrence { Montrose.every(:month, starts: first_day) }
+      # first_day.wday est le jour dans la semaine (par exemple 3 pour le mercredi)
+      # first_day.mday/2 est le numéro de la semaine (par exemple la 2ème semaine du mois)
+      recurrence { Montrose.every(:month, starts: first_day, day: { first_day.wday => [first_day.mday / 7] }, interval: 1) }
     end
 
     trait :every_two_weeks do
-      recurrence { Montrose.every(:week, interval: 2, starts: first_day) }
+      recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 2) }
     end
   end
 end

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -30,11 +30,11 @@ FactoryBot.define do
     trait :monthly do
       # first_day.wday est le jour dans la semaine (par exemple 3 pour le mercredi)
       # first_day.mday/2 est le numéro de la semaine (par exemple la 2ème semaine du mois)
-      recurrence { Montrose.every(:month, starts: first_day,  day: { first_day.wday => [first_day.mday / 7] }, interval: 1) }
+      recurrence { Montrose.every(:month, starts: first_day, day: { first_day.wday => [first_day.mday / 7] }, interval: 1) }
     end
 
     trait :every_two_weeks do
-      recurrence { Montrose.every(:week, interval: 2, starts: first_day) }
+      recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 2) }
     end
 
     after(:build) do |plage_ouverture|

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     trait :weekdays do
       recurrence do
         # Ce format de récurrence correspond à ce qu'on a en base
-        Montrose.every(:week, on: %i[monday tuesday wednesday thursday friday], day: [1, 2, 3, 4, 5], starts: first_day, interval: 1)
+        Montrose.every(:week, on: %i[monday tuesday wednesday thursday friday], starts: first_day, interval: 1)
       end
     end
 
@@ -28,7 +28,9 @@ FactoryBot.define do
     end
 
     trait :monthly do
-      recurrence { Montrose.every(:month, starts: first_day) }
+      # first_day.wday est le jour dans la semaine (par exemple 3 pour le mercredi)
+      # first_day.mday/2 est le numéro de la semaine (par exemple la 2ème semaine du mois)
+      recurrence { Montrose.every(:month, starts: first_day,  day: { first_day.wday => [first_day.mday / 7] }, interval: 1) }
     end
 
     trait :every_two_weeks do

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     trait :weekly do
-      recurrence { Montrose.every(:week, on: [:monday], starts: first_day) }
+      recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1) }
     end
 
     trait :monthly do

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -23,11 +23,11 @@ FactoryBot.define do
       end
     end
 
-    trait :weekly do
+    trait :weekly_on_monday do
       recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1) }
     end
 
-    trait :weekly_without_any_day do
+    trait :once_a_week do
       recurrence { Montrose.every(:week, starts: first_day, interval: 1, until: 2.months.from_now) }
     end
 

--- a/spec/factories/plage_ouverture.rb
+++ b/spec/factories/plage_ouverture.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       recurrence { Montrose.every(:week, on: [:monday], starts: first_day, interval: 1) }
     end
 
+    trait :weekly_without_any_day do
+      recurrence { Montrose.every(:week, starts: first_day, interval: 1, until: 2.months.from_now) }
+    end
+
     trait :monthly do
       # first_day.wday est le jour dans la semaine (par exemple 3 pour le mercredi)
       # first_day.mday/2 est le numéro de la semaine (par exemple la 2ème semaine du mois)

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
     # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
     recurrence_attributes_from_factory = build(:plage_ouverture, :weekly).recurrence.to_hash.keys
 
-    expect(recurrence_attributes_from_factory + [:until]).to eq(plage_ouverture.recurrence.to_hash.keys)
+    expect(recurrence_attributes_from_factory + [:until]).to match_array(plage_ouverture.recurrence.to_hash.keys)
 
     # reload page to check if form is filled correctly
     visit edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
       starts: Time.zone.local(2019, 12, 3)
     )
 
+    # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
+    recurrence_attributes_from_factory = build(:plage_ouverture, :weekly).recurrence.to_hash.keys
+
+    expect(recurrence_attributes_from_factory + [:until]).to eq(plage_ouverture.recurrence.to_hash.keys)
+
     # reload page to check if form is filled correctly
     visit edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
     expect_checked("recurrence_has_recurrence")

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
     expect(plage_ouverture.recurrence_ends_at.to_date).to eq Date.new(2019, 12, 30)
 
     # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
-    recurrence_attributes_from_factory = build(:plage_ouverture, :weekly).recurrence.to_hash.keys
+    recurrence_attributes_from_factory = build(:plage_ouverture, :weekly_on_monday).recurrence.to_hash.keys
 
     expect(recurrence_attributes_from_factory + [:until]).to match_array(plage_ouverture.recurrence.to_hash.keys)
 
@@ -78,7 +78,7 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
     )
 
     # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
-    recurrence_attributes_from_factory = build(:plage_ouverture, :weekly_without_any_day).recurrence.to_hash
+    recurrence_attributes_from_factory = build(:plage_ouverture, :once_a_week).recurrence.to_hash
 
     expect(recurrence_attributes_from_factory.keys).to match_array(plage_ouverture.recurrence.to_hash.keys)
 

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -77,6 +77,11 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
       starts: Time.zone.local(2019, 12, 11)
     )
 
+    # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
+    recurrence_attributes_from_factory = build(:plage_ouverture, :monthly).recurrence.to_hash.keys
+
+    expect(recurrence_attributes_from_factory + [:until]).to match_array(plage_ouverture.recurrence.to_hash.keys)
+
     # reload page to check if form is filled correctly
     visit edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
     expect_checked("recurrence_has_recurrence")

--- a/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
+++ b/spec/features/agents/agent_can_manage_recurrence_on_plage_ouverture_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
       until: Time.zone.local(2019, 12, 30),
       starts: Time.zone.local(2019, 12, 3)
     )
+    expect(plage_ouverture.recurrence_ends_at.to_date).to eq Date.new(2019, 12, 30)
 
     # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
     recurrence_attributes_from_factory = build(:plage_ouverture, :weekly).recurrence.to_hash.keys
@@ -57,6 +58,29 @@ RSpec.describe "Agent can manage recurrence on plage d'ouverture" do
     expect(page).to have_field("recurrence-until")
     # expect(page).to have_field("recurrence-until", with: "30/12/2019")
     # TODO Pourquoi le champs ne contient pas la valeur ici. Quand on le fait à la main, tout va bien.
+
+    visit edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
+    uncheck("recurrence_on_monday")
+    uncheck("recurrence_on_tuesday")
+    uncheck("recurrence_on_wednesday")
+    uncheck("recurrence_on_thursday")
+    uncheck("recurrence_on_friday")
+    uncheck("recurrence_on_saturday")
+
+    click_button("Enregistrer")
+
+    # check if everything is ok in db
+    expect(plage_ouverture.reload.recurrence.to_hash).to eq(
+      every: :week,
+      interval: 1,
+      until: Time.zone.local(2019, 12, 30),
+      starts: Time.zone.local(2019, 12, 3)
+    )
+
+    # On vérifie au passage que les données qu'on crée dans nos factories correspondent bien à ce que l'application peut créer
+    recurrence_attributes_from_factory = build(:plage_ouverture, :weekly_without_any_day).recurrence.to_hash
+
+    expect(recurrence_attributes_from_factory.keys).to match_array(plage_ouverture.recurrence.to_hash.keys)
 
     visit edit_admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture)
     select("mois", from: "recurrence_every")

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Absence, type: :model do
       end
 
       context "if the abence has many occurrences in range" do
-        let(:absence) { build(:absence, :weekly, first_day: Date.new(2019, 7, 20), end_day: Date.new(2019, 7, 23)) }
-        let(:date_range) { Date.new(2019, 7, 29)..Date.new(2019, 8, 4) }
+        let(:absence) { build(:absence, :weekly, first_day: Date.new(2019, 7, 22)) }
+        let(:date_range) { Date.new(2019, 7, 29)..Date.new(2019, 8, 11) }
 
         it do
           expect(subject.size).to eq 2

--- a/spec/models/absence_spec.rb
+++ b/spec/models/absence_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Absence, type: :model do
 
   describe "no reccurence for absence for several days" do
     it "invalid with recurrence and absence on more than one day" do
-      expect(build(:absence, :weekly, first_day: Date.new(2019, 7, 20), end_day: Date.new(2019, 7, 23))).to be_invalid
+      expect(build(:absence, :once_a_week, first_day: Date.new(2019, 7, 20), end_day: Date.new(2019, 7, 23))).to be_invalid
     end
 
     it "valid without recurrence and absence on more than one day" do
@@ -33,18 +33,18 @@ RSpec.describe Absence, type: :model do
         expect(subject.first.starts_at).to eq absence.starts_at
         expect(subject.first.ends_at).to eq absence.first_occurrence_ends_at
       end
+    end
 
-      context "if the abence has many occurrences in range" do
-        let(:absence) { build(:absence, :weekly, first_day: Date.new(2019, 7, 22)) }
-        let(:date_range) { Date.new(2019, 7, 29)..Date.new(2019, 8, 11) }
+    context "if the abence has many occurrences in range" do
+      let(:absence) { create(:absence, :once_a_week, first_day: Date.new(2019, 7, 22)) }
+      let(:date_range) { Date.new(2019, 7, 29)..Date.new(2019, 8, 11) }
 
-        it do
-          expect(subject.size).to eq 2
-          expect(subject.first.starts_at).to eq(absence.starts_at + 1.week) # first one ends in range
-          expect(subject.first.ends_at).to eq(absence.first_occurrence_ends_at + 1.week) # first one ends in range
-          expect(subject.second.starts_at).to eq(absence.starts_at + 2.weeks) # second one starts in range
-          expect(subject.second.ends_at).to eq(absence.first_occurrence_ends_at + 2.weeks) # second one starts in range
-        end
+      it do
+        expect(subject.size).to eq 2
+        expect(subject.first.starts_at).to eq(absence.starts_at + 1.week) # first one ends in range
+        expect(subject.first.ends_at).to eq(absence.first_occurrence_ends_at + 1.week) # first one ends in range
+        expect(subject.second.starts_at).to eq(absence.starts_at + 2.weeks) # second one starts in range
+        expect(subject.second.ends_at).to eq(absence.first_occurrence_ends_at + 2.weeks) # second one starts in range
       end
     end
   end

--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
 
     let(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
     let(:lieu1) { create(:lieu, organisation: organisation) }
-    let!(:plage_ouverture) { create(:plage_ouverture, :weekly, agent: agent1, motifs: [motif], lieu: lieu1, organisation: organisation) }
+    let!(:plage_ouverture) { create(:plage_ouverture, :weekly_on_monday, agent: agent1, motifs: [motif], lieu: lieu1, organisation: organisation) }
 
     let(:lieux) { [] }
     let(:agents) { [] }
@@ -67,7 +67,7 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
     context "when there are several plages for the motif" do
       let(:lieu2) { create(:lieu, organisation: organisation) }
       let(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }
-      let!(:plage_ouverture2) { create(:plage_ouverture, :weekly, agent: agent2, lieu: lieu2, motifs: [motif], organisation: organisation) }
+      let!(:plage_ouverture2) { create(:plage_ouverture, :weekly_on_monday, agent: agent2, lieu: lieu2, motifs: [motif], organisation: organisation) }
 
       context "when the lieu is unspecified" do
         it { is_expected.to contain_exactly(lieu1, lieu2) }

--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
     let(:lieu2) { create(:lieu, organisation: organisation, name: "MDS Arquest") }
 
     before do
-      create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu2, organisation: organisation, first_day: 2.weeks.from_now)
-      create(:plage_ouverture, :weekly, agent: agent, motifs: [motif], lieu: lieu1, organisation: organisation, first_day: 1.week.from_now, recurrence_ends_at: 13.days.from_now)
+      create(:plage_ouverture, :weekly_on_monday, agent: agent, motifs: [motif], lieu: lieu2, organisation: organisation, first_day: 2.weeks.from_now)
+      create(:plage_ouverture, :weekly_on_monday, agent: agent, motifs: [motif], lieu: lieu1, organisation: organisation, first_day: 1.week.from_now, recurrence_ends_at: 13.days.from_now)
     end
 
     it "sorts the results by the date of the next availability" do

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -64,7 +64,7 @@ RSpec.shared_examples_for "recurrence" do
     end
 
     context "when there is a weekly recurrence" do
-      let(:model_instance) { build(model_symbol, :weekly, first_day: Date.new(2019, 7, 22)) }
+      let(:model_instance) { build(model_symbol, :weekly_on_monday, first_day: Date.new(2019, 7, 22)) }
       let(:date_range) { Date.new(2019, 7, 22)..Date.new(2019, 8, 7) }
 
       it do


### PR DESCRIPTION
# Contexte

Dans la suite de https://github.com/betagouv/rdv-service-public/pull/4619, cette PR met à jour les factories de Plage Ouverture et d'absence pour que le format des données de test corresponde mieux à ce qu'on a en prod

# Solution

## Test driven factory

J'ajoute des expect dans la spec d'intégration de création de plage d'ouverture récurrence, ce qui a permet de test driver [cette excellente suggestion de François dans la PR précédente](https://github.com/betagouv/rdv-service-public/pull/4619#discussion_r1751607249), et ensuite j'harmonise le format des factories au sein du fichier.

## Est-ce qu'il manque une validation ?

Ce bout de logique n'empêche pas que les absences et plages d'ouvertures créées en passant explicitement une récurrence depuis le fichier de spec peuvent avoir des récurrences au mauvais format. Ça pourrait se contourner en ajoutant une véritable validation de format sur la récurrence dans les modèles, mais j'ai pas encore assez de recul pour savoir si c'est vraiment une bonne idée.