### PR TITLE
générisation de la capture des exceptions Sentry depuis les jobs

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -11,6 +11,7 @@ module DefaultJobBehaviour
     # Exponential backoff is n^4, so wait times between retries will be as follows:
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
+    # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8
     # it therefore takes more than 8 days for a job to be discarded
     retry_on(StandardError, wait: :exponentially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
 
@@ -30,5 +31,17 @@ module DefaultJobBehaviour
 
   def set_sentry_context
     Sentry.set_context(:rdv_job, queue_name:, job_link:)
+  end
+
+  # cette méthode est appelée depuis config/initializers/sentry_job_retries_subscriber.rb
+  # et depuis les discard_on custom dans les jobs
+  def capture_sentry_exception(exception, level: :error)
+    # adapted from https://github.com/getsentry/sentry-ruby/blob/master/sentry-rails/lib/sentry/rails/active_job.rb#L47-L54
+    Sentry.capture_exception(
+      exception,
+      extra: Sentry::Rails::ActiveJobExtensions::SentryReporter.sentry_context(self),
+      level:,
+      tags: { job_id:, provider_job_id: }
+    )
   end
 end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -11,7 +11,7 @@ module DefaultJobBehaviour
     # Exponential backoff is n^4, so wait times between retries will be as follows:
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
-    # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8
+    # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8 hours
     # it therefore takes more than 8 days for a job to be discarded
     retry_on(StandardError, wait: :exponentially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
 
@@ -36,13 +36,13 @@ module DefaultJobBehaviour
       job_id:,
       job_link:,
       queue_name:,
-      scheduled_at: scheduled_at,
+      scheduled_at:,
     }
 
     if self.class.log_arguments
       context[:arguments] = Sentry::Rails::ActiveJobExtensions::SentryReporter.sentry_serialize_arguments(arguments)
     end
 
-    Sentry.set_context "job", context
+    Sentry.set_context :job, context
   end
 end

--- a/app/jobs/fail_on_purpose_job.rb
+++ b/app/jobs/fail_on_purpose_job.rb
@@ -5,7 +5,7 @@ class FailOnPurposeJob < ApplicationJob
 
   # retry_on(StandardError, wait: 20.seconds, attempts: 3, priority: DefaultJobBehaviour::PRIORITY_OF_RETRIES)
 
-  # discard_on(FailOnPurposeError) { |job, error| job.capture_sentry_exception(error) }
+  # discard_on(FailOnPurposeError) { |_job, error| Sentry.capture_exception(error) }
 
   def perform(message: "This error was raised on purpose")
     Sentry.get_current_scope.set_fingerprint(["FailOnPurposeError", message])

--- a/app/jobs/fail_on_purpose_job.rb
+++ b/app/jobs/fail_on_purpose_job.rb
@@ -3,6 +3,10 @@ class FailOnPurposeError < StandardError; end
 class FailOnPurposeJob < ApplicationJob
   # self.log_arguments = false
 
+  # retry_on(StandardError, wait: 20.seconds, attempts: 3, priority: DefaultJobBehaviour::PRIORITY_OF_RETRIES)
+
+  # discard_on(FailOnPurposeError) { |job, error| job.capture_sentry_exception(error) }
+
   def perform(message: "This error was raised on purpose")
     Sentry.get_current_scope.set_fingerprint(["FailOnPurposeError", message])
     raise FailOnPurposeError, message

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -4,7 +4,7 @@ class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
   queue_as :webhook
-  discard_on(ActiveRecord::RecordNotFound) { |job, error| job.capture_sentry_exception(error) }
+  discard_on(ActiveRecord::RecordNotFound) { |_job, error| Sentry.capture_exception(error) }
 
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -4,7 +4,7 @@ class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
   queue_as :webhook
-  discard_on(ActiveRecord::RecordNotFound) { |_job, error| Sentry.capture_exception(error) }
+  discard_on(ActiveRecord::RecordNotFound) { |job, error| job.capture_sentry_exception(error) }
 
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -27,9 +27,6 @@ Sentry.init do |config|
       return if hint[:exception].is_a?(ActiveRecord::RecordNotFound) && redirected_from_sign_in
     end
 
-    # prevent logging sensitive jobs arguments
-    event.extra&.delete(:arguments) unless event.extra&.dig(:active_job)&.constantize&.log_arguments
-
     event
   rescue StandardError
     event.set_tags(error_in_before_send_callback: true)

--- a/config/initializers/sentry_job_retries_subscriber.rb
+++ b/config/initializers/sentry_job_retries_subscriber.rb
@@ -6,14 +6,5 @@ ActiveSupport::Notifications.subscribe("enqueue_retry.active_job") do |_name, _s
 
   next if !exception || !job.capture_sentry_warning_for_retry?(exception)
 
-  # adapted from https://github.com/getsentry/sentry-ruby/blob/master/sentry-rails/lib/sentry/rails/active_job.rb#L47-L54
-  Sentry.capture_exception(
-    exception,
-    extra: Sentry::Rails::ActiveJobExtensions::SentryReporter.sentry_context(job),
-    level: :warning,
-    tags: {
-      job_id: job.job_id,
-      provider_job_id: job.provider_job_id,
-    }
-  )
+  job.capture_sentry_exception(exception, level: :warning)
 end

--- a/config/initializers/sentry_job_retries_subscriber.rb
+++ b/config/initializers/sentry_job_retries_subscriber.rb
@@ -6,5 +6,5 @@ ActiveSupport::Notifications.subscribe("enqueue_retry.active_job") do |_name, _s
 
   next if !exception || !job.capture_sentry_warning_for_retry?(exception)
 
-  job.capture_sentry_exception(exception, level: :warning)
+  Sentry.capture_exception(exception, level: :warning)
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe ApplicationJob, type: :job do
       expect { perform_enqueued_jobs }.to change(sentry_events, :size).by(1)
 
       expect(sentry_events.last.level).to eq(:warning)
-      expect(sentry_events.last.extra[:job_id]).to eq(enqueued_job_id)
-      expect(sentry_events.last.extra[:arguments]).to eq([123, { _some_kw_arg: 456 }])
-      expect(sentry_events.last.contexts[:rdv_job][:queue_name]).to eq("custom_queue")
-      expect(sentry_events.last.contexts[:rdv_job][:job_link]).to match("/super_admins/good_job/jobs/#{enqueued_job_id}")
+      expect(sentry_events.last.contexts[:job][:job_id]).to eq(enqueued_job_id)
+      expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { _some_kw_arg: 456 }])
+      expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
+      expect(sentry_events.last.contexts[:job][:job_link]).to match("/super_admins/good_job/jobs/#{enqueued_job_id}")
 
       expect(sentry_events.last.exception.values.first.value).to match("Something unexpected happened (RuntimeError)")
       expect(sentry_events.last.exception.values.first.type).to eq("RuntimeError")


### PR DESCRIPTION
# Contexte

Cette PR est extraite de #4626 
Elle contient des refactos, commentaires et petites améliorations que j’ai crue nécessaires pour corriger les events sentry décrits dans cette PR 4626 mais qui ne l’étaient en fait pas.

# Solution

Je rajoute des commentaires pour : 
- montrer comment calculer le délai total du dernier retry
- montrer comment tester des options avancées de retry AJ dans `FailOnPurposeJob`

J’ai aussi déplacé la logique permettant de ne pas envoyer les arguments des jobs à Sentry sur les classes sensibles depuis un hook compliqué dans la config sentry vers le `DefaultJobBehaviour#set_sentry_context`. 

Pour ça, j’ai simplifié l’approche : jusqu’ici je tentais de reproduire au plus fidèlement ce que fait `sentry-rails` pour les jobs ActiveJob cf https://github.com/getsentry/sentry-ruby/blob/master/sentry-rails/lib/sentry/rails/active_job.rb#L47-L54 : 

```rb
Sentry::Rails.capture_exception(
                  e,
                  extra: sentry_context(job),
                  tags: {
                    job_id: job.job_id,
                    provider_job_id: job.provider_job_id
                  }
                )
```

Jusqu’ici ce qu’on faisait était un peu compliqué pour reproduire ça à l’identique en appelant `sentry_context` depuis notre logique de retry. Les tags étaient quant à eux aussi reproduits manuellement dans cet appel depuis les retries.

Il n’y a en fait pas beaucoup d’intérêt à faire ça, il n’y a rien de magique ni de très utile dans ce `sentry_context` ni dans les tags. 
De plus le champ `extra` est déprécié.

Dans cette PR j’ai donc simplement reporté dans notre méthode `DefaultJobBehaviour#set_sentry_context` tout le contexte qu’on veut voir apparaître dans Sentry.
Je continue à déléguer la sérialisation des paramètres à `Sentry::Rails` néanmoins.

Après cette simplification on peut donc appeler `Sentry.capture_exception(exception, level:)` à notre guise depuis le retry subscriber aussi bien que depuis des `discard_on` spécifique dans certains jobs. 
Le contexte sera rempli correctement.

Il n’y a pour l’instant qu’un job qui fait appel custom à discard_on : celui des webhooks. 
C’est à mon avis appelé à être plus utilisé à l’avenir.

## Tests en local

J’ai bien testé le comportement grace au FailOnPurposeJob :
- retries, warning et error
- discard_on
- log_arguments

