### PR TITLE
Visioplainte : index des rdvs

### DIFF
--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,13 +1,18 @@
 class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
-  def index
+  def index # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
+    if params[:ids].blank? && (params[:from].blank? || params[:to].blank?)
+      errors = ["Vous devez préciser le paramètre ids ou les paramètres from et to"]
+      render(json: { errors: errors }, status: :bad_request) and return
+    end
+
     rdvs = authorized_rdv_scope
+
     if params[:ids].present?
       rdvs = rdvs.where(id: params[:ids])
-    elsif params[:from].present? && params[:to].present?
+    end
+
+    if params[:from].present? && params[:to].present?
       rdvs = rdvs.where("starts_at >= ?", Time.zone.parse(params[:from])).where("starts_at <= ?", Time.zone.parse(params[:to]))
-    else
-      errors = ["Vous devez précisez le paramètre ids ou les paramètres from et to"]
-      render(json: { errors: errors }, status: :bad_request) and return
     end
 
     if params[:guichet_ids]

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,4 +1,9 @@
 class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
+  def index
+    rdvs = authorized_rdv_scope
+    render json: Visioplainte::RdvBlueprint.render(rdvs, root: :rdvs)
+  end
+
   def create
     creneau = CreneauxSearch::ForUser.creneau_for(
       starts_at: Time.zone.parse(params[:starts_at]),
@@ -60,8 +65,11 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   private
 
   def find_rdv
+    authorized_rdv_scope.find_by(id: params[:id])
+  end
+
+  def authorized_rdv_scope
     Rdv.joins(organisation: :territory).where(territories: { name: Territory::VISIOPLAINTE_NAME })
-      .find_by(id: params[:id])
   end
 
   def motif

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -47,7 +47,7 @@ namespace :api do
         get :prochain
       end
     end
-    resources :rdvs, only: %i[create destroy] do
+    resources :rdvs, only: %i[create destroy index] do
       member do
         put :cancel
       end

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -116,4 +116,21 @@ RSpec.describe "Visioplainte Rdvs" do
       end
     end
   end
+
+  describe "#index" do
+    subject(:get_index) do
+      get "/api/visioplainte/rdvs/", headers: auth_header
+    end
+
+    before do
+      create_rdv
+    end
+
+    it "returns the list of rdvs" do
+      get_index
+      expect(response.status).to eq 200
+
+      expect(response.parsed_body["rdvs"][0]["starts_at"]).to eq "2024-08-19 08:00:00 +0200"
+    end
+  end
 end

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -119,18 +119,76 @@ RSpec.describe "Visioplainte Rdvs" do
 
   describe "#index" do
     subject(:get_index) do
-      get "/api/visioplainte/rdvs/", headers: auth_header
+      get "/api/visioplainte/rdvs/", params: { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }, headers: auth_header
     end
 
-    before do
-      create_rdv
-    end
+    before { create_rdv }
 
     it "returns the list of rdvs" do
       get_index
       expect(response.status).to eq 200
 
       expect(response.parsed_body["rdvs"][0]["starts_at"]).to eq "2024-08-19 08:00:00 +0200"
+    end
+
+    context "when there are no rdvs for the from and to params" do
+      subject(:get_index) do
+        get "/api/visioplainte/rdvs/", params: { from: "2024-08-22T08:00:00+02:00", to: "2024-08-23T08:00:00+02:00" }, headers: auth_header
+      end
+
+      it "returns an empty list" do
+        get_index
+        expect(response.status).to eq 200
+
+        expect(response.parsed_body["rdvs"]).to be_empty
+      end
+    end
+
+    context "when asking for specific rdv ids" do
+      subject(:get_index) do
+        get "/api/visioplainte/rdvs/", params: { ids: [Rdv.last.id] }, headers: auth_header
+      end
+
+      it "returns the rdvs" do
+        get_index
+        expect(response.status).to eq 200
+
+        expect(response.parsed_body["rdvs"][0]["id"]).to eq Rdv.last.id
+      end
+
+      it "doesn't allow getting a rdv that belongs to another territory" do
+        rdv = create(:rdv)
+        get "/api/visioplainte/rdvs/", params: { ids: [rdv.id] }, headers: auth_header
+
+        expect(response.parsed_body["rdvs"]).to be_empty
+      end
+    end
+
+    context "when filtering by guichet" do
+      let(:date_params) do
+        { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }
+      end
+
+      let(:gendarmerie_guichet_ids) do
+        get "/api/visioplainte/guichets", params: { service: "Gendarmerie" }, headers: auth_header
+        response.parsed_body["guichets"].map { |guichet| guichet["id"] } # rubocop:disable Rails/Pluck
+      end
+
+      it "returns only the rdvs of the given guichets" do
+        # Le rdv créé est pour la police, donc un appel sur les guichets de la gendarmerie renvoie une liste vide
+        get "/api/visioplainte/rdvs/", params: { guichet_ids: gendarmerie_guichet_ids }.merge(date_params), headers: auth_header
+
+        expect(response.parsed_body["rdvs"]).to be_empty
+      end
+    end
+
+    context "without from, to or ids params" do
+      it "returns an error" do
+        get "/api/visioplainte/rdvs/", params: {}, headers: auth_header
+
+        expect(response.status).to eq 400
+        expect(response.parsed_body["errors"].first).to eq "Vous devez précisez le paramètre ids ou les paramètres from et to"
+      end
     end
   end
 end

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -118,26 +118,18 @@ RSpec.describe "Visioplainte Rdvs" do
   end
 
   describe "#index" do
-    subject(:get_index) do
-      get "/api/visioplainte/rdvs/", params: { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }, headers: auth_header
-    end
-
     before { create_rdv }
 
     it "returns the list of rdvs" do
-      get_index
+      get "/api/visioplainte/rdvs/", params: { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }, headers: auth_header
       expect(response.status).to eq 200
 
       expect(response.parsed_body["rdvs"][0]["starts_at"]).to eq "2024-08-19 08:00:00 +0200"
     end
 
     context "when there are no rdvs for the from and to params" do
-      subject(:get_index) do
-        get "/api/visioplainte/rdvs/", params: { from: "2024-08-22T08:00:00+02:00", to: "2024-08-23T08:00:00+02:00" }, headers: auth_header
-      end
-
       it "returns an empty list" do
-        get_index
+        get "/api/visioplainte/rdvs/", params: { from: "2024-08-22T08:00:00+02:00", to: "2024-08-23T08:00:00+02:00" }, headers: auth_header
         expect(response.status).to eq 200
 
         expect(response.parsed_body["rdvs"]).to be_empty
@@ -145,12 +137,8 @@ RSpec.describe "Visioplainte Rdvs" do
     end
 
     context "when asking for specific rdv ids" do
-      subject(:get_index) do
-        get "/api/visioplainte/rdvs/", params: { ids: [Rdv.last.id] }, headers: auth_header
-      end
-
       it "returns the rdvs" do
-        get_index
+        get "/api/visioplainte/rdvs/", params: { ids: [Rdv.last.id] }, headers: auth_header
         expect(response.status).to eq 200
 
         expect(response.parsed_body["rdvs"][0]["id"]).to eq Rdv.last.id

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe "Visioplainte Rdvs" do
       expect(response.parsed_body["rdvs"][0]["starts_at"]).to eq "2024-08-19 08:00:00 +0200"
     end
 
+    describe "authentication" do
+      it "returns a 400 status if the auth header is missing" do
+        get "/api/visioplainte/rdvs/", params: { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }, headers: {}
+        expect(response.status).to eq 401
+        expect(response.parsed_body["rdvs"]).to be_blank
+      end
+    end
+
     context "when there are no rdvs for the from and to params" do
       it "returns an empty list" do
         get "/api/visioplainte/rdvs/", params: { from: "2024-08-22T08:00:00+02:00", to: "2024-08-23T08:00:00+02:00" }, headers: auth_header

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "Visioplainte Rdvs" do
         get "/api/visioplainte/rdvs/", params: {}, headers: auth_header
 
         expect(response.status).to eq 400
-        expect(response.parsed_body["errors"].first).to eq "Vous devez précisez le paramètre ids ou les paramètres from et to"
+        expect(response.parsed_body["errors"].first).to eq "Vous devez préciser le paramètre ids ou les paramètres from et to"
       end
     end
   end

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -166,8 +166,10 @@ RSpec.describe "Visioplainte Rdvs" do
       end
 
       let(:gendarmerie_guichet_ids) do
-        get "/api/visioplainte/guichets", params: { service: "Gendarmerie" }, headers: auth_header
-        response.parsed_body["guichets"].map { |guichet| guichet["id"] } # rubocop:disable Rails/Pluck
+        Agent.joins(:services).where(services: { name: ["Gendarmerie Nationale"] }).pluck(:id)
+      end
+      let(:police_guichet_ids) do
+        Agent.joins(:services).where(services: { name: ["Police Nationale"] }).pluck(:id)
       end
 
       it "returns only the rdvs of the given guichets" do
@@ -175,6 +177,9 @@ RSpec.describe "Visioplainte Rdvs" do
         get "/api/visioplainte/rdvs/", params: { guichet_ids: gendarmerie_guichet_ids }.merge(date_params), headers: auth_header
 
         expect(response.parsed_body["rdvs"]).to be_empty
+
+        get "/api/visioplainte/rdvs/", params: { guichet_ids: police_guichet_ids }.merge(date_params), headers: auth_header
+        expect(response.parsed_body["rdvs"][0]["id"]).to eq Rdv.last.id
       end
     end
 

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
                 description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
                 example: "123,456", required: false
       parameter name: "guichet_ids", in: :query, type: :array,
-                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous. Obligatoire si les paramètres from et to ne sont pas présents.",
+                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous.",
                 example: "123,456", required: false
 
       response 200, "Renvoie la liste" do

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -37,11 +37,9 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
                 Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
                 example: "2024-08-22T19:00:00+02:00", required: false
       parameter name: "ids[]", in: :query, type: :array,
-                description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
-                example: "123", required: false
+                description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir", required: false
       parameter name: "guichet_ids[]", in: :query, type: :array,
-                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous.",
-                example: "456", required: false
+                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous.", required: false
 
       response 200, "Renvoie la liste" do
         run_test!

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
       parameter name: "from", in: :query, type: :string,
                 description: "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
                 example: "2024-08-19T08:00:00+02:00", required: false
-      parameter name: "until", in: :query, type: :string,
+      parameter name: "to", in: :query, type: :string,
                 description: "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
                 example: "2024-08-22T19:00:00+02:00", required: false
       parameter name: "ids", in: :query, type: :array,
@@ -43,6 +43,8 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
 
       response 200, "Renvoie la liste" do
         run_test!
+        let(:from) { "2024-08-19T08:00:00+02:00" }
+        let(:to) { "2024-08-20T08:00:00+02:00" }
       end
     end
     post "Prendre un rdv" do

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
   end
 
   path "/api/visioplainte/rdvs" do
+    get "Lister les rdvs" do
+      with_visioplainte_authentication
+
+      tags "Rendez-vous"
+      description "Liste tous les rendez-vous, et permet de filtrer par date, par guichet, ou sur des rdv spécifiques"
+      parameter name: "from", in: :query, type: :string,
+                description: "datetime au format iso8601. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
+                example: "2024-08-19T08:00:00+02:00", required: false
+      parameter name: "until", in: :query, type: :string,
+                description: "datetime au format iso8601. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
+                example: "2024-08-19T19:00:00+02:00", required: false
+      parameter name: "ids", in: :query, type: :array,
+                description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
+                example: "123,456", required: false
+      parameter name: "guichet_ids", in: :query, type: :array,
+                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous",
+                example: "123,456", required: false
+
+      response 200, "Renvoie la liste" do
+        run_test!
+      end
+    end
     post "Prendre un rdv" do
       with_visioplainte_authentication
 

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -29,10 +29,12 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
       tags "Rendez-vous"
       description "Liste tous les rendez-vous, et permet de filtrer par date, par guichet, ou sur des rdv spécifiques"
       parameter name: "from", in: :query, type: :string,
-                description: "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
+                description: "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé.\
+                Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
                 example: "2024-08-19T08:00:00+02:00", required: false
       parameter name: "to", in: :query, type: :string,
-                description: "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
+                description: "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé.\
+                Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
                 example: "2024-08-22T19:00:00+02:00", required: false
       parameter name: "ids", in: :query, type: :array,
                 description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir",

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
                 description: "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé.\
                 Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
                 example: "2024-08-22T19:00:00+02:00", required: false
-      parameter name: "ids", in: :query, type: :array,
+      parameter name: "ids[]", in: :query, type: :array,
                 description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
-                example: "123,456", required: false
-      parameter name: "guichet_ids", in: :query, type: :array,
+                example: "123", required: false
+      parameter name: "guichet_ids[]", in: :query, type: :array,
                 description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous.",
-                example: "123,456", required: false
+                example: "456", required: false
 
       response 200, "Renvoie la liste" do
         run_test!

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
       tags "Rendez-vous"
       description "Liste tous les rendez-vous, et permet de filtrer par date, par guichet, ou sur des rdv spécifiques"
       parameter name: "from", in: :query, type: :string,
-                description: "datetime au format iso8601. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
+                description: "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
                 example: "2024-08-19T08:00:00+02:00", required: false
       parameter name: "until", in: :query, type: :string,
-                description: "datetime au format iso8601. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
-                example: "2024-08-19T19:00:00+02:00", required: false
+                description: "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
+                example: "2024-08-22T19:00:00+02:00", required: false
       parameter name: "ids", in: :query, type: :array,
                 description: "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
                 example: "123,456", required: false
       parameter name: "guichet_ids", in: :query, type: :array,
-                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous",
+                description: "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous. Obligatoire si les paramètres from et to ne sont pas présents.",
                 example: "123,456", required: false
 
       response 200, "Renvoie la liste" do

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -376,11 +376,11 @@
                     "value": {
                       "guichets": [
                         {
-                          "id": 106,
+                          "id": 138,
                           "name": "GUICHET 1"
                         },
                         {
-                          "id": 107,
+                          "id": 139,
                           "name": "GUICHET 2"
                         }
                       ]
@@ -394,6 +394,90 @@
       }
     },
     "/api/visioplainte/rdvs": {
+      "get": {
+        "summary": "Lister les rdvs",
+        "security": [
+          {
+            "X-VISIOPLAINTE-API-KEY": [
+
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "X-VISIOPLAINTE-API-KEY",
+            "in": "header",
+            "description": "Clé d'API",
+            "example": "visioplainte-api-test-key-123456",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
+            "example": "2024-08-19T08:00:00+02:00",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
+            "example": "2024-08-22T19:00:00+02:00",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ids",
+            "in": "query",
+            "description": "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
+            "example": "123,456",
+            "required": false,
+            "schema": {
+              "type": "array"
+            }
+          },
+          {
+            "name": "guichet_ids",
+            "in": "query",
+            "description": "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous. Obligatoire si les paramètres from et to ne sont pas présents.",
+            "example": "123,456",
+            "required": false,
+            "schema": {
+              "type": "array"
+            }
+          }
+        ],
+        "tags": [
+          "Rendez-vous"
+        ],
+        "description": "Liste tous les rendez-vous, et permet de filtrer par date, par guichet, ou sur des rdv spécifiques",
+        "responses": {
+          "200": {
+            "description": "Renvoie la liste",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "rdvs": [
+
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Prendre un rdv",
         "security": [
@@ -447,17 +531,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 6,
+                      "id": 13,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 110,
+                        "id": 147,
                         "name": "GUICHET 1"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "unknown",
-                      "user_id": 7
+                      "user_id": 14
                     }
                   }
                 },
@@ -633,17 +717,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 8,
+                      "id": 15,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 125,
+                        "id": 162,
                         "name": "GUICHET 1"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "excused",
-                      "user_id": 9
+                      "user_id": 16
                     }
                   }
                 },

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -376,11 +376,11 @@
                     "value": {
                       "guichets": [
                         {
-                          "id": 138,
+                          "id": 143,
                           "name": "GUICHET 1"
                         },
                         {
-                          "id": 139,
+                          "id": 144,
                           "name": "GUICHET 2"
                         }
                       ]
@@ -435,20 +435,20 @@
             }
           },
           {
-            "name": "ids",
+            "name": "ids[]",
             "in": "query",
             "description": "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
-            "example": "123,456",
+            "example": "123",
             "required": false,
             "schema": {
               "type": "array"
             }
           },
           {
-            "name": "guichet_ids",
+            "name": "guichet_ids[]",
             "in": "query",
-            "description": "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous. Obligatoire si les paramètres from et to ne sont pas présents.",
-            "example": "123,456",
+            "description": "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous.",
+            "example": "456",
             "required": false,
             "schema": {
               "type": "array"
@@ -531,17 +531,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 13,
+                      "id": 14,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 147,
+                        "id": 152,
                         "name": "GUICHET 1"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "unknown",
-                      "user_id": 14
+                      "user_id": 15
                     }
                   }
                 },
@@ -717,17 +717,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 15,
+                      "id": 16,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 162,
+                        "id": 167,
                         "name": "GUICHET 1"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "excused",
-                      "user_id": 16
+                      "user_id": 17
                     }
                   }
                 },

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -417,7 +417,7 @@
           {
             "name": "from",
             "in": "query",
-            "description": "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
+            "description": "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé.                Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
             "example": "2024-08-19T08:00:00+02:00",
             "required": false,
             "schema": {
@@ -427,7 +427,7 @@
           {
             "name": "to",
             "in": "query",
-            "description": "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé. Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
+            "description": "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé.                Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
             "example": "2024-08-22T19:00:00+02:00",
             "required": false,
             "schema": {

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -438,7 +438,6 @@
             "name": "ids[]",
             "in": "query",
             "description": "Une liste d'ids des rendez-vous qu'on souhaite obtenir",
-            "example": "123",
             "required": false,
             "schema": {
               "type": "array"
@@ -448,7 +447,6 @@
             "name": "guichet_ids[]",
             "in": "query",
             "description": "Une liste d'ids des guichets sur lesquels on veut filtrer les rendez-vous.",
-            "example": "456",
             "required": false,
             "schema": {
               "type": "array"


### PR DESCRIPTION
# Contexte

Suite de l'implémentation de visioplainte (voir https://github.com/betagouv/rdv-service-public/pull/4593)

On implémente un index des rdvs qui sera utilisé par le back office de visioplainte pour afficher les rdvs aux agents.
On permet plusieurs paramètres pour faciliter plusieurs cas d'usage :
- obtenir tous les rdvs affectés à un guichet pendant une période pour indiquer à un agent son programme de la journée lorsqu'il est sur un guichet
- obtenir une liste de rdv spécifique pour avoir des infos sur un ou plusieurs rdvs spécifiques
- filtrer par date plutôt que d'avoir un système de pagination
