### PR TITLE
Renommage `email` en `account_email`, ajout de `notification_email` pour les users STEP 1

### DIFF
--- a/app/lib/anonymizer/rules/rdv_service_public.rb
+++ b/app/lib/anonymizer/rules/rdv_service_public.rb
@@ -10,6 +10,8 @@ class Anonymizer::Rules::RdvServicePublic
         birth_name
         birth_date
         email
+        account_email
+        notification_email
         unconfirmed_email
         address
         address_details

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,8 @@ class User < ApplicationRecord
 
   # Hooks
   before_save :set_email_to_null_if_blank
+  # Temp
+  before_save :sync_email_column
 
   # Scopes
   default_scope { where(deleted_at: nil) }
@@ -288,5 +290,12 @@ class User < ApplicationRecord
       deleted_at: Time.zone.now,
       email: deleted_email
     )
+  end
+
+  # Temp
+  def sync_email_column
+    if email_changed?
+      self.account_email = email
+    end
   end
 end

--- a/db/migrate/20240912094029_add_notification_account_email_to_user.rb
+++ b/db/migrate/20240912094029_add_notification_account_email_to_user.rb
@@ -4,7 +4,7 @@ class AddNotificationAccountEmailToUser < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :notification_email, :string
     add_column :users, :account_email, :string
-    add_index :users, :notification_email
-    add_index :users, :account_email
+    add_index :users, :notification_email, algorithm: :concurrently
+    add_index :users, :account_email, algorithm: :concurrently
   end
 end

--- a/db/migrate/20240912094029_add_notification_account_email_to_user.rb
+++ b/db/migrate/20240912094029_add_notification_account_email_to_user.rb
@@ -5,6 +5,6 @@ class AddNotificationAccountEmailToUser < ActiveRecord::Migration[7.0]
     add_column :users, :notification_email, :string
     add_column :users, :account_email, :string
     add_index :users, :notification_email, algorithm: :concurrently
-    add_index :users, :account_email, algorithm: :concurrently
+    add_index :users, :account_email, algorithm: :concurrently, unique: true, where: "(account_email IS NOT NULL)"
   end
 end

--- a/db/migrate/20240912094029_add_notification_account_email_to_user.rb
+++ b/db/migrate/20240912094029_add_notification_account_email_to_user.rb
@@ -1,0 +1,10 @@
+class AddNotificationAccountEmailToUser < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :notification_email, :string
+    add_column :users, :account_email, :string
+    add_index :users, :notification_email
+    add_index :users, :account_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_04_145418) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_12_094029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -732,6 +732,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_04_145418) do
     t.string "rdv_invitation_token"
     t.virtual "text_search_terms", type: :tsvector, as: "(((((setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(last_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(first_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(birth_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'C'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(phone_number_formatted, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text)), 'D'::\"char\"))", stored: true
     t.datetime "rdv_invitation_token_updated_at"
+    t.string "notification_email"
+    t.string "account_email"
+    t.index ["account_email"], name: "index_users_on_account_email"
     t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_through"], name: "index_users_on_created_through"
@@ -743,6 +746,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_04_145418) do
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["last_name"], name: "index_users_on_last_name"
+    t.index ["notification_email"], name: "index_users_on_notification_email"
     t.index ["phone_number_formatted"], name: "index_users_on_phone_number_formatted"
     t.index ["rdv_invitation_token"], name: "index_users_on_rdv_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -734,7 +734,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_12_094029) do
     t.datetime "rdv_invitation_token_updated_at"
     t.string "notification_email"
     t.string "account_email"
-    t.index ["account_email"], name: "index_users_on_account_email"
+    t.index ["account_email"], name: "index_users_on_account_email", unique: true, where: "(account_email IS NOT NULL)"
     t.index ["birth_date"], name: "index_users_on_birth_date"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_through"], name: "index_users_on_created_through"

--- a/lib/tasks/backfill_account_email.rake
+++ b/lib/tasks/backfill_account_email.rake
@@ -1,0 +1,11 @@
+namespace :users do
+  desc "Backfill account_email column with data from email column"
+  task backfill_account_email: :environment do
+    User.in_batches do |relation|
+      # rubocop:disable Rails/SkipsModelValidations
+      relation.not(email: nil).update_all("account_email = email")
+      # rubocop:enable Rails/SkipsModelValidations
+    end
+    puts " Done!"
+  end
+end

--- a/lib/tasks/backfill_account_email.rake
+++ b/lib/tasks/backfill_account_email.rake
@@ -3,7 +3,7 @@ namespace :users do
   task backfill_account_email: :environment do
     User.in_batches do |relation|
       # rubocop:disable Rails/SkipsModelValidations
-      relation.not(email: nil).update_all("account_email = email")
+      relation.where.not(email: nil).update_all("account_email = email")
       # rubocop:enable Rails/SkipsModelValidations
     end
     puts " Done!"


### PR DESCRIPTION
Contexte : #4395

Première étape du flow strong migrations.

1 - Create a new column
2 - Write to both columns
3 - Backfill data from the old column to the new column