### PR TITLE
Suppression d’un scoping pundit redondant sur les agendas des agents

### DIFF
--- a/app/controllers/admin/agent_agendas_controller.rb
+++ b/app/controllers/admin/agent_agendas_controller.rb
@@ -1,7 +1,7 @@
 class Admin::AgentAgendasController < AgentAuthController
   def show
     @hide_rdv_a_renseigner_in_main_layout = true
-    @agent = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope).find(params[:id])
+    @agent = Agent.find(params[:id])
     authorize(AgentAgenda.new(agent: @agent, organisation: current_organisation))
     @status = params[:status]
     @organisation = current_organisation

--- a/app/policies/agent/agent_agenda_policy.rb
+++ b/app/policies/agent/agent_agenda_policy.rb
@@ -2,17 +2,13 @@ class Agent::AgentAgendaPolicy < ApplicationPolicy
   include CurrentAgentInPolicyConcern
 
   def show?
-    agent_role_in_record_organisation.present? && (
-      record.agent_id == current_agent.id ||
+    current_agent_role = current_agent.roles.find_by(organisation_id: record.organisation_id)
+    other_agent_role = record.agent.roles.find_by(organisation_id: record.organisation_id)
+
+    return false if current_agent_role.nil? || other_agent_role.nil?
+
+    record.agent_id == current_agent.id ||
       record.agent.confrere_of?(current_agent) ||
-      agent_role_in_record_organisation.can_access_others_planning?
-    )
-  end
-
-  private
-
-  def agent_role_in_record_organisation
-    @agent_role_in_record_organisation ||=
-      current_agent.roles.find_by(organisation_id: record.organisation_id)
+      current_agent_role.can_access_others_planning?
   end
 end

--- a/config/locales/pundit.fr.yml
+++ b/config/locales/pundit.fr.yml
@@ -3,3 +3,5 @@ fr:
     default: 'Vous ne pouvez pas effectuer cette action.'
     agent/organisation_policy:
       show?: Vous ne pouvez pas accéder à cette organisation
+    agent/agent_agenda_policy:
+      show?: Vous ne pouvez pas accéder à l’agenda de cet agent

--- a/spec/policies/agent/agent_agenda_policy_spec.rb
+++ b/spec/policies/agent/agent_agenda_policy_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Agent::AgentAgendaPolicy, type: :policy do
       permissions(:show?) { it { is_expected.not_to permit(pundit_context, agenda) } }
     end
 
+    context "regular agent, other agent does not belong to current organisation" do
+      let!(:service) { create(:service) }
+      let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
+      let!(:organisation2) { create(:organisation) }
+      let!(:other_agent) { create(:agent, basic_role_in_organisations: [organisation2], service: create(:service)) }
+      let(:agenda) { AgentAgenda.new(agent: other_agent, organisation: organisation) }
+
+      permissions(:show?) { it { is_expected.not_to permit(pundit_context, agenda) } }
+    end
+
     context "admin agent, other agent's absence, different service" do
       let!(:service) { create(:service) }
       let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }


### PR DESCRIPTION
Closes #4638

cf erreur sentry https://sentry.incubateur.net/organizations/betagouv/issues/107857/?

# Contexte

Actuellement, si un agent essaie d’accéder à l’agenda d’un agent qui n’existe pas, on peut lever une 404. L’agent voit alors une page "Ressource introuvable".

Cette erreur se produit environ 60x par mois.

On pourrait améliorer l’UX et les erreurs remontées dans sentry en levant plutôt des erreurs de droits d’accès.

# Solution

Je supprime l’appel à `Agent::AgentPolicy::Scope` qui est redondant avec l’appel `authorize` fait juste en dessous.

J’ai relu l’implémentation actuelle de `Agent::AgentPolicy::Scope` et de `AgentAgendaPolicy#show?` et les règles appliquées dans ce dernier me semble correctes. Il me semble que le Scope est moins restrictif que le `AgentAgendaPolicy#show?`. En supprimant l’appel au scope je suis donc assez confiant qu’on ne va pas ouvrir des accès aux agendas d’agents par erreur.

Il manquait néanmoins une validation sur le fait que l’autre agent appartienne bien à l’organisation dans laquelle on souhaite voir son agenda, je l’ai rajouté avec une spec associée.

Les agents seront maintenant redirigés vers la page précédente ou leur page agent accueil avec un flash message d’erreur "Vous ne pouvez pas accéder à l’agenda de cet agent"

Cela limitera aussi le bruit pour nous puisque ces erreurs ne seront plus remontées dans Sentry.
S’il y a des problèmes de droits d’accès aux agendas, on peut espérer que les agents viennent nous contacter avec ce message d’erreur spécifique. 

## Refactos

On pourrait tout à fait refacto cette policy pour : 
- retirer le contexte orga / agent
- la réécrire en PORO sans hériter d’ApplicationPolicy

Je me suis volontairement interdit de faire ces refactos dans cette PR de fix pour ne pas multiplier les sources d’erreur si jamais on voyait des bugs se produire suite à ce fix