### PR TITLE
Cleanup de `app/lib`

### DIFF
--- a/app/lib/data_utils.rb
+++ b/app/lib/data_utils.rb
@@ -1,7 +1,0 @@
-module DataUtils
-  def value_counts(values)
-    counts = Hash.new(0)
-    values.each { counts[_1] += 1 }
-    counts
-  end
-end

--- a/app/lib/departements.rb
+++ b/app/lib/departements.rb
@@ -1,7 +1,0 @@
-require "csv"
-
-module Departements
-  CSV_PATH = Rails.root.join("lib/assets/departements_fr.csv").freeze
-  NAMES = CSV.read(CSV_PATH, headers: :first_row)
-    .to_h { [_1["number"], _1["name"]] }
-end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -128,7 +128,7 @@ class Territory < ApplicationRecord
   private
 
   DEPARTEMENTS_NAMES = CSV.read(Rails.root.join("lib/assets/departements_fr.csv"), headers: :first_row)
-    .to_h { [_1["number"], _1["name"]] }
+    .to_h { [_1["number"], _1["name"]] }.freeze
 
   def fill_name_for_departements
     return if name.present? || departement_number.blank?

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -127,9 +127,12 @@ class Territory < ApplicationRecord
 
   private
 
+  DEPARTEMENTS_NAMES = CSV.read(Rails.root.join("lib/assets/departements_fr.csv"), headers: :first_row)
+    .to_h { [_1["number"], _1["name"]] }
+
   def fill_name_for_departements
     return if name.present? || departement_number.blank?
 
-    self.name = Departements::NAMES[departement_number]
+    self.name = DEPARTEMENTS_NAMES[departement_number]
   end
 end

--- a/app/services/import_zone_rows_service.rb
+++ b/app/services/import_zone_rows_service.rb
@@ -57,7 +57,7 @@ class ImportZoneRowsService < BaseService
   end
 
   def validate_inner_conflicts_cities?
-    conflicts = value_counts(rows_cities.pluck("city_code")).filter { |_city_code, count| count > 1 }
+    conflicts = rows_cities.pluck("city_code").tally.filter { |_city_code, count| count > 1 }
     return true if conflicts.empty?
 
     conflicts.each do |city_code, count|
@@ -67,7 +67,7 @@ class ImportZoneRowsService < BaseService
   end
 
   def validate_inner_conflicts_streets?
-    conflicts = value_counts(rows_streets.pluck("street_code")).filter { |_street_ban_id, count| count > 1 }
+    conflicts = rows_streets.pluck("street_code").tally.filter { |_street_ban_id, count| count > 1 }
     return true if conflicts.empty?
 
     conflicts.each do |street_ban_id, count|
@@ -124,11 +124,5 @@ class ImportZoneRowsService < BaseService
 
   def row_level(row)
     row["street_name"].present? || row["street_code"].present? ? Zone::LEVEL_STREET : Zone::LEVEL_CITY
-  end
-
-  def value_counts(values)
-    counts = Hash.new(0)
-    values.each { counts[_1] += 1 }
-    counts
   end
 end

--- a/app/services/import_zone_rows_service.rb
+++ b/app/services/import_zone_rows_service.rb
@@ -1,6 +1,4 @@
 class ImportZoneRowsService < BaseService
-  include DataUtils
-
   REQUIRED_FIELDS = {
     Zone::LEVEL_CITY => %w[sector_id city_name city_code],
     Zone::LEVEL_STREET => %w[sector_id city_name city_code street_name street_code],
@@ -126,5 +124,11 @@ class ImportZoneRowsService < BaseService
 
   def row_level(row)
     row["street_name"].present? || row["street_code"].present? ? Zone::LEVEL_STREET : Zone::LEVEL_CITY
+  end
+
+  def value_counts(values)
+    counts = Hash.new(0)
+    values.each { counts[_1] += 1 }
+    counts
   end
 end

--- a/db/migrate/20210301135256_create_territories.rb
+++ b/db/migrate/20210301135256_create_territories.rb
@@ -56,7 +56,7 @@ class CreateTerritories < ActiveRecord::Migration[6.0]
     organisation.update_columns(
       territory_id: Territory.find_or_create_by!(
         departement_number: organisation.departement,
-        name: Departements::NAMES.fetch(organisation.departement, "N/A"),
+        name: Territory::DEPARTEMENTS_NAMES.fetch(organisation.departement, "N/A"),
         phone_number: DEPARTEMENT_PHONE_NUMBERS.fetch(organisation.departement, nil)
       ).id
     )


### PR DESCRIPTION
Certains fichiers de `app/lib` sont tout petits et uniquement utilisés à un seul endroit. Pour éviter l'indirection et éviter d'avoir trop de bruit lorsqu'on liste des fichiers de `app/lib`, je propose ici de déplacer le code.