### PR TITLE
Utiliser les espaces insécables autour des ponctuations

### DIFF
--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -7,7 +7,7 @@ tr
 
     - if absence.recurrence.present?
       br
-      | Se répète :
+      | Se répète&nbsp;:
       br
       = sanitize(display_recurrence(absence).join("<br/>"))
   td

--- a/app/views/admin/organisations/online_bookings/show.html.slim
+++ b/app/views/admin/organisations/online_bookings/show.html.slim
@@ -10,10 +10,10 @@
     p La réservation en ligne peut être configurée pour chaque motif de rendez-vous.
 
     - if current_organisation.sectorized?
-      p Cette organisation est sectorisée, les usagers peuvent prendre rendez-vous en saisissant leur adresse sur la page d'accueil :
+      p Cette organisation est sectorisée, les usagers peuvent prendre rendez-vous en saisissant leur adresse sur la page d'accueil&nbsp;:
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: prendre_rdv_url }
     - else
-      p Une fois qu'elle est activée, vous pouvez envoyer ce lien à vos usagers pour qu'ils prennent rendez-vous :
+      p Une fois qu'elle est activée, vous pouvez envoyer ce lien à vos usagers pour qu'ils prennent rendez-vous&nbsp;:
       - org_booking_link = public_link_to_org_url(organisation_id: current_organisation.id, org_slug: current_organisation.slug)
       = render partial: "admin/organisations/online_bookings/booking_link", locals: { booking_link: org_booking_link }
 

--- a/app/views/admin/organisations/show.html.slim
+++ b/app/views/admin/organisations/show.html.slim
@@ -9,19 +9,19 @@
       .card-body
         ul.list-unstyled
           li.mb-2
-            strong> Nom :
+            strong> Nom&nbsp;:
             | #{@organisation.name}
           li.mb-2
-            strong> Téléphone :
+            strong> Téléphone&nbsp;:
             | #{display_value_or_na_placeholder(@organisation.phone_number)}
           li.mb-2
-            strong> Email :
+            strong> Email&nbsp;:
             | #{display_value_or_na_placeholder(@organisation.email)}
           li.mb-2
-            strong> Site web :
+            strong> Site web&nbsp;:
             | #{display_value_or_na_placeholder(@organisation.website)}
           li.mb-2
-            strong> Horaires :
+            strong> Horaires&nbsp;:
             | #{display_value_or_na_placeholder(@organisation.horaires)}
         .text-right= link_to "Modifier", edit_admin_organisation_path(@organisation), class: "btn btn-primary"
 

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -21,25 +21,25 @@
         b Plage d'ouverture ##{@plage_ouverture.id}
       .card-body
         div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Description :
+          .flex-shrink-0.mr-1.font-weight-bold Description&nbsp;:
           span= @plage_ouverture.title
         div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Agent :
+          .flex-shrink-0.mr-1.font-weight-bold Agent&nbsp;:
           span= @plage_ouverture.agent.full_name
         - if @plage_ouverture.lieu
           div.mt-2.d-flex
-            .flex-shrink-0.mr-1.font-weight-bold Lieu :
+            .flex-shrink-0.mr-1.font-weight-bold Lieu&nbsp;:
             = lieu_tag(@plage_ouverture.lieu)
         div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Motifs :
+          .flex-shrink-0.mr-1.font-weight-bold Motifs&nbsp;:
           ul.pl-3.mb-0
             - @plage_ouverture.motifs.each do |motif|
               li= motif_name_with_location_type_and_badges(motif)
         div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Répétition :
+          .flex-shrink-0.mr-1.font-weight-bold Répétition&nbsp;:
           span= @plage_ouverture.recurring? ? "Récurrente" : po_exceptionnelle_tag(@plage_ouverture)
         div.mt-2.d-flex
-          .flex-shrink-0.mr-1.font-weight-bold Dates :
+          .flex-shrink-0.mr-1.font-weight-bold Dates&nbsp;:
           - if @plage_ouverture.recurring?
             = sanitize(display_recurrence(@plage_ouverture).join(" "))
           - else

--- a/app/views/admin/prescription/confirmation.html.slim
+++ b/app/views/admin/prescription/confirmation.html.slim
@@ -38,7 +38,7 @@ main.container
             - if rdv.motif.instruction_for_rdv.present?
               li.list-group-item
                 i.fa.fa-exclamation-triangle>
-                strong Informations supplémentaires :
+                strong Informations supplémentaires&nbsp;:
                 .pl-3.pt-1
                   = instruction_for_rdv_to_html(rdv.motif)
             li.list-group-item

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -67,7 +67,7 @@ ruby:
       - else
         .row.d-flex.justify-content-center
           p
-            | Vous n'avez pas d'usager pour le moment, vous pouvez en créer un dès a présent :
+            | Vous n'avez pas d'usager pour le moment, vous pouvez en créer un dès a présent&nbsp;:
         .row.d-flex.justify-content-center
           = link_to \
             "Créer un usager", \

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -34,7 +34,7 @@
   .mx-3
   - if rdv.users.any?
     div class=("users-details collapse p-3 pt-0")
-      h5.rdv-text-align-center.strong.mb-3> Participants :
+      h5.rdv-text-align-center.strong.mb-3> Participants&nbsp;:
       .row
         - rdv.users.sort_by { _1.last_name.downcase }.each do |user|
           .col-4

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -14,7 +14,7 @@
         - if rdv.context.blank?
           .text-muted = t(".empty_context")
         - else
-          .text-muted Contexte :
+          .text-muted Contexte&nbsp;:
           .border-left.pl-2.mb-1= simple_format(rdv.context, {}, wrapper_tag: :span)
 
 - if rdv.phone?
@@ -40,7 +40,7 @@
       i.fa.fa-fw.fa-map-marker.text-primary-blue>
     p.card-text
       - if rdv.home?
-        | RDV à domicile :
+        | RDV à domicile&nbsp;:
         = human_location(rdv)
       - elsif rdv.public_office?
         = human_location(rdv)

--- a/app/views/admin/rdvs/_short_rdv.html.slim
+++ b/app/views/admin/rdvs/_short_rdv.html.slim
@@ -9,5 +9,5 @@ li.card-body.py-2
         - if short_rdv.context.blank?
           .text-muted Pas de contexte renseigné
         - else
-          .text-muted Contexte :
+          .text-muted Contexte&nbsp;:
           .border-left.pl-2= simple_format(short_rdv.context)

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -46,7 +46,7 @@
             = render "admin/rdvs/print/user_details", user: user
         - if current_organisation.territory.enable_context_field
           .mt-2
-            | Contexte :
+            | Contexte&nbsp;:
             | &nbsp
             - if rdv.context.present?
               = rdv.context
@@ -57,6 +57,6 @@
           i.fa.fa-map-marker-alt>
           = human_location(rdv)
         .mt-2
-          | Agent(s) :
+          | Agent(s)&nbsp;:
           | &nbsp
           = agents_to_sentence(rdv.agents)

--- a/app/views/admin/territories/sectorisation_tests/search.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/search.html.slim
@@ -40,7 +40,7 @@ do |f|
                   span>= "la rue #{zone.street_name} dans la commune #{zone.city_name}"
                 - else
                   span>= "la commune entière #{zone.city_name}"
-                | est attribuée à :
+                | est attribuée à&nbsp;:
                 ul
                   - zone.sector.attributions.to_a.group_by(&:organisation).each_value do |attributions|
                     li= render partial: "attribution", collection: attributions, locals: { sectorisation_test_form: @sectorisation_test_form }
@@ -58,10 +58,10 @@ do |f|
                     - motifs.each do |motif|
                       li= motif_name_and_location_type(motif)
         - else
-          div Aucun résultat : cette adresse n'est attribuée à aucun secteur
+          div Aucun résultat&nbsp;: cette adresse n'est attribuée à aucun secteur
 
         div
-          b Combinaison des motifs disponibles (c'est ce que voit l'usager) :
+          b Combinaison des motifs disponibles (c'est ce que voit l'usager)&nbsp;:
           ul
             - @sectorisation_test_form.available_motifs_unique_names_and_location_types_by_service.each do |service, motifs|
               li

--- a/app/views/admin/territories/sms_configurations/show.html.slim
+++ b/app/views/admin/territories/sms_configurations/show.html.slim
@@ -6,11 +6,11 @@
       .card
         .card-body
           .mb-2
-            strong> Fournisseur :
+            strong> Fournisseur&nbsp;:
             = current_territory.sms_provider || "N/A"
 
           .mb-2
-            strong> Clef API / Mot de passe :
+            strong> Clef API / Mot de passe&nbsp;:
             = current_territory.sms_configuration || "N/A"
 
           .text-right= link_to "Modifier", edit_admin_territory_sms_configuration_path(current_territory), class: "btn btn-primary"

--- a/app/views/agents/webcal_sync/show.html.slim
+++ b/app/views/agents/webcal_sync/show.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, t(".title")
 
-p.mb-1 Allez dans votre agenda externe et ajoutez un nouveau calendrier avec cette URL :
+p.mb-1 Allez dans votre agenda externe et ajoutez un nouveau calendrier avec cette URL&nbsp;:
 
 - calendar_url = ics_calendar_url(current_agent.calendar_uid, protocol: request.protocol, format: :ics)
 .input-group.mb-3[data-controller="clipboard"]

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -1,4 +1,4 @@
 h1 Merci pour votre inscription !
-p <strong>Nous vous invitons à confirmer votre adresse email</strong> et compléter votre inscription en utilisant le lien suivant :
+p <strong>Nous vous invitons à confirmer votre adresse email</strong> et compléter votre inscription en utilisant le lien suivant&nbsp;:
 .btn-wrapper
   = link_to "Confirmer mon compte", confirmation_url(@resource, confirmation_token: @token), class:"btn btn-primary"

--- a/app/views/devise/mailer/unlock_instructions.html.slim
+++ b/app/views/devise/mailer/unlock_instructions.html.slim
@@ -1,6 +1,6 @@
 p Bonjour #{@resource.email}
 p Votre compte a été bloqué suite à un nombre excessif de connexion
-p Cliquez sur le lien ci-dessous pour déverrouiller votre compte :
+p Cliquez sur le lien ci-dessous pour déverrouiller votre compte&nbsp;:
 p Déverrouiller mon compte
 p
   = link_to "Déverrouiller mon compte", unlock_url(@resource, unlock_token: @token)

--- a/app/views/errors/internal_server_error.html.slim
+++ b/app/views/errors/internal_server_error.html.slim
@@ -6,7 +6,7 @@
 
     p Désolé, une erreur s'est produite. Notre équipe technique en a été avertie automatiquement, et va chercher à la résoudre le plus rapidement possible.
 
-    p Vous pouvez retrouver plus d'information sur l'état général de notre service ici :
+    p Vous pouvez retrouver plus d'information sur l'état général de notre service ici&nbsp;:
 
     = render "admin/static_pages/instatus_iframe"
 

--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -3,7 +3,7 @@ footer.footer
     .row
       .col-md-12
         .d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
-          | Accessibilité : non conforme
+          | Accessibilité&nbsp;: non conforme
           = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
             span>= ENV["RDV_SOLIDARITES_VERSION"]
             i.fa.fa-external-link-alt

--- a/app/views/mailers/_demo_content_explanation.html.slim
+++ b/app/views/mailers/_demo_content_explanation.html.slim
@@ -1,5 +1,5 @@
 - if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
   p
-    b Attention : ce mail concerne l'environnement de démo qui contient uniquement des données fictives pour vous aider à réaliser des tests.
+    b Attention&nbsp;: ce mail concerne l'environnement de démo qui contient uniquement des données fictives pour vous aider à réaliser des tests.
   p
     b Il n'y a aucun impact sur vos comptes et vos données réelles présentes sur l'environnement de production.

--- a/app/views/mailers/agents/account_deletion_mailer/upcoming_deletion_warning.html.slim
+++ b/app/views/mailers/agents/account_deletion_mailer/upcoming_deletion_warning.html.slim
@@ -6,7 +6,7 @@ p
   | Sans action de votre part, il sera supprimé automatiquement dans 30 jours.
 
 p
-  | Si vous souhaitez conserver votre compte, il vous suffit de vous connecter sur #{domain.name} via ce lien :
+  | Si vous souhaitez conserver votre compte, il vous suffit de vous connecter sur #{domain.name} via ce lien&nbsp;:
 
 .btn-wrapper= link_to "Connexion", new_agent_session_url, class:"btn btn-primary"
 

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -28,7 +28,7 @@
     .clear
   - if rdv.follow_up?
     div.row-result
-      span.title Référent :
+      span.title Référent&nbsp;:
       span.float-right= rdv.agents.map(&:short_name).sort.to_sentence
       .clear
   div.row-result
@@ -56,5 +56,5 @@
       .clear
   - if rdv.motif.instruction_for_rdv.present? && for_role == :user
     .div.row-result.no-border
-      span.title Informations supplémentaires :
+      span.title Informations supplémentaires&nbsp;:
       = instruction_for_rdv_to_html(rdv.motif)

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -39,7 +39,7 @@ main.container
             - if rdv.motif.instruction_for_rdv.present?
               li.list-group-item
                 i.fa.fa-exclamation-triangle>
-                strong Informations supplémentaires :
+                strong Informations supplémentaires&nbsp;:
                 .pl-3.pt-1
                   = instruction_for_rdv_to_html(rdv.motif)
             li.list-group-item

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -13,7 +13,7 @@ main.container
             .alert.alert-success
               p.mb-0
                 i.fas.fa-lightbulb>
-                | Nouvelle fonctionnalité : Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
+                | Nouvelle fonctionnalité&nbsp;: Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
                 / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
                 - if !territory.sectorized?
                   / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -26,7 +26,7 @@
     - if context.first_matching_motif.collectif?
       h3.rdv-font-weight-700 = "Inscrivez-vous à l'atelier de votre choix :"
     - else
-      h3.rdv-font-weight-700 = "Sélectionnez un créneau :"
+      h3.rdv-font-weight-700 Sélectionnez un créneau&nbsp;:
     .card.mb-3
       .card-body
         - if context.first_matching_motif.collectif?

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -11,7 +11,7 @@
   - if context.unique_motifs_by_name_and_location_type.empty?
     = render "search/nothing_to_show", context: context
   - else
-    h2.rdv-font-weight-700 Sélectionnez le motif de votre RDV :
+    h2.rdv-font-weight-700 Sélectionnez le motif de votre RDV&nbsp;:
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       .card.mb-3
         = link_to prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type)), class: "rdv-background-image-none" do

--- a/app/views/search/_nothing_to_show_contactable_organisation.html.slim
+++ b/app/views/search/_nothing_to_show_contactable_organisation.html.slim
@@ -5,15 +5,15 @@
       ul.list-unstyled
         - if organisation.phone_number.present?
           li.mb-2
-            strong> Téléphone :
+            strong> Téléphone&nbsp;:
             | #{phone_to(organisation.humanized_phone_number)}
         - if organisation.email.present?
           li.mb-2
-            strong> Email :
+            strong> Email&nbsp;:
             | #{mail_to(organisation.email)}
         - if organisation.website.present?
           li.mb-2
-            strong> Site web :
+            strong> Site web&nbsp;:
             = link_to organisation.website, target: "_blank" do
               span> #{organisation.website}
               i.fa.fa-external-link-alt>

--- a/app/views/search/_prescription_banner.html.slim
+++ b/app/views/search/_prescription_banner.html.slim
@@ -5,7 +5,7 @@
         .fr-col-lg-12.mt-4.mb-3
           .fr-grid-row
             .fr-col-lg-7
-              h2.rdv-color-text-title-grey.mb-1.pb-0  Nouvelle fonctionnalité :
+              h2.rdv-color-text-title-grey.mb-1.pb-0  Nouvelle fonctionnalité&nbsp;:
               h2.rdv-color-text-action-high-blue-ecume.mb-2.pb-0  la prescription dans l'espace agent
               p.rdv-font-weight-700 Vous souhaitez rediriger un usager vers une organisation différente de la votre ?
               p

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -2,7 +2,7 @@
   - if context.unique_motifs_by_name_and_location_type.empty?
     = render "search/nothing_to_show", context: context
   - else
-    h2.rdv-font-weight-700 Sélectionnez le service avec qui vous voulez prendre un RDV :
+    h2.rdv-font-weight-700 Sélectionnez le service avec qui vous voulez prendre un RDV&nbsp;:
     - unless context.invitation?
     - context.services.each do |service|
       .card.mb-3

--- a/app/views/static_pages/accessibility.html.slim
+++ b/app/views/static_pages/accessibility.html.slim
@@ -35,22 +35,22 @@
       | pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
 
     ul
-      li E-mail : <a href="mailto:contact@beta.gouv.fr">contact@beta.gouv.fr</a>
+      li E-mail&nbsp;: <a href="mailto:contact@beta.gouv.fr">contact@beta.gouv.fr</a>
     p
       span> Nous essayons de répondre dans les
       b 2 jours ouvrés.
 
     h2 Voie de recours
 
-    p Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
+    p Cette procédure est à utiliser dans le cas suivant&nbsp;: vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
 
     p
-      | Vous pouvez :
+      | Vous pouvez&nbsp;:
       ul
         li Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a>
         li Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits dans votre région</a>
         li
-          | Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) :
+          | Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre)&nbsp;:
           br
           | Défenseur des droits
           br

--- a/app/views/static_pages/cgu.html.slim
+++ b/app/views/static_pages/cgu.html.slim
@@ -2,7 +2,7 @@
 
 .fr-grid-row
   .fr-col-md-8
-    p Les présentes conditions générales d’utilisation (dites « CGU ») encadrent les différents usages de la Plateforme "#{current_domain.name}" et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
+    p Les présentes conditions générales d’utilisation (dites «&nbsp;CGU&nbsp;») encadrent les différents usages de la Plateforme "#{current_domain.name}" et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
     h2 Article 1 - Champ d'application
 
     p La plateforme "#{current_domain.name} " est à l'initiative de l’ Agence Nationale de la Cohésion des Territoires (ANCT).
@@ -14,20 +14,20 @@
     h2 Article 3 - Définitions
 
     ul
-      li « L'Utilisateur » est toute personne utilisant la plateforme "#{current_domain.name}".
-      li « L'Usager » est tout administré utilisant la plateforme "#{current_domain.name}".
-      li « L'Agent » est tout agent public utilisant la plateforme "#{current_domain.name}".
-      li Les « Services » sont les fonctionnalités offertes par la plateforme.
+      li «&nbsp;L'Utilisateur&nbsp;» est toute personne utilisant la plateforme "#{current_domain.name}".
+      li «&nbsp;L'Usager&nbsp;» est tout administré utilisant la plateforme "#{current_domain.name}".
+      li «&nbsp;L'Agent&nbsp;» est tout agent public utilisant la plateforme "#{current_domain.name}".
+      li Les «&nbsp;Services&nbsp;» sont les fonctionnalités offertes par la plateforme.
 
     h2 Article 4 - Fonctionnalités
 
     h3 4.1 Fonctionnalités ouvertes aux Usagers
 
-    p #{current_domain.name} permet à tout Usager qui le souhaite de :
+    p #{current_domain.name} permet à tout Usager qui le souhaite de&nbsp;:
     ul
       li
         p se créer un compte lui permettant de prendre un rendez-vous avec un service public.
-        p A cet effet, il lui suffira de se créer un compte sur le site de la plateforme en fournissant les informations suivantes : nom, prénom, adresse e-mail et numéro de téléphone. Il pourra également remplir une fiche d'information dans laquelle il devra renseigner des informations relatives à sa situation sociale et familiale : adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants.
+        p A cet effet, il lui suffira de se créer un compte sur le site de la plateforme en fournissant les informations suivantes&nbsp;: nom, prénom, adresse e-mail et numéro de téléphone. Il pourra également remplir une fiche d'information dans laquelle il devra renseigner des informations relatives à sa situation sociale et familiale&nbsp;: adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants.
 
       li
         p vérifier s'il est possible de prendre rendez-vous via la plateforme en fonction de son adresse.
@@ -39,7 +39,7 @@
 
     h3 4.2 Fonctionnalités ouvertes aux Agents
 
-    p #{current_domain.name} permet à tout agent réalisant une mission de service public de :
+    p #{current_domain.name} permet à tout agent réalisant une mission de service public de&nbsp;:
     ul
       li Regrouper les actions relatives à la prise de rendez-vous en ligne ;
       li Organiser directement la configuration générale de la prise de rendez-vous ;
@@ -49,7 +49,7 @@
 
     h4 A) Regrouper les actions relatives à la prise de rendez-vous
 
-    p Cette fonctionnalité permet de faciliter la prise de rendez-vous en ligne des usagers, en choisissant certaines modalités relatives à l'interface. Ainsi, la structure pourra :
+    p Cette fonctionnalité permet de faciliter la prise de rendez-vous en ligne des usagers, en choisissant certaines modalités relatives à l'interface. Ainsi, la structure pourra&nbsp;:
     ul
       li Déterminer le service avec lequel l'usager prendra rendez-vous ;
       li Préciser le lieu du rendez-vous ;
@@ -60,7 +60,7 @@
 
     h4 B) Organiser directement la configuration générale de la prise de rendez-vous
 
-    p Cette fonctionnalité permet aux structures de déterminer et préciser les modalités des rendez-vous. Ces modalités sont déterminantes pour l'organisation générale des structures et des prises de rendez-vous. En effet, chaque structure pourra :
+    p Cette fonctionnalité permet aux structures de déterminer et préciser les modalités des rendez-vous. Ces modalités sont déterminantes pour l'organisation générale des structures et des prises de rendez-vous. En effet, chaque structure pourra&nbsp;:
     ul
       li Choisir la durée moyenne de rendez-vous ;
       li Choisir le type de rendez-vous (sur place, téléphone, à domicile) ;
@@ -69,7 +69,7 @@
 
     h4 C) Établir des plages d'ouvertures
 
-    p Cette fonctionnalité permet aux structures de mieux intégrer les rendez-vous pris ou à prendre dans les plages d'ouverture de la structure. En effet, chaque structure pourra :
+    p Cette fonctionnalité permet aux structures de mieux intégrer les rendez-vous pris ou à prendre dans les plages d'ouverture de la structure. En effet, chaque structure pourra&nbsp;:
     ul
       li Déterminer un "nom" pour la plage d'ouverture uniquement visible en interne ;
       li Déterminer un lieu d'ouverture ;
@@ -77,7 +77,7 @@
 
     p Après avoir déterminé ces éléments, la structure devra "créer sa plage". Cette plage préviendra toute prise de rendez-vous en dehors d'horaires ou de moments prévus par la structure. Elle pourra les modifier à tout moment.
 
-    p A ces possibilités, s'ajoutent celles permettant d'intégrer les RDV prévus dans le futur, en :
+    p A ces possibilités, s'ajoutent celles permettant d'intégrer les RDV prévus dans le futur, en&nbsp;:
     ul
       li ajoutant directement un rendez-vous dans l'agenda de la structure ou d'un Agent de manière spécifique ;
       li en précisant les créneaux pour lesquels un Agent n'est pas présent et ne peut donc prendre de rendez-vous.
@@ -88,7 +88,7 @@
 
     h4 E) Gérer les statistiques de la structure.
 
-    p Chaque Agent peut télécharger un export de ses Rendez-vous, et ainsi voir la progression relative aux Rendez-vous manqués (excusés ou non). Les informations suivantes sont disponibles :
+    p Chaque Agent peut télécharger un export de ses Rendez-vous, et ainsi voir la progression relative aux Rendez-vous manqués (excusés ou non). Les informations suivantes sont disponibles&nbsp;:
 
     ul
       li Nombre de Rendez-vous ;
@@ -98,7 +98,7 @@
 
     h2 Article 5 – Responsabilités
 
-    h3 5.1 L’éditeur de la « Plateforme #{current_domain.name} »
+    h3 5.1 L’éditeur de la «&nbsp;Plateforme #{current_domain.name}&nbsp;»
 
     p Les sources des informations diffusées sur la Plateforme sont réputées fiables mais le site ne garantit pas qu’il soit exempt de défauts, d’erreurs ou d’omissions.
 

--- a/app/views/static_pages/mds.html.slim
+++ b/app/views/static_pages/mds.html.slim
@@ -10,7 +10,7 @@
     .fr-col-12.fr-col-lg-8
       h2 L'insertion sociale
       .small-divider
-      p.lead Les professionnels des MDS aident les publics en difficulté (bénéficiaires de minima sociaux, demandeurs d'emploi) dans leurs démarches administratives ou la constitution de dossiers. En cas de gros problèmes financiers ou de difficultés à se loger, ils peuvent vous aider dans la recherche de solutions d'urgence provisoires : hébergement d'urgence, démarches auprès des banques...
+      p.lead Les professionnels des MDS aident les publics en difficulté (bénéficiaires de minima sociaux, demandeurs d'emploi) dans leurs démarches administratives ou la constitution de dossiers. En cas de gros problèmes financiers ou de difficultés à se loger, ils peuvent vous aider dans la recherche de solutions d'urgence provisoires&nbsp;: hébergement d'urgence, démarches auprès des banques...
     .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/social.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
 
@@ -20,13 +20,13 @@
     .fr-col-12.fr-col-lg-8
       h2 L'accompagnement des futures et jeunes mères
       .small-divider
-      p.lead Avant et après une naissance, les équipes des MDS peuvent orienter les femmes vers l'un des centres de protection maternelle et infantile (PMI). Ceux-ci proposent des consultations gratuites : suivi de grossesse, suivi médical des enfants de 0 à 6 ans (examens, pesée, vaccinations), conseils de puériculture et de diététique, les centres de PMI sont aussi des lieux d'information sur la vie affective et sexuelle, la contraception et les infections sexuellement transmissibles.
+      p.lead Avant et après une naissance, les équipes des MDS peuvent orienter les femmes vers l'un des centres de protection maternelle et infantile (PMI). Ceux-ci proposent des consultations gratuites&nbsp;: suivi de grossesse, suivi médical des enfants de 0 à 6 ans (examens, pesée, vaccinations), conseils de puériculture et de diététique, les centres de PMI sont aussi des lieux d'information sur la vie affective et sexuelle, la contraception et les infections sexuellement transmissibles.
 
   .fr-grid-row.align-items-center.mb-4.rdv-flex-wrap-wrap-reverse
     .fr-col-12.fr-col-lg-8
       h2 La prévention et la protection de l'enfance
       .small-divider
-      p.lead Dans le cadre de l'aide sociale à l'enfance (ASE), les travailleurs sociaux et médico-sociaux des MDS offrent un soutien matériel, éducatif et psychologique aux familles qui rencontrent des difficultés dans l'éducation de leurs enfants : aides éducatives à domicile, accueil des jeunes. Des activités de soutien à la parentalité sont également organisées pour permettre aux parents d'exprimer leurs difficultés et rompre leur isolement.
+      p.lead Dans le cadre de l'aide sociale à l'enfance (ASE), les travailleurs sociaux et médico-sociaux des MDS offrent un soutien matériel, éducatif et psychologique aux familles qui rencontrent des difficultés dans l'éducation de leurs enfants&nbsp;: aides éducatives à domicile, accueil des jeunes. Des activités de soutien à la parentalité sont également organisées pour permettre aux parents d'exprimer leurs difficultés et rompre leur isolement.
     .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/enfance.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
 

--- a/app/views/static_pages/mentions_legales.html.slim
+++ b/app/views/static_pages/mentions_legales.html.slim
@@ -6,7 +6,7 @@
     h2 Éditeur de la plateforme
 
     p
-      | La plateforme est éditée par :
+      | La plateforme est éditée par&nbsp;:
       br
       b> Agence nationale de la cohésion des territoires
       br
@@ -18,7 +18,7 @@
       br
       | Téléphone : +33 1 85 58 60 00
       br
-      | Mail :
+      | Mail&nbsp;:
       = mail_to "info@anct.gouv.fr"
 
     h2 Directeur de la publication
@@ -40,7 +40,7 @@
 
     p La conformité aux normes d’accessibilité numérique est un objectif ultérieur mais nous tâchons de rendre ce site accessible à toutes et à tous.
 
-    p Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part. Si vous n'obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Pour en savoir plus sur la politique d'accessibilité numérique de l'État :
+    p Si vous rencontrez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part. Si vous n'obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Pour en savoir plus sur la politique d'accessibilité numérique de l'État&nbsp;:
 
     h2 Sécurité
 

--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -12,27 +12,27 @@
 
     h3 Données à caractère personnel traitées
 
-    p La plateforme peut traiter les données à caractère personnel suivantes :
+    p La plateforme peut traiter les données à caractère personnel suivantes&nbsp;:
 
     ul
       li
-        strong Données relatives au compte Agent :
+        strong Données relatives au compte Agent&nbsp;:
         span> Nom, prénom, adresse mail professionnelle de manière obligatoire, et le rôle de manière facultative ;
       li
-        strong Données relatives au compte Usager :
+        strong Données relatives au compte Usager&nbsp;:
         span> Nom, prénom, adresse e-mail, numéro de téléphone, adresse, caisse d'affiliation, situation familiale, numéro d'allocataire, nombre d'enfants ;
       li
-        strong Données relatives à la fiche "Nouvel Usager" - Responsable :
+        strong Données relatives à la fiche "Nouvel Usager" - Responsable&nbsp;:
         span> Nom, prénom, nom de naissance, date de naissance, adresse e-mail, numéro de téléphone, adresse, champ "remarques", caisse d'affiliation, numéro d'allocataire, situation familiale, nombre d'enfants, modalités de logement (SDS, propriétaire, hébergé, locataire, en accession à la propriété) ;
       li
-        strong Données relatives à la fiche "Nouvel Usager" - Proche :
+        strong Données relatives à la fiche "Nouvel Usager" - Proche&nbsp;:
         span> Nom, prénom, date de naissance, champ "remarques", informations relatives à l'Usager "Type Responsable" ;
       li
-        strong Données de localisation :
+        strong Données de localisation&nbsp;:
         span> Adresse ;
       li
-        strong Données d'hébergeur :
-        span> Identifiant de connexion ; Nature des opérations ;
+        strong Données d'hébergeur&nbsp;:
+        span> Identifiant de connexion&nbsp;; Nature des opérations ;
       li
         strong Cookies.
 
@@ -40,13 +40,13 @@
 
     h3 Base juridique des traitements de données
 
-    p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques :
+    p Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques&nbsp;:
 
     ul
       li l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD ;
       li la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD.
 
-    p Ces fondements sont précisés ci-dessous :
+    p Ces fondements sont précisés ci-dessous&nbsp;:
 
     h4 a) Les données relatives au compte professionnel
     p Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
@@ -66,7 +66,7 @@
     h4 f) Données d'hébergeur
     p Ce traitement de données est nécessaire au respect d’une obligation légale à laquelle le responsable du traitement est soumis au sens de l’article 6-c du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.
 
-    p L’obligation légale est posée par :
+    p L’obligation légale est posée par&nbsp;:
     ul
       li = link_to "la loi LCEN n°2004-575 du 21 juin 2004 pour la confiance dans l’économie numérique ;", "https://www.legifrance.gouv.fr/loda/id/JORFTEXT000000801164/2020-10-26/"
       li = link_to "les articles 1 et 3 du décret n°2021-1362 du 20 octobre 2021.", "https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000044228912"
@@ -77,7 +77,7 @@
 
     h2 Durée de conservation
 
-    p Les données à caractère personnel sont conservées :
+    p Les données à caractère personnel sont conservées&nbsp;:
 
     .fr-table
       table
@@ -112,7 +112,7 @@
 
     h3 Droit des personnes concernées
 
-    p Vous disposez des droits suivants concernant vos données à caractère personnel :
+    p Vous disposez des droits suivants concernant vos données à caractère personnel&nbsp;:
 
     ul
       li Droit d’information ;
@@ -120,11 +120,11 @@
       li Droit de rectification ;
       li Droit de suppression des données.
 
-    p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante :
+    p Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante&nbsp;:
 
     strong = mail_to current_domain.support_email
 
-    p ou par voie postale :
+    p ou par voie postale&nbsp;:
 
     p Agence nationale de la cohésion des territoires
     br
@@ -179,7 +179,7 @@
 
     h3 Sécurité et confidentialité des données
 
-    p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment :
+    p Les mesures techniques et organisationnelles de sécurité adoptées pour assurer la confidentialité, l'intégrité et protéger l'accès des données sont notamment&nbsp;:
     ul
       li Pare feu système.
       li Pare feu applicatif (WAF).
@@ -193,21 +193,21 @@
       li Accès aux données uniquement via un outil d'édition sécurisé (SSL + mot de passe) avec utilisation de comptes nominatifs.
       li Hébergeur de données de santé.
 
-    h2#cookies Utilisation de témoins de connexion (« cookies »)
+    h2#cookies Utilisation de témoins de connexion («&nbsp;cookies&nbsp;»)
 
     p Les cookies utilisés sur RDV-Solidarités ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet.
     p RDV-Solidarités utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
 
     p RDV-Solidarités n'utilise aucun cookies dits "tiers".
 
-    p Il convient d'indiquer que :
+    p Il convient d'indiquer que&nbsp;:
     ul
       li Les données collectées ne sont pas recoupées avec d’autres traitements.
       li Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.
 
     p À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
 
-    p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
+    p Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL)&nbsp;:
 
     ul
       li = link_to "Cookies & traceurs : que dit la loi ?", "https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"

--- a/app/views/static_pages/presentation_for_cnfs.html.slim
+++ b/app/views/static_pages/presentation_for_cnfs.html.slim
@@ -100,7 +100,7 @@ section.py-5
   .fr-container
     .fr-grid-row
       .rdv-text-align-center.m-auto
-        h2.mb-2 Aide Numérique en quelques chiffres c’est :
+        h2.mb-2 Aide Numérique en quelques chiffres c’est&nbsp;:
     .fr-grid-row.mt-4.d-flex.justify-content-around.flex-sm-column.flex-md-row.flex-md-nowrap
       .d-flex.flex-column.align-items-center.flex-v-gap-1em
         .bubble.rdv-background-color-alt-green-menthe.rdv-color-text-action-high-blue-ecume
@@ -125,7 +125,7 @@ section.rdv-background-color-alt-green-menthe.py-5
       .fr-col-md-9.mx-auto
         figure.fr-quote
           blockquote
-            p « J'ai réduit de 30% mes lapins grâce à l'outil RDV.S c'est un outil vraiment top ! »
+            p « J'ai réduit de 30% mes lapins grâce à l'outil RDV.S c'est un outil vraiment top ! »
           figcaption
             p.fr-quote__author Une conseillère numérique France service de la Nièvre
         figure.fr-quote

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -32,7 +32,7 @@ ul.list-group.fr-mb-3w
   - if @rdv.motif.instruction_for_rdv.present?
     li.list-group-item
       i.fa.fa-exclamation-triangle>
-      strong Informations supplémentaires :
+      strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(@rdv.motif)
 

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -64,12 +64,12 @@ ul.list-group.list-group-flush
           | Informations de contact :&nbsp;
       .row
         .col.ml-3
-          span> ✉️ Email :
+          span> ✉️ Email&nbsp;:
           b>= current_user.email
           span>= "(notifications par email #{current_user.notify_by_email? ? 'activées' :  'désactivées'})"
       .row
         .col.ml-3
-          span> 📞 Téléphone :
+          span> 📞 Téléphone&nbsp;:
           = user_notifiable_by_sms_text(current_user)
         .col-auto
           = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -52,7 +52,7 @@ ul.list-group.list-group-flush
   - if rdv.motif.instruction_for_rdv.present?
     li.list-group-item
       i.fa.fa-exclamation-triangle>
-      strong Informations supplémentaires :
+      strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(rdv.motif)
   = render "/users/rdvs/file_attente", rdv: rdv

--- a/app/views/users/user_name_initials_verification/new.html.slim
+++ b/app/views/users/user_name_initials_verification/new.html.slim
@@ -6,7 +6,7 @@
   .card-body
     = render "form", user: current_user
   .car-footer.rdv-text-align-center
-    p Par exemple :
+    p Par exemple&nbsp;:
     p.fw-lighter.fs-6 = t(".examples.first")
     p.fw-lighter.fs-6 = t(".examples.second")
     p.fw-lighter.fs-6 = t(".examples.third")

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -7,7 +7,7 @@ fr:
       send_instructions: "Vous allez recevoir les instructions nécessaires à la confirmation de votre compte dans quelques minutes."
       send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez bientôt recevoir un e-mail contenant les instructions de confirmation de votre compte."
     failure:
-      deleted_account: "Votre compte a été supprimé !"
+      deleted_account: "Votre compte a été supprimé&nbsp;!"
       invited: "Vous avez une invitation en attente. Acceptez-la pour terminer votre inscription."
       already_authenticated: "Votre connexion est déjà active"
       inactive: "Votre compte n'est pas encore activé."
@@ -63,7 +63,7 @@ fr:
       password_change:
         subject: "Votre mot de passe a été modifié avec succès."
     omniauth_callbacks:
-      failure: "Nous n'avons pas pu vous authentifier via %{kind} : '%{reason}'."
+      failure: "Nous n'avons pas pu vous authentifier via %{kind}&nbsp;: '%{reason}'."
       success: "Authentifié avec succès via %{kind}."
     passwords:
       no_token: "Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous avez utilisé un e-mail de ce type, assurez-vous d'utiliser l'URL complète."
@@ -95,8 +95,8 @@ fr:
       not_found: "n'a pas été trouvé(e)"
       not_locked: "n'était pas verrouillé(e)"
       not_saved:
-        one: "Une erreur a empêché ce(tte) %{resource} d'être sauvegardé(e) :"
-        other: "%{count} erreurs ont empêché ce(tte) %{resource} d'être sauvegardé(e) :"
+        one: "Une erreur a empêché ce(tte) %{resource} d'être sauvegardé(e)&nbsp;:"
+        other: "%{count} erreurs ont empêché ce(tte) %{resource} d'être sauvegardé(e)&nbsp;:"
   time:
     formats:
       devise:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,7 +65,7 @@ fr:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validation a échoué : %{errors}"
+        record_invalid: "La validation a échoué&nbsp;: %{errors}"
         restrict_dependent_destroy:
           has_one:
             Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
@@ -213,7 +213,7 @@ fr:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: 'Validation échouée : %{errors}'
+      model_invalid: 'Validation échouée&nbsp;: %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
@@ -231,10 +231,10 @@ fr:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
     template:
-      body: 'Veuillez vérifier les champs suivants : '
+      body: 'Veuillez vérifier les champs suivants&nbsp;: '
       header:
-        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
-        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
+        one: 'Impossible d''enregistrer ce(tte) %{model}&nbsp;: 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model}&nbsp;: %{count} erreurs'
   helpers:
     label:
       agent:
@@ -274,7 +274,7 @@ fr:
       update: Enregistrer
   layouts:
     flash:
-      confirm_export_queued_html: 'Votre export est en cours de création : il sera bientôt disponible dans la <a href="%{exports_path}">liste de vos exports</a>.'
+      confirm_export_queued_html: 'Votre export est en cours de création&nbsp;: il sera bientôt disponible dans la <a href="%{exports_path}">liste de vos exports</a>.'
     currency:
       format:
         delimiter: " "

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -13,7 +13,7 @@ fr:
         bookable_by_hint: "Définissez quel utilisateur peut prendre rendez-vous pour ce motif :"
         visibility_type: Visibilité usager
         booking_delay: Délai de réservation
-        booking_delay_hint: "Vous pouvez définir une “fenêtre de réservation” pour la prise d’un rendez-vous : il s’agit du délai maximum et minimum possible, entre le moment où l’usager prend rendez-vous, et le rendez-vous en lui même. Ces délais ne s'appliquent pas à la prise de rendez-vous par d'autres agents."
+        booking_delay_hint: "Vous pouvez définir une “fenêtre de réservation” pour la prise d’un rendez-vous&nbsp;: il s’agit du délai maximum et minimum possible, entre le moment où l’usager prend rendez-vous, et le rendez-vous en lui même. Ces délais ne s'appliquent pas à la prise de rendez-vous par d'autres agents."
         custom_cancel_warning_message: Message d’avertissement en cas d’annulation
         custom_cancel_warning_message_hint: Ce message sera affiché à l'usager au moment où il lui sera demandé de confirmer l’annulation de son RDV. Si l’annulation du rendez-vous a des conséquences particulières pour l’usager, vous pouvez lui indiquer dans ce message. Cela peut être le cas, par exemple, pour une convocation pour l’ouverture de droits sociaux.
         default_cancel_warning_message: Voulez-vous vraiment annuler ce RDV ?
@@ -62,12 +62,12 @@ fr:
         invisible: Le rendez-vous ne sera pas visible dans l’espace personnel de l’usager, et il ne recevra aucune notification.
       motif/visibility_types/hint_rdv_insertion:
         visible_and_notified: ""
-        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion)"
-        invisible: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion)"
+        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion)"
+        invisible: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion)"
       motif/visibility_types/hint_checkbox:
         visible_and_notified: ""
-        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
-        invisible: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
+        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
+        invisible: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
       # --------------------------------------------
       motif/sectorisation_levels:
         agent: Sectorisation à l'agent

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -7,7 +7,7 @@ fr:
     attributes:
       user:
         organisation: Organisation
-        caisse_affiliation : Caisse d'affiliation
+        caisse_affiliation: Caisse d'affiliation
         affiliation_number: Numéro d'allocataire
         family_situation: Situation familiale
         number_of_children: Nombre d'enfants

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -19,12 +19,12 @@ fr:
       sectorisation_level:
         sectors_attributed_to_orga:
           zero: "Aucun secteur n'est attribué à l'organisation %{organisation}, ce motif n'apparaîtra donc dans aucune recherche usager"
-          one: "Un seul secteur est attribué à l'organisation %{organisation} : %{sectors}"
-          other: "%{count} secteurs sont attribués à l'organisation %{organisation} : %{sectors}"
+          one: "Un seul secteur est attribué à l'organisation %{organisation}&nbsp;: %{sectors}"
+          other: "%{count} secteurs sont attribués à l'organisation %{organisation}&nbsp;: %{sectors}"
         sectors_attributed_to_agents:
           zero: "Aucun secteur n'est attribué à des agents du service %{service}, ce motif n'apparaîtra donc dans aucune recherche usager"
-          one: "Un seul agent du service %{service} est attribué à %{sectors_count_human} : %{sectors}"
-          other: "%{count} agents du service %{service} sont attribués à %{sectors_count_human} : %{sectors}"
+          one: "Un seul agent du service %{service} est attribué à %{sectors_count_human}&nbsp;: %{sectors}"
+          other: "%{count} agents du service %{service} sont attribués à %{sectors_count_human}&nbsp;: %{sectors}"
     index:
       title: Motifs de l'organisation
       sectorisation_level_organisation:

--- a/config/locales/rdvs.fr.yml
+++ b/config/locales/rdvs.fr.yml
@@ -1,7 +1,7 @@
 fr:
   rdvs:
-    title: "Le %{starts_at} (durée : %{duration} minutes)"
-    title_time_only: "Aujourd’hui à %{starts_at} (durée : %{duration} minutes)"
+    title: "Le %{starts_at} (durée&nbsp;: %{duration} minutes)"
+    title_time_only: "Aujourd’hui à %{starts_at} (durée&nbsp;: %{duration} minutes)"
     available_seats:
       one: 1 place restante
       other: "%{count} places restantes"

--- a/config/locales/sectors.yml
+++ b/config/locales/sectors.yml
@@ -2,25 +2,25 @@ fr:
   sectors:
     motifs_with_agent_level_sectorisation_in_service:
       zero: "⚠️ aucun motif du service %{service} n'est sectorisé par agent"
-      one: "1 motif du service %{service} est sectorisé par agent : %{motifs}"
-      other: "%{count} motifs du service %{service} sont sectorisés par agent : %{motifs}"
+      one: "1 motif du service %{service} est sectorisé par agent&nbsp;: %{motifs}"
+      other: "%{count} motifs du service %{service} sont sectorisés par agent&nbsp;: %{motifs}"
     motifs_with_organisation_level_sectorisation:
       zero: "⚠️ aucun motif de %{organisation} n'est sectorisé à l'organisation"
-      one: "Un motif de %{organisation} est sectorisé à l'organisation : %{motifs}"
-      other: "%{count} motifs de %{organisation} sont sectorisés à l'organisation : %{motifs}"
+      one: "Un motif de %{organisation} est sectorisé à l'organisation&nbsp;: %{motifs}"
+      other: "%{count} motifs de %{organisation} sont sectorisés à l'organisation&nbsp;: %{motifs}"
   sectorisation_tests:
     attributed_sectors_count:
       zero: "Aucun secteur attribué"
-      one: "1 secteur attribué :"
-      other: "%{count} secteurs attribués :"
+      one: "1 secteur attribué&nbsp;:"
+      other: "%{count} secteurs attribués&nbsp;:"
     available_motifs_count:
       zero: "aucun motif disponible"
-      one: "1 motif disponible :"
-      other: "%{count} motifs disponibles :"
+      one: "1 motif disponible&nbsp;:"
+      other: "%{count} motifs disponibles&nbsp;:"
     available_motifs_in_service_count:
       one: "1 motif disponible dans le service %{service}"
       other: "%{count} motifs disponibles dans le service %{service}"
     departement_motifs_count:
       zero: "Aucun motif sectorisé à l'échelle du département disponible"
-      one: "1 motif sectorisé à l'échelle du département disponible dans l'organisation %{organisation} pour le service %{service} :"
-      other: "%{count} motifs sectorisés à l'échelle du département disponibles dans l'organisation %{organisation} pour le service %{service} :"
+      one: "1 motif sectorisé à l'échelle du département disponible dans l'organisation %{organisation} pour le service %{service}&nbsp;:"
+      other: "%{count} motifs sectorisés à l'échelle du département disponibles dans l'organisation %{organisation} pour le service %{service}&nbsp;:"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -9,7 +9,7 @@ fr:
       # When using html, text and mark won't be used.
       # html: '<abbr title="required">*</abbr>'
     error_notification:
-      default_message: "Merci de corriger les problèmes suivants :"
+      default_message: "Merci de corriger les problèmes suivants&nbsp;:"
     # Examples
     # labels:
     #   defaults:

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -9,8 +9,8 @@ fr:
         search_for_slots_subtitle: pour %{users_fullname}
         available_places_with_slots:
           zero: Aucun lieu ne propose de disponibilité
-          one: "Un lieu propose des disponibilités :"
-          other: "%{count} lieux proposent des disponibilités :"
+          one: "Un lieu propose des disponibilités&nbsp;:"
+          other: "%{count} lieux proposent des disponibilités&nbsp;:"
       selection_creneaux:
         place_index: Revenir aux filtres
         available_slots_title_html: Créneaux disponibles pour <strong>%{motif}</strong>

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -15,7 +15,7 @@ fr:
         rdv_notifications_header: "Recevoir un email de notification pour mes rendez-vous :"
         plage_ouverture_notifications_header: "Recevoir un email de notification pour mes plages d'ouverture :"
         absence_notifications_header: "Recevoir un email de notification pour mes indisponibilités :"
-        technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra, etc.) avec RDV Solidarités.
+        technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra,&nbsp;etc.) avec RDV Solidarités.
       update:
         done: Préférences de notifications mises à jour.
     exports:

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -120,7 +120,7 @@ fr:
       motif_categories:
         edit:
           title: Catégories de motifs disponibles
-          hint_1: "Les catégories seront/ne seront plus disponibles dans l’interface : les données préexistantes ne seront pas supprimées."
+          hint_1: "Les catégories seront/ne seront plus disponibles dans l’interface&nbsp;: les données préexistantes ne seront pas supprimées."
       rdv_fields:
         edit:
           title: Champs de la fiche RDV

--- a/config/locales/views/lieux.fr.yml
+++ b/config/locales/views/lieux.fr.yml
@@ -4,7 +4,7 @@ fr:
       lieu_available:
         one: 1 lieu est disponible
         other: "%{count} lieux sont disponibles"
-      select_lieu: "Sélectionnez un lieu de RDV :"
+      select_lieu: "Sélectionnez un lieu de RDV&nbsp;:"
       next_availability: Prochaine disponibilité le
       no_availability: Aucune disponibilité
   lieux:
@@ -15,7 +15,7 @@ fr:
       address: "Votre adresse"
       service: "Votre service"
       motif: "Votre motif"
-      address_example: "ex : 21 rue Anatole France, Calais"
+      address_example: "ex&nbsp;: 21 rue Anatole France, Calais"
       change_address: "Modifier l'adresse"
       choose_service: "Choisissez un service"
       choose_this_service: "Choisir ce service"

--- a/config/locales/views/user_name_initials_verification.yml
+++ b/config/locales/views/user_name_initials_verification.yml
@@ -4,6 +4,6 @@ fr:
       new:
         title: Entrez les 3 premières lettres de votre nom de famille
         examples:
-          first: "Sophie Dupont : DUP"
-          second: "Jean De La Fontaine : DEL"
-          third: "Edwige Xi : XI"
+          first: "Sophie Dupont&nbsp;: DUP"
+          second: "Jean De La Fontaine&nbsp;: DEL"
+          third: "Edwige Xi&nbsp;: XI"

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "can see users' RDV" do
       expect(page).to have_content("À venir\n1 RDV")
       click_link "Voir tous les rendez-vous de Tanguy LAVERDURE"
       expect_page_title("Liste des RDV")
-      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
+      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée&nbsp;: #{rdv.duration_in_min} minutes)")
     end
   end
 end

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
     click_link(agent.services.first.name)
     expect(page).to have_content("Sélectionnez le motif de votre RDV :")
     click_link("Accompagnement Formation")
-    expect(page).to have_content("Sélectionnez un lieu de RDV :")
+    expect(page).to have_content("Sélectionnez un lieu de RDV")
     click_link("Prochaine disponibilité")
-    expect(page).to have_content("Sélectionnez un créneau :")
+    expect(page).to have_content("Sélectionnez un créneau")
   end
 
   it "works on the RDV_MAIRIE domain" do

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
       find_all("a", text: "modifier").last.click # Retour en arrière au choix de créneau
 
-      expect(page).to have_content("Sélectionnez un créneau :")
+      expect(page).to have_content("Sélectionnez un créneau")
 
       click_on(lieu.name)
 

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Adding a user to a collective RDV" do
   end
 
   def select_lieu
-    expect(page).to have_content("Sélectionnez un lieu de RDV :")
+    expect(page).to have_content("Sélectionnez un lieu de RDV")
     click_link("Prochaine disponibilité")
   end
 

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "User views his rdv" do
     before { click_link "Vos rendez-vous" }
 
     it do
-      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
+      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée&nbsp;: #{rdv.duration_in_min} minutes)")
       click_link "Voir vos RDV passés"
       expect_page_with_no_record_text("Vous n'avez pas de RDV passés")
     end
@@ -33,6 +33,6 @@ RSpec.describe "User views his rdv" do
     click_link "Vos rendez-vous"
     expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
     click_link "Voir vos RDV passés"
-    expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
+    expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée&nbsp;: #{rdv.duration_in_min} minutes)")
   end
 end

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe RdvsHelper do
   describe "#rdv_title" do
     it "show date, time and duration in minutes" do
       rdv = build(:rdv, starts_at: Time.zone.parse("2020-10-23 12h54"), duration_in_min: 30)
-      expect(rdv_title(rdv)).to eq("Le vendredi 23 octobre 2020 à 12h54 (durée : 30 minutes)")
+      expect(rdv_title(rdv)).to eq("Le vendredi 23 octobre 2020 à 12h54 (durée&nbsp;: 30 minutes)")
     end
 
     it "when rdv starts_at today, show only time and duration in minutes" do
       now = Time.zone.parse("2020-10-23 12h54")
       travel_to(now)
       rdv = build(:rdv, starts_at: now + 3.hours, duration_in_min: 30)
-      expect(rdv_title(rdv)).to eq("Aujourd’hui à 15h54 (durée : 30 minutes)")
+      expect(rdv_title(rdv)).to eq("Aujourd’hui à 15h54 (durée&nbsp;: 30 minutes)")
       travel_back
     end
   end


### PR DESCRIPTION
J'ai utilisé principalement du search and replace, et un peu de repérage manuel.

Pour les règles d'usage je me suis basé lè-dessus : 
https://www.lalanguefrancaise.com/articles/espace-insecable

Je n'ai pas pu corriger les erreurs qui étaient dans des chaînes ruby dans du SLIM, du genre 

```slim
strong = "Voici un exemple :"
```

parce que ce chaînes sont échappées et donc le `&nbsp;` apparaît dans la page.

# Avant (exemple)

![image](https://github.com/user-attachments/assets/f22783f1-67dd-4be2-9ae9-c14ef06b48ca)

# Après (exemple)

![image](https://github.com/user-attachments/assets/8cdd650d-fb85-4a43-8fe5-afaf9869423b)
