### PR TITLE
Amélioration des performances sur le calcul de toutes les occurrences d'une plage d'ouverture ou d'une absence

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -110,7 +110,10 @@ module RecurrenceConcern
     def all_occurrences_for(period)
       # defined as a class method, but typically used on ActiveRecord::Relation
       current_scope ||= all
-      current_scope.flat_map do |element|
+
+      elements_without_ended_reccurrence = current_scope.where("recurrence is null or recurrence_ends_at is null or recurrence_ends_at >= ?", period.begin)
+
+      elements_without_ended_reccurrence.flat_map do |element|
         element.occurrences_for(period).map { |occurrence| [element, occurrence] }
       end.sort_by(&:second)
     end

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -111,9 +111,7 @@ module RecurrenceConcern
       # defined as a class method, but typically used on ActiveRecord::Relation
       current_scope ||= all
 
-      elements_without_ended_reccurrence = current_scope.where("recurrence is null or recurrence_ends_at is null or recurrence_ends_at >= ?", period.begin)
-
-      elements_without_ended_reccurrence.flat_map do |element|
+      current_scope.in_range(period).flat_map do |element|
         element.occurrences_for(period).map { |occurrence| [element, occurrence] }
       end.sort_by(&:second)
     end

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -64,6 +64,27 @@ RSpec.describe RecurrenceConcern do
                                        starts_at: Time.zone.parse("2019-07-31 8h00"),
                                        ends_at: Time.zone.parse("2019-07-31 12h00"))
     end
+
+    it "doesn't return occurrences for an object with a finished recurrence" do
+      create(factory, recurrence: Montrose.every(:week, on: [:monday], starts: Date.new(2019, 7, 1), until: Date.new(2019, 7, 22)),
+                      first_day: Date.new(2019, 7, 1), start_time: Time.zone.parse("8h00"),
+                      end_time: Time.zone.parse("12h00"))
+
+      # On vérifie que le filtre est fait au niveau sql plutôt qu'en instanciant des objets
+      expect_any_instance_of(described_class).not_to receive(:occurrences_for)
+
+      expect(described_class.all_occurrences_for(Date.new(2019, 7, 23)..Date.new(2019, 8, 15))).to be_empty
+    end
+
+    it "returns the last occurrence when it's the first day of the date range" do
+      object = create(factory, recurrence: Montrose.every(:week, on: [:monday], starts: Date.new(2019, 7, 1), until: Date.new(2019, 7, 22)),
+                               first_day: Date.new(2019, 7, 1), start_time: Time.zone.parse("8h00"),
+                               end_time: Time.zone.parse("12h00"))
+
+      expect(described_class.all_occurrences_for(Date.new(2019, 7, 22)..Date.new(2019, 7, 23))).to contain_exactly(
+        [object, Recurrence::Occurrence.new(starts_at: Time.zone.parse("2019-7-22, 8h00"), ends_at: Time.zone.parse("2019-7-22, 12h00"))]
+      )
+    end
   end
 
   shared_examples "#in_range" do

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe RecurrenceConcern do
                       end_time: Time.zone.parse("12h00"))
 
       # On vérifie que le filtre est fait au niveau sql plutôt qu'en instanciant des objets
-      expect_any_instance_of(described_class).not_to receive(:occurrences_for)
+      expect_any_instance_of(described_class).not_to receive(:occurrences_for) # rubocop:disable RSpec/AnyInstance
 
       expect(described_class.all_occurrences_for(Date.new(2019, 7, 23)..Date.new(2019, 8, 15))).to be_empty
     end


### PR DESCRIPTION
# Contexte

En travaillant sur le dernier endpoint de visioplainte, j'allais utiliser `PlageOuverture.all_occurrences_for`, et en lisant le code je me suis rendu compte qu'il y a un gros calcul qu'on pourrait s'épargner.

On utilise typiquement cette méthode dans les controllers qui génèrent le json qui permet d'afficher le contenu d'une semaine de calendrier.
L'implémentation actuelle de `PlageOuverture.all_occurrences_for(Date.new(2024, 9, 16)..Date.new(2024, 4, 22))` fait les opérations suivantes : 
- on instancie toutes les plages d'ouvertures (c'est trop)
- on calcule toutes leurs occurrences (c'est aussi trop)
- on filtre juste les occurrence qui ont lieu entre `Date.new(2024, 9, 16)` et `Date.new(2024, 4, 22)`

# Solution

Cette PR fait une première optimisation évidente : on évite de charger en mémoire les plages d'ouvertures (ou les absences) dont la récurrence se termine avant le début de la période qu'on regarde.

~~Il y a d'autres améliorations possibles, mais je préfère les faire par petites étapes pour minimiser le risque de bug.~~

En fait, on peut faire encore mieux en réutilisant direct le scope `in_range` 🤯 

Au passage j'ajoute une spec qui vérifie le cas général, un edge case, et qui vérifie que le tri est fait en sql et pas en mémoire.

Je m'attends à ce que ça fasse une amélioration visible sur skylight pour `Admin::Agenda::PlageOuverturesController` et `Admin::Agenda::AbsencesController`