### PR TITLE
Harmonisation des noms de params pour visioplainte

### DIFF
--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -1,7 +1,7 @@
 class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   def index # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
-    if params[:ids].blank? && (params[:from].blank? || params[:to].blank?)
-      errors = ["Vous devez préciser le paramètre ids ou les paramètres from et to"]
+    if params[:ids].blank? && (params[:date_debut].blank? || params[:date_fin].blank?)
+      errors = ["Vous devez préciser le paramètre ids ou les paramètres date_debut et date_fin"]
       render(json: { errors: errors }, status: :bad_request) and return
     end
 
@@ -11,8 +11,8 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
       rdvs = rdvs.where(id: params[:ids])
     end
 
-    if params[:from].present? && params[:to].present?
-      rdvs = rdvs.where("starts_at >= ?", Time.zone.parse(params[:from])).where("starts_at <= ?", Time.zone.parse(params[:to]))
+    if params[:date_debut].present? && params[:date_fin].present?
+      rdvs = rdvs.where("starts_at >= ?", Time.zone.parse(params[:date_debut])).where("starts_at <= ?", Time.zone.parse(params[:date_fin]))
     end
 
     if params[:guichet_ids]

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Visioplainte Rdvs" do
     before { create_rdv }
 
     it "returns the list of rdvs" do
-      get "/api/visioplainte/rdvs/", params: { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }, headers: auth_header
+      get "/api/visioplainte/rdvs/", params: { date_debut: "2024-08-19T08:00:00+02:00", date_fin: "2024-08-20T08:00:00+02:00" }, headers: auth_header
       expect(response.status).to eq 200
 
       expect(response.parsed_body["rdvs"][0]["starts_at"]).to eq "2024-08-19 08:00:00 +0200"
@@ -129,15 +129,15 @@ RSpec.describe "Visioplainte Rdvs" do
 
     describe "authentication" do
       it "returns a 400 status if the auth header is missing" do
-        get "/api/visioplainte/rdvs/", params: { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }, headers: {}
+        get "/api/visioplainte/rdvs/", params: { date_debut: "2024-08-19T08:00:00+02:00", date_fin: "2024-08-20T08:00:00+02:00" }, headers: {}
         expect(response.status).to eq 401
         expect(response.parsed_body["rdvs"]).to be_blank
       end
     end
 
-    context "when there are no rdvs for the from and to params" do
+    context "when there are no rdvs for the date_debut and date_fin params" do
       it "returns an empty list" do
-        get "/api/visioplainte/rdvs/", params: { from: "2024-08-22T08:00:00+02:00", to: "2024-08-23T08:00:00+02:00" }, headers: auth_header
+        get "/api/visioplainte/rdvs/", params: { date_debut: "2024-08-22T08:00:00+02:00", date_fin: "2024-08-23T08:00:00+02:00" }, headers: auth_header
         expect(response.status).to eq 200
 
         expect(response.parsed_body["rdvs"]).to be_empty
@@ -162,7 +162,7 @@ RSpec.describe "Visioplainte Rdvs" do
 
     context "when filtering by guichet" do
       let(:date_params) do
-        { from: "2024-08-19T08:00:00+02:00", to: "2024-08-20T08:00:00+02:00" }
+        { date_debut: "2024-08-19T08:00:00+02:00", date_fin: "2024-08-20T08:00:00+02:00" }
       end
 
       let(:gendarmerie_guichet_ids) do
@@ -183,12 +183,12 @@ RSpec.describe "Visioplainte Rdvs" do
       end
     end
 
-    context "without from, to or ids params" do
+    context "without date_debut, date_fin or ids params" do
       it "returns an error" do
         get "/api/visioplainte/rdvs/", params: {}, headers: auth_header
 
         expect(response.status).to eq 400
-        expect(response.parsed_body["errors"].first).to eq "Vous devez préciser le paramètre ids ou les paramètres from et to"
+        expect(response.parsed_body["errors"].first).to eq "Vous devez préciser le paramètre ids ou les paramètres date_debut et date_fin"
       end
     end
   end

--- a/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/rdvs_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
 
       tags "Rendez-vous"
       description "Liste tous les rendez-vous, et permet de filtrer par date, par guichet, ou sur des rdv spécifiques"
-      parameter name: "from", in: :query, type: :string,
+      parameter name: "date_debut", in: :query, type: :string,
                 description: "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé.\
                 Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
                 example: "2024-08-19T08:00:00+02:00", required: false
-      parameter name: "to", in: :query, type: :string,
+      parameter name: "date_fin", in: :query, type: :string,
                 description: "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé.\
                 Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
                 example: "2024-08-22T19:00:00+02:00", required: false
@@ -43,8 +43,8 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do # rub
 
       response 200, "Renvoie la liste" do
         run_test!
-        let(:from) { "2024-08-19T08:00:00+02:00" }
-        let(:to) { "2024-08-20T08:00:00+02:00" }
+        let(:date_debut) { "2024-08-19T08:00:00+02:00" }
+        let(:date_fin) { "2024-08-20T08:00:00+02:00" }
       end
     end
     post "Prendre un rdv" do

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -415,7 +415,7 @@
             }
           },
           {
-            "name": "from",
+            "name": "date_debut",
             "in": "query",
             "description": "datetime au format iso8601. Obligatoire sauf si le paramètre ids est utilisé.                Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent à partir de cette heure",
             "example": "2024-08-19T08:00:00+02:00",
@@ -425,7 +425,7 @@
             }
           },
           {
-            "name": "to",
+            "name": "date_fin",
             "in": "query",
             "description": "datetime au format iso8601.  Obligatoire sauf si le paramètre ids est utilisé.                Permet de filtrer pour obtenir uniquement les rendez-vous qui commencent avant cette heure",
             "example": "2024-08-22T19:00:00+02:00",


### PR DESCRIPTION
Je me suis rendu compte qu'un petit anglicisme s'était glissé dans https://github.com/betagouv/rdv-service-public/pull/4628, et je reprends donc les noms de paramètres qu'on utilise déjà ailleurs dans cette api.