### PR TITLE
Suppression de caractères &nbsp; non-interprétés des locales

### DIFF
--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -7,7 +7,7 @@ fr:
       send_instructions: "Vous allez recevoir les instructions nécessaires à la confirmation de votre compte dans quelques minutes."
       send_paranoid_instructions: "Si votre e-mail existe dans notre base de données, vous allez bientôt recevoir un e-mail contenant les instructions de confirmation de votre compte."
     failure:
-      deleted_account: "Votre compte a été supprimé&nbsp;!"
+      deleted_account: "Votre compte a été supprimé !"
       invited: "Vous avez une invitation en attente. Acceptez-la pour terminer votre inscription."
       already_authenticated: "Votre connexion est déjà active"
       inactive: "Votre compte n'est pas encore activé."
@@ -63,7 +63,7 @@ fr:
       password_change:
         subject: "Votre mot de passe a été modifié avec succès."
     omniauth_callbacks:
-      failure: "Nous n'avons pas pu vous authentifier via %{kind}&nbsp;: '%{reason}'."
+      failure: "Nous n'avons pas pu vous authentifier via %{kind} : '%{reason}'."
       success: "Authentifié avec succès via %{kind}."
     passwords:
       no_token: "Vous ne pouvez accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si vous avez utilisé un e-mail de ce type, assurez-vous d'utiliser l'URL complète."
@@ -95,8 +95,8 @@ fr:
       not_found: "n'a pas été trouvé(e)"
       not_locked: "n'était pas verrouillé(e)"
       not_saved:
-        one: "Une erreur a empêché ce(tte) %{resource} d'être sauvegardé(e)&nbsp;:"
-        other: "%{count} erreurs ont empêché ce(tte) %{resource} d'être sauvegardé(e)&nbsp;:"
+        one: "Une erreur a empêché ce(tte) %{resource} d'être sauvegardé(e) :"
+        other: "%{count} erreurs ont empêché ce(tte) %{resource} d'être sauvegardé(e) :"
   time:
     formats:
       devise:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,7 +65,7 @@ fr:
   activerecord:
     errors:
       messages:
-        record_invalid: "La validation a échoué&nbsp;: %{errors}"
+        record_invalid: "La validation a échoué : %{errors}"
         restrict_dependent_destroy:
           has_one:
             Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
@@ -213,7 +213,7 @@ fr:
       invalid: n'est pas valide
       less_than: doit être inférieur à %{count}
       less_than_or_equal_to: doit être inférieur ou égal à %{count}
-      model_invalid: 'Validation échouée&nbsp;: %{errors}'
+      model_invalid: 'Validation échouée : %{errors}'
       not_a_number: n'est pas un nombre
       not_an_integer: doit être un nombre entier
       odd: doit être impair
@@ -231,10 +231,10 @@ fr:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
     template:
-      body: 'Veuillez vérifier les champs suivants&nbsp;: '
+      body: 'Veuillez vérifier les champs suivants : '
       header:
-        one: 'Impossible d''enregistrer ce(tte) %{model}&nbsp;: 1 erreur'
-        other: 'Impossible d''enregistrer ce(tte) %{model}&nbsp;: %{count} erreurs'
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
   helpers:
     label:
       agent:

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -13,7 +13,7 @@ fr:
         bookable_by_hint: "Définissez quel utilisateur peut prendre rendez-vous pour ce motif :"
         visibility_type: Visibilité usager
         booking_delay: Délai de réservation
-        booking_delay_hint: "Vous pouvez définir une “fenêtre de réservation” pour la prise d’un rendez-vous&nbsp;: il s’agit du délai maximum et minimum possible, entre le moment où l’usager prend rendez-vous, et le rendez-vous en lui même. Ces délais ne s'appliquent pas à la prise de rendez-vous par d'autres agents."
+        booking_delay_hint: "Vous pouvez définir une “fenêtre de réservation” pour la prise d’un rendez-vous : il s’agit du délai maximum et minimum possible, entre le moment où l’usager prend rendez-vous, et le rendez-vous en lui même. Ces délais ne s'appliquent pas à la prise de rendez-vous par d'autres agents."
         custom_cancel_warning_message: Message d’avertissement en cas d’annulation
         custom_cancel_warning_message_hint: Ce message sera affiché à l'usager au moment où il lui sera demandé de confirmer l’annulation de son RDV. Si l’annulation du rendez-vous a des conséquences particulières pour l’usager, vous pouvez lui indiquer dans ce message. Cela peut être le cas, par exemple, pour une convocation pour l’ouverture de droits sociaux.
         default_cancel_warning_message: Voulez-vous vraiment annuler ce RDV ?
@@ -62,12 +62,12 @@ fr:
         invisible: Le rendez-vous ne sera pas visible dans l’espace personnel de l’usager, et il ne recevra aucune notification.
       motif/visibility_types/hint_rdv_insertion:
         visible_and_notified: ""
-        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion)"
-        invisible: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion)"
+        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion)"
+        invisible: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion)"
       motif/visibility_types/hint_checkbox:
         visible_and_notified: ""
-        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
-        invisible: "Les notifications peuvent être envoyées d'une application externe (ex&nbsp;: Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
+        visible_and_not_notified: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
+        invisible: "Les notifications peuvent être envoyées d'une application externe (ex : Motif de Convocation avec RDV-Insertion). Dans ce cas vous pouvez laisser cette case décochée"
       # --------------------------------------------
       motif/sectorisation_levels:
         agent: Sectorisation à l'agent

--- a/config/locales/motifs.yml
+++ b/config/locales/motifs.yml
@@ -19,12 +19,12 @@ fr:
       sectorisation_level:
         sectors_attributed_to_orga:
           zero: "Aucun secteur n'est attribué à l'organisation %{organisation}, ce motif n'apparaîtra donc dans aucune recherche usager"
-          one: "Un seul secteur est attribué à l'organisation %{organisation}&nbsp;: %{sectors}"
-          other: "%{count} secteurs sont attribués à l'organisation %{organisation}&nbsp;: %{sectors}"
+          one: "Un seul secteur est attribué à l'organisation %{organisation} : %{sectors}"
+          other: "%{count} secteurs sont attribués à l'organisation %{organisation} : %{sectors}"
         sectors_attributed_to_agents:
           zero: "Aucun secteur n'est attribué à des agents du service %{service}, ce motif n'apparaîtra donc dans aucune recherche usager"
-          one: "Un seul agent du service %{service} est attribué à %{sectors_count_human}&nbsp;: %{sectors}"
-          other: "%{count} agents du service %{service} sont attribués à %{sectors_count_human}&nbsp;: %{sectors}"
+          one: "Un seul agent du service %{service} est attribué à %{sectors_count_human} : %{sectors}"
+          other: "%{count} agents du service %{service} sont attribués à %{sectors_count_human} : %{sectors}"
     index:
       title: Motifs de l'organisation
       sectorisation_level_organisation:

--- a/config/locales/rdvs.fr.yml
+++ b/config/locales/rdvs.fr.yml
@@ -1,6 +1,6 @@
 fr:
   rdvs:
-    title: "Le %{starts_at} (durée&nbsp;: %{duration} minutes)"
+    title: "Le %{starts_at} (durée : %{duration} minutes)"
     title_time_only: "Aujourd’hui à %{starts_at} (durée&nbsp;: %{duration} minutes)"
     available_seats:
       one: 1 place restante

--- a/config/locales/rdvs.fr.yml
+++ b/config/locales/rdvs.fr.yml
@@ -1,7 +1,7 @@
 fr:
   rdvs:
     title: "Le %{starts_at} (durée : %{duration} minutes)"
-    title_time_only: "Aujourd’hui à %{starts_at} (durée&nbsp;: %{duration} minutes)"
+    title_time_only: "Aujourd’hui à %{starts_at} (durée : %{duration} minutes)"
     available_seats:
       one: 1 place restante
       other: "%{count} places restantes"

--- a/config/locales/sectors.yml
+++ b/config/locales/sectors.yml
@@ -2,25 +2,25 @@ fr:
   sectors:
     motifs_with_agent_level_sectorisation_in_service:
       zero: "⚠️ aucun motif du service %{service} n'est sectorisé par agent"
-      one: "1 motif du service %{service} est sectorisé par agent&nbsp;: %{motifs}"
-      other: "%{count} motifs du service %{service} sont sectorisés par agent&nbsp;: %{motifs}"
+      one: "1 motif du service %{service} est sectorisé par agent : %{motifs}"
+      other: "%{count} motifs du service %{service} sont sectorisés par agent : %{motifs}"
     motifs_with_organisation_level_sectorisation:
       zero: "⚠️ aucun motif de %{organisation} n'est sectorisé à l'organisation"
-      one: "Un motif de %{organisation} est sectorisé à l'organisation&nbsp;: %{motifs}"
-      other: "%{count} motifs de %{organisation} sont sectorisés à l'organisation&nbsp;: %{motifs}"
+      one: "Un motif de %{organisation} est sectorisé à l'organisation : %{motifs}"
+      other: "%{count} motifs de %{organisation} sont sectorisés à l'organisation : %{motifs}"
   sectorisation_tests:
     attributed_sectors_count:
       zero: "Aucun secteur attribué"
-      one: "1 secteur attribué&nbsp;:"
-      other: "%{count} secteurs attribués&nbsp;:"
+      one: "1 secteur attribué :"
+      other: "%{count} secteurs attribués :"
     available_motifs_count:
       zero: "aucun motif disponible"
-      one: "1 motif disponible&nbsp;:"
-      other: "%{count} motifs disponibles&nbsp;:"
+      one: "1 motif disponible :"
+      other: "%{count} motifs disponibles :"
     available_motifs_in_service_count:
       one: "1 motif disponible dans le service %{service}"
       other: "%{count} motifs disponibles dans le service %{service}"
     departement_motifs_count:
       zero: "Aucun motif sectorisé à l'échelle du département disponible"
-      one: "1 motif sectorisé à l'échelle du département disponible dans l'organisation %{organisation} pour le service %{service}&nbsp;:"
-      other: "%{count} motifs sectorisés à l'échelle du département disponibles dans l'organisation %{organisation} pour le service %{service}&nbsp;:"
+      one: "1 motif sectorisé à l'échelle du département disponible dans l'organisation %{organisation} pour le service %{service} :"
+      other: "%{count} motifs sectorisés à l'échelle du département disponibles dans l'organisation %{organisation} pour le service %{service} :"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -9,7 +9,7 @@ fr:
       # When using html, text and mark won't be used.
       # html: '<abbr title="required">*</abbr>'
     error_notification:
-      default_message: "Merci de corriger les problèmes suivants&nbsp;:"
+      default_message: "Merci de corriger les problèmes suivants :"
     # Examples
     # labels:
     #   defaults:

--- a/config/locales/views/agent_searches.fr.yml
+++ b/config/locales/views/agent_searches.fr.yml
@@ -9,8 +9,8 @@ fr:
         search_for_slots_subtitle: pour %{users_fullname}
         available_places_with_slots:
           zero: Aucun lieu ne propose de disponibilité
-          one: "Un lieu propose des disponibilités&nbsp;:"
-          other: "%{count} lieux proposent des disponibilités&nbsp;:"
+          one: "Un lieu propose des disponibilités :"
+          other: "%{count} lieux proposent des disponibilités :"
       selection_creneaux:
         place_index: Revenir aux filtres
         available_slots_title_html: Créneaux disponibles pour <strong>%{motif}</strong>

--- a/config/locales/views/agents.fr.yml
+++ b/config/locales/views/agents.fr.yml
@@ -15,7 +15,7 @@ fr:
         rdv_notifications_header: "Recevoir un email de notification pour mes rendez-vous :"
         plage_ouverture_notifications_header: "Recevoir un email de notification pour mes plages d'ouverture :"
         absence_notifications_header: "Recevoir un email de notification pour mes indisponibilités :"
-        technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra,&nbsp;etc.) avec RDV Solidarités.
+        technical_email_explanation: Les emails de notification sont envoyés avec un fichier .ics qui vous permet de synchroniser votre calendrier (Outlook, zimbra, etc.) avec RDV Solidarités.
       update:
         done: Préférences de notifications mises à jour.
     exports:

--- a/config/locales/views/configuration.yml
+++ b/config/locales/views/configuration.yml
@@ -120,7 +120,7 @@ fr:
       motif_categories:
         edit:
           title: Catégories de motifs disponibles
-          hint_1: "Les catégories seront/ne seront plus disponibles dans l’interface&nbsp;: les données préexistantes ne seront pas supprimées."
+          hint_1: "Les catégories seront/ne seront plus disponibles dans l’interface : les données préexistantes ne seront pas supprimées."
       rdv_fields:
         edit:
           title: Champs de la fiche RDV

--- a/config/locales/views/lieux.fr.yml
+++ b/config/locales/views/lieux.fr.yml
@@ -4,7 +4,7 @@ fr:
       lieu_available:
         one: 1 lieu est disponible
         other: "%{count} lieux sont disponibles"
-      select_lieu: "Sélectionnez un lieu de RDV&nbsp;:"
+      select_lieu: "Sélectionnez un lieu de RDV :"
       next_availability: Prochaine disponibilité le
       no_availability: Aucune disponibilité
   lieux:
@@ -15,7 +15,7 @@ fr:
       address: "Votre adresse"
       service: "Votre service"
       motif: "Votre motif"
-      address_example: "ex&nbsp;: 21 rue Anatole France, Calais"
+      address_example: "ex : 21 rue Anatole France, Calais"
       change_address: "Modifier l'adresse"
       choose_service: "Choisissez un service"
       choose_this_service: "Choisir ce service"

--- a/config/locales/views/user_name_initials_verification.yml
+++ b/config/locales/views/user_name_initials_verification.yml
@@ -4,6 +4,6 @@ fr:
       new:
         title: Entrez les 3 premières lettres de votre nom de famille
         examples:
-          first: "Sophie Dupont&nbsp;: DUP"
-          second: "Jean De La Fontaine&nbsp;: DEL"
-          third: "Edwige Xi&nbsp;: XI"
+          first: "Sophie Dupont : DUP"
+          second: "Jean De La Fontaine : DEL"
+          third: "Edwige Xi : XI"

--- a/spec/features/agents/agent_can_see_users_rdv_spec.rb
+++ b/spec/features/agents/agent_can_see_users_rdv_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "can see users' RDV" do
       expect(page).to have_content("À venir\n1 RDV")
       click_link "Voir tous les rendez-vous de Tanguy LAVERDURE"
       expect_page_title("Liste des RDV")
-      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée&nbsp;: #{rdv.duration_in_min} minutes)")
+      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
     end
   end
 end

--- a/spec/features/users/user_views_his_rdvs_spec.rb
+++ b/spec/features/users/user_views_his_rdvs_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "User views his rdv" do
     before { click_link "Vos rendez-vous" }
 
     it do
-      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée&nbsp;: #{rdv.duration_in_min} minutes)")
+      expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
       click_link "Voir vos RDV passés"
       expect_page_with_no_record_text("Vous n'avez pas de RDV passés")
     end
@@ -33,6 +33,6 @@ RSpec.describe "User views his rdv" do
     click_link "Vos rendez-vous"
     expect_page_with_no_record_text("Vous n'avez pas de RDV à venir")
     click_link "Voir vos RDV passés"
-    expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée&nbsp;: #{rdv.duration_in_min} minutes)")
+    expect(page).to have_content("Le #{I18n.l(rdv.starts_at, format: :human)} (durée : #{rdv.duration_in_min} minutes)")
   end
 end

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RdvsHelper do
   describe "#rdv_title" do
     it "show date, time and duration in minutes" do
       rdv = build(:rdv, starts_at: Time.zone.parse("2020-10-23 12h54"), duration_in_min: 30)
-      expect(rdv_title(rdv)).to eq("Le vendredi 23 octobre 2020 à 12h54 (durée&nbsp;: 30 minutes)")
+      expect(rdv_title(rdv)).to eq("Le vendredi 23 octobre 2020 à 12h54 (durée : 30 minutes)")
     end
 
     it "when rdv starts_at today, show only time and duration in minutes" do

--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe RdvsHelper do
       now = Time.zone.parse("2020-10-23 12h54")
       travel_to(now)
       rdv = build(:rdv, starts_at: now + 3.hours, duration_in_min: 30)
-      expect(rdv_title(rdv)).to eq("Aujourd’hui à 15h54 (durée&nbsp;: 30 minutes)")
+      expect(rdv_title(rdv)).to eq("Aujourd’hui à 15h54 (durée : 30 minutes)")
       travel_back
     end
   end


### PR DESCRIPTION
# Contexte

Des agents remontent un problème sur Zammad https://zammad10.ethibox.fr/#ticket/zoom/16857 et https://zammad10.ethibox.fr/#ticket/zoom/16861

Cela vient de caractères html entities présents dans des valeurs de locales dont le html n’est pas interprété.

Cela a été introduit dans la PR #4641 

# Solution

Je reverte tous les changements qui m’ont l’air dangereux de la PR en question

```sh
git checkout d583770853398f769b61428db871fcac284f87f1^1 -- config/locales
git reset .
git add -p # ajouter manuellement les reverts pertinents
git checkout -p # laisser les changements pertinents (c’est ok dans les clés en `_html`, il y avait un espace en trop après le nom de symbole)
```

puis correction des specs