### PR TITLE
nouvelle route de contrôle vérifiant que les jobs se dépilent

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,10 +1,7 @@
 class HealthController < ApplicationController
   def db_connection
-    if Territory.exists?
-      render status: :ok, plain: "health OK"
-    else
-      render status: :service_unavailable, plain: "health not OK"
-    end
+    Territory.count # cette ligne raisera en cas de problème de connexion
+    render status: :ok, plain: "health OK"
   end
 
   def jobs_queues

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,6 +1,6 @@
 class HealthController < ApplicationController
   def db_connection
-    if Territory.count
+    if Territory.exists?
       render status: :ok, plain: "health OK"
     else
       render status: :service_unavailable, plain: "health not OK"

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,10 +10,6 @@ class StaticPagesController < ApplicationController
 
   def domaines; end
 
-  def health_check
-    Territory.count # check connection to DB is working
-  end
-
   def presentation_for_agents
     render current_domain.presentation_for_agents_template_name, layout: "application_base"
   end

--- a/app/views/static_pages/health_check.html
+++ b/app/views/static_pages/health_check.html
@@ -1,1 +1,0 @@
-<p>Health OK</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,10 +262,13 @@ Rails.application.routes.draw do
     get "confirmation"
   end
 
-  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite domaines health_check].each do |page_name|
+  %w[contact mds accessibility mentions_legales cgu politique_de_confidentialite domaines].each do |page_name|
     get page_name => "static_pages##{page_name}"
   end
   get "/.well-known/microsoft-identity-association" => "static_pages#microsoft_domain_verification", format: :json
+
+  get "health_check" => "health#db_connection"
+  get "health/jobs_queues" => "health#jobs_queues"
 
   get "/budget", to: redirect("https://pad.numerique.gouv.fr/rHMnemklQm6Sww5yVCI9ow?view#RDV-Service-Public", status: 302)
 


### PR DESCRIPTION
# Contexte

Hier, probablement suite à une MàJ de Good Job, il est arrivé par deux fois que les workers arrêtent de dépiler (une partie ou tout) les jobs. 
On n’en n’a pas été averti.
Heureusement, RDVI nous a prévenu de ce problème, ils ont un cron job qui vérifie que des choses sont modifiées dans leur DB.

C’est problématique que nous n’ayons pas de système qui vérifie que les jobs se dépilent à une vitesse raisonnable.

# Solution

Dans cette PR je propose d’ouvrir une nouvelle route `health/jobs_queues` qui vérifie qu’il n’y a pas « trop » de jobs en attente. 
Elle renvoie une 200 si tout va bien et une 503 s’il semble y avoir des bouchons.
L’idée est de surveiller ce nouvel endpoint via un système externe comme updown (à une fréquence modérée par ex 10min).

Pour ça j’ai choisi un seuil arbitraire de 10 jobs en attente par queue après avoir regardé le nombre de jobs moyen performed par heure (voir plus bas).
S’il y a une ou plusieurs queues avec plus de 10 jobs, j’attends un délai arbitraire de 5s pour vérifier si ce nombre a diminué pour chaque queue.
S’il n’a pas diminué pour au moins une des queues, on considère qu’il y a un souci.


```rb
GoodJob::Execution.where("performed_at > ?", 14.days.ago).group("extract(hour from performed_at)").count.sort.each { puts "#{_1}h : #{_2} jobs performed" }; nil

0.0h : 83 jobs performed
1.0h : 90 jobs performed
2.0h : 84 jobs performed
3.0h : 107 jobs performed
4.0h : 274 jobs performed
5.0h : 1450 jobs performed
6.0h : 20545 jobs performed
7.0h : 75993 jobs performed
8.0h : 74757 jobs performed
9.0h : 61822 jobs performed
10.0h : 21434 jobs performed
11.0h : 24666 jobs performed
12.0h : 70660 jobs performed
13.0h : 60186 jobs performed
14.0h : 43242 jobs performed
15.0h : 17442 jobs performed
16.0h : 3058 jobs performed
17.0h : 859 jobs performed
18.0h : 730 jobs performed
19.0h : 6302 jobs performed
20.0h : 26283 jobs performed
21.0h : 361 jobs performed
22.0h : 158 jobs performed
23.0h : 106 jobs performed
```



J’ai au passage rapatrié la route `/health_check` qui fait une vérification de la connexion db depuis `StaticPagesController` vers le nouveau `HealthCheckController`.
Je n’ai pas changé la route `/health_check`.
En revanche j’ai un peu modifié le comportement : elle renverra du texte brut plutôt que du HTML, et elle renverra des 503 si le `Territory.count` retourne 0, ce qui signifie que la db est up mais qu’il y a un problème.
Le cas le plus probable est une 500 en cas de connexion coupée.