### PR TITLE
Renommer "select-options" pour éviter l'ambiguïté avec les <option>

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -60,7 +60,7 @@ module AgentsHelper
                          selected: agent.id),
       class: "select2-input form-control js-planning-agent-select",
       data: {
-        "select-options": {
+        "select2-config": {
           ajax: {
             url: admin_organisation_agents_path(current_organisation),
             dataType: "json",

--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -29,10 +29,12 @@ class Select2Inputs {
 
   getInputOptions = elt => {
     let options = {}
-    if (elt.dataset.selectOptions !== undefined)
-      options = JSON.parse(elt.dataset.selectOptions)
+    if (elt.dataset.select2Config !== undefined)
+      options = JSON.parse(elt.dataset.select2Config)
+
     if (options.disableSearch)
       options.minimumResultsForSearch = Infinity // cf https://select2.org/searching
+
     // Make sure select2 works correctly inside a modal
     // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
     let modal = $(elt).closest(".modal")[0]
@@ -43,7 +45,7 @@ class Select2Inputs {
     // l'utilisateur⋅ice voit seulement un champ de recherche et une mention "Aucun résultat trouvé".
     // Afin d'indiquer clairement qu'il est attendu de commencer à saisir quelque-chose, ce code fait en
     // sorte que la mention soit plutot "Commencez à taper pour rechercher".
-    const isAjax = elt.dataset.selectOptions?.includes("ajax");
+    const isAjax = elt.dataset.select2Config?.includes("ajax");
     const hasAnyOption = Array.from(elt.options).some(opt => opt.value); // we rule out options without value, they are usually placeholders
     if (isAjax && !hasAnyOption) {
       options.minimumInputLength = 1
@@ -61,7 +63,7 @@ class Select2Inputs {
   autoSelectSoleOption = (elt, options) => {
     // This code checks if a select element (represented by the `elt` variable) has only one option.
     // return all options if it is ajax
-    const isAjax = elt.dataset.selectOptions?.includes("ajax");
+    const isAjax = elt.dataset.select2Config?.includes("ajax");
     if (isAjax) return;
 
     // Get all options and remove blank values if exists (placeholders)

--- a/app/javascript/components/select2-inputs.js
+++ b/app/javascript/components/select2-inputs.js
@@ -20,39 +20,39 @@ class Select2Inputs {
   }
 
   initInput = (elt) => {
-    const options = this.getInputOptions(elt)
-    $(elt).select2(options)
+    const config = this.getInputConfig(elt)
+    $(elt).select2(config)
     if (elt.dataset.autoSelectSoleOption) {
-      this.autoSelectSoleOption(elt, options)
+      this.autoSelectSoleOption(elt, config)
     }
   }
 
-  getInputOptions = elt => {
-    let options = {}
+  getInputConfig = elt => {
+    let config = {}
     if (elt.dataset.select2Config !== undefined)
-      options = JSON.parse(elt.dataset.select2Config)
+      config = JSON.parse(elt.dataset.select2Config)
 
-    if (options.disableSearch)
-      options.minimumResultsForSearch = Infinity // cf https://select2.org/searching
+    if (config.disableSearch)
+      config.minimumResultsForSearch = Infinity // cf https://select2.org/searching
 
     // Make sure select2 works correctly inside a modal
     // https://select2.org/troubleshooting/common-problems#select2-does-not-function-properly-when-i-use-it-inside-a-bootst
     let modal = $(elt).closest(".modal")[0]
     if (modal !== undefined)
-      options.dropdownParent = modal
+      config.dropdownParent = modal
 
-    // Lorsque le select est configuré en AJAX **et** qu'aucune option n'est pré-injectée dans le HTML,
+    // Lorsque le select est configuré en AJAX **et** qu'aucune <option> n'est pré-injectée dans le HTML,
     // l'utilisateur⋅ice voit seulement un champ de recherche et une mention "Aucun résultat trouvé".
     // Afin d'indiquer clairement qu'il est attendu de commencer à saisir quelque-chose, ce code fait en
     // sorte que la mention soit plutot "Commencez à taper pour rechercher".
     const isAjax = elt.dataset.select2Config?.includes("ajax");
     const hasAnyOption = Array.from(elt.options).some(opt => opt.value); // we rule out options without value, they are usually placeholders
     if (isAjax && !hasAnyOption) {
-      options.minimumInputLength = 1
-      options.language = { inputTooShort: () => "Commencez à taper pour rechercher" } // Overrides select2/i18n/fr.js
+      config.minimumInputLength = 1
+      config.language = { inputTooShort: () => "Commencez à taper pour rechercher" } // Overrides select2/i18n/fr.js
     }
 
-    return options
+    return config
   }
 
   destroyInputs = () => {

--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -19,7 +19,7 @@
               class: "select2-input js-service-filter", \
               data: { \
                 placeholder: "Sélectionnez un service pour filtrer les motifs", \
-                "select-options": { disableSearch: true }, \
+                "select2-config": { disableSearch: true }, \
               }, \
             }
         .col-md-4
@@ -50,7 +50,7 @@
               multiple: true, \
               class: "select2-input",\
               data: { \
-                "select-options": { \
+                "select2-config": { \
                   ajax: { \
                     url: admin_organisation_agents_path(current_organisation),
                     dataType: "json",

--- a/app/views/admin/merge_users/_user_selection.html.slim
+++ b/app/views/admin/merge_users/_user_selection.html.slim
@@ -24,7 +24,7 @@
         id: attribute, \
         class: "select2-input js-merge-users-user-select js-selectable", \
         data: { \
-          "select-options": { \
+          "select2-config": { \
             ajax: { \
               url: search_admin_organisation_users_path(current_organisation, **url_opts), \
               dataType: "json", \

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -26,7 +26,7 @@ p
           class: "select2-input", \
           data: { \
             placeholder: "Sélectionnez le service auquel le motif sera associé", \
-            "select-options": { disableSearch: true }, \
+            "select2-config": { disableSearch: true }, \
             "auto-select-sole-option": true,
           }, \
         }

--- a/app/views/admin/plage_ouvertures/_form.html.slim
+++ b/app/views/admin/plage_ouvertures/_form.html.slim
@@ -24,7 +24,7 @@
                       class: "select2-input", \
                       data: { \
                         placeholder: "Sélectionnez un lieu", \
-                        "select-options": { disableSearch: true }, \
+                        "select2-config": { disableSearch: true }, \
                         "allow-clear": true, \
                       }, \
                     }

--- a/app/views/admin/prescription/user_selection.html.slim
+++ b/app/views/admin/prescription/user_selection.html.slim
@@ -20,7 +20,7 @@ main.container
                         class: "select2-input",
                         data: { \
                                 width: "auto", \
-                                "select-options": { ajax: { url: search_agents_users_path(organisation_id: current_organisation.id, exclude_ids: @rdv_wizard.query_params[:user_ids]), dataType: "json", delay: 250 } }, \
+                                "select2-config": { ajax: { url: search_agents_users_path(organisation_id: current_organisation.id, exclude_ids: @rdv_wizard.query_params[:user_ids]), dataType: "json", delay: 250 } }, \
                         }
               span.small.text-muted
                 | L'usager n'existe pas ?&nbsp;

--- a/app/views/admin/rdv_wizard_steps/step1.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step1.html.slim
@@ -16,7 +16,7 @@
           class: "select2-input js-service-filter", \
           data: { \
             placeholder: "Sélectionnez un service pour filtrer les motifs", \
-            "select-options": { disableSearch: true }, \
+            "select2-config": { disableSearch: true }, \
           }, \
         }
 

--- a/app/views/admin/rdv_wizard_steps/step2.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step2.html.slim
@@ -55,7 +55,7 @@ ruby:
             class: "select2-input js-new-rdv-users-select",
             data: { \
               width: :style,
-              "select-options": { ajax: { url: search_agents_users_path(exclude_ids: @rdv.users.map(&:id), organisation_id: @rdv.organisation_id), dataType: "json", delay: 250}, placeholder: "Nom, prénom, téléphone, ou email" }, \
+              "select2-config": { ajax: { url: search_agents_users_path(exclude_ids: @rdv.users.map(&:id), organisation_id: @rdv.organisation_id), dataType: "json", delay: 250}, placeholder: "Nom, prénom, téléphone, ou email" }, \
             }
 
           span.small.text-muted

--- a/app/views/admin/rdvs/_rdv_search_form.html.slim
+++ b/app/views/admin/rdvs/_rdv_search_form.html.slim
@@ -21,7 +21,7 @@
               input_html: { \
                 class: "select2-input", \
                 data: { \
-                  "select-options": { \
+                  "select2-config": { \
                     ajax: { \
                       url: admin_organisation_agents_path(@scoped_organisations&.map(&:id)),
                       dataType: "json",
@@ -38,7 +38,7 @@
               input_html: { \
                 class: "select2-input", \
                 data: { \
-                  "select-options": { \
+                  "select2-config": { \
                     ajax: { \
                       url: search_admin_organisation_users_path(@scoped_organisations&.map(&:id)),
                       dataType: "json",

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -81,7 +81,7 @@
                       data: { \
                 width: "auto", \
                 "scroll-to-bottom": params[:add_user].present?, \
-                "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
+                "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
                }
               span.small.text-muted
               | L'usager n'existe pas ?&nbsp;

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -72,7 +72,7 @@
                     data: { \
               width: "auto", \
               "scroll-to-bottom": @add_user_ids.present?, \
-              "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
+              "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
              }
             span.small.text-muted
               | L'usager n'existe pas ?&nbsp;

--- a/app/views/admin/territories/motifs/index.html.slim
+++ b/app/views/admin/territories/motifs/index.html.slim
@@ -11,12 +11,12 @@
       .form-group.col-md-4
         label for="organisation_ids"
           | Organisation(s)
-        select.select2-input[id="organisation_ids" name="organisation_ids[]" multiple data-select-options={ placeholder: "-" }.to_json style="width: 100%"]
+        select.select2-input[id="organisation_ids" name="organisation_ids[]" multiple data-select2-config={ placeholder: "-" }.to_json style="width: 100%"]
           = options_for_select(@organisations.pluck(:name, :id), params[:organisation_ids])
       .form-group.col-md-4
         label for="organisation_ids"
           | Service(s)
-        select.select2-input[id="service_ids" name="service_ids[]" multiple data-select-options={ placeholder: "-" }.to_json style="width: 100%"]
+        select.select2-input[id="service_ids" name="service_ids[]" multiple data-select2-config={ placeholder: "-" }.to_json style="width: 100%"]
           = options_for_select(@services.pluck(:name, :id), params[:service_ids])
     .form-row
       .form-group.col-md-4

--- a/app/views/admin/territories/teams/_form.html.slim
+++ b/app/views/admin/territories/teams/_form.html.slim
@@ -6,7 +6,7 @@
             multiple: true, \
             class: "select2-input", \
             data: { \
-              "select-options": { \
+              "select2-config": { \
                 ajax: { \
                   url: admin_territory_agents_path(current_territory),
                   dataType: "json",

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -82,7 +82,7 @@
                 label: false, \
                 **{input_html: { \
                   class: "select2-input",\
-                  data: { "select-options": { ajax: { url: search_admin_organisation_users_path(current_organisation), dataType: "json", delay: 250 }} }, \
+                  data: { "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation), dataType: "json", delay: 250 }} }, \
                  }}.deep_merge(input_opts[:relative_existing]), \
                 required: true\
               )

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -19,7 +19,7 @@
         .col-md-6
           .form-group.string.optional._search
             = f.label :agent_id, "Agent référent", {class: "form-control-label select optional"}
-            = f.select :agent_id, [], {}, { class: "form-control select optional select2-input", data: { "select-options": { ajax: { url: admin_organisation_agents_path(current_organisation), dataType: "json", delay: 250 } } } }
+            = f.select :agent_id, [], {}, { class: "form-control select optional select2-input", data: { "select2-config": { ajax: { url: admin_organisation_agents_path(current_organisation), dataType: "json", delay: 250 } } } }
 
       input.btn.btn-primary.d-print-none type="submit" value="Rechercher"
 


### PR DESCRIPTION
En travaillant sur #4648 j'ai dû lire et comprendre le code présent dans notre fichier d'initialisation de la librairie Select2 : `app/javascript/components/select2-inputs.js`. Dans ce fichier, nous manipulons :
- la configuration de la librairie Select2, passée en JSON dans un attribut `data` de nos `<select>`
- la liste des nœux `<option>` qui sont descendants du `<select>`

Or, **nous nommons ces deux notions "options"**, ce qui crée beaucoup d'ambiguïté ! :exploding_head: 

Je propose donc ici de nommer la configuration Select2 "config" ou "select2-config". De cette manière, tous les usages du terme "option" dans ce fichier désignent bien les `<option>` HTML.