### PR TITLE
Utiliser l'état des processes GoodJob dans le health check

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -5,7 +5,7 @@ class HealthController < ApplicationController
   end
 
   def jobs_queues
-    stale_processes = GoodJob::Process.all.select(&:stale?)
+    stale_processes = GoodJob::Process.all.select(&:stale?).map(&:id)
     return render(status: :service_unavailable, json: { stale_processes: }) if stale_processes.any?
 
     counts1 = compute_enqueued_jobs_count_by_queue

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -5,6 +5,9 @@ class HealthController < ApplicationController
   end
 
   def jobs_queues
+    stale_processes = GoodJob::Process.all.select(&:stale?)
+    return render(status: :service_unavailable, json: { stale_processes: }) if stale_processes.any?
+
     counts1 = compute_enqueued_jobs_count_by_queue
     queues_with_many_jobs = counts1.select { |_queue, count| count > 10 }
     return render(status: :ok, json: {}) if queues_with_many_jobs.none?


### PR DESCRIPTION
GoodJob utilise une table `good_job_processes` pour suivre l'état des process qui dépilent les jobs. Nous pouvons faire usage de cette table pour détecter un souci dans le dépilage des jobs.

Qu'en dîtes-vous ?