### PR TITLE
Downgrade GoodJob back to 3.27.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem "common_french_passwords"
 
 # Jobs
 # A multithreaded, Postgres-based ActiveJob backend for Ruby on Rails
-gem "good_job", "3.99.1"
+gem "good_job", "3.27.4"
 
 # JSON serialization and queries
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    good_job (3.99.1)
+    good_job (3.27.4)
       activejob (>= 6.0.0)
       activerecord (>= 6.0.0)
       concurrent-ruby (>= 1.0.2)
@@ -691,7 +691,7 @@ DEPENDENCIES
   factory_bot
   faker
   foreman
-  good_job (= 3.99.1)
+  good_job (= 3.27.4)
   groupdate (~> 6.1)
   httpclient!
   icalendar (~> 2.5)


### PR DESCRIPTION
Suite à une MAJ de GoodJob de 3.27.4 à 3.99.1 dans #4632, nous observons des plantages des process, que nous ne parvenons pas à expliquer.

Afin de se donner du temps pour investiguer, nous souhaitons revenir à la version précédente de la gem pour le moment.

Ce downgrade a été testé en démo et visiblement la version 3.27.4 fonctionne très bien avec les colonnes et index ajoutés sans #4632.