### PR TITLE
Désactiver les flaky specs en attendant de les corriger

### DIFF
--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -263,6 +263,11 @@ RSpec.describe "agents can prescribe rdvs" do
         end
 
         it "show both services and motifs" do
+          if Date.new(2024, 10, 19).future?
+            pending # rubocop:disable RSpec/Pending
+            raise "cette flaky spec a été désactivée pendant un mois le temps de travailler dessus"
+          end
+
           expect(page).to have_content(motif_mds.service.name)
           expect(page).to have_content(motif_insertion.service.name)
           click_on motif_mds.service.name

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   end
 
   it "allows changing the location type and adds validation when trying to create a rdv without email or phone number", js: true do
+    if Date.new(2024, 10, 19).future?
+      pending # rubocop:disable RSpec/Pending
+      raise "cette flaky spec a été désactivée pendant un mois le temps de travailler dessus"
+    end
+
     visit admin_organisation_motifs_path(organisation)
     click_on motif.name
     click_on "Modifier"


### PR DESCRIPTION
Depuis quelques semaines, plusieurs flaky specs perturbent grandement notre workflow de travail. Je pense qu'on peut considérer que le retour sur investissement de ces specs est mauvais en l'état actuel. Je propose donc ici de les désactiver pendant un mois, le temps de les corriger (nous comptons allouer du temps pour ça dans le prochain build).

Note : Si le fix proposé dans #4655 n'est pas accepté ou pas efficace, il faudra désactiver ces specs de la même manière.