### PR TITLE
Amélioration des messages de timeouts Typhoeus

### DIFF
--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -14,7 +14,7 @@ Typhoeus.before do |request|
   if request.on_failure.blank?
     request.on_failure do |response|
       if response.timed_out?
-        raise Typhoeus::Errors::TimeoutError, "Timed out calling #{response.request.url}"
+        raise Typhoeus::Errors::TimeoutError, "Timed out calling #{response.request.base_url}"
       end
     end
   end


### PR DESCRIPTION
# Contexte

On a plusieurs erreurs `Typhoeus::Errors::TimeoutError` qui remontent dans Sentry dues à des lenteurs sur l’API de l’ANTS. 
Elles ne sont pas nécessairement groupées ensemble dans Sentry aujourd’hui alors qu’elles auraient tout intérêt à l’être : ce sont des exceptions très similaires. cf cette [requête sur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/?environment=production&project=74&query=is%3Aunresolved+error.type%3ATyphoeus%3A%3AErrors%3A%3ATimeoutError&referrer=issue-list&sort=trends&statsPeriod=7d)

Elles sont reconnues comme différentes par Sentry car nous incluons l’URL intégrale dans le message d’exception et que dans ces cas de requête GET à une API cela inclut des paramètres qui diffèrent pour chaque requête.

# Solution

Dans cette micro-PR je propose de remplacer l’`url` renvoyée dans le message par la `base_url` qui ne contient pas de params cf [doc typhoeus](https://rubydoc.info/github/typhoeus/typhoeus/Typhoeus/Request#url-instance_method). 
Cela devrait permettre de regrouper ces erreurs mais de continuer à dissocier dans le cas où ce sont des endpoints / des hosts différents qui renvoient des timeouts. 

On pourrait aussi purement et simplement ne pas inclure de message du tout, je pense que cela fonctionnerait dans la majorité des cas aussi. 

Pour rappel, on voit quand même dans les breadcrumbs Sentry de chaque exception l’URL et les params complets. 

## Tests

Je n’ai __PAS__ testé ce changement car je ne sais pas trop comment faire ça simplement, que le changement me paraît assez sûr et que je me dis qu’on verra vite un retour à corriger s’il y a une erreur.