### PR TITLE
Ignorer les `ActiveJob::DeserializationError` causées par un `ActiveRecord::RecordNotFound`

### DIFF
--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -2,17 +2,6 @@
 class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
   include DefaultJobBehaviour
 
-  # Only discard DeserializationError if it is caused by a ActiveRecord::RecordNotFound.
-  # We don't want to discard a job when deserialization failed because of a DB failure for example.
-  rescue_from ActiveJob::DeserializationError do |exception|
-    if exception.cause.instance_of?(ActiveRecord::RecordNotFound)
-      Rails.logger.error(exception.message)
-    else
-      Sentry.capture_exception(exception)
-      retry_job
-    end
-  end
-
   # Don't log first failures to Sentry, to prevent noise
   # on temporary unavailability of an external service.
   def capture_sentry_warning_for_retry?(_exception)


### PR DESCRIPTION
# Contexte

Nous avons quelques dizaines d'occurrences par mois de jobs qui échouent à s'exécuter car le RDV auquel ils font référence a été supprimé :

![image](https://github.com/user-attachments/assets/7208b424-be99-4baf-ac6c-aa92e117207c)

On voit que ça concerne des `SmsJob` et des `RdvUpcomingReminderJob`. Dans les deux cas, si le RDV a été supprimé, c'est normal et attendu que le job ne s'exécute pas.

Note : une fois encore, l'option paranoïaque consisterait à garder ces remontées dans Sentry et à ignorer un volume raisonnable. Mais nous avons vu que le bruit généré par ce type de fonctionnement nous empêchait de nous concentrer sur des dysfonctionnements plus importants.

# Solution

Cette logique était déjà en place pour les jobs d'e-mail uniquement, je l'ai déplacée dans `DefaultJobBehaviour` afin qu'elle soit en place dans tous les jobs.
