### PR TITLE
Ajout de motif catégories manquantes dans les seeds

### DIFF
--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -5,8 +5,6 @@
 orientation_category = MotifCategory.create!(short_name: "rsa_orientation", name: "RSA orientation")
 accompagnement_category = MotifCategory.create!(short_name: "rsa_accompagnement", name: "RSA accompagnement")
 
-MotifCategory.create!(short_name: "rsa_orientation", name: "RSA orientation")
-MotifCategory.create!(short_name: "rsa_accompagnement", name: "RSA accompagnement")
 MotifCategory.create!(short_name: "rsa_accompagnement_sociopro", name: "RSA accompagnement socio-pro")
 MotifCategory.create!(short_name: "rsa_accompagnement_social", name: "RSA accompagnement social")
 MotifCategory.create!(short_name: "rsa_cer_signature", name: "RSA signature CER")

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -5,6 +5,21 @@
 orientation_category = MotifCategory.create!(short_name: "rsa_orientation", name: "RSA orientation")
 accompagnement_category = MotifCategory.create!(short_name: "rsa_accompagnement", name: "RSA accompagnement")
 
+MotifCategory.create!(short_name: "rsa_orientation", name: "RSA orientation")
+MotifCategory.create!(short_name: "rsa_accompagnement", name: "RSA accompagnement")
+MotifCategory.create!(short_name: "rsa_accompagnement_sociopro", name: "RSA accompagnement socio-pro")
+MotifCategory.create!(short_name: "rsa_accompagnement_social", name: "RSA accompagnement social")
+MotifCategory.create!(short_name: "rsa_cer_signature", name: "RSA signature CER")
+MotifCategory.create!(short_name: "rsa_follow_up", name: "RSA suivi")
+MotifCategory.create!(short_name: "rsa_insertion_offer", name: "RSA offre insertion pro")
+MotifCategory.create!(short_name: "rsa_orientation_on_phone_platform", name: "RSA orientation sur plateforme téléphonique")
+MotifCategory.create!(short_name: "rsa_atelier_collectif_mandatory", name: "RSA Atelier collectif obligatoire")
+MotifCategory.create!(short_name: "rsa_atelier_rencontres_pro", name: "RSA Atelier rencontres professionnelles")
+MotifCategory.create!(short_name: "rsa_atelier_competences", name: "RSA Atelier compétences")
+MotifCategory.create!(short_name: "rsa_main_tendue", name: "RSA Main Tendue")
+MotifCategory.create!(short_name: "rsa_spie", name: "RSA SPIE")
+MotifCategory.create!(short_name: "rsa_integration_information", name: "RSA Information d'intégration")
+
 # Territories
 territory_drome = Territory.create!(
   departement_number: "26",


### PR DESCRIPTION
Afin de rendre le lien rdvi<>rdvs complet après avoir fait tourner les seeds il nous manquait quelques éléments dans la liste de motifs catégories par défaut. 

Cette liste servira bien sur à notre nouvelle staging mais également en local où l'on avait une erreur lors d'un call à Rdvs si l'on ajoute une configuration de catégorie à un motif non créé chez Rdv-solidarites. 

On fait en effet un `find_by(short_name:` ici : app/controllers/api/rdvinsertion/motif_category_territories_controller.rb
Et on a besoin de trouver l'élément associé afin de compléter la création de la configuration côté rdvi

Fix un retour d'Amaury ici https://github.com/gip-inclusion/rdv-insertion/issues/2266