### PR TITLE
Amélioration des performances sur le calcul des occurrences

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -24,16 +24,6 @@ class CronJob < ApplicationJob
     end
   end
 
-  class WarmUpOccurrencesCache < CronJob
-    def perform
-      [PlageOuverture, Absence].each do |klass|
-        klass.regulieres.not_expired.find_each do |model|
-          model.earliest_future_occurrence_time(refresh: true)
-        end
-      end
-    end
-  end
-
   class DestroyOldRdvsAndInactiveAccountsJob < CronJob
     def perform
       two_years_ago = 2.years.ago

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -110,7 +110,7 @@ module RecurrenceConcern
   def occurrence_start_at_list_for(inclusive_date_range)
     min_until = [inclusive_date_range.end, recurrence_ends_at].compact.min.end_of_day
 
-    datetime_range_start = inclusive_date_range.begin.is_a?(Date) ? inclusive_date_range.begin.beginning_of_day : inclusive_date_range.begin
+    datetime_range_start = inclusive_date_range.begin.is_a?(Date) ? inclusive_date_range.begin.in_time_zone.beginning_of_day : inclusive_date_range.begin
 
     inclusive_datetime_range = datetime_range_start..(inclusive_date_range.end.end_of_day)
 

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -115,7 +115,13 @@ module RecurrenceConcern
     inclusive_datetime_range = datetime_range_start..(inclusive_date_range.end.end_of_day)
 
     if recurring?
-      recurrence.starting(starts_at).fast_forward(inclusive_datetime_range.begin).until(min_until).lazy.select do |occurrence_starts_at|
+      rec = recurrence.starting(starts_at).until(min_until)
+
+      if starts_at <= inclusive_datetime_range.begin
+        rec = rec.fast_forward(inclusive_datetime_range.begin)
+      end
+
+      rec.lazy.select do |occurrence_starts_at|
         event_in_range?(occurrence_starts_at, occurrence_starts_at + duration, inclusive_datetime_range)
       end.to_a
     else

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -109,10 +109,13 @@ module RecurrenceConcern
 
   def occurrence_start_at_list_for(inclusive_date_range)
     min_until = [inclusive_date_range.end, recurrence_ends_at].compact.min.end_of_day
-    inclusive_datetime_range = (inclusive_date_range.begin)..(inclusive_date_range.end.end_of_day)
+
+    datetime_range_start = inclusive_date_range.begin.is_a?(Date) ? inclusive_date_range.begin.beginning_of_day : inclusive_date_range.begin
+
+    inclusive_datetime_range = datetime_range_start..(inclusive_date_range.end.end_of_day)
 
     if recurring?
-      recurrence.starting(starts_at).fast_forward(inclusive_date_range.begin).until(min_until).lazy.select do |occurrence_starts_at|
+      recurrence.starting(starts_at).fast_forward(inclusive_datetime_range.begin).until(min_until).lazy.select do |occurrence_starts_at|
         event_in_range?(occurrence_starts_at, occurrence_starts_at + duration, inclusive_datetime_range)
       end.to_a
     else

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -39,7 +39,7 @@ module CreneauxSearch::Calculator
     end
 
     def ranges_for(plage_ouverture, datetime_range)
-      occurrences = plage_ouverture.occurrences_for(datetime_range, only_future: true)
+      occurrences = plage_ouverture.occurrences_for(datetime_range)
 
       occurrences.map do |occurrence|
         next if occurrence.ends_at < Time.zone.now
@@ -164,7 +164,7 @@ module CreneauxSearch::Calculator
         busy_times = []
         absences.each do |absence|
           if absence.recurrence
-            absence.occurrences_for(range, only_future: true).each do |absence_occurrence|
+            absence.occurrences_for(range).each do |absence_occurrence|
               next if absence_out_of_range?(absence_occurrence, range)
 
               busy_times << BusyTime.new(absence_occurrence)

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -39,12 +39,6 @@ Rails.application.configure do
       class: "CronJob::UpdateExpirationsJob",
     },
 
-    # Préchauffage de cache : pas essentiel mais idéalement quotidien
-    warm_up_occurrences_cache: {
-      cron: "every day at 04:00 Europe/Paris",
-      class: "CronJob::WarmUpOccurrencesCache",
-    },
-
     # Reset de la liste d'usagers en salle d'attente, à vider chaque soir
     destroy_redis_waiting_room_keys: {
       cron: "every day at 21:30 Europe/Paris",

--- a/spec/models/concerns/recurrence_concern_spec.rb
+++ b/spec/models/concerns/recurrence_concern_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe RecurrenceConcern do
     end
 
     it "doesn't return occurrences for an object with a finished recurrence" do
-      create(factory, recurrence: Montrose.every(:week, on: [:monday], starts: Date.new(2019, 7, 1), until: Date.new(2019, 7, 22)),
+      create(factory, recurrence: Montrose.every(:week, on: [:monday], starts: Date.new(2019, 7, 1), until: Date.new(2019, 7, 22), interval: 1),
                       first_day: Date.new(2019, 7, 1), start_time: Time.zone.parse("8h00"),
                       end_time: Time.zone.parse("12h00"))
 
@@ -77,7 +77,7 @@ RSpec.describe RecurrenceConcern do
     end
 
     it "returns the last occurrence when it's the first day of the date range" do
-      object = create(factory, recurrence: Montrose.every(:week, on: [:monday], starts: Date.new(2019, 7, 1), until: Date.new(2019, 7, 22)),
+      object = create(factory, recurrence: Montrose.every(:week, on: [:monday], starts: Date.new(2019, 7, 1), until: Date.new(2019, 7, 22), interval: 1),
                                first_day: Date.new(2019, 7, 1), start_time: Time.zone.parse("8h00"),
                                end_time: Time.zone.parse("12h00"))
 
@@ -127,47 +127,47 @@ RSpec.describe RecurrenceConcern do
     context "with recurrence" do
       it "returns element when start in range" do
         first_day = Date.new(2021, 9, 26)
-        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, interval: 1))
         expect(described_class.in_range(range)).to eq([object])
       end
 
       it "returns element when ends in range" do
         first_day = range.begin - 1.month
-        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end - 2.days))
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end - 2.days, interval: 1))
         expect(described_class.in_range(range)).to eq([object])
       end
 
       it "returns element when start before range and end after range" do
         first_day = range.begin - 1.day
-        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end + 2.days))
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.end + 2.days, interval: 1))
         expect(described_class.in_range(range)).to eq([object])
       end
 
       it "returns element when one occurrence start in range without until day" do
         range = Date.new(2021, 10, 25)..Date.new(2021, 10, 29)
         first_day = monday - 14.days
-        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, interval: 1))
         expect(described_class.in_range(range)).to eq([object])
       end
 
       it "doesnt return element when end before range" do
         first_day = range.begin - 2.months
         create(factory, first_day: first_day,
-                        recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin - 3.days))
+                        recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin - 3.days, interval: 1))
         expect(described_class.in_range(range)).to eq([])
       end
 
       it "returns element when first day of range at the until day" do
         range = Time.zone.parse("2021-10-25 0:00")..Time.zone.parse("2021-10-29 23:59:59.99")
         first_day = monday - 14.days
-        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin.to_date))
+        object = create(factory, first_day: first_day, recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, until: range.begin.to_date, interval: 1))
         expect(described_class.in_range(range)).to eq([object])
       end
 
       it "doesnt return element with recurrence start after range" do
         first_day = range.end + 4.days
         create(factory, first_day: first_day,
-                        recurrence: Montrose.every(:week, on: ["monday"], starts: first_day))
+                        recurrence: Montrose.every(:week, on: ["monday"], starts: first_day, interval: 1))
         expect(described_class.in_range(range)).to eq([])
       end
     end
@@ -176,25 +176,25 @@ RSpec.describe RecurrenceConcern do
   shared_examples "#recurrence_ends_after_first_day" do
     it "valid element when recurrence ends after first_day" do
       starts = Date.new(2021, 10, 27)
-      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts + 1.week))
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts + 1.week, interval: 1))
       expect(recurring_object).to be_valid
     end
 
     it "valid element when recurrence ends is nil" do
       starts = Date.new(2021, 10, 27)
-      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: nil))
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: nil, interval: 1))
       expect(recurring_object).to be_valid
     end
 
     it "invalid element when recurrence ends at first_day" do
       starts = Date.new(2021, 10, 27)
-      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts))
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts, interval: 1))
       expect(recurring_object).to be_invalid
     end
 
     it "invalid element when recurrence ends before first_day" do
       starts = Date.new(2021, 10, 27)
-      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts - 1.week))
+      recurring_object = build(factory, first_day: starts, recurrence: Montrose.every(:week, on: ["wednesday"], starts: starts, until: starts - 1.week, interval: 1))
       expect(recurring_object).to be_invalid
     end
   end

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe PlageOuverture, type: :model do
     it "return plage_ouverture when one occurrence overlapping range" do
       range = now..(now + 30.minutes)
       plage_ouverture = create(:plage_ouverture, first_day: (now - 2.weeks).to_date, start_time: Tod::TimeOfDay.new(10, 45), end_time: Tod::TimeOfDay.new(11, 45),
-                                                 recurrence: Montrose.every(:week, on: ["tuesday"], starts: (now - 2.weeks).to_date))
+                                                 recurrence: Montrose.every(:week, on: ["tuesday"], starts: (now - 2.weeks).to_date, interval: 1))
       expect(described_class.overlapping_range(range)).to eq([plage_ouverture])
     end
 

--- a/spec/models/plage_ouverture_spec.rb
+++ b/spec/models/plage_ouverture_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe PlageOuverture, type: :model do
       create(:plage_ouverture, first_day: (now - 1.week).to_date,
                                start_time: Tod::TimeOfDay.new(10, 45), \
                                end_time: Tod::TimeOfDay.new(11, 45), \
-                               recurrence: Montrose.every(:month, day: { Tuesday: [2] }, starts: (now - 1.week).to_date))
+                               recurrence: Montrose.every(:month, day: { Tuesday: [2] }, starts: (now - 1.week).to_date, interval: 1))
       expect(described_class.overlapping_range(range)).to be_empty
     end
   end

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -576,7 +576,7 @@ RSpec.describe Rdv, type: :model do
       agent = create(:agent)
       rdv = build(:rdv, agents: [agent], starts_at: now + 1.week, ends_at: now + 1.week + 30.minutes)
       create(:plage_ouverture, agent: agent, first_day: (now - 2.weeks).to_date, start_time: Tod::TimeOfDay.new(10, 45), end_time: Tod::TimeOfDay.new(11, 45), lieu: create(:lieu),
-                               recurrence: Montrose.every(:week, on: ["tuesday"], starts: (now - 2.weeks).to_date))
+                               recurrence: Montrose.every(:week, on: ["tuesday"], starts: (now - 2.weeks).to_date, interval: 1))
       expect(rdv.overlapping_plages_ouvertures?).to be(true)
     end
 
@@ -586,7 +586,7 @@ RSpec.describe Rdv, type: :model do
       agent = create(:agent)
       rdv = build(:rdv, agents: [agent], starts_at: now + 1.week, ends_at: now + 1.week + 30.minutes)
       create(:plage_ouverture, agent: agent, first_day: (now - 1.week).to_date, start_time: Tod::TimeOfDay.new(10, 45), end_time: Tod::TimeOfDay.new(11, 45), lieu: create(:lieu),
-                               recurrence: Montrose.every(:month, day: { Tuesday: [2] }, starts: (now - 1.week).to_date))
+                               recurrence: Montrose.every(:month, day: { Tuesday: [2] }, starts: (now - 1.week).to_date, interval: 1))
       expect(rdv.overlapping_plages_ouvertures?).to be(false)
     end
   end
@@ -801,7 +801,7 @@ RSpec.describe Rdv, type: :model do
         first_day: now.to_date,
         start_time: Tod::TimeOfDay.new(9),
         end_time: Tod::TimeOfDay.new(10),
-        recurrence: Montrose.every(:week, on: ["monday"], starts: Time.zone.parse("20210503 00:00"), until: nil)
+        recurrence: Montrose.every(:week, on: ["monday"], starts: Time.zone.parse("20210503 00:00"), until: nil, interval: 1)
       )
     end
 

--- a/spec/services/creneaux_search/calculator/busy_time_spec.rb
+++ b/spec/services/creneaux_search/calculator/busy_time_spec.rb
@@ -56,13 +56,13 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
   context "with an absence with recurrence" do
     it "returns starts_at first occurrence in range" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
-                       recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil))
+                       recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
       expect(described_class.busy_times_for(range, plage_ouverture).first.starts_at).to eq(Time.zone.parse("20211026 9:00"))
     end
 
     it "returns ends_at occurrence in range" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
-                       end_time: Tod::TimeOfDay.new(9, 45), recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil))
+                       end_time: Tod::TimeOfDay.new(9, 45), recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
       expect(described_class.busy_times_for(range, plage_ouverture).first.ends_at).to eq(Time.zone.parse("20211026 9:45"))
     end
 
@@ -72,7 +72,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
              first_day: Date.new(2021, 10, 19),
              start_time: Tod::TimeOfDay.new(9),
              end_time: Tod::TimeOfDay.new(9, 45),
-             recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Time.zone.parse("20211019 9:00"), until: nil))
+             recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
       expect(described_class.busy_times_for(range, plage_ouverture).map(&:ends_at)).to eq([Time.zone.parse("20211026 9:45"), Time.zone.parse("20211029 9:45")])
     end
 
@@ -81,7 +81,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
 
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 22),
                        start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(15),
-                       recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Date.new(2021, 10, 22), until: nil))
+                       recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Date.new(2021, 10, 22), until: nil, interval: 1))
       expect(described_class.busy_times_for(range, plage_ouverture)).to be_empty
     end
   end

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     it "returns PO with recurrences that always running" do
       matching_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11) + 20.minutes)
       recurring_po = create(:plage_ouverture, lieu: lieu, motifs: [motif], first_day: first_day - 1.day, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
-                                              recurrence: Montrose.every(:week, starts: first_day - 1.day))
+                                              recurrence: Montrose.every(:week, starts: first_day - 1.day, interval: 1))
 
       plage_ouvertures = described_class.plage_ouvertures_for(motif, lieu, date_range, [])
       expect(plage_ouvertures).to contain_exactly(matching_po, recurring_po)
@@ -297,7 +297,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     it "returns plage ouverture's 3 occurrences of range" do
       starts_at = Time.zone.parse("20211026 9:00")
       plage_ouverture = build(:plage_ouverture, first_day: starts_at.to_date, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent,
-                                                recurrence: Montrose.every(:week, starts: starts_at.to_date - 1.day, day: [1, 2, 4, 5]))
+                                                recurrence: Montrose.every(:week, starts: starts_at.to_date - 1.day, day: [1, 2, 4, 5], interval: 1))
       range = Date.new(2021, 10, 25)..Date.new(2021, 10, 30)
 
       expected_ranges = [
@@ -313,7 +313,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       travel_to(friday)
       starts_at = friday - 1.week
       plage_ouverture = build(:plage_ouverture, first_day: starts_at.to_date, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent,
-                                                recurrence: Montrose.every(:week, starts: starts_at.to_date - 1.day, day: [5]))
+                                                recurrence: Montrose.every(:week, starts: starts_at.to_date - 1.day, day: [5], interval: 1))
       range = Date.new(2021, 11, 12)..Date.new(2021, 11, 19)
 
       expected_ranges = [(Time.zone.parse("2021-11-19 9:00")..Time.zone.parse("2021-11-19 11:00"))]
@@ -325,7 +325,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       travel_to(friday)
       starts_at = friday - 1.week
       plage_ouverture = build(:plage_ouverture, first_day: starts_at.to_date, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11), agent: agent,
-                                                recurrence: Montrose.every(:week, starts: starts_at.to_date - 1.day, day: [5]))
+                                                recurrence: Montrose.every(:week, starts: starts_at.to_date - 1.day, day: [5], interval: 1))
       create(:rdv, :excused, motif: motif, starts_at: Time.zone.parse("20211112 10:00"), agents: [agent])
       range = Date.new(2021, 11, 12)..Date.new(2021, 11, 19)
 
@@ -430,14 +430,14 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     context "with recurrence" do
       it "return empty when po and it occurrence is out of range" do
         plage_ouverture = build(:plage_ouverture, first_day: friday + 14.days, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
-                                                  recurrence: Montrose.every(:week, starts: friday + 14.days))
+                                                  recurrence: Montrose.every(:week, starts: friday + 14.days, interval: 1))
         range = (friday + 3.days)..(friday + 10.days)
         expect(described_class.ranges_for(plage_ouverture, range)).to eq([])
       end
 
       it "return occurrence of po that in range" do
         plage_ouverture = build(:plage_ouverture, first_day: friday - 14.days, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
-                                                  recurrence: Montrose.every(:week, starts: friday - 14.days))
+                                                  recurrence: Montrose.every(:week, starts: friday - 14.days, interval: 1))
         range = (friday + 3.days)..(friday + 10.days)
         expect(described_class.ranges_for(plage_ouverture, range)).to eq([(Time.zone.parse("20210507 9:00")..Time.zone.parse("20210507 11:00"))])
       end

--- a/spec/services/creneaux_search/next_availability_spec.rb
+++ b/spec/services/creneaux_search/next_availability_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CreneauxSearch::NextAvailability, type: :service do
       end
 
       it "when plage_ouverture is recurrence" do
-        recurrence = Montrose.every(:month, starts: today)
+        recurrence = Montrose.every(:month, starts: today, interval: 1)
         create(:plage_ouverture,
                motifs: [motif], lieu: lieu, agent: agent, organisation: organisation,
                first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
@@ -92,7 +92,7 @@ RSpec.describe CreneauxSearch::NextAvailability, type: :service do
         create(:plage_ouverture,
                motifs: [motif], lieu: lieu, agent: agent, organisation: organisation,
                first_day: today, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
-               recurrence: Montrose.every(:month, starts: today))
+               recurrence: Montrose.every(:month, starts: today, interval: 1))
 
         next_creneau = described_class.find(motif, lieu, [], from: today)
         expect(next_creneau.starts_at).to eq(today.in_time_zone + 1.month + 9.hours)
@@ -110,7 +110,7 @@ RSpec.describe CreneauxSearch::NextAvailability, type: :service do
         create(:plage_ouverture,
                motifs: [motif], lieu: lieu, agent: agent, organisation: organisation,
                first_day: today + 1.week, start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11),
-               recurrence: Montrose.every(:week, starts: 1.week.from_now))
+               recurrence: Montrose.every(:week, starts: 1.week.from_now, interval: 1))
       end
 
       context "when now is later than the plage d'ouverture" do

--- a/spec/services/plage_ouverture_overlap_spec.rb
+++ b/spec/services/plage_ouverture_overlap_spec.rb
@@ -87,77 +87,77 @@ RSpec.describe PlageOuvertureOverlap do
   # po1 recurring, po2 exceptionnelle
 
   context "po1 recurring without end date, po2 exceptionnelle before recurring" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on(%i[monday tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday - 7.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring without end date, po2 exceptionnelle on other day same week" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on(%i[monday tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 3.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring without end date, po2 exceptionnelle on other day next week" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on(%i[monday tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 1.week + 3.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring without end date, po2 exceptionnelle on same day but times don't overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on(%i[monday tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 8.days, 8, 10) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring without end date, po2 exceptionnelle on same day and times overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.weekly.on(%i[monday tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 8.days, 15, 20) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 6 weeks after" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, starts: monday).on(%i[monday tuesday])) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, starts: monday, interval: 1).on(%i[monday tuesday])) }
     let(:po2) { build_po(monday + 6.weeks, 14, 18) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring every 3 weeks without end date, po2 exceptionnelle on same week day 4 weeks after" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, on: %i[monday tuesday], starts: monday)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(3.weeks, on: %i[monday tuesday], starts: monday, interval: 1)) }
     let(:po2) { build_po(monday + 4.weeks, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle before recurring" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday - 7.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle same weekday before po1 end date" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday + 7.days, 14, 18) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle other weekday before po1 end date" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday - 10.days, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 exceptionnelle same weekday after po1 end date" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
     let(:po2) { build_po(monday + 4.weeks, 14, 18) }
 
     it_behaves_like "plage ouvertures do not overlap"
@@ -166,22 +166,22 @@ RSpec.describe PlageOuvertureOverlap do
   ## both recurring
 
   context "po1 and po2 recurring without end date, different weekdays" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday)) }
-    let(:po2) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[wednesday thursday], starts: monday)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, interval: 1)) }
+    let(:po2) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[wednesday thursday], starts: monday, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring without end date, overlapping weekdays" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday)) }
-    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 7.days)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, interval: 1)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 7.days, interval: 1)) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 and po2 recurring without end date, overlapping weekdays but different times" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday)) }
-    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, interval: 1)) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
@@ -201,29 +201,29 @@ RSpec.describe PlageOuvertureOverlap do
   end
 
   context "po1 recurring with end date, po2 recurring without end date, po2 starts before po1 ends, with weekdays overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 7.days)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 7.days, interval: 1)) }
 
     it_behaves_like "plage ouvertures overlap"
   end
 
   context "po1 recurring with end date, po2 recurring without end date, po2 starts before po1 ends, without weekdays overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: %i[wednesday thursday], starts: monday + 7.days)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
+    let(:po2) { build_po(monday + 7.days, 14, 18, Montrose.every(:week, on: %i[wednesday thursday], starts: monday + 7.days, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 recurring with end date, po2 recurring without end date, po2 starts after po1 ends" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 4.weeks, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 4.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
+    let(:po2) { build_po(monday + 4.weeks, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 4.weeks, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring with end date, overlap" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 1.week, until: monday + 5.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
+    let(:po2) { build_po(monday + 1.week, 14, 18, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 1.week, until: monday + 5.weeks, interval: 1)) }
 
     it_behaves_like "plage ouvertures overlap"
   end
@@ -243,36 +243,36 @@ RSpec.describe PlageOuvertureOverlap do
   end
 
   context "po1 and po2 recurring with end date, po2 starts after po1 ends" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 4.weeks, until: monday + 6.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
+    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: %i[tuesday wednesday], starts: monday + 4.weeks, until: monday + 6.weeks, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring with end date, overlap but weekdays mismatch" do
-    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks)) }
-    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: %i[wednesday thursday], starts: monday + 4.weeks, until: monday + 6.weeks)) }
+    let(:po1) { build_po(monday, 14, 18, Montrose.every(:week, on: %i[monday tuesday], starts: monday, until: monday + 3.weeks, interval: 1)) }
+    let(:po2) { build_po(monday + 4.weeks, 10, 12, Montrose.every(:week, on: %i[wednesday thursday], starts: monday + 4.weeks, until: monday + 6.weeks, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring monthly, same time and day but different week" do
-    let(:po1) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 1 })) }
-    let(:po2) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 2 })) }
+    let(:po1) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 1 }, interval: 1)) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 2 }, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 and po2 recurring monthly, same time and week but different days" do
-    let(:po1) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 1 })) }
-    let(:po2) { build_po(monday, 10, 12, Montrose.every(:month, day: { 2 => 2 })) }
+    let(:po1) { build_po(monday, 10, 12, Montrose.every(:month, day: { 1 => 1 }, interval: 1)) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:month, day: { 2 => 2 }, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end
 
   context "po1 is set to recurring but days are not set" do
-    let(:po1) { build_po(monday, 10, 12, Montrose.every(:week, day: nil)) }
-    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, day: { 2 => 2 })) }
+    let(:po1) { build_po(monday, 10, 12, Montrose.every(:week, day: nil, interval: 1)) }
+    let(:po2) { build_po(monday, 10, 12, Montrose.every(:week, day: { 2 => 2 }, interval: 1)) }
 
     it_behaves_like "plage ouvertures do not overlap"
   end

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -108,59 +108,5 @@ RSpec.shared_examples_for "recurrence" do
         expect(subject[0].ends_at).to eq(Time.zone.local(2019, 8, 5, 12))
       end
     end
-
-    describe "the future_only parameter" do
-      # In june of 2022, wednesdays land on 1, 8, 15, 22 and 29.
-      # Let's create a recurrent event that repeats on wednesdays beginning june 1st.
-      # Let's say we wish to search on the whole month (date range is june 1st to 30th).
-      # Let's say today is monday 13th of june.
-      # Using `future_only: false` should return all wednesdays (1, 8, 15, 22 and 29).
-      # Using `future_only: true` should return future wednesdays (15, 22 and 29).
-
-      before { travel_to(Time.zone.local(2022, 6, 13)) }
-
-      let(:first_day) { Date.new(2022, 6, 1) }
-      let(:model_instance) do
-        build(model_symbol,
-              first_day: first_day,
-              start_time: Tod::TimeOfDay.new(8),
-              end_time: Tod::TimeOfDay.new(12),
-              recurrence: Montrose.every(
-                :week,
-                on: [:wednesday],
-                interval: 1,
-                starts: first_day
-              ).to_json)
-      end
-      let(:date_range) { Date.new(2022, 6, 1)..Date.new(2022, 6, 30) }
-
-      context "when using the future_only: false switch" do
-        subject { model_instance.occurrences_for(date_range, only_future: false) }
-
-        it "returns all wednesdays of june" do
-          all_wednesdays_of_june = [
-            Time.zone.parse("2022-06-01 08:00:00"),
-            Time.zone.parse("2022-06-08 08:00:00"),
-            Time.zone.parse("2022-06-15 08:00:00"),
-            Time.zone.parse("2022-06-22 08:00:00"),
-            Time.zone.parse("2022-06-29 08:00:00"),
-          ]
-          expect(subject.map(&:starts_at)).to eq(all_wednesdays_of_june)
-        end
-      end
-
-      context "when using the future_only: true switch" do
-        subject { model_instance.occurrences_for(date_range, only_future: true) }
-
-        it "returns future wednesdays of june (after today which is june 13th)" do
-          future_wednesdays_of_june = [
-            Time.zone.parse("2022-06-15 08:00:00"),
-            Time.zone.parse("2022-06-22 08:00:00"),
-            Time.zone.parse("2022-06-29 08:00:00"),
-          ]
-          expect(subject.map(&:starts_at)).to eq(future_wednesdays_of_june)
-        end
-      end
-    end
   end
 end

--- a/spec/support/recurrence_concern.rb
+++ b/spec/support/recurrence_concern.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples_for "recurrence" do
 
     context "recurring without end date" do
       let(:first_day) { Date.new(2019, 7, 22).in_time_zone }
-      let(:model_instance) { create(model_symbol, first_day: first_day, end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], starts: first_day)) }
+      let(:model_instance) { create(model_symbol, first_day: first_day, end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], starts: first_day, interval: 1)) }
 
       it { is_expected.to be_nil }
     end
@@ -31,7 +31,8 @@ RSpec.shared_examples_for "recurrence" do
     context "recurring with end date" do
       let(:first_day) { Date.new(2019, 11, 17).in_time_zone }
       let(:model_instance) do
-        create(model_symbol, first_day: first_day, end_time: Tod::TimeOfDay.new(12), recurrence: Montrose.every(:week, on: [:tuesday], starts: first_day, until: Date.new(2020, 11, 25).in_time_zone))
+        create(model_symbol, first_day: first_day, end_time: Tod::TimeOfDay.new(12),
+                             recurrence: Montrose.every(:week, on: [:tuesday], starts: first_day, until: Date.new(2020, 11, 25).in_time_zone, interval: 1))
       end
 
       it { is_expected.to eq(Time.zone.local(2020, 11, 25, 12)) }
@@ -97,7 +98,7 @@ RSpec.shared_examples_for "recurrence" do
         build(model_symbol, first_day: first_day,
                             start_time: Tod::TimeOfDay.new(8),
                             end_time: Tod::TimeOfDay.new(12),
-                            recurrence: Montrose.every(:day, starts: first_day, until: Date.new(2019, 8, 5)).to_json,
+                            recurrence: Montrose.every(:day, starts: first_day, until: Date.new(2019, 8, 5), interval: 1).to_json,
                             recurrence_ends_at: Date.new(2019, 8, 5))
       end
       let(:date_range) { Date.new(2019, 8, 5)..Date.new(2019, 8, 11) }


### PR DESCRIPTION
# Contexte

Cette PR remplace https://github.com/betagouv/rdv-service-public/pull/4649


# Solution

Plutôt que de recoder à la main, on utilise la méthode `#fast_forward` de Montrose, qui répond directement à notre besoin.

