### PR TITLE
Revert "Utiliser l'état des processes GoodJob dans le health check"

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -5,9 +5,6 @@ class HealthController < ApplicationController
   end
 
   def jobs_queues
-    stale_processes = GoodJob::Process.all.select(&:stale?).map(&:id)
-    return render(status: :service_unavailable, json: { stale_processes: }) if stale_processes.any?
-
     counts1 = compute_enqueued_jobs_count_by_queue
     queues_with_many_jobs = counts1.select { |_queue, count| count > 10 }
     return render(status: :ok, json: {}) if queues_with_many_jobs.none?


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#4653

Nous avons eu plusieurs cas de processes "stale" mais avec un bon dépilage de jobs, donc on peut conclure que l'état d'un process dans Postgres n'est pas forcément un bon indicateur. Je préfère donc ne pas l'utiliser pour éviter les faux positifs.