### PR TITLE
Améliorations des specs du concern ANTS

### DIFF
--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -214,20 +214,10 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
   end
 
   context "ANTS application ID is consumed" do
-    let(:rdv) do
-      create(
-        :rdv,
-        motif: motif_passeport,
-        users: [user],
-        lieu: lieu,
-        organisation: organisation,
-        starts_at: Time.zone.parse("2020-04-20 08:00:00")
-      )
-    end
-
     describe "after_commit on_update" do
       describe "Rdv is cancelled" do
         it "does not sync with ANTS" do
+          rdv.save!
           stub_ants_status("A123456789", status: "consumed", appointments: [])
           perform_enqueued_jobs do
             rdv.excused!

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
   let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-  let(:lieu) { create(:lieu, organisation: organisation, name: "Lieu1") }
+  let(:lieu) { create(:lieu, organisation: organisation, name: "MDS Soleil") }
   let(:motif_passeport) { create(:motif, motif_category: create(:motif_category, :passeport)) }
   let(:rdv) { build(:rdv, motif: motif_passeport, users: [user], lieu: lieu, organisation: organisation, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
   let(:ants_api_headers) do
@@ -22,10 +22,10 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
       "A123456789",
       appointments: [
         {
-          management_url: Rails.application.routes.url_helpers.users_rdv_url(rdv, host: organisation.domain.host_name),
-          meeting_point: rdv.lieu.name,
+          management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+          meeting_point: "MDS Soleil",
           meeting_point_id: rdv.lieu.id,
-          appointment_date: rdv.starts_at.strftime("%Y-%m-%d %H:%M:%S"),
+          appointment_date: "2020-04-20 08:00:00",
         },
       ]
     )
@@ -45,7 +45,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
                 application_id: "A123456789",
                 appointment_date: "2020-04-20 08:00:00",
                 management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                meeting_point: rdv.lieu.name,
+                meeting_point: "MDS Soleil",
                 meeting_point_id: rdv.lieu.id,
               },
               headers: ants_api_headers
@@ -91,7 +91,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               query: {
                 application_id: "A123456789",
                 appointment_date: "2020-04-20 08:00:00",
-                meeting_point: rdv.lieu.name,
+                meeting_point: "MDS Soleil",
                 meeting_point_id: rdv.lieu.id,
               },
               headers: ants_api_headers
@@ -117,7 +117,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
                 query: {
                   application_id: "A123456789",
                   appointment_date: "2020-04-20 08:00:00",
-                  meeting_point: rdv.lieu.name,
+                  meeting_point: "MDS Soleil",
                   meeting_point_id: rdv.lieu.id,
                 },
                 headers: ants_api_headers
@@ -142,7 +142,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
                   application_id: "A123456789",
                   appointment_date: "2020-04-20 08:00:00",
                   management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                  meeting_point: rdv.lieu.name,
+                  meeting_point: "MDS Soleil",
                   meeting_point_id: rdv.lieu.id,
                 },
                 headers: ants_api_headers

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -7,11 +7,10 @@
 # note : dans les stubs, Webmock reconnaît les requêtes qui ont des query params
 # uniquement si on passe explicitement un with(query: hash_including({...}))
 
-API_URL = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api".freeze
-
 RSpec.describe Ants::AppointmentSerializerAndListener do
   include_context "rdv_mairie_api_authentication"
 
+  let(:api_url) { "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api" }
   let(:headers) do
     # on définit ici les headers attendus sur chaque requête API à l’ANTS
     # ce sont ceux définis dans le context rdv_mairie_api_authentication
@@ -31,12 +30,12 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
-      stub_request(:post, "#{API_URL}/appointments")
+      stub_request(:post, "#{api_url}/appointments")
         .with(
           query: hash_including( # on utilise hash_including pour pouvoir tester management_url avec une regex
             application_id: "A123456789",
@@ -94,7 +93,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
@@ -114,7 +113,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         )
     end
     let!(:delete_stub) do
-      stub_request(:delete, "#{API_URL}/appointments")
+      stub_request(:delete, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "A123456789",
@@ -144,7 +143,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
@@ -164,7 +163,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         )
     end
     let!(:delete_stub) do
-      stub_request(:delete, "#{API_URL}/appointments")
+      stub_request(:delete, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "A123456789",
@@ -195,7 +194,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
@@ -209,7 +208,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
       end
 
       expect(status_stub).to have_been_requested.at_least_once # TODO: la requête ne devrait être faite qu’une fois
-      expect(WebMock).not_to have_requested(:post, "#{API_URL}/appointments")
+      expect(WebMock).not_to have_requested(:post, "#{api_url}/appointments")
     end
   end
 
@@ -221,7 +220,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
@@ -241,7 +240,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         )
     end
     let!(:delete_stub) do
-      stub_request(:delete, "#{API_URL}/appointments")
+      stub_request(:delete, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "A123456789",
@@ -254,7 +253,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         .to_return(status: 200, body: { rowcount: 1 }.to_json)
     end
     let!(:create_stub) do
-      stub_request(:post, "#{API_URL}/appointments")
+      stub_request(:post, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "A123456789",
@@ -289,12 +288,12 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "AABBCCDDEE" }, headers:)
         .to_return(status: 200, body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
-      stub_request(:post, "#{API_URL}/appointments")
+      stub_request(:post, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "AABBCCDDEE",
@@ -328,12 +327,12 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
-      stub_request(:post, "#{API_URL}/appointments")
+      stub_request(:post, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "A123456789",
@@ -367,7 +366,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
     let!(:status_stub) do
-      stub_request(:get, "#{API_URL}/status")
+      stub_request(:get, "#{api_url}/status")
         .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
@@ -387,7 +386,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         )
     end
     let!(:delete_stub) do
-      stub_request(:delete, "#{API_URL}/appointments")
+      stub_request(:delete, "#{api_url}/appointments")
         .with(
           query: {
             application_id: "A123456789",

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         let!(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
         it "créé l’appointment via l’API ANTS" do
-          stub_ants_status("A123456789", status: "validated", appointments: [])
+          stub_request(:get, "#{API_URL}/status")
+            .with(query: { application_ids: "A123456789" })
+            .to_return(
+              status: 200,
+              body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
+            )
           stub_request(:post, "#{API_URL}/appointments")
             .with(query: hash_including(application_id: "A123456789")) # Webmock ne répond pas à la requête POST avec des query params sans cette ligne
             .to_return(status: 200, body: { success: true }.to_json)
@@ -81,21 +86,32 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
       let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
       it "supprime l’appointment via l’API ANTS" do
-        stub_ants_delete("A123456789")
-        stub_ants_status(
-          "A123456789",
-          appointments: [
-            {
-              management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-              meeting_point: "MDS Soleil",
-              meeting_point_id: rdv.lieu.id,
-              appointment_date: "2020-04-20 08:00:00",
-            },
-          ]
-        )
+        stub_request(:delete, "#{API_URL}/appointments")
+          .with(query: hash_including(application_id: "A123456789"))
+          .to_return(status: 200, body: { rowcount: 1 }.to_json)
+        stub_request(:get, "#{API_URL}/status")
+          .with(query: { application_ids: "A123456789" })
+          .to_return(
+            status: 200,
+            body: {
+              "A123456789" => {
+                status: "validated",
+                appointments: [
+                  {
+                    management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                    meeting_point: "MDS Soleil",
+                    meeting_point_id: rdv.lieu.id,
+                    appointment_date: "2020-04-20 08:00:00",
+                  },
+                ],
+              },
+            }.to_json
+          )
+
         perform_enqueued_jobs do
           rdv.destroy
         end
+
         expect(WebMock).to have_requested(:delete, "#{API_URL}/appointments")
           .with(
             query: {
@@ -118,21 +134,32 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
         it "supprime l’appointment via l’API ANTS" do
-          stub_ants_status(
-            "A123456789",
-            appointments: [
-              {
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                meeting_point: "MDS Soleil",
-                meeting_point_id: rdv.lieu.id,
-                appointment_date: "2020-04-20 08:00:00",
-              },
-            ]
-          )
-          stub_ants_delete("A123456789")
+          stub_request(:get, "#{API_URL}/status")
+            .with(query: { application_ids: "A123456789" })
+            .to_return(
+              status: 200,
+              body: {
+                "A123456789" => {
+                  status: "validated",
+                  appointments: [
+                    {
+                      management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                      meeting_point: "MDS Soleil",
+                      meeting_point_id: rdv.lieu.id,
+                      appointment_date: "2020-04-20 08:00:00",
+                    },
+                  ],
+                },
+              }.to_json
+            )
+          stub_request(:delete, "#{API_URL}/appointments")
+            .with(query: hash_including(application_id: "A123456789"))
+            .to_return(status: 200, body: { rowcount: 1 }.to_json)
+
           perform_enqueued_jobs do
             rdv.excused!
           end
+
           expect(WebMock).to have_requested(:delete, "#{API_URL}/appointments")
             .with(
               query: {
@@ -156,22 +183,35 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         before { rdv.excused! }
 
         it "créé l’appointment via l’API ANTS" do
-          stub_ants_status(
-            "A123456789",
-            appointments: [
-              {
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                meeting_point: "MDS Soleil",
-                meeting_point_id: rdv.lieu.id,
-                appointment_date: "2020-04-20 08:00:00",
-              },
-            ]
-          )
-          stub_ants_delete("A123456789")
-          stub_ants_create("A123456789")
+          stub_request(:get, "#{API_URL}/status")
+            .with(query: { application_ids: "A123456789" })
+            .to_return(
+              status: 200,
+              body: {
+                "A123456789" => {
+                  status: "validated",
+                  appointments: [
+                    {
+                      management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                      meeting_point: "MDS Soleil",
+                      meeting_point_id: rdv.lieu.id,
+                      appointment_date: "2020-04-20 08:00:00",
+                    },
+                  ],
+                },
+              }.to_json
+            )
+          stub_request(:delete, "#{API_URL}/appointments")
+            .with(query: hash_including(application_id: "A123456789"))
+            .to_return(status: 200, body: { rowcount: 1 }.to_json)
+          stub_request(:post, "#{API_URL}/appointments")
+            .with(query: hash_including(application_id: "A123456789"))
+            .to_return(status: 200, body: { success: true }.to_json)
+
           perform_enqueued_jobs do
             rdv.seen!
           end
+
           expect(WebMock).to have_requested(:post, "#{API_URL}/appointments")
             .with(
               query: {
@@ -198,11 +238,20 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
       it "créé un nouvel appointment via l’API ANTS" do
         user.reload
-        create_appointment_stub = stub_ants_create("AABBCCDDEE")
-        stub_ants_status("AABBCCDDEE", status: "validated", appointments: [])
+        create_appointment_stub = stub_request(:post, "#{API_URL}/appointments")
+          .with(query: hash_including(application_id: "AABBCCDDEE"))
+          .to_return(status: 200, body: { success: true }.to_json)
+        stub_request(:get, "#{API_URL}/status")
+          .with(query: { application_ids: "AABBCCDDEE" })
+          .to_return(
+            status: 200,
+            body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json
+          )
+
         perform_enqueued_jobs do
           user.update(ants_pre_demande_number: "AABBCCDDEE")
         end
+
         expect(create_appointment_stub).to have_been_requested.at_least_once
       end
     end
@@ -218,11 +267,20 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
       it "déclenche une synchronisation avec l’ANTS" do
         lieu.reload
-        create_appointment_stub = stub_ants_create("A123456789")
-        stub_ants_status("A123456789", status: "validated", appointments: [])
+        create_appointment_stub = stub_request(:post, "#{API_URL}/appointments")
+          .with(query: hash_including(application_id: "A123456789"))
+          .to_return(status: 200, body: { success: true }.to_json)
+        stub_request(:get, "#{API_URL}/status")
+          .with(query: { application_ids: "A123456789" })
+          .to_return(
+            status: 200,
+            body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
+          )
+
         perform_enqueued_jobs do
           lieu.update(name: "Nouveau Lieu")
         end
+
         expect(create_appointment_stub).to have_been_requested.at_least_once
       end
     end
@@ -238,19 +296,28 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
       it "supprime l’appointment via l’API ANTS" do
         user.reload
-        stub_ants_status("A123456789", status: "validated", appointments: [])
-        stub_ants_status(
-          "A123456789",
-          appointments: [
-            {
-              management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-              meeting_point: "MDS Soleil",
-              meeting_point_id: rdv.lieu.id,
-              appointment_date: "2020-04-20 08:00:00",
-            },
-          ]
-        )
-        stub_ants_delete("A123456789")
+        stub_request(:get, "#{API_URL}/status")
+          .with(query: { application_ids: "A123456789" })
+          .to_return(
+            status: 200,
+            body: {
+              "A123456789" => {
+                status: "validated",
+                appointments: [
+                  {
+                    management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                    meeting_point: "MDS Soleil",
+                    meeting_point_id: rdv.lieu.id,
+                    appointment_date: "2020-04-20 08:00:00",
+                  },
+                ],
+              },
+            }.to_json
+          )
+        stub_request(:delete, "#{API_URL}/appointments")
+          .with(query: hash_including(application_id: "A123456789"))
+          .to_return(status: 200, body: { rowcount: 1 }.to_json)
+
         perform_enqueued_jobs do
           user.participations.first.destroy
         end
@@ -268,10 +335,17 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
         it "ne déclenche pas la création d’un nouvel appointment via l’API ANTS" do
-          stub_ants_status("A123456789", status: "consumed", appointments: [])
+          stub_request(:get, "#{API_URL}/status")
+            .with(query: { application_ids: "A123456789" })
+            .to_return(
+              status: 200,
+              body: { "A123456789" => { status: "consumed", appointments: [] } }.to_json
+            )
+
           perform_enqueued_jobs do
             rdv.excused!
           end
+
           expect(WebMock).not_to have_requested(:post, "#{API_URL}/appointments").with(headers: ants_api_headers)
         end
       end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Création de RDV, l’usager a un numéro de pré-demande ANTS" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -41,7 +41,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: hash_including( # on utilise hash_including pour pouvoir tester management_url avec une regex
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id.to_s,
             management_url: %r{http://www\.rdv-mairie-test\.localhost/users/rdvs/\d+} # on ne connaît pas encore l’ID du RDV
           ),
@@ -62,7 +62,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Création de RDV, l’usager n’a pas de numéro de pré-demande ANTS" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let(:user) { create(:user, ants_pre_demande_number: "", organisations: [organisation]) }
     let(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -88,7 +88,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Suppression de RDV" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -104,7 +104,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               appointments: [
                 {
                   management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                  meeting_point: "MDS Soleil",
+                  meeting_point: "Mairie de Saumur",
                   meeting_point_id: rdv.lieu.id,
                   appointment_date: "2020-04-20 08:00:00",
                 },
@@ -119,7 +119,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
           headers:
@@ -138,7 +138,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Annulation de RDV" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -154,7 +154,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               appointments: [
                 {
                   management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                  meeting_point: "MDS Soleil",
+                  meeting_point: "Mairie de Saumur",
                   meeting_point_id: rdv.lieu.id,
                   appointment_date: "2020-04-20 08:00:00",
                 },
@@ -169,7 +169,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
           headers:
@@ -189,7 +189,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Annulation de RDV, l’API de l’ANTS renvoie un statut consumed" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -215,7 +215,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "le RDV est marqué comme vu alors qu’il avait été annulé" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -231,7 +231,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               appointments: [
                 {
                   management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                  meeting_point: "MDS Soleil",
+                  meeting_point: "Mairie de Saumur",
                   meeting_point_id: rdv.lieu.id,
                   appointment_date: "2020-04-20 08:00:00",
                 },
@@ -246,7 +246,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
           headers:
@@ -260,7 +260,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
             management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
           headers:
@@ -283,7 +283,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "l’usager change de numéro de pré-demande ANTS après avoir pris RDV avec un précédent numéro" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -300,7 +300,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             application_id: "AABBCCDDEE",
             appointment_date: "2020-04-20 08:00:00",
             management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
           headers:
@@ -322,7 +322,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Le lieu change de nom" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -361,7 +361,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "un usager est retiré du RDV" do
     let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
     let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
     let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
     let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
@@ -377,7 +377,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               appointments: [
                 {
                   management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                  meeting_point: "MDS Soleil",
+                  meeting_point: "Mairie de Saumur",
                   meeting_point_id: rdv.lieu.id,
                   appointment_date: "2020-04-20 08:00:00",
                 },
@@ -392,7 +392,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           query: {
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
-            meeting_point: "MDS Soleil",
+            meeting_point: "Mairie de Saumur",
             meeting_point_id: rdv.lieu.id,
           },
           headers:

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -12,20 +12,6 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     }
   end
 
-  def stub_ants_status_with_appointments
-    stub_ants_status(
-      "A123456789",
-      appointments: [
-        {
-          management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-          meeting_point: "MDS Soleil",
-          meeting_point_id: rdv.lieu.id,
-          appointment_date: "2020-04-20 08:00:00",
-        },
-      ]
-    )
-  end
-
   describe "RDV callbacks" do
     describe "after_commit on_create" do
       context "l’usager a un numéro de pré-demande ANTS" do
@@ -91,7 +77,17 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
       it "deletes appointment on ANTS" do
         stub_ants_delete("A123456789")
-        stub_ants_status_with_appointments
+        stub_ants_status(
+          "A123456789",
+          appointments: [
+            {
+              management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+              meeting_point: "MDS Soleil",
+              meeting_point_id: rdv.lieu.id,
+              appointment_date: "2020-04-20 08:00:00",
+            },
+          ]
+        )
         perform_enqueued_jobs do
           rdv.destroy
         end
@@ -117,7 +113,17 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
         it "deletes appointment on ANTS" do
-          stub_ants_status_with_appointments
+          stub_ants_status(
+            "A123456789",
+            appointments: [
+              {
+                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                meeting_point: "MDS Soleil",
+                meeting_point_id: rdv.lieu.id,
+                appointment_date: "2020-04-20 08:00:00",
+              },
+            ]
+          )
           stub_ants_delete("A123456789")
           perform_enqueued_jobs do
             rdv.excused!
@@ -145,7 +151,17 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         before { rdv.excused! }
 
         it "creates appointment" do
-          stub_ants_status_with_appointments
+          stub_ants_status(
+            "A123456789",
+            appointments: [
+              {
+                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                meeting_point: "MDS Soleil",
+                meeting_point_id: rdv.lieu.id,
+                appointment_date: "2020-04-20 08:00:00",
+              },
+            ]
+          )
           stub_ants_delete("A123456789")
           stub_ants_create("A123456789")
           perform_enqueued_jobs do
@@ -218,7 +234,17 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
       it "deletes appointment" do
         user.reload
         stub_ants_status("A123456789", status: "validated", appointments: [])
-        stub_ants_status_with_appointments
+        stub_ants_status(
+          "A123456789",
+          appointments: [
+            {
+              management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+              meeting_point: "MDS Soleil",
+              meeting_point_id: rdv.lieu.id,
+              appointment_date: "2020-04-20 08:00:00",
+            },
+          ]
+        )
         stub_ants_delete("A123456789")
         perform_enqueued_jobs do
           user.participations.first.destroy

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
   describe "RDV callbacks" do
     describe "after_commit on_create" do
       it "creates appointment on ANTS" do
-        stub_ants_status("A123456789")
+        stub_ants_status("A123456789", status: "validated", appointments: [])
         stub_ants_create("A123456789")
 
         perform_enqueued_jobs do
@@ -164,7 +164,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         user.reload
 
         perform_enqueued_jobs do
-          stub_ants_status("AABBCCDDEE")
+          stub_ants_status("AABBCCDDEE", status: "validated", appointments: [])
           user.update(ants_pre_demande_number: "AABBCCDDEE")
 
           expect(create_appointment_stub).to have_been_requested.at_least_once
@@ -186,7 +186,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     describe "after_commit: Changing the name of the lieu" do
       it "triggers a sync with ANTS" do
         perform_enqueued_jobs do
-          stub_ants_status("A123456789")
+          stub_ants_status("A123456789", status: "validated", appointments: [])
           lieu.update(name: "Nouveau Lieu")
 
           expect(create_appointment_stub).to have_been_requested.at_least_once
@@ -197,7 +197,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
   describe "Participation callbacks" do
     before do
-      stub_ants_status("A123456789")
+      stub_ants_status("A123456789", status: "validated", appointments: [])
       rdv.save!
       user.reload
       rdv.participations.reload

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -1,3 +1,6 @@
+# dans les stubs, Webmock reconnaît les requêtes qui ont des query params uniquement si on passe explicitement
+# un with(query: hash_including({...}))
+
 API_URL = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api".freeze
 
 RSpec.describe Ants::AppointmentSerializerAndListener do
@@ -27,7 +30,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
           body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
         )
       stub_request(:post, "#{API_URL}/appointments")
-        .with(query: hash_including(application_id: "A123456789")) # Webmock ne répond pas à la requête POST avec des query params sans cette ligne
+        .with(query: hash_including(application_id: "A123456789"))
         .to_return(status: 200, body: { success: true }.to_json)
 
       perform_enqueued_jobs do

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -12,342 +12,326 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     }
   end
 
-  describe "RDV callbacks" do
-    describe "after_commit on_create" do
-      context "l’usager a un numéro de pré-demande ANTS" do
-        let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-        let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-        let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-        let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-        let!(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+  describe "Création de RDV, l’usager a un numéro de pré-demande ANTS" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-        it "créé l’appointment via l’API ANTS" do
-          stub_request(:get, "#{API_URL}/status")
-            .with(query: { application_ids: "A123456789" })
-            .to_return(
-              status: 200,
-              body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
-            )
-          stub_request(:post, "#{API_URL}/appointments")
-            .with(query: hash_including(application_id: "A123456789")) # Webmock ne répond pas à la requête POST avec des query params sans cette ligne
-            .to_return(status: 200, body: { success: true }.to_json)
+    it "Créé l’appointment via l’API ANTS" do
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
+        )
+      stub_request(:post, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789")) # Webmock ne répond pas à la requête POST avec des query params sans cette ligne
+        .to_return(status: 200, body: { success: true }.to_json)
 
-          perform_enqueued_jobs do
-            rdv.save!
-          end
-
-          expect(WebMock).to have_requested(:post, "#{API_URL}/appointments")
-            .with(
-              query: hash_including(
-                application_id: "A123456789",
-                appointment_date: "2020-04-20 08:00:00",
-                meeting_point: "MDS Soleil",
-                meeting_point_id: rdv.lieu.id.to_s,
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}"
-              ),
-              headers: ants_api_headers
-            )
-            .once
-        end
+      perform_enqueued_jobs do
+        rdv.save!
       end
 
-      context "l’usager n’a pas de numéro de pré-demande ANTS" do
-        let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-        let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-        let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-        let(:user) { create(:user, ants_pre_demande_number: "", organisations: [organisation]) }
-        let(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+      expect(WebMock).to have_requested(:post, "#{API_URL}/appointments")
+        .with(
+          query: hash_including(
+            application_id: "A123456789",
+            appointment_date: "2020-04-20 08:00:00",
+            meeting_point: "MDS Soleil",
+            meeting_point_id: rdv.lieu.id.to_s,
+            management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}"
+          ),
+          headers: ants_api_headers
+        )
+        .once
+    end
+  end
 
-        it "n’appelle pas du tout l’API ANTS" do
-          perform_enqueued_jobs do
-            rdv.save!
-          end
-          expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
-        end
+  describe "Création de RDV, l’usager n’a pas de numéro de pré-demande ANTS" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let(:user) { create(:user, ants_pre_demande_number: "", organisations: [organisation]) }
+    let(:rdv) { build(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-        context "et le RDV est annulé" do
-          before { rdv.status = "excused" }
-
-          it "n’appelle pas du tout l’API ANTS" do
-            perform_enqueued_jobs do
-              rdv.save!
-            end
-            expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
-          end
-        end
+    it "n’appelle pas du tout l’API ANTS" do
+      perform_enqueued_jobs do
+        rdv.save!
       end
+      expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
     end
 
-    describe "after_commit on_destroy" do
-      let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-      let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-      let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-      let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+    context "et le RDV est annulé" do
+      before { rdv.status = "excused" }
 
-      it "supprime l’appointment via l’API ANTS" do
-        stub_request(:delete, "#{API_URL}/appointments")
-          .with(query: hash_including(application_id: "A123456789"))
-          .to_return(status: 200, body: { rowcount: 1 }.to_json)
-        stub_request(:get, "#{API_URL}/status")
-          .with(query: { application_ids: "A123456789" })
-          .to_return(
-            status: 200,
-            body: {
-              "A123456789" => {
-                status: "validated",
-                appointments: [
-                  {
-                    management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                    meeting_point: "MDS Soleil",
-                    meeting_point_id: rdv.lieu.id,
-                    appointment_date: "2020-04-20 08:00:00",
-                  },
-                ],
-              },
-            }.to_json
-          )
-
+      it "n’appelle pas du tout l’API ANTS" do
         perform_enqueued_jobs do
-          rdv.destroy
+          rdv.save!
         end
+        expect(WebMock).not_to have_requested(:any, %r{\.ants\.gouv\.fr/api})
+      end
+    end
+  end
 
-        expect(WebMock).to have_requested(:delete, "#{API_URL}/appointments")
-          .with(
-            query: {
-              application_id: "A123456789",
-              appointment_date: "2020-04-20 08:00:00",
-              meeting_point: "MDS Soleil",
-              meeting_point_id: rdv.lieu.id,
+  describe "Suppression de RDV" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+
+    it "supprime l’appointment via l’API ANTS" do
+      stub_request(:delete, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789"))
+        .to_return(status: 200, body: { rowcount: 1 }.to_json)
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: {
+            "A123456789" => {
+              status: "validated",
+              appointments: [
+                {
+                  management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                  meeting_point: "MDS Soleil",
+                  meeting_point_id: rdv.lieu.id,
+                  appointment_date: "2020-04-20 08:00:00",
+                },
+              ],
             },
-            headers: ants_api_headers
-          ).at_least_once
+          }.to_json
+        )
+
+      perform_enqueued_jobs do
+        rdv.destroy
       end
+
+      expect(WebMock).to have_requested(:delete, "#{API_URL}/appointments")
+        .with(
+          query: {
+            application_id: "A123456789",
+            appointment_date: "2020-04-20 08:00:00",
+            meeting_point: "MDS Soleil",
+            meeting_point_id: rdv.lieu.id,
+          },
+          headers: ants_api_headers
+        ).at_least_once
     end
+  end
 
-    describe "after_commit on_update" do
-      describe "le RDV est annulé" do
-        let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-        let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-        let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-        let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-        let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+  describe "Annulation de RDV" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-        it "supprime l’appointment via l’API ANTS" do
-          stub_request(:get, "#{API_URL}/status")
-            .with(query: { application_ids: "A123456789" })
-            .to_return(
-              status: 200,
-              body: {
-                "A123456789" => {
-                  status: "validated",
-                  appointments: [
-                    {
-                      management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                      meeting_point: "MDS Soleil",
-                      meeting_point_id: rdv.lieu.id,
-                      appointment_date: "2020-04-20 08:00:00",
-                    },
-                  ],
+    it "supprime l’appointment via l’API ANTS" do
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: {
+            "A123456789" => {
+              status: "validated",
+              appointments: [
+                {
+                  management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                  meeting_point: "MDS Soleil",
+                  meeting_point_id: rdv.lieu.id,
+                  appointment_date: "2020-04-20 08:00:00",
                 },
-              }.to_json
-            )
-          stub_request(:delete, "#{API_URL}/appointments")
-            .with(query: hash_including(application_id: "A123456789"))
-            .to_return(status: 200, body: { rowcount: 1 }.to_json)
+              ],
+            },
+          }.to_json
+        )
+      stub_request(:delete, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789"))
+        .to_return(status: 200, body: { rowcount: 1 }.to_json)
 
-          perform_enqueued_jobs do
-            rdv.excused!
-          end
-
-          expect(WebMock).to have_requested(:delete, "#{API_URL}/appointments")
-            .with(
-              query: {
-                application_id: "A123456789",
-                appointment_date: "2020-04-20 08:00:00",
-                meeting_point: "MDS Soleil",
-                meeting_point_id: rdv.lieu.id,
-              },
-              headers: ants_api_headers
-            ).at_least_once
-        end
+      perform_enqueued_jobs do
+        rdv.excused!
       end
 
-      describe "le RDV est marqué comme vu alors qu’il avait été annulé" do
-        let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-        let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-        let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-        let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-        let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+      expect(WebMock).to have_requested(:delete, "#{API_URL}/appointments")
+        .with(
+          query: {
+            application_id: "A123456789",
+            appointment_date: "2020-04-20 08:00:00",
+            meeting_point: "MDS Soleil",
+            meeting_point_id: rdv.lieu.id,
+          },
+          headers: ants_api_headers
+        ).at_least_once
+    end
+  end
 
-        before { rdv.excused! }
+  describe "Annulation de RDV, l’API de l’ANTS renvoie un statut consumed" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-        it "créé l’appointment via l’API ANTS" do
-          stub_request(:get, "#{API_URL}/status")
-            .with(query: { application_ids: "A123456789" })
-            .to_return(
-              status: 200,
-              body: {
-                "A123456789" => {
-                  status: "validated",
-                  appointments: [
-                    {
-                      management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                      meeting_point: "MDS Soleil",
-                      meeting_point_id: rdv.lieu.id,
-                      appointment_date: "2020-04-20 08:00:00",
-                    },
-                  ],
+    it "ne déclenche pas la création d’un nouvel appointment via l’API ANTS" do
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: { "A123456789" => { status: "consumed", appointments: [] } }.to_json
+        )
+
+      perform_enqueued_jobs do
+        rdv.excused!
+      end
+
+      expect(WebMock).not_to have_requested(:post, "#{API_URL}/appointments").with(headers: ants_api_headers)
+    end
+  end
+
+  describe "le RDV est marqué comme vu alors qu’il avait été annulé" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+
+    before { rdv.excused! }
+
+    it "créé l’appointment via l’API ANTS" do
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: {
+            "A123456789" => {
+              status: "validated",
+              appointments: [
+                {
+                  management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                  meeting_point: "MDS Soleil",
+                  meeting_point_id: rdv.lieu.id,
+                  appointment_date: "2020-04-20 08:00:00",
                 },
-              }.to_json
-            )
-          stub_request(:delete, "#{API_URL}/appointments")
-            .with(query: hash_including(application_id: "A123456789"))
-            .to_return(status: 200, body: { rowcount: 1 }.to_json)
-          stub_request(:post, "#{API_URL}/appointments")
-            .with(query: hash_including(application_id: "A123456789"))
-            .to_return(status: 200, body: { success: true }.to_json)
+              ],
+            },
+          }.to_json
+        )
+      stub_request(:delete, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789"))
+        .to_return(status: 200, body: { rowcount: 1 }.to_json)
+      stub_request(:post, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789"))
+        .to_return(status: 200, body: { success: true }.to_json)
 
-          perform_enqueued_jobs do
-            rdv.seen!
-          end
-
-          expect(WebMock).to have_requested(:post, "#{API_URL}/appointments")
-            .with(
-              query: {
-                application_id: "A123456789",
-                appointment_date: "2020-04-20 08:00:00",
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                meeting_point: "MDS Soleil",
-                meeting_point_id: rdv.lieu.id,
-              },
-              headers: ants_api_headers
-            ).at_least_once
-        end
+      perform_enqueued_jobs do
+        rdv.seen!
       end
+
+      expect(WebMock).to have_requested(:post, "#{API_URL}/appointments")
+        .with(
+          query: {
+            application_id: "A123456789",
+            appointment_date: "2020-04-20 08:00:00",
+            management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+            meeting_point: "MDS Soleil",
+            meeting_point_id: rdv.lieu.id,
+          },
+          headers: ants_api_headers
+        ).at_least_once
     end
   end
 
-  describe "User callbacks" do
-    describe "after_commit: l’usager change de numéro de pré-demande ANTS" do
-      let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-      let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-      let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-      let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+  describe "l’usager change de numéro de pré-demande ANTS après avoir pris RDV avec un précédent numéro" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-      it "créé un nouvel appointment via l’API ANTS" do
-        user.reload
-        create_appointment_stub = stub_request(:post, "#{API_URL}/appointments")
-          .with(query: hash_including(application_id: "AABBCCDDEE"))
-          .to_return(status: 200, body: { success: true }.to_json)
-        stub_request(:get, "#{API_URL}/status")
-          .with(query: { application_ids: "AABBCCDDEE" })
-          .to_return(
-            status: 200,
-            body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json
-          )
+    it "créé un nouvel appointment via l’API ANTS" do
+      user.reload
+      create_appointment_stub = stub_request(:post, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "AABBCCDDEE"))
+        .to_return(status: 200, body: { success: true }.to_json)
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "AABBCCDDEE" })
+        .to_return(
+          status: 200,
+          body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json
+        )
 
-        perform_enqueued_jobs do
-          user.update(ants_pre_demande_number: "AABBCCDDEE")
-        end
-
-        expect(create_appointment_stub).to have_been_requested.at_least_once
+      perform_enqueued_jobs do
+        user.update(ants_pre_demande_number: "AABBCCDDEE")
       end
+
+      expect(create_appointment_stub).to have_been_requested.at_least_once
     end
   end
 
-  describe "Lieu callbacks" do
-    describe "after_commit: le lieu change de nom" do
-      let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-      let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-      let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-      let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+  describe "Le lieu change de nom" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-      it "déclenche une synchronisation avec l’ANTS" do
-        lieu.reload
-        create_appointment_stub = stub_request(:post, "#{API_URL}/appointments")
-          .with(query: hash_including(application_id: "A123456789"))
-          .to_return(status: 200, body: { success: true }.to_json)
-        stub_request(:get, "#{API_URL}/status")
-          .with(query: { application_ids: "A123456789" })
-          .to_return(
-            status: 200,
-            body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
-          )
+    it "déclenche une synchronisation avec l’ANTS" do
+      lieu.reload
+      create_appointment_stub = stub_request(:post, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789"))
+        .to_return(status: 200, body: { success: true }.to_json)
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
+        )
 
-        perform_enqueued_jobs do
-          lieu.update(name: "Nouveau Lieu")
-        end
-
-        expect(create_appointment_stub).to have_been_requested.at_least_once
+      perform_enqueued_jobs do
+        lieu.update(name: "Nouveau Lieu")
       end
+
+      expect(create_appointment_stub).to have_been_requested.at_least_once
     end
   end
 
-  describe "Participation callbacks" do
-    describe "after_commit: un usager est retiré du RDV" do
-      let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-      let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-      let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-      let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-      let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+  describe "un usager est retiré du RDV" do
+    let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
+    let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
+    let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
 
-      it "supprime l’appointment via l’API ANTS" do
-        user.reload
-        stub_request(:get, "#{API_URL}/status")
-          .with(query: { application_ids: "A123456789" })
-          .to_return(
-            status: 200,
-            body: {
-              "A123456789" => {
-                status: "validated",
-                appointments: [
-                  {
-                    management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                    meeting_point: "MDS Soleil",
-                    meeting_point_id: rdv.lieu.id,
-                    appointment_date: "2020-04-20 08:00:00",
-                  },
-                ],
-              },
-            }.to_json
-          )
-        stub_request(:delete, "#{API_URL}/appointments")
-          .with(query: hash_including(application_id: "A123456789"))
-          .to_return(status: 200, body: { rowcount: 1 }.to_json)
+    it "supprime l’appointment via l’API ANTS" do
+      user.reload
+      stub_request(:get, "#{API_URL}/status")
+        .with(query: { application_ids: "A123456789" })
+        .to_return(
+          status: 200,
+          body: {
+            "A123456789" => {
+              status: "validated",
+              appointments: [
+                {
+                  management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+                  meeting_point: "MDS Soleil",
+                  meeting_point_id: rdv.lieu.id,
+                  appointment_date: "2020-04-20 08:00:00",
+                },
+              ],
+            },
+          }.to_json
+        )
+      stub_request(:delete, "#{API_URL}/appointments")
+        .with(query: hash_including(application_id: "A123456789"))
+        .to_return(status: 200, body: { rowcount: 1 }.to_json)
 
-        perform_enqueued_jobs do
-          user.participations.first.destroy
-        end
-      end
-    end
-  end
-
-  context "ANTS application ID is consumed" do
-    describe "after_commit on_update" do
-      describe "le RDV est annulé" do
-        let(:organisation) { create(:organisation, verticale: :rdv_mairie) }
-        let(:lieu) { create(:lieu, organisation:, name: "MDS Soleil") }
-        let(:motif) { create(:motif, motif_category: create(:motif_category, :passeport)) }
-        let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
-        let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
-
-        it "ne déclenche pas la création d’un nouvel appointment via l’API ANTS" do
-          stub_request(:get, "#{API_URL}/status")
-            .with(query: { application_ids: "A123456789" })
-            .to_return(
-              status: 200,
-              body: { "A123456789" => { status: "consumed", appointments: [] } }.to_json
-            )
-
-          perform_enqueued_jobs do
-            rdv.excused!
-          end
-
-          expect(WebMock).not_to have_requested(:post, "#{API_URL}/appointments").with(headers: ants_api_headers)
-        end
+      perform_enqueued_jobs do
+        user.participations.first.destroy
       end
     end
   end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -12,7 +12,7 @@ API_URL = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api".fr
 RSpec.describe Ants::AppointmentSerializerAndListener do
   include_context "rdv_mairie_api_authentication"
 
-  let(:ants_api_headers) do
+  let(:headers) do
     {
       "Accept" => "application/json",
       "Expect" => "",
@@ -30,7 +30,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
+        .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
@@ -43,7 +43,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point_id: rdv.lieu.id.to_s,
             management_url: %r{http://www\.rdv-mairie-test\.localhost/users/rdvs/\d+}
           ),
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { success: true }.to_json)
     end
@@ -93,7 +93,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
+        .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
           body: {
@@ -120,7 +120,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { rowcount: 1 }.to_json)
     end
@@ -129,7 +129,6 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
       perform_enqueued_jobs do
         rdv.destroy
       end
-
       expect(status_stub).to have_been_requested.at_least_once # TODO: la requête ne devrait être faite qu’une fois
       expect(delete_stub).to have_been_requested.at_least_once # TODO: la requête ne devrait être faite qu’une fois
     end
@@ -144,7 +143,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
+        .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
           body: {
@@ -171,7 +170,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { rowcount: 1 }.to_json)
     end
@@ -195,7 +194,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
+        .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
           body: { "A123456789" => { status: "consumed", appointments: [] } }.to_json
@@ -221,7 +220,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
+        .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
           body: {
@@ -248,7 +247,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { rowcount: 1 }.to_json)
     end
@@ -262,7 +261,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { success: true }.to_json)
     end
@@ -289,11 +288,8 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "AABBCCDDEE" })
-        .to_return(
-          status: 200,
-          body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json
-        )
+        .with(query: { application_ids: "AABBCCDDEE" }, headers:)
+        .to_return(status: 200, body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
       stub_request(:post, "#{API_URL}/appointments")
@@ -305,7 +301,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { success: true }.to_json)
     end
@@ -331,11 +327,8 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
-        .to_return(
-          status: 200,
-          body: { "A123456789" => { status: "validated", appointments: [] } }.to_json
-        )
+        .with(query: { application_ids: "A123456789" }, headers:)
+        .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
       stub_request(:post, "#{API_URL}/appointments")
@@ -347,7 +340,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "Nouveau Lieu",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { success: true }.to_json)
     end
@@ -373,7 +366,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{API_URL}/status")
-        .with(query: { application_ids: "A123456789" })
+        .with(query: { application_ids: "A123456789" }, headers:)
         .to_return(
           status: 200,
           body: {
@@ -400,7 +393,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id,
           },
-          headers: ants_api_headers
+          headers:
         )
         .to_return(status: 200, body: { rowcount: 1 }.to_json)
     end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
   include_context "rdv_mairie_api_authentication"
 
   let(:headers) do
+    # on définit ici les headers attendus sur chaque requête API à l’ANTS
+    # ce sont ceux définis dans le context rdv_mairie_api_authentication
     {
       "Accept" => "application/json",
       "Expect" => "",
@@ -36,12 +38,12 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
     let!(:create_stub) do
       stub_request(:post, "#{API_URL}/appointments")
         .with(
-          query: hash_including(
+          query: hash_including( # on utilise hash_including pour pouvoir tester management_url avec une regex
             application_id: "A123456789",
             appointment_date: "2020-04-20 08:00:00",
             meeting_point: "MDS Soleil",
             meeting_point_id: rdv.lieu.id.to_s,
-            management_url: %r{http://www\.rdv-mairie-test\.localhost/users/rdvs/\d+}
+            management_url: %r{http://www\.rdv-mairie-test\.localhost/users/rdvs/\d+} # on ne connaît pas encore l’ID du RDV
           ),
           headers:
         )

--- a/spec/support/ants_stubs.rb
+++ b/spec/support/ants_stubs.rb
@@ -1,22 +1,24 @@
-API_URL = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api".freeze
-
 def stub_ants_status(application_id, status: "validated", appointments: [])
-  stub_request(:get, "#{API_URL}/status")
-    .with(query: { application_ids: application_id })
-    .to_return(
-      status: 200,
-      body: { application_id => { status:, appointments: } }.to_json
-    )
+  stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=#{application_id}").to_return(
+    status: 200,
+    body: { application_id => { status: status, appointments: appointments } }.to_json
+  )
 end
 
 def stub_ants_create(application_id)
-  stub_request(:post, "#{API_URL}/appointments")
-    .with(query: hash_including(application_id:))
-    .to_return(status: 200, body: { success: true }.to_json)
+  stub_request(:post, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments/*})
+    .with(query: hash_including({ "application_id" => application_id }))
+    .to_return(
+      status: 200,
+      body: { success: true }.to_json
+    )
 end
 
 def stub_ants_delete(application_id)
-  stub_request(:delete, "#{API_URL}/appointments")
-    .with(query: hash_including(application_id:))
-    .to_return(status: 200, body: { rowcount: 1 }.to_json)
+  stub_request(:delete, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments/*})
+    .with(query: hash_including({ "application_id" => application_id }))
+    .to_return(
+      status: 200,
+      body: { rowcount: 1 }.to_json
+    )
 end

--- a/spec/support/ants_stubs.rb
+++ b/spec/support/ants_stubs.rb
@@ -1,12 +1,16 @@
+API_URL = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api".freeze
+
 def stub_ants_status(application_id, status: "validated", appointments: [])
-  stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=#{application_id}").to_return(
-    status: 200,
-    body: { application_id => { status: status, appointments: appointments } }.to_json
-  )
+  stub_request(:get, "#{API_URL}/status")
+    .with(query: { application_ids: application_id })
+    .to_return(
+      status: 200,
+      body: { application_id => { status: status, appointments: appointments } }.to_json
+    )
 end
 
 def stub_ants_create(application_id)
-  stub_request(:post, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments/*})
+  stub_request(:post, "#{API_URL}/appointments")
     .with(query: hash_including({ "application_id" => application_id }))
     .to_return(
       status: 200,
@@ -15,8 +19,8 @@ def stub_ants_create(application_id)
 end
 
 def stub_ants_delete(application_id)
-  stub_request(:delete, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments/*})
-    .with(query: hash_including({ "application_id" => application_id }))
+  stub_request(:delete, "#{API_URL}/appointments")
+    .with(query: hash_including(application_id:))
     .to_return(
       status: 200,
       body: { rowcount: 1 }.to_json

--- a/spec/support/ants_stubs.rb
+++ b/spec/support/ants_stubs.rb
@@ -5,17 +5,14 @@ def stub_ants_status(application_id, status: "validated", appointments: [])
     .with(query: { application_ids: application_id })
     .to_return(
       status: 200,
-      body: { application_id => { status: status, appointments: appointments } }.to_json
+      body: { application_id => { status:, appointments: } }.to_json
     )
 end
 
 def stub_ants_create(application_id)
   stub_request(:post, "#{API_URL}/appointments")
-    .with(query: hash_including({ "application_id" => application_id }))
-    .to_return(
-      status: 200,
-      body: { success: true }.to_json
-    )
+    .with(query: hash_including(application_id:))
+    .to_return(status: 200, body: { success: true }.to_json)
 end
 
 def stub_ants_delete(application_id)

--- a/spec/support/ants_stubs.rb
+++ b/spec/support/ants_stubs.rb
@@ -18,8 +18,5 @@ end
 def stub_ants_delete(application_id)
   stub_request(:delete, "#{API_URL}/appointments")
     .with(query: hash_including(application_id:))
-    .to_return(
-      status: 200,
-      body: { rowcount: 1 }.to_json
-    )
+    .to_return(status: 200, body: { rowcount: 1 }.to_json)
 end


### PR DESCRIPTION
# Aide à la lecture de la PR

Cette PR réécrit commit par commit quasiment tout le fichier de spec du concern ANTS.
Je suppose qu’il est plus efficace de lire la nouvelle version du fichier et la comparer avec l’actuelle, mais c’est peut-être plus digeste de lire commit par commit.

ça peut aussi mériter éventuellement un échange à l’oral pour contextualiser

# Contexte

J’enquête sur des bugs de synchros ANTS. 
Dans ce cadre, je m’apprête à faire des changements dans le concern ANTS.
Avant d’introduire des changements fonctionnels, je propose d’améliorer ces specs pour éviter des PRs trop grosses et indigestes par la suite. 
C’est aussi l’occasion pour moi de mieux comprendre ce code de synchro. 

# Solution

J’ai largement réécrit les specs existants
J’ai gardé les contextes de cas testés existants.
J’ai gardé les expects existants et j’en ai rajouté des nouveaux.

Les descriptions de tests et commentaires sont réécrites en français.
Les specs sont complètement désimbriquées au niveau le plus haut : on ne décrit plus si c’est tel ou tel callback qui doit être déclenché. 
On s’assure uniquement que les bons appels API sont envoyés au bon moment.

L’amélioration de couverture la plus notable est que j’ai **rajouté des expects pour tous les stubs de request webmock**. 
Il y avait de nombreux stubs de requests qui étaient définis mais on ne s’assurait pas qu’ils avaient été appelés, les tests pouvaient donc ne pas avoir le comportement attendu de manière silencieuse.
J’ai choisi de définir des stubs complets qui comprennent les paramètres et retours attendus et ensuite de faire de simples `expect(stub).to have_been_requested` dans les tests.
On aurait aussi pu le faire à l’envers en définissant des stubs sans paramètres et de tester ces paramètres dans l’expect mais ça me semblait plus verbeux, moins lisible et moins évolutif.

J’ai dé-générisé les contextes de cette PR : il n’y a plus aucun `let` partagés, ils sont tous redéfinis dans chaque contexte.
C’est un choix très discutable mais je trouve que ça rend chaque test lisible indépendemment et ça évite d’avoir à faire des choses comme `before { rdv.save! }` sur les specs où on veut un rdv déjà en base alors que le `let` définit un rdv non-sauvegardé. 
Ça évite aussi de redéfinir des `let` qui se superposent quand on veut diverger du let de base.
C’est absolument anti-DRY et ça rajoute de nombreuses lignes mais je pense que c’est acceptable voire souhaitable dans les specs.

Similairement, j’ai dé-générisé les stubs de requests à l’API ANTS. 
On n’utilise plus les helpers comme `stub_ants_create` dans ces specs.
On stubbe chaque requête, ses paramètres et son retour attendus avec Webmock directement dans chaque contexte.
Cela m’a permis de rajouter de nombreux détails de tests importants ici : par exemple dans le test de changement de nom de lieu ça permet de vérifier qu’on créé un nouvel appointment avec le bon nom.
