### PR TITLE
Discard les SmsJob lorsque le RDV a été supprimé

### DIFF
--- a/app/jobs/rdv_upcoming_reminder_job.rb
+++ b/app/jobs/rdv_upcoming_reminder_job.rb
@@ -16,7 +16,7 @@ class RdvUpcomingReminderJob < ApplicationJob
   discard_on(TooLateError)
 
   discard_on(ActiveJob::DeserializationError) do |_job, error|
-    # Si le RDV a été supprimé avant l’éxecution du job (ou d’un retry)
+    # Si le RDV a été supprimé avant l’éxecution du job (ou d’un retry)
     # C’est un comportement attendu, on ne veut pas retry ni être notifié sur Sentry
     next if error.cause.is_a?(ActiveRecord::RecordNotFound)
 

--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -4,6 +4,16 @@ class SmsJob < ApplicationJob
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
 
+  discard_on(ActiveJob::DeserializationError) do |_job, error|
+    # Si le RDV a été supprimé avant l'exécution du job (ou d’un retry)
+    # C’est un comportement attendu, on ne veut pas retry ni être notifié sur Sentry
+    next if error.cause.is_a?(ActiveRecord::RecordNotFound)
+
+    # dans le cas encore jamais vu où la désérialisation échouerait pour d’autres raisons
+    # il ne sert à rien de retry non plus, mais on aimerait en être notifié
+    Sentry.capture_exception(error)
+  end
+
   def perform(sender_name:, phone_number:, content:, territory_id:, receipt_params:)
     territory = Territory.find(territory_id)
     provider = ENV["FORCE_SMS_PROVIDER"].presence || territory&.sms_provider || ENV["DEFAULT_SMS_PROVIDER"].presence || :debug_logger

--- a/spec/jobs/sms_job_spec.rb
+++ b/spec/jobs/sms_job_spec.rb
@@ -66,5 +66,13 @@ RSpec.describe SmsJob do
       expect(sentry_events.last.exception.values.last.type).to eq("RuntimeError")
       expect(sentry_events.last.exception.values.last.value).to eq("erreur inattendue (RuntimeError)")
     end
+
+    it "does not warn sentry if RDV was deleted" do
+      rdv = create(:rdv)
+      described_class.perform_later(receipt_params: { rdv: rdv })
+      rdv.destroy!
+      expect { perform_enqueued_jobs }.to change(enqueued_jobs, :size).by(-1)
+      expect(sentry_events).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Remplace #4664

# Contexte

Parfois les `SmsJob` s'exécutent mais le RDV passé dans les `receipt_params` a été supprimé, et on a donc une `ActiveJob::DeserializationError` : 
https://sentry.incubateur.net/organizations/betagouv/issues/93243

> ActiveJob::DeserializationError - Error while trying to deserialize arguments: Couldn't find Rdv with 'id'=111616

Dans ce cas de RDV supprimé, il ne sert à rien d'envoyer un SMS avec un lien vers une 404, donc on doit discard le job.

# Solution

Nous pouvons avoir dans SmsJob le même comportement que dans `RdvUpcomingReminderJob` (ajouté dans #4626) et que dans `ApplicationMailerDeliveryJob` (ajouté dans #2982).

On pourrait factoriser dans un concern, mais ça crée de l'indirection, vous avez un avis ? :shrug: 