### PR TITLE
Fix d'une autre flaky spec similaire à #4655

### DIFF
--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -135,7 +135,12 @@ RSpec.describe "User can search rdv on rdv mairie" do
       fill_in("user_last_name", with: "Mairie")
       fill_in("user_ants_pre_demande_number", with: "5544332211")
       click_button("Enregistrer")
-      alain = User.find_by(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211")
+
+      # Pour éviter une flaky spec (causée par l'animation CSS de la modale ?),
+      # on vérifie directement que le proche est bien enregistré dans la base.
+      wait_for { User.exists?(first_name: "Alain", last_name: "", ants_pre_demande_number: "5544332211") }.to be(true)
+
+      alain = User.find_by(first_name: "Alain", last_name: "", ants_pre_demande_number: "5544332211")
       expect(alain).to be_present
 
       check(user.full_name)

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -135,7 +135,6 @@ RSpec.describe "User can search rdv on rdv mairie" do
       fill_in("user_last_name", with: "Mairie")
       fill_in("user_ants_pre_demande_number", with: "5544332211")
       click_button("Enregistrer")
-      expect(page).to have_content("Alain MAIRIE")
       alain = User.find_by(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211")
       expect(alain).to be_present
 

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -138,9 +138,9 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
       # Pour éviter une flaky spec (causée par l'animation CSS de la modale ?),
       # on vérifie directement que le proche est bien enregistré dans la base.
-      wait_for { User.exists?(first_name: "Alain", last_name: "", ants_pre_demande_number: "5544332211") }.to be(true)
+      wait_for { User.exists?(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211") }.to be(true)
 
-      alain = User.find_by(first_name: "Alain", last_name: "", ants_pre_demande_number: "5544332211")
+      alain = User.find_by(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211")
       expect(alain).to be_present
 
       check(user.full_name)


### PR DESCRIPTION
Une autre flaky spec s'est révélée : https://github.com/betagouv/rdv-service-public/actions/runs/11122835232/job/30904954544

```
  1) User can search rdv on rdv mairie with no previous appointments can add a relative with their ants_pre_demande_number
     Failure/Error: expect(page).to have_content("Alain MAIRIE")

     Selenium::WebDriver::Error::WebDriverError:
       navigation detected by remote end: Inspected target navigated or closed
         (Session info: chrome=129.0.6668.58)
```

Elle ressemble beaucoup à ce qui a été corrigé dans #4655, ça plante au niveau du `have_content`, peut-être à cause d'une modale ? En tout cas le fix a semblé fonctionné, donc ici on fait pareil : on a va attendre que les données soient stockées en base. On peut virer le `have_content` puisque le reste de la spec vérifie bien que le proche est pris en compte.