### PR TITLE
feat(api): Add rdvi user show endpoint

### DIFF
--- a/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
+++ b/app/controllers/api/rdvinsertion/agent_auth_base_controller.rb
@@ -1,6 +1,9 @@
 class Api::Rdvinsertion::AgentAuthBaseController < Api::V1::AgentAuthBaseController
   private
 
+  # Cette authentification est faite via un secret partagé avec rdv-insertion qui se trouve
+  # dans la variable d'environnement `SHARED_SECRET_FOR_AGENTS_AUTH`.
+  # Ainsi nous sommes sûrs ici que les appels authentifiés sont émis par l'application rdv-insertion.
   def authenticate_agent
     authenticate_agent_with_shared_secret
   end

--- a/app/controllers/api/rdvinsertion/users_controller.rb
+++ b/app/controllers/api/rdvinsertion/users_controller.rb
@@ -1,0 +1,27 @@
+class Api::Rdvinsertion::UsersController < Api::Rdvinsertion::AgentAuthBaseController
+  before_action :set_user, only: [:show]
+
+  def show
+    render_record @user, agent_context: fake_agent_context
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+    authorize @user
+  end
+
+  # Pour pouvoir récupérer les ids de toutes les organisations rdv_insertion auxquelles l'usager appartient,
+  # on s'appuie sur l'option agent_context que prend en compte le `UserBlueprint`. Pour récupérer tous les organisation ids,
+  # il faut un contexte d'un agent appartenant à toutes les organisations rdvi de l'usager. Comme il n'y en a pas toujours,
+  # on simule un agent appartenant à toutes ces organisations. Cette endpoint ne pouvant être appelé que par l'appli rdv-insertion,
+  # on considère que c'est ok. Voir https://github.com/betagouv/rdv-service-public/pull/4495#issuecomment-2344176006
+  def fake_agent_context
+    AgentOrganisationContext.new(object_faking_agent_belonging_in_all_user_rdvi_orgs, nil)
+  end
+
+  def object_faking_agent_belonging_in_all_user_rdvi_orgs
+    OpenStruct.new(organisation_ids: @user.organisations.select(&:rdv_insertion?).map(&:id))
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -36,6 +36,7 @@ namespace :api do
     resource :referent_assignations, only: [] do
       post :create_many, on: :collection
     end
+    resources :users, only: %i[show]
     resources :motif_categories, only: %i[create]
     resources :motif_category_territories, only: %i[create]
   end

--- a/spec/requests/api/rdvinsertion/users_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/users_request_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "rdv-insertion API: users" do
+  let(:agent) { create(:agent, basic_role_in_organisations: [organisation_rdv_insertion]) }
+  let(:user) { create(:user, organisations: [organisation_rdv_insertion, other_organisation_rdv_insertion, organisation_rdv_solidarites]) }
+
+  let(:shared_secret) { "S3cr3T" }
+  let(:auth_headers) { api_auth_headers_with_shared_secret(agent, shared_secret) }
+
+  let(:organisation_rdv_insertion) { create(:organisation, verticale: "rdv_insertion") }
+  let(:other_organisation_rdv_insertion) { create(:organisation, verticale: "rdv_insertion") }
+  let(:organisation_rdv_solidarites) { create(:organisation, verticale: "rdv_solidarites") }
+
+  before do
+    allow(ENV).to receive(:fetch).with("SHARED_SECRET_FOR_AGENTS_AUTH").and_return(shared_secret)
+  end
+
+  it "returns the user along with the rdv_insertion related user_profiles" do
+    get api_rdvinsertion_user_path(user.id), headers: auth_headers
+    expect(response.status).to eq(200)
+    response_user_profiles = response.parsed_body.dig("user", "user_profiles")
+    response_organisation_ids = response_user_profiles.map { |user_profile| user_profile.dig("organisation", "id") }
+    expect(response_organisation_ids).to contain_exactly(organisation_rdv_insertion.id, other_organisation_rdv_insertion.id)
+  end
+end


### PR DESCRIPTION
Répond à https://github.com/gip-inclusion/rdv-insertion/issues/2244
Fait suite à #4495 

# Contexte

Je remets ce qui est écrit dans le ticket: 

Dans certains cas, lorsqu'un usager créé depuis rdvsp a un rdv placé sur une organisation présente dans rdv-insertion, pour une catégorie de motif gérée par l'organisation dans rdv-insertion, nous importons le rdv ainsi que l'usager sur rdv-insertion.
Cependant, lorsque l'on crée l'usager sur rdv-i, on le lie uniquement à l'organisation du rdv en question. 
Or cet usager peut potentiellement déjà appartenir à plusieurs organisations déjà présentes sur rdv-i. Ainsi il en résulte un problème de synchronisation: 
* on n'affiche pas toutes ses orgas sur rdvi
* on laisse la possibilité de l'ajouter sur ces orgas depuis rdv-i ce qui engendrera des erreurs

# Solution

## Première implémentation 

Après avoir essayé de rajouter les ids des organisations dans le blueprint des usagers dans #4495 pour les récupérer directement dans les webhooks, on a remarqué que ce n'était pas si simple:

* Si on ajoute directement les `organisation_ids` sans conditions, on renvoie des informations auquel l'agent n'a normalement pas accès
* Si on ajoute les `organisation_ids` seulement pour les webhooks rdv-insertion, cela crée du code spécifique à rdv-insertion dans une nouvelle partie du code
* Si on restreint les `organisation_ids` au territoire du `rdv`, on obtient pas tous les `organisation_ids` lorsque l'usager est présent sur plusieurs territoires (ce qui peut arriver)

## Nouvelle implémentation 

Il a donc été décidé avec @victormours (voir [cette discussion](https://github.com/betagouv/rdv-service-public/pull/4495#issuecomment-2344176006)) que faire un endpoint spécifique à rdv-insertion que rdv-insertion appellerait au moment de traiter le webhook lorsqu'un nouvel usager est importé serait plus adapté.

Cet endpoint rejoindrait la liste des endpoints namespacés `api/rdvinsertion/` accessible uniquement via l'appli rdv-insertion puisque l'authentification s'y fait via un secret partagé entre nos 2 applications.

Aussi, pour pouvoir récupérer tous les ids des organisations rdv-insertion de l'usager (i.e dont la `verticale` est `rdv_insertion`) , on a décidé de profiter de l'option `agent_context` que prend déjà le `UserBlueprint` et qui quand elle est passée permet de rendre les `user_profiles` dont l'agent a accès. 
Seulement comme il n'y a pas forcément d'agent qui appartienne à toutes ces organisations, Victor proposait de faire quelque chose d'un peu hacky qui consiste à mocker un agent appartenant à toutes ces organisations. Comme cet endpoint ne peut être appelé que via rdv-insertion, on considère que c'est ok d'avoir ce comportement spécifique. Ainsi le code spécifique à rdv-i sera bien isolé.

# Remarque non liée à la PR

J'ai remarqué en écrivant le test que les autres endpoints spécifiques à rdv-insertion apparaissaient dans la doc publique de l'API. 
![image](https://github.com/user-attachments/assets/1b6834de-423c-4ec4-8c21-97659d035f6a)

Je ne suis pas sûr qu'on veuille vraiment ça ? Je n'ai pas trouvé d'endroits où cette décision a été prise, je vois juste que les tests ont été écrits de cette façon dans [cette PR](https://github.com/betagouv/rdv-service-public/pull/3899) (validée par mes soins) mais je ne pense pas qu'on ait eu de discussions préalables sur ce sujet.
Si ce n'est pas quelque chose que l'on veut on pourra se charger de réécrire ces tests dans une autre PR.
