### PR TITLE
[WIP] refactor des stubs ANTS dans les specs

### DIFF
--- a/spec/support/ants_stubs.rb
+++ b/spec/support/ants_stubs.rb
@@ -1,24 +1,22 @@
+API_URL = "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api".freeze
+
 def stub_ants_status(application_id, status: "validated", appointments: [])
-  stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=#{application_id}").to_return(
-    status: 200,
-    body: { application_id => { status: status, appointments: appointments } }.to_json
-  )
+  stub_request(:get, "#{API_URL}/status")
+    .with(query: { application_ids: application_id })
+    .to_return(
+      status: 200,
+      body: { application_id => { status:, appointments: } }.to_json
+    )
 end
 
 def stub_ants_create(application_id)
-  stub_request(:post, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments/*})
-    .with(query: hash_including({ "application_id" => application_id }))
-    .to_return(
-      status: 200,
-      body: { success: true }.to_json
-    )
+  stub_request(:post, "#{API_URL}/appointments")
+    .with(query: hash_including(application_id:))
+    .to_return(status: 200, body: { success: true }.to_json)
 end
 
 def stub_ants_delete(application_id)
-  stub_request(:delete, %r{https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/appointments/*})
-    .with(query: hash_including({ "application_id" => application_id }))
-    .to_return(
-      status: 200,
-      body: { rowcount: 1 }.to_json
-    )
+  stub_request(:delete, "#{API_URL}/appointments")
+    .with(query: hash_including(application_id:))
+    .to_return(status: 200, body: { rowcount: 1 }.to_json)
 end


### PR DESCRIPTION
# Contexte

En refactorant les specs du concern ANTS j’ai un peu refacto les helpers de stubs de requêtes ANTS.
C’est finalement découplé de l’autre PR #4671 puisque je n’utilise plus ces helpers dans le test du concern.
J’ai donc ouvert cette autre PR pour isoler ces petits changements

# Solution

TODO : décrire les changements