### PR TITLE
désactivation du cop RSpec/ExampleLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,10 +140,7 @@ RSpec/ContextWording:
   Enabled: False
 
 RSpec/ExampleLength:
-  Max: 30
-  Exclude:
-    - 'spec/features/**/*'
-    - 'spec/requests/api/**/*'
+  Enabled: false
 
 RSpec/LetSetup:
   Enabled: false

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe ParticipationExporter, type: :service do
   describe "#xls_string_from_rdvs_rows" do
-    # rubocop:disable RSpec/ExampleLength
     it "return export with header" do
       rdv = create(
         :rdv,
@@ -70,7 +69,6 @@ RSpec.describe ParticipationExporter, type: :service do
         "agent@mail.com"
       )
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 
   describe "#row_array_from rdv" do

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe RdvExporter, type: :service do
   describe "#xls_string_from_rdvs_rows" do
-    # rubocop:disable RSpec/ExampleLength
     it "return export with header" do
       rdv = create(:rdv, created_at: Time.zone.parse("2023-01-01"), agents: [create(:agent, email: "agent@mail.com")])
       rdv_row = described_class.row_array_from(rdv)
@@ -41,7 +40,6 @@ RSpec.describe RdvExporter, type: :service do
       expect(first_data_row.first).to eq(2023)
       expect(first_data_row.last).to eq("agent@mail.com")
     end
-    # rubocop:enable RSpec/ExampleLength
   end
 
   describe "#row_array_from rdv" do


### PR DESCRIPTION
# Contexte

Dans le cadre de #4676 j’ai écrit des specs qui ne respectent pas la longueur maximale imposée par ce cop.
J’ai isolé les changements sur la config rubocop dans cette PR.

# Solution

Je propose de désactiver ce cop entièrement.
Il est déjà désactivé sur des types entiers de specs (features et requests/api).
Il est aussi désactivé manuellement dans deux fichiers de specs.

Je pense qu’en règle générale les cops de respect de longueur ne sont pas pertinents, ils n’indiquent pas de manière claire d’améliorer le code.
Découper artificiellement en plusieurs méthodes ou génériser le code n’aide pas forcément la lecture, en particulier les codes.