### PR TITLE
Correctif pour la modification des usagers invités lors du récap de rdv

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -29,18 +29,11 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   end
 
   def rdv_invitation_token
-    @user.rdv_invitation_token_updated_at = Time.zone.now
-    assign_rdv_invitation_token if @user.rdv_invitation_token.nil?
+    @user.set_rdv_invitation_token!
     render json: { invitation_token: @user.rdv_invitation_token }
   end
 
   private
-
-  def assign_rdv_invitation_token
-    @user.assign_rdv_invitation_token
-    @user.invited_through = "external"
-    @user.save!
-  end
 
   def set_organisation
     @organisation = params[:organisation_id].present? ? Organisation.find(params[:organisation_id]) : nil

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -38,7 +38,7 @@ module TokenInvitable
     return if current_user.present? # no need to sign in if the user is already connected
 
     user = invitation.user
-    user.mark_as_signed_in_with_invitation_token!(rdv: invitation.rdv)
+    user.signed_in_with_invitation_token!(rdv: invitation.rdv)
     sign_in(user, store: false)
   end
 

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -38,7 +38,7 @@ module TokenInvitable
     return if current_user.present? # no need to sign in if the user is already connected
 
     user = invitation.user
-    user.only_invited!(rdv: invitation.rdv)
+    user.mark_as_signed_in_with_invitation_token!(rdv: invitation.rdv)
     sign_in(user, store: false)
   end
 

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -32,11 +32,11 @@ class UserAuthController < ApplicationController
   end
 
   def authenticated_user_root_path
-    current_user.only_invited? ? root_path : users_rdvs_path
+    current_user.signed_in_with_invitation_token? ? root_path : users_rdvs_path
   end
 
   def should_verify_user_name_initials?
-    return false unless current_user.only_invited?
+    return false unless current_user.signed_in_with_invitation_token?
     return false if cookies.encrypted[user_name_initials_cookie_name] == true
 
     true

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -47,13 +47,13 @@ class Users::RdvWizardStepsController < UserAuthController
 
   def next_step_index
     idx = current_step_index + 2 # steps start at 1 + increment
-    idx += 1 if current_step_index.zero? && current_user.only_invited? # we skip the step 2 in the context of an invitation
+    idx += 1 if current_step_index.zero? && current_user.signed_in_with_invitation_token? # we skip the step 2 in the context of an invitation
     idx
   end
 
   def set_step_titles
     @step_titles = (0..3).map do |idx|
-      I18n.t("users.rdv_wizard_steps.step#{idx}.title") unless idx == 2 && current_user.only_invited?
+      I18n.t("users.rdv_wizard_steps.step#{idx}.title") unless idx == 2 && current_user.signed_in_with_invitation_token?
     end.compact
   end
 

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -114,7 +114,7 @@ class Users::RdvsController < UserAuthController
   end
 
   def set_can_see_rdv_motif
-    @can_see_rdv_motif = !current_user.only_invited?
+    @can_see_rdv_motif = !current_user.signed_in_with_invitation_token?
   end
 
   def redirect_if_creneau_not_available

--- a/app/form_models/agent_prescripteur_rdv_wizard.rb
+++ b/app/form_models/agent_prescripteur_rdv_wizard.rb
@@ -12,10 +12,6 @@ class AgentPrescripteurRdvWizard
     @motif ||= rdv.motif
   end
 
-  def invitation?
-    false
-  end
-
   def params_to_selections
     query_params
   end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -26,10 +26,6 @@ module UserRdvWizard
       end
     end
 
-    def invitation?
-      @user&.signed_in_with_invitation_token?
-    end
-
     def params_to_selections
       if @rdv.present?
         return @attributes.merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -27,7 +27,7 @@ module UserRdvWizard
     end
 
     def invitation?
-      @attributes[:invitation_token].present?
+      @user&.signed_in_with_invitation_token?
     end
 
     def params_to_selections

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,13 +200,13 @@ class User < ApplicationRecord
     nil
   end
 
-  def only_invited!(rdv: nil)
-    @only_invited = true
+  def mark_as_signed_in_with_invitation_token!(rdv: nil)
+    @signed_in_with_invitation_token = true
     @invitation_rdv = rdv
   end
 
-  def only_invited?
-    @only_invited == true
+  def signed_in_with_invitation_token?
+    @signed_in_with_invitation_token
   end
 
   def invited_for_rdv?(rdv)
@@ -249,13 +249,13 @@ class User < ApplicationRecord
   end
 
   def confirmation_required?
-    return false if only_invited?
+    return false if signed_in_with_invitation_token?
 
     super
   end
 
   def reconfirmation_required?
-    return false if only_invited?
+    return false if signed_in_with_invitation_token?
 
     super
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -223,8 +223,19 @@ class User < ApplicationRecord
     end
   end
 
-  def assign_rdv_invitation_token
-    self.rdv_invitation_token = generate_rdv_invitation_token
+  def set_rdv_invitation_token!
+    self.rdv_invitation_token_updated_at = Time.zone.now
+
+    if rdv_invitation_token.nil?
+      assign_attributes(
+        rdv_invitation_token: generate_rdv_invitation_token,
+        invited_through: "external"
+      )
+    end
+
+    save!
+
+    rdv_invitation_token
   end
 
   def ants_pre_demande_number=(value)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,7 +200,7 @@ class User < ApplicationRecord
     nil
   end
 
-  def mark_as_signed_in_with_invitation_token!(rdv: nil)
+  def signed_in_with_invitation_token!(rdv: nil)
     @signed_in_with_invitation_token = true
     @invitation_rdv = rdv
   end

--- a/app/policies/user/rdv_policy.rb
+++ b/app/policies/user/rdv_policy.rb
@@ -10,7 +10,7 @@ class User::RdvPolicy < ApplicationPolicy
   # rubocop:enable Style/ArrayIntersect
 
   def index?
-    !current_user.only_invited?
+    !current_user.signed_in_with_invitation_token?
   end
 
   def new?
@@ -29,7 +29,7 @@ class User::RdvPolicy < ApplicationPolicy
   def show?
     return true if record.collectif? && record.bookable_by_everyone_or_bookable_by_invited_users? && rdv_belongs_to_user_or_relatives?
 
-    rdv_belongs_to_user_or_relatives? && (!current_user.only_invited? || current_user.invited_for_rdv?(record))
+    rdv_belongs_to_user_or_relatives? && (!current_user.signed_in_with_invitation_token? || current_user.invited_for_rdv?(record))
   end
 
   def cancel?
@@ -41,7 +41,7 @@ class User::RdvPolicy < ApplicationPolicy
   end
 
   def can_change_participants?
-    !current_user.only_invited? && current_user.participation_for(record).not_cancelled? && !record.in_the_past?
+    !current_user.signed_in_with_invitation_token? && current_user.participation_for(record).not_cancelled? && !record.in_the_past?
   end
 
   alias creneaux? edit?

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -15,7 +15,7 @@ html lang="fr"
     = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
     = dsfr_header logo_text: "République<br>Française".html_safe do |header|
       - header.with_operator_image title: "Accueil - RDV #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: "RDV #{current_domain.name}"
-      - if current_user.present? && !current_user.only_invited?
+      - if current_user.present? && !current_user.signed_in_with_invitation_token?
         ruby:
           header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, classes: "fr-icon-calendar-fill"
           header.with_tool_link title: "Vos informations", path: users_informations_path

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -5,9 +5,8 @@ ul.list-group.list-group-flush
         i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
         | Motif :&nbsp;
         = rdv_wizard.motif.name
-      - unless rdv_wizard.invitation?
-        .col-auto
-          = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
+      .col-auto
+        = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
 
   - case rdv_wizard.motif.location_type
   - when Motif.location_types[:phone]
@@ -29,9 +28,8 @@ ul.list-group.list-group-flush
           i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
           | Lieu :&nbsp;
           = rdv_wizard.creneau.lieu.full_name
-        - unless rdv_wizard.invitation?
-          .col-auto
-            = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
+        .col-auto
+          = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
   - else
     = raise "unrecognized location_type: #{rdv_wizard.motif.location_type.inspect}"
 
@@ -41,22 +39,18 @@ ul.list-group.list-group-flush
         i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
         | Date du rendez-vous :&nbsp;
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
-      - unless rdv_wizard.invitation?
-        .col-auto
-          = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
+      .col-auto
+        = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
   - if rdv_wizard.is_a?(UserRdvWizard::Step3)
     li.list-group-item
       .row
         .col
           i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
           | Usager :&nbsp;
-          - if !rdv_wizard.invitation?
-            = users_to_sentence(rdv_wizard.users)
-          - else
-            = current_user.full_name
-        - unless rdv_wizard.invitation?
-          .col-auto
-            = link_to "modifier", new_users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query)
+          = users_to_sentence(rdv_wizard.users)
+        .col-auto
+          - step_number = current_user&.signed_in_with_invitation_token? ? 1 : 2 # Les usagers connectés par invitation ont une étape de moins
+          = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)
     li.list-group-item
       .row
         .col

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -49,8 +49,8 @@ ul.list-group.list-group-flush
           | Usager :&nbsp;
           = users_to_sentence(rdv_wizard.users)
         .col-auto
-          - step_number = current_user&.signed_in_with_invitation_token? ? 1 : 2 # Les usagers connectés par invitation ont une étape de moins
-          = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)
+          - step = current_user&.signed_in_with_invitation_token? ? 1 : 2 # Les usagers connectés par invitation ont une étape de moins
+          = link_to "modifier", new_users_rdv_wizard_step_path(step: , **@rdv_wizard.to_query)
     li.list-group-item
       .row
         .col

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -10,7 +10,7 @@ ruby:
     .col-md-6= f.input :first_name, placeholder: "Prénom", disabled: user.logged_once_with_franceconnect?
     .col-md-6= f.input :last_name, placeholder: "Nom"
   .form-row
-    - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
+    - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
       .col-md-6= f.input :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
       .col-md-6= f.input :birth_date, as: :string, input_html: { type: "date" }, disabled: user.logged_once_with_franceconnect?
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
@@ -21,14 +21,14 @@ ruby:
         .fa.fa-info
       div= I18n.t("users.franceconnect_frozen_fields")
   = f.input :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
-  - if current_user.only_invited?
+  - if current_user.signed_in_with_invitation_token?
     = f.input :email, disabled: user.email.present? && !user.email_changed?, required: true
   - if user.phone_number.present? && !user.phone_number_mobile?
     .alert.alert-warning Vous ne recevrez pas de SMS avec ce numéro non-mobile
   div.mb-2 Préférences de notifications
   div= f.input :notify_by_email
   div= f.input :notify_by_sms
-  - unless current_user.only_invited? || current_domain == Domain::RDV_MAIRIE
+  - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
     = f.input :address, input_html: {value: address_value, class: "places-js-container" }, required: rdv_wizard&.motif&.home?
 

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -20,9 +20,9 @@ ruby:
       .mr-3
         .fa.fa-info
       div= I18n.t("users.franceconnect_frozen_fields")
-  = f.input :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
   - if current_user.signed_in_with_invitation_token?
     = f.input :email, disabled: user.email.present? && !user.email_changed?, required: true
+  = f.input :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
   - if user.phone_number.present? && !user.phone_number_mobile?
     .alert.alert-warning Vous ne recevrez pas de SMS avec ce numéro non-mobile
   div.mb-2 Préférences de notifications

--- a/db/seeds/rdv_insertion.rb
+++ b/db/seeds/rdv_insertion.rb
@@ -262,7 +262,7 @@ user1 = User.create!(
   birth_date: 30.years.ago,
   organisations: [org_drome1, org_drome2]
 )
-user1.assign_rdv_invitation_token
+user1.set_rdv_invitation_token!
 user1.save!
 
 user2 = User.create!(
@@ -275,7 +275,7 @@ user2 = User.create!(
   birth_date: 30.years.ago,
   organisations: [org_yonne]
 )
-user2.assign_rdv_invitation_token
+user2.set_rdv_invitation_token!
 user2.save!
 
 # On reprend ci dessous les paramêtres que Rdvi utilise pour générer l'url d'invitation.

--- a/docs/invitations.md
+++ b/docs/invitations.md
@@ -2,34 +2,4 @@
 
 Le code qui génére le lien d'invitation dans le service de RDVI `Invitations::ComputeLink` dédié est présent dans ce fichier https://github.com/betagouv/rdv-insertion/blob/9c03e5a6c720a88826e84ca854fd5ccb6135569a/app/services/invitations/compute_link.rb#L2
 
-Pour tester **depuis RDVSP** dans une console rails par exemple vous pouvez utiliser le code suivant.
-`user` doit avoir un `rdv_invitation_token` assigné via la méthode `assign_rdv_invitation_token` et être sauvegardé.
-Il doit faire parti de l'organisation.
-`organisation` doit avoir un `motif` avec une catégorie de motif, la valeur de `bookable_by` doit être `:agents_and_prescripteurs_and_invited_users` et des plages d'ouvertures doivent être créées pour le motif.
-
-```ruby
-city_code = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:city_code]
-street_ban_id = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:street_ban_id]
-longitude, latitude = GeoCoding.new.find_geo_coordinates(user.address)
-invitation_token = user.rdv_invitation_token
-organisation_id = organisation.id
-motif_category_short_name = motif.motif_category.short_name
-address = user.address
-departement = organisation.territory.departement_number
-
-attributes = {
-  longitude: longitude,
-  latitude: latitude,
-  city_code: city_code,
-  street_ban_id: street_ban_id,
-  departement: departement,
-  address: address,
-  invitation_token: invitation_token,
-  organisation_ids: [organisation_id],
-  motif_category_short_name: motif_category_short_name,
-  # Optionnel : lieu spécifique et referents
-  # lieu_id: 1
-  # referent_ids: [1, 2]
-}
-invitation_link = "#{ENV['HOST']}/prendre_rdv?#{attributes.to_query}"
-```
+Pour tester en local **depuis RDVSP** dans une console rails par exemple vous pouvez utiliser le script dans `scripts/invite_user.rb`.

--- a/scripts/invite_user.rb
+++ b/scripts/invite_user.rb
@@ -6,15 +6,12 @@
 # puis charger l'url renvoyée en local
 class InviteUser
   def self.run_and_get_invitation_link!(user, organisation)
-    user.assign_rdv_invitation_token
-    user.save!
-
+    invitation_token = user.set_rdv_invitation_token!
     motif = organisation.motifs.where.not(motif_category_id: nil).last
 
     city_code = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:city_code]
     street_ban_id = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:street_ban_id]
     longitude, latitude = GeoCoding.new.find_geo_coordinates(user.address)
-    invitation_token = user.rdv_invitation_token
     organisation_id = organisation.id
     motif_category_short_name = motif.motif_category.short_name
     address = user.address

--- a/scripts/invite_user.rb
+++ b/scripts/invite_user.rb
@@ -1,0 +1,40 @@
+# Un script pour tester les invitations en local depuis la console
+#
+# Typiquement, après avoir chargé les seeds, vous pouvez faire
+# load "scripts/invite_user.rb"
+# InviteUser.run_and_get_invitation_link!(User.find_by(email: "jean.rsavalence@testinvitation.fr"), Organisation.find_by(name: "Plateforme mutualisée d'orientation"))
+# puis charger l'url renvoyée en local
+class InviteUser
+  def self.run_and_get_invitation_link!(user, organisation)
+    user.assign_rdv_invitation_token
+    user.save!
+
+    motif = organisation.motifs.where.not(motif_category_id: nil).last
+
+    city_code = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:city_code]
+    street_ban_id = GeoCoding.new.get_geolocation_results(user.address, organisation.territory.departement_number)[:street_ban_id]
+    longitude, latitude = GeoCoding.new.find_geo_coordinates(user.address)
+    invitation_token = user.rdv_invitation_token
+    organisation_id = organisation.id
+    motif_category_short_name = motif.motif_category.short_name
+    address = user.address
+    departement = organisation.territory.departement_number
+
+    attributes = {
+      longitude: longitude,
+      latitude: latitude,
+      city_code: city_code,
+      street_ban_id: street_ban_id,
+      departement: departement,
+      address: address,
+      invitation_token: invitation_token,
+      organisation_ids: [organisation_id],
+      motif_category_short_name: motif_category_short_name,
+      # Optionnel : lieu spécifique et referents
+      # lieu_id: 1
+      # referent_ids: [1, 2]
+    }
+
+    "#{ENV['HOST']}/prendre_rdv?#{attributes.to_query}"
+  end
+end

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -124,16 +124,11 @@ RSpec.describe TokenInvitable, type: :controller do
       allow(invitation).to receive(:rdv)
     end
 
-    it "signs in the user" do
+    it "connecte l'usager et indique le mode de connexion utilisé" do
       subject
       expect(response).to be_successful
       expect(assigns(:current_user)).to eq(user)
-    end
-
-    it "marks the user as only_invited" do
-      subject
-      expect(response).to be_successful
-      expect(assigns(:current_user).only_invited?).to be(true)
+      expect(assigns(:current_user).signed_in_with_invitation_token?).to be(true)
     end
 
     context "when the token is invalid" do
@@ -170,7 +165,7 @@ RSpec.describe TokenInvitable, type: :controller do
           subject
           expect(response).to be_successful
           expect(assigns(:current_user)).to eq(user)
-          expect(assigns(:current_user).only_invited?).to be(false)
+          expect(assigns(:current_user)).not_to(be_signed_in_with_invitation_token)
         end
       end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -6,11 +6,7 @@ RSpec.describe SearchController, type: :controller do
   let!(:departement_number) { "75" }
   let!(:city_code) { "75007" }
   let!(:address) { "20 avenue de ségur" }
-  let!(:invitation_token) do
-    user.assign_rdv_invitation_token
-    user.save!
-    user.rdv_invitation_token
-  end
+  let!(:invitation_token) { user.set_rdv_invitation_token! }
 
   let!(:user) { create(:user, organisations: [organisation]) }
 

--- a/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
+++ b/spec/controllers/users/rdv_wizard_steps_controller_spec.rb
@@ -36,11 +36,7 @@ RSpec.describe Users::RdvWizardStepsController, type: :controller do
       end
 
       context "with invitation token" do
-        let!(:invitation_token) do
-          user.assign_rdv_invitation_token
-          user.save!
-          user.rdv_invitation_token
-        end
+        let!(:invitation_token) { user.set_rdv_invitation_token! }
 
         before { request.session[:invitation] = { invitation_token:, expires_at: 10.hours.from_now } }
 

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -297,11 +297,7 @@ RSpec.describe Users::RdvsController, type: :controller do
       end
 
       context "with a valid invitation token" do
-        let!(:invitation_token) do
-          user.assign_rdv_invitation_token
-          user.save!
-          user.rdv_invitation_token
-        end
+        let!(:invitation_token) { user.set_rdv_invitation_token! }
 
         before do
           request.session[:invitation] = { invitation_token:, expires_at: 1.hour.from_now }
@@ -366,11 +362,7 @@ RSpec.describe Users::RdvsController, type: :controller do
       end
 
       context "with a valid invitation token" do
-        let!(:invitation_token) do
-          user.assign_rdv_invitation_token
-          user.save!
-          user.rdv_invitation_token
-        end
+        let!(:invitation_token) { user.set_rdv_invitation_token! }
 
         before do
           request.session[:invitation] = { invitation_token: invitation_token, expires_at: 1.hour.from_now }

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -149,11 +149,7 @@ RSpec.describe "public pages", js: true do
 
       context "when invited" do
         let!(:user) { create(:user) }
-        let!(:invitation_token) do
-          user.assign_rdv_invitation_token
-          user.save!
-          user.rdv_invitation_token
-        end
+        let!(:invitation_token) { user.set_rdv_invitation_token! }
 
         it "root path with a city_code and a service page is accessible" do
           path = prendre_rdv_path(

--- a/spec/features/users/online_booking/creneaux_selection_spec.rb
+++ b/spec/features/users/online_booking/creneaux_selection_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "User can select a creneau" do
 
     context "when the user is invited" do
       let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", motifs: [motif]) }
-      let!(:rdv_invitation_token) { SecureRandom.uuid }
-      let!(:user) { create(:user, rdv_invitation_token:) }
+      let!(:rdv_invitation_token) { user.set_rdv_invitation_token! }
+      let!(:user) { create(:user) }
 
       it "shows that no creneau is available" do
         visit prendre_rdv_path(motif_category_short_name: "rsa_orientation", invitation_token: rdv_invitation_token, lieu_id: lieu.id, departement: "92", organisation_ids: [organisation.id])

--- a/spec/features/users/online_booking/with_invitation_spec.rb
+++ b/spec/features/users/online_booking/with_invitation_spec.rb
@@ -16,11 +16,7 @@ RSpec.describe "User can be invited" do
                   birth_date: Date.new(1988, 12, 20),
                   organisations: [organisation])
   end
-  let!(:invitation_token) do
-    user.assign_rdv_invitation_token
-    user.save!
-    user.rdv_invitation_token
-  end
+  let!(:invitation_token) { user.set_rdv_invitation_token! }
   let!(:agent) { create(:agent) }
   let!(:departement_number) { "26" }
   let!(:city_code) { "26000" }

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -20,11 +20,7 @@ RSpec.describe "Adding a user to a collective RDV" do
   let!(:other_user1) { create(:user) }
   let!(:other_user2) { create(:user) }
   let!(:rdv2) { create(:rdv, :without_users, motif: motif2, agents: [agent], organisation: organisation, lieu: lieu2) }
-  let!(:invitation_token) do
-    invited_user.assign_rdv_invitation_token
-    invited_user.save!
-    invited_user.rdv_invitation_token
-  end
+  let!(:invitation_token) { user.set_rdv_invitation_token!  }
 
   let(:params) do
     {

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Adding a user to a collective RDV" do
   let!(:other_user1) { create(:user) }
   let!(:other_user2) { create(:user) }
   let!(:rdv2) { create(:rdv, :without_users, motif: motif2, agents: [agent], organisation: organisation, lieu: lieu2) }
-  let!(:invitation_token) { user.set_rdv_invitation_token!  }
+  let!(:invitation_token) { invited_user.set_rdv_invitation_token!  }
 
   let(:params) do
     {

--- a/spec/policies/user/participation_policy_spec.rb
+++ b/spec/policies/user/participation_policy_spec.rb
@@ -65,9 +65,7 @@ RSpec.describe User::ParticipationPolicy, type: :policy do
   context "User is invited to participate" do
     let!(:participation) { create(:participation, user: user, rdv: rdv) }
 
-    before do
-      allow(user).to receive(:only_invited?).and_return(true)
-    end
+    before { user.mark_as_signed_in_with_invitation_token! }
 
     it_behaves_like "permit actions", :participation, :create?, :cancel?
     it_behaves_like "included in scope"
@@ -77,9 +75,7 @@ RSpec.describe User::ParticipationPolicy, type: :policy do
     let!(:rdv) { create(:rdv, :collectif, :without_users, organisation: organisation, agents: [agent], starts_at: Time.zone.yesterday) }
     let!(:participation) { create(:participation, user: user2, rdv: rdv) }
 
-    before do
-      participation.update(status: "revoked")
-    end
+    before { participation.update(status: "revoked") }
 
     it_behaves_like "not permit actions", :participation, :create?, :cancel?
     it_behaves_like "not included in scope"

--- a/spec/policies/user/participation_policy_spec.rb
+++ b/spec/policies/user/participation_policy_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe User::ParticipationPolicy, type: :policy do
   context "User is invited to participate" do
     let!(:participation) { create(:participation, user: user, rdv: rdv) }
 
-    before { user.mark_as_signed_in_with_invitation_token! }
+    before { user.signed_in_with_invitation_token! }
 
     it_behaves_like "permit actions", :participation, :create?, :cancel?
     it_behaves_like "included in scope"

--- a/spec/policies/user/rdv_policy_spec.rb
+++ b/spec/policies/user/rdv_policy_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe User::RdvPolicy, type: :policy do
   end
 
   context "User signed in with an invitation token" do
-    before { user.mark_as_signed_in_with_invitation_token! }
+    before { user.signed_in_with_invitation_token! }
 
     it_behaves_like "permit actions", :rdv, :new?, :create?
     it_behaves_like "not permit actions", :rdv, :index?, :edit?, :update?, :creneaux?, :cancel?, :show?
@@ -81,7 +81,7 @@ RSpec.describe User::RdvPolicy, type: :policy do
     context "User is invited, rdv has no users" do
       let(:rdv) { create(:rdv, :collectif, :without_users, organisation: organisation, agents: [agent]) }
 
-      before { user.mark_as_signed_in_with_invitation_token! }
+      before { user.signed_in_with_invitation_token! }
 
       it_behaves_like "permit actions", :rdv, :new?
       it_behaves_like "not permit actions", :rdv, :index?, :edit?, :update?, :creneaux?, :cancel?, :show?, :create?

--- a/spec/policies/user/rdv_policy_spec.rb
+++ b/spec/policies/user/rdv_policy_spec.rb
@@ -45,10 +45,8 @@ RSpec.describe User::RdvPolicy, type: :policy do
     it_behaves_like "not included in scope"
   end
 
-  context "User is invited" do
-    before do
-      allow(user).to receive(:only_invited?).and_return(true)
-    end
+  context "User signed in with an invitation token" do
+    before { user.mark_as_signed_in_with_invitation_token! }
 
     it_behaves_like "permit actions", :rdv, :new?, :create?
     it_behaves_like "not permit actions", :rdv, :index?, :edit?, :update?, :creneaux?, :cancel?, :show?
@@ -83,9 +81,7 @@ RSpec.describe User::RdvPolicy, type: :policy do
     context "User is invited, rdv has no users" do
       let(:rdv) { create(:rdv, :collectif, :without_users, organisation: organisation, agents: [agent]) }
 
-      before do
-        allow(user).to receive(:only_invited?).and_return(true)
-      end
+      before { user.mark_as_signed_in_with_invitation_token! }
 
       it_behaves_like "permit actions", :rdv, :new?
       it_behaves_like "not permit actions", :rdv, :index?, :edit?, :update?, :creneaux?, :cancel?, :show?, :create?


### PR DESCRIPTION
# Contexte
<img width="853" alt="Screenshot 2024-10-02 at 19 05 02" src="https://github.com/user-attachments/assets/991f5b86-11e1-401a-9efb-7de88c225dcf">

Cette PR corrige https://sentry.incubateur.net/organizations/betagouv/issues/19409/?environment=production&query=is%3Aunresolved+is%3Aunlinked&referrer=issue-stream&statsPeriod=30d&stream_index=0

C'est dans le contexte de l'effort de diminution du bruit : cette erreur a lieu depuis 2 ans à un faible volume.

Le bug se produisait pour les usagers qui prenaient rendez-vous par invitation : au moment de l'écran de confirmation du rendez-vous, le lien pour modifier l'usager menait vers cette erreur 500.

# Solution

Après discussion avec Amine, j'ai eu confirmation que l'implémentation de la méthode `UserRdvWizard#invitation?` était obsolète depuis que les invitations permettent de se connecter (voir #3629)

Le premier commit est purement cosmétique : c'est un renommage de la méthode `only_invited?` qui vise à la rendre plus facile à comprendre.

Le deuxième commit est une première correction du bug : on continue de ne pas afficher le lien vers le formulaire d'usager si  l'usager est invité.

Le troisième commit est une petite correction d'interface : le champs email avait été mis entre le numéro de téléphone et le message d'erreur sur le numéro de téléphone.

Le quatrième commit est en fait le bon correctif : avec le fonctionnement actuel des invitations, il n'est jamais nécessaire de cacher les liens de navigation (ce qui serait une UX horrible parce que ça empêcherait de corriger des erreurs). Le bon comportement est celui qui est actuellement en prod, c'est à dire toujours afficher ces liens. Le vrai correctif est de changer l'étape vers laquelle on est redirigé si on clique sur ce lien de modification
