### PR TITLE
Correction d'une spec a11y sur la liste des plages

### DIFF
--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "agents page", js: true do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    create_list(:plage_ouverture, 3, agent: agent, organisation: organisation)
+    create_list(:plage_ouverture, 3, :once_a_week, agent: agent, organisation: organisation)
     login_as(agent, scope: :agent)
 
     path = admin_organisation_agent_plage_ouvertures_path(organisation, agent)

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "agents page", js: true do
     territory = create(:territory, departement_number: "75")
     organisation = create(:organisation, territory: territory)
     agent = create(:agent, email: "totoagent@example.com", basic_role_in_organisations: [organisation])
-    create_list(:plage_ouverture, 3, agent: agent)
+    create_list(:plage_ouverture, 3, agent: agent, organisation: organisation)
     login_as(agent, scope: :agent)
 
     path = admin_organisation_agent_plage_ouvertures_path(organisation, agent)


### PR DESCRIPTION
# Contexte

En travaillant sur #4684, j'ai déclenché l'échec d'une spec qui vérifie l'accessibilité : `features/accessibility/agents_pages_spec.rb:34`.

Jusqu'à maintenant, cette spec créait des plages, mais dans une autre orga que l'orga courante. La spec charge ensuite la page de liste des plages, et vérifie qu'elle est accessible. La page n'affiche aucune plage (car elles ne sont pas dans l'orga courante). Je pense que l'on peut supposer que si la spec crée des plages, c'est pour qu'elles soient affichées.

Dans cette PR, on fait en sorte que cette spec affiche les plages.

# Solution


Le test d'accessibilité échoue parce que le tag "Exceptionnelle" affiché à côté du nom de la plage n'a pas des couleurs assez contrastées : 

![image](https://github.com/user-attachments/assets/5de7d12e-74c0-4327-bf98-3a71f2423741)

Une solution consisterait à modifier cette couleur, la couleur `cyan`, utilisée pour l'état sémantique `info` : 

![image](https://github.com/user-attachments/assets/7e0f519a-56c7-4176-b581-6c83befe524d)


Ceci étant dit, ça semble risqué de modifier ainsi une couleur utilisée à travers toute l'appli. J'ai donc préféré modifier le teste pour qu'il crée des plages récurrentes, et que le tag "Exceptionnelle" ne s'affiche plus. 

Ça ne corrige pas les couleurs du tag, mais ça permet d'avoir une spec qui teste malgré tout plus d'éléments (car la page affiche des plages désormais).

Je suis conscient que ce choix de stratégie va à l'encontre de nos priorités sur l'accessibilité, mais je ne sais pas comment corriger ça de façon simple, donc je corrige au moins la spec pour qu'elle soit cohérente.