### PR TITLE
Retirer une config ajoutée pour la stack OVH (health check HTTP)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,8 +47,6 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
-  # Voir health_check_spec.rb pour les infos de contexte
-  config.ssl_options = { redirect: { exclude: proc { |env| env&.path&.start_with?("/health_check") } } }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -1,14 +1,4 @@
 RSpec.describe "health checks" do
-  #
-  # Cet endpoint a été ajouté lors de la migration de Scalingo vers OVH.
-  # En effet, la nouvelle stack a besoin d'un endpoint de health check pour
-  # savoir si l'appli tourne, et la redémarrer si nécessaire.
-  #
-  # La particularité de cette route est qu'elle doit être accessible en
-  # production en HTTP plutôt qu'en HTTP, car l'agent qui fait le health
-  # check est interne au réseau Kubernetes (le HTTPS en géré à l'extérieur).
-  # Nous avons donc défini une config.ssl_options qui exclut cette route.
-  #
   describe "/health_check" do
     it "returns HTTP 200" do
       get "/health_check"


### PR DESCRIPTION
Cette exception au `force_ssl`  avait été ajoutée à l'époque où l'on tentait de migrer vers une infra OVH, ce qui a été abandonné.

Cette route est désormais utilisé par un service externe (updown.io), qui appelle l'adresse HTTPS.