### PR TITLE
Revert "Ne plus utiliser `current_organisation` dans `Agent::RdvPolicy`"

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -202,10 +202,6 @@ class Agent < ApplicationRecord
     role_in_organisation(organisation).admin?
   end
 
-  def access_level_in(organisation)
-    role_in_organisation(organisation)&.access_level
-  end
-
   def territorial_admin_in?(territory)
     territorial_role_in(territory).present?
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -17,5 +17,11 @@ class ApplicationPolicy
     def self.apply(pundit_user, scope)
       new(pundit_user, scope).resolve
     end
+
+    def in_scope?(object)
+      return false if object&.id.blank?
+
+      resolve.where(id: object.id).any?
+    end
   end
 end

--- a/app/presenters/rdv_ending_shortly_before_presenter.rb
+++ b/app/presenters/rdv_ending_shortly_before_presenter.rb
@@ -18,7 +18,7 @@ class RdvEndingShortlyBeforePresenter
   private
 
   def in_scope?
-    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).resolve.include?(rdv) if rdv
+    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).in_scope?(rdv)
   end
 
   def i18n_key

--- a/app/presenters/rdvs_overlapping_rdv_presenter.rb
+++ b/app/presenters/rdvs_overlapping_rdv_presenter.rb
@@ -18,7 +18,7 @@ class RdvsOverlappingRdvPresenter
   private
 
   def in_scope?
-    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).resolve.include?(rdv) if rdv
+    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).in_scope?(rdv)
   end
 
   def i18n_key

--- a/app/views/admin/lieux/_lieu.html.slim
+++ b/app/views/admin/lieux/_lieu.html.slim
@@ -1,4 +1,4 @@
-- nb_rdv = Agent::RdvPolicy::Scope.new(AgentOrganisationContext.new(current_agent, current_organisation), Rdv).resolve.for_today.merge(lieu.rdvs).count
+- nb_rdv = Agent::RdvPolicy::Scope.apply(AgentOrganisationContext.new(current_agent, current_organisation), Rdv).for_today.merge(lieu.rdvs).count
 tr id="lieu_#{lieu.id}"
   td
     = lieu.name

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe RdvEndingShortlyBeforePresenter, type: :presenter do
     subject { presenter.warning_message }
 
     before do
-      dbl = instance_double(Agent::RdvPolicy::DepartementScope, resolve: rdv_in_scope ? [rdv] : [])
+      dbl = instance_double(Agent::RdvPolicy::DepartementScope, in_scope?: in_scope_mock_value)
       allow(Agent::RdvPolicy::DepartementScope).to receive(:new).with(agent_context, Rdv).and_return(dbl)
     end
 
     context "same agent (=> in scope)" do
-      let(:rdv_in_scope) { true }
+      let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent, organisation: organisation) }
       let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
@@ -22,7 +22,7 @@ RSpec.describe RdvEndingShortlyBeforePresenter, type: :presenter do
     end
 
     context "rdv from other agent but still in scope" do
-      let(:rdv_in_scope) { true }
+      let(:in_scope_mock_value) { true }
       let!(:organisation) { create(:organisation) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }
@@ -34,7 +34,7 @@ RSpec.describe RdvEndingShortlyBeforePresenter, type: :presenter do
     end
 
     context "rdv from other agent and not in scope" do
-      let(:rdv_in_scope) { false }
+      let(:in_scope_mock_value) { false }
       let!(:organisation) { create(:organisation) }
       let(:agent_context) { instance_double(AgentOrganisationContext, agent: build(:agent), organisation: organisation) }
       let!(:user) { create(:user, first_name: "Milos", last_name: "FORMAN") }


### PR DESCRIPTION
Reverts betagouv/rdv-service-public#4678

Nous avons de gros problèmes de perf avec la nouvelle implem de la scope.