### PR TITLE
Nettoyage des seeds et de l'api de Visioplainte pour supprimer la police

### DIFF
--- a/app/controllers/api/visioplainte/base_controller.rb
+++ b/app/controllers/api/visioplainte/base_controller.rb
@@ -4,6 +4,8 @@ class Api::Visioplainte::BaseController < ActionController::Base # rubocop:disab
 
   before_action :authenticate_with_api_key
 
+  GENDARMERIE_SERVICE_NAME = "Gendarmerie Nationale".freeze
+
   def authenticate_with_api_key
     authorized = ActiveSupport::SecurityUtils.secure_compare(
       request.headers["X-VISIOPLAINTE-API-KEY"] || "",

--- a/app/controllers/api/visioplainte/creneaux_controller.rb
+++ b/app/controllers/api/visioplainte/creneaux_controller.rb
@@ -2,11 +2,6 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
   before_action :validate_date_debut
   before_action :validate_date_range, only: [:index]
 
-  SERVICE_NAMES = {
-    "Police" => "Police Nationale",
-    "Gendarmerie" => GENDARMERIE_SERVICE_NAME,
-  }.freeze
-
   def index
     creneaux = CreneauxSearch::ForUser.new(
       motif: motif,
@@ -38,15 +33,15 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
     end
   end
 
-  def self.find_motif(service_param)
+  def self.find_motif
     Motif.joins(organisation: :territory).where(territories: { name: Territory::VISIOPLAINTE_NAME })
-      .joins(:service).find_by(service: { name: SERVICE_NAMES[service_param] || GENDARMERIE_SERVICE_NAME })
+      .joins(:service).find_by(service: { name: GENDARMERIE_SERVICE_NAME })
   end
 
   private
 
   def motif
-    @motif ||= self.class.find_motif(params[:service])
+    @motif ||= self.class.find_motif
   end
 
   def creneau_to_hash(creneau)
@@ -57,13 +52,8 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
   end
 
   def validate_date_debut
-    errors = []
-
     if params[:date_debut].blank?
-      errors << "Paramètre date_debut manquant"
-    end
-
-    if errors.any?
+      errors = ["Paramètre date_debut manquant"]
       render(json: { errors: errors }, status: :bad_request) and return
     end
   end

--- a/app/controllers/api/visioplainte/guichets_controller.rb
+++ b/app/controllers/api/visioplainte/guichets_controller.rb
@@ -2,7 +2,7 @@ class Api::Visioplainte::GuichetsController < Api::Visioplainte::BaseController
   def self.guichets
     Agent.joins(roles: { organisation: :territory }).where(territories: { name: Territory::VISIOPLAINTE_NAME })
       .where(roles: { access_level: AgentRole::ACCESS_LEVEL_INTERVENANT })
-      .joins(:services).where(services: { name: gendarmerie_service_name })
+      .joins(:services).where(services: { name: GENDARMERIE_SERVICE_NAME })
   end
 
   def index

--- a/app/controllers/api/visioplainte/guichets_controller.rb
+++ b/app/controllers/api/visioplainte/guichets_controller.rb
@@ -2,7 +2,7 @@ class Api::Visioplainte::GuichetsController < Api::Visioplainte::BaseController
   def self.guichets
     Agent.joins(roles: { organisation: :territory }).where(territories: { name: Territory::VISIOPLAINTE_NAME })
       .where(roles: { access_level: AgentRole::ACCESS_LEVEL_INTERVENANT })
-      .joins(:services).where(services: { name: Api::Visioplainte::CreneauxController::SERVICE_NAMES["Gendarmerie"] })
+      .joins(:services).where(services: { name: gendarmerie_service_name })
   end
 
   def index

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -28,7 +28,7 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
       motif: motif
     )
     if creneau.blank?
-      errors = { errors: ["Pas de créneau disponible pour ce service à la date demandée"] }
+      errors = { errors: ["Pas de créneau disponible à la date demandée"] }
 
       render(json: errors, status: :unprocessable_entity) and return
     end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -91,6 +91,6 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   end
 
   def motif
-    @motif ||= Api::Visioplainte::CreneauxController.find_motif(params[:service])
+    @motif ||= Api::Visioplainte::CreneauxController.find_motif
   end
 end

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -52,14 +52,3 @@ Agent.create!(
     { organisation: orga_gendarmerie, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
   ]
 )
-
-PlageOuverture.create!(
-  title: "Permanence classique",
-  organisation: orga_gendarmerie,
-  agent: guichet_gendarmerie,
-  motifs: [motif],
-  first_day: Date.tomorrow,
-  start_time: Tod::TimeOfDay.new(8),
-  end_time: Tod::TimeOfDay.new(12),
-  recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday])
-)

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -2,32 +2,16 @@ territory = Territory.create(name: "placeholder")
 
 territory.update_columns(name: Territory::VISIOPLAINTE_NAME) # rubocop:disable Rails/SkipsModelValidations
 
-service_police = Service.create!(name: "Police Nationale", short_name: "Police")
 service_gendarmerie = Service.create!(name: "Gendarmerie Nationale", short_name: "Gendarmerie")
 
-territory.services << service_police
 territory.services << service_gendarmerie
 
-orga_police = Organisation.create!(
-  name: "Plateforme Visioplainte Police",
-  territory: territory
-)
 orga_gendarmerie = Organisation.create!(
   name: "Plateforme Visioplainte Gendarmerie",
   territory: territory
 )
 
-motif_police = Motif.create!(
-  name: "Dépôt de plainte par visioconférence",
-  default_duration_in_min: 30,
-  min_public_booking_delay: 2 * 60 * 60,
-  color: "#FF7C00",
-  location_type: :visio,
-  service: service_police,
-  visibility_type: Motif::VISIBLE_AND_NOT_NOTIFIED,
-  organisation: orga_police
-)
-Motif.create!(
+motif = Motif.create!(
   name: "Dépôt de plainte par visioconférence",
   default_duration_in_min: 30,
   min_public_booking_delay: 2 * 60 * 60,
@@ -37,22 +21,6 @@ Motif.create!(
   visibility_type: Motif::VISIBLE_AND_NOT_NOTIFIED,
   organisation: orga_gendarmerie
 )
-
-superviseur_police = Agent.new(
-  first_name: "Francis",
-  last_name: "Factice",
-  email: "francis.factice@visioplainte.sandbox.gouv.fr",
-  uid: "francis.factice@visioplainte.sandbox.gouv.fr",
-  invitation_accepted_at: 10.days.ago,
-  password: "Rdvservicepublictest1!",
-  services: [service_police],
-  roles_attributes: [
-    { organisation: orga_police, access_level: AgentRole::ACCESS_LEVEL_ADMIN },
-  ]
-)
-superviseur_police.skip_confirmation!
-superviseur_police.save!
-AgentTerritorialAccessRight.create(agent: superviseur_police, territory: territory)
 
 superviseur_gendarmerie = Agent.new(
   first_name: "Gaston",
@@ -69,26 +37,7 @@ superviseur_gendarmerie.skip_confirmation!
 superviseur_gendarmerie.save!
 AgentTerritorialAccessRight.create(agent: superviseur_gendarmerie, territory: territory)
 
-guichet_police1 = Agent.create!(
-  last_name: "Guichet 1",
-  services: [service_police],
-  roles_attributes: [
-    { organisation: orga_police, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
-  ]
-)
-
-PlageOuverture.create!(
-  title: "Permanence classique",
-  organisation: orga_police,
-  agent: guichet_police1,
-  motifs: [motif_police],
-  first_day: Date.tomorrow,
-  start_time: Tod::TimeOfDay.new(8),
-  end_time: Tod::TimeOfDay.new(12),
-  recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday])
-)
-
-Agent.create!(
+guichet_gendarmerie = Agent.create!(
   last_name: "Guichet 1",
   services: [service_gendarmerie],
   roles_attributes: [
@@ -102,4 +51,15 @@ Agent.create!(
   roles_attributes: [
     { organisation: orga_gendarmerie, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
   ]
+)
+
+PlageOuverture.create!(
+  title: "Permanence classique",
+  organisation: orga_gendarmerie,
+  agent: guichet_gendarmerie,
+  motifs: [motif],
+  first_day: Date.tomorrow,
+  start_time: Tod::TimeOfDay.new(8),
+  end_time: Tod::TimeOfDay.new(12),
+  recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday])
 )

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -11,7 +11,7 @@ orga_gendarmerie = Organisation.create!(
   territory: territory
 )
 
-motif = Motif.create!(
+Motif.create!(
   name: "Dépôt de plainte par visioconférence",
   default_duration_in_min: 30,
   min_public_booking_delay: 2 * 60 * 60,
@@ -37,7 +37,7 @@ superviseur_gendarmerie.skip_confirmation!
 superviseur_gendarmerie.save!
 AgentTerritorialAccessRight.create(agent: superviseur_gendarmerie, territory: territory)
 
-guichet_gendarmerie = Agent.create!(
+Agent.create!(
   last_name: "Guichet 1",
   services: [service_gendarmerie],
   roles_attributes: [

--- a/spec/requests/api/visioplainte/authentication_spec.rb
+++ b/spec/requests/api/visioplainte/authentication_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe "Authentification" do
     stub_env_with(VISIOPLAINTE_API_KEY: "visioplainte-api-test-key-123456")
     let(:creneaux_params) do
       {
-        service: "Police",
+        service: "Gendarmerie",
         date_debut: "2024-08-19",
         date_fin: "2024-08-25",
       }

--- a/spec/requests/api/visioplainte/creneaux_spec.rb
+++ b/spec/requests/api/visioplainte/creneaux_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Visioplainte Creneaux" do
   context "when there are available créneaux" do
     let(:creneaux_params) do
       {
-        service: "Police",
+        service: "Gendarmerie",
         date_debut: "2024-08-19",
         date_fin: "2024-08-25",
       }
@@ -36,55 +36,17 @@ RSpec.describe "Visioplainte Creneaux" do
       creneaux = get_request[:creneaux]
       expect(creneaux.first).to eq(
         {
-          starts_at: "2024-08-19T08:00:00+02:00",
-          duration_in_min: 30,
-        }
-      )
-    end
-  end
-
-  describe "service param" do
-    let(:creneaux_params) do
-      {
-        service: "Gendarmerie",
-        date_debut: "2024-08-19",
-        date_fin: "2024-08-25",
-      }
-    end
-
-    it "allows to get Gendarmerie creneaux as well" do
-      creneaux = get_request[:creneaux]
-      expect(creneaux.first).to eq(
-        {
           starts_at: "2024-08-19T14:00:00+02:00",
           duration_in_min: 30,
         }
       )
-    end
-
-    context "when passing an invalid param" do
-      let(:creneaux_params) do
-        {
-          service: "Service social",
-          date_debut: "2024-08-19",
-          date_fin: "2024-08-25",
-        }
-      end
-
-      it "shows an error" do
-        get_request
-        expect(response.status).to eq 400
-        expect(get_request).to eq(
-          { errors: ["Le paramètre service doit avoir pour valeur 'Police' ou 'Gendarmerie'"] }
-        )
-      end
     end
   end
 
   describe "date de début et de fin" do
     let(:creneaux_params) do
       {
-        service: "Police",
+        service: "Gendarmerie",
         date_debut: "2024-08-19",
         date_fin: "2024-08-19",
       }
@@ -93,14 +55,14 @@ RSpec.describe "Visioplainte Creneaux" do
     it "returns the creneaux included on the last day" do
       creneaux = get_request[:creneaux]
       expect(creneaux.count).to eq 8
-      expect(creneaux.first[:starts_at]).to eq "2024-08-19T08:00:00+02:00"
-      expect(creneaux.last[:starts_at]).to eq "2024-08-19T11:30:00+02:00"
+      expect(creneaux.first[:starts_at]).to eq "2024-08-19T14:00:00+02:00"
+      expect(creneaux.last[:starts_at]).to eq "2024-08-19T17:30:00+02:00"
     end
 
     context "when date_debut is missing" do
       let(:creneaux_params) do
         {
-          service: "Police",
+          service: "Gendarmerie",
           date_fin: "2024-08-19",
         }
       end
@@ -116,7 +78,7 @@ RSpec.describe "Visioplainte Creneaux" do
     context "when asking for a too big range" do
       let(:creneaux_params) do
         {
-          service: "Police",
+          service: "Gendarmerie",
           date_debut: "2024-08-19",
           date_fin: "2024-10-19",
         }

--- a/spec/requests/api/visioplainte/guichets_spec.rb
+++ b/spec/requests/api/visioplainte/guichets_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Visioplainte Guichets" do
   end
 
   let(:service_gendarmerie) do
-    Service.find_by(name: Api::Visioplainte::CreneauxController::SERVICE_NAMES["Gendarmerie"])
+    Service.find_by(name: "Gendarmerie Nationale")
   end
 
   include_context "Visioplainte Auth"

--- a/spec/requests/api/visioplainte/rdvs_spec.rb
+++ b/spec/requests/api/visioplainte/rdvs_spec.rb
@@ -2,6 +2,16 @@ RSpec.describe "Visioplainte Rdvs" do
   before do
     travel_to Time.zone.local(2024, 8, 18, 14, 0, 0)
     load Rails.root.join("db/seeds/visioplainte.rb")
+    PlageOuverture.create!(
+      title: "Permanence classique",
+      organisation: Organisation.last,
+      agent: Agent.find_by(last_name: "Guichet 1"),
+      motifs: [Motif.last],
+      first_day: Date.tomorrow,
+      start_time: Tod::TimeOfDay.new(8),
+      end_time: Tod::TimeOfDay.new(12),
+      recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday])
+    )
   end
 
   include_context "Visioplainte Auth"

--- a/spec/requests/api/visioplainte/swagger_doc/creneaux_spec.rb
+++ b/spec/requests/api/visioplainte/swagger_doc/creneaux_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
   before do
     travel_to Time.zone.local(2024, 8, 18, 14, 0, 0)
     load Rails.root.join("db/seeds/visioplainte.rb")
+    create(:plage_ouverture,
+           organisation: orga_gendarmerie,
+           agent: orga_gendarmerie.agents.first,
+           motifs: orga_gendarmerie.motifs,
+           first_day: Date.tomorrow,
+           start_time: Tod::TimeOfDay.new(8),
+           end_time: Tod::TimeOfDay.new(18),
+           recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday]))
+  end
+
+  let(:orga_gendarmerie) do
+    Organisation.find_by(name: "Plateforme Visioplainte Gendarmerie") # créée dans les seeds
   end
 
   path "/api/visioplainte/creneaux" do
@@ -15,11 +27,6 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
 
       response 200, "Renvoie les créneaux" do
         run_test!
-        parameter name: :service, in: :query, type: :string,
-                  description: "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. " \
-                               "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
-                  example: "Police", required: true
-
         parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra",
                   example: "2024-12-22", required: true
         parameter name: "date_fin", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), dernier jour de la liste de créneaux qu’on renverra (inclus dans les résultats)",
@@ -33,7 +40,6 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
                },
                required: ["creneaux"]
 
-        let(:service) { "Police" }
         let(:date_debut) { "2024-08-19" }
         let(:date_fin) { "2024-08-25" }
 
@@ -56,16 +62,10 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
 
       tags "Créneaux"
       description "Renvoie le prochain créneau disponible"
-      parameter name: :service, in: :query, type: :string,
-                description: "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. " \
-                             "Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
-                example: "Police", required: true
-
       parameter name: "date_debut", in: :query, type: :string, description: "date au format iso8601 (YYYY-MM-DD), date à partir de laquelle on cherche des créneaux",
                 example: "2024-12-22", required: true
 
       let(:date_debut) { "2024-08-19" }
-      let(:service) { "Police" }
 
       response 200, "Renvoie le prochain créneau disponible" do
         run_test!
@@ -90,7 +90,7 @@ RSpec.describe "Visioplainte API", swagger_doc: "visioplainte/api.json" do
         specify do
           expect(parsed_response_body).to eq(
             {
-              errors: ["Aucun créneau n'est disponible après cette date pour ce service."],
+              errors: ["Aucun créneau n'est disponible après cette date"],
             }.deep_stringify_keys
           )
         end

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -28,16 +28,6 @@
             }
           },
           {
-            "name": "service",
-            "in": "query",
-            "description": "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
-            "example": "Police",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "date_debut",
             "in": "query",
             "description": "date au format iso8601 (YYYY-MM-DD), premier jour de la liste de créneaux qu’on renverra",
@@ -104,6 +94,54 @@
                           "duration_in_min": 30
                         },
                         {
+                          "starts_at": "2024-08-19T12:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T12:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T13:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T13:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T14:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T14:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T15:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T15:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T16:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T16:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T17:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-19T17:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
                           "starts_at": "2024-08-20T08:00:00+02:00",
                           "duration_in_min": 30
                         },
@@ -133,6 +171,54 @@
                         },
                         {
                           "starts_at": "2024-08-20T11:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T12:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T12:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T13:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T13:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T14:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T14:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T15:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T15:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T16:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T16:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T17:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-20T17:30:00+02:00",
                           "duration_in_min": 30
                         },
                         {
@@ -168,6 +254,54 @@
                           "duration_in_min": 30
                         },
                         {
+                          "starts_at": "2024-08-22T12:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T12:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T13:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T13:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T14:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T14:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T15:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T15:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T16:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T16:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T17:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-22T17:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
                           "starts_at": "2024-08-23T08:00:00+02:00",
                           "duration_in_min": 30
                         },
@@ -197,6 +331,54 @@
                         },
                         {
                           "starts_at": "2024-08-23T11:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T12:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T12:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T13:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T13:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T14:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T14:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T15:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T15:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T16:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T16:30:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T17:00:00+02:00",
+                          "duration_in_min": 30
+                        },
+                        {
+                          "starts_at": "2024-08-23T17:30:00+02:00",
                           "duration_in_min": 30
                         }
                       ]
@@ -247,16 +429,6 @@
             "in": "header",
             "description": "Clé d'API",
             "example": "visioplainte-api-test-key-123456",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "service",
-            "in": "query",
-            "description": "Indique si on souhaite obtenir les créneaux de la plateforme de la gendarmerie ou de la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
-            "example": "Police",
             "required": true,
             "schema": {
               "type": "string"
@@ -316,7 +488,7 @@
                   "example": {
                     "value": {
                       "errors": [
-                        "Aucun créneau n'est disponible après cette date pour ce service."
+                        "Aucun créneau n'est disponible après cette date"
                       ]
                     }
                   }
@@ -376,11 +548,11 @@
                     "value": {
                       "guichets": [
                         {
-                          "id": 158,
+                          "id": 90,
                           "name": "GUICHET 1"
                         },
                         {
-                          "id": 159,
+                          "id": 91,
                           "name": "GUICHET 2"
                         }
                       ]
@@ -457,34 +629,34 @@
                     "value": {
                       "plages_ouverture": [
                         {
-                          "id": 43,
+                          "id": 28,
                           "starts_at": "2024-08-19T09:00:00+02:00",
                           "ends_at": "2024-08-19T12:00:00+02:00",
-                          "guichet_id": 164
+                          "guichet_id": 94
                         },
                         {
-                          "id": 43,
+                          "id": 28,
                           "starts_at": "2024-08-20T09:00:00+02:00",
                           "ends_at": "2024-08-20T12:00:00+02:00",
-                          "guichet_id": 164
+                          "guichet_id": 94
                         },
                         {
-                          "id": 43,
+                          "id": 28,
                           "starts_at": "2024-08-21T09:00:00+02:00",
                           "ends_at": "2024-08-21T12:00:00+02:00",
-                          "guichet_id": 164
+                          "guichet_id": 94
                         },
                         {
-                          "id": 43,
+                          "id": 28,
                           "starts_at": "2024-08-22T09:00:00+02:00",
                           "ends_at": "2024-08-22T12:00:00+02:00",
-                          "guichet_id": 164
+                          "guichet_id": 94
                         },
                         {
-                          "id": 43,
+                          "id": 28,
                           "starts_at": "2024-08-23T09:00:00+02:00",
                           "ends_at": "2024-08-23T12:00:00+02:00",
-                          "guichet_id": 164
+                          "guichet_id": 94
                         }
                       ]
                     }
@@ -600,16 +772,6 @@
             }
           },
           {
-            "name": "service",
-            "in": "query",
-            "description": "Indique si on souhaite prendre rendez-vous avec la gendarmerie ou la police. Les deux valeurs possibles sont donc 'Police' ou 'Gendarmerie'",
-            "example": "Police",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "starts_at",
             "in": "query",
             "description": "datetime au format iso8601. Normalement c'est une des valeurs proposées par l'endpoint de liste des créneaux.",
@@ -637,8 +799,8 @@
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 172,
-                        "name": "GUICHET 1"
+                        "id": 98,
+                        "name": "Gaston BIDON"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "unknown",
@@ -701,7 +863,7 @@
                   "example": {
                     "value": {
                       "errors": [
-                        "Pas de créneau disponible pour ce service à la date demandée"
+                        "Pas de créneau disponible à la date demandée"
                       ]
                     }
                   }
@@ -823,8 +985,8 @@
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 187,
-                        "name": "GUICHET 1"
+                        "id": 107,
+                        "name": "Gaston BIDON"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "excused",


### PR DESCRIPTION
# Contexte

J'ai reçu un mail du dev Sensiolabs qui bosse sur Visioplainte : il avait l'impression que l'endpoint de liste des plages d'ouvertures ne marchait pas, mais c'est parce qu'il avait créé les plages d'ouverture dans l'orga de police et pas celle de la gendarmerie.

Pour rappel, la police a quitté le projet en cours de route, donc les endpoints plus récents ne proposent pas de filtrer par service, et renvoient automatiquement les données de la gendarmerie

# Solution

Pour éviter les confusions aussi bien chez Sensiolabs que chez nous, cette PR propose donc de supprimer toutes les références à la police dans les seeds, la documentation de l'api, et le code de l'api.
Le dev de Sensiolabs a confirmé qu'ils étaient ok avec ça.