### PR TITLE
Amélioration des flashes de confirmation côté usager

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -5,7 +5,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message!(:success, :confirmed)
+      set_flash_message!(:notice, :confirmed)
       respond_with_navigational(resource) do
         redirect_to after_confirmation_path_for(resource_name, resource)
       end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -5,7 +5,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message!(:notice, :confirmed)
+      set_flash_message!(:success, :confirmed)
       respond_with_navigational(resource) do
         redirect_to after_confirmation_path_for(resource_name, resource)
       end

--- a/app/controllers/users/file_attentes_controller.rb
+++ b/app/controllers/users/file_attentes_controller.rb
@@ -13,7 +13,7 @@ class Users::FileAttentesController < UserAuthController
       flash[:alert] = "Vous n'êtes plus sur la liste d'attente"
     else
       FileAttente.create(rdv_id: file_attente_params[:rdv_id], user_id: file_attente_params[:user_id])
-      flash[:notice] = "Vous êtes à présent sur la liste d'attente"
+      flash[:success] = "Vous êtes à présent sur la liste d'attente"
     end
     redirect_to request.referer.to_s
   end

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -62,7 +62,7 @@ class Users::ParticipationsController < UserAuthController
   def change_participation_status(status)
     existing_participation.change_status_and_notify(current_user, status)
     set_user_name_initials_verified
-    flash[:notice] = "Participation confirmée" if existing_participation.status == "unknown"
+    flash[:success] = "Participation confirmée" if existing_participation.status == "unknown"
     flash[:notice] = "Participation annulée" if existing_participation.status == "excused"
     redirect_to users_rdv_path(@rdv, invitation_token: existing_participation.participation_token)
   end
@@ -74,7 +74,7 @@ class Users::ParticipationsController < UserAuthController
 
     new_participation.create_and_notify!(current_user)
     set_user_name_initials_verified
-    flash[:notice] = "Participation confirmée"
+    flash[:success] = "Participation confirmée"
     redirect_to users_rdv_path(@rdv, invitation_token: new_participation.participation_token)
   end
 

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -42,7 +42,8 @@ class Users::RdvsController < UserAuthController
       notifier = Notifiers::RdvCreated.new(@rdv, current_user)
       notifier.perform
       set_user_name_initials_verified
-      redirect_to users_rdv_path(@rdv, invitation_token: notifier.participations_tokens_by_user_id[current_user.id]), success: t(".rdv_confirmed")
+      flash[:success] = t(".rdv_confirmed")
+      redirect_to users_rdv_path(@rdv, invitation_token: notifier.participations_tokens_by_user_id[current_user.id])
     else
       # TODO: cette liste de paramètres devrait ressembler a SearchController#search_params, mais sans certains paramètres de choix du wizard de créneaux
       query = {

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -42,7 +42,7 @@ class Users::RdvsController < UserAuthController
       notifier = Notifiers::RdvCreated.new(@rdv, current_user)
       notifier.perform
       set_user_name_initials_verified
-      redirect_to users_rdv_path(@rdv, invitation_token: notifier.participations_tokens_by_user_id[current_user.id]), notice: t(".rdv_confirmed")
+      redirect_to users_rdv_path(@rdv, invitation_token: notifier.participations_tokens_by_user_id[current_user.id]), success: t(".rdv_confirmed")
     else
       # TODO: cette liste de paramètres devrait ressembler a SearchController#search_params, mais sans certains paramètres de choix du wizard de créneaux
       query = {

--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -19,7 +19,7 @@ class Users::RelativesController < UserAuthController
     authorize(@user)
     return_location = request.referer
     if @user.save
-      flash[:notice] = "#{@user.full_name} a été ajouté comme proche."
+      flash[:success] = "#{@user.full_name} a été ajouté comme proche."
       return_location = add_query_string_params_to_url(request.referer, created_user_id: @user.id)
     end
     respond_modal_with @user, location: return_location
@@ -32,7 +32,7 @@ class Users::RelativesController < UserAuthController
   def update
     authorize(@user)
     if @user.update(user_params)
-      flash[:notice] = "Les informations de votre proche #{@user.full_name} ont été mises à jour."
+      flash[:success] = "Les informations de votre proche #{@user.full_name} ont été mises à jour."
       redirect_to users_informations_path
     else
       render :edit

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -8,7 +8,7 @@ class Users::UsersController < UserAuthController
     @user = current_user
     authorize(@user)
     if @user.update(user_params)
-      flash[:notice] = "Vos informations ont été mises à jour."
+      flash[:success] = "Vos informations ont été mises à jour."
       redirect_to users_informations_path
     else
       render :edit

--- a/spec/requests/users/participations_spec.rb
+++ b/spec/requests/users/participations_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Users::Participants", type: :request do
     describe "POST /users/rdvs/:rdv_id/participants, norminal case" do
       it "set a confirmation notice message for users_rdv_participations POST for current_user participation" do
         post users_rdv_participations_path(rdv)
-        expect(flash[:notice]).to eq("Participation confirmée")
+        expect(flash[:success]).to eq("Participation confirmée")
         expect(response).to redirect_to(users_rdv_path(rdv, invitation_token: token))
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe "Users::Participants", type: :request do
 
       it "specific user" do
         post users_rdv_participations_path(rdv, user_id: user.id)
-        expect(flash[:notice]).to eq("Participation confirmée")
+        expect(flash[:success]).to eq("Participation confirmée")
         expect(rdv.reload.users.count).to eq(1)
         expect(response).to redirect_to(users_rdv_path(rdv, invitation_token: token))
       end
@@ -54,7 +54,7 @@ RSpec.describe "Users::Participants", type: :request do
 
         it "change to other relative user" do
           post users_rdv_participations_path(rdv, user_id: user_other_child.id)
-          expect(flash[:notice]).to eq("Participation confirmée")
+          expect(flash[:success]).to eq("Participation confirmée")
           expect(rdv.reload.users).to contain_exactly(user_other_child, other_user)
           # Change to relative isnt allowed with invitation and doesnt redirect with invitation token
           expect(response).to redirect_to(users_rdv_path(rdv))
@@ -63,7 +63,7 @@ RSpec.describe "Users::Participants", type: :request do
 
       it "cannot create participation for non relatives users" do
         post users_rdv_participations_path(rdv, user_id: user.id)
-        expect(flash[:notice]).to eq("Participation confirmée")
+        expect(flash[:success]).to eq("Participation confirmée")
         expect(response).to redirect_to(users_rdv_path(rdv, invitation_token: token))
         post users_rdv_participations_path(rdv, user_id: user2.id)
         expect(rdv.reload.users).to contain_exactly(user)
@@ -86,11 +86,11 @@ RSpec.describe "Users::Participants", type: :request do
   describe "Participation update (if excused)" do
     let(:participation1) { create(:participation, rdv: rdv, user: user) }
 
-    it "display notice" do
+    it "displays a confirmation message" do
       participation1.update!(status: "excused")
       expect(rdv.reload.users).to contain_exactly(user)
       post users_rdv_participations_path(rdv, user_id: user.id)
-      expect(flash[:notice]).to eq("Participation confirmée")
+      expect(flash[:success]).to eq("Participation confirmée")
       expect(rdv.reload.users).to contain_exactly(user)
     end
   end


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1220" alt="Screenshot 2024-10-08 at 15 36 47" src="https://github.com/user-attachments/assets/223e14f6-9af4-4c89-98dd-2181ffafc3d3"> | <img width="1235" alt="Screenshot 2024-10-08 at 15 36 23" src="https://github.com/user-attachments/assets/664ecea7-b168-4339-adc2-ba37ef601018">

# Contexte

En faisant des captures d'écran pour l'intégration avec DS, je me suis rendu compte qu'on utilisait le mauvais type de flash pour la plupart des messages de confirmation, et que c'était trivial à corriger pour faire des screenshots plus convaincants.

# Solution

Cette PR passe les flashes de `notice` à `success` pour les confirmations d'action non destructives (les confirmations d'actions destructives restent des notices).

J'ai voulu faire la même chose côté agent, et j'ai compris pourquoi on ne l'avait pas fait avant : les flashes sucess avec bootstrap sont très moches. J'ai donc laissé l'existant, mais ça me donne encore plus envie qu'on puisse utiliser le dsfr côté agents.
