### PR TITLE
Petite amélioration de performances sur le calcul de créneaux

### DIFF
--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -125,12 +125,12 @@ module RecurrenceConcern
         event_in_range?(occurrence_starts_at, occurrence_starts_at + duration, inclusive_datetime_range)
       end.to_a
     else
-      event_in_range?(starts_at, first_occurrence_ends_at, inclusive_datetime_range) ? [starts_at] : []
+      event_in_range?(starts_at, ends_at, inclusive_datetime_range) ? [starts_at] : []
     end
   end
 
   def event_in_range?(event_starts_at, event_ends_at, range)
-    range.cover?(event_starts_at) || range.cover?(event_ends_at) || (event_starts_at < range.begin && range.end < event_ends_at)
+    (event_starts_at..event_ends_at).overlap?(range)
   end
 
   def set_recurrence_ends_at

--- a/app/models/concerns/recurrence_concern.rb
+++ b/app/models/concerns/recurrence_concern.rb
@@ -108,13 +108,13 @@ module RecurrenceConcern
   private
 
   def occurrence_start_at_list_for(inclusive_date_range)
-    min_until = [inclusive_date_range.end, recurrence_ends_at].compact.min.end_of_day
-
     datetime_range_start = inclusive_date_range.begin.is_a?(Date) ? inclusive_date_range.begin.in_time_zone.beginning_of_day : inclusive_date_range.begin
 
     inclusive_datetime_range = datetime_range_start..(inclusive_date_range.end.end_of_day)
 
     if recurring?
+      min_until = [inclusive_date_range.end, recurrence_ends_at].compact.min.end_of_day
+
       rec = recurrence.starting(starts_at).until(min_until)
 
       if starts_at <= inclusive_datetime_range.begin

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -152,18 +152,13 @@ module CreneauxSearch::Calculator
         absences = plage_ouverture.agent.absences
           .not_expired
           .in_range(range)
+
         busy_times = []
         absences.each do |absence|
-          if absence.recurrence
-            absence.occurrences_for(range).each do |absence_occurrence|
-              next if absence_out_of_range?(absence_occurrence, range)
+          absence.occurrences_for(range).each do |absence_occurrence|
+            next if absence_out_of_range?(absence_occurrence, range)
 
-              busy_times << BusyTime.new(absence_occurrence.starts_at, absence_occurrence.ends_at)
-            end
-          else
-            next if absence_out_of_range?(absence, range)
-
-            busy_times << BusyTime.new(absence.starts_at, absence.ends_at)
+            busy_times << BusyTime.new(absence_occurrence.starts_at, absence_occurrence.ends_at)
           end
         end
         busy_times

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -44,7 +44,7 @@ module CreneauxSearch::Calculator
       occurrences.map do |occurrence|
         next if occurrence.ends_at < Time.zone.now
 
-        (plage_ouverture.start_time.on(occurrence.starts_at)..plage_ouverture.end_time.on(occurrence.ends_at))
+        occurrence.starts_at..occurrence.ends_at
       end.compact
     end
 

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -119,20 +119,9 @@ module CreneauxSearch::Calculator
   class BusyTime
     attr_reader :starts_at, :ends_at
 
-    def initialize(object)
-      case object
-      when Date
-        @starts_at = object.beginning_of_day
-        @ends_at = object.end_of_day
-      when Rdv, Recurrence::Occurrence
-        @starts_at = object.starts_at
-        @ends_at = object.ends_at
-      when Absence
-        @starts_at = object.start_time.on(object.first_day)
-        @ends_at = object.end_time.on(object.end_day.presence || object.first_day)
-      else
-        raise ArgumentError, "busytime can't be build with a #{object.class}"
-      end
+    def initialize(starts_at, ends_at)
+      @starts_at = starts_at
+      @ends_at = ends_at
     end
 
     def range
@@ -152,8 +141,10 @@ module CreneauxSearch::Calculator
       end
 
       def busy_times_from_rdvs(range, plage_ouverture)
-        plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end).map do |rdv|
-          BusyTime.new(rdv)
+        rdv_scope = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+
+        rdv_scope.pluck(:starts_at, :ends_at).map do |starts_at, ends_at|
+          BusyTime.new(starts_at, ends_at)
         end
       end
 
@@ -167,30 +158,26 @@ module CreneauxSearch::Calculator
             absence.occurrences_for(range).each do |absence_occurrence|
               next if absence_out_of_range?(absence_occurrence, range)
 
-              busy_times << BusyTime.new(absence_occurrence)
+              busy_times << BusyTime.new(absence_occurrence.starts_at, absence_occurrence.ends_at)
             end
           else
             next if absence_out_of_range?(absence, range)
 
-            busy_times << BusyTime.new(absence)
+            busy_times << BusyTime.new(absence.starts_at, absence.ends_at)
           end
         end
         busy_times
       end
 
       def absence_out_of_range?(absence, range)
-        if absence.is_a?(Recurrence::Occurrence)
-          start_date_time = absence.starts_at
-          end_date_time = absence.ends_at
-        else
-          start_date_time = absence.start_time.on(absence.first_day)
-          end_date_time = absence.end_time.on(absence.end_day)
-        end
+        start_date_time = absence.starts_at
+        end_date_time = absence.ends_at
+
         end_date_time < range.begin || range.end < start_date_time
       end
 
       def busy_times_from_off_days(date_range)
-        OffDays.all_in_date_range(date_range).map { |off_day| BusyTime.new(off_day) }
+        OffDays.all_in_date_range(date_range).map { |off_day| BusyTime.new(off_day.beginning_of_day, off_day.end_of_day) }
       end
     end
   end

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
     it "return empty free times with an absence over range" do
       absence = build(:absence, first_day: Date.new(2021, 11, 26), start_time: Tod::TimeOfDay.new(8), end_time: Tod::TimeOfDay.new(12))
       range = Time.zone.parse("20211126 9:00")..Time.zone.parse("20211126 11:00")
-      busy_times = [CreneauxSearch::Calculator::BusyTime.new(absence)]
+      busy_times = [CreneauxSearch::Calculator::BusyTime.new(absence.starts_at, absence.ends_at)]
       expect(described_class.split_range_recursively(range, busy_times)).to eq([])
     end
   end


### PR DESCRIPTION
# Contexte

On a actuellement des problèmes de timeouts sur le calcul de créneaux côté ANTS, ce qui fait que dans la pratique certaines mairies ne sont pas branchées sur le moteur de recherche de l'ANTS.
On a récemment fait pas mal d'amélioration sur le calcul des occurrences et le calcul de créneaux.

Cette PR propose donc de capitaliser sur la connaissance qu'on a de cette partie de l'appli pour continuer d'améliorer les performances et de simplifier le code (ce qui permettra encore d'autres améliorations de performance).

# Solution

La principale amélioration ici est de ne pas initialiser tout un objet activerecord Rdv pour générer un BusyTime, mais uniquement de faire un pluck des données nécessaire (starts_at et ends_at).

Ça ne devrait pas avoir un impact énorme sur les performances, mais ça permet de faire quelques refactos qui vont simplifier la prochaine étape (à savoir faire une seule requête pour aller chercher les absences et rdvs).

Les modifications dans le RecurrenceConcern sont uniquement des simplifications du code (c'est vrai que ça aurait pu être dans une autre pr, mais ça permet de grouper les simplifications)

Une lecture commit par commit peut faciliter la review.


