### PR TITLE
Correctif en cas d'ajout de participation en double

### DIFF
--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -59,9 +59,9 @@
         .d-flex.justify-content-start.mb-2
           - if rdv.remaining_seats? && rdv.not_cancelled?
             = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "btn btn-outline-primary btn-sm" do
-              span
-                = "Ajouter un participant"
               span.ml-1
                 i.fa.fa-fw.fa-user-plus>
+              span
+                = "Ajouter un participant"
           .text-muted.align-self-center.ml-2
             = render "admin/rdvs/participants_count", rdv: rdv

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -72,25 +72,26 @@
               = f.fields_for :participations, @rdv.participations do |participation_form|
                 = render "admin/participations/form", form: participation_form
 
-            .form-group
-              = select_tag :status,
-                      options_for_select([]),
-                      include_blank: "Ajouter un usager",
-                      required: false,
-                      class: "select2-input js-rdv-user-select",
-                      data: { \
-                width: "auto", \
-                "scroll-to-bottom": params[:add_user].present?, \
-                "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
-               }
+            div.form-row.grid-align-center.pb-4
+              .flex-grow-1.pr-4
+                = select_tag :status,
+                        options_for_select([]),
+                        include_blank: "Ajouter un usager",
+                        required: false,
+                        class: "select2-input js-rdv-user-select",
+                        data: { \
+                  width: "auto", \
+                  "scroll-to-bottom": params[:add_user].present?, \
+                  "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
+                 }
               span.small.text-muted
-              | L'usager n'existe pas ?&nbsp;
-              = link_to \
-                "Créer un usager", \
-                new_admin_organisation_user_path( \
-                  current_organisation, modal: true, return_location: request.url, role: default_service_selection_from(@rdv.motif.service) \
-                    ), \
-                data: { modal: true }
+                | L'usager n'existe pas ?&nbsp;
+                = link_to \
+                  "Créer un usager", \
+                  new_admin_organisation_user_path( \
+                    current_organisation, modal: true, return_location: request.url, role: default_service_selection_from(@rdv.motif.service) \
+                      ), \
+                  data: { modal: true }
 
             .text-right
               = link_to t("helpers.back"), admin_organisation_rdv_path(current_organisation, @rdv), class: "btn btn-link"

--- a/app/views/admin/rdvs_collectifs/_rdv.html.slim
+++ b/app/views/admin/rdvs_collectifs/_rdv.html.slim
@@ -30,8 +30,8 @@
       .col-md-6
         = render "admin/rdvs_collectifs/participants_info", rdv: rdv
         - if rdv.remaining_seats? && rdv.not_cancelled?
-          = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "d-flex card-text mb-2" do
-            div.mr-1
+          = link_to edit_admin_organisation_rdvs_collectif_path(rdv.organisation, rdv), class: "btn btn-outline-primary btn-sm" do
+            span.mr-1
               i.fa.fa-fw.fa-user-plus>
-            div
+            span
               = "Ajouter un participant"

--- a/app/views/admin/rdvs_collectifs/edit.html.slim
+++ b/app/views/admin/rdvs_collectifs/edit.html.slim
@@ -63,17 +63,18 @@
             = f.fields_for :participations, @participations_to_add do |participation_form|
               = render "admin/participations/form", form: participation_form
 
-          .form-group
-            = select_tag :status,
-                    options_for_select([]),
-                    include_blank: "Ajouter un usager",
-                    required: false,
-                    class: "select2-input js-rdv-user-select",
-                    data: { \
-              width: "auto", \
-              "scroll-to-bottom": @add_user_ids.present?, \
-              "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
-             }
+          div.form-row.grid-align-center.pb-4
+            .flex-grow-1.pr-4
+              = select_tag :status,
+                      options_for_select([]),
+                      include_blank: "Ajouter un usager",
+                      required: false,
+                      class: "select2-input js-rdv-user-select",
+                      data: { \
+                width: "auto", \
+                "scroll-to-bottom": @add_user_ids.present?, \
+                "select2-config": { ajax: { url: search_admin_organisation_users_path(current_organisation, exclude_ids: @rdv.participations.map(&:user_id)), dataType: "json", delay: 250 } }, \
+               }
             span.small.text-muted
               | L'usager n'existe pas ?&nbsp;
               = link_to \

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -169,6 +169,14 @@ RSpec.describe Rdv::Updatable, type: :concern do
         expect_notifications_sent_for(rdv, user_added, :rdv_created)
         expect_notifications_sent_for(rdv, user_removed, :rdv_cancelled)
       end
+
+      context "quand un des usager qu'on ajoute est déjà inscrit comme participant au rdv" do
+        let(:rdv) { create(:rdv, agents: [agent], motif: motif, users: [user_staying, user_removed, user_added]).reload }
+
+        it "garde l'usager et n'envoie pas de notification supplémentaire" do
+          rdv.update_and_notify(agent, attributes)
+        end
+      end
     end
   end
 

--- a/spec/models/concerns/rdv/updatable_spec.rb
+++ b/spec/models/concerns/rdv/updatable_spec.rb
@@ -171,10 +171,20 @@ RSpec.describe Rdv::Updatable, type: :concern do
       end
 
       context "quand un des usager qu'on ajoute est déjà inscrit comme participant au rdv" do
-        let(:rdv) { create(:rdv, agents: [agent], motif: motif, users: [user_staying, user_removed, user_added]).reload }
+        let(:rdv) { create(:rdv, agents: [agent], motif: motif, users: [user_staying, user_added]).reload }
+
+        let(:attributes) do
+          {
+            participations_attributes: {
+              0 => { user_id: user_staying.id, send_lifecycle_notifications: 1, id: rdv.participations.find_by(user_id: user_staying.id).id, _destroy: false },
+              1 => { user_id: user_added.id, send_lifecycle_notifications: 1 },
+            },
+          }
+        end
 
         it "garde l'usager et n'envoie pas de notification supplémentaire" do
           rdv.update_and_notify(agent, attributes)
+          expect_no_notifications
         end
       end
     end


### PR DESCRIPTION
# Contexte

https://sentry.incubateur.net/organizations/betagouv/issues/108654/?environment=production&query=is%3Aunresolved+is%3Aunlinked&referrer=issue-stream&statsPeriod=30d&stream_index=2

On a un petit volume d'erreurs lorsque des agents ajoutent des participants déjà inscrits à un rdv collectif.

# Solution

Les trois premiers commits sont une procrastination cosmétique pour uniformiser l'interface (en préférant les options un peut plus ergonomiques).
Les trois derniers commits contiennent la spec et le fix.
