### PR TITLE
Chargement asynchrone des absences lors du calcul de créneaux

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: ./bin/start_web_server
 jobs: bundle exec good_job start
-postdeploy: bundle exec rake db:migrate
+postdeploy: bundle exec rake db:schema:load db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: ./bin/start_web_server
 jobs: bundle exec good_job start
-postdeploy: bundle exec rake db:schema:load db:seed
+postdeploy: bundle exec rake db:migrate

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -167,14 +167,13 @@ module CreneauxSearch::Calculator
       end
 
       def absence_out_of_range?(absence, range)
-        start_date_time = absence.starts_at
-        end_date_time = absence.ends_at
-
-        end_date_time < range.begin || range.end < start_date_time
+        absence.ends_at < range.begin || range.end < absence.starts_at
       end
 
       def busy_times_from_off_days(date_range)
-        OffDays.all_in_date_range(date_range).map { |off_day| BusyTime.new(off_day.beginning_of_day, off_day.end_of_day) }
+        OffDays.all_in_date_range(date_range).map do |off_day|
+          BusyTime.new(off_day.beginning_of_day, off_day.end_of_day)
+        end
       end
     end
   end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -14,7 +14,7 @@ module CreneauxSearch::Calculator
       scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
-        .includes(%i[organisation agent])
+        .includes(:agent)
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?
       scope

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,5 +74,8 @@ module Lapin
     config.x.rack_attack.limit = 50
 
     config.exceptions_app = routes # Permet les pages d'erreur custom
+
+    config.active_record.async_query_executor = :global_thread_pool
+    config.active_record.global_executor_concurrency = 4 # update the pool size in database.yml if you change this
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,9 +25,9 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   # And also GoodJob doc: https://github.com/bensheldon/good_job#database-connections
-  # For web containers, pool size is puma's default number of threads.
+  # For web containers, pool size is puma's default number of threads, plus the number of threads defined by global_executor_concurrency
   # For GoodJob container, pool size is GOOD_JOB_MAX_THREADS (5) + 3 (1 for LISTEN/NOTIFY, 2 for CRON)
-  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : ENV.fetch("RAILS_MAX_THREADS", 5).to_i %>
+  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : (ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 4) %>
 
 development:
   <<: *default

--- a/spec/models/active_record_configuration_spec.rb
+++ b/spec/models/active_record_configuration_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "ActiveRecord configuration" do
+RSpec.describe "ActiveRecord configuration" do # rubocop:disable RSpec/DescribeClass
   it "has enough connections" do
     # voir https://guides.rubyonrails.org/configuring.html#config-active-record-global-executor-concurrency
     pool_size = ActiveRecord::Base.connection.pool.stat[:size]

--- a/spec/models/active_record_configuration_spec.rb
+++ b/spec/models/active_record_configuration_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe "ActiveRecord configuration" do
+  it "has enough connections" do
+    # voir https://guides.rubyonrails.org/configuring.html#config-active-record-global-executor-concurrency
+    pool_size = ActiveRecord::Base.connection.pool.stat[:size]
+    expect(pool_size).to eq(ENV.fetch("RAILS_MAX_THREADS", 5) + Rails.configuration.active_record.global_executor_concurrency)
+  end
+end


### PR DESCRIPTION
# Contexte

Cette PR continue https://github.com/betagouv/rdv-service-public/pull/4693

# Solution
Voici à quoi ressemble le récap skylight pour un calcul de créneaux :

<img width="1400" alt="Screenshot 2024-10-10 at 11 36 57" src="https://github.com/user-attachments/assets/51bcbe60-cd90-420b-88cf-6dcbf2c38562">

Il semble donc qu'on pourrait gagner du temps en parallélisant le chargement des absences et des rdvs lors de la génération des busy times.

Voir ce très bon article de skylight sur load_async https://blog.skylight.io/rails-7-load_async/ et aussi cet article qui parle des dangers de load_async : https://pawelurbanek.com/rails-load-async


J'ai aussi réfléchi à d'autres approches pour utiliser load_async dans ce contexte, mais elles sont moins pratiques à mettre en oeuvre :
- générer tous les busy times de manière asynchrone dans `calculate_free_times` avant de faire tous les appels à `split_range_recursively` : ça risquerait de faire trop d'appels en parallèles et de surcharger la db
- preloader les busy times d'un range pendant qu'on fait le `split_range_recursively` du range suivant : possible, mais assez complexe à écrire. Ça ne marche pas avec des pluck (qu'on utilise pour les rdv), mais c'est pas trop grave.

