### PR TITLE
Correction des redirection vers des referer externes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,4 +107,18 @@ class ApplicationController < ActionController::Base
   def page_number
     params[:page].presence&.to_i || 1
   end
+
+  def redirect_to_internal_referer_or(path)
+    if request.referer
+      internal_referer = Domain::ALL.map(&:host_name).any? do |hostname|
+        URI(request.referer).host == hostname
+      end
+
+      if internal_referer
+        redirect_to(request.referer) and return
+      end
+    end
+
+    redirect_to(path)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,18 +107,4 @@ class ApplicationController < ActionController::Base
   def page_number
     params[:page].presence&.to_i || 1
   end
-
-  def redirect_to_internal_referer_or(path)
-    if request.referer
-      internal_referer = Domain::ALL.map(&:host_name).any? do |hostname|
-        URI(request.referer).host == hostname
-      end
-
-      if internal_referer
-        redirect_to(request.referer) and return
-      end
-    end
-
-    redirect_to(path)
-  end
 end

--- a/app/controllers/concerns/admin/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/admin/authenticated_controller_concern.rb
@@ -31,7 +31,6 @@ module Admin::AuthenticatedControllerConcern
   def agent_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
     flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
-
-    redirect_to_internal_referer_or(authenticated_agent_root_path)
+    redirect_to authenticated_agent_root_path
   end
 end

--- a/app/controllers/concerns/admin/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/admin/authenticated_controller_concern.rb
@@ -31,6 +31,7 @@ module Admin::AuthenticatedControllerConcern
   def agent_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
     flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
-    redirect_to(request.referer || authenticated_agent_root_path)
+
+    redirect_to_internal_referer_or(authenticated_agent_root_path)
   end
 end

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -28,7 +28,7 @@ class UserAuthController < ApplicationController
   def user_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
     flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
-    redirect_to(request.referer || authenticated_user_root_path)
+    redirect_to_internal_referer_or(authenticated_user_root_path)
   end
 
   def authenticated_user_root_path

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -28,7 +28,7 @@ class UserAuthController < ApplicationController
   def user_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
     flash[:error] = t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default
-    redirect_to_internal_referer_or(authenticated_user_root_path)
+    redirect_to authenticated_user_root_path
   end
 
   def authenticated_user_root_path


### PR DESCRIPTION
# Contexte

On a des erreurs de type ActionController::Redirecting::UnsafeRedirectError quand on essaye de rediriger des utilisateurs vers un referer externe suite à une tentative d'accès à une page qu'ils ne peuvent pas voir.
Typiquement, ça arrive si quelqu'un envoie par mail un lien vers une page auquelle le destinataire n'a pas accès, ou si dans un pad partagé il y a un lien vers une page à laquelle on ne peut pas accéder (c'est d'ailleurs une bonne manière de reproduire le bug).

# Solution

La première solution que j'avais en tête était de vérifier si le referer est interne ou non (si c'est un lien de notre appli ou non), et de faire la redirection en fonction de ça (voir le premier commit).

Mais cette approche pose problème : si on redirige vers le referer qui est une page de notre appli, ça veut dire qu'on a des liens dans l'appli qui ne devraient pas s'afficher (on ne devrait proposer que des liens qui sont clicables).
Ça ne semble pas être une bonne idée d'ajouter du code pour gérer ce cas qui ne devrait pas exister.

Le seul autre cas où un lien interne de notre application pourrait aboutir à ce genre d'erreur est si l'utilisateur a changé de compte entre le chargement de la page et le clic sur le lien.
Dans ce cas, ça semble aussi être une mauvaise idée de rediriger vers le referer, parce que le deuxième compte n'y aura pas forcément accès.

Au final, la solution la plus simple semble être de toujours rediriger vers la page d'accueil si on essaye d'accéder à une page qu'on n'a pas le droit de voir, d'où le deuxième commit.

