### PR TITLE
MàJ de SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,3 @@
-[Cf docs/0-docs.md#Security Policy](docs/0-docs.md#Security Policy)
+Please [contact us](mailto:contact@rdv-solidarites.fr) to report any security vulnerability.
+
+Thank you!

--- a/docs/0-docs.md
+++ b/docs/0-docs.md
@@ -21,18 +21,7 @@
   - [l'instance `production-rdv-mairie`](https://updown.io/hv6l)
   - [l'instance `demo-rdv-solidarites`](https://updown.io/0jrc)
 
-## Security Policy
-
-### Supported Versions
-
-We try to keep up with the latest versions of all our dependencies, as much as possible.
-
-### Reporting a Vulnerability
-
-Please [contact us](mailto:contact@rdv-solidarites.fr) to report any vulnerability. Thank you!
-
 ## Développement
 
 - [Installation](1-installation.md)
 - [Contribuer](2-contributions.md)
-

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:support-incubateur@anct.gouv.fr
+Contact: mailto:contact@rdv-solidarites.fr
 Policy: https://incubateur.anct.gouv.fr/security-policy
 Preferred-Languages: fr, en
 Expires: 2023-12-01T00:00:00.000Z


### PR DESCRIPTION
## Contexte

On se prépare pour l’homologation de sécurité

## Problème

Le fichier SECURITY.md contient un lien relatif pas très pratique.

Le fichier docs/0-docs.md contient une info qui n’est plus notre stratégie actuelle : 

>  We try to keep up with the latest versions of all our dependencies, as much as possible.

## Solution

- supprimer l’info fausse sur la MàJ des dépendances
- Inliner les informations de contact dans SECURITY.md