### PR TITLE
Mise en place d'une staging et endpoint de réinitialisation de visioplainte

### DIFF
--- a/app/controllers/api/visioplainte/base_controller.rb
+++ b/app/controllers/api/visioplainte/base_controller.rb
@@ -21,4 +21,28 @@ class Api::Visioplainte::BaseController < ActionController::Base # rubocop:disab
       )
     end
   end
+
+  def reset
+    # On met plusieurs guard clauses de sécurité pour s'assurer qu'on ne peut appeler cette méthode destructive que sur la staging
+    return unless ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"
+    return unless ENV["VISIOPLAINTE_API_KEY"].start_with?("visioplainte-staging-api-key-")
+    return unless ENV["FRANCECONNECT_HOST"] == "fcp.integ01.dev-franceconnect.fr"
+
+    territory = Territory.find_by(name: Territory::VISIOPLAINTE_NAME)
+
+    territory.organisations.find_each do |organisation|
+      organisation.plage_ouvertures.delete_all
+      organisation.rdvs.destroy_all
+      organisation.user_profiles.destroy_all
+      organisation.agents.find_each do |a|
+        a.rdvs.delete_all
+        a.roles.delete_all
+        a.destroy!
+      end
+    end
+    territory.destroy! # Ce destroy fera les suppressions restantes en cascade via des dependent: :destroy
+
+    load Rails.root.join("db/seeds/visioplainte.rb")
+    head :ok
+  end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -107,6 +107,12 @@ class Domain
         # Les review apps utilisent un domaine de Scalingo, elles
         # ne permettent donc pas d'utiliser plusieurs domaines.
         URI.parse(ENV.fetch("HOST", nil)).host
+      elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"
+        {
+          RDV_SOLIDARITES => "staging.rdv-solidarites.fr",
+          RDV_AIDE_NUMERIQUE => "staging.rdv-aide-numerique.fr",
+          RDV_MAIRIE => "staging.rdv-service-public.fr",
+        }.fetch(self)
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
         {
           RDV_SOLIDARITES => "demo.rdv-solidarites.fr",

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -54,6 +54,11 @@ namespace :api do
         put :cancel
       end
     end
+
+    # Une route pour réinitialiser les données en staging
+    if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"
+      post :reset, to: "base#reset"
+    end
   end
 end
 

--- a/db/seeds/visioplainte.rb
+++ b/db/seeds/visioplainte.rb
@@ -2,7 +2,7 @@ territory = Territory.create(name: "placeholder")
 
 territory.update_columns(name: Territory::VISIOPLAINTE_NAME) # rubocop:disable Rails/SkipsModelValidations
 
-service_gendarmerie = Service.create!(name: "Gendarmerie Nationale", short_name: "Gendarmerie")
+service_gendarmerie = Service.find_or_create_by!(name: "Gendarmerie Nationale", short_name: "Gendarmerie")
 
 territory.services << service_gendarmerie
 
@@ -23,10 +23,10 @@ Motif.create!(
 )
 
 superviseur_gendarmerie = Agent.new(
-  first_name: "Gaston",
-  last_name: "Bidon",
-  email: "gaston.bidon@visioplainte.sandbox.gouv.fr",
-  uid: "gaston.bidon@visioplainte.sandbox.gouv.fr",
+  first_name: "Superviseur",
+  last_name: "Fictif",
+  email: "superviseur.fictif@staging.rdv-service-public.fr",
+  uid: "superviseur.fictif@staging.rdv-service-public.fr",
   password: "Rdvservicepublictest1!",
   services: [service_gendarmerie],
   roles_attributes: [
@@ -37,18 +37,12 @@ superviseur_gendarmerie.skip_confirmation!
 superviseur_gendarmerie.save!
 AgentTerritorialAccessRight.create(agent: superviseur_gendarmerie, territory: territory)
 
-Agent.create!(
-  last_name: "Guichet 1",
-  services: [service_gendarmerie],
-  roles_attributes: [
-    { organisation: orga_gendarmerie, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
-  ]
-)
-
-Agent.create!(
-  last_name: "Guichet 2",
-  services: [service_gendarmerie],
-  roles_attributes: [
-    { organisation: orga_gendarmerie, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
-  ]
-)
+30.times do |i|
+  Agent.create!(
+    last_name: "Guichet #{i}",
+    services: [service_gendarmerie],
+    roles_attributes: [
+      { organisation: orga_gendarmerie, access_level: AgentRole::ACCESS_LEVEL_INTERVENANT },
+    ]
+  )
+end

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,6 @@
+# Staging
+
+
+L'environnement de staging permet de fournir un environnement stable pour les tests des partenaires externes avant de mettre en ligne en démo.
+Il est utile notamment pour les tests qui nécessitent de réinitialiser les données, ce qui est généralement difficile à faire sur la démo, puisqu'elle est utilisée avec des données durable pour les démo de formation de certains départements.
+Cet environnement est sur l'application Scalingo `staging-rdv-service-public`

--- a/spec/requests/api/visioplainte/guichets_spec.rb
+++ b/spec/requests/api/visioplainte/guichets_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Visioplainte Guichets" do
     get "/api/visioplainte/guichets", headers: auth_header
     parsed_response_body = response.parsed_body.deep_symbolize_keys
 
-    expect(parsed_response_body[:guichets]).to contain_exactly(
+    expect(parsed_response_body[:guichets]).to include(
       {
         id: anything, name: "GUICHET 1",
       },

--- a/spec/requests/api/visioplainte/reset_spec.rb
+++ b/spec/requests/api/visioplainte/reset_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe "Réinitialisation des données (voir l'intro de la doc Swagger)" do
+  before do
+    travel_to Time.zone.local(2024, 8, 18, 14, 0, 0)
+    load Rails.root.join("db/seeds/visioplainte.rb")
+  end
+
+  let(:guichet) { Agent.find_by(last_name: "Guichet 1") }
+  let(:orga_gendarmerie) { guichet.organisations.last }
+
+  let!(:rdv) { create(:rdv, organisation: orga_gendarmerie, motif: orga_gendarmerie.motifs.last, agents: [guichet]) }
+
+  context "in a non-staging environnement" do
+    include_context "Visioplainte Auth"
+
+    it "doesn't even have the route" do
+      expect do
+        post "/api/visioplainte/reset", headers: auth_header
+      end.to raise_error(ActionController::RoutingError)
+
+      expect(rdv.reload).to be_present
+    end
+  end
+
+  context "in a staging environnement" do
+    stub_env_with(
+      VISIOPLAINTE_API_KEY: "visioplainte-staging-api-key-123456",
+      FRANCECONNECT_HOST: "fcp.integ01.dev-franceconnect.fr"
+    )
+
+    around do |example|
+      with_modified_env(RDV_SOLIDARITES_INSTANCE_NAME: "STAGING") do
+        Rails.application.reload_routes!
+        example.run
+      end
+      Rails.application.reload_routes!
+    end
+
+    context "without authentication" do
+      it "returns an error and doesn't delete any data" do
+        post "/api/visioplainte/reset", headers: []
+        expect(response.status).to eq 401
+        expect(rdv.reload).to be_present
+      end
+    end
+
+    context "with authentication and the proper variables" do
+      stub_env_with(
+        VISIOPLAINTE_API_KEY: "visioplainte-staging-api-key-123456",
+        FRANCECONNECT_HOST: "fcp.integ01.dev-franceconnect.fr"
+      )
+
+      let(:auth_header) do
+        { "X-VISIOPLAINTE-API-KEY": "visioplainte-staging-api-key-123456" }
+      end
+
+      it "resets the data" do
+        post "/api/visioplainte/reset", headers: auth_header
+        expect(response.status).to eq 200
+        expect(Rdv.last).to be_blank
+        new_organisation = Organisation.find_by(name: "Plateforme Visioplainte Gendarmerie")
+        expect(new_organisation.agents.count).to eq 31
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -27,6 +27,17 @@ RSpec.configure do |config|
           ```
           curl --request GET --url "https://demo.rdv.anct.gouv.fr/api/visioplainte/creneaux" --header "X-VISIOPLAINTE-API-KEY: LA_CLE_D_API"
           ```
+
+          # Réinitialisation des données sur l'environnement de staging
+
+          La staging de RDV Service Public a vocation à être utilisée par l'environnement de qualification du téléservice Visioplainte.
+          Afin de faciliter les tests sur l'environnement de staging, un endpoint permet de réinitialiser les données.
+          Cet endpoint n'est disponible qu'en staging, pas en production, ni en démo, ni en local.
+
+          Cet appel ce fait avec un POST sur le path /api/visioplainte/reset, par exemple :
+          ```
+          curl -X POST --url "https://staging.rdv-service-public.fr/api/visioplainte/reset" --header "X-VISIOPLAINTE-API-KEY: LA_CLE_D_API"
+          ```
         MARKDOWN
       },
     },

--- a/swagger/visioplainte/api.json
+++ b/swagger/visioplainte/api.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "API RDV Service Public pour Visioplainte",
     "version": "v1",
-    "description": "# Authentification\n\nL'authentification à l'api se fait en passant la clé d'api dans le header `X-VISIOPLAINTE-API-KEY`.\n\nPar exemple:\n```\ncurl --request GET --url \"https://demo.rdv.anct.gouv.fr/api/visioplainte/creneaux\" --header \"X-VISIOPLAINTE-API-KEY: LA_CLE_D_API\"\n```\n"
+    "description": "# Authentification\n\nL'authentification à l'api se fait en passant la clé d'api dans le header `X-VISIOPLAINTE-API-KEY`.\n\nPar exemple:\n```\ncurl --request GET --url \"https://demo.rdv.anct.gouv.fr/api/visioplainte/creneaux\" --header \"X-VISIOPLAINTE-API-KEY: LA_CLE_D_API\"\n```\n\n# Réinitialisation des données sur l'environnement de staging\n\nLa staging de RDV Service Public a vocation à être utilisée par l'environnement de qualification du téléservice Visioplainte.\nAfin de faciliter les tests sur l'environnement de staging, un endpoint permet de réinitialiser les données.\nCet endpoint n'est disponible qu'en staging, pas en production, ni en démo, ni en local.\n\nCet appel ce fait avec un POST sur le path /api/visioplainte/reset, par exemple :\n```\ncurl -X POST --url \"https://staging.rdv-service-public.fr/api/visioplainte/reset\" --header \"X-VISIOPLAINTE-API-KEY: LA_CLE_D_API\"\n```\n"
   },
   "paths": {
     "/api/visioplainte/creneaux": {
@@ -548,12 +548,124 @@
                     "value": {
                       "guichets": [
                         {
-                          "id": 90,
+                          "id": 998,
+                          "name": "GUICHET 0"
+                        },
+                        {
+                          "id": 999,
                           "name": "GUICHET 1"
                         },
                         {
-                          "id": 91,
+                          "id": 1000,
                           "name": "GUICHET 2"
+                        },
+                        {
+                          "id": 1001,
+                          "name": "GUICHET 3"
+                        },
+                        {
+                          "id": 1002,
+                          "name": "GUICHET 4"
+                        },
+                        {
+                          "id": 1003,
+                          "name": "GUICHET 5"
+                        },
+                        {
+                          "id": 1004,
+                          "name": "GUICHET 6"
+                        },
+                        {
+                          "id": 1005,
+                          "name": "GUICHET 7"
+                        },
+                        {
+                          "id": 1006,
+                          "name": "GUICHET 8"
+                        },
+                        {
+                          "id": 1007,
+                          "name": "GUICHET 9"
+                        },
+                        {
+                          "id": 1008,
+                          "name": "GUICHET 10"
+                        },
+                        {
+                          "id": 1009,
+                          "name": "GUICHET 11"
+                        },
+                        {
+                          "id": 1010,
+                          "name": "GUICHET 12"
+                        },
+                        {
+                          "id": 1011,
+                          "name": "GUICHET 13"
+                        },
+                        {
+                          "id": 1012,
+                          "name": "GUICHET 14"
+                        },
+                        {
+                          "id": 1013,
+                          "name": "GUICHET 15"
+                        },
+                        {
+                          "id": 1014,
+                          "name": "GUICHET 16"
+                        },
+                        {
+                          "id": 1015,
+                          "name": "GUICHET 17"
+                        },
+                        {
+                          "id": 1016,
+                          "name": "GUICHET 18"
+                        },
+                        {
+                          "id": 1017,
+                          "name": "GUICHET 19"
+                        },
+                        {
+                          "id": 1018,
+                          "name": "GUICHET 20"
+                        },
+                        {
+                          "id": 1019,
+                          "name": "GUICHET 21"
+                        },
+                        {
+                          "id": 1020,
+                          "name": "GUICHET 22"
+                        },
+                        {
+                          "id": 1021,
+                          "name": "GUICHET 23"
+                        },
+                        {
+                          "id": 1022,
+                          "name": "GUICHET 24"
+                        },
+                        {
+                          "id": 1023,
+                          "name": "GUICHET 25"
+                        },
+                        {
+                          "id": 1024,
+                          "name": "GUICHET 26"
+                        },
+                        {
+                          "id": 1025,
+                          "name": "GUICHET 27"
+                        },
+                        {
+                          "id": 1026,
+                          "name": "GUICHET 28"
+                        },
+                        {
+                          "id": 1027,
+                          "name": "GUICHET 29"
                         }
                       ]
                     }
@@ -632,31 +744,31 @@
                           "id": 28,
                           "starts_at": "2024-08-19T09:00:00+02:00",
                           "ends_at": "2024-08-19T12:00:00+02:00",
-                          "guichet_id": 94
+                          "guichet_id": 1058
                         },
                         {
                           "id": 28,
                           "starts_at": "2024-08-20T09:00:00+02:00",
                           "ends_at": "2024-08-20T12:00:00+02:00",
-                          "guichet_id": 94
+                          "guichet_id": 1058
                         },
                         {
                           "id": 28,
                           "starts_at": "2024-08-21T09:00:00+02:00",
                           "ends_at": "2024-08-21T12:00:00+02:00",
-                          "guichet_id": 94
+                          "guichet_id": 1058
                         },
                         {
                           "id": 28,
                           "starts_at": "2024-08-22T09:00:00+02:00",
                           "ends_at": "2024-08-22T12:00:00+02:00",
-                          "guichet_id": 94
+                          "guichet_id": 1058
                         },
                         {
                           "id": 28,
                           "starts_at": "2024-08-23T09:00:00+02:00",
                           "ends_at": "2024-08-23T12:00:00+02:00",
-                          "guichet_id": 94
+                          "guichet_id": 1058
                         }
                       ]
                     }
@@ -794,17 +906,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 14,
+                      "id": 17,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 98,
-                        "name": "Gaston BIDON"
+                        "id": 1090,
+                        "name": "Superviseur FICTIF"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "unknown",
-                      "user_id": 15
+                      "user_id": 18
                     }
                   }
                 },
@@ -980,17 +1092,17 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "id": 16,
+                      "id": 19,
                       "created_at": "2024-08-18 14:00:00 +0200",
                       "duration_in_min": 30,
                       "ends_at": "2024-08-19 08:30:00 +0200",
                       "guichet": {
-                        "id": 107,
-                        "name": "Gaston BIDON"
+                        "id": 1183,
+                        "name": "Superviseur FICTIF"
                       },
                       "starts_at": "2024-08-19 08:00:00 +0200",
                       "status": "excused",
-                      "user_id": 17
+                      "user_id": 20
                     }
                   }
                 },


### PR DESCRIPTION
# Contexte

Dans le cadre de l'intégration avec Visioplainte, l'équipe de Sensiolabs a besoin d'un environnement pour que "la MOA puisse faire des tests fonctionnels", c'est à dire que leur équipe produit puisse tester l'appli.
C'est ce qu'ils appellent l'environnement de "qualif" dans leur vocabulaire.

Ils ont donc besoin d'un environnement sur lequel ils peuvent tester plein de scénarios (et créer plein de plages d'ouvertures et de rdv), et ensuite réinitialiser cet environnement à la demande pour faire encore d'autres tests (de manière similaire à ce qu'on ferait sur une review app sur laquelle ou ferait beaucoup de tests successifs).

Ils ne peuvent pas vraiment utiliser notre démo, puisqu'ils s'en serviront pour brancher leur environnement de préprod, sur lequel ils ne font pas de réinitialisation des données (ce qui correspond bien à notre démo).

Ils ont besoin d'une url stable pour pouvoir faire une demande d'ouverture de leur firewall vers ce nom de domaine, ça sera donc [staging.rdv-service-public.fr](url).

# Solution

Cette PR propose donc un premier commit pour pouvoir utiliser une nouvelle appli scalingo comme environnement de staging, et un deuxième commit pour proposer un endpoint de réinitialisation de cette staging pour visioplainte.

