### PR TITLE
[WIP] Extraire la logique de sérialisation du concern ANTS

### DIFF
--- a/app/models/concerns/ants/appointment_listener.rb
+++ b/app/models/concerns/ants/appointment_listener.rb
@@ -1,5 +1,5 @@
 module Ants
-  module AppointmentSerializerAndListener
+  module AppointmentListener
     extend ActiveSupport::Concern
 
     ATTRIBUTES_TO_WATCH = %w[id status starts_at lieu_id].freeze
@@ -8,29 +8,29 @@ module Ants
       attr_accessor :needs_sync_to_ants, :obsolete_application_id
 
       Rdv.before_commit do |rdv|
-        Ants::AppointmentSerializerAndListener.mark_for_sync([rdv]) if rdv.watching_attributes_for_ants_api_changed?
+        Ants::AppointmentListener.mark_for_sync([rdv]) if rdv.watching_attributes_for_ants_api_changed?
       end
       User.before_commit do |user|
-        Ants::AppointmentSerializerAndListener.mark_for_sync(user.rdvs) if user.saved_change_to_ants_pre_demande_number?
+        Ants::AppointmentListener.mark_for_sync(user.rdvs) if user.saved_change_to_ants_pre_demande_number?
       end
       Participation.before_commit do |participation|
-        Ants::AppointmentSerializerAndListener.mark_for_sync([participation.rdv], obsolete_application_id: participation.user.ants_pre_demande_number)
+        Ants::AppointmentListener.mark_for_sync([participation.rdv], obsolete_application_id: participation.user.ants_pre_demande_number)
       end
       Lieu.before_commit do |lieu|
-        Ants::AppointmentSerializerAndListener.mark_for_sync(lieu.rdvs) if lieu.saved_change_to_name?
+        Ants::AppointmentListener.mark_for_sync(lieu.rdvs) if lieu.saved_change_to_name?
       end
 
       Rdv.after_commit do |rdv|
-        Ants::AppointmentSerializerAndListener.enqueue_sync_for_marked_record([rdv]) if rdv.watching_attributes_for_ants_api_changed?
+        Ants::AppointmentListener.enqueue_sync_for_marked_record([rdv]) if rdv.watching_attributes_for_ants_api_changed?
       end
       User.after_commit do |user|
-        Ants::AppointmentSerializerAndListener.enqueue_sync_for_marked_record(user.rdvs) if user.saved_change_to_ants_pre_demande_number?
+        Ants::AppointmentListener.enqueue_sync_for_marked_record(user.rdvs) if user.saved_change_to_ants_pre_demande_number?
       end
       Participation.after_commit do |participation|
-        Ants::AppointmentSerializerAndListener.enqueue_sync_for_marked_record([participation.rdv])
+        Ants::AppointmentListener.enqueue_sync_for_marked_record([participation.rdv])
       end
       Lieu.after_commit do |lieu|
-        Ants::AppointmentSerializerAndListener.enqueue_sync_for_marked_record(lieu.rdvs) if lieu.saved_change_to_name?
+        Ants::AppointmentListener.enqueue_sync_for_marked_record(lieu.rdvs) if lieu.saved_change_to_name?
       end
     end
 

--- a/app/models/concerns/ants/appointment_listener.rb
+++ b/app/models/concerns/ants/appointment_listener.rb
@@ -34,15 +34,6 @@ module Ants
       end
     end
 
-    def serialize_for_ants_api
-      {
-        meeting_point_id: lieu.id.to_s,
-        meeting_point: lieu.name,
-        appointment_date: starts_at.strftime("%Y-%m-%d %H:%M:%S"),
-        management_url: Rails.application.routes.url_helpers.users_rdv_url(self, host: organisation.domain.host_name),
-      }
-    end
-
     def watching_attributes_for_ants_api_changed?
       saved_changes.keys & ATTRIBUTES_TO_WATCH
     end

--- a/app/models/concerns/ants/appointment_listener.rb
+++ b/app/models/concerns/ants/appointment_listener.rb
@@ -49,7 +49,7 @@ module Ants
 
     def self.enqueue_sync_for_marked_record(rdvs)
       rdvs.select(&:needs_sync_to_ants).each do |rdv|
-        Ants::SyncAppointmentJob.perform_later_for(rdv)
+        Ants::SyncAppointmentJob.perform_later_for(rdv, obsolete_application_id: rdv.obsolete_application_id)
         rdv.assign_attributes(needs_sync_to_ants: false)
       end
     end

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -12,7 +12,7 @@ class Rdv < ApplicationRecord
   include Rdv::UsingWaitingRoom
   include Rdv::HardcodedAttributeNamesConcern
   include IcsPayloads::Rdv
-  include Ants::AppointmentSerializerAndListener
+  include Ants::AppointmentListener
   include CreatedByConcern
 
   # Attributes
@@ -74,7 +74,7 @@ class Rdv < ApplicationRecord
   before_validation { self.uuid ||= SecureRandom.uuid }
   before_create :set_created_by_for_participations
   # voir Outlook::EventSerializerAndListener pour d'autres callbacks
-  # voir Ants::AppointmentSerializerAndListener pour d'autres callbacks
+  # voir Ants::AppointmentListener pour d'autres callbacks
 
   # Scopes
   scope :not_cancelled, -> { where(status: NOT_CANCELLED_STATUSES) }

--- a/spec/models/concerns/ants/appointment_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_listener_spec.rb
@@ -7,7 +7,7 @@
 # note : dans les stubs, Webmock reconnaît les requêtes qui ont des query params
 # uniquement si on passe explicitement un with(query: hash_including({...}))
 
-RSpec.describe Ants::AppointmentSerializerAndListener do
+RSpec.describe Ants::AppointmentListener do
   include_context "rdv_mairie_api_authentication"
 
   let(:api_url) { "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api" }


### PR DESCRIPTION
WIP : on a rediscuté avec Victor, je vais réadapter cette PR


> [!NOTE]
> Cette PR est nettement plus lisible commit par commit

# Contexte

PR de refacto extraite de #4663 pour clarifier cette dernière.

Le service `Ants::AppointmentSerializerAndListener` embarque actuellement un tout petit bout de logique de sérialisation qui n’est utilisé qu’à un endroit : le job de synchronisation.

Cela rajoute une indirection et donne deux responsabilité à ce concern.
De plus, il y a aussi une méthode `rdv_attributes` dans le job qui fait elle aussi de la sérialisation.

L’attribut `obsolete_application_id` est aujourd’hui passé comme un de ces `rdv_attributes`. C’est un peu perturbant car ce n’est pas un « vrai » attribut AR du RDV. C’est un attribut transitif qui sert uniquement au passage d’info entre les hooks `before_commit` et `after_commit`. 

# Solution

Pour simplifier et éviter l’indirection, je déplace la logique de sérialisation dans le job de synchro et je la réunis dans l’unique méthode `rdv_attributes`.

Je sors aussi l’`obsolete_application_id` de cette méthode `rdv_attributes`. 
Il est maintenant passé comme un argument propre du job. 
En effet si on le laissait dans la méthode il posait maintenant problème car il n’était plus passé correctement entre le concern et le job.
Pour info, je m’oriente vers une sortie de ce bout de code de suppression des applications obsolètes dans un autre job indépendant.

En revanche je ne touche pas à l’attribut virtuel `rdv.obsolete_application_id` utilisé pour passer l’info dans le concern pour l’instant.