### PR TITLE
Ne plus stocker les emails secondaires des cnfs

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -11,7 +11,7 @@ class CustomDeviseMailer < Devise::Mailer
     @user_params = opts[:user_params] || {}
     if record.is_a?(Agent) && record.conseiller_numerique? && record.invited_by.nil?
       opts[:subject] = "📧 Invitation sur RDV Aide Numérique"
-      opts[:cc] = record.cnfs_secondary_email if record.cnfs_secondary_email.present?
+      opts[:cc] = opts[:cnfs_secondary_email] if opts[:cnfs_secondary_email].present?
       devise_mail(record, :invitation_instructions_cnfs, opts)
     else
       opts[:reply_to] = record.invited_by&.email

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,6 +1,7 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
+  self.ignored_columns += [:cnfs_secondary_email]
   # Mixins
   has_paper_trail(
     only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at]

--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -52,14 +52,19 @@ class AddConseillerNumerique
 
   def invite_agent(organisation)
     Agent.invite!(
-      email: @conseiller_numerique.email,
-      cnfs_secondary_email: @conseiller_numerique.secondary_email,
-      first_name: @conseiller_numerique.first_name.capitalize,
-      last_name: @conseiller_numerique.last_name,
-      external_id: @conseiller_numerique.external_id,
-      services: [service],
-      password: SecureRandom.base64(32),
-      roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
+      {
+        email: @conseiller_numerique.email,
+        first_name: @conseiller_numerique.first_name.capitalize,
+        last_name: @conseiller_numerique.last_name,
+        external_id: @conseiller_numerique.external_id,
+        services: [service],
+        password: SecureRandom.base64(32),
+        roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
+      },
+      nil,
+      {
+        cnfs_secondary_email: @conseiller_numerique.secondary_email,
+      }
     ).tap do |agent|
       agent.agent_territorial_access_rights.find_or_create_by!(territory: territory)
     end

--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -70,8 +70,8 @@ class AddConseillerNumerique
         password: SecureRandom.base64(32),
         roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
       },
-      nil,
-      {
+      nil, # cet argument est le invited_by, qui n'a pas de sens dans ce contexte
+      { # ce troisième argument permet de passer des options au mailer Devise
         cnfs_secondary_email: @conseiller_numerique.secondary_email,
       }
     ).tap do |agent|

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe AddConseillerNumerique do
       expect(Agent.last).to have_attributes(
         external_id: "exemple@conseiller-numerique.fr",
         email: "exemple@conseiller-numerique.fr",
-        cnfs_secondary_email: "mail_perso@gemelle.com",
         first_name: "Camille",
         last_name: "Clavier"
       )

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -48,7 +48,11 @@ RSpec.describe AddConseillerNumerique do
       perform_enqueued_jobs
       invitation_email = ActionMailer::Base.deliveries.last
 
-      expect(invitation_email).to have_attributes(to: ["exemple@tierslieuxettransitions.fr"], from: ["support@rdv-aide-numerique.fr"])
+      expect(invitation_email).to have_attributes(
+        to: ["exemple@tierslieuxettransitions.fr"],
+        from: ["support@rdv-aide-numerique.fr"],
+        cc: ["mail_perso@gemelle.com"]
+      )
     end
   end
 


### PR DESCRIPTION
# Contexte

On est en train de changer les adresses mails auxquelles on envoie les invitations aux cnfs, et au passage j'ai vu qu'on pouvait se passer de persister l'adresse secondaire des cnfs.

On se sert de cette adresse secondaire pour la mettre en cc des mails d'invitations sur leur boîte professionnelle. Elle est donc utile uniquement au moment de l'invitation, et il n'y a pas de raison de la persister

# Solution

Je pense qu'à l'époque on connaissait moins bien l'interface de la méthode `#invite!`. Les évènements de cet été m'ont amené à la lire de plus près, et on peut donc utiliser sa forme avec trois arguements : le deuxième argument est un `invited_by` qui reste nil, et le troisième sont les options qu'on utilise dans le mailer.

Une prochaine Pr viendra supprimer la colonne avec une safe migration.

