### PR TITLE
Changement des adresses mails des cnfs

### DIFF
--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -2,7 +2,7 @@ class AddConseillerNumerique
   class ConseillerNumerique
     include ActiveModel::Model
 
-    attr_accessor :email, :first_name, :last_name, :external_id, :secondary_email
+    attr_accessor :email, :first_name, :last_name, :external_id, :secondary_email, :old_email
   end
 
   class Structure
@@ -44,6 +44,15 @@ class AddConseillerNumerique
         Rails.logger.info("#{@conseiller_numerique.email} existe déjà mais semble avoir changé d'organisation. Ajoutons-le dans #{organisation.name}")
         existing_agent.roles.create!(organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
       end
+
+      # supprimer cette mise à jour une fois que tous les agents ont confirmé leur changement d'email
+      agent_with_old_email = Agent.active.find_by(
+        external_id: @conseiller_numerique.external_id,
+        email: @conseiller_numerique.old_email,
+        unconfirmed_email: nil
+      )
+
+      agent_with_old_email&.update(email: @conseiller_numerique.email)
     else
       Rails.logger.info "Invitation de #{@conseiller_numerique.email}..."
       invite_agent(organisation)

--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -21,6 +21,7 @@ conseillers_numeriques.each do |conseiller_numerique|
       external_id: external_id,
       email: conseiller_numerique["email professionnel secondaire"],
       secondary_email: conseiller_numerique["email"],
+      old_email: conseiller_numerique["email professionnel"],
       first_name: conseiller_numerique["prenom"],
       last_name: conseiller_numerique["nom"],
       structure: {

--- a/scripts/import_conseillers_numeriques.rb
+++ b/scripts/import_conseillers_numeriques.rb
@@ -9,7 +9,7 @@ require "csv"
 conseillers_numeriques = CSV.read("/tmp/uploads/embauches.csv", headers: true, col_sep: ";", liberal_parsing: true)
 
 conseillers_numeriques.each do |conseiller_numerique|
-  next if conseiller_numerique["email professionnel"].blank? || conseiller_numerique["Compte activé"]&.strip != "oui"
+  next if conseiller_numerique["email professionnel secondaire"].blank? || conseiller_numerique["Compte activé"]&.strip != "oui"
 
   external_id = "conseiller-numerique-#{conseiller_numerique['ID conseiller']}"
 
@@ -19,7 +19,7 @@ conseillers_numeriques.each do |conseiller_numerique|
   Sentry.with_scope do |scope|
     processed_params = {
       external_id: external_id,
-      email: conseiller_numerique["email professionnel"],
+      email: conseiller_numerique["email professionnel secondaire"],
       secondary_email: conseiller_numerique["email"],
       first_name: conseiller_numerique["prenom"],
       last_name: conseiller_numerique["nom"],

--- a/spec/services/add_conseiller_numerique_spec.rb
+++ b/spec/services/add_conseiller_numerique_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe AddConseillerNumerique do
   let!(:territory) { create(:territory, :conseillers_numeriques) }
   let(:params) do
     {
-      external_id: "exemple@conseiller-numerique.fr",
-      email: "exemple@conseiller-numerique.fr",
+      external_id: "conseiller-numerique-123456",
+      email: "exemple@tierslieuxettransitions.fr",
       secondary_email: "mail_perso@gemelle.com",
       first_name: "Camille",
       last_name: "Clavier",
@@ -28,8 +28,8 @@ RSpec.describe AddConseillerNumerique do
       described_class.process!(params)
       expect(Agent.count).to eq 1
       expect(Agent.last).to have_attributes(
-        external_id: "exemple@conseiller-numerique.fr",
-        email: "exemple@conseiller-numerique.fr",
+        external_id: "conseiller-numerique-123456",
+        email: "exemple@tierslieuxettransitions.fr",
         cnfs_secondary_email: "mail_perso@gemelle.com",
         first_name: "Camille",
         last_name: "Clavier"
@@ -48,14 +48,14 @@ RSpec.describe AddConseillerNumerique do
       perform_enqueued_jobs
       invitation_email = ActionMailer::Base.deliveries.last
 
-      expect(invitation_email).to have_attributes(to: ["exemple@conseiller-numerique.fr"], from: ["support@rdv-aide-numerique.fr"])
+      expect(invitation_email).to have_attributes(to: ["exemple@tierslieuxettransitions.fr"], from: ["support@rdv-aide-numerique.fr"])
     end
   end
 
   describe "special cases for the agent" do
     context "when the conseiller numerique has already been imported" do
       context "and they still exists with the same email" do
-        before { create(:agent, external_id: "exemple@conseiller-numerique.fr") }
+        before { create(:agent, external_id: "conseiller-numerique-123456") }
 
         it "does nothing" do
           expect { described_class.process!(params) }.not_to change { [Agent.count, Agent.maximum(:updated_at)] }
@@ -69,8 +69,8 @@ RSpec.describe AddConseillerNumerique do
           described_class.process!(params)
           expect(Agent.count).to eq 2
           expect(Agent.last).to have_attributes(
-            external_id: "exemple@conseiller-numerique.fr",
-            email: "exemple@conseiller-numerique.fr",
+            external_id: "conseiller-numerique-123456",
+            email: "exemple@tierslieuxettransitions.fr",
             first_name: "Camille",
             last_name: "Clavier"
           )
@@ -87,7 +87,7 @@ RSpec.describe AddConseillerNumerique do
 
       context "and their organisation's external_id changed" do
         let!(:old_organisation) { create(:organisation, external_id: "019283") } # this ID is not the provided one
-        let!(:agent) { create(:agent, external_id: "exemple@conseiller-numerique.fr", admin_role_in_organisations: [old_organisation]) }
+        let!(:agent) { create(:agent, external_id: "conseiller-numerique-123456", admin_role_in_organisations: [old_organisation]) }
 
         it "adds the agent to the new org" do
           expect(agent.organisations).to eq([old_organisation])


### PR DESCRIPTION
# Contexte

Voir https://www.notion.so/rdvs/Continuer-de-proposer-RDV-Aide-Num-rique-aux-Conums-ff7a5362cb6b43d09edcfd29930a2244

Le 15 novembre prochain, tous les cnfs perderont accès à leur boîte mail en `@conseiller-numerique.fr`. La bonne nouvelle c'est que l'espace coop nous donne quand même leur adresse mail professionnelle primaire fournie par leur structure

Il faut donc qu'on prenne deux actions :
- les nouveaux cnfs doivent être invités sur leur  adresse mail professionnelle (et pas sur celle en `@conseiller-numerique.fr`)
- on doit mettre à jour les adresses mails des cnfs existants

# Solution

Les deux commis de cette PR font ces deux actions


