### PR TITLE
ajouter du contexte Sentry lors des erreurs dans CanHaveRdvWizardContext

### DIFF
--- a/app/controllers/concerns/can_have_rdv_wizard_context.rb
+++ b/app/controllers/concerns/can_have_rdv_wizard_context.rb
@@ -22,7 +22,10 @@ module CanHaveRdvWizardContext
     end
 
     @rdv_wizard = rdv_wizard
-  rescue StandardError => e
+  rescue ArgumentError => e
+    # on a des erreurs sur la recherche de créneau et j’aimerais avoir plus de contexte pour comprendre ce qui se passe
+    # https://sentry.incubateur.net/organizations/betagouv/issues/108784
+    Sentry.set_context(:rdv_wizard_context, { user_return_to: session[:user_return_to] })
     Sentry.capture_exception(e)
   end
 end


### PR DESCRIPTION
# Contexte

Des erreurs (invisibles pour les usagers) se produisent sur la page de sign_in lorsque la session contient une URL de retour post-sign-in qui commence par `/users/rdv_wizard_step/new` mais ne contient pas de param `departement`. 

On manque de contexte actuellement pour comprendre quelles sont ces urls et pourquoi ne contiennent elles pas ce département

# Solution

Je rajoute du contexte sentry pour logger ces `session[:user_return_to]` 

J’ai aussi dégénérisé le `rescue StandardError`  en `rescue ArgumentError` car ça semble être la seule erreur qui se produit et ça me paraissait un peu dangereux de tout catcher.
