### PR TITLE
Correction de crash suite à #4709

### DIFF
--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,4 +1,8 @@
-- in_scope = Agent::PlageOuverturePolicy::Scope.new(current_agent, model.overlapping_plages_ouvertures).resolve
+ruby:
+    in_scope = Agent::PlageOuverturePolicy::Scope
+    .new(current_agent, model.overlapping_plages_ouvertures)
+    .resolve
+    .merge(model.overlapping_plages_ouvertures)
 
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1


### PR DESCRIPTION
`model.overlapping_plages_ouvertures` est parfois un array, parfois une `ActiveRecord::Relation`, et en utilisant `merge`, ça fonctionne pour les deux cas.