### PR TITLE
Oubli de #4685 : réparer la self-suppression usager

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def destroy
-    authorize([:user, resource])
+    authorize(resource, policy_class: User::UserPolicy)
     # users from rdv-insertion have to be monitored wether they want it or not, so we don't allow them to destroy themselves
     if @rdv_insertion_organisations.empty?
       resource.soft_delete


### PR DESCRIPTION
Un oubli dans #4685 cause un crash lors de la suppression  par l'usager lui-même.

https://sentry.incubateur.net/organizations/betagouv/issues/126177/?project=74&referrer=webhooks_plugin

J'ajouterai un test pour cette action dans un autre PR, pour l'instant on va rétablir la feature. J'ai testé en local et ça fonctionne.