### PR TITLE
Remplacer policy_scope.find par authorize dans Admin::UsersController

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -69,7 +69,6 @@ class Admin::UsersController < AgentAuthController
   end
 
   def show
-    authorize(@user, policy_class: Agent::UserPolicy)
     @participations = @user.participations.where(rdvs: policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).merge(@user.rdvs))
     @referent_agents = policy_scope(@user.referent_agents, policy_scope_class: Agent::AgentPolicy::Scope).includes(:services)
     respond_modal_with @user if from_modal?
@@ -77,14 +76,12 @@ class Admin::UsersController < AgentAuthController
 
   def edit
     @user_form = user_form_object
-    authorize(@user, policy_class: Agent::UserPolicy)
     respond_modal_with @user_form if from_modal?
   end
 
   def update
     @user.assign_attributes(user_params)
     @user_form = user_form_object
-    authorize(@user, policy_class: Agent::UserPolicy)
     @user.skip_reconfirmation! if @user.encrypted_password.blank?
     user_updated = @user_form.save
     if from_modal?
@@ -97,13 +94,11 @@ class Admin::UsersController < AgentAuthController
   end
 
   def invite
-    authorize(@user, policy_class: Agent::UserPolicy)
     @user.invite!(domain: current_domain)
     redirect_to admin_organisation_user_path(current_organisation, @user), notice: "L’usager a été invité."
   end
 
   def destroy
-    authorize(@user, policy_class: Agent::UserPolicy)
     if @user.can_be_soft_deleted_from_organisation?(current_organisation)
       @user.soft_delete(current_organisation)
       flash[:notice] = "L’usager a été supprimé."
@@ -184,6 +179,7 @@ class Admin::UsersController < AgentAuthController
   end
 
   def set_user
-    @user = policy_scope(User, policy_scope_class: Agent::UserPolicy::Scope).find(params[:id])
+    @user = User.find(params[:id])
+    authorize(@user, policy_class: Agent::UserPolicy)
   end
 end

--- a/config/locales/pundit.fr.yml
+++ b/config/locales/pundit.fr.yml
@@ -5,3 +5,9 @@ fr:
       show?: Vous ne pouvez pas accéder à cette organisation
     agent/agent_agenda_policy:
       show?: Vous ne pouvez pas accéder à l’agenda de cet agent
+    agent/user_policy:
+      show?: Vous n’avez pas les droits suffisants pour voir cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
+      edit?: Vous n’avez pas les droits suffisants pour modifier cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
+      update?: Vous n’avez pas les droits suffisants pour modifier cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
+      invite?: Vous n’avez pas les droits suffisants pour inviter cet usager.
+      destroy?: Vous n’avez pas les droits suffisants pour supprimer cet usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.


### PR DESCRIPTION
## Contexte

L’erreur `ActiveRecord::RecordNotFound` se produit fréquemment sur le contrôleur `Admin::UsersController` : https://sentry.incubateur.net/organizations/betagouv/issues/113413

Elle se produit principalement sur le edit mais aussi sur d’autres actions :

<img width="315" alt="image" src="https://github.com/user-attachments/assets/0895467c-0e97-4dfb-ae4d-ab21fa689af2">

J’ai regardé certains des events. 

Il y a des cas où l’usager a été supprimé entre temps. C’est une « vraie » `ActiveRecord::RecordNotFound`. On pourrait améliorer le comportement actuel : la 404 est assez brutale pour ce cas et probablement peu aidante ET on ne veut probablement pas être informé de ces cas sur Sentry. Je réserve ça pour une autre PR.

Il y a d’autres cas où il semble que c’était un problème de droits. Je n’ai néanmoins pas réussi à reproduire. Peut-être qu’entre temps les usagers ou les permissions des agents ont changé. En tout cas le comportement actuel est sous-optimal : on affiche une 404 à tort car c’est un problème de droits et on lève une erreur dans Sentry alors que c’est un cas attendu. 

## Solution

Je propose de remplacer dans le `set_user` de ces routes le `policy_scope(..).find(params[:id])` par un `authorize(User.find)`. 

Des erreurs 404 RecordNotFound seront donc toujours levées dans le cas d’usagers supprimées ou d’ID erronnés. 

Mais pour les autres cas on lèvera des erreurs Pundit interceptées. Les agents seront alors redirigés vers leur page d’accueil avec un flash .

J’en profite pour rajouter des messages pundit plus clairs pour les actions qui vont changer de comportement suite à cette PR.

J’ai hésité à mettre de l’écriture inclusive pour "usager·e" mais je me suis retenu car ça ne marche pas très bien pour ce mot avec l’accent grave malheureusement, et qu’on ne le fait pas beaucoup dans l’appli. 

## Tests

J’ai testé en local les différentes routes impactées, et leur version modale aussi.