### PR TITLE
Bannières pour le changement d'adresse mail des cnfs

### DIFF
--- a/app/views/admin/agents/_cnfs_email_change_banner.html.slim
+++ b/app/views/admin/agents/_cnfs_email_change_banner.html.slim
@@ -15,4 +15,3 @@
           | Vous avez reçu un mail à l'adresse #{current_agent.unconfirmed_email} pour changer votre adresse email.
           br
           | Cliquez sur le lien de confirmation dans ce mail pour finaliser votre changement d'adresse
-

--- a/app/views/admin/agents/_cnfs_email_change_banner.html.slim
+++ b/app/views/admin/agents/_cnfs_email_change_banner.html.slim
@@ -1,7 +1,7 @@
 - if current_agent.email.end_with?("conseiller-numerique.fr")
   .row.mt-2
     .col-md-12
-      - if current_agent.unconfirmed_email.blank? || (current_agent.confirmation_sent_at < 1.week.ago)
+      - if current_agent.unconfirmed_email.blank? || (current_agent.confirmation_sent_at && current_agent.confirmation_sent_at < 1.week.ago)
         .d-print-none.alert.alert-warning.alert-dismissible.fade.show
           a.close.rdv-background-image-none(href="#" data-dismiss="alert" aria-label='Close')
             i.fa.fa-times

--- a/app/views/admin/agents/_cnfs_email_change_banner.html.slim
+++ b/app/views/admin/agents/_cnfs_email_change_banner.html.slim
@@ -1,0 +1,18 @@
+- if current_agent.email.end_with?("conseiller-numerique.fr")
+  .row.mt-2
+    .col-md-12
+      - if current_agent.unconfirmed_email.blank?
+        .d-print-none.alert.alert-warning.alert-dismissible.fade.show
+          a.close.rdv-background-image-none(href="#" data-dismiss="alert" aria-label='Close')
+            i.fa.fa-times
+          = "L'adresse #{current_agent.email} sera inaccessible à partir du 15 novembre."
+          br
+          | Pour éviter de perdre accès à #{current_domain.name}, #{link_to("mettez votre adresse email à jour", edit_agent_registration_path)} dès maintenant
+      - else
+        .d-print-none.alert.alert-info.alert-dismissible.fade.show
+          a.close.rdv-background-image-none(href="#" data-dismiss="alert" aria-label='Close')
+            i.fa.fa-times
+          | Vous avez reçu un mail à l'adresse #{current_agent.unconfirmed_email} pour changer votre adresse email.
+          br
+          | Cliquez sur le lien de confirmation dans ce mail pour finaliser votre changement d'adresse
+

--- a/app/views/admin/agents/_cnfs_email_change_banner.html.slim
+++ b/app/views/admin/agents/_cnfs_email_change_banner.html.slim
@@ -1,7 +1,7 @@
 - if current_agent.email.end_with?("conseiller-numerique.fr")
   .row.mt-2
     .col-md-12
-      - if current_agent.unconfirmed_email.blank?
+      - if current_agent.unconfirmed_email.blank? || (current_agent.confirmation_sent_at < 1.week.ago)
         .d-print-none.alert.alert-warning.alert-dismissible.fade.show
           a.close.rdv-background-image-none(href="#" data-dismiss="alert" aria-label='Close')
             i.fa.fa-times

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -16,6 +16,7 @@ html lang="fr"
             = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: defined?(current_organisation) ? current_organisation : nil
           .container-fluid
             = render "layouts/flash"
+            = render "admin/agents/cnfs_email_change_banner"
             - if content_for :title
               .page-title-box
                 h1.page-title.pb-2= yield :title


### PR DESCRIPTION
# Contexte

Dans la suite de https://github.com/betagouv/rdv-service-public/pull/4706, après discussion avec Nesserine, Mehdi et Léa, on ajoute dans le produit une bannière pour inciter les cnfs à changer leur adresse mail

## Captures d'écran

<img width="1420" alt="Screenshot 2024-10-16 at 15 31 51" src="https://github.com/user-attachments/assets/055e715c-5a3f-4dfa-85f0-95a42f7feaa2">

<img width="1420" alt="Screenshot 2024-10-16 at 15 36 19" src="https://github.com/user-attachments/assets/f6da0db0-e7fa-4d9c-ba93-c0347b5d1602">
