### PR TITLE
clarification des messages d’erreur pundit existants

### DIFF
--- a/config/locales/pundit.fr.yml
+++ b/config/locales/pundit.fr.yml
@@ -1,7 +1,7 @@
 fr:
   pundit:
-    default: 'Vous ne pouvez pas effectuer cette action.'
+    default: Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action
     agent/organisation_policy:
-      show?: Vous ne pouvez pas accéder à cette organisation
+      show?: Vous n’avez pas les droits suffisants pour accéder à cette organisation
     agent/agent_agenda_policy:
-      show?: Vous ne pouvez pas accéder à l’agenda de cet agent
+      show?: Vous n’avez pas les droits suffisants pour accéder à l’agenda de cet agent

--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
       it "rejects the change and redirects" do
         subject
         expect(response.status).to eq 302
-        expect(flash[:error]).to eq "Vous ne pouvez pas accéder à cette organisation"
+        expect(flash[:error]).to eq "Vous n’avez pas les droits suffisants pour accéder à cette organisation"
         expect(Agent.last.email).not_to eq "hacker@renard.com"
       end
     end

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Users::RdvsController, type: :controller do
         it "doesn't find a creneau" do
           post_create
           expect(Rdv.count).to eq(0)
-          expect(flash[:error]).to eq "Vous ne pouvez pas effectuer cette action."
+          expect(flash[:error]).to eq "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
         end
       end
     end
@@ -130,7 +130,7 @@ RSpec.describe Users::RdvsController, type: :controller do
 
           put :cancel, params: { id: rdv.id }
           expect(response).to redirect_to(users_rdvs_path)
-          expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.")
+          expect(flash[:error]).to eq("Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action")
         end
       end
     end
@@ -372,7 +372,7 @@ RSpec.describe Users::RdvsController, type: :controller do
           get :index
 
           expect(response).to redirect_to(root_path)
-          expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.")
+          expect(flash[:error]).to eq("Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action")
         end
       end
     end
@@ -448,7 +448,7 @@ RSpec.describe Users::RdvsController, type: :controller do
       before { subject }
 
       it { expect(response).to redirect_to(users_rdvs_path) }
-      it { expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.") }
+      it { expect(flash[:error]).to eq("Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action") }
     end
   end
 
@@ -506,7 +506,7 @@ RSpec.describe Users::RdvsController, type: :controller do
       it "is not authorized" do
         subject
         expect(response).to redirect_to(users_rdvs_path)
-        expect(flash[:error]).to eq("Vous ne pouvez pas effectuer cette action.")
+        expect(flash[:error]).to eq("Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action")
       end
     end
   end

--- a/spec/features/agents/admin_can_configure_the_territory_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_territory_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Admin can configure the territory", type: :feature do
       agent = create(:agent, basic_role_in_organisations: [organisation], role_in_territories: [])
       login_as(agent, scope: :agent)
       visit edit_admin_territory_path(territory, agent)
-      expect(page).to have_content("Vous ne pouvez pas effectuer cette action")
+      expect(page).to have_content("Vous n’avez pas les droits suffisants")
     end
   end
 end

--- a/spec/features/territory_admins/can_crud_webhook_spec.rb
+++ b/spec/features/territory_admins/can_crud_webhook_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe "territory admin can crud webhooks endpoints" do
   it "has correct permissions for other territories" do
     other_territory = create(:territory)
     visit admin_territory_webhook_endpoints_path(territory_id: other_territory.id)
-    expect(page).to have_content "Vous ne pouvez pas effectuer cette action."
+    expect(page).to have_content "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
   end
 end

--- a/spec/features/territory_admins/can_crud_webhook_spec.rb
+++ b/spec/features/territory_admins/can_crud_webhook_spec.rb
@@ -41,6 +41,6 @@ RSpec.describe "territory admin can crud webhooks endpoints" do
   it "has correct permissions for other territories" do
     other_territory = create(:territory)
     visit admin_territory_webhook_endpoints_path(territory_id: other_territory.id)
-    expect(page).to have_content "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
+    expect(page).to have_content "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
   end
 end

--- a/spec/requests/agents/users_controller_search_spec.rb
+++ b/spec/requests/agents/users_controller_search_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Agents::UsersController, "#search" do
       sign_in agent
       get search_agents_users_path(organisation_id: other_organisation)
       expect(response).to have_http_status(:found) # 302 redirects
-      expect(flash[:error]).to eq("Vous ne pouvez pas accéder à cette organisation")
+      expect(flash[:error]).to eq("Vous n’avez pas les droits suffisants pour accéder à cette organisation")
     end
   end
 end


### PR DESCRIPTION
# Contexte

Suite de https://github.com/betagouv/rdv-service-public/pull/4698#pullrequestreview-2366478080

Le message d’erreur générique affiché est « Vous ne pouvez pas effectuer cette action » ce qui me paraît ok mais améliorable :

-    « effectuer une action » lorsqu’on veut juste visiter une page ce n’est pas très clair
-    on ne dit pas pourquoi on ne peut pas faire cette action.

# Solution

Je propose de remplacer par « Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action »
