### PR TITLE
ajout d’un message indiquant une potentielle suppression sur la 404

### DIFF
--- a/app/views/errors/not_found.html.slim
+++ b/app/views/errors/not_found.html.slim
@@ -6,6 +6,8 @@
 
     p La page que vous cherchez est introuvable. Veuillez nous excuser pour la gêne occasionnée.
 
+    p Si vous souhaitiez accéder à un RDV ou un agent, il est possible qu’il ait été supprimé.
+
     p Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible.
 
     p


### PR DESCRIPTION
# Contexte

En travaillant sur les messages d’erreur des droits insuffisants je me suis rendu compte que l’expérience usager est peu claire pour les usagers/agents essayant d’accéder à des ressources supprimées. 

Actuellement, on lève une `RecordNotFound` interceptée par Rails et on affiche la page 404. 
Le contenu de cette page ne suggère pas du tout que le problème peut venir d’une suppression alors que c’est probablement le cas principal.

# Solution

Je rajoute simplement une ligne pour indiquer qu’il s’agit peut-être d’une suppression.
J’ai essayé de ne pas utiliser de mot compliqué et d’être bref.


![SCR-20241016-pndg](https://github.com/user-attachments/assets/91b88880-f973-4d9d-8fd0-eea935d7b27d)


D’autres pistes seront probablement à étudier, on pourrait réfléchir à faire une 404 spéciale pour les RecordNotFound par exemple.