### PR TITLE
[WIP] ANTS: déplacement du obsolete_application_id en job param

### DIFF
--- a/app/models/concerns/ants/appointment_serializer_and_listener.rb
+++ b/app/models/concerns/ants/appointment_serializer_and_listener.rb
@@ -58,7 +58,7 @@ module Ants
 
     def self.enqueue_sync_for_marked_record(rdvs)
       rdvs.select(&:needs_sync_to_ants).each do |rdv|
-        Ants::SyncAppointmentJob.perform_later_for(rdv)
+        Ants::SyncAppointmentJob.perform_later_for(rdv, obsolete_application_id: rdv.obsolete_application_id)
         rdv.assign_attributes(needs_sync_to_ants: false)
       end
     end


### PR DESCRIPTION
> [!NOTE]
> Cette PR est lisible commit par commit


# Contexte

PR de refacto extraite de #4663 pour clarifier cette dernière.

Nouvelle version de #4704 en laissant la sérialisation dans le concern.

Ci-dessous : 
- « le concern » référence `Ants::AppointmentSerializerAndListener` 
- « le job » référence `Ants::SyncAppointmentJob`

La logique de sérialisation est actuellement partagée entre le concern et le job, ce qui ne facilite pas la compréhension du code ni la lecture.

L’attribut `obsolete_application_id` est aujourd’hui passé comme un de ces attributs sérialisés.
C’est un peu perturbant car ce n’est pas un « vrai » attribut AR du RDV. 
C’est un attribut transitif qui sert uniquement au passage d’info entre les hooks `before_commit` et `after_commit`. 

# Solution

2 commits :

## 1er commit : sortir le `obsolete_application_id` des attributs sérialisés

`obsolete_application_id` est maintenant passé comme un argument propre du job. 

Je ne touche pas à l’attribut virtuel `rdv.obsolete_application_id` utilisé pour passer l’info entre les hooks dans le concern pour l’instant.

## 2ème commit : unifier la logique de sérialisation dans le concern

