### PR TITLE
Paralléliser les recherches de rdv dans la recherche de créneaux

### DIFF
--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -141,13 +141,13 @@ module CreneauxSearch::Calculator
     end
 
     def busy_times
-      busy_times = @rdvs.map do |rdv|
-        BusyTime.new(rdv.starts_at, rdv.ends_at)
-      end
-
-      busy_times += busy_times_from_off_days
+      busy_times = busy_times_from_off_days
 
       busy_times += busy_times_from_absences
+
+      busy_times += @rdvs.map do |rdv|
+        BusyTime.new(rdv.starts_at, rdv.ends_at)
+      end
 
       # Le tri est nécessaire, surtout pour les surcharges.
       busy_times.sort_by(&:starts_at)

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -143,6 +143,7 @@ module CreneauxSearch::Calculator
     def busy_times
       busy_times = busy_times_from_off_days
 
+      # On calcule les occurrences des absences en premier pour laisser aux rdvs le temps de finir de charger
       busy_times += busy_times_from_absences
 
       busy_times += @rdvs.map do |rdv|

--- a/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
+++ b/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
   subject(:busy_times) do
-    described_class.preload_busy_times_for(range, plage_ouverture).busy_times
+    described_class.start_loading_busy_times_for(range, plage_ouverture).busy_times
   end
 
   let(:monday) { Time.zone.parse("20211025 10:00") }
@@ -93,28 +93,28 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
     context "with a range on a single day" do
       it "returns off_day from beginning of day to end of day" do
         christmas_morning = Time.zone.parse("2024-12-25 8:00")..Time.zone.parse("2024-12-25 12:00")
-        busy_time = described_class.preload_busy_times_for(christmas_morning, plage_ouverture).busy_times.first
+        busy_time = described_class.start_loading_busy_times_for(christmas_morning, plage_ouverture).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         regular_monday_morning =  Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-13 12:00")
-        expect(described_class.preload_busy_times_for(regular_monday_morning, plage_ouverture).busy_times).to be_empty
+        expect(described_class.start_loading_busy_times_for(regular_monday_morning, plage_ouverture).busy_times).to be_empty
       end
     end
 
     context "with a range spanning several days" do
       it "returns off_day from beginning of day to end of day" do
         christmas_week = Time.zone.parse("2024-12-20 8:00")..Time.zone.parse("2024-12-26 12:00")
-        busy_time = described_class.preload_busy_times_for(christmas_week, plage_ouverture).busy_times.first
+        busy_time = described_class.start_loading_busy_times_for(christmas_week, plage_ouverture).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         all_work_week = Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-19 12:00")
-        expect(described_class.preload_busy_times_for(all_work_week, plage_ouverture).busy_times).to be_empty
+        expect(described_class.start_loading_busy_times_for(all_work_week, plage_ouverture).busy_times).to be_empty
       end
     end
   end

--- a/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
+++ b/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
@@ -43,12 +43,14 @@ RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
       expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211028 12"))
     end
 
-    it "dont return BusyTime if absence is out of range" do
-      range = Time.zone.parse("2021-10-26 9:00")..Time.zone.parse("2021-10-29 11:00")
+    context "absence is out of range" do
+      let(:range) { Time.zone.parse("2021-10-26 9:00")..Time.zone.parse("2021-10-29 11:00") }
 
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 29), start_time: Tod::TimeOfDay.new(14),
-                       end_day: Date.new(2021, 10, 29), end_time: Tod::TimeOfDay.new(15))
-      expect(busy_times).to be_empty
+      it "doesn't return BusyTime" do
+        create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 29), start_time: Tod::TimeOfDay.new(14),
+                         end_day: Date.new(2021, 10, 29), end_time: Tod::TimeOfDay.new(15))
+        expect(busy_times).to be_empty
+      end
     end
   end
 

--- a/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
+++ b/spec/services/creneaux_search/calculator/busy_time_preloader_spec.rb
@@ -1,4 +1,8 @@
-RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
+RSpec.describe CreneauxSearch::Calculator::BusyTimePreloader, type: :service do
+  subject(:busy_times) do
+    described_class.preload_busy_times_for(range, plage_ouverture).busy_times
+  end
+
   let(:monday) { Time.zone.parse("20211025 10:00") }
   let(:range) { Time.zone.parse("2021-10-26 8:00")..Time.zone.parse("2021-10-29 12:00") }
   let(:plage_ouverture) { create(:plage_ouverture) }
@@ -6,42 +10,37 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
   before { travel_to(monday) }
 
   it "returns empty busy times without RDV or absence" do
-    expect(described_class.busy_times_for(range, plage_ouverture)).to eq([])
+    expect(busy_times).to eq([])
   end
 
   context "with a RDV" do
-    it "returns BusyTime object in array with a RDV" do
-      create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"))
-      expect(described_class.busy_times_for(range, plage_ouverture).first).to be_a(described_class)
-    end
-
-    it "returns BusyTime that starts_at as RDV starts_at" do
-      create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.starts_at).to eq(Time.zone.parse("20211027 9:00"))
-    end
-
-    it "returns BusyTime that ends_at as RDV ends_at" do
+    it "returns a BusyTime with the correct attributes" do
       create(:rdv, agents: [plage_ouverture.agent], starts_at: Time.zone.parse("20211027 9:00"), ends_at: Time.zone.parse("20211027 9:40"))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.ends_at).to eq(Time.zone.parse("20211027 9:40"))
+
+      busy_time = busy_times.first
+      expect(busy_time).to have_attributes(
+        starts_at: Time.zone.parse("20211027 9:00"),
+        ends_at: Time.zone.parse("20211027 9:40")
+      )
     end
   end
 
   context "with an absence without recurrence" do
     it "returns BusyTime starts_at as absence first_day and start_time" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.starts_at).to eq(Time.zone.parse("20211027 9:00"))
+      expect(busy_times.first.starts_at).to eq(Time.zone.parse("20211027 9:00"))
     end
 
     it "returns BusyTime ends_at as absence first_day and end_time when end_day is nil" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9), end_day: nil,
                        end_time: Tod::TimeOfDay.new(9, 40))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.ends_at).to eq(Time.zone.parse("20211027 9:40"))
+      expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211027 9:40"))
     end
 
     it "returns BusyTime ends_at as absence end_day and end_time" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 27), start_time: Tod::TimeOfDay.new(9),
                        end_day: Date.new(2021, 10, 28), end_time: Tod::TimeOfDay.new(12))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.ends_at).to eq(Time.zone.parse("20211028 12"))
+      expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211028 12"))
     end
 
     it "dont return BusyTime if absence is out of range" do
@@ -49,7 +48,7 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
 
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 29), start_time: Tod::TimeOfDay.new(14),
                        end_day: Date.new(2021, 10, 29), end_time: Tod::TimeOfDay.new(15))
-      expect(described_class.busy_times_for(range, plage_ouverture)).to be_empty
+      expect(busy_times).to be_empty
     end
   end
 
@@ -57,13 +56,13 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
     it "returns starts_at first occurrence in range" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
                        recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.starts_at).to eq(Time.zone.parse("20211026 9:00"))
+      expect(busy_times.first.starts_at).to eq(Time.zone.parse("20211026 9:00"))
     end
 
     it "returns ends_at occurrence in range" do
       create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 19), start_time: Tod::TimeOfDay.new(9),
                        end_time: Tod::TimeOfDay.new(9, 45), recurrence: Montrose.every(:week, on: ["tuesday"], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
-      expect(described_class.busy_times_for(range, plage_ouverture).first.ends_at).to eq(Time.zone.parse("20211026 9:45"))
+      expect(busy_times.first.ends_at).to eq(Time.zone.parse("20211026 9:45"))
     end
 
     it "returns a busy_time for each occurrence in range" do
@@ -73,16 +72,18 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
              start_time: Tod::TimeOfDay.new(9),
              end_time: Tod::TimeOfDay.new(9, 45),
              recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Time.zone.parse("20211019 9:00"), until: nil, interval: 1))
-      expect(described_class.busy_times_for(range, plage_ouverture).map(&:ends_at)).to eq([Time.zone.parse("20211026 9:45"), Time.zone.parse("20211029 9:45")])
+      expect(busy_times.map(&:ends_at)).to eq([Time.zone.parse("20211026 9:45"), Time.zone.parse("20211029 9:45")])
     end
 
-    it "dont return BusyTime if absence occurrence is out of range" do
-      range = Time.zone.parse("2021-10-29 9:00")..Time.zone.parse("2021-10-29 11:00")
+    context "if absence occurrence is out of range" do
+      let(:range) { Time.zone.parse("2021-10-29 9:00")..Time.zone.parse("2021-10-29 11:00") }
 
-      create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 22),
-                       start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(15),
-                       recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Date.new(2021, 10, 22), until: nil, interval: 1))
-      expect(described_class.busy_times_for(range, plage_ouverture)).to be_empty
+      it "doesn't return BusyTime" do
+        create(:absence, agent: plage_ouverture.agent, first_day: Date.new(2021, 10, 22),
+                         start_time: Tod::TimeOfDay.new(14), end_time: Tod::TimeOfDay.new(15),
+                         recurrence: Montrose.every(:week, on: %w[tuesday friday], starts: Date.new(2021, 10, 22), until: nil, interval: 1))
+        expect(busy_times).to be_empty
+      end
     end
   end
 
@@ -90,28 +91,28 @@ RSpec.describe CreneauxSearch::Calculator::BusyTime, type: :service do
     context "with a range on a single day" do
       it "returns off_day from beginning of day to end of day" do
         christmas_morning = Time.zone.parse("2024-12-25 8:00")..Time.zone.parse("2024-12-25 12:00")
-        busy_time = described_class.busy_times_for(christmas_morning, plage_ouverture).first
+        busy_time = described_class.preload_busy_times_for(christmas_morning, plage_ouverture).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         regular_monday_morning =  Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-13 12:00")
-        expect(described_class.busy_times_for(regular_monday_morning, plage_ouverture)).to be_empty
+        expect(described_class.preload_busy_times_for(regular_monday_morning, plage_ouverture).busy_times).to be_empty
       end
     end
 
     context "with a range spanning several days" do
       it "returns off_day from beginning of day to end of day" do
         christmas_week = Time.zone.parse("2024-12-20 8:00")..Time.zone.parse("2024-12-26 12:00")
-        busy_time = described_class.busy_times_for(christmas_week, plage_ouverture).first
+        busy_time = described_class.preload_busy_times_for(christmas_week, plage_ouverture).busy_times.first
         expect(busy_time.starts_at).to eq(Time.zone.parse("2024-12-25 0:00"))
         expect(busy_time.ends_at).to be_within(1.second).of(Time.zone.parse("2024-12-25 23:59:59"))
       end
 
       it "returns off_day that in given range only" do
         all_work_week = Time.zone.parse("2021-12-13 8:00")..Time.zone.parse("2021-12-19 12:00")
-        expect(described_class.busy_times_for(all_work_week, plage_ouverture)).to be_empty
+        expect(described_class.preload_busy_times_for(all_work_week, plage_ouverture).busy_times).to be_empty
       end
     end
   end


### PR DESCRIPTION
En discutant avec Adrien, on a vu qu'on pouvait encore améliorer la recherche de créneaux.

# Contexte

Le premier load_async a bien marché, on peut maintenant paralléliser encore plus.

<img width="1326" alt="Screenshot 2024-10-17 at 12 19 11" src="https://github.com/user-attachments/assets/4c7ad779-2138-4abf-bc5a-27b62066e8df">

Cette PR propose de lancer en parallèle toutes les requêtes de rdv et d'absence pour toutes les occurrences d'une plage d'ouverture (dans les limites de dates de la recherche évidemment).

# Solution

Avant cette pr, on chargeait en asynchrone les absences pendant que les rdv étaient chargés en synchrone.

Avec cette PR, on lance en asynchrone le chargement de toutes les absences et tous les rdv pour une plage d'ouverture.
On s'attend donc à faire disparaître (ou au moins largement diminuer) le temps de chargement de tous les rdvs.

On se remet à instancier des Rdv, mais on n'avait pas mesure d'amélioration de performance quand on avait arrêté de les instancier (je pense que c'est négligeable par rapport aux autres choses qu'on fait).

Est-ce que ça ne serait pas mieux de faire une seule requête ? Si, mais c'est plus difficile à écrire.

Est-ce que ça ne serait pas mieux d'avoir un meilleur index pour la requête sur la table des rdvs ? Oui, aussi, mais c'est plus de travail.


