### PR TITLE
Eviter les rechargements inutiles lors des calculs de créneaux ANTS

### DIFF
--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -118,9 +118,9 @@ class Api::Ants::EditorController < Api::Ants::BaseController
   def time_slot_url(creneau)
     creneaux_url(
       starts_at: creneau.starts_at.strftime("%Y-%m-%d %H:%M"),
-      lieu_id: creneau.lieu.id,
+      lieu_id: creneau.lieu_id,
       motif_id: creneau.motif.id,
-      public_link_organisation_id: creneau.lieu.organisation.id,
+      public_link_organisation_id: creneau.motif.organisation_id,
       duration: creneau.motif.default_duration_in_min
     )
   end


### PR DESCRIPTION
# Contexte

J'ai fais des tests en local avec un dump de l'instance RDV Mairie, j'ai repris une requête de l'ants pour aller chercher les dispos de Dammartin, j'ai regardé les logs activerecord, et j'ai vu ça 😱  : 
<img width="1242" alt="Screenshot 2024-10-17 at 19 14 07" src="https://github.com/user-attachments/assets/f337934a-cdd1-4073-ad65-395ac84f6727">

En fait pour générer le json, on fait plein d'appels AR qui utilisent le cache, mais qui prennent beaucoup de temps

# Solution

Juste en évitant d'accéder aux objets lieu et organisation depuis le créneau, on évite tous ces appels au cache.
En local, avec la requête de Dammartin ça me fait passer d'environ 3.5s à 2.0s ⚡ 


URL pour tester en local : http://www.rdv-mairie.localhost:3000/api/ants/availableTimeSlots?start_date=2024-10-17&end_date=2025-01-17&meeting_point_ids=7&meeting_point_ids=65&reason=PASSPORT&documents_number=1

