### PR TITLE
Reapply de #4709 (Supprimer la notion de `DepartementScope`)

### DIFF
--- a/app/controllers/admin/agenda/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/agenda/plage_ouvertures_controller.rb
@@ -2,21 +2,17 @@ class Admin::Agenda::PlageOuverturesController < Admin::Agenda::BaseController
   def index
     @agent = Agent.find(params[:agent_id])
     @organisation = Organisation.find(params[:organisation_id])
+
+    plage_ouvertures = policy_scope(@agent.plage_ouvertures, policy_scope_class: Agent::PlageOuverturePolicy::Scope)
+      .includes(:lieu, :organisation)
+    plage_ouvertures = plage_ouvertures.where(id: params[:plages_ids]) if params[:plages_ids].present?
+
     @plage_ouverture_occurrences = plage_ouvertures.all_occurrences_for(date_range_params)
   end
 
   private
 
-  def plage_ouvertures
-    plage = custom_policy.includes(:lieu, :organisation).where(agent: @agent)
-    plage = plage.where(id: params[:plages_ids]) if params[:plages_ids].present?
-    plage
-  end
-
-  # TODO: custom policy waiting for policies refactoring
-  def custom_policy
-    context = AgentOrganisationContext.new(current_agent, @organisation)
-    Agent::PlageOuverturePolicy::DepartementScope.new(context, PlageOuverture)
-      .resolve
+  def pundit_user
+    current_agent
   end
 end

--- a/app/controllers/admin/agenda/rdvs_controller.rb
+++ b/app/controllers/admin/agenda/rdvs_controller.rb
@@ -2,8 +2,7 @@ class Admin::Agenda::RdvsController < Admin::Agenda::BaseController
   def index
     agent = Agent.find(params[:agent_id])
     @organisation = Organisation.find(params[:organisation_id])
-    @rdvs = custom_policy
-      .merge(agent.rdvs)
+    @rdvs = policy_scope(agent.rdvs, policy_scope_class: Agent::RdvPolicy::Scope)
       .includes(%i[organisation lieu motif users participations])
     @rdvs = @rdvs.where(starts_at: time_range_params)
     @rdvs = @rdvs.where(status: Rdv::NOT_CANCELLED_STATUSES) unless current_agent.display_cancelled_rdv
@@ -11,10 +10,7 @@ class Admin::Agenda::RdvsController < Admin::Agenda::BaseController
 
   private
 
-  # TODO: custom policy waiting for policies refactoring
-  def custom_policy
-    context = AgentOrganisationContext.new(current_agent, @organisation)
-    Agent::RdvPolicy::DepartementScope.new(context, Rdv)
-      .resolve
+  def pundit_user
+    current_agent
   end
 end

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -88,11 +88,4 @@ module PlageOuverturesHelper
   def po_exceptionnelle_tag(plage_ouverture)
     tag.span("Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
   end
-
-  def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)
-    Agent::PlageOuverturePolicy::DepartementScope
-      .new(pundit_user, PlageOuverture)
-      .resolve
-      .merge(plage_ouvertures)
-  end
 end

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -88,4 +88,11 @@ module PlageOuverturesHelper
   def po_exceptionnelle_tag(plage_ouverture)
     tag.span("Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
   end
+
+  def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)
+    Agent::PlageOuverturePolicy::Scope
+      .new(pundit_user, PlageOuverture)
+      .resolve
+      .merge(plage_ouvertures)
+  end
 end

--- a/app/policies/agent/plage_ouverture_policy.rb
+++ b/app/policies/agent/plage_ouverture_policy.rb
@@ -55,7 +55,4 @@ class Agent::PlageOuverturePolicy < ApplicationPolicy
       end
     end
   end
-
-  class DepartementScope < Scope
-  end
 end

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -74,7 +74,4 @@ class Agent::RdvPolicy < ApplicationPolicy
       end
     end
   end
-
-  class DepartementScope < Scope
-  end
 end

--- a/app/presenters/plage_ouverture_presenter.rb
+++ b/app/presenters/plage_ouverture_presenter.rb
@@ -33,7 +33,7 @@ class PlageOuverturePresenter
   end
 
   def in_scope?
-    Agent::PlageOuverturePolicy::DepartementScope
+    Agent::PlageOuverturePolicy::Scope
       .new(agent_context, PlageOuverture)
       .resolve
       .where(id: plage_ouverture.id)

--- a/app/presenters/rdv_ending_shortly_before_presenter.rb
+++ b/app/presenters/rdv_ending_shortly_before_presenter.rb
@@ -18,7 +18,7 @@ class RdvEndingShortlyBeforePresenter
   private
 
   def in_scope?
-    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).in_scope?(rdv)
+    @in_scope ||= Agent::RdvPolicy::Scope.new(agent_context, Rdv).in_scope?(rdv)
   end
 
   def i18n_key

--- a/app/presenters/rdvs_overlapping_rdv_presenter.rb
+++ b/app/presenters/rdvs_overlapping_rdv_presenter.rb
@@ -18,7 +18,7 @@ class RdvsOverlappingRdvPresenter
   private
 
   def in_scope?
-    @in_scope ||= Agent::RdvPolicy::DepartementScope.new(agent_context, Rdv).in_scope?(rdv)
+    @in_scope ||= Agent::RdvPolicy::Scope.new(agent_context, Rdv).in_scope?(rdv)
   end
 
   def i18n_key

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,5 +1,4 @@
-/ On utilise ici `merge` car `overlapping_plages_ouvertures` peut retourner soit un `Array` soit une `ActiveRecord::Relation`
-- in_scope = Agent::PlageOuverturePolicy::Scope.new(current_agent, PlageOuverture).resolve.merge(model.overlapping_plages_ouvertures)
+- in_scope = filter_plage_ouvertures_in_departement_scope(model.overlapping_plages_ouvertures)
 
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,4 +1,5 @@
-- in_scope = Agent::PlageOuverturePolicy::Scope.new(current_agent, model.overlapping_plages_ouvertures).resolve
+/ On utilise ici `merge` car `overlapping_plages_ouvertures` peut retourner soit un `Array` soit une `ActiveRecord::Relation`
+- in_scope = Agent::PlageOuverturePolicy::Scope.new(current_agent, PlageOuverture).resolve.merge(model.overlapping_plages_ouvertures)
 
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,4 +1,4 @@
-- in_scope = filter_plage_ouvertures_in_departement_scope(model.overlapping_plages_ouvertures)
+- in_scope = Agent::PlageOuverturePolicy::Scope.new(current_agent, model.overlapping_plages_ouvertures).resolve
 
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     end
   end
 
-  shared_examples "included in departement scope" do
-    it "is included in departement scope" do
-      expect(Agent::RdvPolicy::DepartementScope.new(pundit_context, Rdv).resolve).to include(rdv)
-    end
-  end
-
-  shared_examples "not included in departement scope" do
-    it "is not included in departement scope" do
-      expect(Agent::RdvPolicy::DepartementScope.new(pundit_context, Rdv).resolve).not_to include(rdv)
-    end
-  end
-
   context "existing RDV from same agent" do
     let(:organisation) { create(:organisation) }
     let(:service) { create(:service) }
@@ -49,7 +37,6 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
 
     it_behaves_like "not permit actions", :rdv, :show?, :edit?, :update?, :destroy?
     it_behaves_like "not included in scope"
-    it_behaves_like "not included in departement scope"
 
     context "for secretariat" do
       let(:service_agent) { build(:service, :secretariat) }
@@ -57,7 +44,6 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
       it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
       it_behaves_like "not permit actions", :rdv, :destroy?
       it_behaves_like "included in scope"
-      it_behaves_like "included in departement scope"
     end
 
     context "for admin" do
@@ -65,7 +51,6 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
 
       it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?, :destroy?
       it_behaves_like "included in scope"
-      it_behaves_like "included in departement scope"
     end
 
     context "except if the rdv concerns the connected agent" do
@@ -74,7 +59,6 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
       it_behaves_like "permit actions", :rdv, :show?, :edit?, :update?
       it_behaves_like "not permit actions", :rdv, :destroy?
       it_behaves_like "included in scope"
-      it_behaves_like "included in departement scope"
     end
   end
 

--- a/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
+++ b/spec/presenters/rdv_ending_shortly_before_presenter_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe RdvEndingShortlyBeforePresenter, type: :presenter do
     subject { presenter.warning_message }
 
     before do
-      dbl = instance_double(Agent::RdvPolicy::DepartementScope, in_scope?: in_scope_mock_value)
-      allow(Agent::RdvPolicy::DepartementScope).to receive(:new).with(agent_context, Rdv).and_return(dbl)
+      dbl = instance_double(Agent::RdvPolicy::Scope, in_scope?: in_scope_mock_value)
+      allow(Agent::RdvPolicy::Scope).to receive(:new).with(agent_context, Rdv).and_return(dbl)
     end
 
     context "same agent (=> in scope)" do


### PR DESCRIPTION
La PR #4709 contenait un raté : la première ligne de `_overlapping_plage_ouvertures.html.slim` avait été modifiée pour ne plus utiliser la méthode de helper `filter_plage_ouvertures_in_departement_scope`, permettant ainsi de supprimer cette méthode de helper. L'erreur, c'est que cette méthode utilisait soigneusement `ActiveRecord::Relation#merge` pour combiner avec la scope la valeur de `#overlapping_plages_ouvertures`. En effet, cette méthode peut retourne soir un `Array`, soit une `ActiveRecord::Relation`.

J'ai tenté de corriger ce crash dans #4711 dans la précipitation mais j'ai aussi fait une erreur. Tout a été revert dans #4712.

Afin de ne pas tout mélanger, dans cette PR je ne touche pas au helper ni cette partie du code. Je m'occuperai de clarifier la valeur de retour de `#overlapping_plages_ouvertures`, que je trouve piégeuse, dans une autre PR.

J'ajoute malgré  tout dans cette PR une spec pour le chemin qui avait été cassé lors du merge de la première tentative.