### PR TITLE
Correction du crash de la liste de RDV causée par `human_attribute_value`

### DIFF
--- a/app/models/concerns/human_attribute_value.rb
+++ b/app/models/concerns/human_attribute_value.rb
@@ -36,7 +36,12 @@ module HumanAttributeValue
 
       context = options.delete(:context)
       attr_i18n_scope = [attr_name.to_s.pluralize, context].compact.join("/")
-      human_attribute_name("#{attr_i18n_scope}.#{value}", options)
+      attr = "#{attr_i18n_scope}.#{value}"
+
+      # Rails does not support I18n keys ending with "." since https://github.com/rails/rails/pull/44300
+      attr = attr.delete_suffix(".")
+
+      human_attribute_name(attr, options)
     end
 
     # Returns a hash of the attribute values => localized text.

--- a/app/models/concerns/human_attribute_value.rb
+++ b/app/models/concerns/human_attribute_value.rb
@@ -39,7 +39,8 @@ module HumanAttributeValue
       attr = "#{attr_i18n_scope}.#{value}"
 
       # Rails does not support I18n keys ending with "." since https://github.com/rails/rails/pull/44300
-      attr = attr.delete_suffix(".")
+      # This regexp removes any number of dots from the end of the string.
+      attr = attr.sub(/\.*\z/, "")
 
       human_attribute_name(attr, options)
     end

--- a/spec/models/concerns/human_attribute_value_spec.rb
+++ b/spec/models/concerns/human_attribute_value_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe HumanAttributeValue do
 
     context "string value ends with a dot (.)" do
       it "works" do
-        user = User.new(notes: "C'est ainsi.")
-        expect(user.human_attribute_value(:notes)).to eq("C'est ainsi.")
+        expect(User.new(notes: "C'est ainsi.").human_attribute_value(:notes)).to eq("C'est ainsi.")
+        expect(User.new(notes: "Hélas...").human_attribute_value(:notes)).to eq("Hélas...")
       end
     end
 

--- a/spec/models/concerns/human_attribute_value_spec.rb
+++ b/spec/models/concerns/human_attribute_value_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe HumanAttributeValue do
       it { is_expected.to be_nil }
     end
 
+    context "string value ends with a dot (.)" do
+      it "works" do
+        user = User.new(notes: "C'est ainsi.")
+        expect(user.human_attribute_value(:notes)).to eq("C'est ainsi.")
+      end
+    end
+
     context "bool value is true" do
       let(:attr_name) { :some_bool }
       let(:value) { true }


### PR DESCRIPTION
# Contexte

Suite à la mise à jour à Rails 7.1, notre méthode `human_attribute_value` plante lorsque la valeur passée finit par `.`.

Le message d'erreur est :

```
translation data 
  {:invitation_token=>"Code d’invitation", :email=>"Email", :first_name=>"Prénom", :name=>"Nom", :last_name=>"Nom d’usage", :birth_name=>"Nom de naissance", :birth_date=>"Date de naissance", :phone_number=>"Téléphone", :address=>"Adresse", :password=>"Mot de passe", :current_password=>"Mot de passe actuel", :created_at=>"Création", :updated_at=>"Modification", :invitation_sent_at=>"Invitation envoyée", :invitation_accepted_at=>"Invitation acceptée", :confirmed_at=>"Confirmation", :city_name=>"Nom de la commune", :city_code=>"Code commune INSEE", :responsible_id=>"Responsable"}
can not be used with :count => 1. key 'one' is missing. (ActionView::Template::Error)
```

Il semble que le processus de resolve des clés à partir d'une string contenant des points a été modifié dans https://github.com/rails/rails/pull/44300. J'ai essayé de revert cette PR localement et le crash n'avais plus lieu, c'est donc bien la cause du crash, combinée avec notre méthode maison `human_attribute_value` qui n'est visiblement pas extensivement testée

# Solution

J'ai ajouté un test qui reproduit le crash et puis j'ai modifié notre méthode `human_attribute_value` pour qu'elle retire les éventuels points présents en fin de clé.

## Risques

Notre méthode `human_attribute_value` est une surcouche sur les fonctionnements du système de traduction de Rails, et de ce fait elle est sensible aux changements de comportements de Rails. Bien que je salue le côté pratique de cette méthode, j'ai toujours trouvé qu'elle était difficile à comprendre et "hacky". Il serait intéressant d'imaginer des implémentation alternatives, pas forcément basées sur le système I18n.