### PR TITLE
Correctif de la mise à jour à Ruby 3.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,8 @@ gem "bigdecimal"
 gem "csv"
 gem "drb"
 gem "observer"
+gem "logger"
+gem "ostruct"
 
 group :development do
   #  Hot reload

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.1)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -353,6 +354,7 @@ GEM
       date
       net-protocol
     net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)
@@ -402,6 +404,7 @@ GEM
       validate_url
       webfinger (~> 1.2)
     orm_adapter (0.5.0)
+    ostruct (0.6.0)
     pagy (6.5.0)
     paper_trail (15.2.0)
       activerecord (>= 6.1)
@@ -736,6 +739,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen
+  logger
   lograge
   mail
   montrose
@@ -744,6 +748,7 @@ DEPENDENCIES
   omniauth-microsoft_graph
   omniauth-rails_csrf_protection
   omniauth_openid_connect
+  ostruct
   paper_trail
   parallel_tests
   parser (= 3.3.5.0)


### PR DESCRIPTION
Lors du merge de #4726, la CI sur la branche de prod a échoué avec le messages suivant :

```
Downloading net-pop-0.1.2 revealed dependencies not in the API or the lockfile
(net-protocol (>= 0)).
Running `bundle update net-pop` should fix the problem.
```

https://github.com/betagouv/rdv-service-public/actions/runs/11456045693/job/31873340237

Cette PR corrective : 
- lance la commande suggérée dans le message d'erreur
- ajoute deux gems explicitement dans le `Gemfile` pour éviter les warnings suivants

```
/home/francois/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activesupport-7.1.4.1/lib/active_support/logger_thread_safe_level.rb:4: warning: /home/francois/.rbenv/versions/3.3.5/lib/ruby/3.3.0/logger.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/home/francois/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/jbuilder-2.11.5/lib/jbuilder.rb:7: warning: /home/francois/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of jbuilder-2.11.5 to request adding ostruct into its gemspec.
```