### PR TITLE
Page de contacts : tri et groupement par département

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -6,7 +6,21 @@ class StaticPagesController < ApplicationController
 
   def accessibility; end
 
-  def contact; end
+  def contact
+    territories_with_phone_number = Territory.where.not(phone_number_formatted: nil)
+    territories_group_by_department = territories_with_phone_number
+      .where(departement_number: Territory::DEPARTEMENTS_NAMES.keys)
+      .order(:departement_number, :name).group_by(&:departement_number)
+
+    territories_without_department = territories_with_phone_number
+      .where.not(departement_number: Territory::DEPARTEMENTS_NAMES.keys)
+      .order(:name)
+
+    render locals: {
+      territories_group_by_department: territories_group_by_department,
+      territories_without_department: territories_without_department,
+    }
+  end
 
   def domaines; end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,11 +10,11 @@ class StaticPagesController < ApplicationController
     territories_with_phone_number = Territory.where.not(phone_number_formatted: nil)
     territories_group_by_department = territories_with_phone_number
       .where(departement_number: Territory::DEPARTEMENTS_NAMES.keys)
-      .order(:departement_number, :name).group_by(&:departement_number)
+      .order(:departement_number).ordered_by_name.group_by(&:departement_number)
 
     territories_without_department = territories_with_phone_number
       .where.not(departement_number: Territory::DEPARTEMENTS_NAMES.keys)
-      .order(:name)
+      .ordered_by_name
 
     render locals: {
       territories_group_by_department: territories_group_by_department,

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -1,6 +1,9 @@
 class Territory < ApplicationRecord
   has_paper_trail
 
+  DEPARTEMENTS_NAMES = CSV.read(Rails.root.join("lib/assets/departements_fr.csv"), headers: :first_row)
+    .to_h { [_1["number"], _1["name"]] }.freeze
+
   SPECIAL_NAMES = [
     MAIRIES_NAME = "Mairies".freeze,
     CNFS_NAME = "Conseillers Numériques".freeze,
@@ -65,9 +68,6 @@ class Territory < ApplicationRecord
     where(id: Organisation.with_upcoming_rdvs.distinct.select(:territory_id))
   }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(territories.name))")) }
-  scope :with_phone_number_formatted, -> { where.not(phone_number_formatted: nil) }
-  scope :with_valid_department, -> { where(departement_number: DEPARTEMENTS_NAMES.keys) }
-  scope :with_invalid_department, -> { where.not(departement_number: DEPARTEMENTS_NAMES.keys) }
 
   ## -
 
@@ -133,9 +133,6 @@ class Territory < ApplicationRecord
   end
 
   private
-
-  DEPARTEMENTS_NAMES = CSV.read(Rails.root.join("lib/assets/departements_fr.csv"), headers: :first_row)
-    .to_h { [_1["number"], _1["name"]] }.freeze
 
   def fill_name_for_departements
     return if name.present? || departement_number.blank?

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -65,6 +65,9 @@ class Territory < ApplicationRecord
     where(id: Organisation.with_upcoming_rdvs.distinct.select(:territory_id))
   }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(territories.name))")) }
+  scope :with_phone_number_formatted, -> { where.not(phone_number_formatted: nil) }
+  scope :with_valid_department, -> { where(departement_number: DEPARTEMENTS_NAMES.keys) }
+  scope :with_invalid_department, -> { where.not(departement_number: DEPARTEMENTS_NAMES.keys) }
 
   ## -
 
@@ -123,6 +126,10 @@ class Territory < ApplicationRecord
     OPTIONAL_RDV_WAITING_ROOM_FIELD_TOGGLES.keys.any? do |waiting_room_field|
       send(waiting_room_field)
     end
+  end
+
+  def department_name
+    DEPARTEMENTS_NAMES[departement_number]
   end
 
   private

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -1,7 +1,7 @@
 - content_for :title, "Contact"
 
-- Territory.where.not(phone_number_formatted: nil).order(:departement_number, :name).group_by(&:departement_number).each do |department_number, territories|
-  h2 #{department_number}
+- Territory.with_phone_number_formatted.with_valid_department.order(:departement_number, :name).group_by(&:departement_number).each do |department_number, territories|
+  h2 #{department_number} - #{territories.first.department_name}
   ul.list-group.mb-2
     - territories.each do |territory|
       li
@@ -9,6 +9,11 @@
         = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
 
 h2 Autres contacts
+ul.list-group.mb-2
+  - Territory.with_phone_number_formatted.with_invalid_department.order(:name).each do |territory|
+    li
+      span> #{territory.name}
+      = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
 span> Voir
 = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
 

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -1,14 +1,16 @@
 - content_for :title, "Contact"
 
-h2 Votre département
-ul.list-group.mb-2
-  - Territory.where.not(phone_number: nil).each do |territory|
-    li
-      span> #{territory}
-      = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
-  li
-    span> Autres départements, voir
-    = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
+- Territory.where.not(phone_number_formatted: nil).order(:departement_number, :name).group_by(&:departement_number).each do |department_number, territories|
+  h2 #{department_number}
+  ul.list-group.mb-2
+    - territories.each do |territory|
+      li
+        span> #{territory.name}
+        = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
+
+h2 Autres contacts
+span> Voir
+= link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
 
 .fr-grid-row.mt-4#tech-support
   .fr-col-md-8

--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, "Contact"
 
-- Territory.with_phone_number_formatted.with_valid_department.order(:departement_number, :name).group_by(&:departement_number).each do |department_number, territories|
+- territories_group_by_department.each do |department_number, territories|
   h2 #{department_number} - #{territories.first.department_name}
   ul.list-group.mb-2
     - territories.each do |territory|
@@ -10,7 +10,7 @@
 
 h2 Autres contacts
 ul.list-group.mb-2
-  - Territory.with_phone_number_formatted.with_invalid_department.order(:name).each do |territory|
+  - territories_without_department.each do |territory|
     li
       span> #{territory.name}
       = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"


### PR DESCRIPTION
Closes #4744 

Review app : https://demo-rdv-solidarites-pr4750.osc-secnum-fr1.scalingo.io/contact (pas forcément nécessaire ici, mais c’était pour tester le fonctionnement des reviews app pour ma première PR).

# Contexte

La page de contact avait plusieurs petits soucis : 
- Les territoires n’étaient pas triés
- On affichait des territoires qui n’avaient pas de numéro de téléphone
- On mentionnait des « départements » alors que l’usage des territoires a évolué et ne se limite plus à un territoire par département.

# Solution

- On récupère que les territoires qui ont un `phone_number_formatted` non nul plutôt que d’utiliser le `phone_number` qui peut être _empty_.
- On trie par `departement_number` puis par `name`
- On groupe et on affiche les résultats par `departement_number`

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [x] Préparer des captures de l’interface avant et après

## Captures d'écran

Avant | Après
:- | -:
<img width="907" alt="image" src="https://github.com/user-attachments/assets/93aae995-c8e6-4b94-ae24-ead7cf399234"> | <img width="775" alt="image" src="https://github.com/user-attachments/assets/52cdce78-ba2b-44c1-a75b-da4763827dc6">
