### PR TITLE
Ajout AntoineGirard au mapping des contributeurs dans le reminder de PR

### DIFF
--- a/.github/workflows/pull_requests_reminder.yml
+++ b/.github/workflows/pull_requests_reminder.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           webhook-url: ${{ secrets.PR_REMINDER_WEBHOOK_URL }}
           provider: slack
-          github-provider-map: "francois-ferrandis:francois.ferrandis,victormours:victor.mours,aminedhobb:amine.dhobb,Holist:romain.neuville,Michaelvilleneuve:michael.villeneuve"
+          github-provider-map: "francois-ferrandis:francois.ferrandis,victormours:victor.mours,aminedhobb:amine.dhobb,Holist:romain.neuville,Michaelvilleneuve:michael.villeneuve,AntoineGirard:antoine.girard"
           channel: "startup-rdv-service-public-dev"


### PR DESCRIPTION
# Contexte

Suite à mon arrivée dans l’équipe ajout du mapping entre mon compte Mattermost et mon compte Github dans le job de reminder de PR.

# Solution

N/A

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après

## Captures d'écran

N/A
