### PR TITLE
fix(api): Disable bypass_sign in devise_token_auth

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -1,4 +1,10 @@
 DeviseTokenAuth.setup do |config|
+  # By default DeviseTokenAuth will not check user's #active_for_authentication?
+  # which includes confirmation check on each call (it will do it only on sign in).
+  # If you want it to be validated on each request (for example, to be able to deactivate logged in users on the fly),
+  # set it to false.
+  config.bypass_sign_in = false
+
   # By default the authorization headers will change after each request. The
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -3,6 +3,8 @@ DeviseTokenAuth.setup do |config|
   # which includes confirmation check on each call (it will do it only on sign in).
   # If you want it to be validated on each request (for example, to be able to deactivate logged in users on the fly),
   # set it to false.
+  # Passer cette option à true risque de causer un cookie overflow au moment de logger l'agent via la gem.
+  # Plus de détails sur ce sujet ici: https://github.com/betagouv/rdv-service-public/pull/4753
   config.bypass_sign_in = false
 
   # By default the authorization headers will change after each request. The


### PR DESCRIPTION
# Contexte

Depuis quelques jours on a des retours d'usagers qui n'arrivent pas à se connecter à rdv-insertion via leur identifants/mdp rdv-sp. 
En regardant sur le Sentry de rdv-sp on voit qu'on a effectivement plusieurs erreurs `ActionDispatch::Cookies::CookieOverflow` au moment d'appeler l'API rdv-sp depuis rdv-insertion: https://sentry.incubateur.net/organizations/betagouv/issues/128176/?project=74&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=6

En investiguant, je me suis rendu compte que la gem `devise_token_auth` utilisait par défaut la méthode `bypass_sign_in` de devise pour logger les usagers (voir [ici](https://github.com/lynndylanhurley/devise_token_auth/blob/b7fcfdf98a84a5d2ae22e005eaa372a668cc9c76/app/controllers/devise_token_auth/concerns/set_user_by_token.rb#L90)). 
Or cette méthode sérialise l'`Agent` en entier en session. Pour certains agents (notamment ceux qui ont un `microsoft_graph_token` et un `refresh_microsoft_graph_token`), `agent#as_json` peut être trop lourd et causer donc le cookie overflow.

# Solution

En lisant [la doc de la gem ](https://maicolben.gitbooks.io/devise-token-auth/content/docs/config/initialization.html), on voit que le `bypass_sign_in` est activé par défaut pour ne pas appeler la méthode de devise `active_for_authentication?` à chaque requête. 
Or je pense qu'appeler cette méthode peut être utile, notamment pour qu'un agent ayant été soft deleté après avoir récupéré un token de l'API voit son token invalidé immédiatement.
Je set donc l'option `bypass_sign_in` à `false`. La gem utilisera alors la méthode `sign_in` normale de `devise` (avec l'option `store: false`), ce qui fait que l'agent ne sera pas sérialisé en entier dans la session et qui devrait donc régler le problème de cookie overflow.

