### PR TITLE
Correction de la spec CreneauxSearch::ForAgent#next_availabilities lorsqu’il y a un jour férié

### DIFF
--- a/spec/services/creneaux_search/for_agent_spec.rb
+++ b/spec/services/creneaux_search/for_agent_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe CreneauxSearch::ForAgent, type: :service do
     let(:lieu2) { create(:lieu, organisation: organisation, name: "MDS Arquest") }
 
     before do
+      travel_to(Date.new(2024, 10, 15)) # On fixe la date pour éviter de tomber sur un lundi férié
       create(:plage_ouverture, :weekly_on_monday, agent: agent, motifs: [motif], lieu: lieu2, organisation: organisation, first_day: 2.weeks.from_now)
       create(:plage_ouverture, :weekly_on_monday, agent: agent, motifs: [motif], lieu: lieu1, organisation: organisation, first_day: 1.week.from_now, recurrence_ends_at: 13.days.from_now)
     end


### PR DESCRIPTION
# Contexte

Lorsque nous avons un lundi férié dans les 2 semaines suivantes, cela casse un test. Cela ne se produit que parce que dans la récurrence, on indique une date de début et un nombre de récurrences. 
En l’occurrence, ce cas ne peut pas se produire dans le produit, car nous demandons à l’utilisateur une date de début et une date de fin.

# Solution

On fixe la date de début à un jour où il n’y a pas de jour férié proche.

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après

## Captures d'écran

N/A
