### PR TITLE
Spec : on supprime les travel_back redondants

### DIFF
--- a/spec/helpers/rdvs_helper_spec.rb
+++ b/spec/helpers/rdvs_helper_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe RdvsHelper do
       travel_to(now)
       rdv = build(:rdv, starts_at: now + 3.hours, duration_in_min: 30)
       expect(rdv_title(rdv)).to eq("Aujourd’hui à 15h54 (durée : 30 minutes)")
-      travel_back
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -260,7 +260,6 @@ RSpec.describe User, type: :model do
 
       travel_to(today)
       expect(user.rdvs_future_without_ongoing(organisation)).to eq([next_rdv])
-      travel_back
     end
 
     it "returns only future rdv" do
@@ -276,7 +275,6 @@ RSpec.describe User, type: :model do
       travel_to(now)
 
       expect(user.rdvs_future_without_ongoing(organisation)).to eq([future_rdv])
-      travel_back
     end
   end
 
@@ -310,7 +308,6 @@ RSpec.describe User, type: :model do
       travel_to(now)
       user = build(:user, birth_date: Date.new(2016, 5, 30))
       expect(user.minor?).to be true
-      travel_back
     end
 
     it "return false when user birth is 2000 and we are in 2020" do
@@ -318,7 +315,6 @@ RSpec.describe User, type: :model do
       travel_to(now)
       user = build(:user, birth_date: Date.new(2000, 5, 30))
       expect(user.minor?).to be false
-      travel_back
     end
 
     it "return false when no birthdate" do

--- a/spec/services/rdvs_overlapping_spec.rb
+++ b/spec/services/rdvs_overlapping_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe RdvsOverlapping, type: :service do
       overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day + 15.minutes)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
-      travel_back
     end
 
     it "return rdvs that starts during rdv" do
@@ -17,7 +16,6 @@ RSpec.describe RdvsOverlapping, type: :service do
       overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
-      travel_back
     end
 
     it "return rdvs that starts before and end after rdv" do
@@ -27,7 +25,6 @@ RSpec.describe RdvsOverlapping, type: :service do
       overlapped_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 30.minutes, duration_in_min: 60)
       created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day - 15.minutes, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([overlapped_rdv])
-      travel_back
     end
 
     it "do not return rdv that starts just at rdv's end" do
@@ -37,7 +34,6 @@ RSpec.describe RdvsOverlapping, type: :service do
       created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       create(:rdv, agents: [agent], starts_at: now + 1.day + 30.minutes, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([])
-      travel_back
     end
 
     it "do not return rdv that end just at rdv's start" do
@@ -47,7 +43,6 @@ RSpec.describe RdvsOverlapping, type: :service do
       create(:rdv, agents: [agent], starts_at: now + 1.day - 30.minutes, duration_in_min: 30)
       created_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       expect(described_class.new(created_rdv).rdvs_overlapping_rdv).to eq([])
-      travel_back
     end
 
     it "returns RDV with exact same times" do
@@ -57,7 +52,6 @@ RSpec.describe RdvsOverlapping, type: :service do
       existing_rdv = create(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       new_rdv = build(:rdv, agents: [agent], starts_at: now + 1.day, duration_in_min: 30)
       expect(described_class.new(new_rdv).rdvs_overlapping_rdv).to eq([existing_rdv])
-      travel_back
     end
   end
 end


### PR DESCRIPTION
# Contexte et solution

~~Afin d’éviter de futurs flaky specs avec des `travel_to` pour lesquels on a oublié de faire le `travel_back` on le fait dans la config globale des specs.~~

Depuis Rails 5.2, le `travel_back` est automatique après chaque test. Voir : https://github.com/rails/rails/commit/f51cf2e4b558787e6027b63d1ad051d553dfc80f

On supprime donc les `travel_back` redondants.