### PR TITLE
Corriger la serialization ICS des plages sans titre

### DIFF
--- a/app/models/concerns/ics_payloads/plage_ouverture.rb
+++ b/app/models/concerns/ics_payloads/plage_ouverture.rb
@@ -2,11 +2,11 @@ module IcsPayloads
   module PlageOuverture
     def payload(action = nil)
       payload = {
-        name: "plage-ouverture-#{title.parameterize}-#{starts_at.to_s.parameterize}.ics",
+        name: "plage-ouverture-#{title.presence || id}-#{starts_at.to_s.parameterize}.ics",
         starts_at: starts_at,
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,
-        summary: "#{IcalFormatters::Ics::ICS_UID_SUFFIX} #{title}",
+        summary: "#{IcalFormatters::Ics::ICS_UID_SUFFIX} #{title_with_default}",
         rrule: IcalFormatters::Rrule.from_recurrence(recurrence),
         domain: domain,
       }

--- a/app/models/concerns/ics_payloads/plage_ouverture.rb
+++ b/app/models/concerns/ics_payloads/plage_ouverture.rb
@@ -2,7 +2,7 @@ module IcsPayloads
   module PlageOuverture
     def payload(action = nil)
       payload = {
-        name: "plage-ouverture-#{title.presence || id}-#{starts_at.to_s.parameterize}.ics",
+        name: "plage-ouverture-#{title.presence&.parameterize || id}-#{starts_at.to_s.parameterize}.ics",
         starts_at: starts_at,
         ends_at: first_occurrence_ends_at,
         ical_uid: ical_uid,

--- a/spec/models/concerns/ics_payloads/plage_ouverture_spec.rb
+++ b/spec/models/concerns/ics_payloads/plage_ouverture_spec.rb
@@ -15,9 +15,27 @@ RSpec.describe IcsPayloads::PlageOuverture do
     end
 
     describe ":name" do
-      let(:plage_ouverture) { build(:plage_ouverture, title: "something", start_time: Time.zone.parse("12h30"), first_day: Date.new(2020, 11, 13)) }
+      let(:plage_ouverture) { build(:plage_ouverture, title: "something", start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }
 
-      it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-something-2020-11-13-12-30-00-0100.ics") }
+      it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-something-2020-11-13-09-00-00-0100.ics") }
+
+      context "when title is empty" do
+        let(:plage_ouverture) { create(:plage_ouverture, title: nil, start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }
+
+        it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-#{plage_ouverture.id}-2020-11-13-09-00-00-0100.ics") }
+      end
+    end
+
+    describe ":summary" do
+      let(:plage_ouverture) { build(:plage_ouverture, title: "something") }
+
+      it { expect(plage_ouverture.payload[:summary]).to eq("RDV Solidarités something") }
+
+      context "when title is empty" do
+        let(:plage_ouverture) { create(:plage_ouverture, title: nil) }
+
+        it { expect(plage_ouverture.payload[:summary]).to eq("RDV Solidarités Plage d'ouverture ##{plage_ouverture.id}") }
+      end
     end
 
     describe ":starts_at" do

--- a/spec/models/concerns/ics_payloads/plage_ouverture_spec.rb
+++ b/spec/models/concerns/ics_payloads/plage_ouverture_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe IcsPayloads::PlageOuverture do
     end
 
     describe ":name" do
-      let(:plage_ouverture) { build(:plage_ouverture, title: "something", start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }
+      let(:plage_ouverture) { build(:plage_ouverture, title: "Permanence mairie", start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }
 
-      it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-something-2020-11-13-09-00-00-0100.ics") }
+      it { expect(plage_ouverture.payload[:name]).to eq("plage-ouverture-permanence-mairie-2020-11-13-09-00-00-0100.ics") }
 
       context "when title is empty" do
         let(:plage_ouverture) { create(:plage_ouverture, title: nil, start_time: Tod::TimeOfDay.new(9), first_day: Date.new(2020, 11, 13)) }


### PR DESCRIPTION
Dans #4756 on rend les titres de plages optionnels. On avait oublié de gérer ce cas dans le serializer ICS, j'ai donc géré ça et ajouté les tests nécessaires sur les attributs ICS qui utilisent le titre.

Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/128794