### PR TITLE
Petit correctif sur des icônes et sur un lien de doc

### DIFF
--- a/app/views/admin/motifs/form/_resa_en_ligne.html.slim
+++ b/app/views/admin/motifs/form/_resa_en_ligne.html.slim
@@ -17,7 +17,7 @@
             = f.radio_button(:bookable_by, :agents_and_prescripteurs, "data-action": "change->motif-form#refreshSections", "data-motif-form-target": "bookableByRadios")
             span.ml-1= sanitize(I18n.t("activerecord.attributes.motif/bookable_by/radio_label_html.agents_and_prescripteurs"))
             p.text-muted.font-14.mt-1
-              = sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.agents_and_prescripteurs"), scrubber: :prune)
+              = sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.agents_and_prescripteurs"), scrubber: :prune) # Le scrubber: :prune permet de conserver le target _blank sur un lien
 
     - if rdvi_mode
       .form-row

--- a/app/views/admin/motifs/form/_resa_en_ligne.html.slim
+++ b/app/views/admin/motifs/form/_resa_en_ligne.html.slim
@@ -17,7 +17,8 @@
             = f.radio_button(:bookable_by, :agents_and_prescripteurs, "data-action": "change->motif-form#refreshSections", "data-motif-form-target": "bookableByRadios")
             span.ml-1= sanitize(I18n.t("activerecord.attributes.motif/bookable_by/radio_label_html.agents_and_prescripteurs"))
             p.text-muted.font-14.mt-1
-              = sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.agents_and_prescripteurs"), scrubber: :prune) # Le scrubber: :prune permet de conserver le target _blank sur un lien
+              / Le scrubber: :prune permet de conserver le target _blank sur un lien
+              = sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.agents_and_prescripteurs"), scrubber: :prune)
 
     - if rdvi_mode
       .form-row

--- a/app/views/admin/motifs/form/_resa_en_ligne.html.slim
+++ b/app/views/admin/motifs/form/_resa_en_ligne.html.slim
@@ -17,7 +17,7 @@
             = f.radio_button(:bookable_by, :agents_and_prescripteurs, "data-action": "change->motif-form#refreshSections", "data-motif-form-target": "bookableByRadios")
             span.ml-1= sanitize(I18n.t("activerecord.attributes.motif/bookable_by/radio_label_html.agents_and_prescripteurs"))
             p.text-muted.font-14.mt-1
-              = sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.agents_and_prescripteurs"))
+              = sanitize(I18n.t("activerecord.attributes.motif/bookable_by/hint.agents_and_prescripteurs"), scrubber: :prune)
 
     - if rdvi_mode
       .form-row

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -32,9 +32,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .fa.fa-video-camera>
       = "RDV par visioconférence "
-      = link_to(rdv.visio_url, target: :_blank) do
-        = "rejoindre la visioconférence "
-        i.fa.fa-external-link[aria-hidden="true"]
+      = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
 
   li.list-group-item
     .row

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -100,8 +100,8 @@ fr:
         agents: >
           Seuls vous et les agents de votre organisation peuvent ajouter des rendez-vous à votre agenda.
         agents_and_prescripteurs: >
-          Les agents et prescripteurs d’autres organisations peuvent ajouter des rendez-vous à votre agenda. Voir la 
-          <a href="https://rdvs.notion.site/Travailler-avec-les-prescripteurs-de-mon-territoire-b44f509920a34b5fbfa9b47bb57a7c28">documentation</a>
+          Les agents et prescripteurs d’autres organisations peuvent ajouter des rendez-vous à votre agenda. Voir la
+          <a href="https://rdv-service-public-1.gitbook.io/rdv-service-public/toutes-les-notions/utiliser-la-prescription-externe" target="_blank">documentation  <i class="fa fa-external-link" /></a>
           pour plus d’informations.
         agents_and_prescripteurs_and_invited_users: >
           Les agents, prescripteurs, et usagers peuvent ajouter des rendez-vous dans votre agenda.


### PR DESCRIPTION
# Contexte

En faisant un petit hallway testing avec l'équipe technique de l'incubateur des territoires, on a repéré une icône en trop et une icône manquante sur des liens externes

## Captures d'écran

Avant | Après
:- | -:
<img width="849" alt="Screenshot 2024-10-31 at 10 06 55" src="https://github.com/user-attachments/assets/b8ca5110-7751-4978-b9e4-cae49b68763d">|<img width="898" alt="Screenshot 2024-10-31 at 10 06 00" src="https://github.com/user-attachments/assets/74d7dd12-2ed2-4fd9-9e06-c3451bf827e0">
<img width="1136" alt="Screenshot 2024-10-31 at 10 06 47" src="https://github.com/user-attachments/assets/3af4e4d7-2312-41de-ae58-71ae4ef89183">|<img width="1121" alt="Screenshot 2024-10-31 at 10 06 38" src="https://github.com/user-attachments/assets/6a2d6e2e-6396-45e7-bbcc-9f3646b84220">