### PR TITLE
Afficher les numéros de téléphone de contact dans un format cohérent

### DIFF
--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -6,14 +6,14 @@
     - territories.each do |territory|
       li
         span> #{territory.name}
-        = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
+        = link_to territory.humanized_phone_number, "tel:#{territory.phone_number_formatted}"
 
 h2 Autres contacts
 ul.list-group.mb-2
   - territories_without_department.each do |territory|
     li
       span> #{territory.name}
-      = link_to territory.phone_number, "tel:#{territory.phone_number_formatted}"
+      = link_to territory.humanized_phone_number, "tel:#{territory.phone_number_formatted}"
 span> Voir
 = link_to "l'annuaire des services publics", "https://lannuaire.service-public.fr/"
 


### PR DESCRIPTION
# Contexte

Les numéros de téléphone de la page contact sont actuellement affichés tels qu'ils ont été saisis. Cette PR propose de les afficher dans un format "standard" et cohérent.

# Solution

En utilisant `humanized_phone_number`, on obtient automatiquement les formats `01 23 45 67 89` et `0 800 12 34 56`.

## Captures d'écran


Avant | Après
:- | -:
<img width="849" alt="Screenshot 2024-10-31 at 10 06 55" src="https://github.com/user-attachments/assets/66568cfe-74fd-4880-95f7-c90962529e70">|<img width="898" alt="Screenshot 2024-10-31 at 10 06 00" src="https://github.com/user-attachments/assets/d77e5772-2890-4cf0-88d5-b9268845bc8b">