### PR TITLE
fix(stats): libellé du nombre de structures

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -187,7 +187,7 @@
 
     .card.mb-5
       .card-header
-        = "#{@territories.count} structures utilisent RDV-Solidarités"
+        = "#{@territories.count} structures utilisent #{current_domain.name}"
       .card-body
         ul
           - @territories.ordered_by_name.each do |territory|

--- a/app/views/stats/notifications_index.html.slim
+++ b/app/views/stats/notifications_index.html.slim
@@ -19,7 +19,7 @@
 
     .card.mb-5
       .card-header
-        = "#{@territories.count} structures utilisent RDV-Solidarités"
+        = "#{@territories.count} structures utilisent #{current_domain.name}"
       .card-body
         ul
           - @territories.ordered_by_name.each do |territory|


### PR DESCRIPTION
# Contexte

On affichait "RDV-Solidarités" sur la page de stats, quelle que soit la plateforme.

# Solution

On fait varier le titre de la card en fonction de la plateforme.


