### PR TITLE
fix(stats): mise à jour de l’alerte d’information

### DIFF
--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -185,7 +185,7 @@
       .card-body
         p #{@agents.where.not(microsoft_graph_token: nil).count} agents utilisent la synchronisation d'agenda avec Outlook
 
-    .card.mb-5
+    .card.mb-3
       .card-header
         = "#{@territories.count} structures utilisent #{current_domain.name}"
       .card-body
@@ -193,3 +193,13 @@
           - @territories.ordered_by_name.each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
+
+    .fr-alert.fr-alert--info.fr-mb-5v
+      - if ENV["APP"] == "production-rdv-solidarites"
+        | Les statistiques données sur cette page sont le cumul de RDV Solidarités et RDV Aide Numérique.&#32;
+        | Vous pouvez consulter les statistiques de l'instance RDV Service Public sur&#32;
+        = link_to "rdv.anct.gouv.fr/stats", "https://rdv.anct.gouv.fr/stats", title: "Page de statistiques RDV Service Public - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"
+      - else
+        | Les statistiques données sur cette page sont uniquement celles de l'instance RDV Service Public.&#32;
+        | Vous pouvez consulter les statistiques de RDV Solidarités et RDV Aide Numérique sur&#32;
+        = link_to "rdv-solidarites.fr/stats", "https://rdv-solidarites.fr/stats", title: "Page de statistiques RDV Solidarités et RDV Aide Némurique - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -193,7 +193,3 @@
           - @territories.ordered_by_name.each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
-        .alert.alert-info.d-flex.align-items-center
-          .mr-3
-            i.fa.fa-info
-          = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."

--- a/app/views/stats/notifications_index.html.slim
+++ b/app/views/stats/notifications_index.html.slim
@@ -17,7 +17,7 @@
           h3.card-subtitle Par #{Receipt.human_attribute_name(attribute).downcase}
           = column_chart receipts_stats_path(group_by: attribute, departement: @departement, territory: @territory), stacked: true
 
-    .card.mb-5
+    .card.mb-3
       .card-header
         = "#{@territories.count} structures utilisent #{current_domain.name}"
       .card-body
@@ -25,3 +25,13 @@
           - @territories.ordered_by_name.each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
+
+    .fr-alert.fr-alert--info.fr-mb-5v
+      - if ENV["APP"] == "production-rdv-solidarites"
+        | Les statistiques données sur cette page sont le cumul de RDV Solidarités et RDV Aide Numérique.&#32;
+        | Vous pouvez consulter les statistiques de l'instance RDV Service Public sur&#32;
+        = link_to "rdv.anct.gouv.fr/stats", "https://rdv.anct.gouv.fr/stats", title: "Page de statistiques RDV Service Public - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"
+      - else
+        | Les statistiques données sur cette page sont uniquement celles de l'instance RDV Service Public.&#32;
+        | Vous pouvez consulter les statistiques de RDV Solidarités et RDV Aide Numérique sur&#32;
+        = link_to "rdv-solidarites.fr/stats", "https://rdv-solidarites.fr/stats", title: "Page de statistiques RDV Solidarités et RDV Aide Némurique - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"

--- a/app/views/stats/notifications_index.html.slim
+++ b/app/views/stats/notifications_index.html.slim
@@ -25,7 +25,3 @@
           - @territories.ordered_by_name.each do |territory|
             li = link_to territory, stats_path(territory: territory)
         .m-3 = link_to "Retour aux statistiques de la plateforme", stats_path
-        .alert.alert-info.d-flex.align-items-center
-          .mr-3
-            i.fa.fa-info
-          = "Les chiffres donnés sur cette page englobent les plateformes #{Domain::ALL.map(&:name).join(' et ')} indifféremment."


### PR DESCRIPTION
# Contexte

En regardant les pages de stats de RDV Solidarités et RDV Service Public, il semble que l’alerte indiquant que les stats affichées sont celles de toutes les plateformes confondues n’est plus valable.

# Solution

~~On supprime la mention désuète.~~

Suite à la discussion, on passe l’alerte au DSFR et on l’utilise pour notifier : 
- Sur RDV Service Public : que les données de RDV Solidarités/RDV Aide Numérique sont dispo sur le RDV Solidarités
- Sur RDV Solidarités : qu’il s’agit des données de RDV Solidarités et RDV Aide Numérique et que les données de RDV SP sont dispo sur le site de RDV SP

| Avant | Après |
|-|-|
| ![image](https://github.com/user-attachments/assets/4a849945-1b6d-4397-be81-f7c0b2c6afe1) | ![image](https://github.com/user-attachments/assets/9205106c-2087-47b3-80fb-1d87d21ed13b) |


