### PR TITLE
Migration de la page Mot de passe oublié vers le DSFR

### DIFF
--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -3,12 +3,16 @@
 .card
   .card-body
     = form_for resource, as: resource_name, url: password_path(resource_name) do |f|
-      .rdv-text-align-center.w-75.m-auto
       = render "devise/shared/error_messages", resource: resource
-      .form-group
-        = f.email_field :email, autofocus: true, required: true, placeholder: "nom.prenom@email.com", class: "form-control"
-      .form-group.mb-0.rdv-text-align-center
-        = f.submit "Envoyer", class: "btn btn btn-primary"
+      .fr-input-group
+        = f.label :email, "Adresse e-mail", class: "fr-label" do
+          = "Adresse email"
+          span.fr-hint-text Format attendu : nom@domaine.fr
+        = f.email_field :email, autofocus: true, required: true, placeholder: "nom.prenom@email.com", class: "fr-input"
+
+      ul.fr-btns-group.fr-mt-2w
+        li
+          = f.submit "Envoyer", class: "fr-mt-2v fr-btn"
 
     hr
     .rdv-text-align-center

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -8,20 +8,17 @@
         = f.label :email, "Adresse e-mail", class: "fr-label" do
           = "Adresse email"
           span.fr-hint-text Format attendu : nom@domaine.fr
-        = f.email_field :email, autofocus: true, required: true, placeholder: "nom.prenom@email.com", class: "fr-input"
+        = f.email_field :email, autofocus: true, required: true, class: "fr-input"
 
-      ul.fr-btns-group.fr-mt-2w
-        li
-          = f.submit "Envoyer", class: "fr-mt-2v fr-btn"
+      .rdv-text-align-center
+        = f.submit "Envoyer", class: "fr-mb-4v fr-btn"
 
     hr
     .rdv-text-align-center
       p.rdv-color-text-mention-grey
         | Vous avez un compte ?&nbsp;
-        = link_to new_session_path(resource_name) do
-          b Se connecter
+        = link_to "Se connecter", new_session_path(resource_name), class: "fr-link"
 
       p.rdv-color-text-mention-grey
         | Vous n'avez pas de compte ?&nbsp;
-        = link_to new_registration_path(resource_name) do
-          b Je m'inscris
+        = link_to "Je m’inscris", new_registration_path(resource_name), class: "fr-link"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -21,7 +21,7 @@
         = link_to("conditions générales d'utilisation", cgu_path)
 
       .form-group.mb-0.rdv-text-align-center
-        = f.button :submit, "Je m'inscris"
+        = f.button :submit, "Je m’inscris"
 
     hr.fr-my-2w
     .rdv-text-align-center

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -15,7 +15,7 @@
       p.rdv-color-text-mention-grey
         | Vous n'avez pas de compte ?&nbsp;
         = link_to new_registration_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)) do
-          b Je m'inscris
+          b Je m’inscris
 
     - if @rdv_wizard
       hr.fr-my-2w

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe "User signs up and signs in" do
     it ".sign_up, .confirm, .sign_in and then signs out" do
       visit "http://www.rdv-solidarites-test.localhost/"
       click_link "Se connecter"
-      click_link "Je m'inscris"
+      click_link "Je m’inscris"
       fill_in :user_first_name, with: user.first_name
       fill_in :user_last_name, with: user.last_name
       fill_in :user_email, with: user.email
-      click_on "Je m'inscris"
+      click_on "Je m’inscris"
       expect(page).to have_current_path(users_pending_registration_path, ignore_query: true)
       expect_flash_info(I18n.t("devise.registrations.signed_up_but_unconfirmed"))
       open_email(user.email)
@@ -32,11 +32,11 @@ RSpec.describe "User signs up and signs in" do
     it ".sign_up, .invite!, accept_invite and then signs out" do
       visit "http://www.rdv-solidarites-test.localhost/"
       click_link "Se connecter"
-      click_link "Je m'inscris"
+      click_link "Je m’inscris"
       fill_in :user_first_name, with: invited_user.first_name
       fill_in :user_last_name, with: invited_user.last_name
       fill_in :user_email, with: invited_user.email
-      click_on "Je m'inscris"
+      click_on "Je m’inscris"
       expect(page).to have_current_path(users_pending_registration_path, ignore_query: true)
       expect_flash_info(I18n.t("devise.registrations.signed_up_but_unconfirmed"))
       open_email(invited_user.email)
@@ -57,11 +57,11 @@ RSpec.describe "User signs up and signs in" do
     it "sends a new invite" do
       visit "http://www.rdv-aide-numerique-test.localhost/"
       click_link "Se connecter"
-      click_link "Je m'inscris"
+      click_link "Je m’inscris"
       fill_in :user_first_name, with: unconfirmed_user.first_name
       fill_in :user_last_name, with: unconfirmed_user.last_name
       fill_in :user_email, with: unconfirmed_user.email
-      click_on "Je m'inscris"
+      click_on "Je m’inscris"
 
       open_email(unconfirmed_user.email)
       expect(current_email.subject).to eq("Vous avez été invité sur RDV Aide Numérique")

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -423,7 +423,7 @@ RSpec.describe "User can search for rdvs" do
 
   def sign_up
     # Login page
-    click_link("Je m'inscris")
+    click_link("Je m’inscris")
 
     # Sign up page
     expect(page).to have_content("Inscription")
@@ -431,7 +431,7 @@ RSpec.describe "User can search for rdvs" do
     fill_in(:user_last_name, with: "Lapin")
     fill_in("Email", with: "michel@lapin.fr")
     fill_in("Téléphone", with: "0612345678")
-    click_button("Je m'inscris")
+    click_button("Je m’inscris")
 
     # Confirmation email
     open_email("michel@lapin.fr")

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       click_on("08:00")
 
       expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
-      click_on("Je m'inscris")
+      click_on("Je m’inscris")
 
       fill_in "user_first_name", with: "David"
       fill_in "user_last_name", with: "Nchicode"
       fill_in "user_email", with: "davidnchicode@crotonmail.com"
-      click_on("Je m'inscris")
+      click_on("Je m’inscris")
 
       open_email("davidnchicode@crotonmail.com")
       current_email.click_link("Confirmer mon compte")


### PR DESCRIPTION
Review app: https://demo-rdv-solidarites-pr4768.osc-secnum-fr1.scalingo.io/

# Contexte

Dans le cadre du passage au DSFR, nous retravaillions le formulaire de mot de passe oublié de session.

# Solution



# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [x] Préparer des captures de l’interface avant et après

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/08ad33b0-4a36-498f-b7d2-3b45eb412190) | ![image](https://github.com/user-attachments/assets/9cf77092-3884-42fe-b7e6-9c457a8ee4a3)

