### PR TITLE
Utiliser la version récente de devise_token_auth désormais dispo sur Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem "omniauth-rails_csrf_protection"
 # OO authorization for Rails
 gem "pundit"
 # Token based authentication for rails. Uses Devise + OmniAuth.
-gem "devise_token_auth", "1.2.3", git: "https://github.com/lynndylanhurley/devise_token_auth" # la version publiés sur Rubygems n'est pas compatible Rails 7.1
+gem "devise_token_auth", "1.2.4"
 # List of frequently used passwords
 gem "common_french_passwords"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/lynndylanhurley/devise_token_auth
-  revision: 812711e4776f2eab2de8a057bd5befc023fb666b
-  specs:
-    devise_token_auth (1.2.3)
-      bcrypt (~> 3.0)
-      devise (> 3.5.2, < 5)
-      rails (>= 4.2.0, < 7.3)
-
-GIT
   remote: https://github.com/nahi/httpclient.git
   revision: d57cc6d5ffee1b566b5c189fe6dc8cc89570b812
   ref: d57cc6d
@@ -221,6 +212,10 @@ GEM
     devise_invitable (2.0.9)
       actionmailer (>= 5.0)
       devise (>= 4.6)
+    devise_token_auth (1.2.4)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 7.3)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -721,7 +716,7 @@ DEPENDENCIES
   devise!
   devise-async
   devise_invitable
-  devise_token_auth (= 1.2.3)!
+  devise_token_auth (= 1.2.4)
   dotenv-rails
   drb
   dsfr-view-components


### PR DESCRIPTION
Dans #3998 j'ai fait pointer notre `Gemfile` vers le dépôt GitHub de `devise_token_auth` car les versions récentes n'avaient pas été released sur Rubygems. C'est maintenant fait avec la version 1.2.4 donc je fais pointer vers Rubygems.

Le changelog : https://github.com/lynndylanhurley/devise_token_auth/blob/master/CHANGELOG.md#v124-2024-10-21