### PR TITLE
Désactiver temporairement les flaky specs (2nde édition)

### DIFF
--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -134,6 +134,11 @@ RSpec.describe "agents can prescribe rdvs" do
 
   describe "creating a user along the way" do
     it "leaves the user both in local and distant organisation", js: true do
+      if Date.new(2024, 12, 19).future?
+        pending # rubocop:disable RSpec/Pending
+        raise "cette flaky spec a été désactivée le temps de travailler dessus"
+      end
+
       go_to_prescription_page
       # Select Service
       find("h3", text: motif_mds.service.name).ancestor("a").click
@@ -263,9 +268,9 @@ RSpec.describe "agents can prescribe rdvs" do
         end
 
         it "show both services and motifs" do
-          if Date.new(2024, 10, 19).future?
+          if Date.new(2024, 12, 19).future?
             pending # rubocop:disable RSpec/Pending
-            raise "cette flaky spec a été désactivée pendant un mois le temps de travailler dessus"
+            raise "cette flaky spec a été désactivée le temps de travailler dessus"
           end
 
           expect(page).to have_content(motif_mds.service.name)

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   end
 
   it "allows changing the location type and adds validation when trying to create a rdv without email or phone number", js: true do
-    if Date.new(2024, 10, 19).future?
+    if Date.new(2024, 12, 19).future?
       pending # rubocop:disable RSpec/Pending
-      raise "cette flaky spec a été désactivée pendant un mois le temps de travailler dessus"
+      raise "cette flaky spec a été désactivée le temps de travailler dessus"
     end
 
     visit admin_organisation_motifs_path(organisation)


### PR DESCRIPTION
Ces flaky specs nous gênent au quotidien et visiblement on ne prend pas le temps de les corriger. Je désactive donc jusqu'à mi-décembre.

Note : j'ai ajouté une spec car j'ai vu qu'elle avait échoué il y a 5 jours sur la branche `production`, voir l'action de CI ici : 
https://github.com/betagouv/rdv-service-public/actions/runs/11591827980/job/32272414883

Nous avions déjà précédemment désactivé ces specs dans #4656 pour se laisser le temps de les corriger, en vain.