### PR TITLE
Éviter le bruit dans Sentry en cas de rate-limiting de Outlook

### DIFF
--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -44,5 +44,6 @@ module DefaultJobBehaviour
     end
 
     Sentry.set_context :job, context
+    Sentry.set_tags(executions: executions)
   end
 end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -11,7 +11,7 @@ module DefaultJobBehaviour
     # Exponential backoff is n^4, so wait times between retries will be as follows:
     # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
     # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
-    # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8 hours
+    # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8 days
     # it therefore takes more than 8 days for a job to be discarded
     retry_on(StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
 

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -36,7 +36,7 @@ module Outlook
     def capture_sentry_warning_for_retry?(exception)
       # Ces erreurs se produisent parfois à la première exécution, puis le job passe au retry.
       if exception.class.in?([Outlook::ApiClient::RefreshTokenError, Outlook::ApiClient::RateLimitingError])
-        executions > 4
+        executions > 3
       else
         super
       end

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -34,8 +34,8 @@ module Outlook
     end
 
     def capture_sentry_warning_for_retry?(exception)
-      # Cette erreur se produit parfois à la première exécution, puis le job passe au retry.
-      if exception.is_a?(Outlook::ApiClient::RefreshTokenError)
+      # Ces erreurs se produisent parfois à la première exécution, puis le job passe au retry.
+      if exception.class.in?([Outlook::ApiClient::RefreshTokenError, Outlook::ApiClient::RateLimitingError])
         executions > 4
       else
         super

--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -4,6 +4,7 @@ module Outlook
     class NotFoundError < ApiError; end
     class AlreadyExistsError < ApiError; end
     class RefreshTokenError < ApiError; end
+    class RateLimitingError < ApiError; end
 
     def initialize(agent)
       @agent = agent
@@ -102,6 +103,8 @@ module Outlook
                           NotFoundError
                         when "ErrorDuplicateTransactionId"
                           AlreadyExistsError
+                        when "ApplicationThrottled"
+                          RateLimitingError
                         else
                           ApiError
                         end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ApplicationJob, type: :job do
       expect(sentry_events.last.contexts[:job][:arguments]).to eq([123, { _some_kw_arg: 456 }])
       expect(sentry_events.last.contexts[:job][:queue_name]).to eq("custom_queue")
       expect(sentry_events.last.contexts[:job][:job_link]).to match("/super_admins/good_job/jobs/#{enqueued_job_id}")
+      expect(sentry_events.last.tags[:executions]).to eq(1)
 
       expect(sentry_events.last.exception.values.first.value).to match("Something unexpected happened (RuntimeError)")
       expect(sentry_events.last.exception.values.first.type).to eq("RuntimeError")


### PR DESCRIPTION
Erreur Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/128698

# Contexte

Nous avons vu la semaine dernière des bursts de cette erreur (une centaine par jour) : 

> Application is over its MailboxConcurrency limit. (Outlook::ApiClient::ApiError)

Il s'agit du rate limiting de Outlook. D'après ce que je vois, les jobs passent toujours au premier retry, il est donc disproportionné de remonter l'info dans Sentry dès le premier essai.

# Solution

Le 3ème arrive au bout de 1 minute 30 secondes. Le 4ème retry arrive au bout de 6 minutes. J'hésite à attendre 3 ou 4 retries avant de nous alerter. :thinking: Des opinions ?

## Fait au passage

J'ai ajouté au passage le nombre d'executions dans les tags Sentry, je pense que c'est une donnée souvent utile pour en savoir plus sur nos erreurs de jobs. :wink: 