### PR TITLE
Éviter d'abandonner un job d'unlink Outlook en cas d'erreur inconnue

### DIFF
--- a/app/jobs/outlook/mass_destroy_event_job.rb
+++ b/app/jobs/outlook/mass_destroy_event_job.rb
@@ -4,14 +4,14 @@ module Outlook
 
     def perform(agent)
       client = Outlook::ApiClient.new(agent)
+
       agent.agents_rdvs.where.not(outlook_id: nil).each do |agents_rdv|
         client.delete_event!(agents_rdv.outlook_id)
 
         # On utilise #update_columns pour éviter de lancer les callbacks, dont notamment celui qui amène à l'exécution de ce job
-        agents_rdv&.update_columns(outlook_id: nil) # rubocop:disable Rails/SkipsModelValidations
-      rescue Outlook::ApiClient::ApiError
-        nil
+        agents_rdv.update_columns(outlook_id: nil) # rubocop:disable Rails/SkipsModelValidations
       end
+
       agent.update!(microsoft_graph_token: nil, refresh_microsoft_graph_token: nil, outlook_disconnect_in_progress: false)
     end
   end

--- a/spec/jobs/outlook/mass_destroy_event_job_spec.rb
+++ b/spec/jobs/outlook/mass_destroy_event_job_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Outlook::MassDestroyEventJob, type: :job do
     end
   end
 
-  context "when there is an error while destroying one of the events" do
+  context "when there is an ErrorItemNotFound error while destroying one of the events" do
     before do
       stub_request(:delete, "https://graph.microsoft.com/v1.0/me/Events/abc")
         .with(headers: expected_headers)
@@ -59,21 +59,44 @@ RSpec.describe Outlook::MassDestroyEventJob, type: :job do
       stub_request(:delete, "https://graph.microsoft.com/v1.0/me/Events/def")
         .with(headers: expected_headers)
         .to_return(
-          status: 403,
-          body: {
-            "error" => {
-              "message" => "The specified object was not found in the store.",
-            },
-          }.to_json,
+          status: 404,
+          body: { error: { code: "ErrorItemNotFound", message: "The specified object was not found in the store." } }.to_json,
           headers: {}
         )
     end
 
-    it "unsyncs the agent" do
+    it "unsyncs the agent and clears the agents_rdvs.outlook_id column" do
       expect do
         described_class.perform_now(agent)
       end.to change { agent.reload.microsoft_graph_token }.to(nil)
         .and change { agent.reload.refresh_microsoft_graph_token }.to(nil)
+        .and change { agents_rdv.reload.outlook_id }.to(nil)
+        .and change { agents_rdv2.reload.outlook_id }.to(nil)
+    end
+  end
+
+  context "when there is an unknown error while destroying one of the events" do
+    before do
+      stub_request(:delete, "https://graph.microsoft.com/v1.0/me/Events/abc")
+        .with(headers: expected_headers)
+        .to_return(status: 204, body: "", headers: {})
+      stub_request(:delete, "https://graph.microsoft.com/v1.0/me/Events/def")
+        .with(headers: expected_headers)
+        .to_return(
+          status: 500,
+          body: { error: { code: "NeverSeenBeforeError", message: "Did not expect that one, did you?" } }.to_json,
+          headers: {}
+        )
+    end
+
+    it "retries the job but does no unlink agent nor agents_rdvs.outlook_id column for the RDV that triggered the error" do
+      expect do
+        described_class.perform_now(agent)
+      end.to change(enqueued_jobs, :size).by(1) # job is re-enqueued
+
+      expect(agent.reload.microsoft_graph_token).not_to be_nil
+      expect(agent.reload.refresh_microsoft_graph_token).not_to be_nil
+      expect(agents_rdv2.reload.outlook_id).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
# Contexte

En travaillant sur #4772 j'ai remarqué que `Outlook::MassDestroyEventJob` avait une mauvaise gestion des erreurs. En effet, pour chaque RDV de l'agent, le job fait un appel à l'API Outlook pour supprimer l'événement Outlook correspondant.

Comportement actuel : si Outlook renvoie une erreur lors de cette requête de suppression, on ignore cette erreur et on vide la colonne `agents_rdvs.outlook_id` de notre côté. Ça signifie par exemple que si Outlook nous renvoie une simple erreur de rate-limiting, on va laisser l'événement Outlook exister mais vider son `outlook_id` chez nous !

Comportement désiré : 
- si outlook renvoie une erreur `ErrorItemNotFound`, on considère que l'événement Outlook a déjà été supprimé et on vide notre référence `outlook_id`
- si l'erreur est d'un autre type, on retry le job (ce cas ne s'est jamais présenté)

# Solution

J'ai découvert que la méthode `Outlook::ApiClient#delete_event!` faisait déjà un `rescue` "en interne", donc j'ai simplement retiré le `rescue` du `Outlook::MassDestroyEventJob` pour laisser les exceptions remonter et déclencher un retry.

J'ai décliné la spec existante en 2 specs : 
- le job rencontre une erreur `ErrorItemNotFound` (j'ai pu copier le corps de la réponse depuis [une vraie erreur](https://sentry.incubateur.net/organizations/betagouv/issues/128187))
- le job rencontre une erreur inconnue => retry