### PR TITLE
Permettre aux agents d'avoir des équipes dans plusieurs territoires

### DIFF
--- a/app/controllers/admin/territories/agents_controller.rb
+++ b/app/controllers/admin/territories/agents_controller.rb
@@ -31,13 +31,13 @@ class Admin::Territories::AgentsController < Admin::Territories::BaseController
   def edit; end
 
   def update_teams
-    # cf PR https://github.com/betagouv/rdv-service-public/pull/4525
-    raise TeamsInMultipleTerritoriesError if @agent.teams.where.not(territory: current_territory).exists?
-
     team_ids = Team
       .where(id: params[:agent][:team_ids].compact_blank, territory: current_territory) # filtering on territory is not done in policy anymore
       .pluck(:id)
-    if @agent.update(team_ids:)
+
+    team_ids_from_other_territories = @agent.agent_teams.joins(:team).where.not(teams: { territory_id: current_territory.id }).pluck(:team_id)
+
+    if @agent.update(team_ids: team_ids + team_ids_from_other_territories)
       flash[:success] = "Les équipes de l’agent ont été mises à jour"
       redirect_to edit_admin_territory_agent_path(current_territory, @agent.id)
     else

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -60,7 +60,7 @@ h1
         = t(".agent_teams_legend")
       = simple_form_for @agent, url: update_teams_admin_territory_agent_path(current_territory, @agent) do |f|
         .card-body
-          = f.input :team_ids, collection: current_territory.teams,
+          = f.input :team_ids, collection: current_territory.teams.ordered_by_name,
                 label: t(".teams"),
                 label_method: :name,
                 input_html: { \

--- a/spec/features/territory_admins/update_teams_for_agent_spec.rb
+++ b/spec/features/territory_admins/update_teams_for_agent_spec.rb
@@ -24,10 +24,11 @@ RSpec.describe "update an agent's teams" do
   it "allows changing the agent teams in this territory" do
     visit edit_admin_territory_agent_path(agent.id, territory_id: territory.id)
     unselect "Equipe actuelle", from: "Équipes"
-    # find(".select2-search__field").send_keys("Nouv")
-    # expect(page).to have_content("Nouvelle")
     select "Nouvelle équipe", from: "Équipes"
 
     click_on "Enregistrer"
+
+    expect(page).to have_content("Les équipes de l’agent ont été mises à jour")
+    expect(agent.reload.teams).to contain_exactly(other_team_in_first_territory, other_team_in_other_territory)
   end
 end

--- a/spec/features/territory_admins/update_teams_for_agent_spec.rb
+++ b/spec/features/territory_admins/update_teams_for_agent_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "update an agent's teams" do
+  let(:territory_admin) { create(:agent) }
+  let(:agent) { create(:agent, basic_role_in_organisations: [orga]) }
+
+  let(:territory) { create(:territory) }
+  let(:other_territory) { create(:territory) }
+  let(:orga) { create(:organisation, territory:) }
+
+  let(:team) { create(:team, territory: territory, name: "Equipe actuelle") }
+  let!(:other_team_in_first_territory)  { create(:team, territory: territory, name: "Nouvelle équipe") }
+  let!(:other_team_in_other_territory)  { create(:team, territory: other_territory) }
+
+  let(:multi_territory_agent) { create(:agent) }
+
+  before do
+    create(:agent_territorial_access_right, agent: territory_admin, territory: territory, allow_to_manage_teams: true)
+    create(:agent_territorial_access_right, agent:, territory: territory)
+    AgentTeam.create!(agent:, team:)
+    AgentTeam.create!(agent:, team: other_team_in_other_territory)
+
+    login_as(territory_admin, scope: :agent)
+  end
+
+  it "allows changing the agent teams in this territory" do
+    visit edit_admin_territory_agent_path(agent.id, territory_id: territory.id)
+    unselect "Equipe actuelle", from: "Équipes"
+    # find(".select2-search__field").send_keys("Nouv")
+    # expect(page).to have_content("Nouvelle")
+    select "Nouvelle équipe", from: "Équipes"
+
+    click_on "Enregistrer"
+  end
+end

--- a/spec/features/territory_admins/update_teams_for_agent_spec.rb
+++ b/spec/features/territory_admins/update_teams_for_agent_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "update an agent's teams" do
   before do
     create(:agent_territorial_access_right, agent: territory_admin, territory: territory, allow_to_manage_teams: true)
     create(:agent_territorial_access_right, agent:, territory: territory)
-    AgentTeam.create!(agent:, team:)
-    AgentTeam.create!(agent:, team: other_team_in_other_territory)
+    AgentTeam.create!(agent: agent, team: team)
+    AgentTeam.create!(agent: agent, team: other_team_in_other_territory)
 
     login_as(territory_admin, scope: :agent)
   end

--- a/spec/features/territory_admins/update_teams_for_agent_spec.rb
+++ b/spec/features/territory_admins/update_teams_for_agent_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "update an agent's teams" do
 
   let(:team) { create(:team, territory: territory, name: "Equipe actuelle") }
   let!(:other_team_in_first_territory)  { create(:team, territory: territory, name: "Nouvelle équipe") }
-  let!(:other_team_in_other_territory)  { create(:team, territory: other_territory) }
+  let(:other_team_in_other_territory) { create(:team, territory: other_territory) }
 
   let(:multi_territory_agent) { create(:agent) }
 


### PR DESCRIPTION
# Contexte

L'erreur TeamsInMultipleTerritoriesError a été levée (voir https://sentry.incubateur.net/organizations/betagouv/issues/129836/?environment=production&project=74&query=is%3Aunresolved+is%3Aunlinked&referrer=issue-stream&statsPeriod=30d&stream_index=1).

Je pense qu'à l'époque on été pas sûrs de comment gérer correctement les agents qui ont des équipes dans plusieurs territoires.

# Solution

En relisant le code, j'ai trouvé une manière simple de permettre de gérer ce cas : on ajoute juste une ligne pour garder les équipes hors du territoire courant. (et donc on modifie seulement les équipes du territoire courant)

Le premier commit ajoute un test qui échoue, le deuxième le fait passer au vert, le troisième ajoute un scope pour ordonner les équipes, parce que ça fait toujours du bien.

