### PR TITLE
Migration inscription usager vers le DSFR

### DIFF
--- a/app/form_builders/dsfr_form_builder.rb
+++ b/app/form_builders/dsfr_form_builder.rb
@@ -12,6 +12,10 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
     dsfr_input_field(attribute, :email_field, opts)
   end
 
+  def dsfr_phone_field(attribute, opts = {})
+    dsfr_input_field(attribute, :phone_field, opts)
+  end
+
   def dsfr_date_field(attribute, opts = {})
     dsfr_input_field(attribute, :date_field, opts)
   end
@@ -139,7 +143,7 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def required_tag
-    @template.content_tag(:span, "*", class: "fr-ml-1w fr-text-error")
+    @template.content_tag(:span, "*", class: "fr-text-error")
   end
 
   def hint(text)

--- a/app/form_builders/dsfr_form_builder.rb
+++ b/app/form_builders/dsfr_form_builder.rb
@@ -1,5 +1,6 @@
 # Source: https://github.com/etalab/data_pass/blob/develop/app/form_builders/dsfr_form_builder.rb
-# Quelques modifications ont été appliqué car nous n’utilisons pas encore I18n pour les lebel et les hints
+# Quelques modifications ont été appliquées car nous n’utilisons pas i18n pour les labels et les hints
+# et nous n’utilisons pas tous les types de champs
 class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::OutputSafetyHelper
@@ -16,112 +17,20 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
     dsfr_input_field(attribute, :phone_field, opts)
   end
 
-  def dsfr_date_field(attribute, opts = {})
-    dsfr_input_field(attribute, :date_field, opts)
-  end
-
-  def dsfr_text_area(attribute, opts = {})
-    dsfr_input_field(attribute, :text_area, opts)
-  end
-
-  def dsfr_number_field(attribute, opts = {})
-    dsfr_input_field(attribute, :number_field, opts)
-  end
-
-  def dsfr_url_field(attribute, opts = {})
-    dsfr_input_field(attribute, :url_field, opts)
-  end
-
-  def dsfr_file_field(attribute, opts = {})
-    opts[:class] ||= "fr-upload-group"
-
-    existing_file_link = link_to_file(attribute)
-    required = opts[:required] && !existing_file_link
-
-    dsfr_input_group(attribute, opts) do
-      @template.safe_join(
-        [
-          label_with_hint(attribute, opts),
-          file_field(attribute, class: "fr-upload", autocomplete: "off", required:, **enhance_input_options(opts).except(:class, :required)),
-          error_message(attribute),
-          existing_file_link,
-          link_to_file(attribute),
-        ].compact
-      )
-    end
-  end
-
-  def dsfr_check_box(attribute, opts = {})
-    dsfr_input_group(attribute, opts) do
-      @template.content_tag(:div, class: "fr-checkbox-group") do
-        @template.safe_join(
-          [
-            check_box(attribute, class: input_classes(opts), disabled: check_box_disabled, **enhance_input_options(opts).except(:class)),
-            opts[:label] || label_with_hint(attribute, opts),
-          ]
-        )
-      end
-    end
-  end
-
   def dsfr_input_group(attribute, opts, &block)
     @template.content_tag(:div, class: input_group_classes(attribute, opts)) do
       yield(block)
     end
   end
 
-  def dsfr_radio_buttons(attribute, choices, opts = {})
-    @template.content_tag(:fieldset, class: "fr-fieldset") do
-      @template.safe_join(
-        [
-          @template.content_tag(
-            :legend,
-            sanitize(@object.class.human_attribute_name(attribute).concat(hint(attribute))),
-            class: "fr-fieldset__legend--regular fr-fieldset__legend"
-          ),
-          choices.map { |choice| dsfr_radio_option(attribute, choice, opts) },
-        ]
-      )
-    end
-  end
-
-  def dsfr_radio_option(attribute, value, opts = {})
-    @template.content_tag(:div, class: "fr-fieldset__element") do
-      @template.content_tag(:div, class: "fr-radio-group") do
-        @template.safe_join(
-          [
-            radio_button(attribute, value, **opts),
-            label([attribute, value].join("_").to_sym, value: label_value(attribute)),
-          ]
-        )
-      end
-    end
-  end
-
-  def dsfr_select(attribute, choices, opts = {})
-    @template.content_tag(:div, class: "fr-select-group") do
-      @template.safe_join(
-        [
-          label_with_hint(attribute, opts),
-          dsfr_select_tag(attribute, choices, opts),
-          error_message(attribute),
-        ]
-      )
-    end
-  end
-
   private
-
-  def dsfr_select_tag(attribute, choices, opts)
-    select(attribute, choices, { include_blank: opts[:include_blank] }, class: "fr-select", **enhance_input_options(opts).except(:class))
-  end
 
   def dsfr_input_field(attribute, input_kind, opts = {})
     dsfr_input_group(attribute, opts) do
       @template.safe_join(
         [
           label_with_hint(attribute, opts),
-          public_send(input_kind, attribute, class: input_classes(opts), autocomplete: "off", **enhance_input_options(opts).except(:class)),
+          public_send(input_kind, attribute, class: "fr-input", **opts.except(:class)),
           error_message(attribute),
         ]
       )
@@ -130,15 +39,11 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
 
   def label_with_hint(attribute, opts = {})
     label(attribute, class: "fr-label") do
-      label_value = [label_value(attribute)]
-      label_value.push(required_tag) if opts[:required]
+      label_and_tags = [label_value(attribute)]
+      label_and_tags.push(required_tag) if opts[:required]
+      label_and_tags.push(hint_tag(opts[:hint])) if opts[:hint]
 
-      @template.safe_join(
-        [
-          label_value,
-          hint(opts[:hint]),
-        ]
-      )
+      @template.safe_join(label_and_tags)
     end
   end
 
@@ -146,7 +51,7 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
     @template.content_tag(:span, "*", class: "fr-text-error")
   end
 
-  def hint(text)
+  def hint_tag(text)
     return "" unless text
 
     @template.content_tag(:span, class: "fr-hint-text") do
@@ -170,31 +75,6 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
     arr.compact.join(" ")
   end
 
-  def input_classes(opts)
-    join_classes(
-      [
-        "fr-input",
-        opts[:code] && "fr-input--code",
-        input_width_class(opts),
-      ]
-    )
-  end
-
-  def link_to_file(attribute)
-    file = @object.send(attribute)
-    return unless file.attached? && file.persisted?
-
-    @template.content_tag(:div, class: "fr-input-group__text fr-mt-1w") do
-      @template.link_to(file.filename, rails_blob_path(file, disposition: "inline", only_path: true), target: "_blank", rel: "noopener")
-    end
-  end
-
-  def input_width_class(opts)
-    return "" if opts[:width].blank?
-
-    opts[:width].split.map { |spec| "fr-col-#{spec}" }.join(" ")
-  end
-
   def input_group_classes(attribute, opts)
     join_classes(
       [
@@ -207,13 +87,5 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
 
   def label_value(attribute)
     (@object.try(:object) || @object).class.human_attribute_name(attribute)
-  end
-
-  def enhance_input_options(opts)
-    opts
-  end
-
-  def check_box_disabled
-    false
   end
 end

--- a/app/form_builders/dsfr_form_builder.rb
+++ b/app/form_builders/dsfr_form_builder.rb
@@ -2,6 +2,7 @@
 # Quelques modifications ont été appliqué car nous n’utilisons pas encore I18n pour les lebel et les hints
 class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   include Rails.application.routes.url_helpers
+  include ActionView::Helpers::OutputSafetyHelper
 
   def dsfr_text_field(attribute, opts = {})
     dsfr_input_field(attribute, :text_field, opts)
@@ -28,7 +29,7 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def dsfr_file_field(attribute, opts = {})
-    opts[:class] ||= 'fr-upload-group'
+    opts[:class] ||= "fr-upload-group"
 
     existing_file_link = link_to_file(attribute)
     required = opts[:required] && !existing_file_link
@@ -37,10 +38,10 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
       @template.safe_join(
         [
           label_with_hint(attribute, opts),
-          file_field(attribute, class: 'fr-upload', autocomplete: 'off', required:, **enhance_input_options(opts).except(:class, :required)),
+          file_field(attribute, class: "fr-upload", autocomplete: "off", required:, **enhance_input_options(opts).except(:class, :required)),
           error_message(attribute),
           existing_file_link,
-          link_to_file(attribute)
+          link_to_file(attribute),
         ].compact
       )
     end
@@ -48,11 +49,11 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
 
   def dsfr_check_box(attribute, opts = {})
     dsfr_input_group(attribute, opts) do
-      @template.content_tag(:div, class: 'fr-checkbox-group') do
+      @template.content_tag(:div, class: "fr-checkbox-group") do
         @template.safe_join(
           [
             check_box(attribute, class: input_classes(opts), disabled: check_box_disabled, **enhance_input_options(opts).except(:class)),
-            opts[:label] || label_with_hint(attribute, opts)
+            opts[:label] || label_with_hint(attribute, opts),
           ]
         )
       end
@@ -66,27 +67,27 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def dsfr_radio_buttons(attribute, choices, opts = {})
-    @template.content_tag(:fieldset, class: 'fr-fieldset') do
+    @template.content_tag(:fieldset, class: "fr-fieldset") do
       @template.safe_join(
         [
           @template.content_tag(
             :legend,
-            @object.class.human_attribute_name(attribute).concat(hint(attribute)).html_safe,
-            class: 'fr-fieldset__legend--regular fr-fieldset__legend'
+            sanitize(@object.class.human_attribute_name(attribute).concat(hint(attribute))),
+            class: "fr-fieldset__legend--regular fr-fieldset__legend"
           ),
-          choices.map { |choice| dsfr_radio_option(attribute, choice, opts) }
+          choices.map { |choice| dsfr_radio_option(attribute, choice, opts) },
         ]
       )
     end
   end
 
   def dsfr_radio_option(attribute, value, opts = {})
-    @template.content_tag(:div, class: 'fr-fieldset__element') do
-      @template.content_tag(:div, class: 'fr-radio-group') do
+    @template.content_tag(:div, class: "fr-fieldset__element") do
+      @template.content_tag(:div, class: "fr-radio-group") do
         @template.safe_join(
           [
             radio_button(attribute, value, **opts),
-            label([attribute, value].join('_').to_sym, value: label_value(attribute))
+            label([attribute, value].join("_").to_sym, value: label_value(attribute)),
           ]
         )
       end
@@ -94,12 +95,12 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def dsfr_select(attribute, choices, opts = {})
-    @template.content_tag(:div, class: 'fr-select-group') do
+    @template.content_tag(:div, class: "fr-select-group") do
       @template.safe_join(
         [
           label_with_hint(attribute, opts),
           dsfr_select_tag(attribute, choices, opts),
-          error_message(attribute)
+          error_message(attribute),
         ]
       )
     end
@@ -108,7 +109,7 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   private
 
   def dsfr_select_tag(attribute, choices, opts)
-    select(attribute, choices, { include_blank: opts[:include_blank] }, class: 'fr-select', **enhance_input_options(opts).except(:class))
+    select(attribute, choices, { include_blank: opts[:include_blank] }, class: "fr-select", **enhance_input_options(opts).except(:class))
   end
 
   def dsfr_input_field(attribute, input_kind, opts = {})
@@ -116,61 +117,61 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
       @template.safe_join(
         [
           label_with_hint(attribute, opts),
-          public_send(input_kind, attribute, class: input_classes(opts), autocomplete: 'off', **enhance_input_options(opts).except(:class)),
-          error_message(attribute)
+          public_send(input_kind, attribute, class: input_classes(opts), autocomplete: "off", **enhance_input_options(opts).except(:class)),
+          error_message(attribute),
         ]
       )
     end
   end
 
   def label_with_hint(attribute, opts = {})
-    label(attribute, class: 'fr-label') do
+    label(attribute, class: "fr-label") do
       label_value = [label_value(attribute)]
       label_value.push(required_tag) if opts[:required]
 
       @template.safe_join(
         [
           label_value,
-          hint(opts[:hint])
+          hint(opts[:hint]),
         ]
       )
     end
   end
 
   def required_tag
-    @template.content_tag(:span, '*', class: 'fr-ml-1w fr-text-error')
+    @template.content_tag(:span, "*", class: "fr-ml-1w fr-text-error")
   end
 
   def hint(text)
-    return '' unless text
+    return "" unless text
 
-    @template.content_tag(:span, class: 'fr-hint-text') do
+    @template.content_tag(:span, class: "fr-hint-text") do
       text
     end
 
-    @template.content_tag(:span, text.html_safe, class: 'fr-hint-text')
+    @template.content_tag(:span, text, class: "fr-hint-text")
   end
 
   def error_message(attr)
     return if @object.errors[attr].none?
 
-    @template.content_tag(:p, class: 'fr-messages-group') do
-      @object.errors.full_messages_for(attr).map { |msg|
-        @template.content_tag(:span, msg, class: 'fr-message fr-message--error')
-      }.join.html_safe
+    @template.content_tag(:p, class: "fr-messages-group") do
+      safe_join(@object.errors.full_messages_for(attr).map do |msg|
+        @template.content_tag(:span, msg, class: "fr-message fr-message--error")
+      end)
     end
   end
 
   def join_classes(arr)
-    arr.compact.join(' ')
+    arr.compact.join(" ")
   end
 
   def input_classes(opts)
     join_classes(
       [
-        'fr-input',
-        opts[:code] && 'fr-input--code',
-        input_width_class(opts)
+        "fr-input",
+        opts[:code] && "fr-input--code",
+        input_width_class(opts),
       ]
     )
   end
@@ -179,23 +180,23 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
     file = @object.send(attribute)
     return unless file.attached? && file.persisted?
 
-    @template.content_tag(:div, class: 'fr-input-group__text fr-mt-1w') do
-      @template.link_to(file.filename, rails_blob_path(file, disposition: 'inline', only_path: true), target: '_blank', rel: 'noopener')
+    @template.content_tag(:div, class: "fr-input-group__text fr-mt-1w") do
+      @template.link_to(file.filename, rails_blob_path(file, disposition: "inline", only_path: true), target: "_blank", rel: "noopener")
     end
   end
 
   def input_width_class(opts)
-    return '' if opts[:width].blank?
+    return "" if opts[:width].blank?
 
-    opts[:width].split.map { |spec| "fr-col-#{spec}" }.join(' ')
+    opts[:width].split.map { |spec| "fr-col-#{spec}" }.join(" ")
   end
 
   def input_group_classes(attribute, opts)
     join_classes(
       [
-        'fr-input-group',
-        @object.errors[attribute].any? ? 'fr-input-group--error' : nil,
-        opts[:class]
+        "fr-input-group",
+        @object.errors[attribute].any? ? "fr-input-group--error" : nil,
+        opts[:class],
       ]
     )
   end

--- a/app/form_builders/dsfr_form_builder.rb
+++ b/app/form_builders/dsfr_form_builder.rb
@@ -1,0 +1,214 @@
+# Source: https://github.com/etalab/data_pass/blob/develop/app/form_builders/dsfr_form_builder.rb
+# Quelques modifications ont été appliqué car nous n’utilisons pas encore I18n pour les lebel et les hints
+class DsfrFormBuilder < ActionView::Helpers::FormBuilder
+  include Rails.application.routes.url_helpers
+
+  def dsfr_text_field(attribute, opts = {})
+    dsfr_input_field(attribute, :text_field, opts)
+  end
+
+  def dsfr_email_field(attribute, opts = {})
+    dsfr_input_field(attribute, :email_field, opts)
+  end
+
+  def dsfr_date_field(attribute, opts = {})
+    dsfr_input_field(attribute, :date_field, opts)
+  end
+
+  def dsfr_text_area(attribute, opts = {})
+    dsfr_input_field(attribute, :text_area, opts)
+  end
+
+  def dsfr_number_field(attribute, opts = {})
+    dsfr_input_field(attribute, :number_field, opts)
+  end
+
+  def dsfr_url_field(attribute, opts = {})
+    dsfr_input_field(attribute, :url_field, opts)
+  end
+
+  def dsfr_file_field(attribute, opts = {})
+    opts[:class] ||= 'fr-upload-group'
+
+    existing_file_link = link_to_file(attribute)
+    required = opts[:required] && !existing_file_link
+
+    dsfr_input_group(attribute, opts) do
+      @template.safe_join(
+        [
+          label_with_hint(attribute, opts),
+          file_field(attribute, class: 'fr-upload', autocomplete: 'off', required:, **enhance_input_options(opts).except(:class, :required)),
+          error_message(attribute),
+          existing_file_link,
+          link_to_file(attribute)
+        ].compact
+      )
+    end
+  end
+
+  def dsfr_check_box(attribute, opts = {})
+    dsfr_input_group(attribute, opts) do
+      @template.content_tag(:div, class: 'fr-checkbox-group') do
+        @template.safe_join(
+          [
+            check_box(attribute, class: input_classes(opts), disabled: check_box_disabled, **enhance_input_options(opts).except(:class)),
+            opts[:label] || label_with_hint(attribute, opts)
+          ]
+        )
+      end
+    end
+  end
+
+  def dsfr_input_group(attribute, opts, &block)
+    @template.content_tag(:div, class: input_group_classes(attribute, opts)) do
+      yield(block)
+    end
+  end
+
+  def dsfr_radio_buttons(attribute, choices, opts = {})
+    @template.content_tag(:fieldset, class: 'fr-fieldset') do
+      @template.safe_join(
+        [
+          @template.content_tag(
+            :legend,
+            @object.class.human_attribute_name(attribute).concat(hint(attribute)).html_safe,
+            class: 'fr-fieldset__legend--regular fr-fieldset__legend'
+          ),
+          choices.map { |choice| dsfr_radio_option(attribute, choice, opts) }
+        ]
+      )
+    end
+  end
+
+  def dsfr_radio_option(attribute, value, opts = {})
+    @template.content_tag(:div, class: 'fr-fieldset__element') do
+      @template.content_tag(:div, class: 'fr-radio-group') do
+        @template.safe_join(
+          [
+            radio_button(attribute, value, **opts),
+            label([attribute, value].join('_').to_sym, value: label_value(attribute))
+          ]
+        )
+      end
+    end
+  end
+
+  def dsfr_select(attribute, choices, opts = {})
+    @template.content_tag(:div, class: 'fr-select-group') do
+      @template.safe_join(
+        [
+          label_with_hint(attribute, opts),
+          dsfr_select_tag(attribute, choices, opts),
+          error_message(attribute)
+        ]
+      )
+    end
+  end
+
+  private
+
+  def dsfr_select_tag(attribute, choices, opts)
+    select(attribute, choices, { include_blank: opts[:include_blank] }, class: 'fr-select', **enhance_input_options(opts).except(:class))
+  end
+
+  def dsfr_input_field(attribute, input_kind, opts = {})
+    dsfr_input_group(attribute, opts) do
+      @template.safe_join(
+        [
+          label_with_hint(attribute, opts),
+          public_send(input_kind, attribute, class: input_classes(opts), autocomplete: 'off', **enhance_input_options(opts).except(:class)),
+          error_message(attribute)
+        ]
+      )
+    end
+  end
+
+  def label_with_hint(attribute, opts = {})
+    label(attribute, class: 'fr-label') do
+      label_value = [label_value(attribute)]
+      label_value.push(required_tag) if opts[:required]
+
+      @template.safe_join(
+        [
+          label_value,
+          hint(opts[:hint])
+        ]
+      )
+    end
+  end
+
+  def required_tag
+    @template.content_tag(:span, '*', class: 'fr-ml-1w fr-text-error')
+  end
+
+  def hint(text)
+    return '' unless text
+
+    @template.content_tag(:span, class: 'fr-hint-text') do
+      text
+    end
+
+    @template.content_tag(:span, text.html_safe, class: 'fr-hint-text')
+  end
+
+  def error_message(attr)
+    return if @object.errors[attr].none?
+
+    @template.content_tag(:p, class: 'fr-messages-group') do
+      @object.errors.full_messages_for(attr).map { |msg|
+        @template.content_tag(:span, msg, class: 'fr-message fr-message--error')
+      }.join.html_safe
+    end
+  end
+
+  def join_classes(arr)
+    arr.compact.join(' ')
+  end
+
+  def input_classes(opts)
+    join_classes(
+      [
+        'fr-input',
+        opts[:code] && 'fr-input--code',
+        input_width_class(opts)
+      ]
+    )
+  end
+
+  def link_to_file(attribute)
+    file = @object.send(attribute)
+    return unless file.attached? && file.persisted?
+
+    @template.content_tag(:div, class: 'fr-input-group__text fr-mt-1w') do
+      @template.link_to(file.filename, rails_blob_path(file, disposition: 'inline', only_path: true), target: '_blank', rel: 'noopener')
+    end
+  end
+
+  def input_width_class(opts)
+    return '' if opts[:width].blank?
+
+    opts[:width].split.map { |spec| "fr-col-#{spec}" }.join(' ')
+  end
+
+  def input_group_classes(attribute, opts)
+    join_classes(
+      [
+        'fr-input-group',
+        @object.errors[attribute].any? ? 'fr-input-group--error' : nil,
+        opts[:class]
+      ]
+    )
+  end
+
+  def label_value(attribute)
+    (@object.try(:object) || @object).class.human_attribute_name(attribute)
+  end
+
+  def enhance_input_options(opts)
+    opts
+  end
+
+  def check_box_disabled
+    false
+  end
+end

--- a/app/views/devise/shared/_dsfr_error_messages.html.slim
+++ b/app/views/devise/shared/_dsfr_error_messages.html.slim
@@ -1,7 +1,10 @@
 - if resource.errors.any?
   .fr-alert.fr-alert--error.fr-mb-2w
     ul
-      - resource.errors.full_messages.uniq.each do |message|
-        li = "#{message}."
-    - if resource.errors[:email]&.include?(I18n.t("errors.messages.taken"))
-      .fr-mb-3v= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email), class: "fr-link"
+      - resource.errors.each do |error|
+        - if error.match?(:email, t("activerecord.errors.models.user.attributes.email.taken"))
+          li
+            = "#{t('activerecord.errors.models.user.attributes.email.taken')}. "
+            = link_to('Avez-vous oublié votre mot de passe ?', new_password_path(resource_name, "email": resource.email), class: 'fr-link')
+        - else
+          li= error.full_message

--- a/app/views/devise/shared/_dsfr_error_messages.html.slim
+++ b/app/views/devise/shared/_dsfr_error_messages.html.slim
@@ -1,10 +1,7 @@
 - if resource.errors.any?
   .fr-alert.fr-alert--error.fr-mb-2w
     ul
-      - resource.errors.each do |error|
-        - if error.match?(:email, t("activerecord.errors.models.user.attributes.email.taken"))
-          li
-            = "#{t('activerecord.errors.models.user.attributes.email.taken')}. "
-            = link_to('Avez-vous oublié votre mot de passe ?', new_password_path(resource_name, "email": resource.email), class: 'fr-link')
-        - else
-          li= error.full_message
+      - resource.errors.full_messages.uniq.each do |message|
+        li = message
+    - if resource.errors[:email]&.include?(I18n.t("errors.messages.taken"))
+      .fr-mb-3v= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email), class: "fr-link"

--- a/app/views/devise/shared/_dsfr_error_messages.html.slim
+++ b/app/views/devise/shared/_dsfr_error_messages.html.slim
@@ -1,6 +1,7 @@
 - if resource.errors.any?
   .fr-alert.fr-alert--error.fr-mb-2w
-    h3.fr-alert__title Erreur
     ul
       - resource.errors.full_messages.uniq.each do |message|
-        li = message
+        li = "#{message}."
+    - if resource.errors[:email]&.include?(I18n.t("errors.messages.taken"))
+      .fr-mb-3v= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email), class: "fr-link"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -9,21 +9,19 @@
       = render "common/franceconnect_button"
 
       h2 Se créer un compte avec un email
-      = render "devise/shared/error_messages", resource: resource
-      - if resource.errors[:email]&.include?(I18n.t("errors.messages.taken"))
-        .fr-mb-3v= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email), class: "fr-link"
+      = render "devise/shared/dsfr_error_messages", resource: resource
       .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
         .fr-col-6
           = f.dsfr_text_field :first_name, label: "Prénom", required: true
         .fr-col-6
           = f.dsfr_text_field :last_name, label: "Nom", required: true
       = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true
-      = f.dsfr_text_field :phone_number, label: "Numéro de téléphone", hint: "Vous recevrez les rappels et les informations du RDV sur ce numéro."
+      = f.dsfr_phone_field :phone_number, label: "Numéro de téléphone", hint: "Vous recevrez les rappels et les informations du RDV sur ce numéro."
 
       .form-group
         small
-        span> En vous inscrivant, vous acceptez les
-        = link_to("conditions générales d'utilisation", cgu_path, class: "fr-link")
+        span
+          | En vous inscrivant, vous acceptez les #{link_to("conditions générales d'utilisation", cgu_path, class: "fr-link")}.
 
       .rdv-text-align-center
         = f.submit "Je m’inscris", class: "fr-btn"
@@ -31,5 +29,5 @@
     hr.fr-my-2w
     .rdv-text-align-center
       p
-        | Vous avez un compte ?&nbsp;
+        | Vous avez un compte ?
         = link_to "Se connecter", new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)), class: "fr-link"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -4,28 +4,32 @@
   = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
 
   .card-body
-    = simple_form_for resource, as: :user, url: registration_path(resource_name) do |f|
-      .mb-3= render "common/franceconnect_button"
+    = form_for resource, as: :user, url: registration_path(resource_name), builder: DsfrFormBuilder do |f|
+      h2 Se créer un compte avec FranceConnect
+      = render "common/franceconnect_button"
+
+      h2 Se créer un compte avec un email
       = render "devise/shared/error_messages", resource: resource
       - if resource.errors[:email]&.include?(I18n.t("errors.messages.taken"))
-        .mb-3= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email)
-      .form-row
-        .col-6= f.input :first_name, required: true
-        .col-6= f.input :last_name, required: true
-      = f.input :email, as: :email, placeholder: "nom.prenom@email.com", required: true
-      = f.input :phone_number, as: :tel, placeholder: "06 39 98 12 34", hint: "Vous recevrez les rappels et les informations du RDV sur ce numéro."
+        .fr-mb-3v= link_to "Mot de passe oublié ?", new_password_path(resource_name, "email": resource.email), class: "fr-link"
+      .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+        .fr-col-6
+          = f.dsfr_text_field :first_name, label: "Prénom", required: true
+        .fr-col-6
+          = f.dsfr_text_field :last_name, label: "Nom", required: true
+      = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true
+      = f.dsfr_text_field :phone_number, label: "Numéro de téléphone", hint: "Vous recevrez les rappels et les informations du RDV sur ce numéro."
 
       .form-group
         small
         span> En vous inscrivant, vous acceptez les
-        = link_to("conditions générales d'utilisation", cgu_path)
+        = link_to("conditions générales d'utilisation", cgu_path, class: "fr-link")
 
-      .form-group.mb-0.rdv-text-align-center
-        = f.button :submit, "Je m’inscris"
+      .rdv-text-align-center
+        = f.submit "Je m’inscris", class: "fr-btn"
 
     hr.fr-my-2w
     .rdv-text-align-center
-      p.rdv-color-text-mention-grey
+      p
         | Vous avez un compte ?&nbsp;
-        = link_to new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)) do
-          b Se connecter
+        = link_to "Se connecter", new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)), class: "fr-link"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -74,6 +74,10 @@ fr:
             Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
             dépendants existent
       models:
+        user:
+          attributes:
+            email:
+              taken: "L’email que vous avez saisi est déjà utilisé"
         team:
           attributes:
             agents:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -74,10 +74,6 @@ fr:
             Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
             dépendants existent
       models:
-        user:
-          attributes:
-            email:
-              taken: "L’email que vous avez saisi est déjà utilisé"
         team:
           attributes:
             agents:


### PR DESCRIPTION
Review app : https://demo-rdv-solidarites-pr4791.osc-secnum-fr1.scalingo.io/users/sign_up

# Contexte

On passe le formulaire de connexion au DSFR.

# Solution

Cette PR est aussi l’occasion d’ouvrir une discussion concernant l’introduction d’un DSFR form builder.
En passant le formulaire au DSFR, j’ai voulu utiliser le wrapper Simple Form `dsfr_wrapper` et je me suis aperçu qu’il ne nous permettait de répondre que partiellement à notre besoin.
J’y vois notamment 2 limites :
- Il ne nous permet pas de gérer correctement l’introduction d’un span dans le label pour afficher un hint, conformément au DSFR (problème déjà rencontré sur la page de connexion).
- Il nous permet d’afficher l’erreur de saisie en dessous du champ, mais il ne nous permet pas de passer le champ en rouge, car on doit appliquer une classe à la div parente, ce qui ne semble pas possible en l’état.

Nous avons des collègues sur d’autres projets Rails qui ont fait le choix d’intégrer un Form Builder qui correspond exactement à notre besoin sur le projet [APLyPro](https://github.com/betagouv/aplypro/blob/main/app/helpers/dsfr_form_builder.rb) ou [DataPass](https://github.com/etalab/data_pass/blob/develop/app/form_builders/dsfr_form_builder.rb).

Je vous propose donc ici une introduction d’un form builder très similaire avec quelques modifications pour correspondre à notre besoin.

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [x] Préparer des captures de l’interface avant et après

## Captures d'écran

Avant | Après
:- | -:
<img width="836" alt="image" src="https://github.com/user-attachments/assets/e0a32fbe-4f42-4599-b04a-8bcbffe2b9ed"> | <img width="860" alt="image" src="https://github.com/user-attachments/assets/079ccce6-3775-4c94-86da-fc1ba7c23137">
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/fec50136-7a34-436d-ad82-ebbcaf029606"> | <img width="1219" alt="image" src="https://github.com/user-attachments/assets/f66fb23d-8e50-4172-8b8e-8b064f99ff6c">
