### PR TITLE
Fix Users::RegistrationsController#create/update layout

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,7 +5,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   after_action :allow_iframe
 
   layout "application"
-  layout "application_narrow", only: %i[new edit pending]
+  layout "application_narrow", only: %i[new create edit pending]
 
   def create
     return invite_and_redirect(existing_unconfirmed_user) if existing_unconfirmed_user

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,7 +5,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   after_action :allow_iframe
 
   layout "application"
-  layout "application_narrow", only: %i[new create edit pending]
+  layout "application_narrow", only: %i[new create update edit pending]
 
   def create
     return invite_and_redirect(existing_unconfirmed_user) if existing_unconfirmed_user


### PR DESCRIPTION
# Contexte

Quand on fait une erreur de saisie dans le formulaire d’inscription, le formulaire proposé n’utilise pas le même layout ce qui provoque une différence de largeur.

<img width="1796" alt="image" src="https://github.com/user-attachments/assets/e708962e-f026-4fe0-bb25-a4fb03fe2199">
<img width="1798" alt="image" src="https://github.com/user-attachments/assets/d5c06e7b-2e9d-447a-9266-602ecf11c3ea">


# Solution

On utilise le même layout sur le `new` et le `create`.

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après

## Captures d'écran

Avant | Après
:- | -:
_mettre un screenshot ici_ | _et ici_
