### PR TITLE
Fix - Condition d’apparition du titre FranceConnect

### DIFF
--- a/app/views/common/_franceconnect_button.html.slim
+++ b/app/views/common/_franceconnect_button.html.slim
@@ -6,4 +6,3 @@
 
   p
     = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", class: "fr-link", title: "Qu’est-ce que FranceConnect ? - Nouvelle fenêtre"
-

--- a/app/views/common/_franceconnect_button.html.slim
+++ b/app/views/common/_franceconnect_button.html.slim
@@ -1,11 +1,9 @@
-- if current_domain.france_connect_enabled || params[:force_franceconnect].present?
-  .rdv-text-align-center
-    .fr-connect-group
-      = link_to "/omniauth/franceconnect", class: "fr-connect", method: :post, title: "S’identifier avec FranceConnect" do
-        span.fr-connect__login S’identifier avec
-        span.fr-connect__brand FranceConnect
+.rdv-text-align-center
+  .fr-connect-group
+    = link_to "/omniauth/franceconnect", class: "fr-connect", method: :post, title: "S’identifier avec FranceConnect" do
+      span.fr-connect__login S’identifier avec
+      span.fr-connect__brand FranceConnect
 
-    p
-      = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", class: "fr-link", title: "Qu’est-ce que FranceConnect ? - Nouvelle fenêtre"
+  p
+    = link_to "Qu’est-ce que FranceConnect ?", "https://franceconnect.gouv.fr/", target: "_blank", class: "fr-link", title: "Qu’est-ce que FranceConnect ? - Nouvelle fenêtre"
 
-  p.fr-hr-or ou

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -5,8 +5,11 @@
 
   .card-body
     = form_for resource, as: :user, url: registration_path(resource_name), builder: DsfrFormBuilder do |f|
-      h2 Se créer un compte avec FranceConnect
-      = render "common/franceconnect_button"
+      - if current_domain.france_connect_enabled || params[:force_franceconnect].present?
+        h2 Se créer un compte avec FranceConnect
+        = render "common/franceconnect_button"
+
+        p.fr-hr-or ou
 
       h2 Se créer un compte avec un email
       = render "devise/shared/dsfr_error_messages", resource: resource
@@ -29,5 +32,5 @@
     hr.fr-my-2w
     .rdv-text-align-center
       p
-        | Vous avez un compte ?
+        = "Vous avez un compte ? "
         = link_to "Se connecter", new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)), class: "fr-link"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -32,5 +32,5 @@
     hr.fr-my-2w
     .rdv-text-align-center
       p
-        = "Vous avez un compte ? "
-        = link_to "Se connecter", new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)), class: "fr-link"
+        | Vous avez un compte ?
+        =< link_to "Se connecter", new_session_path(resource_name, params: params.permit(:lieu_id, :motif_id, :starts_at)), class: "fr-link"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -4,8 +4,11 @@
   = render "users/rdv_wizard_steps/rdv_wizard_summary", rdv_wizard: @rdv_wizard if @rdv_wizard.present?
 
   .card-body
-    h2 Se connecter avec FranceConnect
-    = render "common/franceconnect_button"
+    - if current_domain.france_connect_enabled || params[:force_franceconnect].present?
+      h2 Se connecter avec FranceConnect
+      = render "common/franceconnect_button"
+
+      p.fr-hr-or ou
 
     h2 Se connecter avec son compte
 


### PR DESCRIPTION
# Contexte

Sur le domaine rdv-aide-numerique.fr le titre « Se connecter avec FranceConnect apparait alors que FranceConnect est désactivé.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/e8ea8c9d-8de5-4bfc-a700-3d4981bf44bc) | ![image](https://github.com/user-attachments/assets/6bb1f66d-4ab8-4ee1-9515-095a15d58259)
![image](https://github.com/user-attachments/assets/af82f75a-eaf7-4e35-aefb-28a658a80772) | ![image](https://github.com/user-attachments/assets/f9927378-f2e5-4734-850c-e203e8d86967)


