### PR TITLE
Permettre le support des numéros spéciaux à 4 chiffres

### DIFF
--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,1 +1,2 @@
 Phonelib.default_country = "FR"
+Phonelib.parse_special = true


### PR DESCRIPTION
# Contexte

Certains conseils départementaux utilisent des numéros spéciaux comme numéros de contact. Des retours que nous avons eu ce sont des numéros à 4 chiffres.

Or par défaut, Phonelib ne supporte pas ces numéros et ils ne sont donc pas considérés comme valides (ce qui est courant pour un usecase d'usager "normaux" mais pas pour des entités gouvernementales qui peuvent y avoir accès).

![image](https://github.com/user-attachments/assets/c23c5290-01fc-44d1-9cb1-0b0c85e1091c)

# Solution

La librairie phone lib permet le support de ces numéros en activant l'option `parse_special`
Une fois l'option activée, phone lib considère ces numéros comme valides, ce qui devrait en chaîne s'appliquer aux différents models comme les Lieux.

<img width="340" alt="image" src="https://github.com/user-attachments/assets/9ebfb43a-4443-4fc7-9f46-ee0a0257937e">

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2432