### PR TITLE
Revert "Utiliser l’adresse de réponse magique comme adresse d’envoi des emails de RDV adressés aux usagers (#4795)"

### DIFF
--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -11,7 +11,7 @@ class Users::RdvMailer < ApplicationMailer
     @token = params[:token]
   end
 
-  default to: -> { @user.email }
+  default to: -> { @user.email }, reply_to: -> { TransferEmailReplyJob.reply_address_for_rdv(@rdv) }
 
   def rdv_created
     self.ics_payload = @rdv.payload(:create, @user)
@@ -52,9 +52,5 @@ class Users::RdvMailer < ApplicationMailer
 
   def domain
     @rdv.domain
-  end
-
-  def default_from
-    TransferEmailReplyJob.reply_address_for_rdv(@rdv)
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let(:mail) { described_class.with(rdv: rdv, user: user, token: token).rdv_created }
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to be_nil
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
 
     it "renders the subject" do
@@ -80,9 +80,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     it "renders the headers" do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_updated(old_starts_at: previous_starting_time, lieu_id: nil)
-
-      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
 
     it "indicates the previous and current values" do
@@ -116,8 +116,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       user = rdv.users.first
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
-      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
     end
 
     it "subject contains date of cancelled rdv" do
@@ -173,8 +174,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     it "send mail to user" do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_upcoming_reminder
-      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
       expect(mail.html_part.body.raw_source).to include("/users/rdvs/#{rdv.id}?invitation_token=12345")
     end
@@ -192,7 +194,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+          expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Solidarités))
@@ -204,7 +206,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+          expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Solidarités))
@@ -216,7 +218,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to match(/"RDV Aide Numérique" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
+          expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-aide-numerique.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-aide-numerique-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Aide Numérique))
@@ -228,8 +230,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to match(/RDV Service Public <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites\.fr>/)
-          # les guillemets autour de "RDV Service Public" disparaissent probablement ici car il n’y a que des caractères ASCII
+          expect(mail[:from].to_s).to eq(%(RDV Service Public <support@rdv-service-public.fr>))
           expect(mail.html_part.body.to_s).to include(%(src="/logo_rdv_service_public.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-mairie-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Service Public))


### PR DESCRIPTION
This reverts commit 291a9bf69927bb4a119c792a9d08e3bef98bfb13.

# Problème

On est en train d’envoyer des emails concernant les rdvs aux usagers sur toutes les instances avec comme adresses d’expéditeurs des `rdv+abcd-1234@reply.rdv-solidarites.fr` ce qui pose plusieurs problèmes : 

- si les usagers répondent ça va arriver sur le inbound parse webhook brevo et arriver sur l’instant RDVS
- mauvaise UX pour les usagers car ils voient une adresse d’expéditeur surprenante

Note : avant cette PR et (après ce revert donc) on envoyait déjà des emails avec les mauvais reply-to il me semble

# Suite

On va résoudre ce souci en envoyant des emails avec les expéditeurs de chaque sous-domaine mais ça prend un peu de temps à mettre en place car on doit mettre en place les DNS etc