### PR TITLE
Redirection vers la page demandée après une connexion à ProConnect

### DIFF
--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -46,7 +46,7 @@ class AgentConnectController < ApplicationController
 
       bypass_sign_in agent, scope: :agent
       session[:agent_connect_id_token] = callback_client.id_token_for_logout
-      redirect_to root_path
+      redirect_to after_sign_in_path_for(agent)
     else
       # On pourrait améliorer le cas d'erreur décrit dans https://github.com/betagouv/rdv-service-public/issues/4360
       flash[:error] = "Il n'y a pas de compte agent pour l'adresse mail #{callback_client.user_email}.<br />" \

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe AgentConnectController do
     before do
       session[:agent_connect_state] = state
       AgentConnectStubs.stub_callback_requests(code, user_info)
+
+      session[:agent_return_to] = "/agents/edit" # Pour simuler le retour vers la page demandée avant la connexion
     end
 
     it "updates and logs in the agent" do
@@ -62,6 +64,8 @@ RSpec.describe AgentConnectController do
         last_sign_in_at: be_within(10.seconds).of(Time.zone.now)
       )
       expect(session["agent_connect_id_token"]).to be_present
+
+      expect(response).to redirect_to("/agents/edit")
     end
 
     context "when the agent has a name with two words" do


### PR DESCRIPTION
# Contexte

Contrairement à la connexion par email/mot de passe, après la connexion par ProConnect, on ne redirige pas l'agent vers la page qu'il demandait avant de se connecter.
C'était un simple oubli.

Cette PR permet de diminuer le diff de la PR pour l'OAuth d'une ligne ! 🎉 

# Solution

On réutilise le mécanisme prévu par Devise pour ça