### PR TITLE
Add `GET api/rdvinsertion/users/:user_id/referent_assignations` endpoint

### DIFF
--- a/app/controllers/api/rdvinsertion/referent_assignations_controller.rb
+++ b/app/controllers/api/rdvinsertion/referent_assignations_controller.rb
@@ -5,11 +5,8 @@ class Api::Rdvinsertion::ReferentAssignationsController < Api::Rdvinsertion::Age
   def index
     referent_assignations = ReferentAssignation
       .where(user: @user)
-      .where(
-        agent_id: Agent.joins(:organisations)
-                       .where(organisations: { verticale: "rdv_insertion" })
-                       .select(:id)
-      )
+      .joins(agent: :organisations)
+      .where(organisations: { verticale: "rdv_insertion" })
       .distinct
 
     render_collection referent_assignations

--- a/app/controllers/api/rdvinsertion/referent_assignations_controller.rb
+++ b/app/controllers/api/rdvinsertion/referent_assignations_controller.rb
@@ -1,5 +1,19 @@
 class Api::Rdvinsertion::ReferentAssignationsController < Api::Rdvinsertion::AgentAuthBaseController
-  before_action :set_user, :set_agents, only: %i[create_many]
+  before_action :set_user, only: %i[create_many index]
+  before_action :set_agents, only: %i[create_many]
+
+  def index
+    referent_assignations = ReferentAssignation
+      .where(user: @user)
+      .where(
+        agent_id: Agent.joins(:organisations)
+                       .where(organisations: { verticale: "rdv_insertion" })
+                       .select(:id)
+      )
+      .distinct
+
+    render_collection referent_assignations
+  end
 
   def create_many
     @agents.each { |agent| ReferentAssignation.find_or_create_by!(user: @user, agent: agent) }

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -36,7 +36,9 @@ namespace :api do
     resource :referent_assignations, only: [] do
       post :create_many, on: :collection
     end
-    resources :users, only: %i[show]
+    resources :users, only: %i[show] do
+      resources :referent_assignations, only: %i[index]
+    end
     resources :motif_categories, only: %i[create]
     resources :motif_category_territories, only: %i[create]
   end

--- a/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
@@ -79,4 +79,26 @@ RSpec.describe "Referent Assignation authentified API" do
       end
     end
   end
+
+  describe "GET /api/rdvinsertion/users/:id/referent_assignations" do
+    let(:agent) { create(:agent, basic_role_in_organisations: [organisation_rdv_insertion]) }
+    let(:user) { create(:user, organisations: [organisation_rdv_insertion], referent_agents: [agent, other_agent]) }
+    let(:other_agent) { create(:agent, basic_role_in_organisations: [organisation_rdv_solidarites]) }
+    let(:organisation_rdv_insertion) { create(:organisation, verticale: "rdv_insertion") }
+    let(:organisation_rdv_solidarites) { create(:organisation, verticale: "rdv_solidarites") }
+    let(:shared_secret) { "S3cr3T" }
+    let(:auth_headers) { api_auth_headers_with_shared_secret(agent, shared_secret) }
+
+    before do
+      allow(ENV).to receive(:fetch).with("SHARED_SECRET_FOR_AGENTS_AUTH").and_return(shared_secret)
+    end
+
+    it "returns the referent assignations" do
+      get api_rdvinsertion_user_referent_assignations_path(user.id), headers: auth_headers
+      expect(response.status).to eq(200)
+      response_referent_assignations = response.parsed_body["referent_assignations"]
+      response_referent_assignations_agent_ids = response_referent_assignations.map { |referent_assignation| referent_assignation.dig("agent", "id") }
+      expect(response_referent_assignations_agent_ids).to contain_exactly(agent.id)
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/gip-inclusion/rdv-insertion/issues/2475

# Contexte

Dans certains cas, lorsqu'un usager créé depuis rdvsp a un rdv placé sur une organisation présente dans rdv-insertion, pour une catégorie de motif gérée par l'organisation dans rdv-insertion, nous importons le rdv ainsi que l'usager sur rdv-insertion.
De même, lorsque l'on crée un nouvel usager avec une adresse mail qui est déjà rattachée à un usager sur rdv-sp, on lie l'usager créé sur rdvi à l'usager déjà présent sur RDVSP.

Cependant, si celui-ci a déjà des référents assignés sur rdv-sp, nous ne les récupérons pas. Ainsi il en résulte un problème de synchronisation:

* on n'affiche pas tous les référents de l'usager sur rdvi
* on a la possibilité d'assigner un référent déjà assigné depuis rdv-i ce qui engendrera des erreurs 

Il faudrait donc récupérer les référents déjà assignés à l'usager lors de son importation dans rdv-i.
Nous avons déjà fait ce travail pour résoudre le même problème sur les `user_profiles` de l'usager dans #4674 

# Solution

Après discussion avec @victormours , il a été décidé de ne pas passer les assignations de référents au moment de la sérialisation de l'usager (via le `UserBlueprint`) comme ça a été fait pour les organisations rattachées à l'usager. Cette décision a été prise pour ne pas surcharger le payload des usagers et ne pas compliquer davantage la logique sur le blueprint.

À la place, nous introduisons un endpoint `Api::Rdvinsertion::ReferentAssignationsController#index`, scopé à rdv-insertion (et qui donc ne peut être appelé que depuis rdv-i), qui renvoie les assignations de référents d'un usager. Les référents renvoyés ne concernent que des agents présents dans des organisations rdv-insertion.
