### PR TITLE
Générisation des adresses magiques de réponse aux autres instances et environnements

### DIFF
--- a/app/controllers/inbound_emails_controller.rb
+++ b/app/controllers/inbound_emails_controller.rb
@@ -6,7 +6,7 @@ class InboundEmailsController < ActionController::Base
 
   before_action :authenticate_brevo
 
-  def sendinblue
+  def brevo
     payload = request.params["items"].first
     TransferEmailReplyJob.perform_later(payload)
   end

--- a/app/controllers/inbound_emails_controller.rb
+++ b/app/controllers/inbound_emails_controller.rb
@@ -4,7 +4,7 @@
 class InboundEmailsController < ActionController::Base
   skip_before_action :verify_authenticity_token
 
-  before_action :authenticate_sendinblue
+  before_action :authenticate_brevo
 
   def sendinblue
     payload = request.params["items"].first
@@ -13,10 +13,10 @@ class InboundEmailsController < ActionController::Base
 
   private
 
-  def authenticate_sendinblue
-    return if ActiveSupport::SecurityUtils.secure_compare(ENV["SENDINBLUE_INBOUND_PASSWORD"], params[:password])
+  def authenticate_brevo
+    return if ActiveSupport::SecurityUtils.secure_compare(ENV["BREVO_INBOUND_PASSWORD"], params[:password])
 
-    Sentry.capture_message("Sendinblue inbound controller was called without valid password", fingerprint: ["sib_inbound_pw_invalid"])
+    Sentry.capture_message("Brevo inbound controller was called without valid password", fingerprint: ["brevo_inbound_pw_invalid"])
     head :unauthorized
   end
 end

--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -7,10 +7,16 @@ class TransferEmailReplyJob < ApplicationJob
   self.log_arguments = false
 
   def self.reply_address_for_rdv(rdv)
-    "rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"
+    return nil if rdv.domain.reply_host_name.nil?
+
+    "rdv+#{rdv.uuid}@#{rdv.domain.reply_host_name}"
   end
 
-  UUID_EXTRACTOR = /rdv\+([a-f0-9\-]*)@reply\.rdv-solidarites\.fr/
+  UUID_EXTRACTOR = /rdv\+([a-f0-9\-]*)@reply\.[a-z\-\.]+$/
+
+  def self.uuid_from_email_address(email_address)
+    email_address.match(UUID_EXTRACTOR)&.captures&.first
+  end
 
   def perform(sendinblue_hash)
     @sendinblue_hash = sendinblue_hash.with_indifferent_access
@@ -50,7 +56,7 @@ class TransferEmailReplyJob < ApplicationJob
   end
 
   def uuid
-    source_mail.to.first.match(UUID_EXTRACTOR)&.captures&.first
+    self.class.uuid_from_email_address(source_mail.to.first)
   end
 
   def extracted_response

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -109,8 +109,8 @@ class Domain
         URI.parse(ENV.fetch("HOST", nil)).host
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"
         {
-          RDV_SOLIDARITES => "staging.rdv-solidarites.fr",
-          RDV_AIDE_NUMERIQUE => "staging.rdv-aide-numerique.fr",
+          RDV_SOLIDARITES => "staging.rdv-solidarites.fr", # sous-domaine pas configuré
+          RDV_AIDE_NUMERIQUE => "staging.rdv-aide-numerique.fr", # sous-domaine pas configuré
           RDV_MAIRIE => "staging.rdv-service-public.fr",
         }.fetch(self)
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -143,6 +143,46 @@ class Domain
     end
   end
 
+  def reply_host_name
+    case Rails.env.to_sym
+    when :production
+      if ENV["IS_REVIEW_APP"] == "true"
+        nil
+      elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "STAGING"
+        {
+          RDV_MAIRIE => "reply.staging.rdv-service-public.fr",
+          # c’est le seul staging réellement ouvert pour l’instant
+        }.fetch(self, nil)
+      elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
+        {
+          RDV_SOLIDARITES => "reply.demo.rdv-solidarites.fr",
+          RDV_AIDE_NUMERIQUE => "reply.demo.rdv-aide-numerique.fr",
+          RDV_MAIRIE => "reply.demo.rdv-service-public.fr",
+        }.fetch(self)
+      else
+        {
+          RDV_SOLIDARITES => "reply.rdv-solidarites.fr",
+          RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique.fr",
+          RDV_MAIRIE => "reply.rdv-service-public.fr", # TODO: remplacer par anct.gouv.fr une fois les DNS déployés
+        }.fetch(self)
+      end
+    when :development
+      {
+        RDV_SOLIDARITES => "reply.rdv-solidarites.localhost",
+        RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique.localhost",
+        RDV_MAIRIE => "reply.rdv-mairie.localhost",
+      }.fetch(self)
+    when :test
+      {
+        RDV_SOLIDARITES => "reply.rdv-solidarites-test.localhost",
+        RDV_AIDE_NUMERIQUE => "reply.rdv-aide-numerique-test.localhost",
+        RDV_MAIRIE => "reply.rdv-mairie-test.localhost",
+      }.fetch(self)
+    else
+      raise "Rails.env not recognized: #{Rails.env.inspect}"
+    end
+  end
+
   def default?
     self == RDV_MAIRIE
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -341,7 +341,8 @@ Rails.application.routes.draw do
   get "/organisations/*rest", to: redirect("admin/organisations/%{rest}")
   # old agenda rule was bookmarked by some agents
   get "admin/organisations/:organisation_id/agents/:agent_id", to: redirect("/admin/organisations/%{organisation_id}/agent_agendas/%{agent_id}")
-  post "/inbound_emails/sendinblue", controller: :inbound_emails, action: :sendinblue
+  post "/inbound_emails/sendinblue", controller: :inbound_emails, action: :brevo # TODO: supprimer après la transition
+  post "/inbound_emails/brevo", controller: :inbound_emails, action: :brevo
 
   # This route redirects invitations to rdv-insertion so that rdv-insertion
   # can use rdvs domain name in their emails

--- a/scalingo.json
+++ b/scalingo.json
@@ -77,7 +77,7 @@
       "value": "change_me_if_needed"
     },
 
-    "SENDINBLUE_INBOUND_PASSWORD": {
+    "BREVO_INBOUND_PASSWORD": {
       "description": "Cette valeur est passée en paramètre dans le webhook que nous avons défini chez SendInBlue. C'est un secret, donc non hérité en review app.",
       "value": "change_me_if_needed"
     },

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -1,97 +1,99 @@
 RSpec.describe TransferEmailReplyJob do
-  subject(:perform_job) { described_class.perform_now(sendinblue_payload) }
+  describe "#perform" do
+    subject(:perform_job) { described_class.perform_now(sendinblue_payload) }
 
-  before do
-    # Set a fixed date so we can assert on dates within email body
-    travel_to(Time.zone.parse("2022-05-17 16:00:00"))
-  end
+    before do
+      # Set a fixed date so we can assert on dates within email body
+      travel_to(Time.zone.parse("2022-05-17 16:00:00"))
+    end
 
-  let!(:user) { create(:user, email: "bene_ficiaire@lapin.fr", first_name: "Bénédicte", last_name: "Ficiaire") }
-  let!(:agent) { create(:agent, email: "je_suis_un_agent@departement.fr") }
-  let(:rdv_uuid) { "8fae4d5f-4d63-4f60-b343-854d939881a3" }
-  let!(:rdv) { create(:rdv, users: [user], agents: [agent], uuid: rdv_uuid) }
+    let!(:user) { create(:user, email: "bene_ficiaire@lapin.fr", first_name: "Bénédicte", last_name: "Ficiaire") }
+    let!(:agent) { create(:agent, email: "je_suis_un_agent@departement.fr") }
+    let(:rdv_uuid) { "8fae4d5f-4d63-4f60-b343-854d939881a3" }
+    let!(:rdv) { create(:rdv, users: [user], agents: [agent], uuid: rdv_uuid) }
 
-  let(:sendinblue_valid_payload) do
-    # The usual payload has more info, but I removed non-essential fields for readability.
-    # See: https://developers.sendinblue.com/docs/inbound-parsing-api-1#sample-payload
-    {
-      Cc: [],
-      ReplyTo: nil,
-      Subject: "coucou",
-      Attachments: [],
-      Headers: {
-        "Message-ID": "<d6c8663e3763aa750345a76c17f435a2bd14eded.camel@lapin.fr>",
+    let(:sendinblue_valid_payload) do
+      # The usual payload has more info, but I removed non-essential fields for readability.
+      # See: https://developers.sendinblue.com/docs/inbound-parsing-api-1#sample-payload
+      {
+        Cc: [],
+        ReplyTo: nil,
         Subject: "coucou",
-        From: "Bénédicte Ficiaire <bene_ficiaire@lapin.fr>",
-        To: "rdv+8fae4d5f-4d63-4f60-b343-854d939881a3@reply.rdv-solidarites.fr",
-        Date: "Thu, 12 May 2022 12:22:15 +0200",
-      },
-      ExtractedMarkdownMessage: "Je souhaite annuler mon RDV",
-      ExtractedMarkdownSignature: nil,
-      RawHtmlBody: %(<html dir="ltr"><head></head><body style="text-align:left; direction:ltr;"><div>Je souhaite annuler mon RDV</div>\n</body></html>\n),
-      RawTextBody: "Je souhaite annuler mon RDV\n",
-    }
-  end
-  let(:sendinblue_payload) { sendinblue_valid_payload } # use valid payload by default
-
-  context "when all goes well" do
-    it "sends a notification email to the agent, containing the user reply" do
-      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
-      transferred_email = ActionMailer::Base.deliveries.last
-      expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
-      expect(transferred_email[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
-      expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
-      expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
-      expect(transferred_email.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))
+        Attachments: [],
+        Headers: {
+          "Message-ID": "<d6c8663e3763aa750345a76c17f435a2bd14eded.camel@lapin.fr>",
+          Subject: "coucou",
+          From: "Bénédicte Ficiaire <bene_ficiaire@lapin.fr>",
+          To: "rdv+8fae4d5f-4d63-4f60-b343-854d939881a3@reply.rdv-solidarites.fr",
+          Date: "Thu, 12 May 2022 12:22:15 +0200",
+        },
+        ExtractedMarkdownMessage: "Je souhaite annuler mon RDV",
+        ExtractedMarkdownSignature: nil,
+        RawHtmlBody: %(<html dir="ltr"><head></head><body style="text-align:left; direction:ltr;"><div>Je souhaite annuler mon RDV</div>\n</body></html>\n),
+        RawTextBody: "Je souhaite annuler mon RDV\n",
+      }
     end
-  end
+    let(:sendinblue_payload) { sendinblue_valid_payload } # use valid payload by default
 
-  context "when reply token does not match any in DB" do
-    let(:rdv_uuid) { "6df62597-632e-4be1-a273-708ab58e4765" }
-
-    it "sends a notification email to the default mailbox, containing the user reply" do
-      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
-      transferred_email = ActionMailer::Base.deliveries.last
-      expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
-      expect(transferred_email.from).to eq(["support@rdv-solidarites.fr"])
-      expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
-      expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
-    end
-  end
-
-  context "when an e-mail address does not match our pattern" do
-    let(:sendinblue_payload) do
-      sendinblue_valid_payload.tap { |hash| hash[:Headers][:To] = "nimportequoi@reply.rdv-solidarites.fr" }
-    end
-
-    it "is forwarded to default mailbox" do
-      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
-      transferred_email = ActionMailer::Base.deliveries.last
-      expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
-      expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
-    end
-  end
-
-  context "when several agents are linked to the RDV" do
-    let!(:other_agent) { create(:agent, email: "autre@departement.fr").tap { |a| rdv.agents << a } }
-
-    it "sends one email with all agents in the TO: field" do
-      perform_job
-      expect(ActionMailer::Base.deliveries.last.to).to contain_exactly("je_suis_un_agent@departement.fr", "autre@departement.fr")
-    end
-  end
-
-  context "when attachments are present" do
-    let(:sendinblue_payload) do
-      sendinblue_valid_payload.tap do |hash|
-        hash[:Attachments] = [{ Name: "mon_scan.pdf", ContentType: "application/pdf" }]
+    context "when all goes well" do
+      it "sends a notification email to the agent, containing the user reply" do
+        expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        transferred_email = ActionMailer::Base.deliveries.last
+        expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
+        expect(transferred_email[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+        expect(transferred_email.html_part.body.to_s).to include("Dans le cadre du RDV du 20 mai, l'usager⋅e Bénédicte FICIAIRE a envoyé")
+        expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
+        expect(transferred_email.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv.organisation_id}/rdvs/#{rdv.id}))
       end
     end
 
-    it "mentions the attachments in the notification e-mail" do
-      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
-      transferred_email = ActionMailer::Base.deliveries.last
-      expect(transferred_email.html_part.body.to_s).to include(%(Le mail de l'usager⋅e avait en pièce jointe "mon_scan.pdf".))
+    context "when reply token does not match any in DB" do
+      let(:rdv_uuid) { "6df62597-632e-4be1-a273-708ab58e4765" }
+
+      it "sends a notification email to the default mailbox, containing the user reply" do
+        expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        transferred_email = ActionMailer::Base.deliveries.last
+        expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
+        expect(transferred_email.from).to eq(["support@rdv-solidarites.fr"])
+        expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+        expect(transferred_email.html_part.body.to_s).to include("Je souhaite annuler mon RDV") # reply content
+      end
+    end
+
+    context "when an e-mail address does not match our pattern" do
+      let(:sendinblue_payload) do
+        sendinblue_valid_payload.tap { |hash| hash[:Headers][:To] = "nimportequoi@reply.rdv-solidarites.fr" }
+      end
+
+      it "is forwarded to default mailbox" do
+        expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        transferred_email = ActionMailer::Base.deliveries.last
+        expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
+        expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+      end
+    end
+
+    context "when several agents are linked to the RDV" do
+      let!(:other_agent) { create(:agent, email: "autre@departement.fr").tap { |a| rdv.agents << a } }
+
+      it "sends one email with all agents in the TO: field" do
+        perform_job
+        expect(ActionMailer::Base.deliveries.last.to).to contain_exactly("je_suis_un_agent@departement.fr", "autre@departement.fr")
+      end
+    end
+
+    context "when attachments are present" do
+      let(:sendinblue_payload) do
+        sendinblue_valid_payload.tap do |hash|
+          hash[:Attachments] = [{ Name: "mon_scan.pdf", ContentType: "application/pdf" }]
+        end
+      end
+
+      it "mentions the attachments in the notification e-mail" do
+        expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        transferred_email = ActionMailer::Base.deliveries.last
+        expect(transferred_email.html_part.body.to_s).to include(%(Le mail de l'usager⋅e avait en pièce jointe "mon_scan.pdf".))
+      end
     end
   end
 end

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -1,4 +1,43 @@
 RSpec.describe TransferEmailReplyJob do
+  describe "#uuid_from_email_address" do
+    %w[
+      rdv+b1a2-3c4f@reply.rdv-solidarites.fr
+      rdv+b1a2-3c4f@reply.rdv-aide-numerique.fr
+      rdv+b1a2-3c4f@reply.rdv-service-public.fr
+      rdv+b1a2-3c4f@reply.staging.rdv-service-public.fr
+      rdv+b1a2-3c4f@reply.demo.rdv-solidarites.fr
+      rdv+b1a2-3c4f@reply.demo.rdv-aide-numerique.fr
+      rdv+b1a2-3c4f@reply.demo.rdv-service-public.fr
+    ].each do |email_address|
+      it "should extract UUID from #{email_address}" do
+        expect(described_class.uuid_from_email_address(email_address)).to eq("b1a2-3c4f")
+      end
+    end
+  end
+
+  describe "#reply_address_for_rdv" do
+    it "uses rdv domain reply_host_name" do
+      rdv = build(:rdv)
+      domain = instance_double(Domain)
+
+      allow(rdv).to receive(:uuid).and_return("aabb-1122")
+      allow(rdv).to receive(:domain).and_return(domain)
+      allow(domain).to receive(:reply_host_name).and_return "reply.rdv-solidarites.fr"
+
+      expect(described_class.reply_address_for_rdv(rdv)).to eq("rdv+aabb-1122@reply.rdv-solidarites.fr")
+    end
+
+    it "returns nil for a rdv whose domain reply_host_name is nil" do
+      rdv = build(:rdv)
+      domain = instance_double(Domain)
+
+      allow(rdv).to receive(:domain).and_return(domain)
+      allow(domain).to receive(:reply_host_name).and_return nil
+
+      expect(described_class.reply_address_for_rdv(rdv)).to be_nil
+    end
+  end
+
   describe "#perform" do
     subject(:perform_job) { described_class.perform_now(sendinblue_payload) }
 
@@ -70,6 +109,18 @@ RSpec.describe TransferEmailReplyJob do
         transferred_email = ActionMailer::Base.deliveries.last
         expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
         expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+      end
+    end
+
+    context "when an e-mail address matches our pattern for a demo host" do
+      let(:sendinblue_payload) do
+        sendinblue_valid_payload.tap { |hash| hash[:Headers][:To] = "rdv+8fae4d5f-4d63-4f60-b343-854d939881a3@reply.demo.rdv-solidarites.fr" }
+      end
+
+      it "sends a notification email to the agent" do
+        expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        transferred_email = ActionMailer::Base.deliveries.last
+        expect(transferred_email.to).to eq(["je_suis_un_agent@departement.fr"])
       end
     end
 

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     it "renders the headers" do
       expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
     end
 
     it "renders the subject" do
@@ -82,7 +82,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_updated(old_starts_at: previous_starting_time, lieu_id: nil)
       expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
     end
 
     it "indicates the previous and current values" do
@@ -118,7 +118,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
       expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
     end
 
     it "subject contains date of cancelled rdv" do
@@ -176,7 +176,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_upcoming_reminder
       expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites.fr"])
+      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
       expect(mail.html_part.body.raw_source).to include("/users/rdvs/#{rdv.id}?invitation_token=12345")
     end

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -4,4 +4,40 @@ RSpec.describe Domain do
       expect(domain.to_h.compact.keys).to match_array(described_class.members)
     end
   end
+
+  describe "#reply_host_name" do
+    context "en prod" do
+      before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production")) }
+
+      it "renvoie les bons domaines" do
+        expect(described_class.find("RDV_SOLIDARITES").reply_host_name).to eq("reply.rdv-solidarites.fr")
+        expect(described_class.find("RDV_AIDE_NUMERIQUE").reply_host_name).to eq("reply.rdv-aide-numerique.fr")
+        expect(described_class.find("RDV_MAIRIE").reply_host_name).to eq("reply.rdv-service-public.fr")
+      end
+    end
+
+    context "en demo" do
+      before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production")) }
+
+      stub_env_with(RDV_SOLIDARITES_INSTANCE_NAME: "DEMO")
+
+      it "renvoie les bons domaines" do
+        expect(described_class.find("RDV_SOLIDARITES").reply_host_name).to eq("reply.demo.rdv-solidarites.fr")
+        expect(described_class.find("RDV_AIDE_NUMERIQUE").reply_host_name).to eq("reply.demo.rdv-aide-numerique.fr")
+        expect(described_class.find("RDV_MAIRIE").reply_host_name).to eq("reply.demo.rdv-service-public.fr")
+      end
+    end
+
+    context "en staging" do
+      before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production")) }
+
+      stub_env_with(RDV_SOLIDARITES_INSTANCE_NAME: "STAGING")
+
+      it "renvoie les bons domaines" do
+        expect(described_class.find("RDV_SOLIDARITES").reply_host_name).to be_nil
+        expect(described_class.find("RDV_AIDE_NUMERIQUE").reply_host_name).to be_nil
+        expect(described_class.find("RDV_MAIRIE").reply_host_name).to eq("reply.staging.rdv-service-public.fr")
+      end
+    end
+  end
 end

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Handling an email reply from a user" do
-  subject(:receive_sendinblue_callback) do
-    post "/inbound_emails/sendinblue?password=#{password_param}",
+  subject(:receive_brevo_callback) do
+    post "/inbound_emails/brevo?password=#{password_param}",
          params: { items: [{ Subject: "Dummy email" }] }.to_json,
          headers: { "Content-Type" => "application/json" }
   end
@@ -12,7 +12,7 @@ RSpec.describe "Handling an email reply from a user" do
 
     it "enqueues the job that handles transferring the email" do
       expect do
-        receive_sendinblue_callback
+        receive_brevo_callback
       end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:mailers)
     end
   end
@@ -21,11 +21,11 @@ RSpec.describe "Handling an email reply from a user" do
     let(:password_param) { "inv4l1d" }
 
     it "does not enqueue any job" do
-      expect { receive_sendinblue_callback }.not_to have_enqueued_job
+      expect { receive_brevo_callback }.not_to have_enqueued_job
     end
 
     it "warns Sentry" do
-      receive_sendinblue_callback
+      receive_brevo_callback
       expect(sentry_events.last.message).to eq("Brevo inbound controller was called without valid password")
     end
   end

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Handling an email reply from a user" do
          headers: { "Content-Type" => "application/json" }
   end
 
-  stub_env_with(SENDINBLUE_INBOUND_PASSWORD: "S3cr3T")
+  stub_env_with(BREVO_INBOUND_PASSWORD: "S3cr3T")
 
   context "when using a valid password" do
     let(:password_param) { "S3cr3T" }
@@ -26,7 +26,7 @@ RSpec.describe "Handling an email reply from a user" do
 
     it "warns Sentry" do
       receive_sendinblue_callback
-      expect(sentry_events.last.message).to eq("Sendinblue inbound controller was called without valid password")
+      expect(sentry_events.last.message).to eq("Brevo inbound controller was called without valid password")
     end
   end
 end


### PR DESCRIPTION
> [!NOTE]
> à lire commit par commit et en ignorant les espaces changés pour un diff des specs nettement plus clair

# Contexte

Cette PR concerne les adresses de réponse « magiques » qu’on utilise dans les emails envoyés aux usagers concernant des RDV.
 
Suite au déploiement puis au revert de #4795 on s’est rendus compte qu’actuellement, on envoie des emails avec des adresses de réponse en `reply.rdv-solidarites.fr` partout : 

- depuis rdv.anct.gouv.fr
- depuis rdv-aide-numerique.fr
- depuis demo.rdv-solidarites.fr

Cela pose différents problèmes : 

- incohérence pour les usagers qui reçoivent des emails avec des adresses de réponses surprenantes
- s’iels répondent effectivement, leur email arrive systématiquement sur l’instance RDVS et on cherche potentiellement l’ID du RDV de l’autre instance. Par chance, a priori, les ID de l’autre instance sont largement inférieurs à ceux encore existants dans RDVS, et donc on se replie sur un transfert vers support.

Après cette réalisation, on imagine qu’une partie du support trop élevé vient de ces emails de l’instance RDVSP qui auraient dû être transférés aux agents mais qui ont été transféré au support Zammad.

# Solution

Dans cette PR je fais en sorte d’utiliser des domaines `reply.rdv-aide-numerique.fr`, `reply.demo.rdv-solidarites.fr` etc...

Pour l’instance RDVSP j’ai utilisé ici `reply.rdv-service-public.fr` plutôt que `reply.rdv.anct.gouv.fr` pour aller plus vite car on a la main sur les DNS du premier mais ceux du second ça peut prendre plusieurs jours à mettre à jour. 
On va faire la demande et on pourra basculer une fois que les changements DNS auront été faits et vérifiés.

## Choix techniques

J’ai fait le choix d’écrire une nouvelle méthode `Domain#reply_host_name` qui énumère tous les cas et ressemble donc beaucoup à `Domain#host_name`. 
J’avais fait un essai en écrivant qqch comme `host_name.sub(/^www/, "").prepend("reply.")..`.
C’était plus concis mais à mon avis moins lisible.

# À faire avant le déploiement

Configurer et vérifier les DNS sur

domaine | configuré | validé
-|-|-
reply.rdv-solidarites.fr | ✅  | ✅ 
reply.rdv-aide-numerique.fr | |
reply.rdv-service-public.fr | |
reply.staging.rdv-service-public.fr | |
reply.demo.rdv-solidarites.fr | |
reply.demo.rdv-aide-numerique.fr | |
reply.demo.rdv-service-public.fr | |

# Pour la suite

- Configurer et utiliser reply.rdv.anct.gouv.fr
- Envisager de réappliquer #4795 si on continue à avoir trop de tickets support