### PR TITLE
Correction de la doc d'API /api/v1/users (retirer `notes` et `logement`)

### DIFF
--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -84,9 +84,6 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
       parameter name: "family_situation", in: :query, type: :string, description: "Situation familiale", example: "single", required: false
       parameter name: "number_of_children", in: :query, type: :integer, description: "Nombre d'enfants", example: "3", required: false
 
-      parameter name: "logement", in: :query, type: :string, enum: %w[sdf heberge en_accession_propriete proprietaire autre locataire], description: "Type de logement de l'utilisateur",
-                example: "locataire", required: false
-      parameter name: "notes", in: :query, type: :string, description: "Une note sur l'utilisateur", example: "Super note", required: false
       parameter name: "notify_by_sms", in: :query, type: :boolean, description: "Accepte les notifications par SMS", example: "true", required: false
       parameter name: "notify_by_email", in: :query, type: :boolean, description: "Accepte les notifications par email", example: "true", required: false
       parameter name: "responsible_id", in: :query, type: :integer, description: "ID de l'usager·ère responsable", example: 123, required: false
@@ -111,8 +108,6 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         let(:affiliation_number) { "101010" }
         let(:family_situation) { "single" }
         let(:number_of_children) { 3 }
-        let(:notes) { "Super note" }
-        let(:logement) { "locataire" }
         let(:notify_by_sms) { false }
         let(:notify_by_email) { false }
         let!(:user_responsible) { create(:user) }
@@ -145,10 +140,6 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         it { expect(user.reload.family_situation).to eq(family_situation) }
 
         it { expect(user.reload.number_of_children).to eq(number_of_children) }
-
-        it { expect(user.reload.notes).to eq(notes) }
-
-        it { expect(user.reload.logement).to eq(logement) }
 
         it { expect(user.reload.notify_by_sms).to eq(notify_by_sms) }
 
@@ -349,8 +340,6 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         let(:caisse_affiliation) { "caf" }
         let(:affiliation_number) { "101010" }
         let(:family_situation) { "single" }
-        let(:notes) { "Quelques remarques" }
-        let(:logement) { :locataire }
         let(:number_of_children) { 3 }
         let(:notify_by_sms) { false }
         let(:notify_by_email) { false }

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -4006,34 +4006,6 @@
             }
           },
           {
-            "name": "logement",
-            "in": "query",
-            "enum": [
-              "sdf",
-              "heberge",
-              "en_accession_propriete",
-              "proprietaire",
-              "autre",
-              "locataire"
-            ],
-            "description": "Type de logement de l'utilisateur",
-            "example": "locataire",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "notes",
-            "in": "query",
-            "description": "Une note sur l'utilisateur",
-            "example": "Super note",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
             "name": "notify_by_sms",
             "in": "query",
             "description": "Accepte les notifications par SMS",


### PR DESCRIPTION
*Cette incohérence a été révélée par le fuzzing dans #4809 (travail en cours).*

La doc swagger pour la création et l'update d'usagers mentionne les champs `notes` et `logement`. Or, ces champs ne sont pas pris en compte car absents de la méthode `Api::V1::UsersController#user_params`.

Nous pourrions les ajouter aux champs traités, mais j'ai tendance à préférer garder l'API la plus petite possible, et n'ajouter des possibilités que si c'est nécessaire. De plus ces champs sont sensibles et propres au médico-social, donc ça paraît peu stratégique de les offrir dans une API qui va être utilisée dans une stratégie de généralisation.