### PR TITLE
Séparer la homepage de la première page de recherche de rdv

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,18 +6,25 @@ class SearchController < ApplicationController
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social
   after_action :allow_iframe
 
+  def home
+    if current_domain == Domain::RDV_MAIRIE
+      render "dsfr/rdv_mairie/homepage"
+    else
+      search_rdv
+    end
+  end
+
   def search_rdv
     # TODO : public_link_organisation_id has to work if agent is logged in ?
     if current_agent && params[:prescripteur] == Prescripteur::INTERNE && session[:agent_prescripteur_organisation_id]
       redirect_to search_creneau_admin_organisation_prescription_path(session[:agent_prescripteur_organisation_id], agent_search_params)
-    end
-    @context = if invitation?
-                 WebInvitationSearchContext.new(user: current_user, query_params: query_params)
-               else
-                 WebSearchContext.new(user: current_user, query_params: query_params)
-               end
-    if current_domain == Domain::RDV_MAIRIE && request.path == "/"
-      render "dsfr/rdv_mairie/homepage"
+    else
+      @context = if invitation?
+                   WebInvitationSearchContext.new(user: current_user, query_params: query_params)
+                 else
+                   WebSearchContext.new(user: current_user, query_params: query_params)
+                 end
+      render :search_rdv
     end
   end
 

--- a/app/views/search/_address_selection.html.slim
+++ b/app/views/search/_address_selection.html.slim
@@ -1,1 +1,0 @@
-= render(current_domain.address_selection_template_name, context: context)

--- a/app/views/search/search_rdv.html.slim
+++ b/app/views/search/search_rdv.html.slim
@@ -4,7 +4,7 @@
 
 / Adress selection partials have multiple sections
 - if @context.current_step == :address_selection
-  = render @context, context: @context
+  = render(current_domain.address_selection_template_name, context: @context)
 - else
   section.rdv-background-color-alt-grey.py-4
     = render @context, context: @context

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -330,8 +330,6 @@ Rails.application.routes.draw do
   get "accueil_mds", to: redirect("presentation_agent", status: 307)
   get "presentation_agent" => "static_pages#presentation_for_agents"
 
-  resources :lieux, only: %i[index show]
-
   root "search#home"
 
   get "/prendre_rdv", to: "search#search_rdv"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -298,7 +298,6 @@ Rails.application.routes.draw do
     "users/rdvs/#{path_params[:id]}#{query_params}"
   end), as: "rdv_short"
 
-  # TODO: remplacer `prendre_rdv` par le root_path
   get "prdv", to: (redirect do |_path_params, req|
     query_params = format_redirect_params(req.params)
     "prendre_rdv#{query_params}"
@@ -332,9 +331,9 @@ Rails.application.routes.draw do
   get "presentation_agent" => "static_pages#presentation_for_agents"
 
   resources :lieux, only: %i[index show]
-  root "search#search_rdv"
 
-  # TODO: remplacer `prendre_rdv` par le root_path
+  root "search#home"
+
   get "/prendre_rdv", to: "search#search_rdv"
 
   # temporary route after admin namespace introduction


### PR DESCRIPTION
# Contexte

Cette PR sépare en deux actions de controllers les routes de la homepage et du parcours de rdv via le path `/prendre_rdv`.
Elle me sera utile pour la PR sur l'oauth pour pouvoir appliquer de la logique spécifique à la homepage sans la mélanger à celle de la recherche de rdv.
Mais je pense qu'elle pourra aussi être utile pour clarifier d'autres cas où on distingue la page d'accueil et la page de prise de rdv, notamment https://github.com/betagouv/rdv-service-public/pull/4808.

# Solution

Au passage on supprime un niveau d'indirection créé par la vue `app/views/search/_address_selection.html.slim`
