### PR TITLE
Suppression env var RAILS_SERVE_STATIC_FILES

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,9 +20,8 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # Rails should serve static files itself, we don’t have a NGINX or Apache setup in prod
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
# Contexte

En travaillant sur #4816 je me suis demandé si la variable d’environnement `RAILS_SERVE_STATIC_FILES` avait une utilité.

Elle n’est utilisée que dans l’env de prod pour activer ou désactiver le service des fichiers statiques par Rails. 

cf https://github.com/rails/rails/blob/main/guides/source/configuring.md?plain=1#L522

> Configures whether Rails should serve static files from the public directory.
Defaults to `true`.
> If the server software (e.g. NGINX or Apache) should serve static files instead,
set this value to `false`.

Nous n’avons - à ma connaissance - pas de mécanisme sur Scalingo pour servir les fichiers statiques autre que le serveur rails lui même.

La var d’env est définie et vaut `enabled` sur : 
- production-rdv-mairie
- production-rdv-solidarites
- rdv-solidarites-staging
- les review apps

Elle n’est (étonnemment) pas définie sur
- staging-rdv-service-public

Je ne comprends pas bien comment ça fonctionne dans ce cas 🤔

# Solution

Dans cette PR je propose : 
- de supprimer la variable d’environnement `RAILS_SERVE_STATIC_FILES` 
- et d’activer tout le temps le service des fichiers statiques par Rails

Le comportement va donc (peut-être) changer sur `staging-rdv-service-public` 
Je ne sais pas comment ça fonctionne aujourd’hui.
Soit la configuration fallbacke quand même pour servir les fichiers via Rails, soit il y a un mécanisme parallèle, par exemple les assets sont recompilés en prod au runtime ?