### PR TITLE
Mise à jour de la date d'expiration du token Outlook

### DIFF
--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -126,17 +126,18 @@ class CronJob < ApplicationJob
 
   class WarnAboutExpiringAzureAppSecrets < CronJob
     def perform
+      return if ENV["AZURE_APPLICATION_CLIENT_ID"].blank?
       return if ENV["AZURE_SECRET_EXPIRE_DATE"].blank?
 
       application_key_expiration_date = Date.parse(ENV["AZURE_SECRET_EXPIRE_DATE"])
-      key_refresh_url = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/ad7b4a46-0051-47b6-bf31-713aa849e5d4/isMSAApp~/true"
+      key_refresh_url = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/#{ENV['AZURE_APPLICATION_CLIENT_ID']}/isMSAApp~/true"
 
       if 2.months.from_now > application_key_expiration_date
         error_message = <<~ERROR
           Le secret de client de l'application d'oauth Microsoft expire dans moins de 2 mois.
           Pour que la synchro Outlook continue de fonctionner, vous générez un nouveau secret via #{key_refresh_url}
-          Les identifiants pour se connecter sont dans Passbolt sous le nom "Compte Dev pour Oauth Microsoft".
-          Vous devrez ensuite mettre la valeur du secret dans la variable d'env AZURE_APPLICATION_CLIENT_SECRET, et mettre à jour la date de cet avertissement.
+          Les identifiants pour se connecter sont dans Vaultwarden sous le nom "Compte Dev pour Oauth Microsoft".
+          Vous devrez ensuite mettre la valeur du secret dans la variable d'env AZURE_APPLICATION_CLIENT_SECRET, et "AZURE_SECRET_EXPIRE_DATE".
         ERROR
         Sentry.capture_message(error_message, fingerprint: ["WarnAboutExpiringAzureAppSecrets"])
       end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -126,7 +126,9 @@ class CronJob < ApplicationJob
 
   class WarnAboutExpiringAzureAppSecrets < CronJob
     def perform
-      application_key_expiration_date = Date.new(2025, 1, 10)
+      return if ENV["APP"] != "production-rdv-solidarites"
+
+      application_key_expiration_date = Date.new(2025, 3, 18)
       key_refresh_url = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/ad7b4a46-0051-47b6-bf31-713aa849e5d4/isMSAApp~/true"
 
       if 2.months.from_now > application_key_expiration_date

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -126,9 +126,9 @@ class CronJob < ApplicationJob
 
   class WarnAboutExpiringAzureAppSecrets < CronJob
     def perform
-      return if ENV["APP"] != "production-rdv-solidarites"
+      return if ENV["AZURE_SECRET_EXPIRE_DATE"].blank?
 
-      application_key_expiration_date = Date.new(2025, 3, 18)
+      application_key_expiration_date = Date.parse(ENV["AZURE_SECRET_EXPIRE_DATE"])
       key_refresh_url = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/ad7b4a46-0051-47b6-bf31-713aa849e5d4/isMSAApp~/true"
 
       if 2.months.from_now > application_key_expiration_date


### PR DESCRIPTION
Comme indiqué dans le message d'erreur mis en place dans #3968, j'ai mis à jour le token d'API pour l'instance RDV-Solidarités, puis j'ai mis à jour la valeur de `AZURE_APPLICATION_CLIENT_SECRET` sur cette instance.

J'ai hésité à mettre des dates séparées pour les instances RDV-S, Mairie et Démo mais 
- l'instance démo a des tokens qui durent longtemps et c'est pas très grave si on est pas prévenus de leur expiration
- l'instance Mairie (RDV-SP) semble avoir un token inconnu, je suppose que c'est parce qu'on n'utilise pas Outlook dessus, car quand j'ai essayé de linker un compte Microsoft, j'ai eu l'erreur : 

> invalid_request: The provided value for the input parameter 'redirect_uri' is not valid. The expected value is a URI which matches a redirect URI registered for this client application.

~~Donc j'ai fait en sorte que le code indique que ce job ne concerne que l'instance historique.~~

Edit : Antoine a suggéré d'avoir la date d'expiration dans une variable d'ENV et j'adore cette solution, let's go !

# Déploiement

J'ai mis en place la variable d'ENV, je pense déployer cette PR pour déclencher un restart sans interruption des containers. Ensuite je supprimerai l'ancien token.