### PR TITLE
Correction de l’appel aux policies pour les proches côté usagers

### DIFF
--- a/app/controllers/users/relatives_controller.rb
+++ b/app/controllers/users/relatives_controller.rb
@@ -3,8 +3,6 @@ class Users::RelativesController < UserAuthController
 
   respond_to :html
 
-  before_action :set_user, only: %i[edit update destroy]
-
   def new
     @user = current_user.relatives.new
     authorize(@user, policy_class: User::UserPolicy)
@@ -26,10 +24,12 @@ class Users::RelativesController < UserAuthController
   end
 
   def edit
+    @user = User.find(params[:id])
     authorize(@user, policy_class: User::UserPolicy)
   end
 
   def update
+    @user = User.find(params[:id])
     authorize(@user, policy_class: User::UserPolicy)
     if @user.update(user_params)
       flash[:success] = "Les informations de votre proche #{@user.full_name} ont été mises à jour."
@@ -40,16 +40,13 @@ class Users::RelativesController < UserAuthController
   end
 
   def destroy
+    @user = User.find(params[:id])
     authorize(@user, policy_class: User::UserPolicy)
     flash[:notice] = "Votre proche a été supprimé." if @user.soft_delete
     redirect_to users_informations_path
   end
 
   private
-
-  def set_user
-    @user = policy_scope(User, policy_scope_class: User::UserPolicy::Scope).find(params.require(:id))
-  end
 
   def user_params
     params.require(:user).permit(:first_name, :last_name, :birth_date, :ants_pre_demande_number)


### PR DESCRIPTION
# Contexte

Je m’approche peu à peu du rajout de validation pour les numéros ANTS sur les proches.
Cette PR est un petit refacto préliminaire.

# Problème

J’ai remarqué qu’on appelle `policy_scope` en plus de `authorize` sur 3 routes individuelles de `Users::RelativesController`.

C’est (légèrement) gênant pour la remontée d’erreurs dans Sentry car on peut lever à tort des `ActiveRecord::NotFound` au lieu d’erreurs de permissions `Pundit`. Par exemple si on donne un ID existant mais pour lequel l’usager connecté n’a pas les droits cela va lever à tort une `ActiveRecord::NotFound`.

# Solution

Je supprime l’appel à policy_scope.

Je dégènérise aussi le `before_action` en inlinant le `@user = User.find(params[:id])` sur chaque route individuelle.
Cela me permet d’anticiper un changement que je vais faire dans une PR future : ne plus définir @user comme une variable d’instance mais comme une simple variable locale.
Ça enlève aussi un niveau d’indirection qui ne me paraît pas très utile ici.