### PR TITLE
Export : on ajoute une colonne pour savoir si le RDV est collectif

### DIFF
--- a/app/services/participation_exporter.rb
+++ b/app/services/participation_exporter.rb
@@ -24,6 +24,7 @@ module ParticipationExporter
     "code postal du responsable",
     "créé par",
     "email(s) professionnel.le(s)",
+    "rdv collectif",
   ].freeze
 
   def self.xls_string_from_participations_rows(participations_rows)
@@ -89,6 +90,7 @@ module ParticipationExporter
       extract_postal_code_from(user.user_to_notify.address),
       rdv.author,
       rdv.agents.map(&:email).join(", "),
+      rdv.motif.collectif ? "oui" : "non",
     ]
   end
 

--- a/app/services/rdv_exporter.rb
+++ b/app/services/rdv_exporter.rb
@@ -23,6 +23,7 @@ module RdvExporter
     "code postal du premier responsable",
     "créé par",
     "email(s) professionnel.le(s)",
+    "rdv collectif",
   ].freeze
 
   def self.xls_string_from_rdvs_rows(rdvs_rows)
@@ -84,6 +85,7 @@ module RdvExporter
       code_postal_premier_responsable(rdv),
       rdv.author,
       rdv.agents.map(&:email).join(", "),
+      rdv.motif.collectif ? "oui" : "non",
     ]
   end
   # rubocop:enable Metrics/PerceivedComplexity

--- a/spec/services/participation_exporter_spec.rb
+++ b/spec/services/participation_exporter_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe ParticipationExporter, type: :service do
         "date naissance",
         "code postal du responsable",
         "créé par",
-        "email(s) professionnel.le(s)"
+        "email(s) professionnel.le(s)",
+        "rdv collectif"
       )
 
       expect(first_data_row).to contain_exactly(
@@ -66,7 +67,8 @@ RSpec.describe ParticipationExporter, type: :service do
         "01/01/2000",
         nil,
         "Dans le cadre du RGPD, cette information n'est plus conservée au delà d'un an.",
-        "agent@mail.com"
+        "agent@mail.com",
+        "non"
       )
     end
   end

--- a/spec/services/rdv_exporter_spec.rb
+++ b/spec/services/rdv_exporter_spec.rb
@@ -34,11 +34,12 @@ RSpec.describe RdvExporter, type: :service do
           "code postal du premier responsable", # S
           "créé par", # T
           "email(s) professionnel.le(s)", # U
+          "rdv collectif", # V
         ]
       )
 
       expect(first_data_row.first).to eq(2023)
-      expect(first_data_row.last).to eq("agent@mail.com")
+      expect(first_data_row.last).to eq("non")
     end
   end
 


### PR DESCRIPTION
# Contexte

Les admins de territoires aimeraient savoir dans leurs exports s'ils s’agissaient d’un RDV collectif ou non.

# Solution

On rajoute la colonne « rdv collectif » dans l’export.

On ajoute la colonne à la fin pour ne pas casser des automatisations des agents.

