### PR TITLE
Réapplique "Utiliser l’adresse de réponse magique comme adresse d’envoi des emails de RDV adressés aux usagers"

### DIFF
--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -21,7 +21,7 @@ class TransferEmailReplyJob < ApplicationJob
   def perform(sendinblue_hash)
     @sendinblue_hash = sendinblue_hash.with_indifferent_access
 
-    if rdv
+    if rdv&.agents&.pluck(:email)&.compact&.any?
       notify_agents
     else
       forward_to_default_mailbox

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -11,7 +11,7 @@ class Users::RdvMailer < ApplicationMailer
     @token = params[:token]
   end
 
-  default to: -> { @user.email }, reply_to: -> { TransferEmailReplyJob.reply_address_for_rdv(@rdv) }
+  default to: -> { @user.email }
 
   def rdv_created
     self.ics_payload = @rdv.payload(:create, @user)
@@ -52,5 +52,9 @@ class Users::RdvMailer < ApplicationMailer
 
   def domain
     @rdv.domain
+  end
+
+  def default_from
+    TransferEmailReplyJob.reply_address_for_rdv(@rdv)
   end
 end

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -146,5 +146,16 @@ RSpec.describe TransferEmailReplyJob do
         expect(transferred_email.html_part.body.to_s).to include(%(Le mail de l'usager⋅e avait en pièce jointe "mon_scan.pdf".))
       end
     end
+
+    context "quand le RDV est avec un agent intervenant sans email" do
+      let!(:agent) { create(:agent, :intervenant) }
+
+      it "transfère le mail à notre support" do
+        expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+        transferred_email = ActionMailer::Base.deliveries.last
+        expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
+        expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
+      end
+    end
   end
 end

--- a/spec/mailers/users/rdv_mailer_spec.rb
+++ b/spec/mailers/users/rdv_mailer_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
     let(:mail) { described_class.with(rdv: rdv, user: user, token: token).rdv_created }
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost>/)
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
+      expect(mail.reply_to).to be_nil
     end
 
     it "renders the subject" do
@@ -80,9 +80,9 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     it "renders the headers" do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_updated(old_starts_at: previous_starting_time, lieu_id: nil)
-      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+
+      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost/)
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
     end
 
     it "indicates the previous and current values" do
@@ -116,9 +116,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
       user = rdv.users.first
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_cancelled
 
-      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost>/)
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
     end
 
     it "subject contains date of cancelled rdv" do
@@ -174,9 +173,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
     it "send mail to user" do
       mail = described_class.with(rdv: rdv, user: user, token: token).rdv_upcoming_reminder
-      expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost>/)
       expect(mail.to).to eq([user.email])
-      expect(mail.reply_to).to eq(["rdv+#{rdv.uuid}@reply.rdv-solidarites-test.localhost"])
       expect(mail.html_part.body).to include("Nous vous rappellons que vous avez un RDV prévu")
       expect(mail.html_part.body.raw_source).to include("/users/rdvs/#{rdv.id}?invitation_token=12345")
     end
@@ -194,7 +192,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+          expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost>/)
           expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Solidarités))
@@ -206,7 +204,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to eq(%("RDV Solidarités" <support@rdv-solidarites.fr>))
+          expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost/)
           expect(mail.html_part.body.to_s).to include(%(src="/logo_solidarites.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-solidarites-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Solidarités))
@@ -218,7 +216,7 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-aide-numerique.fr>))
+          expect(mail[:from].to_s).to match(/"RDV Aide Numérique" <rdv\+[a-z0-9\-]+@reply\.rdv-aide-numerique-test\.localhost>/)
           expect(mail.html_part.body.to_s).to include(%(src="/logo_aide_numerique.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-aide-numerique-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Aide Numérique))
@@ -230,7 +228,8 @@ RSpec.describe Users::RdvMailer, type: :mailer do
 
         it "works" do
           mail = described_class.with(rdv: rdv, user: rdv.users.first, token: "12345").send(action)
-          expect(mail[:from].to_s).to eq(%(RDV Service Public <support@rdv-service-public.fr>))
+          expect(mail[:from].to_s).to match(/RDV Service Public <rdv\+[a-z0-9\-]+@reply\.rdv-mairie-test\.localhost>/)
+          # les guillemets autour de "RDV Service Public" disparaissent probablement ici car il n’y a que des caractères ASCII
           expect(mail.html_part.body.to_s).to include(%(src="/logo_rdv_service_public.png))
           expect(mail.html_part.body.to_s).to include(%(href="http://www.rdv-mairie-test.localhost))
           expect(mail.html_part.body.to_s).to include(%(L’équipe RDV Service Public))


### PR DESCRIPTION
This reverts commit df3d24364f9b33f8220a446ae219dd41c50d883b.

On réapplique #4795
Elle avait été annulée avec #4802

# Problème

On reçoit encore trop de tickets de support d’usagers qui ne devraient pas nous arriver : demandes de créneaux, demandes d’annulations, partage d’infos confidentielles etc...

On a du mal à identifier d’où viennent ces tickets, mais une partie vient encore probablement de réponse aux emails transactionnels.

# Contexte des PRs

**adresses magiques** = les emails comme `rdv+abcd-uuid@reply.rdv-solidarites.fr`
 
Les domaines en `reply.x` sont configurés pour passer par brevo inbound parse qui nous prévient de tout email reçu par webhook.

Jusqu’à la PR #4807 on utilisait le domaine `reply.rdv-solidarites.fr` sur toutes nos instances et environnements. 
C’est maintenant corrigé, on utilise dorénavant des domaines comme `reply.demo.rdv-solidarites.fr` ou `reply.rdv-service-public.fr`. 
Les domaines et les inbound parse webhooks sont configurés sur Brevo pour pointer vers les bonnes instances scalingo.

On n’a pas encore configuré le domaine `reply.rdv.anct.gouv.fr`, on est en attente de l’ANCT pour le faire. 
On utilise temporairement `rdv-service-public.fr` en remplacement.

# Solution

On re-met en place l’envoi des emails depuis un FROM utilisant les adresses magiques.
On n’envoie plus de REPLY-TO
Les usagers qui reçoivent des emails transactionnels concernant des RDVs ne devraient donc plus être en mesure de nous écrire à nous l’équipe technique.
Leurs réponses à ces emails seront toutes redirigées vers les agents.
