### PR TITLE
Form - Suppression de la div field_with_errors

### DIFF
--- a/config/initializers/field_with_errors.rb
+++ b/config/initializers/field_with_errors.rb
@@ -1,0 +1,6 @@
+# Par défaut, Rails ajoute une div avec une classe CSS "field_with_errors" aux champs de formulaire qui contiennent
+# des erreurs. Nous n’utilisons pas cette classe CSS dans notre design, et l’ajout de cette div rentre en conflit avec
+# certains éléments du DSFR. Nous désactivons ce comportement avec le code suivant.
+ActionView::Base.field_error_proc = proc do |html_tag, _|
+  html_tag.html_safe # rubocop:disable Rails/OutputSafety
+end


### PR DESCRIPTION
# Contexte

En implémentant des formulaires au DSFR, je me suis rendu compte que la div `field_with_errors` qui était ajouté par défaut cassait certain comportement des inputs du DSFR. 
Cela semble dû au fait que cette div rajoute une couche dans la hiérarchie.

# Solution

Compte tenu du fait que nous n’utilisons pas cette div pour styliser les composants, je vous propose la suppression de ce comportement.
L’implémentation parait être courante dans les projets Rails.
Le problème semble avoir été rencontré aussi du côté de Data Pass : https://github.com/etalab/data_pass/blob/d5d3a0d7c5b5d042f800d87de06adb6d124d568a/config/environment.rb#L7

