### PR TITLE
Redirection des agents qui se déconnectent vers la page de connexion

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -17,7 +17,7 @@ class Agents::SessionsController < Devise::SessionsController
 
       agent_connect_client = AgentConnectOpenIdClient::Logout.new(session.delete(:agent_connect_id_token))
 
-      redirect_to agent_connect_client.agent_connect_logout_url(root_url), allow_other_host: true
+      redirect_to agent_connect_client.agent_connect_logout_url(new_agent_session_url), allow_other_host: true
     else
       super
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,8 @@ class ApplicationController < ActionController::Base
     return "https://#{ENV['FRANCECONNECT_HOST']}/api/v1/logout" \
       if @connected_with_franceconnect
 
+    return new_agent_session_path if resource == :agent
+
     super
   end
 

--- a/spec/controllers/agents/sessions_controller_spec.rb
+++ b/spec/controllers/agents/sessions_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Agents::SessionsController do
         expect(redirect_url_query_params.symbolize_keys).to match(
           id_token_hint: "fake_agent_connect_id_token",
           state: anything,
-          post_logout_redirect_uri: "http://test.host/"
+          post_logout_redirect_uri: new_agent_session_url
         )
       end
     end

--- a/spec/features/agents/account/agent_can_logout_spec.rb
+++ b/spec/features/agents/account/agent_can_logout_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe "Agent can logout" do
+  let!(:agent) { create(:agent) }
+
+  it "redirects to the login page" do
+    visit new_agent_session_path
+    fill_in "Email", with: agent.email
+    fill_in "password", with: "Correcth0rse!"
+    click_on "Se connecter"
+    click_on "Se déconnecter"
+    expect(page).to have_current_path(new_agent_session_path, ignore_query: true)
+  end
+end


### PR DESCRIPTION
# Contexte

Durant la discussion sur le bug du calendrier avec Mehdi et Teo, nous nous sommes rendu compte que cela n’avait pas beaucoup de sens de rediriger les agents vers la page d’accueil.
Nous changeons donc cette logique pour rediriger vers la page de connexion après déconnexion.


