### PR TITLE
Ajout de la created_at sur le point d’API qui renvoie les RDVs

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -2,7 +2,7 @@ class RdvBlueprint < Blueprinter::Base
   identifier :id
 
   fields :uuid, :status, :starts_at, :ends_at, :duration_in_min, :address, :context, :cancelled_at,
-         :max_participants_count, :users_count, :name, :collectif, :created_by_type, :created_by_id
+         :max_participants_count, :users_count, :name, :collectif, :created_by_type, :created_by_id, :created_at
 
   # Retrocompatibilité avec l'ancien format de l'API pour created_by
   field :created_by do |rdv, _options|

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -98,6 +98,7 @@ RSpec.configure do |config|
               cancelled_at: { type: "string", nullable: true },
               collectif: { type: "boolean" },
               context: { type: "string", nullable: true },
+              created_at: { type: "string" },
               created_by: { type: "string", enum: %w[agent user file_attente prescripteur] },
               created_by_type: { type: "string", enum: %w[Agent User FileAttente Prescripteur] },
               created_by_id: { type: "integer" },

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "API de RDV Service Public",
     "version": "v1",
-    "description": "L'API de RDV Service Public permet à nos partenaires, comme par exemple Démarches Simplifiées et RDV Insertion, de développer des intégrations qui permettent d'ajouter de la gestion de rendez-vous dans leurs applications métier.\nElle peut aussi être utilisée pour synchroniser les calendriers des agetns de votre administration avec ceux qu'ils ont sur leur compte RDV Service Public.\n\nL'API est disponible pour nos trois marques : RDV Service Public, RDV Solidarités, et RDV Aide Numérique.\n\nToutes les fonctionnalités de l'application ne sont pas encore disponibles via l’API. Contactez-nous si vous avez besoin de fonctionnalités qui ne sont pas encore présentes.\n\n# Requêtes\n\nL'API adhère aux principes REST :\n\n- requêtes `GET` : lecture sans modification\n- requêtes `POST` : création de nouvelle ressource\n- requêtes `PATCH` : mise à jour d'une ressource existante\n- requêtes `DELETE` : suppression d'une ressource\n\nLes paramètres des requêtes `GET` doivent être envoyés via les query string de la requête.\n\nLes paramètres des requêtes `POST` doivent être transmis dans le corps de la requête sous un format JSON valide, et doivent contenir le header `Content-Type: application/json`.\n\nLes paramètres doivent respecter les formats suivants :\n- `DATE` : \"YYYY-MM-DD\" par exemple : \"2021-10-21\"\n- `TIME` : H:m[:s], par exemple : \"10:30\"\n\n# Versionnage\n\nL'API est versionnée. La version actuelle est 1.0 (référencée comme v1 dans les points de terminaison).\n\n# Routes\n\nLes points de terminaison de l'API sont accessibles par une route de la forme : `https://<domain>/api/<version>/<endpoint>`.\n\nAvec :\n\n- `version` est la version de l'API\n- `endpoint` est le nom du point de terminaison\n\nPar exemple, on aura : `https://<domain>/api/v1/absences`\n\nPour la version production, les requêtes doivent être adressées à https://www.rdv-solidarites.fr et non à https://rdv-solidarites.fr.\n\nPour la version démo, les requêtes doivent être adressées à https://demo.rdv-solidarites.fr.\n\n# Authentification\n\nCertains points de terminaison sont réservés aux agents authentifiés, dans la limite de leur rôle au sein de l'application.\n\n## Headers d'authentification\n\nTous les agents peuvent utiliser l'API. Les requêtes faites sur l'API sont authentifiées grace à des tokens d'accès associés à chaque agent. Chaque action faite via l'API est donc attribuable à un agent.\n\nPour récupérer le token d'accès d'un agent il faut faire une première requête `POST` à l'url `https://www.rdv-solidarites.fr/api/v1/auth/sign_in` en passant en paramètres JSON l'email et le mot de passe de l'agent. Par exemple (avec HTTPie) :\n\n```httpie\nhttp --json POST 'https://www.rdv-solidarites.fr/api/v1/auth/sign_in' \\\n  email='martine@demo.rdv-solidarites.fr' password='123456'\n```\n\nEn cas de succès d'authentification, la réponse à cette requête contiendra dans le corps le détail de l'agent, et dans les headers les token d'accès à l'API. Par exemple :\n\n```http\nHTTP/1.1 200 OK\nX-Frame-Options: SAMEORIGIN\nX-XSS-Protection: 1; mode=block\nX-Content-Type-Options: nosniff\nX-Download-Options: noopen\nX-Permitted-Cross-Domain-Policies: none\nReferrer-Policy: strict-origin-when-cross-origin\nContent-Type: application/json; charset=utf-8\naccess-token: SFYBngO55ImjD1HOcv-ivQ< token-type: Bearer\nclient: Z6EihQAY9NWsZByfZ47i_Q< expiry: 1605600758\nuid: martine@demo.rdv-solidarites.fr\nETag: W/\"0fe52663d6745c922160384e13afe1e1\"\nCache-Control: max-age=0, private, must-revalidate\nX-Meta-Request-Version: 0.7.2\nX-Request-Id: 291fab6a-043b-4b9c-b4b9-3c7fc9c9453a\nX-Runtime: 0.194743< Transfer-Encoding: chunked\n* Connection #0 to host rdv-solidarites.fr left intact\n{\n  \"data\": {\n    \"id\":1,\n    \"deleted_at\":null,\n    \"email\":\"martine@demo.rdv-solidarites.fr\",\n    \"provider\":\"email\",\n    \"service_id\":1,\n    \"role\":\"admin\",\n    \"last_name\":\"VALIDAY\",\n    \"first_name\":\"Martine\",\n    \"uid\":\"martine@demo.rdv-solidarites.fr\",\n    \"allow_password_change\":false\n  }\n}\n* Closing connection 0\n```\n\nLes 3 headers essentiels pour l'authentification sont les suivants :\n\n```http\naccess-token: SFYBngO55ImjD1HOcv-ivQ\nclient: Z6EihQAY9NWsZByfZ47i_Q\nuid: martine@demo.rdv-solidarites.fr\n```\n\n- `access-token` : c'est le jeton d'accès qui vous a été attribué. Il a une durée de vie de 24h, après ça il vous faudra reproduire cette procédure pour en récupérer un nouveau.\n- `client` : un identifiant unique associé à l'appareil depuis lequel vous avez effectué la requête\n- `uid` : l'identifiant de l'agent dans l'API, égal à l'email de l'agent.\n\n**Ces 3 headers doivent être transmis avec chacune de vos requêtes successives à l'API**, peu importe la méthode HTTP.\n\n## Permissions\n\nLes rôles et permissions des agents sont les mêmes via l'API que depuis l'interface web.\n\nC'est à dire que les agents classiques ont accès à leur service uniquement, les agents du service secrétariat peuvent accéder aux agendas des agents des autres services, les agents admin ont accès à toute l'organisation, etc.\n\nPar défaut, les requêtes en lecture n'appliquent aucun filtre et retourneront toutes les ressources auxquelles a accès l'agent connecté. Par exemple si un agent admin fait une requête pour accéder à la liste des absences sans filtre, l'API retournera toutes les absences de tous les agents appartenant aux organisations dont fait partie cet agent admin, ce qui peut faire beaucoup.\n\n\n\n# Sérialisation\n\nL'API supporte uniquement le format JSON. Toutes les réponses envoyées par l'API contiendront le header `Content-Type: application/json` et leur contenu est présent dans le body dans un format JSON à désérialiser.\n\n# Pagination des réponses par listes\n\nTous les points de terminaison qui retournent des listes sont paginés. De manière générale, tout point de terminaison qui retourne une liste peut retourner une liste vide.\n\n## Paramètres\n\nLe paramètre (optionnel) `page` permet d'accéder à une page donnée. Sauf précision contraire dans la documentation d'un point de terminaison donné, on retrouve 100 éléments par page.\n\n## Résultats\n\nLa réponse contient en outre un objet meta qui indique le nombre total de pages et d’items, par exemple :\n\n```rb\n{\n  […],\n  \"meta\": {\n      \"current_page\": 1,\n      \"total_count\": 112,\n      \"total_pages\": 2\n  }\n}\n```\n\n# Rate limiting\n\nL'utilisation de l'API est limitée pour les points de terminaison sans authentification. Vous pouvez effectuer au maximum 50 appels par minutes. Si vous dépassez cette limite, une erreur 429 vous sera renvoyée et vous trouverez le temps que vous devez attendre avant de relancer une requête dans le header (`Retry-After`).\n\n# Dépréciations\n\n**ATTENTION le champ `created_by` des `rdvs` et des `participations` est déprécié au profit du champ `created_by_type`.**\n\n\n# Codes de retour\n\nL'API est susceptible de retourner les codes suivants :\n\n| Code  | Nom                   | Description                                                                   |\n| ----  | --------              | --------                                                                      |\n| `200` | Success               | Succès                                                                        |\n| `204` | No Content            | Succès mais la réponse ne contient pas de données (exemple : suppression)     |\n| `400` | Bad Request           | La requête est invalide                                                       |\n| `401` | Unauthorized          | L'authentification a échoué                                                   |\n| `403` | Forbidden             | Droits insuffisants pour réaliser l'action demandée                           |\n| `404` | Not Found             | La ressource est introuvable                                                  |\n| `422` | Unprocessable Entity  | La donnée transmise est mal formattée                                         |\n| `429` | Too Many Requests     | Trop de requêtes ont été effectuées                                           |\n| `500` | Internal Server Error | Une erreur serveur produite (l'équipe technique est notifiée automatiquement) |\n\n# Erreurs\n\nEn cas d'erreur reconnue par le système (par exemple erreur 422), les champs suivants seront présents dans la réponse pour vous informer sur les problèmes :\n\n- `errors` : [ERREUR] : liste d'erreurs groupées par attribut problèmatique au format machine\n- `error_messages` : [ERREUR] : idem mais dans un format plus facilement lisible.\n\n# Principes fonctionnels\n\n- Les statuts des RDV et des participants.\n\nLe statut du RDV (status) est un statut général. **Il n'est pas représentatif des statuts individuels des usagers.**\n\n**Chaque participant au RDV a son propre statut de participation porté par l'association `participations` du RDV.**\n\nPour les RDV avec l'attribut collectif à false les statuts du/des participants et du RDV seront tous identiques. (dans l'exemple suivant : `seen`)\n\nIl est conseillé malgrés tout d'utiliser les statuts des participants (dans `participations`) quelque soit le type de rdv.\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": false,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n\nPour les RDV avec l'attribut collectif à true les statuts du/des participants peuvent être différents.\n\nIci, le RDV a un status `seen` mais les 3 participants ont des status de participation différents.\n- Tristan Leroux s'est présenté au RDV collectif : `seen`\n- Roger Lapin ne s'est pas présenté et n'a pas annulé : `noshow`\n- Marie Dupont a annulé sa venue : `excused`\n\n`users_count` représente le nombre d'inscrits au RDV en temps réél (Tous les statuts hors `revoked` et `excused`)\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": true,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n"
+    "description": "L'API de RDV Service Public permet à nos partenaires, comme par exemple Démarches Simplifiées et RDV Insertion,d'ajouter de la gestion de rendez-vous dans leurs applications métier.\nElle peut aussi être utilisée pour synchroniser les calendriers des agents de votre administration avec ceux qu'ils ont sur leur compte RDV Service Public.\n\nL'API est disponible pour nos trois marques : RDV Service Public, RDV Solidarités, et RDV Aide Numérique.\n\nToutes les fonctionnalités de l'application ne sont pas encore disponibles via l’API. Contactez-nous si vous avez besoin de fonctionnalités qui ne sont pas encore présentes.\n\n# Requêtes\n\nL'API adhère aux principes REST :\n\n- requêtes `GET` : lecture sans modification\n- requêtes `POST` : création de nouvelle ressource\n- requêtes `PATCH` : mise à jour d'une ressource existante\n- requêtes `DELETE` : suppression d'une ressource\n\nLes paramètres des requêtes `GET` doivent être envoyés via les query string de la requête.\n\nLes paramètres des requêtes `POST` doivent être transmis dans le corps de la requête sous un format JSON valide, et doivent contenir le header `Content-Type: application/json`.\n\nLes paramètres doivent respecter les formats suivants :\n- `DATE` : \"YYYY-MM-DD\" par exemple : \"2021-10-21\"\n- `TIME` : H:m[:s], par exemple : \"10:30\"\n\n# Routes\n\nPour la version production, les requêtes doivent être adressées à https://www.rdv-solidarites.fr et non à https://rdv-solidarites.fr.\n\nPour la version démo, les requêtes doivent être adressées à https://demo.rdv-solidarites.fr.\n\n# Authentification\n\nPresque tous les points de terminaison sont réservés aux agents authentifiés, dans la limite de leur rôle au sein de l'application.\n\n## Headers d'authentification\n\nTous les agents peuvent utiliser l'API. Les requêtes faites sur l'API sont authentifiées grace à des tokens d'accès associés à chaque agent. Chaque action faite via l'API est donc attribuable à un agent.\n\nPour récupérer le token d'accès d'un agent il faut faire une première requête `POST` à l'url `https://www.rdv-solidarites.fr/api/v1/auth/sign_in` en passant en paramètres JSON l'email et le mot de passe de l'agent. Par exemple (avec HTTPie) :\n\n```httpie\nhttp --json POST 'https://www.rdv-solidarites.fr/api/v1/auth/sign_in' \\\n  email='martine@demo.rdv-solidarites.fr' password='123456'\n```\n\nEn cas de succès d'authentification, la réponse à cette requête contiendra dans le corps le détail de l'agent, et dans les headers les token d'accès à l'API. Par exemple :\n\n```http\nHTTP/1.1 200 OK\nX-Frame-Options: SAMEORIGIN\nX-XSS-Protection: 1; mode=block\nX-Content-Type-Options: nosniff\nX-Download-Options: noopen\nX-Permitted-Cross-Domain-Policies: none\nReferrer-Policy: strict-origin-when-cross-origin\nContent-Type: application/json; charset=utf-8\naccess-token: SFYBngO55ImjD1HOcv-ivQ< token-type: Bearer\nclient: Z6EihQAY9NWsZByfZ47i_Q< expiry: 1605600758\nuid: martine@demo.rdv-solidarites.fr\nETag: W/\"0fe52663d6745c922160384e13afe1e1\"\nCache-Control: max-age=0, private, must-revalidate\nX-Meta-Request-Version: 0.7.2\nX-Request-Id: 291fab6a-043b-4b9c-b4b9-3c7fc9c9453a\nX-Runtime: 0.194743< Transfer-Encoding: chunked\n* Connection #0 to host rdv-solidarites.fr left intact\n{\n  \"data\": {\n    \"id\":1,\n    \"deleted_at\":null,\n    \"email\":\"martine@demo.rdv-solidarites.fr\",\n    \"provider\":\"email\",\n    \"service_id\":1,\n    \"role\":\"admin\",\n    \"last_name\":\"VALIDAY\",\n    \"first_name\":\"Martine\",\n    \"uid\":\"martine@demo.rdv-solidarites.fr\",\n    \"allow_password_change\":false\n  }\n}\n* Closing connection 0\n```\n\nLes 3 headers essentiels pour l'authentification sont les suivants :\n\n```http\naccess-token: SFYBngO55ImjD1HOcv-ivQ\nclient: Z6EihQAY9NWsZByfZ47i_Q\nuid: martine@demo.rdv-solidarites.fr\n```\n\n- `access-token` : c'est le jeton d'accès qui vous a été attribué. Il a une durée de vie de 24h, après ça il vous faudra reproduire cette procédure pour en récupérer un nouveau.\n- `client` : un identifiant unique associé à l'appareil depuis lequel vous avez effectué la requête\n- `uid` : l'identifiant de l'agent dans l'API, égal à l'email de l'agent.\n\n**Ces 3 headers doivent être transmis avec chacune de vos requêtes successives à l'API**, peu importe la méthode HTTP.\n\n## Permissions\n\nLes rôles et permissions des agents sont les mêmes via l'API que depuis l'interface web.\n\nC'est à dire que les agents classiques ont accès à leur service uniquement, les agents du service secrétariat peuvent accéder aux agendas des agents des autres services, les agents admin ont accès à toute l'organisation, etc.\n\nPar défaut, les requêtes en lecture n'appliquent aucun filtre et retourneront toutes les ressources auxquelles a accès l'agent connecté. Par exemple si un agent admin fait une requête pour accéder à la liste des absences sans filtre, l'API retournera toutes les absences de tous les agents appartenant aux organisations dont fait partie cet agent admin, ce qui peut faire beaucoup.\n\n\n\n# Sérialisation\n\nL'API supporte uniquement le format JSON. Toutes les réponses envoyées par l'API contiendront le header `Content-Type: application/json` et leur contenu est présent dans le body dans un format JSON à désérialiser.\n\n# Pagination des réponses par listes\n\nTous les points de terminaison qui retournent des listes sont paginés. De manière générale, tout point de terminaison qui retourne une liste peut retourner une liste vide.\n\n## Paramètres\n\nLe paramètre (optionnel) `page` permet d'accéder à une page donnée. Sauf précision contraire dans la documentation d'un point de terminaison donné, on retrouve 100 éléments par page.\n\n## Résultats\n\nLa réponse contient en outre un objet meta qui indique le nombre total de pages et d’items, par exemple :\n\n```rb\n{\n  […],\n  \"meta\": {\n      \"current_page\": 1,\n      \"total_count\": 112,\n      \"total_pages\": 2\n  }\n}\n```\n\n# Dépréciations\n\n**ATTENTION le champ `created_by` des `rdvs` et des `participations` est déprécié au profit du champ `created_by_type`.**\n\n\n# Codes de retour\n\nL'API est susceptible de retourner les codes suivants :\n\n| Code  | Nom                   | Description                                                                   |\n| ----  | --------              | --------                                                                      |\n| `200` | Success               | Succès                                                                        |\n| `204` | No Content            | Succès mais la réponse ne contient pas de données (exemple : suppression)     |\n| `400` | Bad Request           | La requête est invalide                                                       |\n| `401` | Unauthorized          | L'authentification a échoué                                                   |\n| `403` | Forbidden             | Droits insuffisants pour réaliser l'action demandée                           |\n| `404` | Not Found             | La ressource est introuvable                                                  |\n| `422` | Unprocessable Entity  | La donnée transmise est mal formattée                                         |\n| `429` | Too Many Requests     | Trop de requêtes ont été effectuées                                           |\n| `500` | Internal Server Error | Une erreur serveur produite (l'équipe technique est notifiée automatiquement) |\n\n# Erreurs\n\nEn cas d'erreur reconnue par le système (par exemple erreur 422), les champs suivants seront présents dans la réponse pour vous informer sur les problèmes :\n\n- `errors` : [ERREUR] : liste d'erreurs groupées par attribut problèmatique au format machine\n- `error_messages` : [ERREUR] : idem mais dans un format plus facilement lisible.\n\n# Principes fonctionnels\n\n- Les statuts des RDV et des participants.\n\nLe statut du RDV (status) est un statut général. **Il n'est pas représentatif des statuts individuels des usagers.**\n\n**Chaque participant au RDV a son propre statut de participation porté par l'association `participations` du RDV.**\n\nPour les RDV avec l'attribut collectif à false les statuts du/des participants et du RDV seront tous identiques. (dans l'exemple suivant : `seen`)\n\nIl est conseillé malgrés tout d'utiliser les statuts des participants (dans `participations`) quelque soit le type de rdv.\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": false,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"LEROUX\",\n          }\n        }\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n\nPour les RDV avec l'attribut collectif à true les statuts du/des participants peuvent être différents.\n\nIci, le RDV a un status `seen` mais les 3 participants ont des status de participation différents.\n- Tristan Leroux s'est présenté au RDV collectif : `seen`\n- Roger Lapin ne s'est pas présenté et n'a pas annulé : `noshow`\n- Marie Dupont a annulé sa venue : `excused`\n\n`users_count` représente le nombre d'inscrits au RDV en temps réél (Tous les statuts hors `revoked` et `excused`)\n\n```rb\n{\n  \"rdvs\": [\n    {\n      \"id\": 8,\n      \"collectif\": true,\n      \"status\": \"seen\",\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"participations\": [\n        {\n          \"id\": 8,\n          \"status\": \"seen\",\n          \"user\": {\n            \"id\": 10,\n            \"first_name\": \"Tristan\",\n            \"last_name\": \"LEROUX\",\n          }\n        },\n        {\n          \"id\": 9,\n          \"status\": \"noshow\",\n          \"user\": {\n            \"id\": 11,\n            \"first_name\": \"Roger\",\n            \"last_name\": \"LAPIN\",\n          }\n        },\n        {\n          \"id\": 7,\n          \"status\": \"excused\",\n          \"user\": {\n            \"id\": 12,\n            \"first_name\": \"Marie\",\n            \"last_name\": \"DUPONT\",\n          }\n        },\n      ],\n      \"users_count\": 2,\n    }\n  ],\n}\n```\n"
   },
   "components": {
     "securitySchemes": {
@@ -67,6 +67,9 @@
           "context": {
             "type": "string",
             "nullable": true
+          },
+          "created_at": {
+            "type": "string"
           },
           "created_by": {
             "type": "string",
@@ -1076,7 +1079,7 @@
     },
     {
       "name": "PublicLink",
-      "description": "Désigne des liens publics de recherche d'un territoire. Ces liens permettent d'accéder directement à la recherche, préfiltrée sur un territoire donné."
+      "description": "Utilisé pour faire la correspondance entre des ids externes et des liens de prises de RDV au sein d'un territoire. Ces liens permettent d'accéder directement à la recherche de créneaux pour une organisation donnée.\nCet endpoint est limité à 50 appels par minute par adresse IP.\n"
     },
     {
       "name": "Absence",
@@ -1093,8 +1096,12 @@
       "description": "Serveur de démo"
     },
     {
+      "url": "https://rdv.anct.gouv.fr",
+      "description": "Serveur de production pour RDV Service Public"
+    },
+    {
       "url": "https://www.rdv-solidarites.fr",
-      "description": "Serveur de production"
+      "description": "Serveur de production pour RDV Solidarités"
     }
   ],
   "paths": {
@@ -1307,17 +1314,17 @@
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Agrippin",
+                          "first_name": "Alphée",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Menard"
+                          "last_name": "Gauthier"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20241003T104425Z\r\nUID:absence_18@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20241121T093048Z\r\nUID:absence_18@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_18@RDV Solidarités",
                         "organisation": {
-                          "id": 134,
+                          "id": 149,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1412,7 +1419,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -1497,19 +1504,19 @@
                       "absence": {
                         "id": 27,
                         "agent": {
-                          "id": 156,
+                          "id": 173,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Eugénie",
+                          "first_name": "Acanthe",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Fontaine"
+                          "last_name": "Fernandez"
                         },
-                        "end_day": "2024-10-04",
+                        "end_day": "2024-11-22",
                         "end_time": "15:30:00",
-                        "first_day": "2024-10-04",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20241003T104426Z\r\nUID:absence_27@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20241004T100000\r\nDTEND;TZID=Europe/Paris:20241004T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "first_day": "2024-11-22",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20241121T093049Z\r\nUID:absence_27@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20241122T100000\r\nDTEND;TZID=Europe/Paris:20241122T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_27@RDV Solidarités",
                         "organisation": {
-                          "id": 148,
+                          "id": 163,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1560,7 +1567,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -1710,19 +1717,19 @@
                       "absence": {
                         "id": 39,
                         "agent": {
-                          "id": 168,
+                          "id": 185,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Audebert",
+                          "first_name": "Manon",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Prévost"
+                          "last_name": "Laporte"
                         },
-                        "end_day": "2024-10-04",
+                        "end_day": "2024-11-22",
                         "end_time": "15:30:00",
-                        "first_day": "2024-10-04",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20241003T104427Z\r\nUID:absence_39@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20241004T100000\r\nDTEND;TZID=Europe/Paris:20241004T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "first_day": "2024-11-22",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20241121T093050Z\r\nUID:absence_39@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20241122T100000\r\nDTEND;TZID=Europe/Paris:20241122T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_39@RDV Solidarités",
                         "organisation": {
-                          "id": 160,
+                          "id": 175,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1773,7 +1780,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -1907,7 +1914,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -2018,11 +2025,11 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 192,
+                          "id": 209,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Brigitte",
+                          "first_name": "Laurène",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Poulain"
+                          "last_name": "Philippe"
                         }
                       ],
                       "meta": {
@@ -2171,7 +2178,7 @@
                     "value": {
                       "motifs": [
                         {
-                          "id": 102,
+                          "id": 118,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2180,16 +2187,16 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 86,
+                            "id": 90,
                             "name": "Catégorie de motif n°1",
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 201,
-                          "service_id": 316
+                          "organisation_id": 216,
+                          "service_id": 348
                         },
                         {
-                          "id": 103,
+                          "id": 119,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
                           "collectif": false,
@@ -2198,13 +2205,13 @@
                           "instruction_for_rdv": null,
                           "location_type": "public_office",
                           "motif_category": {
-                            "id": 87,
+                            "id": 91,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 201,
-                          "service_id": 316
+                          "organisation_id": 216,
+                          "service_id": 348
                         }
                       ],
                       "meta": {
@@ -2335,35 +2342,35 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 234,
+                          "id": 249,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 235,
+                          "id": 250,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 236,
+                          "id": 251,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 237,
+                          "id": 252,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 238,
+                          "id": 253,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -2487,7 +2494,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 245,
+                        "id": 260,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -2602,7 +2609,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 249,
+                        "id": 264,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -2649,7 +2656,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -2693,15 +2700,15 @@
                       "public_links": [
                         {
                           "external_id": "ext_id_A",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/297"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/312"
                         },
                         {
                           "external_id": "ext_id_B",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/298"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/313"
                         },
                         {
                           "external_id": "ext_id_C",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/299"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/314"
                         }
                       ]
                     }
@@ -2863,32 +2870,33 @@
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 275,
+                              "id": 292,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Pascale",
+                              "first_name": "Luc",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Prévost"
+                              "last_name": "Laurent"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
+                          "created_at": "2024-11-21 10:30:55 +0100",
                           "created_by": "agent",
-                          "created_by_id": 275,
+                          "created_by_id": 292,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 97,
+                            "id": 108,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "name": "Lieu n°1",
-                            "organisation_id": 309,
+                            "organisation_id": 324,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 157,
+                            "id": 173,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -2897,17 +2905,17 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 141,
+                              "id": 145,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 311,
-                            "service_id": 407
+                            "organisation_id": 326,
+                            "service_id": 439
                           },
                           "name": null,
                           "organisation": {
-                            "id": 309,
+                            "id": 324,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -2918,13 +2926,13 @@
                               "id": 13,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 275,
+                              "created_by_id": 292,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 68,
+                                "id": 70,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
@@ -2932,20 +2940,20 @@
                                 "birth_name": null,
                                 "caisse_affiliation": "caf",
                                 "case_number": null,
-                                "created_at": "2024-10-03 12:44:33 +0200",
+                                "created_at": "2024-11-21 10:30:55 +0100",
                                 "email": "usager_1@lapin.fr",
                                 "family_situation": "divorced",
-                                "first_name": "Marc",
+                                "first_name": "Arcadie",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "MOREAU",
+                                "last_name": "DUPONT",
                                 "logement": "locataire",
                                 "notes": "Super note",
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
                                 "number_of_children": 12,
-                                "phone_number": "646258745",
-                                "phone_number_formatted": "+33646258745",
+                                "phone_number": "07 45 60 55 12",
+                                "phone_number_formatted": "+33745605512",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -2956,7 +2964,7 @@
                           "status": "unknown",
                           "users": [
                             {
-                              "id": 68,
+                              "id": 70,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
@@ -2964,27 +2972,27 @@
                               "birth_name": null,
                               "caisse_affiliation": "caf",
                               "case_number": null,
-                              "created_at": "2024-10-03 12:44:33 +0200",
+                              "created_at": "2024-11-21 10:30:55 +0100",
                               "email": "usager_1@lapin.fr",
                               "family_situation": "divorced",
-                              "first_name": "Marc",
+                              "first_name": "Arcadie",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "MOREAU",
+                              "last_name": "DUPONT",
                               "logement": "locataire",
                               "notes": "Super note",
                               "notify_by_email": true,
                               "notify_by_sms": true,
                               "number_of_children": 12,
-                              "phone_number": "646258745",
-                              "phone_number_formatted": "+33646258745",
+                              "phone_number": "07 45 60 55 12",
+                              "phone_number_formatted": "+33745605512",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "f2ec0b24-db7b-47be-a550-7bcb857dc288"
+                          "uuid": "cf91d166-980c-40ea-a0a1-161f851b7693"
                         }
                       ],
                       "meta": {
@@ -3103,14 +3111,14 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 376,
+                          "id": 393,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Émeric",
+                          "first_name": "Hincmar",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Da silva"
+                          "last_name": "Schneider"
                         },
                         "user": {
-                          "id": 144,
+                          "id": 146,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
@@ -3118,20 +3126,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-10-03 12:44:39 +0200",
+                          "created_at": "2024-11-21 10:31:00 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Marceline",
+                          "first_name": "Eugène",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MORIN",
+                          "last_name": "CARLIER",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "655935387",
-                          "phone_number_formatted": "+33655935387",
+                          "phone_number": "07 66 40 82 40",
+                          "phone_number_formatted": "+33766408240",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3159,7 +3167,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -3284,7 +3292,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -3412,14 +3420,14 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 402,
+                          "id": 417,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         "user": {
-                          "id": 160,
+                          "id": 162,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
@@ -3427,20 +3435,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-10-03 12:44:40 +0200",
+                          "created_at": "2024-11-21 10:31:01 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Jeannel",
+                          "first_name": "Maurice",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DUFOUR",
+                          "last_name": "PASQUIER",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "0684072040",
-                          "phone_number_formatted": "+33684072040",
+                          "phone_number": "06 41 86 69 90",
+                          "phone_number_formatted": "+33641866990",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3468,7 +3476,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -3620,7 +3628,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -3739,7 +3747,7 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 177,
+                        "id": 179,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
@@ -3747,7 +3755,7 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-10-03 12:44:42 +0200",
+                        "created_at": "2024-11-21 10:31:02 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -3759,14 +3767,14 @@
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "784872388",
-                        "phone_number_formatted": "+33784872388",
+                        "phone_number": "7 96 38 63 01",
+                        "phone_number_formatted": "+33796386301",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 423,
+                              "id": 438,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -3816,7 +3824,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour voir cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations."
                       ]
                     }
                   }
@@ -4050,7 +4058,7 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 216,
+                        "id": 214,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
@@ -4058,7 +4066,7 @@
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-10-03 12:44:43 +0200",
+                        "created_at": "2024-11-21 10:31:03 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Alain",
@@ -4073,7 +4081,7 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 215,
+                          "id": 213,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
@@ -4081,25 +4089,25 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-10-03 12:44:43 +0200",
+                          "created_at": "2024-11-21 10:31:03 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Renée",
+                          "first_name": "Sidoine",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "DELAUNAY",
+                          "last_name": "FOURNIER",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "742209196",
-                          "phone_number_formatted": "+33742209196",
+                          "phone_number": "06 61 82 64 72",
+                          "phone_number_formatted": "+33661826472",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 215,
+                        "responsible_id": 213,
                         "user_profiles": null
                       }
                     }
@@ -4235,7 +4243,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "VS5JNYJB"
+                      "invitation_token": "EXERVVAY"
                     }
                   }
                 },
@@ -4277,7 +4285,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
                       ]
                     }
                   }
@@ -4374,7 +4382,7 @@
                     "value": {
                       "users": [
                         {
-                          "id": 234,
+                          "id": 232,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
@@ -4382,20 +4390,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-10-03 12:44:44 +0200",
+                          "created_at": "2024-11-21 10:31:04 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Brunon",
+                          "first_name": "Fortunée",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ROUSSEL",
+                          "last_name": "DUVAL",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "0643630277",
-                          "phone_number_formatted": "+33643630277",
+                          "phone_number": "6 44 89 62 61",
+                          "phone_number_formatted": "+33644896261",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4658,7 +4666,7 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 245,
+                        "id": 243,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
@@ -4666,7 +4674,7 @@
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-10-03 12:44:45 +0200",
+                        "created_at": "2024-11-21 10:31:05 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Johnny",
@@ -4681,7 +4689,7 @@
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 244,
+                          "id": 242,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
@@ -4689,25 +4697,25 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-10-03 12:44:45 +0200",
+                          "created_at": "2024-11-21 10:31:05 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Josse",
+                          "first_name": "Athalie",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "ROBERT",
+                          "last_name": "SANCHEZ",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 15 83 22 56",
-                          "phone_number_formatted": "+33615832256",
+                          "phone_number": "0613789921",
+                          "phone_number_formatted": "+33613789921",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 244,
+                        "responsible_id": 242,
                         "user_profiles": null
                       }
                     }
@@ -4854,7 +4862,7 @@
                     "value": {
                       "users": [
                         {
-                          "id": 254,
+                          "id": 252,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
@@ -4862,20 +4870,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2024-10-03 12:44:45 +0200",
+                          "created_at": "2024-11-21 10:31:05 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Jehanne",
+                          "first_name": "Enguerrand",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEMAITRE",
+                          "last_name": "PHILIPPE",
                           "logement": "locataire",
                           "notes": "Super note",
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "0652453458",
-                          "phone_number_formatted": "+33652453458",
+                          "phone_number": "06 49 06 78 71",
+                          "phone_number_formatted": "+33649067871",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4998,7 +5006,7 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 259,
+                        "id": 257,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
@@ -5006,7 +5014,7 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2024-10-03 12:44:46 +0200",
+                        "created_at": "2024-11-21 10:31:06 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -5018,14 +5026,14 @@
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "7 58 35 20 60",
-                        "phone_number_formatted": "+33758352060",
+                        "phone_number": "07 99 09 63 08",
+                        "phone_number_formatted": "+33799096308",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 495,
+                              "id": 508,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -5075,7 +5083,7 @@
                         }
                       ],
                       "error_messages": [
-                        "Vous ne pouvez pas effectuer cette action."
+                        "Vous n’avez pas les droits suffisants pour voir cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations."
                       ]
                     }
                   }
@@ -5345,8 +5353,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 30,
-                        "organisation_id": 519,
+                        "id": 26,
+                        "organisation_id": 528,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -5549,8 +5557,8 @@
                   "example": {
                     "value": {
                       "webhook_endpoint": {
-                        "id": 35,
-                        "organisation_id": 532,
+                        "id": 28,
+                        "organisation_id": 535,
                         "subscriptions": [
                           "rdv",
                           "user",


### PR DESCRIPTION
# Contexte

Le département du Var est venu vers nous pour nous demander s'il était possible d’avoir dans l’API d’avoir la date de création d’un RDV. Cela leur permettra notamment de calculer le délai entre la prise de RDV et le jour du RDV.

À ce jour, nous ne voyons pas de raison de ne pas exposer cette info dans l’API. De plus, elle pourra être utile à d’autres. Nous avons eu des remontées similaires de calcul de délai dans un atelier sur les stats.

# Solution

Ajout de l’attribut dans le blueprint + màj du swagger.

