### PR TITLE
ajout d’un commentaire sur motifs.rdvs_cancellable_by_user

### DIFF
--- a/db/migrate/20241122082916_add_comment_motif_rdvs_cancellable_by_users.rb
+++ b/db/migrate/20241122082916_add_comment_motif_rdvs_cancellable_by_users.rb
@@ -1,0 +1,5 @@
+class AddCommentMotifRdvsCancellableByUsers < ActiveRecord::Migration[7.1]
+  def change
+    change_column_comment :motifs, :rdvs_cancellable_by_user, from: nil, to: "Option invisible dans l’interface agents, utilisée par RDV Insertion pour des motifs de convocations"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_29_151445) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_22_082916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -435,7 +435,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_29_151445) do
     t.boolean "collectif", default: false, comment: "Indique s'il s'agit d'un rdv collectif ou individuel. Un rdv considéré comme individuel peut quand même avoir plusieurs participants, par exemple un parent et son enfant qui renouvellent tous les deux leur carte d'indentité en même temps. Un rdv collectif sera ouvert à plusieurs participants qui ne se connaissent pas entre eux.\n"
     t.enum "location_type", default: "public_office", null: false, comment: "Là où le rdv aura lieu : \"public_office\" pour \"Sur place\" (généralement dans les bureaux de l'organisation), \"phone\" pour au téléphone (l'agent appelle l'usager), \"home\" pour le domicile de l'usager\n", enum_type: "location_type"
     t.boolean "rdvs_editable_by_user", default: true, comment: "Indique si on autorise aux usagers de changer la date du rdv via l'interface web\n"
-    t.boolean "rdvs_cancellable_by_user", default: true
+    t.boolean "rdvs_cancellable_by_user", default: true, comment: "Option invisible dans l’interface agents, utilisée par RDV Insertion pour des motifs de convocations"
     t.bigint "motif_category_id"
     t.enum "bookable_by", default: "agents", null: false, enum_type: "bookable_by"
     t.index "to_tsvector('simple'::regconfig, (COALESCE(name, (''::text)::character varying))::text)", name: "index_motifs_name_vector", using: :gin


### PR DESCRIPTION
# Contexte

Traitement du ticket https://zammad10.ethibox.fr/#ticket/zoom/18585
Discussion Mattermost https://mattermost.incubateur.net/betagouv/pl/k1x9w5xc3fr68rebyi3xm85y9e

# Problème

La colonne `motifs.rdvs_cancellable_by_user` n’est pas visible ou modifiable dans l’interface agents mais est pourtant utilisée par RDVI sur certains motifs cf https://github.com/betagouv/rdv-service-public/pull/2511#issuecomment-1151385734

Ce n’est pas facilement découvrable et laisse penser que c’est une colonne correspondant à une fonctionnalité abandonnée ce qui n’est pas le cas.

# Solution

Rajouter un commentaire sur la colonne de la db
