### PR TITLE
feat(agent/calendar): une réponse AJAX 401 redirige vers la connexion

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -250,7 +250,12 @@ class CalendarRdvSolidarites {
     return now >= activeStart && now <= activeEnd;
   }
 
-  handleAjaxError = () => {
+  handleAjaxError = (response) => {
+    if (response.xhr.status === 401) {
+      window.location = this.calendarEl.attributes["data-sign-in-path"].value;
+      return;
+    }
+
     alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr.`);
   }
 }

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -20,6 +20,7 @@
       data-display-saturdays="#{current_agent.display_saturdays}"
       data-display-sundays="#{current_territory.name == Territory::VISIOPLAINTE_NAME}"
       data-event-sources-json="#{[admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json), admin_api_agenda_rdvs_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json), admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, in_background: true, format: :json), OffDays.to_full_calendar_array].to_json}"
+      data-sign-in-path="#{new_agent_session_path}"
     ]
     .mt-3.flex-grow-1.text-right
       .m-2


### PR DESCRIPTION
# Contexte

Le calendrier des agents et rafraîchit à chaque retour sur l’onglet, or, il est possible que l’agent se déconnecte dans un autre onglet ou que sa session expire. Dans ce cas, au retour sur un onglet ouvert sur le calendrier, il voit ce message :

![image](https://github.com/user-attachments/assets/ba74e52f-f6d4-4075-9904-745c871d67e5)

On souhaite éviter cela et rediriger l’agent vers la page de connexion en cas de déconnexion.

# Solution

Dans le `handleAjaxError` on redirige les agents vers la page de connexion si la réponse est une 401.

