### PR TITLE
On retire la review app du template de PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 Closes #XXXX
 
-Review app : https://demo-rdv-solidarites-prXXXX.osc-secnum-fr1.scalingo.io/
-
 # Contexte
 
 Décrire le pourquoi des modifications


### PR DESCRIPTION
Le lien de la review app étant maintenant mis automatiquement dans le corps de la PR lors de sa création, je propose de retirer cet élément du template de PR.