### PR TITLE
fix: Admin::AgentsController flaky spec

### DIFF
--- a/spec/controllers/admin/agents_controller_spec.rb
+++ b/spec/controllers/admin/agents_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Admin::AgentsController, type: :controller do
       it "returns agents as JSON" do
         francis = create(:agent, first_name: "Francis", last_name: "Factice", organisations: [organisation])
         get :index, params: { term: "fra", organisation_id: organisation.id, format: :json }
-        expect(response.parsed_body).to eq({ "results" => [{ "id" => francis.id, "text" => "FACTICE Francis" }] })
+        expect(response.parsed_body["results"]).to include({ "id" => francis.id, "text" => "FACTICE Francis" })
       end
     end
   end


### PR DESCRIPTION
# Contexte

```
Failures:

  1) Admin::AgentsController GET #index JSON version returns agents as JSON
     Failure/Error: expect(response.parsed_body).to eq({ "results" => [{ "id" => francis.id, "text" => "FACTICE Francis" }] })

       expected: {"results"=>[{"id"=>685, "text"=>"FACTICE Francis"}]}
            got: {"results"=>[{"id"=>685, "text"=>"FACTICE Francis"}, {"id"=>684, "text"=>"BRUNET France"}]}

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -"results" => [{"id"=>685, "text"=>"FACTICE Francis"}],
       +"results" => [{"id"=>685, "text"=>"FACTICE Francis"}, {"id"=>684, "text"=>"BRUNET France"}],
     # ./spec/controllers/admin/agents_controller_spec.rb:31:in `block (4 levels) in <main>'
     # ./spec/rails_helper.rb:95:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:94:in `block (2 levels) in <top (required)>'
.
Finished in 1 minute 51.05 seconds (files took 8.29 seconds to load)
706 examples, 1 failure

Failed examples:

rspec ./spec/controllers/admin/agents_controller_spec.rb:28 # Admin::AgentsController GET #index JSON version returns agents as JSON
```

Dans le code de la spec on recherche des agents qui contiennent le term `fra`. Si agent ou agent1 défini dans les `let!` plus haut contiennent aussi ces termes, il n’y a pas qu’un seul résultat.

# Solution

On vérifie donc que Francis Factice est inclus dans les résultats mais n’est pas forcément l’unique résultat.

