### PR TITLE
ProConnect : suppression du texte d'explication du changement de nom de la page de connexion

### DIFF
--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -9,12 +9,7 @@ h1.rdv-text-align-center.text-dark.mt-0.font-weight-bold.mb-4 Connexion à #{cur
         i.fa.fa-info
       span
         - if display_inclusion_connect_button?
-          = "Privilégiez maintenant ProConnect qui remplace Agent Connect et Inclusion Connect. "
-          br
           | Si nécessaire, #{link_to("cliquez ici", inclusion_connect_auth_path)} pour continuer d'utiliser Inclusion Connect.
-
-        - else
-          = "Vous pouvez dès maintenant utiliser ProConnect à la place d’Agent Connect. "
   .row.pt-2.pb-2
     .col
       hr


### PR DESCRIPTION

# Contexte

Ça fait maintenant 6 semaines qu'on a ajouté un texte pour expliquer le changement de nom de AgentConnect à ProConnect (#4713)

On considère que le message est passé, et qu'on peut alléger notre page de connexion en supprimant ce texte.

Inclusion Connect reste encore ouvert pendant quelques semaines donc ce texte là est encore actif.

## Captures d'écran

Avant | Après
:- | -:
<img width="1360" alt="Screenshot 2024-11-27 at 16 48 08" src="https://github.com/user-attachments/assets/3c1c6df3-d5b9-409d-b9e5-5fe9068d8de3"> | <img width="1377" alt="Screenshot 2024-11-27 at 16 48 21" src="https://github.com/user-attachments/assets/1a7789b0-3b52-4b0c-af88-307ce3dfe659">


