### PR TITLE
Améliorer la regexp de validation email pour prendre en compte à minima 2 caractéres pour l'extension

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -224,7 +224,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/
+  config.email_regexp = /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
Nous avons certaines différences entre la validation email coté rdvi un peu plus stricte et rdvsp.
Cela pose problème dans nos jobs de webhook en provenance de rdvsp car les validations ne passent pas.
La validation email utilisée par rdvsp **accepte les extensions de domaine avec une seule lettre**.
Or il s'agit d'erreur de saisie.
Je change ici la regexp pour qu'elle soit à l'identique avec celle de rdvi et demande à minima 2 caractères pour l'extension.
Il y a 36 usagers en production dans rdvsp qui ont un email erroné (@sfr.f, @gmail.c, @organge.f ...) et deviendront invalides, je me chargerai de les corriger manuellement une fois cette PR passée.
