### PR TITLE
Ne pas annuler le job CI de feature spec si l'autre échoue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,9 @@ jobs:
     name: Feature Tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        # cette strategy permet de lancer deux jobs de feature specs en parallèle pour accélérer l’éxecution
+        # cette strategy permet de lancer deux jobs de feature specs en parallèle pour accélérer l’exécution
         dirname: [agents, "*"]
         include: 
           - dirname: agents


### PR DESCRIPTION
# Problème 

Lorsqu'un des deux jobs de feature specs échoue, l'autre est interrompu par GitHub Actions : 

![image](https://github.com/user-attachments/assets/b4d7e329-6092-46bc-8ba4-f84156fbb3d1)

Dans la plupart des cas, cet autre job est interrompu alors qu'il était sur le point de passer : 

![image](https://github.com/user-attachments/assets/95aabbf7-8853-4838-97f7-9365465b9ed4)

(exemple tiré ici : https://github.com/betagouv/rdv-service-public/actions/runs/12069712676/job/33657579178)

Il est inutile d'interrompre un job lorsqu'un autre échoue puisque les jobs sont indépendants. Quand on interrompt l'autre job, on est ensuite forcés de le relancer à la main inutilement. :triumph: 

# Solution

Définir `fail-fast: false` dans notre stratégie. :zap: 

La doc ici : https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast