### PR TITLE
Correctif sur le formulaire de lieux

### DIFF
--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -13,7 +13,7 @@
 / All forms
 = f.input :name, required: true
 - unless is_nested_form
-  = f.input :phone_number
+  = f.input :phone_number, hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)
 = f.input :address, input_html: { class: "places-js-container" }
 = f.hidden_field :latitude
 = f.hidden_field :longitude

--- a/config/locales/models/lieu.fr.yml
+++ b/config/locales/models/lieu.fr.yml
@@ -29,4 +29,4 @@ fr:
           Si le lieu est ouvert, de nouveaux rendez-vous et plages d’ouvertures peuvent y être posés.
           Fermez un lieu pour ne plus le voir dans les menus.
         name: Le nom apparaîtra dans les notifications par email et SMS aux usagers.
-        phone_number: Ce numéro sera affiché coté usager pour leurs permettre de vous contacter. Faites en sorte que les personnes qui répondront au téléphone puissent avoir accès à RDV-Solidarités.
+        phone_number: Ce numéro sera affiché coté usager pour leurs permettre de vous contacter. Faites en sorte que les personnes qui répondront au téléphone puissent avoir accès à %{app_name}.


### PR DESCRIPTION
Un tout petit fix en passant. Dans ce petit hint on affichait systématiquement "RDV-Solidarités" (avec le tiret 😱 ) même si on est sur RDV Service Public

## Captures d'écran

Avant | Après
:- | -:
<img width="804" alt="Screenshot 2024-11-28 at 17 05 47" src="https://github.com/user-attachments/assets/5ec0d2bd-c737-4cab-832d-e2226edaf8ba"> | <img width="795" alt="Screenshot 2024-11-28 at 17 05 55" src="https://github.com/user-attachments/assets/44760c25-8e8f-4225-9d13-295b6ddc9e4d">
