### PR TITLE
Passage du formulaire de mot de passe usager au DSFR

### DIFF
--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -5,14 +5,10 @@
     - if @from_confirmation
       p.rdv-color-text-mention-grey Pour finaliser votre inscription, veuillez définir un mot de passe.
 
-    = simple_form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put } do |f|
-      = render "devise/shared/error_messages", resource: resource
-      = f.input :reset_password_token, as: :hidden
+    = form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, builder: DsfrFormBuilder do |f|
+      = f.hidden_field :reset_password_token
       .form-group
-        = f.password_field :password, as: :password, label: "Mot de passe", class: "form-control", autocomplete: "new-password", required: true, id: "password"
-        span.fa.fa-fw.fa-eye.toggle-password role="button" tabindex="0"
-
-        = render "agents/mot_de_passes/new_password_hints"
+        = render "common/form/password_input", f: f, live_validation: true
 
       .rdv-text-align-center
-        = f.submit "Enregistrer", class: "btn btn btn-primary"
+        = f.submit "Enregistrer", class: "fr-btn"

--- a/spec/features/users/account/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/account/user_can_reset_his_password_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe "User resets his password spec" do
     current_email.click_link("Changer")
     expect(page).to have_content("Définir mon mot de passe")
 
-    fill_in "password", with: "q1w2e3r4t5y6"
+    fill_in "Mot de passe", with: "q1w2e3r4t5y6"
     expect { click_on "Enregistrer" }.not_to change { user.reload.encrypted_password }
     expect(page).to have_content("Ce mot de passe fait partie d'une liste de mots de passe fréquemment utilisés")
 
-    fill_in "password", with: "pasassezfort"
+    fill_in "Mot de passe", with: "pasassezfort"
     expect { click_on "Enregistrer" }.not_to change { user.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe doit comporter au moins un chiffre.")
 
-    fill_in "password", with: "Corr3ctHorse,"
+    fill_in "Mot de passe", with: "Corr3ctHorse,"
 
     expect { click_on "Enregistrer" }.to change { user.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe a été édité avec succès")

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "User signs up and signs in" do
       current_email.click_link "Confirmer mon compte"
       expect_flash_info(I18n.t("devise.confirmations.confirmed"))
       expect(page).to have_content("Définir mon mot de passe")
-      fill_in :password, with: user.password
+      fill_in "Mot de passe", with: user.password
       click_on "Enregistrer"
       expect_flash_info(I18n.t("devise.passwords.updated")) # auto-connected
       click_link "Déconnexion"

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe "User can search for rdvs" do
     # Password reset page after confirmation
     expect(page).to have_content("Votre compte a été validé")
     expect(page).to have_content("Définir mon mot de passe")
-    fill_in(:password, with: "Rdvservicepublictest1!")
+    fill_in("Mot de passe", with: "Rdvservicepublictest1€")
     click_button("Enregistrer")
   end
 

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
       open_email("davidnchicode@crotonmail.com")
       current_email.click_link("Confirmer mon compte")
-      fill_in "password", with: "Rdvservicepublictest1!"
+      fill_in "Mot de passe", with: "Rdvservicepublictest1!"
       click_on("Enregistrer")
 
       # Page de formulaire où l'on peut ajouter le nom de naissance, la date de naissance, le téléphone...


### PR DESCRIPTION
# Contexte

Dans le cadre de notre passage au DSFR, on change tous les formulaires de connexion.

# Solution

On réutilise les _partials_ créés précédemment.

## Captures d'écran

Avant | Après
:- | -:
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/54c3fee5-6053-4dc9-a5d9-777678a9375d"> | <img width="1288" alt="image" src="https://github.com/user-attachments/assets/a2d86db4-fdad-4d81-a174-f21d4562b7c5">
<img width="827" alt="image" src="https://github.com/user-attachments/assets/aaf69b2a-3465-40df-aeba-d63812bf0055"> | <img width="857" alt="image" src="https://github.com/user-attachments/assets/73310e89-4be7-46e6-b621-4d7fa07e7f8e">


