### PR TITLE
Ajout des liens de visio au PDF des rdvs

### DIFF
--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -13,6 +13,12 @@
           = rdv.motif_name
         .rdv-status.px-2.py-2 class="rdv-status-#{rdv.status}" id="rdv-#{rdv.id}-status"
           = rdv.human_attribute_value(:status).upcase
+      - if rdv.motif.visio?
+        .pl-3.pt-2
+          .fa.fa-video-camera>
+          = "RDV par visioconférence "
+          = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
+
       .card-body
         - rdv.participations.each do |participation|
           ruby:


### PR DESCRIPTION
# Contexte

Dans les CDAD, beaucoup de RDV par visio sont fait par des intervenants qui n'accèdent pas directement à RDV Solidarités, mais qui reçoivent les pdv exportés par les secrétaires.
Ils ont donc besoin du lien pour accéder à la visio.
Cette Pr ajoute ce lien dans le pdf.

# Solution

On affiche le lien.
Historiquement on était assez discret sur les endroits où on affichait les liens de visio, mais ça semble être un cas légitime.

## Captures d'écran

Avant | Après
:- | -:
<img width="1399" alt="Screenshot 2024-11-28 at 17 36 04" src="https://github.com/user-attachments/assets/bb8c23f8-5f98-430c-85fb-0d69d8ddee6d"> | <img width="1376" alt="Screenshot 2024-11-28 at 17 35 28" src="https://github.com/user-attachments/assets/9c32eb9d-0dde-4f62-b207-256fbad85446">


