### PR TITLE
Tentative de correction sur une flaky spec pour la création de comptes CNFS

### DIFF
--- a/app/services/add_conseiller_numerique.rb
+++ b/app/services/add_conseiller_numerique.rb
@@ -68,7 +68,7 @@ class AddConseillerNumerique
         last_name: @conseiller_numerique.last_name,
         external_id: @conseiller_numerique.external_id,
         services: [service],
-        password: SecureRandom.base64(32),
+        password: "#{SecureRandom.base64(32)}Aa1!", # Les derniers caractères nous assurent que le mot de passe est valide selon StrongPasswordConcern
         roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
       }
     ).tap do |agent|


### PR DESCRIPTION
Closes #XXXX

# Contexte

On a eu plusieurs fois de échecs de `./spec/requests/api/conseiller_numerique/account_spec.rb:59` sur la CI, avec le message suivant :
```
  1) Création de comptes de conseillers numériques when the api key is configured properly with the correct api key returns a 201 response
     Failure/Error: agent.agent_territorial_access_rights.find_or_create_by!(territory: territory)

     ActiveRecord::RecordNotSaved:
       You cannot call create unless the parent is saved
     # ./app/services/add_conseiller_numerique.rb:75:in `block in invite_agent'
```

Et en fait c'est peut-être un bug occasionnel en prod.

# Solution

Ce message d'erreur indique que l'agent n'a pas pu être persisté, probablement parce qu'une des validation échouait.
La seule source plausible d'aléatoire semble être le mot de passe choisit au hasard. Les chaînes de caractères générées par `SecureRandom.base64(32)` ressemblent à `"gIlQ+ritIIZgGLjKGZfU7whdxberhf9BHm13A1YBdOI="`.
J'imagine que c'est possible que de temps en temps on n'ai pas de majuscule, ou de chiffre (il semble qu'on aura toujours le `=` final qui garanti au moins un caractère spécial).

On ajoute donc des caractères manuellement pour s'assurer de toujours répondre aux contraintes sur les mots de passe (et on continue de faire confiance à `SecureRandom.base64(32)` pour générer assez d'entropie par ailleurs).

