### PR TITLE
Migration changement email/mot de passe usager vers le DSFR

### DIFF
--- a/app/form_builders/dsfr_form_builder.rb
+++ b/app/form_builders/dsfr_form_builder.rb
@@ -45,7 +45,7 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
   def dsfr_label_with_hint(attribute, opts = {})
     label_class = "fr-label #{opts[:class]}"
     label(attribute, class: label_class) do
-      label_and_tags = [label_value(attribute)]
+      label_and_tags = [label_value(attribute, opts)]
       label_and_tags.push(required_tag) if opts[:required] && display_required_tags
       label_and_tags.push(hint_tag(opts[:hint])) if opts[:hint]
 
@@ -91,7 +91,9 @@ class DsfrFormBuilder < ActionView::Helpers::FormBuilder
     )
   end
 
-  def label_value(attribute)
+  def label_value(attribute, opts)
+    return opts[:label] if opts[:label]
+
     (@object.try(:object) || @object).class.human_attribute_name(attribute)
   end
 end

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -19,7 +19,7 @@
         .fr-grid-row.fr-grid-row--gutters
           .fr-col-md-6= f.dsfr_text_field :first_name, required: true
           .fr-col-md-6= f.dsfr_text_field :last_name, required: true
-        = render "common/form/new_password_input", f: f, live_validation: true, hint: "Choisissez votre mot de passe"
+        = render "common/form/new_password_input", f: , hint: "Choisissez votre mot de passe"
 
         .fr-btns-group.fr-btns-group--inline.fr-btns-group--right
           .fr-mt-2w= f.submit t("devise.invitations.edit.submit_button"), class: "fr-btn"

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -19,7 +19,7 @@
         .fr-grid-row.fr-grid-row--gutters
           .fr-col-md-6= f.dsfr_text_field :first_name, required: true
           .fr-col-md-6= f.dsfr_text_field :last_name, required: true
-        = render "common/form/password_input", f: f, live_validation: true
+        = render "common/form/new_password_input", f: f, live_validation: true, hint: "Choisissez votre mot de passe"
 
         .fr-btns-group.fr-btns-group--inline.fr-btns-group--right
           .fr-mt-2w= f.submit t("devise.invitations.edit.submit_button"), class: "fr-btn"

--- a/app/views/common/form/_current_password_input.html.slim
+++ b/app/views/common/form/_current_password_input.html.slim
@@ -1,0 +1,9 @@
+- attribute_name = defined?(name) ? name : :password
+= f.dsfr_input_group attribute_name, class: "fr-password fr-mt-2w"
+  = f.dsfr_label_with_hint attribute_name, class: "fr-label", for: "password", hint: defined?(hint) ? hint : nil, label: defined?(password_label) ? password_label : nil
+  .fr-input-wrap
+    = f.password_field attribute_name, autocomplete: "current-password", required: true, class: "fr-password__input fr-input"
+    = f.dsfr_error_message attribute_name
+  .fr-password__checkbox.fr-checkbox-group.fr-checkbox-group--sm
+    input type="checkbox" aria-label="Afficher le mot de passe" id="password-show"
+    label for="password-show" class="fr-password__checkbox fr-label" Afficher

--- a/app/views/common/form/_current_password_input.html.slim
+++ b/app/views/common/form/_current_password_input.html.slim
@@ -1,9 +1,12 @@
-- attribute_name = defined?(name) ? name : :password
-= f.dsfr_input_group attribute_name, class: "fr-password fr-mt-2w"
-  = f.dsfr_label_with_hint attribute_name, class: "fr-label", for: "password", hint: defined?(hint) ? hint : nil, label: defined?(password_label) ? password_label : nil
+/# locals: (f:, name: :password, hint: nil, password_label: nil, forgotten_password_link: false)
+
+= f.dsfr_input_group name, class: "fr-password fr-mt-2w"
+  = f.dsfr_label_with_hint name, class: "fr-label", for: "password", hint: hint, label: password_label
   .fr-input-wrap
-    = f.password_field attribute_name, autocomplete: "current-password", required: true, class: "fr-password__input fr-input"
-    = f.dsfr_error_message attribute_name
+    = f.password_field name, autocomplete: "current-password", required: true, class: "fr-password__input fr-input"
+    = f.dsfr_error_message name
   .fr-password__checkbox.fr-checkbox-group.fr-checkbox-group--sm
     input type="checkbox" aria-label="Afficher le mot de passe" id="password-show"
     label for="password-show" class="fr-password__checkbox fr-label" Afficher
+  - if forgotten_password_link
+    = link_to "Mot de passe oublié ?", new_password_path(resource_name), class: "fr-link"

--- a/app/views/common/form/_new_password_input.html.slim
+++ b/app/views/common/form/_new_password_input.html.slim
@@ -1,10 +1,10 @@
 = f.dsfr_input_group :password, class: "fr-password fr-mt-2w", data: {component: "js_dsfr_new_password"}
-  = f.dsfr_label_with_hint :password, class: "fr-label fr-password__label", hint: "Choisissez votre mot de passe"
+  = f.dsfr_label_with_hint :password, class: "fr-label fr-password__label", hint: defined?(hint) ? hint : nil, label: defined?(password_label) ? password_label : nil
   .fr-input-wrap
     = f.password_field :password, class: "fr-input fr-password__input", required: "true", autocomplete: "new-password"
     = f.dsfr_error_message :password
   .fr-password__checkbox.fr-checkbox-group.fr-checkbox-group--sm
-    input#password-show[class="fr-checkbox" aria-label="Afficher le mot de passe" aria-describedby="password-show-messages" type="checkbox"]
-    label.fr-password__checkbox.fr-label[for = "password-show"] Afficher
+    input#new-password-show[class="fr-checkbox" aria-label="Afficher le mot de passe" type="checkbox"]
+    label.fr-password__checkbox.fr-label[for = "new-password-show"] Afficher
   - if defined?(live_validation) && live_validation
     = render "common/form/password_live_validation"

--- a/app/views/common/form/_new_password_input.html.slim
+++ b/app/views/common/form/_new_password_input.html.slim
@@ -1,10 +1,11 @@
+/# locals: (f:, hint: nil, password_label: nil)
+
 = f.dsfr_input_group :password, class: "fr-password fr-mt-2w", data: {component: "js_dsfr_new_password"}
-  = f.dsfr_label_with_hint :password, class: "fr-label fr-password__label", hint: defined?(hint) ? hint : nil, label: defined?(password_label) ? password_label : nil
+  = f.dsfr_label_with_hint :password, class: "fr-label fr-password__label", hint: hint, label: password_label
   .fr-input-wrap
     = f.password_field :password, class: "fr-input fr-password__input", required: "true", autocomplete: "new-password"
     = f.dsfr_error_message :password
   .fr-password__checkbox.fr-checkbox-group.fr-checkbox-group--sm
     input#new-password-show[class="fr-checkbox" aria-label="Afficher le mot de passe" type="checkbox"]
     label.fr-password__checkbox.fr-label[for = "new-password-show"] Afficher
-  - if defined?(live_validation) && live_validation
-    = render "common/form/password_live_validation"
+  = render "common/form/password_live_validation"

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -8,7 +8,7 @@
     = form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, builder: DsfrFormBuilder do |f|
       = f.hidden_field :reset_password_token
       .form-group
-        = render "common/form/new_password_input", f: f, live_validation: true
+        = render "common/form/new_password_input", f: f
 
       .rdv-text-align-center
         = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -8,7 +8,7 @@
     = form_for resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, builder: DsfrFormBuilder do |f|
       = f.hidden_field :reset_password_token
       .form-group
-        = render "common/form/password_input", f: f, live_validation: true
+        = render "common/form/new_password_input", f: f, live_validation: true
 
       .rdv-text-align-center
         = f.submit "Enregistrer", class: "fr-btn"

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -3,25 +3,17 @@
 .card
   .card-body
     - if resource.logged_once_with_franceconnect?
-      .alert.alert-info.d-flex.align-items-center
-        .mr-3
-          .fa.fa-info
-        div Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
-    = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }) do |f|
-      = render "devise/shared/error_messages", resource: resource
-      = f.input :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), placeholder: "nom.prenom@email.com"
+      .fr-alert.fr-alert--info.fr-mb-3w
+        | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
+    = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: DsfrFormBuilder do |f|
+      = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         .form-text.rdv-color-text-mention-grey.mb-2
           | En attente de confirmation pour #{resource.unconfirmed_email}
-      = f.input :password, label: "Nouveau mot de passe", autocomplete: "new-password"
-      = render "agents/mot_de_passes/new_password_hints"
-      .form-text.rdv-color-text-mention-grey.mb-2
-        | Laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.
-      = f.input :current_password, placeholder: "Votre mot de passe actuel", required: true, autocomplete: "current-password"
-      .form-text.rdv-color-text-mention-grey.mb-2
-        | Renseignez votre mot de passe actuel pour tout changement.
-      .rdv-text-align-right= f.submit "Modifier", class: "btn btn-primary"
+      = render "common/form/new_password_input", f: f, live_validation: true, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
+      = render "common/form/current_password_input", f: f, name: :current_password, hint: "Renseignez votre mot de passe actuel pour tout changement.", password_label: "Mot de passe actuel"
+      .rdv-text-align-right= f.submit "Modifier", class: "fr-btn"
       .mt-5.rdv-text-align-center
         hr
         p.font-13 Vous souhaitez supprimer votre compte ?
-        = link_to "Supprimer", user_registration_path, data:{ confirm: @rdv_insertion_organisations.blank? ? "Voulez-vous vraiment supprimer votre compte ?" : "Vous ne pourrez plus vous connecter à votre compte mais les données liées aux structures d'insertion ne seront pas supprimées. Vos données liées à d'autres structures seront bien supprimées." }, method: :delete, class: "btn btn-outline-danger btn-sm"
+        = link_to "Supprimer", user_registration_path, data:{ confirm: @rdv_insertion_organisations.blank? ? "Voulez-vous vraiment supprimer votre compte ?" : "Vous ne pourrez plus vous connecter à votre compte mais les données liées aux structures d'insertion ne seront pas supprimées. Vos données liées à d'autres structures seront bien supprimées." }, method: :delete, class: "fr-btn fr-btn--secondary"

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -10,7 +10,7 @@
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         .form-text.rdv-color-text-mention-grey.mb-2
           | En attente de confirmation pour #{resource.unconfirmed_email}
-      = render "common/form/new_password_input", f: f, live_validation: true, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
+      = render "common/form/new_password_input", f:, hint: "Choisissez votre mot de passe ou laissez ce champ vide si vous ne souhaitez pas changer votre mot de passe.", password_label: "Nouveau mot de passe"
       = render "common/form/current_password_input", f: f, name: :current_password, hint: "Renseignez votre mot de passe actuel pour tout changement.", password_label: "Mot de passe actuel"
       .rdv-text-align-right= f.submit "Modifier", class: "fr-btn"
       .mt-5.rdv-text-align-center

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -12,22 +12,10 @@
 
     h2 Se connecter avec son compte
 
-    = form_for resource, as: resource_name, url: session_path(resource_name) do |f|
+    = form_for resource, as: resource_name, url: session_path(resource_name), builder: DsfrFormBuilder do |f|
       = render "devise/shared/error_messages", resource: resource
-      .fr-input-group
-        = f.label :email, class: "fr-label" do
-          = "Adresse email"
-          span.fr-hint-text Format attendu : nom@domaine.fr
-        = f.email_field :email, autofocus: true, class: "fr-input"
-      .fr-password
-        = f.label :password, class: "fr-label", for: "password"
-        .fr-input-wrap
-          = f.password_field :password, autocomplete: "current-password", required: true, class: "fr-password__input fr-input", id: "password"
-        .fr-password__checkbox.fr-checkbox-group.fr-checkbox-group--sm
-          input type="checkbox" aria-label="Afficher le mot de passe" id="password-show"
-          label for="password-show" class="fr-password__checkbox fr-label" Afficher
-
-        = link_to "Mot de passe oublié ?", new_password_path(resource_name), class: "fr-link"
+      = f.dsfr_email_field :email, autofocus: true, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email"
+      = render "common/form/current_password_input", f:, forgotten_password_link: true
 
       .rdv-text-align-center
         = f.submit "Se connecter", class: "fr-mt-2v fr-btn"

--- a/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
+++ b/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "User is redirected back to requested page after login" do
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
 
     fill_in("user_email", with: user.email)
-    fill_in("password", with: user.password)
+    fill_in("user_password", with: user.password)
     click_button("Se connecter")
     expect(page).to have_current_path("/users/rdvs")
   end

--- a/spec/features/users/account/user_session_expires_spec.rb
+++ b/spec/features/users/account/user_session_expires_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "User session expiration" do
   it "is done 30 minutes after last visit" do
     visit new_user_session_path
     fill_in "Adresse email", with: user.email
-    fill_in "password", with: password
+    fill_in "user_password", with: password
     within("main") { click_on "Se connecter" }
     expect_to_be_logged_in
 

--- a/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
+++ b/spec/features/users/account/user_signs_up_and_signs_in_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "User signs up and signs in" do
       click_link "Se connecter"
       within("form") do
         fill_in :user_email, with: agent.email
-        fill_in :password, with: agent.password
+        fill_in :user_password, with: agent.password
         click_on "Se connecter"
       end
       expect(page).to have_current_path(admin_organisation_agent_agenda_path(agent.organisations.first, agent), ignore_query: true)
@@ -91,8 +91,8 @@ RSpec.describe "User signs up and signs in" do
 
       it "shows a warning and advises to change the password" do
         visit new_user_session_path
-        fill_in "Adresse email", with: agent.email
-        fill_in "password", with: "tropfaible"
+        fill_in :user_email, with: agent.email
+        fill_in :user_password, with: "tropfaible"
         within("main") { click_on "Se connecter" }
         expect(page).to have_content("Votre mot de passe est trop faible")
       end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -465,8 +465,8 @@ RSpec.describe "User can search for rdvs" do
     expect(page).to have_content("Inscription")
     fill_in(:user_first_name, with: "Michel")
     fill_in(:user_last_name, with: "Lapin")
-    fill_in("Email", with: "michel@lapin.fr")
-    fill_in("Téléphone", with: "0612345678")
+    fill_in("Adresse email", with: "michel@lapin.fr")
+    fill_in("Numéro de téléphone", with: "0612345678")
     click_button("Je m’inscris")
 
     # Confirmation email

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
                                                        public_link_organisation_id: organisation.id, duration: 50))
 
       fill_in("user_email", with: user.email)
-      fill_in("password", with: user.password)
+      fill_in("user_password", with: user.password)
       click_button("Se connecter")
 
       expect(page).to have_field("Numéro de pré-demande ANTS")
@@ -126,7 +126,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       visit creneaux_url
 
       fill_in("user_email", with: user.email)
-      fill_in("password", with: user.password)
+      fill_in("user_password", with: user.password)
       click_button("Se connecter")
 
       fill_in("user_ants_pre_demande_number", with: "1122334455")
@@ -163,7 +163,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
       visit creneaux_url
 
       fill_in("user_email", with: user.email)
-      fill_in("password", with: user.password)
+      fill_in("user_password", with: user.password)
       click_button("Se connecter")
 
       fill_in("user_ants_pre_demande_number", with: "1234ABC")
@@ -181,7 +181,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         visit creneaux_url
 
         fill_in("user_email", with: user.email)
-        fill_in("password", with: user.password)
+        fill_in("user_password", with: user.password)
         click_button("Se connecter")
 
         fill_in("user_ants_pre_demande_number", with: "abcd1234ef")
@@ -200,7 +200,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         visit creneaux_url
 
         fill_in("user_email", with: user.email)
-        fill_in("password", with: user.password)
+        fill_in("user_password", with: user.password)
         click_button("Se connecter")
 
         fill_in("user_ants_pre_demande_number", with: "  ")
@@ -223,7 +223,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         visit creneaux_url
 
         fill_in("user_email", with: user.email)
-        fill_in("password", with: user.password)
+        fill_in("user_password", with: user.password)
         click_button("Se connecter")
 
         fill_in("user_ants_pre_demande_number", with: "5544332211")
@@ -243,7 +243,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         expect(page).to have_content("Motif : Passeport")
 
         fill_in("user_email", with: user.email)
-        fill_in("password", with: user.password)
+        fill_in("user_password", with: user.password)
         click_button("Se connecter")
 
         expect(page).to have_field("Numéro de pré-demande ANTS")
@@ -266,7 +266,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
         expect(page).to have_content("Motif : Retrait")
 
         fill_in("user_email", with: user.email)
-        fill_in("password", with: user.password)
+        fill_in("user_password", with: user.password)
         click_button("Se connecter")
 
         expect(page).not_to have_field("Numéro de pré-demande ANTS")
@@ -285,7 +285,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
           expect(page).to have_content("Motif : Retrait")
 
           fill_in("user_email", with: user.email)
-          fill_in("password", with: user.password)
+          fill_in("user_password", with: user.password)
           click_button("Se connecter")
 
           expect(page).not_to have_field("Numéro de pré-demande ANTS")

--- a/spec/features/users/online_booking/on_rdv_service_public_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_service_public_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "User can search rdv on rdv service public" do
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
 
     fill_in("user_email", with: user.email)
-    fill_in("password", with: user.password)
+    fill_in("user_password", with: user.password)
     click_button("Se connecter")
 
     expect(page).not_to have_field("Numéro de pré-demande ANTS")

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer.")
       fill_in("user_email", with: logged_user.email)
-      fill_in("password", with: logged_user.password)
+      fill_in("user_password", with: logged_user.password)
 
       click_button("Se connecter")
       click_button("Continuer")


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4862.osc-secnum-fr1.scalingo.io/)

# Contexte

Dans le cadre de notre passage au DSFR, et de la migration des pages de connexion, inscription, etc. on migre également la page de changement d’email et de mot de passe.

# Solution

Création de 2 partials distincts pour l’input de nouveau mot de passe et pour celui de mot de passe courant.

## Captures d'écran

Avant | Après
:- | -:
<img width="858" alt="image" src="https://github.com/user-attachments/assets/e6d21b8b-a824-4067-8461-172ed84e370c"> | <img width="837" alt="image" src="https://github.com/user-attachments/assets/0c3a8e24-a8d9-4ca4-a692-46deab6e1c00">
