### PR TITLE
Petit correctif pour la création d'application oauth

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -215,7 +215,7 @@ Doorkeeper.configure do
   # #call can be used in order to allow conditional checks (to allow non-SSL
   # redirects to localhost for example).
   #
-  force_ssl_in_redirect_uri(!Rails.env.local? && ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO")
+  force_ssl_in_redirect_uri(!Rails.env.local? || ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO")
   #
   # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -215,7 +215,7 @@ Doorkeeper.configure do
   # #call can be used in order to allow conditional checks (to allow non-SSL
   # redirects to localhost for example).
   #
-  force_ssl_in_redirect_uri(!Rails.env.local? || ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO")
+  force_ssl_in_redirect_uri(!Rails.env.local? && ENV["RDV_SOLIDARITES_INSTANCE_NAME"] != "DEMO")
   #
   # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
 

--- a/scripts/create_oauth_application.rb
+++ b/scripts/create_oauth_application.rb
@@ -3,7 +3,8 @@
 
 application = Doorkeeper::Application.create!(
   name: ARGV[0],
-  redirect_uri: ARGV[1]
+  redirect_uri: ARGV[1],
+  logo_base64: ""
 )
 
 puts "L'id de l'application est:"
@@ -12,5 +13,5 @@ puts application.uid
 puts "Le secret de l'application est :"
 puts application.plaintext_secret
 
-puts "\rEnregistrez-le tout de suite dans un système de sécurité car il ne sera plus consultable."
+puts "\rEnregistrez-le tout de suite dans un système sécurisé car il ne sera plus consultable."
 puts "Vous pouvez ajouter un logo à l'application."


### PR DESCRIPTION
En créant l'application oauth pour Mon Suivi Social, je me suis rendu compte que la condition pour autoriser les `localhost` sur la démo n'était pas la bonne, et qu'il fallait éviter d'avoir un `logo_base64` nil.
Cette pr corrige ces petites étourderies.