### PR TITLE
Clarifier que les jours fériées sont automatiquement considérés comme des indispos

### DIFF
--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -1,4 +1,7 @@
 module AbsencesHelper
+
+  CALENDAR_BACKGROUND_COLOR = "rgba(127, 140, 141, 0.7)"
+
   def absence_tag(absence)
     if absence.expired?
       tag.span("Passée", class: "badge badge-light")

--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -1,6 +1,5 @@
 module AbsencesHelper
-
-  CALENDAR_BACKGROUND_COLOR = "rgba(127, 140, 141, 0.7)"
+  CALENDAR_BACKGROUND_COLOR = "rgba(127, 140, 141, 0.7)".freeze
 
   def absence_tag(absence)
     if absence.expired?

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -68,6 +68,7 @@ class CalendarRdvSolidarites {
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: this.handleAjaxError,
       defaultDate: this.getDefaultDate(),
+      allDaySlot: false,
       defaultView: this.getDefaultView(),
       viewSkeletonRender: function (info) {
         localStorage.setItem("calendarDefaultView", info.view.type);

--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -60,22 +60,12 @@ class OffDays
 
   def self.to_full_calendar_array
     JOURS_FERIES.map do |jour_ferie|
-      [
-        {
-          title: "Jour férié 🎉",
-          start: jour_ferie.beginning_of_day.as_json,
-          end: jour_ferie.end_of_day.as_json,
-          backgroundColor: "#6F6F71",
-          allDay: true,
-          extendedProps: { jour_feries: true },
-        },
-        {
-          title: "Jour férié",
-          start: jour_ferie.beginning_of_day.as_json,
-          end: jour_ferie.end_of_day.as_json,
-          backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
-        },
-      ]
-    end.flatten
+      {
+        title: "Jour férié",
+        start: jour_ferie.beginning_of_day.as_json,
+        end: jour_ferie.end_of_day.as_json,
+        backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
+      }
+    end
   end
 end

--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -60,14 +60,22 @@ class OffDays
 
   def self.to_full_calendar_array
     JOURS_FERIES.map do |jour_ferie|
-      {
-        title: "Jour férié 🎉",
-        start: jour_ferie.beginning_of_day.as_json,
-        end: jour_ferie.end_of_day.as_json,
-        backgroundColor: "#6F6F71",
-        allDay: true,
-        extendedProps: { jour_feries: true },
-      }
-    end
+      [
+        {
+          title: "Jour férié 🎉",
+          start: jour_ferie.beginning_of_day.as_json,
+          end: jour_ferie.end_of_day.as_json,
+          backgroundColor: "#6F6F71",
+          allDay: true,
+          extendedProps: { jour_feries: true },
+        },
+        {
+          title: "Jour férié",
+          start: jour_ferie.beginning_of_day.as_json,
+          end: jour_ferie.end_of_day.as_json,
+          backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
+        },
+      ]
+    end.flatten
   end
 end

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -48,3 +48,7 @@
         = t(".create_absence")
       - else
         = t(".create_absence_for", full_name: @agent.full_name_or_email)
+
+.alert.alert-dismissible.alert-info
+  i.fa.fa-info-circle
+  = " Les jours fériées sont automatiquement considérés comme indisponibles."

--- a/app/views/admin/api/agenda/absences/index.json.jb
+++ b/app/views/admin/api/agenda/absences/index.json.jb
@@ -3,7 +3,7 @@
     title: absence.title,
     start: occurrence.starts_at.as_json,
     end: occurrence.ends_at.as_json,
-    backgroundColor: "rgba(127, 140, 141, 0.7)",
+    backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
     url: edit_admin_organisation_absence_path(@organisation, absence),
   }
 end

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -37,4 +37,12 @@ RSpec.describe OffDays, type: :service do
       end
     end
   end
+
+  describe ".to_full_calendar_array" do
+    it "returns the proper format for full calendar" do
+      array = described_class.to_full_calendar_array
+      expect(array[0]).to have_keys(:title, :start, :end, :backgroundColor)
+      expect(array[1][:backgroundColor]).to eq "rgba(127, 140, 141, 0.7)"
+    end
+  end
 end

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe OffDays, type: :service do
   describe ".to_full_calendar_array" do
     it "returns the proper format for full calendar" do
       array = described_class.to_full_calendar_array
-      expect(array[0]).to have_keys(:title, :start, :end, :backgroundColor)
-      expect(array[1][:backgroundColor]).to eq "rgba(127, 140, 141, 0.7)"
+      expect(array[0].keys).to match_array(%i[title start end backgroundColor])
+      expect(array[0][:backgroundColor]).to eq "rgba(127, 140, 141, 0.7)"
     end
   end
 end


### PR DESCRIPTION
# Contexte

En bossant tous ensemble chez François, on s'est rendu compte qu'il y avait une légende urbaine sur les jours fériés : Léa était en train de discuter avec un agent, et elle lui a dit qu'il fallait créer des indispos sur les jours fériés, alors que notre recherche de créneaux considère automatiquement que les jours fériés.


# Solution

L'émergence de cette légende urbaine est causée par un manque de clarté dans notre interface : rien n'indique ce fonctionnement.

On propose donc ici de l'expliciter de deux manières :
- sur le calendrier on affiche une absence sur la journée plutôt que juste le "Jour férié 🎉 " dans le header. Cela permet au passage de supprimer ce header qui n'était utilisé que pour ça, et gagner un peu de place d'affichage pour les évènements en fin d'après-midi !
- sur l'index des indisponibilités, on ajoute un petit bandeau d'info qui explicite ce comportement.


## Captures d'écran

Avant | Après
:- | -:
<img width="1440" alt="Screenshot 2024-12-04 at 14 16 54" src="https://github.com/user-attachments/assets/de461b31-abb9-4d31-8876-6c8424f9aeac">|<img width="1435" alt="Screenshot 2024-12-04 at 14 34 07" src="https://github.com/user-attachments/assets/68d382ae-edbe-44e9-b3d9-8f5b0411693f">
<img width="1440" alt="Screenshot 2024-12-04 at 14 17 04" src="https://github.com/user-attachments/assets/7e6144fd-4f12-48f1-9724-af19162e95f3">|<img width="1440" alt="Screenshot 2024-12-04 at 14 16 07" src="https://github.com/user-attachments/assets/a263e021-3c04-46d0-ba84-354a0cfd8399">

