### PR TITLE
Ajout des refresh_token pendant l'oauth

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -159,7 +159,7 @@ Doorkeeper.configure do
   # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
   # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
   #
-  # use_refresh_token
+  use_refresh_token
 
   # Provide support for an owner to be assigned to each registered application (disabled by default)
   # Optional parameter confirmation: true (default: false) if you want to enforce ownership of

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe "OAuth provider", ignore_js_errors: true, js: true do
     click_on "Continuer"
     expect(page).to have_content("Votre email est francis@factice.org")
 
+    expect(Doorkeeper::AccessToken.last.refresh_token).to be_present
+
     click_on "Déconnexion"
 
     # On est déconnecté du client et de RDV Service Public

--- a/spec/support/fake_oauth_client.rb
+++ b/spec/support/fake_oauth_client.rb
@@ -17,7 +17,7 @@ class FakeOauthClient < Sinatra::Base
     status 200
     if session[:email]
       <<-HTML
-        Votre email est #{session[:email]}, et votre token est #{session[:access_token]}
+        Votre email est #{session[:email]}, votre token est #{session[:access_token]}, et votre refresh_token est #{session[:refresh_token]}
         <a href="/logout">Déconnexion</a>
       HTML
     else
@@ -32,6 +32,7 @@ class FakeOauthClient < Sinatra::Base
   get "/omniauth/rdvservicepublic/callback" do
     session[:email] = request.env["omniauth.auth"]["info"]["agent"]["email"]
     session[:access_token] = request.env["omniauth.auth"]["credentials"]["token"]
+    session[:refresh_token] = request.env["omniauth.auth"]["credentials"]["refresh_token"]
 
     redirect to("/")
   end


### PR DESCRIPTION
# Contexte

Cette PR ajoute les refresh_token qui permettront aux client de l'api de générer un nouvel access_token quand celui de l'oauth expire

# Solution

On utilise la config de base de Doorkeeper (et les tokens sont chiffrés)
