### PR TITLE
Correctif pour les oauths apps dans le seed des review apps

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -215,7 +215,11 @@ Doorkeeper.configure do
   # #call can be used in order to allow conditional checks (to allow non-SSL
   # redirects to localhost for example).
   #
-  force_ssl_in_redirect_uri(!Rails.env.local? && ENV["RDV_SOLIDARITES_INSTANCE_NAME"] != "DEMO")
+  force_ssl_in_redirect_uri(
+    !Rails.env.local? &&
+      ENV["RDV_SOLIDARITES_INSTANCE_NAME"] != "DEMO" &&
+      ENV["IS_REVIEW_APP"] != "true"
+  )
   #
   # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
 


### PR DESCRIPTION
Cette PR permet la création d'appli oauth avec des url de callback non-ssl sur les review apps.
Elle corrige https://github.com/betagouv/rdv-service-public/pull/4867#issuecomment-2527777598
