### PR TITLE
Correctif pour les icônes de lien externes en double

### DIFF
--- a/app/views/admin/creneaux_search/_prescription_cta.html.slim
+++ b/app/views/admin/creneaux_search/_prescription_cta.html.slim
@@ -3,8 +3,6 @@
     p
       | Vous pouvez aussi élargir votre recherche aux créneaux ouverts à la prescription dans d'autres organisations.
       span  Plus d'informations dans
-      = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
-        span.mr-1  la documentation
-        i.fa.fa-external-link-alt>
+      = link_to "la documentation", "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank"
     p
       = link_to("Élargir la recherche", search_creneau_admin_organisation_prescription_path(user_ids: @form.user_ids, departement: current_territory.departement_number), class: "btn btn-outline-primary")

--- a/app/views/admin/motifs/form/_notifs_et_instructions.html.slim
+++ b/app/views/admin/motifs/form/_notifs_et_instructions.html.slim
@@ -21,24 +21,18 @@
               placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
               input_html: { rows: 5 },
               wrapper_html: { class: "mb-1" }
-      = link_to image_path("motif_form/restriction_for_rdv.png"), target: "_blank" do
-        span> Voir un exemple
-        i.fa.fa-external-link-alt>
+      = link_to  "Voir un exemple", image_path("motif_form/restriction_for_rdv.png"), target: "_blank"
     .mt-3
       = f.input :instruction_for_rdv,
               label: sanitize("Instructions affichées <strong>après</strong> la prise du RDV"),
               placeholder: "Laissez vide si vous ne souhaitez pas donner d’instruction.",
               input_html: { rows: 5 },
               wrapper_html: { class: "mb-1" }
-      = link_to image_path("motif_form/instruction_for_rdv.png"), target: "_blank" do
-        span> Voir un exemple
-        i.fa.fa-external-link-alt>
+      = link_to "Voir un exemple", image_path("motif_form/instruction_for_rdv.png"), target: "_blank"
     .mt-3
       = f.input :custom_cancel_warning_message,
               label: sanitize("Message d’avertissement </strong>en cas d’annulation</strong>"),
               placeholder: "Laissez vide si vous ne souhaitez pas afficher de messager d’avertissement.",
               input_html: { rows: 5 },
               wrapper_html: { class: "mb-1" }
-      = link_to image_path("motif_form/custom_cancel_warning_message.png"), target: "_blank" do
-        span> Voir un exemple
-        i.fa.fa-external-link-alt>
+      = link_to  "Voir un exemple", image_path("motif_form/custom_cancel_warning_message.png"), target: "_blank"

--- a/app/views/admin/motifs/form/_resa_en_ligne.html.slim
+++ b/app/views/admin/motifs/form/_resa_en_ligne.html.slim
@@ -77,9 +77,7 @@
       h5.card-title.mb-2= Motif.human_attribute_name("sectorisation_level_title")
       .mb-3
         span>= Motif.human_attribute_name("sectorisation_level_hint")
-        = link_to "https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-territoire/sectorisation-geographique/" do
-          span> Voir la documentation concernant la sectorisation
-          i.fa.fa-external-link-alt>
+        = link_to  "Voir la documentation concernant la sectorisation", "https://doc.rdv-solidarites.fr/guide-utilisation/pour-un-territoire/sectorisation-geographique/", target: "_blank"
       .mb-2
         = label_tag do
           = f.radio_button(:sectorisation_level, Motif::SECTORISATION_LEVEL_DEPARTEMENT)

--- a/app/views/admin/rdvs/_rdv_details.html.slim
+++ b/app/views/admin/rdvs/_rdv_details.html.slim
@@ -27,9 +27,7 @@
     i.fa.fa-video-camera.text-primary-blue>
     = "Par visioconférence "
     - if should_display_link
-      = link_to(rdv.visio_url, target: :_blank) do
-        = "démarrer la visioconférence "
-        i.fa.fa-external-link[aria-hidden="true"]
+      = link_to("démarrer la visioconférence ", rdv.visio_url, target: :_blank)
     - else
       br
       small.text-muted = "Le lien de visioconférence s'affiche uniquement pour l'agent qui assure le RDV et les secrétaires."

--- a/app/views/admin/static_pages/support.html.slim
+++ b/app/views/admin/static_pages/support.html.slim
@@ -11,9 +11,7 @@
       .card-body
         p
           span> Explorez les fonctionnalités de l'outil à travers la
-          = link_to current_domain.documentation_url do
-            span> documentation
-            i.fa.fa-external-link-alt>
+          = link_to "documentation", current_domain.documentation_url, target: "_blank"
 
     .card
       .card-header

--- a/app/views/admin/territories/zone_imports/new.html.slim
+++ b/app/views/admin/territories/zone_imports/new.html.slim
@@ -73,10 +73,8 @@
     ul
       li
         span> ⚠️ Utilisez les
-        = link_to "https://fr.wikipedia.org/wiki/Code_officiel_g%C3%A9ographique#Code_commune", target: "_blank" do
-          span> codes communes INSEE
-          i.fa.fa-external-link-alt>
-        | et non les codes postaux
+        = link_to "codes communes INSEE", "https://fr.wikipedia.org/wiki/Code_officiel_g%C3%A9ographique#Code_commune", target: "_blank"
+        |  et non les codes postaux
       li Utilisez un format XLS ou CSV (délimité par des virgules)
       li Utilisez un encodage UTF-8
       li
@@ -92,6 +90,4 @@
         span> Les codes rue à utiliser sont ceux de la
         span>= link_to "Base Adresse Nationale", "https://adresse.data.gouv.fr/", target: "_blank"
         span>et sont obligatoires. Ils sont au format `69323_4344` où la première partie est le code commune et la deuxième désigne la rue spécifique. Pour rajouter ces codes dans votre fichier, vous pouvez utiliser
-        span>= link_to "https://adresse.data.gouv.fr/csv", target: "_blank" do
-          span> cet outil web
-          i.fa.fa-external-link-alt>
+        span>= link_to "cet outil web", "https://adresse.data.gouv.fr/csv", target: "_blank"

--- a/app/views/admin/territories/zones/_form.html.slim
+++ b/app/views/admin/territories/zones/_form.html.slim
@@ -43,7 +43,7 @@
     .col-6
       = f.input :city_name, input_html: { readonly: true }, required: true
     .col-6
-      = f.input :city_code, input_html: { readonly: true }, required: true, hint: "code postal ≠ <a href='https://fr.wikipedia.org/wiki/Code_officiel_g%C3%A9ographique#Code_commune' target='_blank'>code commune INSEE <i class='fa fa-external-link-alt'></i></a>".html_safe
+      = f.input :city_code, input_html: { readonly: true }, required: true, hint: "code postal ≠ <a href='https://fr.wikipedia.org/wiki/Code_officiel_g%C3%A9ographique#Code_commune' target='_blank'>code commune INSEE</a>".html_safe
 
   - if zone.level_street?
     .row

--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -4,9 +4,8 @@ footer.footer
       .col-md-12
         .d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
           | Accessibilité&nbsp;: non conforme
-          = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}" do
+          = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}", target: "_blank" do
             span>= ENV["RDV_SOLIDARITES_VERSION"]
-            i.fa.fa-external-link-alt
           = link_to mentions_legales_path do
             span> Mentions Légales
           = link_to cgu_path do

--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -4,7 +4,7 @@ footer.footer
       .col-md-12
         .d-none.d-md-flex.flex-wrap.flex-gap-1em.justify-content-end.mb-2
           | Accessibilité&nbsp;: non conforme
-          = link_to "https://github.com/betagouv/rdv-solidarites.fr/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}", target: "_blank" do
+          = link_to "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", title: "Aller au code source de #{current_domain.name}", target: "_blank" do
             span>= ENV["RDV_SOLIDARITES_VERSION"]
           = link_to mentions_legales_path do
             span> Mentions Légales

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -26,9 +26,7 @@ main.container
 
               p.mb-0
               span> Pour en savoir plus consultez
-              = link_to "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank" do
-                span> la documentation
-                i.fa.fa-external-link-alt>
+              = link_to "la documentation", "https://rdvs.notion.site/Prescription-f1c857697c68421d91592ae88364c05d", target: "_blank"
 
           p
             = "Ces informations permettront à l'agent qui assure le rendez-vous de savoir qui l'a planifié, "

--- a/app/views/search/_nothing_to_show_contactable_organisation.html.slim
+++ b/app/views/search/_nothing_to_show_contactable_organisation.html.slim
@@ -14,6 +14,4 @@
         - if organisation.website.present?
           li.mb-2
             strong> Site web&nbsp;:
-            = link_to organisation.website, target: "_blank" do
-              span> #{organisation.website}
-              i.fa.fa-external-link-alt>
+            = link_to organisation.website, organisation.website, target: "_blank"

--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -6,8 +6,7 @@
     .rdv-text-align-center
       - unless email_tld_infos(@email_tld).blank?
         = link_to email_tld_infos(@email_tld)[:url], target: "blank", class: "btn btn-link" do
-          span.mr-2 #{email_tld_infos(@email_tld)[:name]}
-          i.fa.fa-external-link-alt
+          span #{email_tld_infos(@email_tld)[:name]}
 
       - if apple_mobile_device? # could not find android equivalent
         .mt-2

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -84,7 +84,7 @@ fr:
         visio: Par visioconférence
       motif/location_types/hint:
         public_office: L'agent reçoit l'usager sur place, au lieu sélectionné (MDS...).
-        visio: L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV. L'agent se connecte au <a href="https://www.numerique.gouv.fr/outils-agents/webconference-etat/" target="_blank">service de webconférence de l'État <i class="fa fa-external-link" /></a> avec ProConnect pour démarrer la visioconférence.
+        visio: L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV. L'agent se connecte au <a href="https://www.numerique.gouv.fr/outils-agents/webconference-etat/" target="_blank">service de webconférence de l'État</a> avec ProConnect pour démarrer la visioconférence.
         phone: L’agent appelle le numéro indiqué sur la fiche de l'usager.
         home: L’agent se rend à l'adresse indiquée sur la fiche de l'usager.
       motif/bookable_by/radio_label_html:
@@ -101,7 +101,7 @@ fr:
           Seuls vous et les agents de votre organisation peuvent ajouter des rendez-vous à votre agenda.
         agents_and_prescripteurs: >
           Les agents et prescripteurs d’autres organisations peuvent ajouter des rendez-vous à votre agenda. Voir la
-          <a href="https://rdv-service-public-1.gitbook.io/rdv-service-public/toutes-les-notions/utiliser-la-prescription-externe" target="_blank">documentation  <i class="fa fa-external-link" /></a>
+          <a href="https://rdv-service-public-1.gitbook.io/rdv-service-public/toutes-les-notions/utiliser-la-prescription-externe" target="_blank">documentation</a>
           pour plus d’informations.
         agents_and_prescripteurs_and_invited_users: >
           Les agents, prescripteurs, et usagers peuvent ajouter des rendez-vous dans votre agenda.


### PR DESCRIPTION
# Contexte

Suite à l'ajout du dsfr sur l'interface agent dans https://github.com/betagouv/rdv-service-public/pull/4852, il y a des icônes de lien externe qui s'affichent en double

# Solution

Avant on devait les ajouter manuellement, et maintenant le dsfr le fait pour nous. J'ai donc supprimé tous les `fa-external-link`


## Captures d'écran

Avant | Après
:- | -:
<img width="526" alt="Screenshot 2024-12-09 at 16 04 12" src="https://github.com/user-attachments/assets/cc8ddcb1-9c76-427d-af7a-1dd0b5224c8d">| <img width="555" alt="Screenshot 2024-12-09 at 16 03 46" src="https://github.com/user-attachments/assets/47a417d8-f2d6-4583-ac90-dde077ab62d1">

