### PR TITLE
Passage des erreurs de validation au DSFR

### DIFF
--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -11,13 +11,13 @@
       = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
       .d-flex.justify-content-between.align-items-center
         div
-          a[
+          a.fr-btn.fr-btn--secondary[
             data-toggle="collapse"
             data-target=".js-collapse-warning-confirmation"
             href="#"
             onclick="document.querySelector('.js-ignore-benign-errors').setAttribute('disabled', 'disabled');"
           ] Annuler et modifier
-        div= f.submit "Confirmer en ignorant les avertissements", class: "fr-btn fr-btn--secondary"
+        div= f.submit "Confirmer en ignorant les avertissements", class: "fr-btn fr-btn--tertiary"
       hr
 
 - elsif model.errors.any?

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,6 +1,6 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
-  .fr-alert.fr-alert--warning.mb-0
+  .fr-alert.fr-alert--warning
     ul.fr-m-0.list-unstyled
       - model.benign_errors.each do |msg|
         li
@@ -8,21 +8,21 @@
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
-      small.form-text.rdv-color-text-mention-grey.mb-3 Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant.
+      small.form-text.rdv-color-text-mention-grey.fr-mb-3w Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant.
       = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
-      .d-flex.justify-content-between
+      .d-flex.justify-content-between.align-items-center
         div
-          a.btn.btn-outline-dark[
+          a[
             data-toggle="collapse"
             data-target=".js-collapse-warning-confirmation"
             href="#"
             onclick="document.querySelector('.js-ignore-benign-errors').setAttribute('disabled', 'disabled');"
           ] Annuler et modifier
-        div= f.submit "Confirmer en ignorant les avertissements", class: "btn btn-link"
+        div= f.submit "Confirmer en ignorant les avertissements", class: "fr-btn fr-btn--secondary"
       hr
 
 - elsif model.errors.any?
   .fr-alert.fr-alert--error.fr-mb-1w
-    ul.m-0.pl-2
+    ul.fr-m-0.fr-pl-2w
       - errors_full_messages(model).uniq.each do |msg|
         li= msg

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,7 +1,7 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
   .fr-alert.fr-alert--warning.fr-mb-2w
-    ul.list-unstyled.fr-mb-0
+    ul.fr-mb-0[class="#{'list-unstyled' if model.benign_errors&.count == 1}"]
       - model.benign_errors.each do |msg|
         li
           = msg
@@ -22,6 +22,7 @@
 
 - elsif model.errors.any?
   .fr-alert.fr-alert--error.fr-mb-1w
-    ul.fr-m-0.fr-pl-2w
-      - errors_full_messages(model).uniq.each do |msg|
+    - error_messages = errors_full_messages(model).uniq
+    ul.fr-m-0.fr-pl-2w[class="#{'list-unstyled' if error_messages.count == 1}"]
+      - error_messages.each do |msg|
         li= msg

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,10 +1,9 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
-  .alert.alert-warning.show.mb-0
-    ul.m-0.pl-1.list-unstyled
+  .fr-alert.fr-alert--warning.mb-0
+    ul.fr-m-0.list-unstyled
       - model.benign_errors.each do |msg|
         li
-          i.fa-solid.fa-triangle-exclamation.mr-2
           = msg
 
   - if local_assigns[:f]
@@ -23,7 +22,7 @@
       hr
 
 - elsif model.errors.any?
-  .alert.alert-danger.fade.show
+  .fr-alert.fr-alert--error.fr-mb-1w
     ul.m-0.pl-2
       - errors_full_messages(model).uniq.each do |msg|
         li= msg

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,14 +1,13 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
-  .fr-alert.fr-alert--warning
-    ul.fr-m-0.list-unstyled
+  .fr-alert.fr-alert--warning.fr-mb-2w
+    ul.list-unstyled.fr-mb-0
       - model.benign_errors.each do |msg|
         li
           = msg
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
-      small.form-text.rdv-color-text-mention-grey.fr-mb-3w Ces avertissements ne sont pas bloquants, vous pouvez les ignorer en confirmant.
       = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
       .d-flex.justify-content-between.align-items-center
         div

--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -1,7 +1,7 @@
 - if model.respond_to?(:errors_are_all_benign?) && model.errors_are_all_benign?
   / warnings only appear if there are no other errors
   .fr-alert.fr-alert--warning.fr-mb-2w
-    ul.fr-mb-0[class="#{'list-unstyled' if model.benign_errors&.count == 1}"]
+    ul.fr-mb-0[class="#{"list-unstyled" if model.benign_errors&.count == 1}"]
       - model.benign_errors.each do |msg|
         li
           = msg
@@ -23,6 +23,6 @@
 - elsif model.errors.any?
   .fr-alert.fr-alert--error.fr-mb-1w
     - error_messages = errors_full_messages(model).uniq
-    ul.fr-m-0.fr-pl-2w[class="#{'list-unstyled' if error_messages.count == 1}"]
+    ul.fr-m-0.fr-pl-2w[class="#{"list-unstyled" if error_messages.count == 1}"]
       - error_messages.each do |msg|
         li= msg


### PR DESCRIPTION
# Contexte

On continue de passer des parties de notre interface au dsfr. Maintenant qu'il est disponible partout, on peut passer les messages d'erreur métier et d'avertissement au DSFR.

On pourrait aussi réfléchir à revoir le texte des avertissements, mais c'est en dehors du scope de cette PR.

# Solution

On fait une traduction directe au DSFR des composants d'erreur de validation et d'avertissement


## Captures d'écran

Avant | Après
:- | -:
<img width="1022" alt="Screenshot 2024-12-12 at 18 07 58" src="https://github.com/user-attachments/assets/eeab7c1c-0552-4e60-91e4-d01194b83ebc" />|<img width="1043" alt="Screenshot 2024-12-12 at 18 07 45" src="https://github.com/user-attachments/assets/51bbed48-5405-42eb-887f-17f6a9ddfe3a" />
<img width="825" alt="Screenshot 2024-12-12 at 18 06 53" src="https://github.com/user-attachments/assets/5417af06-c446-4926-b85d-1e76352bfa53" />|<img width="1015" alt="Screenshot 2024-12-12 at 18 07 13" src="https://github.com/user-attachments/assets/27dcab8a-a41a-403a-a9c9-771db8152e4b" />


