### PR TITLE
Fix(admin/motif): double icon sur le lien de modification

### DIFF
--- a/app/views/admin/territories/motifs/_motifs_table.html.slim
+++ b/app/views/admin/territories/motifs/_motifs_table.html.slim
@@ -53,7 +53,7 @@ table.table.table-centered.table-bordered.table-sm.mb-0[class=(display_checkboxe
           td.p-0
             .d-flex
               - if @current_tab != :archived
-                = link_to edit_admin_organisation_motif_path(motif.organisation, motif), class: "btn btn-link", title: t("admin.motifs.actions.edit"), target: :_blank do
+                = link_to edit_admin_organisation_motif_path(motif.organisation, motif), class: "btn btn-link fr-raw-link", title: "#{t('admin.motifs.actions.edit')} - Ouvre une ouvelle fenêtre", target: :_blank do
                   i.fa.fa-edit
               - if motif.archived?
                 - if motif_policy.unarchive?


### PR DESCRIPTION
# Contexte

Suite à l’intégration du DSFR dans l’interface agent [ici](https://github.com/betagouv/rdv-service-public/pull/4852), nous avons des icônes qui sont apparues après chaque lien qui ouvre un nouvel onglet (`rel="_blank"`).
Ceci permet à l’utilisateur de comprendre qu’il va arriver sur un site externe.

Dans le cas présent, je suppose que nous avons mis l’ouverture par défaut des éditions de motifs dans un nouvel onglet pour permettre aux agents de faire des éditions de plusieurs motifs en simultané dans des onglets différents.

L’ajout du DSFR a donc ajouté un deuxième icône à côté de l’icône existant, ce qui rend le tableau et les actions beaucoup moins lisibles.

# Solution

- On utilise `fr-raw-link` pour revenir à un lien sans icône
- On en profite pour rajouter la mention de l’ouverture d’une nouvelle fenêtre dans le titre (pour avancer un peu plus sur l’accessibilité)

À terme, nous pourrons peut-être rediscuter de savoir si ouvrir automatiquement un nouvel onglet quand il ne s’agit pas d’un lien externe est une bonne pratique.

# Checklist

- [x] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [x] Préparer des captures de l’interface avant et après

## Captures d'écran

Avant | Après
:- | -:
<img width="369" alt="image" src="https://github.com/user-attachments/assets/7c836936-d748-4df4-9d78-e25b09b7a68e"> | <img width="406" alt="image" src="https://github.com/user-attachments/assets/0e6ea118-d28e-4950-8eea-be98ef9717c3">

