### PR TITLE
Correctif pour le hover du bouton "Trouver un RDV"

### DIFF
--- a/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
+++ b/app/javascript/stylesheets/structure/_bootstrap_overrides.scss
@@ -12,9 +12,14 @@ a.stretched-link[href] {
 }
 
 // ces règles sont nécessaires pour corriger certains défauts venant du bootstrap reset
-main .fr-btn:hover {
+
+main .fr-btn:hover,  // Ce sélecteur vise tous les boutons du corps de page
+.left-side-menu .fr-btn:hover // ce sélecteur vise le bouton Trouver un RDV côté agent
+{
   color: var(--text-inverted-blue-france);
+  // note: on met des préfixes main et left-side-menu car on ne veut pas que cet override s’applique dans le header DSFR
 }
+
 main .fr-btn.fr-btn--secondary:hover {
   color: var(--text-action-high-blue-france);
 }

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -28,7 +28,10 @@
   background: $bg-leftbar;
   scrollbar-width: thin;
 
-  a:not(.btn-primary) {
+  a.fr-btn:hover {
+    color: var(--text-inverted-blue-france); // Pour corriger l'état au hover du bouton 'Trouver un RDV'
+  }
+  a:not(.fr-btn) {
     color: $menu-item;
     transition: all 0.2s;
 

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -28,11 +28,6 @@
   background: $bg-leftbar;
   scrollbar-width: thin;
 
-  a.fr-btn:hover {
-    color: var(
-      --text-inverted-blue-france
-    ); // Pour corriger l'état au hover du bouton 'Trouver un RDV'
-  }
   a:not(.fr-btn) {
     color: $menu-item;
     transition: all 0.2s;

--- a/app/javascript/stylesheets/structure/_left-menu.scss
+++ b/app/javascript/stylesheets/structure/_left-menu.scss
@@ -29,7 +29,9 @@
   scrollbar-width: thin;
 
   a.fr-btn:hover {
-    color: var(--text-inverted-blue-france); // Pour corriger l'état au hover du bouton 'Trouver un RDV'
+    color: var(
+      --text-inverted-blue-france
+    ); // Pour corriger l'état au hover du bouton 'Trouver un RDV'
   }
   a:not(.fr-btn) {
     color: $menu-item;

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -13,7 +13,7 @@ nav.left-side-menu-wrapper
       ul.side-nav.list-unstyled#menu-agent.pb-3.mb-0
         li.p-2
           .d-flex.justify-content-center
-            = link_to "Trouver un RDV", search_rdv_slot_url_with(@user), class: "btn btn-primary align-bottom text-white"
+            = link_to "Trouver un RDV", search_rdv_slot_url_with(@user), class: "fr-btn"
         li.current-organisation
           = current_organisation_in_left_menu do
             .d-flex.justify-content-between.w-100


### PR DESCRIPTION
Cette PR corrige l'affichage du bouton principal au hover, et au passage on le met au DSFR.

Avant | Après
:- | -:
<img width="188" alt="Screenshot 2024-12-11 at 12 08 00" src="https://github.com/user-attachments/assets/ed908dd3-f9d5-49df-bf7b-55bace724cae"> | <img width="199" alt="Screenshot 2024-12-11 at 12 07 09" src="https://github.com/user-attachments/assets/968728d9-8eb2-432b-9e5c-7d114bcef2d1">


