### PR TITLE
Correctif pour l'affichage dans le calendrier des rendez-vous dont l'usager est en salle d'attente

### DIFF
--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -55,7 +55,7 @@
 
 @import "./structure/bootstrap_overrides";
 
-a[href] {
+a[href]:not(.fc-event-waiting) {
   background-image: none; // pour éviter le soulignement des liens
 }
 

--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -136,6 +136,7 @@
     transparent 75%,
     transparent
   );
+  background-repeat: repeat;
   background-size: 1rem 1rem;
 }
 


### PR DESCRIPTION
Causé par le passage au dsfr de lundi, ce correctif permet de revenir au fonctionnement précédent.

## Captures d'écran

Avant | Après
:- | -:
<img width="338" alt="Screenshot 2024-12-11 at 15 17 33" src="https://github.com/user-attachments/assets/f3489e1f-c84a-4441-a3db-05ba9743a7b0" />|<img width="380" alt="Screenshot 2024-12-11 at 15 15 48" src="https://github.com/user-attachments/assets/ccf51661-d8a6-449d-aeae-8392973a6384" />
