### PR TITLE
Utiliser un expéditeur no-reply pour les mails usagers Devise

### DIFF
--- a/app/controllers/inbound_emails_controller.rb
+++ b/app/controllers/inbound_emails_controller.rb
@@ -8,7 +8,7 @@ class InboundEmailsController < ActionController::Base
 
   def brevo
     payload = request.params["items"].first
-    TransferEmailReplyJob.perform_later(payload)
+    HandleInboundEmailJob.perform_later(payload)
   end
 
   private

--- a/app/jobs/handle_inbound_email_job.rb
+++ b/app/jobs/handle_inbound_email_job.rb
@@ -21,7 +21,9 @@ class HandleInboundEmailJob < ApplicationJob
   def perform(sendinblue_hash)
     @sendinblue_hash = sendinblue_hash.with_indifferent_access
 
-    if rdv&.agents&.pluck(:email)&.compact&.any?
+    if source_mail.to.first.match(/ne-pas-repondre@reply\.[a-z\-\.]+$/)
+      reply_no_reply
+    elsif rdv&.agents&.pluck(:email)&.compact&.any?
       notify_agents
     else
       forward_to_default_mailbox
@@ -29,6 +31,10 @@ class HandleInboundEmailJob < ApplicationJob
   end
 
   private
+
+  def reply_no_reply
+    Users::NoReplyMailer.with(source_mail:).no_reply.deliver_now
+  end
 
   def notify_agents
     Agents::ReplyTransferMailer.notify_agent_of_user_reply(

--- a/app/jobs/handle_inbound_email_job.rb
+++ b/app/jobs/handle_inbound_email_job.rb
@@ -1,6 +1,6 @@
 # cf /docs/interconnexions/brevo.md
 
-class TransferEmailReplyJob < ApplicationJob
+class HandleInboundEmailJob < ApplicationJob
   queue_as :mailers
 
   # Pour éviter de fuiter des données personnelles dans les logs

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -28,4 +28,11 @@ class ApplicationMailer < ActionMailer::Base
   def default_from
     domain.support_email
   end
+
+  def no_reply_from
+    rfc5322_name_and_email(
+      "Ne pas répondre - #{domain.name}",
+      "ne-pas-repondre@#{domain.reply_host_name}"
+    )
+  end
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -24,12 +24,7 @@ class CustomDeviseMailer < Devise::Mailer
   private
 
   def set_no_reply_for_users
-    if @resource.is_a?(User)
-      mail.from = rfc5322_name_and_email(
-        "Ne pas répondre - #{domain.name}",
-        "ne-pas-repondre@#{domain.reply_host_name}"
-      )
-    end
+    mail.from = no_reply_from if @resource.is_a?(User)
   end
 
   def domain

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -6,6 +6,8 @@ class CustomDeviseMailer < Devise::Mailer
   helper :application
   default template_path: "devise/mailer"
 
+  after_action :set_no_reply_for_users
+
   def invitation_instructions(record, token, opts = {})
     @token = token
     @user_params = opts[:user_params] || {}
@@ -20,6 +22,15 @@ class CustomDeviseMailer < Devise::Mailer
   end
 
   private
+
+  def set_no_reply_for_users
+    if @resource.is_a?(User)
+      mail.from = rfc5322_name_and_email(
+        "Ne pas répondre - #{domain.name}",
+        "ne-pas-repondre@#{domain.reply_host_name}"
+      )
+    end
+  end
 
   def domain
     resource.domain

--- a/app/mailers/users/file_attente_mailer.rb
+++ b/app/mailers/users/file_attente_mailer.rb
@@ -24,6 +24,6 @@ class Users::FileAttenteMailer < ApplicationMailer
   end
 
   def default_from
-    TransferEmailReplyJob.reply_address_for_rdv(@rdv)
+    HandleInboundEmailJob.reply_address_for_rdv(@rdv)
   end
 end

--- a/app/mailers/users/no_reply_mailer.rb
+++ b/app/mailers/users/no_reply_mailer.rb
@@ -1,0 +1,30 @@
+class Users::NoReplyMailer < ApplicationMailer
+  class UnrecognizableEmailAddressError < StandardError; end
+
+  # @param [Mail::Message] source_mail : le mail initial envoyé par l’usager et transféré par Brevo à notre serveur
+  def no_reply
+    mail(
+      from: no_reply_from,
+      to: params[:source_mail].from.first,
+      subject: "Mail non reçu"
+    )
+  end
+
+  private
+
+  def domain
+    @domain ||= begin
+      reply_email_domain = params[:source_mail].to.first.split("@").last
+      case reply_email_domain
+      when /rdv-solidarites/
+        Domain::RDV_SOLIDARITES
+      when /rdv-service-public/ || /rdv\.anct\.gouv/ || /rdv-mairie/
+        Domain::RDV_MAIRIE
+      when /rdv-aide-numerique/
+        Domain::RDV_AIDE_NUMERIQUE
+      else
+        raise UnrecognizableEmailAddressError, params[:source_mail].to.to_s
+      end
+    end
+  end
+end

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -55,6 +55,6 @@ class Users::RdvMailer < ApplicationMailer
   end
 
   def default_from
-    TransferEmailReplyJob.reply_address_for_rdv(@rdv)
+    HandleInboundEmailJob.reply_address_for_rdv(@rdv)
   end
 end

--- a/app/views/mailers/users/no_reply_mailer/no_reply.html.slim
+++ b/app/views/mailers/users/no_reply_mailer/no_reply.html.slim
@@ -1,0 +1,10 @@
+div
+  p
+    ' Votre réponse email n’a pas pu être délivrée.
+    | Cette adresse n’est pas destinée à recevoir des réponses.
+  p
+    ' Si vous souhaitez annuler ou décaler un RDV, vous pouvez cliquer sur les liens reçus dans les précédents emails ou bien
+    = link_to "retrouver tous vos RDV en vous connectant ici", new_user_session_url(host: domain.host_name)
+    '.
+  .btn-wrapper
+    = link_to("J’ai besoin d’aide", contact_url(host: domain.host_name), class: "btn btn-primary")

--- a/spec/features/users/account/user_can_reset_his_password_spec.rb
+++ b/spec/features/users/account/user_can_reset_his_password_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "User resets his password spec" do
         fill_in "user_email", with: user.email
         click_on "Envoyer"
         open_email(user.email)
-        expect(current_email.base.email[:from].to_s).to eq(%("RDV Aide Numérique" <support@rdv-aide-numerique.fr>))
+        expect(current_email.base.email[:from].to_s).to eq(%("Ne pas répondre - RDV Aide Numérique" <ne-pas-repondre@reply.rdv-aide-numerique-test.localhost>))
         expect(current_email.html_part.body.to_s).to include('<a href="http://www.rdv-aide-numerique-test.localhost/users/password/edit?reset_password_token=')
       end
     end

--- a/spec/jobs/handle_inbound_email_job_spec.rb
+++ b/spec/jobs/handle_inbound_email_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe TransferEmailReplyJob do
+RSpec.describe HandleInboundEmailJob do
   describe "#uuid_from_email_address" do
     %w[
       rdv+b1a2-3c4f@reply.rdv-solidarites.fr

--- a/spec/jobs/handle_inbound_email_job_spec.rb
+++ b/spec/jobs/handle_inbound_email_job_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe HandleInboundEmailJob do
     end
   end
 
-  describe "#perform" do
+  describe "#perform - pour des réponses à des mails transactionnels de RDV" do
     subject(:perform_job) { described_class.perform_now(sendinblue_payload) }
 
     before do
@@ -156,6 +156,38 @@ RSpec.describe HandleInboundEmailJob do
         expect(transferred_email.to).to eq(["support@rdv-solidarites.fr"])
         expect(transferred_email.html_part.body.to_s).to include(%(L'usager⋅e "Bénédicte Ficiaire" &lt;bene_ficiaire@lapin.fr&gt; a répondu))
       end
+    end
+  end
+
+  describe "#perform - pour des réponses au emails ne-pas-repondre" do
+    subject(:perform_job) { described_class.perform_now(sendinblue_payload) }
+
+    let(:sendinblue_payload) do
+      {
+        Cc: [],
+        ReplyTo: nil,
+        Subject: "",
+        Attachments: [],
+        Headers: {
+          "Message-ID": "<d6c8663e3763aa750345a76c17f435a2bd14eded.camel@lapin.fr>",
+          Subject: "",
+          From: "Bénédicte Ficiaire <bene_ficiaire@lapin.fr>",
+          To: "ne-pas-repondre@reply.rdv-solidarites.fr",
+          Date: "Thu, 12 May 2022 12:22:15 +0200",
+        },
+        ExtractedMarkdownMessage: "Je souhaite annuler mon RDV",
+        ExtractedMarkdownSignature: nil,
+        RawHtmlBody: %(<html dir="ltr"><head></head><body style="text-align:left; direction:ltr;"><div>Je souhaite annuler mon RDV</div>\n</body></html>\n),
+        RawTextBody: "Je souhaite annuler mon RDV\n",
+      }
+    end
+
+    it "répond automatiquement à l’usager" do
+      expect { perform_job }.to change { ActionMailer::Base.deliveries.size }.by(1)
+      transferred_email = ActionMailer::Base.deliveries.last
+      expect(transferred_email.to).to eq(["bene_ficiaire@lapin.fr"])
+      expect(transferred_email.from).to eq(["ne-pas-repondre@reply.rdv-solidarites-test.localhost"])
+      expect(transferred_email.html_part.body.to_s).to include(%(Votre réponse email n’a pas pu être délivrée))
     end
   end
 end

--- a/spec/mailers/custom_devise_mailer_domain_spec.rb
+++ b/spec/mailers/custom_devise_mailer_domain_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe CustomDeviseMailer, "#domain" do
 
   def expect_to_use_domain(domain)
     expect(sent_email.body).to include(domain.host_name)
-    expect(sent_email[:from].unparsed_value).to match(%("#{domain.name}" <#{domain.support_email}>))
+    expect(sent_email[:from].unparsed_value).to match(%("Ne pas répondre - #{domain.name}" <ne-pas-repondre@#{domain.reply_host_name}>))
   end
 
   context "when user has no RDV" do

--- a/spec/mailers/previews/users/no_reply_mailer_preview.rb
+++ b/spec/mailers/previews/users/no_reply_mailer_preview.rb
@@ -1,0 +1,10 @@
+class Users::NoReplyMailerPreview < ActionMailer::Preview
+  def no_reply
+    source_mail = Mail.new do
+      from "jeanne@barret.fr"
+      to "ne-pas-repondre@reply.rdv-solidarites-test.localhost"
+    end
+
+    Users::NoReplyMailer.with(source_mail:).no_reply
+  end
+end

--- a/spec/mailers/users/no_reply_mailer_spec.rb
+++ b/spec/mailers/users/no_reply_mailer_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe Users::NoReplyMailer, type: :mailer do
+  describe "#no_reply" do
+    context "l’usager a répondu à l’adresse no-reply du même environnement" do
+      let(:source_mail) do
+        Mail.new do
+          from "jeanne@barret.fr"
+          to "ne-pas-repondre@reply.rdv-solidarites-test.localhost"
+        end
+      end
+
+      it "répond depuis la même adresse no-reply" do
+        mail = described_class.with(source_mail:).no_reply
+        expect(mail[:from].to_s).to eq(%("Ne pas répondre - RDV Solidarités" <ne-pas-repondre@reply.rdv-solidarites-test.localhost>))
+        expect(mail.to).to eq(["jeanne@barret.fr"])
+      end
+    end
+
+    context "l’usager a répondu à une adresse no-reply d’un autre environnement" do
+      let(:source_mail) do
+        Mail.new do
+          from "jeanne@barret.fr"
+          to "ne-pas-repondre@reply.rdv-solidarites.fr"
+        end
+      end
+
+      it "répond depuis l’adresse no-reply de l’environnement courant" do
+        mail = described_class.with(source_mail:).no_reply
+        expect(mail[:from].to_s).to eq(%("Ne pas répondre - RDV Solidarités" <ne-pas-repondre@reply.rdv-solidarites-test.localhost>))
+        expect(mail.to).to eq(["jeanne@barret.fr"])
+      end
+    end
+
+    context "l’adresse n’est pas reconnaissable" do
+      let(:source_mail) do
+        Mail.new do
+          from "jeanne@barret.fr"
+          to "adresse@surprenante.fr"
+        end
+      end
+
+      it "répond depuis l’adresse no-reply de l’environnement courant" do
+        expect { described_class.with(source_mail:).no_reply.deliver_now }.to raise_exception Users::NoReplyMailer::UnrecognizableEmailAddressError
+      end
+    end
+  end
+end

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Handling an email reply from a user" do
     it "enqueues the job that handles transferring the email" do
       expect do
         receive_brevo_callback
-      end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:mailers)
+      end.to have_enqueued_job(HandleInboundEmailJob).with({ "Subject" => "Dummy email" }).on_queue(:mailers)
     end
   end
 


### PR DESCRIPTION
> [!NOTE]
> Cette PR est plus agréable à lire commit par commit

# Contexte & problème

Les mails de confirmation d’inscription, de réinitialisation de mot de passe etc, sont actuellement envoyés depuis nos adresses support. 

On suppose qu’une partie des tickets Zammad usagers viennent de là : les usagers cliqueraient sur l’adresse d’expéditeur de ces emails et rédigeraient des nouveaux emails sans sujet.

Pour la majorité de ces tickets de support, on est dans l’incapacité d’aider les usagers.

cf [cette page Notion](https://www.notion.so/rdvs/Diminuer-les-tickets-usagers-partie-2-no-reply-et-formulaire-de-contact-15a2b05ced4180b09c4df3e54dbec9e4).

# Solution

On envoie maintenant ces emails depuis des adresses `ne-pas-repondre@reply.rdv-solidarites.fr` etc . C’est aussi l’approche adoptée par Démarches Simplifiées.

Si un usager écrit (ou répond) quand même à l’adresse ne-pas-répondre, on envoie une réponse automatique.

J’ai fait le choix de réutiliser le mécanisme de mails inbound de Brevo pour répondre automatiquement à ces emails plutôt qu’un mécanisme de webmail plus classique.
L’intérêt est de pouvoir harmoniser l’aspect de cet email et le garder dans notre codebase plutôt que sur un outil externe.

# Screenshots

