### PR TITLE
Rendre les boutons de retour prise de RDV usager + accessible

### DIFF
--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -3,7 +3,7 @@
   - if context.lieu.present?
     .card.card-hoverable
       .card-body
-        = link_to path_to_lieu_selection(params), class: "d-block stretched-link" do
+        = link_to path_to_lieu_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du lieu" do
           .row
             .col-auto.align-self-center
               i.fa.fa-chevron-left
@@ -13,7 +13,7 @@
   - elsif context.user_selected_organisation.present?
       .card.card-hoverable
         .card-body
-          = link_to path_to_organisation_selection(params), class: "d-block stretched-link" do
+          = link_to path_to_organisation_selection(params), class: "d-block stretched-link", title: "Retour à la sélection de l’organisation" do
             .row
               .col-auto.align-self-center
                 i.fa.fa-chevron-left

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,7 +1,7 @@
 .fr-container
   .card
     .card-body
-      = link_to path_to_service_selection(params), class: "d-block stretched-link" do
+      = link_to path_to_service_selection(params), class: "d-block stretched-link", title: "Retour à la selection du service" do
         .row
           .col-auto.align-self-center
             i.fa.fa-chevron-left

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -1,6 +1,6 @@
 .card.card-hoverable
   .card-body
-    = link_to path_to_motif_selection(params), class: "d-block stretched-link" do
+    = link_to path_to_motif_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du motif" do
       .row
         .col-auto.align-self-center
           i.fa.fa-chevron-left


### PR DESCRIPTION
# Contexte

En faisant des tests sur le parcours usager avec VoiceOver, je me suis aperçu que les boutons de retours aux étapes précédentes n’étaient pas du tout compréhensibles. En effet, le lecteur d’écran lit le nom du service/motif/lieu sélectionné, mais il n’est possible de savoir que c’est un bouton retour que par la présence de la flèche.

# Solution

Nous allons retravailler prochainement les boutons retours de ce parcours. 
En attendant, j’ajoute juste des title pour que ça soit un peu plus compréhensible avec l’utilisation d’un lecteur d’écran.

