### PR TITLE
Filtrer les lieux qu'on renvoie à l'ants

### DIFF
--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -51,8 +51,7 @@ class Api::Ants::EditorController < Api::Ants::BaseController
   }.freeze
 
   def self.lieux
-    Lieu.joins(:organisation)
-      .where(organisations: { ants_connectable: true })
+    Lieu.enabled.joins(:organisation).where(organisations: { ants_connectable: true })
   end
 
   private

--- a/spec/requests/api/ants/get_managed_meeting_points_spec.rb
+++ b/spec/requests/api/ants/get_managed_meeting_points_spec.rb
@@ -23,9 +23,17 @@ RSpec.describe "ANTS API: getManagedMeetingPoints" do
              longitude: 4.0348016639327,
              latitude: 60.549140395451)
     end
+    let!(:single_use_lieu) do
+      create(:lieu, organisation: organisation, availability: :single_use)
+    end
+
+    let!(:disabled_lieu) do
+      create(:lieu, organisation: organisation, availability: :disabled)
+    end
+
     let(:organisation) { create(:organisation, ants_connectable: true) }
 
-    it "returns a list of lieux" do
+    it "returns a list of enabled lieux" do
       get "/api/ants/getManagedMeetingPoints", headers: { "X-HUB-RDV-AUTH-TOKEN" => "" }
       expect(response.parsed_body).to contain_exactly({
         id: lieu1.id.to_s,


### PR DESCRIPTION
# Contexte

L'ants nous a envoyé un mail pour demander de ne plus renvoyer des lieux qui ne sont pas des mairies en réponse aux appels api qu'ils font.

<img width="731" alt="Capture d’écran 2024-12-11 à 15 30 12" src="https://github.com/user-attachments/assets/3c28d073-202e-49c5-a00a-e23c4c40c555" />

On a effectivement les 13 lieux suivants qui sont des lieux à usage uniques, ou supprimés : 
-  Police Municipale
-  Coursac
-  Le Châtelard
-  Saint-Maximin
-  Atelier CV
-  Mairie de Moulin
-  MONTARON BEAUCAMP
-  mansouri
-  JACQUELIN
-  DIGONNET
-  Mairie de Luc en DIois
-  MAUVOISIN
-  chautard


# Solution

On filtre les lieux qu'on renvoie à l'ants pour uniquement envoyer les lieux actifs (de toutes façons les autres n'ont pas vocation à proposer des rdv accessibles depuis le moteur de recherche de l'ants)

Ça ne résout pas tous les cas : certains lieux sont actifs, mais n'ont pas vocation à proposer des rdvs passeport/cni. Pour ces lieux là, la solution actuellement serait de les déplacer dans une autre organisation que celle de la mairie
