### PR TITLE
Utiliser from plutôt que reply-to dans les emails de file d’attente

### DIFF
--- a/app/mailers/users/file_attente_mailer.rb
+++ b/app/mailers/users/file_attente_mailer.rb
@@ -24,6 +24,6 @@ class Users::FileAttenteMailer < ApplicationMailer
   end
 
   def default_from
-    HandleInboundEmailJob.reply_address_for_rdv(@rdv)
+    TransferEmailReplyJob.reply_address_for_rdv(@rdv)
   end
 end

--- a/app/mailers/users/file_attente_mailer.rb
+++ b/app/mailers/users/file_attente_mailer.rb
@@ -5,7 +5,7 @@ class Users::FileAttenteMailer < ApplicationMailer
     @token = params[:token]
   end
 
-  default to: -> { @user.email }, reply_to: -> { TransferEmailReplyJob.reply_address_for_rdv(@rdv) }
+  default to: -> { @user.email }
 
   def new_creneau_available
     subject = t("users.file_attente_mailer.new_creneau_available.title")
@@ -21,5 +21,9 @@ class Users::FileAttenteMailer < ApplicationMailer
 
   def domain
     @rdv.domain
+  end
+
+  def default_from
+    HandleInboundEmailJob.reply_address_for_rdv(@rdv)
   end
 end

--- a/spec/mailers/users/file_attente_mailer_spec.rb
+++ b/spec/mailers/users/file_attente_mailer_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Users::FileAttenteMailer, type: :mailer do
+  describe "#new_creneau_available" do
+    let(:rdv) { create(:rdv) }
+    let(:user) { rdv.users.first }
+    let(:mail) { described_class.with(rdv:, user:).new_creneau_available }
+
+    specify do
+      expect(mail[:from].to_s).to match(/"RDV Solidarités" <rdv\+[a-z0-9\-]+@reply\.rdv-solidarites-test\.localhost>/)
+      expect(mail.to).to eq([user.email])
+      expect(mail.reply_to).to be_nil
+      expect(mail.subject).to eq("Un créneau vient de se liberer !")
+      expect(mail.body.raw_source).to match(/Des créneaux pour votre RDV/) # for some reason, mail.html_part is nil
+    end
+  end
+end


### PR DESCRIPTION
# Contexte

Je m’intéresse à la réduction du bruit parmi les tickets zammad provenant d’emails usagers (cf [cette page notion](https://www.notion.so/rdvs/Diminuer-les-tickets-usagers-partie-2-no-reply-et-formulaire-de-contact-15a2b05ced4180b09c4df3e54dbec9e4)).

J’ai remarqué en itérant sur les endroits où on utilise l’adresse support dans le produit côté usagers qu’on continue à envoyer les emails de file d’attente depuis les adresses support, avec un reply-to magique vers le(s) agent(s).

# Solution

Je supprime le reply-to et je remplace l’expéditeur par l’adresse magique.
On a déjà fait la même chose pour la vaste majorité des emails envoyés aux usagers, c’est à dire les emails de notif de RDV.

J’en profite pour rajouter une spec sur ce mailer qui n’était pas testé jusqu’ici