### PR TITLE
Permettre aux usagers de joindre l'organisation avec laquelle ils ont rendez-vous

### DIFF
--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -1,21 +1,21 @@
 ul.list-group.list-group-flush.fr-mb-3w
-  li.list-group-item
+  li.list-group-item.fr-pl-0
     .fa.fa-calendar>
     = rdv_title(rdv)
     = rdv_tag(rdv)
 
   - if rdv.motif.restriction_for_rdv.present?
-    li.list-group-item.alert.alert-warning
+    li.list-group-item.fr-pl-0.alert.alert-warning
       .fa.fa-warning>
       = restriction_for_rdv_to_html(rdv.motif)
 
   - if rdv.home?
-    li.list-group-item
+    li.list-group-item.fr-pl-0
       .fa.fa-home>
       | Ce RDV se déroulera à domicile
 
   - elsif rdv.public_office?
-    li.list-group-item
+    li.list-group-item.fr-pl-0
       .fa.fa-map-marker-alt>
       = human_location(rdv)
       - if rdv.lieu&.phone_number
@@ -24,17 +24,17 @@ ul.list-group.list-group-flush.fr-mb-3w
         = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
   - elsif rdv.phone?
-    li.list-group-item
+    li.list-group-item.fr-pl-0
       .fa.fa-phone>
       | RDV Téléphonique
 
   - elsif rdv.motif.visio?
-    li.list-group-item
+    li.list-group-item.fr-pl-0
       .fa.fa-video-camera>
       = "RDV par visioconférence "
       = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
 
-  li.list-group-item
+  li.list-group-item.fr-pl-0
     .row
       .col
         .fa.fa-user>
@@ -44,17 +44,16 @@ ul.list-group.list-group-flush.fr-mb-3w
         span>
         = link_to "modifier", users_rdv_participations_path(rdv)
   - if @can_see_rdv_motif
-    li.list-group-item
+    li.list-group-item.fr-pl-0
       i.fa.fa-info-circle>
       = rdv.motif_name
   - if rdv.motif.instruction_for_rdv.present?
-    li.list-group-item
+    li.list-group-item.fr-pl-0
       i.fa.fa-exclamation-triangle>
       strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(rdv.motif)
   = render "/users/rdvs/file_attente", rdv: rdv
-
 
   - if rdv.phone_number || rdv.organisation.website.present?
     h2.fr-h6.fr-mt-2w Contact de #{rdv.organisation.name}

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -77,6 +77,7 @@ ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
     li
       button.fr-btn.fr-btn--tertiary[data-fr-opened="false" aria-controls="js-cancel-participation-modal-#{rdv.id}"] Annuler votre participation
 
+
 = render( \
         "common/modal_confirmation", \
         id: "js-cancel-rdv-modal-#{rdv.id}", \
@@ -96,3 +97,20 @@ ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
         confirm_message: "Oui, annuler votre participation", \
         confirm_link_options: { method: :put } \
 )
+
+hr
+
+h2 Contact de #{rdv.organisation.name}
+- if rdv.lieu&.phone_number.present?
+  p
+    span.fr-icon-phone-fill[aria-hidden="true"]
+    = phone_to(rdv.lieu.humanized_phone_number)
+- elsif rdv.organisation.phone_number.present?
+  p
+    span.fr-icon-phone-fill[aria-hidden="true"]
+    = phone_to(rdv.organisation.humanized_phone_number)
+- if rdv.organisation.website.present?
+  p
+    span.fr-icon-phone-fill[aria-hidden="true"]
+    = "Site web : "
+    = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -67,7 +67,7 @@ ul.list-group.list-group-flush.fr-mb-3w
       - if rdv.organisation.website.present?
         p
           span.fr-icon-global-fill.fr-mr-1w[aria-hidden="true"]
-          = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"
+          = link_to "Site web", rdv.organisation.website, target: "_blank"
 
   / Check for authorizations and already cancelled rdv/participation
   - unless policy(rdv, policy_class: User::RdvPolicy).cancel? || \

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -1,27 +1,25 @@
 ul.list-group.list-group-flush.fr-mb-3w
   li.list-group-item.fr-pl-0
-    .fa.fa-calendar>
+    .fa.fa-calendar.fr-mr-1w
     = rdv_title(rdv)
     = rdv_tag(rdv)
 
   - if rdv.motif.restriction_for_rdv.present?
-    li.list-group-item.fr-pl-0.alert.alert-warning
-      .fa.fa-warning>
+    li.list-group-item.fr-pl-0.fr-py-2w.alert.alert-warning
+      .fa.fa-warning.fr-mr-1w
       = restriction_for_rdv_to_html(rdv.motif)
 
-  - if rdv.home?
-    li.list-group-item.fr-pl-0
-      .fa.fa-home>
+  li.list-group-item.fr-pl-0.fr-py-2w
+    - if rdv.home?
+      .fa.fa-home.fr-mr-1w
       | Ce RDV se déroulera à domicile
 
-  - elsif rdv.public_office?
-    li.list-group-item.fr-pl-0
-      .fa.fa-map-marker-alt>
+    - elsif rdv.public_office?
+      .fa.fa-map-marker-alt.fr-mr-1w
       = human_location(rdv)
 
-  - elsif rdv.phone?
-    li.list-group-item.fr-pl-0
-      .fa.fa-phone>
+    - elsif rdv.phone?
+      .fa.fa-phone.fr-mr-1w
       | RDV Téléphonique
       p.fr-mb-1v
         - if current_user.signed_in_with_invitation_token?
@@ -29,27 +27,26 @@ ul.list-group.list-group-flush.fr-mb-3w
         - else
           | L'agent vous appellera au #{current_user.phone_number}.
 
-  - elsif rdv.motif.visio?
-    li.list-group-item.fr-pl-0
-      .fa.fa-video-camera>
+    - elsif rdv.motif.visio?
+      .fa.fa-video-camera.fr-mr-1w
       = "RDV par visioconférence "
       = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
 
-  li.list-group-item.fr-pl-0
+  li.list-group-item.fr-pl-0.fr-py-2w
     .row
       .col
-        .fa.fa-user>
+        .fa.fa-user.fr-mr-1w
         = users_to_sentence(rdv.users)
     - if policy(rdv, policy_class: User::RdvPolicy).can_change_participants?
       .col-auto
         span>
         = link_to "modifier", users_rdv_participations_path(rdv)
   - if @can_see_rdv_motif
-    li.list-group-item.fr-pl-0
-      i.fa.fa-info-circle>
+    li.list-group-item.fr-pl-0.fr-py-2w
+      i.fa.fa-info-circle.fr-mr-1w
       = rdv.motif_name
   - if rdv.motif.instruction_for_rdv.present?
-    li.list-group-item.fr-pl-0
+    li.list-group-item.fr-pl-0.fr-py-2w
       i.fa.fa-exclamation-triangle>
       strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -77,7 +77,6 @@ ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
     li
       button.fr-btn.fr-btn--tertiary[data-fr-opened="false" aria-controls="js-cancel-participation-modal-#{rdv.id}"] Annuler votre participation
 
-
 = render( \
         "common/modal_confirmation", \
         id: "js-cancel-rdv-modal-#{rdv.id}", \

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -55,6 +55,19 @@ ul.list-group.list-group-flush.fr-mb-3w
         = instruction_for_rdv_to_html(rdv.motif)
   = render "/users/rdvs/file_attente", rdv: rdv
 
+
+  - if rdv.phone_number || rdv.organisation.website.present?
+    h2.fr-h6.fr-mt-2w Contact de #{rdv.organisation.name}
+    .d-flex
+      - if rdv.phone_number
+        p.fr-mr-2w
+          span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+          = phone_to(rdv.organisation.humanized_phone_number)
+      - if rdv.organisation.website.present?
+        p
+          span.fr-icon-global-fill.fr-mr-1w[aria-hidden="true"]
+          = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"
+
   / Check for authorizations and already cancelled rdv/participation
   - unless policy(rdv, policy_class: User::RdvPolicy).cancel? || \
       policy(current_user.participation_for(rdv), policy_class: User::ParticipationPolicy).cancel? || \
@@ -97,18 +110,4 @@ ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
         confirm_link_options: { method: :put } \
 )
 
-hr
 
-- phone_number =rdv.lieu&.phone_number.presence || rdv.organisation.phone_number.presence
-
-- if phone_number || rdv.organisation.website.present?
-  h2.fr-h3 Contact de #{rdv.organisation.name}
-  - if phone_number
-    p
-      span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-      = phone_to(rdv.organisation.humanized_phone_number)
-  - if rdv.organisation.website.present?
-    p
-      span.fr-icon-computer-fill.fr-mr-1w[aria-hidden="true"]
-      = "Site web : "
-      = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -56,13 +56,14 @@ ul.list-group.list-group-flush.fr-mb-3w
         = instruction_for_rdv_to_html(rdv.motif)
   = render "/users/rdvs/file_attente", rdv: rdv
 
-  - if rdv.phone_number || rdv.organisation.website.present?
-    h2.fr-h6.fr-mt-2w Contact de #{rdv.organisation.name}
+- if rdv.phone_number || rdv.organisation.website.present?
+  .fr-mb-2w
+    h2.fr-h6.fr-mt-3w Contact de #{rdv.organisation.name}
     .d-flex
       - if rdv.phone_number
         p.fr-mr-2w
           span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-          = phone_to(rdv.phone_number)
+          = phone_to(rdv.phone_number, title: "Numéro de téléphone")
       - if rdv.organisation.website.present?
         p
           span.fr-icon-global-fill.fr-mr-1w[aria-hidden="true"]

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -102,13 +102,13 @@ hr
 - phone_number =rdv.lieu&.phone_number.presence || rdv.organisation.phone_number.presence
 
 - if phone_number || rdv.organisation.website.present?
-  h2 Contact de #{rdv.organisation.name}
+  h2.fr-h3 Contact de #{rdv.organisation.name}
   - if phone_number
     p
-      span.fr-icon-phone-fill[aria-hidden="true"]
+      span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
       = phone_to(rdv.organisation.humanized_phone_number)
   - if rdv.organisation.website.present?
     p
-      span.fr-icon-computer-fill[aria-hidden="true"]
+      span.fr-icon-computer-fill.fr-mr-1w[aria-hidden="true"]
       = "Site web : "
       = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -109,5 +109,3 @@ ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
         confirm_message: "Oui, annuler votre participation", \
         confirm_link_options: { method: :put } \
 )
-
-

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -99,17 +99,16 @@ ul.fr-btns-group.fr-btns-group--inline.fr-mb-0
 
 hr
 
-h2 Contact de #{rdv.organisation.name}
-- if rdv.lieu&.phone_number.present?
-  p
-    span.fr-icon-phone-fill[aria-hidden="true"]
-    = phone_to(rdv.lieu.humanized_phone_number)
-- elsif rdv.organisation.phone_number.present?
-  p
-    span.fr-icon-phone-fill[aria-hidden="true"]
-    = phone_to(rdv.organisation.humanized_phone_number)
-- if rdv.organisation.website.present?
-  p
-    span.fr-icon-phone-fill[aria-hidden="true"]
-    = "Site web : "
-    = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"
+- phone_number =rdv.lieu&.phone_number.presence || rdv.organisation.phone_number.presence
+
+- if phone_number || rdv.organisation.website.present?
+  h2 Contact de #{rdv.organisation.name}
+  - if phone_number
+    p
+      span.fr-icon-phone-fill[aria-hidden="true"]
+      = phone_to(rdv.organisation.humanized_phone_number)
+  - if rdv.organisation.website.present?
+    p
+      span.fr-icon-computer-fill[aria-hidden="true"]
+      = "Site web : "
+      = link_to rdv.organisation.website, rdv.organisation.website, target: "_blank"

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -18,15 +18,16 @@ ul.list-group.list-group-flush.fr-mb-3w
     li.list-group-item.fr-pl-0
       .fa.fa-map-marker-alt>
       = human_location(rdv)
-      - if rdv.lieu&.phone_number
-        span>
-        span.fa.fa-phone>
-        = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
   - elsif rdv.phone?
     li.list-group-item.fr-pl-0
       .fa.fa-phone>
       | RDV Téléphonique
+      p.fr-mb-1v
+        - if current_user.signed_in_with_invitation_token?
+          | L'agent vous appellera au numéro que vous lui avez indiqué.
+        - else
+          | L'agent vous appellera au #{current_user.phone_number}.
 
   - elsif rdv.motif.visio?
     li.list-group-item.fr-pl-0
@@ -61,7 +62,7 @@ ul.list-group.list-group-flush.fr-mb-3w
       - if rdv.phone_number
         p.fr-mr-2w
           span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
-          = phone_to(rdv.organisation.humanized_phone_number)
+          = phone_to(rdv.phone_number)
       - if rdv.organisation.website.present?
         p
           span.fr-icon-global-fill.fr-mr-1w[aria-hidden="true"]


### PR DESCRIPTION

Avant | Après
:- | -:
<img width="1268" alt="Screenshot 2024-12-12 at 17 57 53" src="https://github.com/user-attachments/assets/b2956da4-ab11-415d-971e-bcb1216e4a79" />| <img width="1233" alt="Screenshot 2024-12-12 at 17 58 08" src="https://github.com/user-attachments/assets/5270a19e-c67a-4060-819d-40effc597a7e" />


# Contexte

Les infos qu'on donne aux usagers sont très minimalistes : on ne donne très peu d'info sur la structure avec laquelle ils ont rendez-vous. Si le lieu a un numéro de téléphone et que le rendez-vous est sur place, on l'indique, mais c'est un cas minoritaire.
On ne donne aucune information sur l'organisation, contrairement à ce qu'on fait lors de la prise de rendez-vous (si un usager cherche un créneau mais n'a aucun résultat, on lui affichera le numéro de téléphone, l'adresse mail et le site web de l'organisation).

Voici un récap de ces différents cas de figure sur metabase : on a plus d'un million de rdvs où le lieu n'a pas de numéro de téléphone mais l'orga en a un.

https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/question/222-numeros-de-telephones-des-lieux-et-des-organisations 

<img width="916" alt="Screenshot 2024-12-12 at 18 00 04" src="https://github.com/user-attachments/assets/ce3caee4-fe13-4587-966c-dea85bd85004" />

**Il semble très probable que cette impossibilité de contacter l'organisation fait que les usagers finissent par nous contacter à la place (puisque notre page de contact le permet).**

# Solution

On redirige le flux de demande vers les organisations qui sauront y répondre. D'après ce que je comprends certaines référentes sont réticentes à ce qu'on affiche l'adresse mail de l'organisation, donc cette PR ne propose pas encore ça.
