### PR TITLE
Permettre de renseigner un rendez-vous quand l'usager arrive en avance

### DIFF
--- a/app/views/admin/rdvs/_individual_rdv_status_dropdown.html.slim
+++ b/app/views/admin/rdvs/_individual_rdv_status_dropdown.html.slim
@@ -5,7 +5,7 @@
     = Rdv.human_attribute_value(:status, rdv.temporal_status, disable_cast: true)
   .dropdown-menu
     - if rdv.status == "unknown"
-      - if rdv.starts_at < Time.zone.now
+      - if rdv.starts_at < Time.zone.now.end_of_day # On veut permettre de renseigner un rendez-vous si l'usage arrive en avance
         = render "admin/rdvs/individual_rdv_status_dropdown_item", rdv: rdv, status: "seen",  quick_update: quick_update
         = render "admin/rdvs/individual_rdv_status_dropdown_item", rdv: rdv, status: "noshow",  quick_update: quick_update
         .dropdown-divider


### PR DESCRIPTION
# Contexte

Suite à la mise en prod de https://github.com/betagouv/rdv-service-public/pull/4882, on ne permet plus d'indiquer qu'un usage s'est présenté au rendez-vous avant le début du rendez-vous. C'est bloquant pour les secrétaire d'accueil, qui renseignent le statut du rendez-vous quand l'usager arrive, généralement avant le début de son rendez-vous.

# Solution

On corrige la condition pour permettre de renseigner le rendez-vous

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après

## Captures d'écran

Avant | Après
:- | -:
<img width="1432" alt="Screenshot 2024-12-16 at 10 04 49" src="https://github.com/user-attachments/assets/bd25fbb8-9645-4b97-adbd-602ee30b33e1" />| <img width="1456" alt="Screenshot 2024-12-16 at 10 04 38" src="https://github.com/user-attachments/assets/9a681c53-836f-451e-86e8-1fe633db9390" />
