### PR TITLE
Ajout des Territorial Access Rights dans la super admin

### DIFF
--- a/app/controllers/super_admins/agent_territorial_access_rights_controller.rb
+++ b/app/controllers/super_admins/agent_territorial_access_rights_controller.rb
@@ -1,0 +1,4 @@
+module SuperAdmins
+  class AgentTerritorialAccessRightsController < SuperAdmins::ApplicationController
+  end
+end

--- a/app/dashboards/agent_dashboard.rb
+++ b/app/dashboards/agent_dashboard.rb
@@ -16,6 +16,7 @@ class AgentDashboard < Administrate::BaseDashboard
     roles: Field::HasMany,
     territories: Field::HasMany,
     territorial_roles: Field::HasMany,
+    agent_territorial_access_rights: Field::HasMany,
     services: Field::HasMany,
     agent_services: Field::HasMany,
     invitation_sent_at: Field::DateTime,
@@ -46,6 +47,7 @@ class AgentDashboard < Administrate::BaseDashboard
     roles
     agent_services
     territorial_roles
+    agent_territorial_access_rights
     invitation_sent_at
     created_at
     deleted_at

--- a/app/dashboards/agent_territorial_access_right_dashboard.rb
+++ b/app/dashboards/agent_territorial_access_right_dashboard.rb
@@ -1,0 +1,70 @@
+require "administrate/base_dashboard"
+
+class AgentTerritorialAccessRightDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    territory: Field::BelongsTo,
+    agent: Field::BelongsTo,
+    allow_to_manage_teams: Field::Boolean,
+    allow_to_manage_access_rights: Field::Boolean,
+    allow_to_invite_agents: Field::Boolean,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    territory
+    agent
+    allow_to_manage_teams
+    allow_to_manage_access_rights
+    allow_to_invite_agents
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    agent
+    territory
+    allow_to_manage_teams
+    allow_to_manage_access_rights
+    allow_to_invite_agents
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    allow_to_manage_teams
+    allow_to_manage_access_rights
+    allow_to_invite_agents
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how agent roles are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(agent_role)
+  #   "AgentRole ##{agent_role.id}"
+  # end
+end

--- a/app/policies/super_admin/agent_territorial_access_right_policy.rb
+++ b/app/policies/super_admin/agent_territorial_access_right_policy.rb
@@ -1,0 +1,5 @@
+class SuperAdmin::AgentTerritorialAccessRightPolicy < DefaultSuperAdminPolicy
+  alias show? team_member?
+  alias edit? team_member?
+  alias update? team_member?
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -254,6 +254,11 @@ fr:
       territory:
         roles: "Admins du Territoire"
         admin_agents: "Admins du Territoire"
+      agent_territorial_access_right:
+        allow_to_manage_teams: "Peut gérer les équipes"
+        allow_to_manage_access_rights: "Peut gérer les droits d’accès"
+        allow_to_invite_agents: "Peut inviter d’autres agents"
+
     add: Ajouter
     back: Retour
     clone: Dupliquer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       resources :migrations, only: %i[new create]
     end
     resources :agent_roles, only: %i[show edit update destroy]
+    resources :agent_territorial_access_rights, only: %i[show edit update]
     resources :agent_services, only: %i[show destroy]
     resources :user_profiles, only: %i[destroy]
     resources :super_admins, only: %i[index destroy]


### PR DESCRIPTION
# Contexte

https://mattermost.incubateur.net/betagouv/pl/9jdjt888ejgxzgdmocfsp7fixr

# Solution

Rajoute la possibilité de voir et d’éditer les territorial access rights d’un agent depuis la super admin

## Captures d'écran

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/6e7face5-d78f-4feb-a183-d46a39a6dfcb" />

Je propose de ne permettre d’éditer que les trois booléens de droits et pas l’agent ou le territoire

<img width="1045" alt="image" src="https://github.com/user-attachments/assets/debf736e-ee75-4c6e-81e5-5c170e51fa4b" />

# Test

testable sur la review app ici : 

https://rdv-solidarites:test@demo-rdv-solidarites-pr4902.osc-secnum-fr1.scalingo.io/super_admins