### PR TITLE
Migration des boutons d’inscription atelier collectif au DSFR et a11y

### DIFF
--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -64,6 +64,10 @@ a[disabled] {
   color: white;
 }
 
+.rdv-color-active-blue {
+  color: var(--background-active-blue-france);
+}
+
 // GRID
 
 .d-grid {

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,7 +1,7 @@
 .fr-container
   = render "search/selected_motif_recap", context: context
   - if context.lieu.present?
-    .card.card-hoverable
+    .card
       .card-body
         = link_to path_to_lieu_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du lieu" do
           .row
@@ -11,30 +11,33 @@
               h2.pb-1.mb-1.card-title= context.lieu.name
               .card-subtitle= context.lieu.address
   - elsif context.user_selected_organisation.present?
-      .card.card-hoverable
-        .card-body
-          = link_to path_to_organisation_selection(params), class: "d-block stretched-link", title: "Retour à la sélection de l’organisation" do
-            .row
-              .col-auto.align-self-center
-                i.fa.fa-chevron-left
-              .col
-                h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
-                = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
+    .card
+      .card-body
+        = link_to path_to_organisation_selection(params), class: "d-block stretched-link", title: "Retour à la sélection de l’organisation" do
+          .row
+            .col-auto.align-self-center
+              i.fa.fa-chevron-left
+            .col
+              h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
+              = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
   - if context.no_availability?
     = render "search/nothing_to_show", context: context
   - else
     - if context.first_matching_motif.collectif?
-      h3.rdv-font-weight-700 = "Inscrivez-vous à l'atelier de votre choix :"
+      h3 = "Inscrivez-vous à l'atelier de votre choix :"
     - else
-      h3.rdv-font-weight-700 Sélectionnez un créneau&nbsp;:
-    .card.mb-3
-      .card-body
-        - if context.first_matching_motif.collectif?
-          - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
-            = render "search/rdv_collectif", rdv: rdv
-        - elsif context.unique_motifs_by_name_and_location_type.present?
+      h3 Sélectionnez un créneau&nbsp;:
+    - if context.first_matching_motif.collectif?
+      ul.fr-raw-list
+        - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|
+          = render "search/rdv_collectif", rdv: rdv
+    - elsif context.unique_motifs_by_name_and_location_type.present?
+      .card.mb-3
+        .card-body
           = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
-        - else
+    - else
+      .card.mb-3
+        .card-body
           .alert.alert-warning
             = "Le motif "
             b= context.first_matching_motif.name

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -6,23 +6,22 @@ li.card
       h4.rdv-color-active-blue = rdv.motif.name
     ul.fr-raw-list
       li.card-text.fr-mb-1w
-        span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
-        strong> Animé par
-        = agents_to_sentence(rdv.agents)
-
-      li.card-text.fr-mb-1w
         span.fr-icon-calendar-2-fill.fr-mr-1w[aria-hidden="true"]
-        strong = "Date : "
-        = l(rdv.starts_at, format: :human)
+        = "Date : "
+        strong = l(rdv.starts_at, format: :human)
       li.card-text.fr-mb-1w
         span.fr-icon-timer-fill.fr-mr-1w[aria-hidden="true"]
-        strong = "Durée : "
-        = "#{rdv.duration_in_min} minutes"
+        = "Durée : "
+        strong = "#{rdv.duration_in_min} minutes"
+      li.card-text.fr-mb-1w
+        span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
+        = "Animé par "
+        strong = agents_to_sentence(rdv.agents)
       li.card-text.fr-mb-1w
         span.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
         = I18n.t("rdvs.participants", count: rdv.users_count)
 
-  .card-footer
+  .card-footer.rdv-text-align-right
     - if current_user&.participation_for(rdv)&.not_cancelled?
       .rdv-color-text-default-success
         span.fr-icon-success-line.fr-mr-1w[aria-hidden="true"]

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -2,24 +2,30 @@ li.card
   .card-body
     - if rdv.name.present?
       h4.rdv-color-active-blue = rdv.name
+    - else
+      h4.rdv-color-active-blue = rdv.motif.name
     ul.fr-raw-list
-      li.card-text.fr-icon-user-fill.fr-mb-1w
+      li.card-text.fr-mb-1w
+        span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
         strong> Animé par
         = agents_to_sentence(rdv.agents)
 
-      li.card-text.fr-icon-calendar-2-fill.fr-mb-1w
+      li.card-text.fr-mb-1w
+        span.fr-icon-calendar-2-fill.fr-mr-1w[aria-hidden="true"]
         strong = "Date : "
         = l(rdv.starts_at, format: :human)
-      li.card-text.fr-icon-timer-fill.fr-mb-1w
+      li.card-text.fr-mb-1w
+        span.fr-icon-timer-fill.fr-mr-1w[aria-hidden="true"]
         strong = "Durée : "
         = "#{rdv.duration_in_min} minutes"
-      li.card-text.fr-icon-team-fill.fr-mb-1w
-        strong = "Nombre de participants : "
-        = "#{show_participants_count(rdv)}"
+      li.card-text.fr-mb-1w
+        span.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
+        = I18n.t("rdvs.participants", count: rdv.users_count)
 
   .card-footer
     - if current_user&.participation_for(rdv)&.not_cancelled?
-      .fr-icon-success-line.rdv-color-text-default-success
+      .rdv-color-text-default-success
+        span.fr-icon-success-line.fr-mr-1w[aria-hidden="true"]
         = "Vous êtes déjà inscrit pour cet atelier."
     - else
       = link_to "S'inscrire", @context.wizard_after_creneau_selection_path(rdv_collectif_id: rdv.id), class: "fr-btn fr-btn--secondary fr-icon-user-add-line fr-btn--icon-left"

--- a/app/views/search/_rdv_collectif.html.slim
+++ b/app/views/search/_rdv_collectif.html.slim
@@ -1,26 +1,25 @@
-.card
-  .card-header
-    = rdv_title(rdv)
+li.card
   .card-body
-    .card-text
-      - if rdv.name.present?
-        p
-          strong= rdv.name
-      i.fa.fa-fw.fa-user>
-      strong> Animé par
-      = agents_to_sentence(rdv.agents)
+    - if rdv.name.present?
+      h4.rdv-color-active-blue = rdv.name
+    ul.fr-raw-list
+      li.card-text.fr-icon-user-fill.fr-mb-1w
+        strong> Animé par
+        = agents_to_sentence(rdv.agents)
 
-    .card-text
-      i.fa.fa-fw.fa-clock>
-      = "#{rdv.duration_in_min} minutes"
-    .card-text
-      i.fa.fa-fw.fa-users>
-      = show_participants_count(rdv)
+      li.card-text.fr-icon-calendar-2-fill.fr-mb-1w
+        strong = "Date : "
+        = l(rdv.starts_at, format: :human)
+      li.card-text.fr-icon-timer-fill.fr-mb-1w
+        strong = "Durée : "
+        = "#{rdv.duration_in_min} minutes"
+      li.card-text.fr-icon-team-fill.fr-mb-1w
+        strong = "Nombre de participants : "
+        = "#{show_participants_count(rdv)}"
 
   .card-footer
     - if current_user&.participation_for(rdv)&.not_cancelled?
-      .rdv-color-text-mention-grey Vous êtes déjà inscrit pour cet atelier.
+      .fr-icon-success-line.rdv-color-text-default-success
+        = "Vous êtes déjà inscrit pour cet atelier."
     - else
-      = link_to @context.wizard_after_creneau_selection_path(rdv_collectif_id: rdv.id), class: "d-flex card-text mb-2" do
-        i.fa.fa-fw.fa-user-plus>
-        | &nbsp;S'inscrire
+      = link_to "S'inscrire", @context.wizard_after_creneau_selection_path(rdv_collectif_id: rdv.id), class: "fr-btn fr-btn--secondary fr-icon-user-add-line fr-btn--icon-left"


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4906.osc-secnum-fr1.scalingo.io/)
# Contexte

Dans le cadre du passage au DSFR, on utilise des boutons du DSFR pour l’écran d’inscription à des ateliers collectifs. 

# Solution

- Utilisation d’un bouton DSFR (en secondary, car on ne peut théoriquement avoir qu’un bouton primaire par page)
- Utilisation des icônes DSFR
- Ajout de texte permettant la compréhension avec les lecteurs d’écran
- Utilisation de liste pour une meilleure compréhension a11y

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/7674a5d5-0989-49e2-847c-9917ade21dd6) | ![image](https://github.com/user-attachments/assets/bd16edac-eb71-42f4-ae93-2683c01fe3b2)
![image](https://github.com/user-attachments/assets/69e2c569-5a53-49b6-8894-17b8edf3752d) | ![image](https://github.com/user-attachments/assets/33f812ac-94b3-45f2-8b51-90e9e6e45990)


