### PR TITLE
Petites améliorations de la prise de rdv côté agent

### DIFF
--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -17,7 +17,7 @@ module MotifsHelper
   end
 
   def motif_name_with_location_and_group_type(motif)
-    "#{motif.name} (#{motif.human_attribute_value(:location_type)} - #{human_group_type_value(motif)})"
+    "#{motif.name} - #{'RDV collectif ' if motif.collectif?}#{motif.human_attribute_value(:location_type)} "
   end
 
   def motif_name_and_service(motif)
@@ -112,10 +112,6 @@ module MotifsHelper
     value += tag.div(hint, class: "text-muted") if arg_value.present? && arg_value.exclude?("text-muted") && hint.present?
     tag.div(tag.div(legend, class: "col-md-4 text-right") +
         tag.div(value, class: "col-md-8 text-bold"), class: "row")
-  end
-
-  def human_group_type_value(motif)
-    t("activerecord.attributes.motif/collectifs.#{motif.collectif?}")
   end
 
   def available_slots_count(motif)

--- a/app/views/admin/motifs/_visibility.html.slim
+++ b/app/views/admin/motifs/_visibility.html.slim
@@ -1,11 +1,12 @@
-h6.mb-2
-  i.fa.fa-clipboard-check.mr-1
-  span.mr-1= t(".default_html", motif: link_to(motif.name, admin_organisation_motif_path(current_organisation, motif), target: "_blank"))
-.ml-3
-  = boolean_tag(motif.visible_and_notified?) do
-    = sanitize(motif.human_attribute_value(:visibility_type, context: :html))
-    p.mb-0
-      span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint)
-      - if current_organisation.rdv_insertion?
-        br
-        span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)
+- unless motif.visible_and_notified?
+  h6.mb-2
+    i.fa.fa-clipboard-check.mr-1
+    span.mr-1= t(".default_html", motif: link_to(motif.name, admin_organisation_motif_path(current_organisation, motif), target: "_blank"))
+  .ml-3
+    = boolean_tag(motif.visible_and_notified?) do
+      = sanitize(motif.human_attribute_value(:visibility_type, context: :html))
+      p.mb-0
+        span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint)
+        - if current_organisation.rdv_insertion?
+          br
+          span.text-muted.font-14= motif.human_attribute_value(:visibility_type, context: :hint_rdv_insertion)

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Agent can create a Rdv with wizard" do
     expect_page_title("Nouveau RDV pour le 02/10/2019 à 00:00")
     expect(page).to have_selector("h2", text: "Motif")
     select(motif.name, from: "rdv_motif_id")
-    expect(page).to have_select("rdv_motif_id", text: "Super Motif (Sur place - RDV collectif)", exact: true)
+    expect(page).to have_select("rdv_motif_id", text: "Super Motif - RDV collectif Sur place", exact: true)
     click_button("Continuer")
   end
 


### PR DESCRIPTION
# Contexte

Cette PR officialise les deux propositions qu'on a validé en discutant de https://github.com/betagouv/rdv-service-public/pull/4905

## Choix de motifs

On allège le choix de motif en arrêtant de répéter que les motifs de rdv individuels sont des motifs individuels : par défaut les rdv sont individuels, ça ajoute du bruit de le répéter dans un select qui en a déjà beaucoup. En plus pour toutes les organisations qui ne proposent pas de rdv collectifs, c'est inutile (ce qui est la plupart des organisations).
Pour le contexte, ça avait été ajouté suite à cette issue : https://github.com/betagouv/rdv-service-public/issues/2788. Le but initial était d'identifier facilement les rdv collectifs, ce qui reste possible


Avant | Après
:- | -:
<img width="1084" alt="Screenshot 2024-12-17 at 16 05 30" src="https://github.com/user-attachments/assets/d15f25b2-20bd-40c8-801d-2c9778042853" />|<img width="1137" alt="Screenshot 2024-12-17 at 16 05 03" src="https://github.com/user-attachments/assets/4c56326e-655c-4976-9d79-e6a571d46b0d" />

## Notifications

Dans l'écran actuel, on indique de trois manières différentes ce qui peut se passer pour les notifications ("Comportement normal du motif", préférence de l'usager, checkboxes pour le rdv). Dans la quasi-totalité des cas, le motif est "visible et notifié", c'est à dire qu'il est possible d'envoyer des notifications, et que le rdv sera visible pour l'usager dans son espace personnel.
C'est le comportement attendu, donc ça ne sert à rien de polluer l'interface avec ces infos

En revanche, pour les rdv non notifiées ou non visibles, il est risqué de modifier cette interface, puisqu'elle intervient pour éviter d'envoyer des notifications pour des situations sensibles, comme des problèmes de violences conjugales. On préfère donc ne pas modifier à la légère l'interface dans ce cas, et on pourra l'étudier de plus près à la rentrée.

Avant | Après
:- | -:
<img width="790" alt="Screenshot 2024-12-17 at 16 07 02" src="https://github.com/user-attachments/assets/a9350cae-6277-4cad-beb3-503beead47c4" />|<img width="787" alt="Screenshot 2024-12-17 at 16 07 15" src="https://github.com/user-attachments/assets/92901abd-69af-469a-9191-9790df1b3c9c" />


