### PR TITLE
Usager: remove bootstrap jumbotron

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -26,7 +26,7 @@
 @import "~bootstrap/scss/breadcrumb";
 @import "~bootstrap/scss/pagination";
 @import "~bootstrap/scss/badge";
-@import "~bootstrap/scss/jumbotron";
+//@import "~bootstrap/scss/jumbotron";
 @import "~bootstrap/scss/alert";
 @import "~bootstrap/scss/progress";
 @import "~bootstrap/scss/media";


### PR DESCRIPTION
# Contexte

Le compostant bootstrap jumbotron n’est pas utilisé. Dans l’objectif de se séparer de bootstrap, on retire l’import

