### PR TITLE
Usager: remove bootstrap nav and navbar

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -20,8 +20,8 @@
 @import "~bootstrap/scss/button-group";
 @import "~bootstrap/scss/input-group";
 @import "~bootstrap/scss/custom-forms";
-@import "~bootstrap/scss/nav";
-@import "~bootstrap/scss/navbar";
+//@import "~bootstrap/scss/nav";
+//@import "~bootstrap/scss/navbar";
 @import "~bootstrap/scss/card";
 @import "~bootstrap/scss/breadcrumb";
 @import "~bootstrap/scss/pagination";


### PR DESCRIPTION
# Contexte

Le compostant bootstrap nav/navbar ne sont pas utilisés. Dans l’objectif de se séparer de bootstrap, on retire l’import
