### PR TITLE
Usager: remove font awesome

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -3,7 +3,7 @@
 @import "~bootstrap/scss/mixins";
 @import "./_variables";
 @import "./_variables_dsfr";
-@import "./fontawesome_imports";
+
 // import bootstrap file by file so we can remove unwanted rules component by component
 // cf https://github.com/twbs/bootstrap/blob/v4.3.1/scss/bootstrap.scss
 @import "~bootstrap/scss/root";


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4912.osc-secnum-fr1.scalingo.io/)
[Review app](https://demo-rdv-solidarites-pr4912.osc-secnum-fr1.scalingo.io/)
# Contexte

Il semble que nous n’utilisons plus aucune icône font awesome côté usager. On peut donc retirer l’import.

Pour info : 
- Ça fait diminuer d’un tiers le `application.css`
- Et on s’évite le chargement de 300ko de font