### PR TITLE
Utilisation des icônes DSFR pour l’autocomplete

### DIFF
--- a/app/javascript/components/places-inputs.js
+++ b/app/javascript/components/places-inputs.js
@@ -77,17 +77,17 @@ class PlacesInput {
   suggestionTemplate = suggestion => {
     const { type, name } = suggestion
     const icon = {
-      housenumber: "map-marker",
-      locality: "map-pin",
-      municipality: "city",
-      street: 'road'
+      housenumber: "home-4-fill",
+      locality: "road-map-fill",
+      municipality: "community-fill",
+      street: 'map-pin-2-fill'
     }[type] || "question"
     const details = this.getDetails(suggestion).join(", ")
     const content = `<b>${name}</b> <span class='text-muted'>${details}</span>`
     return `
       <div class='d-flex'>
-        <div class='ml-1'><i class="fa fa-${icon}"></i></div>
-        <div class='ml-1'>${content}</div>
+        <div class='fr-ml-1w'><i class="fr-icon-${icon}"></i></div>
+        <div class='fr-ml-1w'>${content}</div>
       </div>
     `
   }

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -14,5 +14,5 @@ section.rdv-background-color-flat-blue-ecume.fr-pt-4w.fr-pb-8w
           .col-lg-9= f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
           .col-lg-3.align-self-end
             = f.button :button, id: "search_submit", class: "btn-white btn-lg w-100 text-center", disabled: true do
-              i.fa.fa-search>
+              span.fr-icon-search-line.fr-mr-1w[aria-hidden="true"]
               | Rechercher


### PR DESCRIPTION
# Contexte

On souhaite retirer l’usage de font-awesome pour passer sur des icônes DSFR uniquement. On fait donc le changement au niveau de l’autocomplete d’adresse.

L’icône route n’étant pas présent dans le DSFR, j’ai dû faire quelques ajustements.


## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/e5a0cd86-4670-4cc5-b1f5-77dd7284bb1d)  | ![image](https://github.com/user-attachments/assets/8740fee5-3260-44c6-ae64-78a8230b708e)
![image](https://github.com/user-attachments/assets/ced6d934-363a-4b4c-a87a-b6d7c9aa356a) | ![image](https://github.com/user-attachments/assets/a75518d9-8ff6-4bd3-842c-1f0f3d5bb64e)
![image](https://github.com/user-attachments/assets/a9861a16-e590-428f-8e4d-aab550769bc0) | ![image](https://github.com/user-attachments/assets/4d15cac3-2d2c-4c7a-8966-841152be5708)

