### PR TITLE
Correctif pour l'envoi de notifications d'annulation alors que la participation ne l'a pas configuré

### DIFF
--- a/app/models/concerns/rdv/updatable.rb
+++ b/app/models/concerns/rdv/updatable.rb
@@ -38,7 +38,7 @@ module Rdv::Updatable
 
   def new_cancelled_notifier(author, previous_participations)
     # Don't notify RDV cancellation to users that had previously cancelled their individual participation
-    available_users_for_notif = previous_participations.select(&:not_cancelled?).map(&:user)
+    available_users_for_notif = previous_participations.select(&:send_lifecycle_notifications?).select(&:not_cancelled?).map(&:user)
     Notifiers::RdvCancelled.new(self, author, available_users_for_notif)
   end
 

--- a/spec/features/agents/cancel_rdv_spec.rb
+++ b/spec/features/agents/cancel_rdv_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Agent can cancel a RDV", js: true do
     expect(rdv.reload.status).to eq("revoked")
 
     perform_enqueued_jobs
-    # expect(ActionMailer::Base.deliveries.map(&:to)).to be_empty
+    expect(ActionMailer::Base.deliveries.map(&:to)).to be_empty
     expect(Receipt.all).to be_empty
   end
 end

--- a/spec/features/agents/cancel_rdv_spec.rb
+++ b/spec/features/agents/cancel_rdv_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe "Agent can cancel a RDV", js: true do
+  let(:rdv) { create(:rdv) }
+  let(:agent) { rdv.agents.first }
+
+  before do
+    rdv.participations.first.update!(send_lifecycle_notifications: false)
+    stub_netsize_ok
+    login_as(agent, scope: :agent)
+  end
+
+  it "n'envoie pas de notification si la participation a désactivé les notifications" do
+    visit admin_organisation_rdv_path(rdv.organisation, rdv)
+    find(".dropdown-toggle", text: "Rendez-vous à venir").click
+    accept_alert do
+      find("span", text: "Annulé à l’initiative du service").click
+    end
+    sleep 1 # Pour attendre que la requête ajax se finisse
+    expect(rdv.reload.status).to eq("revoked")
+
+    perform_enqueued_jobs
+    # expect(ActionMailer::Base.deliveries.map(&:to)).to be_empty
+    expect(Receipt.all).to be_empty
+  end
+end


### PR DESCRIPTION
pour le contexte : https://zammad10.ethibox.fr/#ticket/zoom/19478

On a eu des rdv pour lesquels les notifications étaient désactivées, mais les notifications d'annulation ont quand même été annulées.
Cette PR ajoute un test qui reproduit le bug, puis un correctif.

Il y a peut-être une correction plus systématique pour nous éviter d'écrire d'autres variantes de ce bug à l'avenir, mais dans l'immédiat je préfère déjà corriger ça.