### PR TITLE
On affiche l’aide au RDV de suivi que si nécessaire

### DIFF
--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -65,7 +65,7 @@ module Users::CreneauxWizardConcern
   end
 
   def follow_up_motifs?
-    Motif.where(service: services).exists?(follow_up: true, deleted_at: nil)
+    @follow_up_motifs ||= Motif.where(service: services).exists?(follow_up: true, deleted_at: nil)
   end
 
   def next_availability_by_lieux

--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -65,7 +65,7 @@ module Users::CreneauxWizardConcern
   end
 
   def follow_up_motifs?
-    @follow_up_motifs ||= Motif.where(service: services).exists?(follow_up: true, deleted_at: nil)
+    @follow_up_motifs ||= Motif.where(service: services).where.not(bookable_by: :agents).exists?(follow_up: true, deleted_at: nil)
   end
 
   def next_availability_by_lieux

--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -64,6 +64,10 @@ module Users::CreneauxWizardConcern
     @services ||= matching_motifs.includes(:service).map(&:service).uniq.sort_by(&:name)
   end
 
+  def follow_up_motifs?
+    Motif.where(service: services).exists?(follow_up: true, deleted_at: nil)
+  end
+
   def next_availability_by_lieux
     return @next_availability_by_lieux if @next_availability_by_lieux
 

--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -13,6 +13,6 @@
     - if context.follow_up_motifs?
       .card
         .m-2
-          | Pour prendre un RDV de suivi avec un de vos agents référent,
+          | Pour prendre un RDV de suivi avec un de vos agents référents,
           span>
           = link_to("connectez-vous", users_rdvs_path)

--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -10,8 +10,9 @@
             span>
             | vos rendez-vous
   - else
-    .card
-      .m-2
-        | Pour prendre un RDV de suivi avec un de vos agents référent,
-        span>
-        = link_to("connectez-vous", users_rdvs_path)
+    - if context.follow_up_motifs?
+      .card
+        .m-2
+          | Pour prendre un RDV de suivi avec un de vos agents référent,
+          span>
+          = link_to("connectez-vous", users_rdvs_path)

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -46,18 +46,18 @@ RSpec.describe "Search", type: :request do
       end
 
       context "when territory has no follow up motifs" do
-        it "does not show a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
+        it "n’affiche pas l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-          expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+          expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
 
       context "when territory has follow up motifs" do
         let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true) }
 
-        it "shows a hint to help find a rdv with a referent agent in case the user is looking for the service of a follow_up motifs" do
+        it "affiche l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-          expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+          expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
     end
@@ -75,18 +75,18 @@ RSpec.describe "Search", type: :request do
       end
 
       context "when territory has no follow up motifs" do
-        it "does not show a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
+        it "n’affiche pas l’invitation à se connecter" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-          expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+          expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
 
       context "when territory has follow up motifs" do
         let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true) }
 
-        it "shows a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
+        it "affiche l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-          expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+          expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
     end

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -45,9 +45,20 @@ RSpec.describe "Search", type: :request do
         expect(response.body).to include("Sélectionnez le service avec qui vous voulez prendre un RDV")
       end
 
-      it "shows a hint to help find a rdv with a referent agent in case the user is looking for the service of a follow_up motifs" do
-        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-        expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+      context "when territory has no follow up motifs" do
+        it "does not show a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
+          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+        end
+      end
+
+      context "when territory has follow up motifs" do
+        let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true) }
+
+        it "shows a hint to help find a rdv with a referent agent in case the user is looking for the service of a follow_up motifs" do
+          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+        end
       end
     end
 
@@ -63,9 +74,20 @@ RSpec.describe "Search", type: :request do
         expect(response.body).to include("Sélectionnez le motif de votre RDV")
       end
 
-      it "shows a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
-        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-        expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+      context "when territory has no follow up motifs" do
+        it "does not show a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
+          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+        end
+      end
+
+      context "when territory has follow up motifs" do
+        let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true) }
+
+        it "shows a hint to help find a rdv with a referent agent in case the user is looking for follow_up motifs" do
+          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référent")
+        end
       end
     end
   end

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -45,19 +45,29 @@ RSpec.describe "Search", type: :request do
         expect(response.body).to include("Sélectionnez le service avec qui vous voulez prendre un RDV")
       end
 
-      context "when territory has no follow up motifs" do
+      context "lorsqu’il n’y a pas de motif de suivi associé aux services" do
         it "n’affiche pas l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
           expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
 
-      context "when territory has follow up motifs" do
-        let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true) }
+      context "lorsqu’il y a un motif de suivi associé aux services" do
+        let(:bookable_by) { :everyone }
+        let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true, bookable_by:) }
 
         it "affiche l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
           expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référents")
+        end
+
+        context "lorsque le motif est réservable que par un agent" do
+          let(:bookable_by) { :agents }
+
+          it "n’affiche pas l’invitation à se connecter" do
+            get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+            expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
+          end
         end
       end
     end
@@ -74,19 +84,29 @@ RSpec.describe "Search", type: :request do
         expect(response.body).to include("Sélectionnez le motif de votre RDV")
       end
 
-      context "when territory has no follow up motifs" do
+      context "lorsqu’il n’y a pas de motif de suivi associé aux services" do
         it "n’affiche pas l’invitation à se connecter" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
           expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
 
-      context "when territory has follow up motifs" do
-        let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true) }
+      context "lorsqu’il y a un motif de suivi associé aux services" do
+        let(:bookable_by) { :everyone }
+        let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true, bookable_by:) }
 
         it "affiche l’invitation à se connecter pour prendre un RDV de suivi" do
           get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
           expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référents")
+        end
+
+        context "lorsque le motif est réservable que par un agent" do
+          let(:bookable_by) { :agents }
+
+          it "n’affiche pas l’invitation à se connecter" do
+            get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+            expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
+          end
         end
       end
     end


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4918.osc-secnum-fr1.scalingo.io/)
# Contexte

Dans le parcours de prise de RDV, nous avons un bandeau qui incite les usagers qui souhaitent prendre un RDV de suivi avec leur agent référent à se connecter.

Ce bandeau ne concerne que : 
- 3,5% des RDV sur RDVS
- 0% des RDV sur RDVSP

L’idée est donc d’afficher le bandeau que si on est dans un contexte dans lequel il peut potentiellement y avoir un RDV de suivi.

# Solution

- On regarde si dans la liste des services du contexte courant, il y a des motifs de prise de RDV de suivi.
- S'il y a au moins un motif de RDV de suivi (non archivé), on affiche le bandeau d’aide à la connexion.

Conséquence : 
- nous n’affichons plus le bandeau sur RDVSP
- nous affichons le bandeau que pour 33/113 territoires