### PR TITLE
Amélioration de performances : éviter le tri sur le max_public_booking_delay quand c'est possible

### DIFF
--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -96,7 +96,7 @@ module Users::CreneauxWizardConcern
   def after_max_public_booking_delay?(date)
     # On a déjà le first_matching_motif en mémoire au moment où on appelle cette méthode
     # Dans la plupart des cas, tous les motifs ont le même max_booking_delay
-    # On s'en sert donc pour éviter de faire le tri sur tous les matching_motifs si possible
+    # On s'en sert donc pour éviter de chercher le maximum sur tous les matching_motifs si possible
     if date < (Time.zone.now + first_matching_motif.max_public_booking_delay.seconds).to_date
       return false
     end

--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -93,8 +93,19 @@ module Users::CreneauxWizardConcern
     creneaux.empty? && next_availability.nil?
   end
 
-  def max_public_booking_delay
-    matching_motifs.maximum("max_public_booking_delay")
+  def after_max_public_booking_delay?(date)
+    # On a déjà le first_matching_motif en mémoire au moment où on appelle cette méthode
+    # Dans la plupart des cas, tous les motifs ont le même max_booking_delay
+    # On s'en sert donc pour éviter de faire le tri sur tous les matching_motifs si possible
+    if date < (Time.zone.now + first_matching_motif.max_public_booking_delay.seconds).to_date
+      return false
+    end
+
+    # TODO: on pourrait peut-être rendre cette requête plus rapide avec un index sur motifs.max_public_booking_delay
+    # Elle peut etre assez longue, donc on fait un memoize pour éviter de la faire plusieurs fois
+    @max_public_booking_delay ||= matching_motifs.maximum("max_public_booking_delay")
+
+    date >= (Time.zone.now + @max_public_booking_delay.seconds).to_date
   end
 
   private

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -30,7 +30,7 @@ class SearchContext
   end
 
   def first_matching_motif
-    matching_motifs.first
+    @first_matching_motif ||= matching_motifs.first
   end
 
   def referent_agents

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -34,7 +34,7 @@
     - elsif context.unique_motifs_by_name_and_location_type.present?
       .card.mb-3
         .card-body
-          = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, max_public_booking_delay: context.max_public_booking_delay, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
+          = render "search/creneaux", lieu: context.lieu, creneaux: context.creneaux, date_range: context.date_range, departement: context.departement, address: context.address, city_code: context.city_code, next_availability: context.next_availability, query_params: context.query_params, context: context
     - else
       .card.mb-3
         .card-body

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -26,7 +26,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                     - if creneau.motif.follow_up?
                       br
                       small= creneau.agent.short_name
-            - elsif date >= (Time.now + max_public_booking_delay.seconds).to_date
+            - elsif context.after_max_public_booking_delay?(date)
               p.rdv-text-align-center.rdv-color-text-mention-grey
                 | Date fermée à la reservation
             - elsif creneaux.any?
@@ -43,7 +43,7 @@ div id="creneaux-lieu-#{lieu&.id}"
                   strong= l(next_availability.starts_at, format: :human)
                 .ml-2
                   i.fa.fa-chevron-right
-    - if params[:date].blank? || (params[:date].to_date + 6.days) < (Time.now + max_public_booking_delay.seconds).to_date
+    - if params[:date].blank? || !context.after_max_public_booking_delay?(params[:date].to_date + 6.days)
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
         = link_to prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class: "btn btn-primary", data: { disable_with: "..." }, aria: { label: "semaine suivante"} do
           span.d-md-none.mr-1


### PR DESCRIPTION
# Contexte

On a récemment eu pas mal de problèmes de ralentissement sur la base le matin. C'est peut-être lié à des requêtes à la db qui sont trop gourmandes en mémoire.

Lors de la recherche de créneaux on fait beaucoup de requêtes de ce type : 
```
SELECT MAX("motifs"."max_public_booking_delay") FROM "motifs" INNER JOIN "organisations" ON "organisations"."id" = "motifs"."organisation_id" WHERE ("motifs"."id" IN
```
Et les logs et stats postgres disponible dans scalingo semblent indiquer que cette requête est très longue :

<img width="1510" alt="Screenshot 2024-12-19 at 13 48 37" src="https://github.com/user-attachments/assets/dea9bb5d-c36e-4f4e-95b2-024e0fb1bc0b" />

Elle correspond à la méthode suivante : 
```ruby
module Users::CreneauxWizardConcern
 
  def max_public_booking_delay
    matching_motifs.maximum("max_public_booking_delay")
  end

end
```

Il n'y a pas d'index sur `motifs.max_public_booking_delay`, et `matching_motifs` est une requête particulièrement complexe.

# Solution

Je suis sur le point de partir en congés pendant 2 semaines, donc je préfère faire le changement le plus petit possible pour limiter au maximum les effets de bord. Je ne vais donc pas ajouter d'index ici (trop d'incertitudes).

En revanche, on peut utiliser notre connaissance métier : ce `max_public_booking_delay` est uniquement utilisé dans`app/views/search/_creneaux.html.slim` pour savoir si les dates qu'on regarde sont fermées à la réservation pour tous les motifs.

Or, dans la plupart des cas, tous les motifs ont le même `max_public_booking_delay` (généralement 2 mois).

On peut donc commencer par regarder si la date est en dessous du `max_public_booking_delay` du `first_matching_motif`, qu'on a déjà chargé en mémoire.

Dans la plupart des cas, on sera à moins de ce `max_public_booking_delay`, et on n'aura pas besoin de faire la requête sur tous les matching_motifs.

Dans certains cas, on sera au delà de ce `max_public_booking_delay`, et on fera la requête très longue comme on le fait aujourd'hui.


On s'attend à ce que ça accélère ce temps de réponse sur skylight : https://www.skylight.io/app/applications/RgR7i58P67xN/1734594060/45m/endpoints/SearchController%23search_rdv?responseType=html

L'interface reste inchangée.
