### PR TITLE
Page contact : utilisation du DSFR pour les alertes et les icônes

### DIFF
--- a/app/views/static_pages/contact.html.slim
+++ b/app/views/static_pages/contact.html.slim
@@ -22,13 +22,10 @@ span> Voir
     h3
       = mail_to current_domain.support_email,
         subject: "[Problème Usager]",
-        body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "btn btn-primary" do
-        span>
-          i.fa.fa-envelope
+        body: "Code postal: \n\rNom: \n\rProblème ou Question:", class: "fr-btn fr-btn--icon-left fr-icon-mail-fill" do
         | Contacter l'équipe technique
 
-    .alert.alert-warning.my-4.d-flex.align-items-center
-      i.fa.fa-exclamation-triangle>
+    .fr-alert.fr-alert--warning.fr-mb-3w
       .ml-2
         - if current_domain == Domain::RDV_MAIRIE
           ' Nous ne pouvons pas débloquer d'autres créneaux que ceux affichés,


### PR DESCRIPTION
# Contexte

On continue de se séparer des alertes Bootstrap et des icônes font-awesome 🧹 

## Captures d'écran

Avant | Après
:- | -:
<img width="920" alt="image" src="https://github.com/user-attachments/assets/466b6daa-47ee-404b-aa4c-8ccdbe6b8b5f" /> | <img width="908" alt="image" src="https://github.com/user-attachments/assets/673b266d-8a71-4a83-93f8-b402f71ee567" />
