### PR TITLE
Formulaire info perso: utilisation du DSFR pour les alertes et les icones

### DIFF
--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -16,15 +16,13 @@ ruby:
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
     = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   - if user.logged_once_with_franceconnect?
-    .alert.alert-info.d-flex.align-items-center
-      .mr-3
-        .fa.fa-info
-      div= I18n.t("users.franceconnect_frozen_fields")
+    .fr-alert.fr-alert--info.fr-mb-1w
+      = I18n.t("users.franceconnect_frozen_fields")
   - if current_user.signed_in_with_invitation_token?
     = f.input :email, disabled: user.email.present? && !user.email_changed?, required: true
   = f.input :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
   - if user.phone_number.present? && !user.phone_number_mobile?
-    .alert.alert-warning Vous ne recevrez pas de SMS avec ce numéro non-mobile
+    .fr-alert.fr-alert--warning.fr-mb-1w Vous ne recevrez pas de SMS avec ce numéro non-mobile
   div.mb-2 Préférences de notifications
   div= f.input :notify_by_email
   div= f.input :notify_by_sms


### PR DESCRIPTION
# Contexte

On continue de se séparer des alertes Bootstrap et des icônes font-awesome 🧹

## Captures d'écran

Avant | Après
:- | -:
<img width="771" alt="image" src="https://github.com/user-attachments/assets/b091e3e1-80ef-4cbd-987f-20bbb5aeae5f" /> | <img width="729" alt="image" src="https://github.com/user-attachments/assets/ff623dd3-c640-4222-99c0-befd8d8dc1e4" />
<img width="805" alt="image" src="https://github.com/user-attachments/assets/048cae0c-877b-4ab0-abe8-eb832b7b5ff9" /> | <img width="798" alt="image" src="https://github.com/user-attachments/assets/8eaafc6b-d3ae-4330-9a7b-8f9d5a386859" />

