### PR TITLE
Fix: flaky spec agent can create RDV collectif

### DIFF
--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "Agent can create a Rdv collectif from the agenda" do
     stub_netsize_ok
     travel_to(now)
     login_as(agent, scope: :agent)
+    # Depuis que les jours fériés sont affichés sur la journée complète dans le calendrier,
+    # cela peut nous empêcher de cliquer sur une plage horaire et générer une flaky.
+    # On les retire pour ce test
+    allow(OffDays).to receive(:to_full_calendar_array).and_return([])
     visit admin_organisation_agent_agenda_path(organisation, agent)
   end
 


### PR DESCRIPTION
# Contexte

Depuis que nous affichons les jours fériés sur la journée entière, nous avons une flaky.
Si le test démarre une semaine où il y a un jour férié, cela peut empêcher de cliquer pour créer un RDV.

Pour corriger ce problème simplement, j’ai décidé de mocker OffDays et de retourner un tableau vide. 
