### PR TITLE
Fix: agent agenda off days contrast

### DIFF
--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -1,5 +1,5 @@
 module AbsencesHelper
-  CALENDAR_BACKGROUND_COLOR = "rgba(127, 140, 141, 0.7)".freeze
+  CALENDAR_BACKGROUND_COLOR = "rgba(52, 57, 58, 0.7)".freeze
 
   def absence_tag(absence)
     if absence.expired?

--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -65,6 +65,7 @@ class OffDays
         start: jour_ferie.beginning_of_day.as_json,
         end: jour_ferie.end_of_day.as_json,
         backgroundColor: AbsencesHelper::CALENDAR_BACKGROUND_COLOR,
+        textColor: "white",
       }
     end
   end

--- a/spec/controllers/admin/api/agenda/absences_controller_spec.rb
+++ b/spec/controllers/admin/api/agenda/absences_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::Api::Agenda::AbsencesController, type: :controller do
               "title" => absence.title,
               "start" => absence.starts_at.as_json,
               "end" => absence.ends_at.as_json,
-              "backgroundColor" => "rgba(127, 140, 141, 0.7)",
+              "backgroundColor" => "rgba(52, 57, 58, 0.7)",
               "url" => "/admin/organisations/#{organisation.id}/absences/#{absence.id}/edit",
             },
           ]

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "Agent can create a Rdv collectif from the agenda" do
     stub_netsize_ok
     travel_to(now)
     login_as(agent, scope: :agent)
+    # Depuis que les jours fériés sont affichés sur la journée complète dans le calendrier,
+    # cela peut nous empêcher de cliquer sur une plage horaire et générer une flaky.
+    # On les retire pour ce test
+    allow(OffDays).to receive(:to_full_calendar_array).and_return([])
     visit admin_organisation_agent_agenda_path(organisation, agent)
   end
 

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe OffDays, type: :service do
   describe ".to_full_calendar_array" do
     it "returns the proper format for full calendar" do
       array = described_class.to_full_calendar_array
-      expect(array[0].keys).to match_array(%i[title start end backgroundColor])
-      expect(array[0][:backgroundColor]).to eq "rgba(127, 140, 141, 0.7)"
+      expect(array[0].keys).to match_array(%i[title start end backgroundColor textColor])
+      expect(array[0][:backgroundColor]).to eq "rgba(52, 57, 58, 0.7)"
     end
   end
 end


### PR DESCRIPTION
> [!NOTE]
> Nous avions 2 PR qui étaient nécessaire pour corriger des tests. Afin de pouvoir les passer sur la branche production nous avons donc mergé #4923  ici

# Contexte

Nous avions un test cassé, car les niveaux de contraste utilisé pour les jours fériés n’était pas bon. J’ai donc fais l’ajustement ci-dessous.

## Captures d'écran

Avant | Après
:- | -:
<img width="444" alt="image" src="https://github.com/user-attachments/assets/70406328-edf0-4efa-90df-0b4857ded0d7" /> | <img width="437" alt="image" src="https://github.com/user-attachments/assets/83029539-3840-4253-a8be-3d3c31b7644e" />
