### PR TITLE
Fix: suppression de l’icône en doublon mot de passe de l’agent est trop faible

### DIFF
--- a/app/services/password_checker.rb
+++ b/app/services/password_checker.rb
@@ -10,7 +10,6 @@ class PasswordChecker
 
   def error_message(app_name)
     <<~MESSAGE
-      <div class="fa fa-exclamation-triangle mr-1" />
       Votre mot de passe est trop faible, vous devez le mettre à jour pour continuer d'utiliser #{app_name}.
       <a href="#{Rails.application.routes.url_helpers.edit_agent_mot_de_passes_path}">Changer de mot de passe</a>
     MESSAGE


### PR DESCRIPTION
# Contexte

Suite au passage des alertes au DSFR, une icône font awesome est resté caché. On la retire.

## Captures d'écran

Avant | Après
:- | -:
<img width="1608" alt="image" src="https://github.com/user-attachments/assets/8b317971-16fe-475e-a97d-8591e1c68078" /> | <img width="1593" alt="image" src="https://github.com/user-attachments/assets/a4d2ce61-3b23-4aef-869b-fd27c57bdbdc" />
