### PR TITLE
Suppression de l’ancien layout flash

### DIFF
--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -1,8 +1,0 @@
-- %i[success notice error alert].each do |type|
-  - if flash[type]
-    .row.mt-2
-      .col-md-12
-        .d-print-none.alert.alert-dismissible.fade.show class=alert_class_for(type)
-          a.close.rdv-background-image-none(href="#" data-dismiss="alert" aria-label='Close')
-            i.fa.fa-times
-          = sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune)

--- a/spec/views/flash_spec.rb
+++ b/spec/views/flash_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe "layouts/_flash", type: :view do
+RSpec.describe "layouts/_flash_dsfr", type: :view do
   it "sanitizes JS out of links" do
     notice = <<~HTML
       <a href="javascript:alert('hi');">Cliquez ici</a>
     HTML
-    render(partial: "layouts/flash", locals: { flash: { notice: notice } })
+    render(partial: "layouts/flash_dsfr", locals: { flash: { notice: notice } })
     expect(rendered).to include("<a>Cliquez ici</a>")
   end
 
@@ -28,7 +28,7 @@ RSpec.describe "layouts/_flash", type: :view do
       <em>Less important</em>
     HTML
 
-    render(partial: "layouts/flash", locals: { flash: { notice: notice } })
+    render(partial: "layouts/flash_dsfr", locals: { flash: { notice: notice } })
     expect(rendered.squish).to include(expected_output.squish)
   end
 end


### PR DESCRIPTION
# Contexte

Dans des PR précédentes, nous avons basculé tous les usages du `layouts/flash` vers le `layout/flash_dsfr`
Nous pouvons donc supprimer l’ancien layout flash.

À terme, nous pourrons envisager de renommer le flash_dsfr en flash tout court.
