### PR TITLE
Use DSFR icons RDV summary wizard

### DIFF
--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -2,7 +2,7 @@ ul.list-group.list-group-flush
   li.list-group-item
     .row
       .col
-        i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+        span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
         | Motif :&nbsp;
         = rdv_wizard.motif.name
       .col-auto
@@ -11,21 +11,21 @@ ul.list-group.list-group-flush
   - case rdv_wizard.motif.location_type
   - when Motif.location_types[:phone]
     li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+      span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
       | RDV téléphonique
   - when Motif.location_types[:home]
     li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+      span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
       | RDV à domicile
   - when Motif.location_types[:visio]
     li.list-group-item
-      i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+      span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
       | RDV par visioconférence
   - when Motif.location_types[:public_office]
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
           | Lieu :&nbsp;
           = rdv_wizard.creneau.lieu.full_name
         .col-auto
@@ -36,7 +36,7 @@ ul.list-group.list-group-flush
   li.list-group-item
     .row
       .col
-        i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+        span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
         | Date du rendez-vous :&nbsp;
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
       .col-auto
@@ -45,7 +45,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
           | Usager :&nbsp;
           = users_to_sentence(rdv_wizard.users)
         .col-auto
@@ -54,7 +54,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
           | Informations de contact :&nbsp;
       .row
         .col.ml-3
@@ -71,7 +71,7 @@ ul.list-group.list-group-flush
     li.list-group-item
       .row
         .col
-          i.fa.fa-check.fa-fw.mr-1.rdv-color-text-default-success
+          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
           | Prescripteur :&nbsp;
           = @rdv_wizard.prescripteur.full_name
         .col-auto


### PR DESCRIPTION
# Contexte

Toujours dans l’optique de supprimer font awesome, on passe les icônes du RDV summary wizard au DSFR.

## Captures d'écran

Avant | Après
:- | -:
<img width="664" alt="image" src="https://github.com/user-attachments/assets/cb7e475e-b5b6-4fb6-b54c-10bb0a2ccdb0" /> | <img width="644" alt="image" src="https://github.com/user-attachments/assets/0c53d83e-3e43-4344-8c43-b505f02ffaec" />
