### PR TITLE
MAJ de la gem `json` (meilleures perfs) 🎁

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
-    json (2.7.2)
+    json (2.9.1)
     json-jwt (1.16.6)
       activesupport (>= 4.2)
       aes_key_wrap


### PR DESCRIPTION
La gem `json` standard a reçu des optimisations de perf significatives récemment, le pourquoi et le comment (si vous êtes très curieux) sont exposés ici :
https://byroot.github.io/ruby/json/2024/12/15/optimizing-ruby-json-part-1.html

On peut voir ici que ces améliorations ont été publiées dans la gem :
https://github.com/ruby/json/releases

Je ne m'attends pas à une différence significative pour nos cas d'usages, mais si on peut gagner quelques millisecondes sur de grosses réponses API, pourquoi pas !