### PR TITLE
[Expérimental] Mesure de couverture en prod avec `coverband`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "sentry-rails"
 gem "skylight"
 # Block & throttle abusive requests
 gem "rack-attack"
+# Ruby production code coverage collection and reporting (line of code usage)
+gem "coverband"
 # Dépendance interne pour anonymiser les records AR
 gem "anonymizer", path: "lib/anonymizer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,8 @@ GEM
     common_french_passwords (0.0.1)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
+    coverband (6.1.4)
+      redis (>= 3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -735,6 +737,7 @@ DEPENDENCIES
   climate_control
   common_french_passwords
   connection_pool
+  coverband
   csv
   database_cleaner
   devise!

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,0 +1,6 @@
+Coverband.configure do |config|
+  config.csp_policy = true
+
+  # default false. Experimental support for routes usage tracking.
+  config.track_routes = true
+end

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,4 +1,7 @@
 Coverband.configure do |config|
+  # L'interface web de Coverband nécessite un eval() en JS, ce que notre content_security_policy.rb interdit.
+  # En activant cette config, on fait en sorte d'utiliser un CSP spécifique pour l'interface de Coverband
+  # Voir : https://github.com/danmayer/coverband/pull/447
   config.csp_policy = true
 
   # default false. Experimental support for routes usage tracking.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,6 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
-
-  mount Coverband::Reporters::Web.new, at: "/coverband"
-
   ## OAUTH ##
   devise_scope :user do
     get "omniauth/franceconnect/callback" => "omniauth_callbacks#franceconnect"
@@ -54,6 +51,7 @@ Rails.application.routes.draw do
 
     authenticate :super_admin do
       mount GoodJob::Engine => "good_job"
+      mount Coverband::Reporters::Web.new, at: "/coverage"
     end
   end
   get "super_admin", to: redirect("super_admins", status: 301)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
+
+  mount Coverband::Reporters::Web.new, at: "/coverband"
+
   ## OAUTH ##
   devise_scope :user do
     get "omniauth/franceconnect/callback" => "omniauth_callbacks#franceconnect"
@@ -51,7 +54,6 @@ Rails.application.routes.draw do
 
     authenticate :super_admin do
       mount GoodJob::Engine => "good_job"
-      mount Coverband::Reporters::Web.new, at: "/coverage"
     end
   end
   get "super_admin", to: redirect("super_admins", status: 301)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
 
     authenticate :super_admin do
       mount GoodJob::Engine => "good_job"
+      mount Coverband::Reporters::Web.new, at: "/coverage"
     end
   end
   get "super_admin", to: redirect("super_admins", status: 301)


### PR DESCRIPTION
Un type malin a partagé cette gem [dans le channel Mattermost dédié au Ruby](https://mattermost.incubateur.net/betagouv/pl/4bjhe8oh4t81tqwwiy697ukqfy).

Je pense que ça peut nous aider à avoir de la visibilité sur l'usage de certaines features, et bien sûr pour détecter du code mort, voire des bugs.

# Plan de déploiement

L'idée générale est de déployer prudemment, puis de déterminer si les informations fournies sont utiles, afin de décider si l'on veut garder cette instrumentation sur le long terme ou pas.

- [X] Test en review app de l'activation / désactivation via `COVERBAND_DISABLE_AUTO_START`
- [x] Merge de la PR en la désactivant en prod : on teste seulement en démo
- [ ] Activation pour l'instance `production-rdv-mairie` un début de semaine afin d'avoir un rapport Skylight sur impacts de perf
- [ ] Si pas d'impact, activation sur l'instance historique

Au bout de quelques jours, on pourra discuter des informations données par la gem.

# Pour tester

https://demo-rdv-solidarites-pr4934.osc-secnum-fr1.scalingo.io/coverband