### PR TITLE
Migration instructions confirmation compte au DSFR

### DIFF
--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -11,4 +11,4 @@
         .fr-mt-2w
           - if email_tld_infos(@email_tld).present?
             .fr-hr-or.fr-mb-2w ou
-          = link_to "#{t('devise.invitations.invitation.open_app_mail')}", "message://", target: "_blank", class: "fr-icon"
+          = link_to t("devise.invitations.invitation.open_app_mail"), "message://", target: "_blank", class: "fr-icon"

--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -5,13 +5,10 @@
     p = t("devise.invitations.invitation.click_on_link_sent")
     .rdv-text-align-center
       - unless email_tld_infos(@email_tld).blank?
-        = link_to email_tld_infos(@email_tld)[:url], target: "blank", class: "btn btn-link" do
-          span #{email_tld_infos(@email_tld)[:name]}
+        = link_to "Ouvrir #{email_tld_infos(@email_tld)[:name]}", email_tld_infos(@email_tld)[:url], target: "_blank", class: "fr-link"
 
       - if apple_mobile_device? # could not find android equivalent
-        .mt-2
+        .fr-mt-2w
           - if email_tld_infos(@email_tld).present?
-            .mb-2 OU
-          = link_to "message://", target: "blank", class: "btn btn-primary d-block" do
-            i.fa.fa-envelope>
-            span> = t("devise.invitations.invitation.open_app_mail")
+            .fr-hr-or.fr-mb-2w ou
+          = link_to "#{t('devise.invitations.invitation.open_app_mail')}", "message://", target: "_blank", class: "fr-icon"

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -40,7 +40,7 @@ fr:
         title: "Inscription"
         invitation_token: "Code d’invitation"
         submit_button: "Créer son compte"
-        click_on_link_sent: "Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé"
+        click_on_link_sent: "Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé, pour confirmer votre inscription."
     mailer:
       invitation_instructions_for_agents:
         body: "Vous avez été invité par %{inviter} à rejoindre %{domain_name} en tant qu'agent du service %{service}"

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -40,7 +40,7 @@ fr:
         title: "Inscription"
         invitation_token: "Code d’invitation"
         submit_button: "Créer son compte"
-        click_on_link_sent: "Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé, pour confirmer votre inscription."
+        click_on_link_sent: "Veuillez cliquer sur le lien dans l'email qui vient de vous être envoyé pour confirmer votre inscription."
     mailer:
       invitation_instructions_for_agents:
         body: "Vous avez été invité par %{inviter} à rejoindre %{domain_name} en tant qu'agent du service %{service}"


### PR DESCRIPTION
# Contexte

On continue à migrer les éléments non DSFR vers le DSFR.

# Solution

- On retire l’usage des boutons ici car nous n’avons pas le droit d’utiliser des boutons pour des liens de navigation externe.

## Captures d'écran

Avant | Après
:- | -:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/a3e3d3b0-f20d-4625-9438-78bc3634704a" /> | <img width="840" alt="image" src="https://github.com/user-attachments/assets/67787183-0313-4597-976a-b4370a10aca3" />
