### PR TITLE
Migration des icônes RDV usager au DSFR

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -49,9 +49,9 @@ module RdvsHelper
 
   def rdv_tag(rdv)
     if rdv.cancelled_at || current_user&.participation_for(rdv)&.cancelled?
-      tag.span("Annulé", class: "badge badge-warning")
+      tag.span("Annulé", class: "fr-badge fr-badge--sm fr-badge--warning fr-badge--no-icon fr-ml-1w")
     elsif rdv.starts_at.future?
-      tag.span("À venir", class: "badge bg-info")
+      tag.span("À venir", class: "fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon fr-ml-1w")
     end
   end
 

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -2,7 +2,7 @@
 
 ul.list-group.fr-mb-3w
   li.list-group-item
-    span.fr-icon.fr-icon-info-fill.fr-mr-1w[aria-hidden="true"]
+    span.fr-icon.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
     = @rdv.motif_name
 
   li.list-group-item
@@ -17,7 +17,7 @@ ul.list-group.fr-mb-3w
 
   - elsif @rdv.public_office?
     li.list-group-item
-      span.fr-icon.fr-icon-map-pin-2-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(@rdv)
       - if @rdv.lieu&.phone_number
         br

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -2,42 +2,42 @@
 
 ul.list-group.fr-mb-3w
   li.list-group-item
-    i.fa.fa-info-circle>
+    span.fr-icon.fr-icon-info-fill.fr-mr-1w[aria-hidden="true"]
     = @rdv.motif_name
 
   li.list-group-item
-    .fa.fa-calendar>
+    span.fr-icon.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
     = rdv_title(@rdv)
     = rdv_tag(@rdv)
 
   - if @rdv.home?
     li.list-group-item
-      .fa.fa-home>
+      span.fr-icon.fr-icon-home-4-fill.fr-mr-1w[aria-hidden="true"]
       | Ce RDV se déroulera à domicile
 
   - elsif @rdv.public_office?
     li.list-group-item
-      .fa.fa-map-marker-alt>
+      span.fr-icon.fr-icon-map-pin-2-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(@rdv)
       - if @rdv.lieu&.phone_number
-        span>
-        span.fa.fa-phone>
+        br
+        span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
         = link_to @rdv.lieu.phone_number, "tel:#{@rdv.lieu.phone_number_formatted}"
 
   - elsif @rdv.phone?
     li.list-group-item
-      .fa.fa-phone>
+      span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
       | RDV Téléphonique
 
   - if @rdv.motif.instruction_for_rdv.present?
     li.list-group-item
-      i.fa.fa-exclamation-triangle>
+      span.fr-icon.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
       strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(@rdv.motif)
 
   li.list-group-item
-    i.fa.fa-users>
+    span.fr-icon.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
     | Participant
 
     = form_tag users_rdv_participations_path(@rdv) do
@@ -51,4 +51,4 @@ ul.list-group.fr-mb-3w
       .form-group
         = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?), data: { modal: true }
       .form-group
-        = submit_tag "Enregistrer", class: "btn btn-primary"
+        = submit_tag "Enregistrer", class: "fr-btn"

--- a/app/views/users/rdvs/_file_attente.html.slim
+++ b/app/views/users/rdvs/_file_attente.html.slim
@@ -1,6 +1,6 @@
 - if rdv.available_to_file_attente?
   li.list-group-item
-    i.fa.fa-bell>
+    span.fr-icon.fr-icon-notification-3-fill.fr-mr-1w[aria-hidden="true"]
     | Vous souhaitez prendre RDV plus tôt ?
     - fa = rdv.file_attentes.where(user: current_user).first || FileAttente.new(user: current_user, rdv: rdv)
     = simple_form_for fa, url: users_file_attente_path, html: { method: :post, class: "form-inline" }, wrapper: :inline_form, remote: false  do |f|

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -16,7 +16,7 @@ ul.list-group.list-group-flush.fr-mb-3w
 
   - elsif rdv.public_office?
     li.list-group-item
-      span.fr-icon.fr-icon-map-pin-2-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(rdv)
       - if rdv.lieu&.phone_number
         br
@@ -45,7 +45,7 @@ ul.list-group.list-group-flush.fr-mb-3w
         = link_to "modifier", users_rdv_participations_path(rdv)
   - if @can_see_rdv_motif
     li.list-group-item
-      span.fr-icon.fr-icon-info-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
       = rdv.motif_name
   - if rdv.motif.instruction_for_rdv.present?
     li.list-group-item

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -1,43 +1,43 @@
 ul.list-group.list-group-flush.fr-mb-3w
   li.list-group-item
-    .fa.fa-calendar>
+    span.fr-icon.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
     = rdv_title(rdv)
     = rdv_tag(rdv)
 
   - if rdv.motif.restriction_for_rdv.present?
     li.list-group-item.alert.alert-warning
-      .fa.fa-warning>
+      span.fr-icon.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
       = restriction_for_rdv_to_html(rdv.motif)
 
   - if rdv.home?
     li.list-group-item
-      .fa.fa-home>
+      span.fr-icon.fr-icon-home-4-fill.fr-mr-1w[aria-hidden="true"]
       | Ce RDV se déroulera à domicile
 
   - elsif rdv.public_office?
     li.list-group-item
-      .fa.fa-map-marker-alt>
+      span.fr-icon.fr-icon-map-pin-2-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(rdv)
       - if rdv.lieu&.phone_number
-        span>
-        span.fa.fa-phone>
+        br
+        span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
         = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
   - elsif rdv.phone?
     li.list-group-item
-      .fa.fa-phone>
+      span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
       | RDV Téléphonique
 
   - elsif rdv.motif.visio?
     li.list-group-item
-      .fa.fa-video-camera>
+      span.fr-icon.fr-icon-mac-fill.fr-mr-1w[aria-hidden="true"]
       = "RDV par visioconférence "
       = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
 
   li.list-group-item
     .row
       .col
-        .fa.fa-user>
+        span.fr-icon.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
         = users_to_sentence(rdv.users)
     - if policy(rdv, policy_class: User::RdvPolicy).can_change_participants?
       .col-auto
@@ -45,11 +45,11 @@ ul.list-group.list-group-flush.fr-mb-3w
         = link_to "modifier", users_rdv_participations_path(rdv)
   - if @can_see_rdv_motif
     li.list-group-item
-      i.fa.fa-info-circle>
+      span.fr-icon.fr-icon-info-fill.fr-mr-1w[aria-hidden="true"]
       = rdv.motif_name
   - if rdv.motif.instruction_for_rdv.present?
     li.list-group-item
-      i.fa.fa-exclamation-triangle>
+      span.fr-icon.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
       strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(rdv.motif)
@@ -63,7 +63,7 @@ ul.list-group.list-group-flush.fr-mb-3w
       rdv.in_the_past?
 
     li.list-group-item.font-italic
-      i.fa.fa-ban>
+      span.fr-icon.fr-icon-close-circle-fill.fr-mr-1w[aria-hidden="true"]
       | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
 
 ul.fr-btns-group.fr-btns-group--inline.fr-mb-0

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe "Adding a user to a collective RDV" do
 
   def expect_cancel_participation
     expect do
-      expect(page).to have_content("À venir")
+      expect(page).to have_content(/À venir/i)
       click_on("Annuler votre participation")
       click_link("Oui, annuler votre participation", match: :first)
       expect(page).to have_content("Participation annulée")
-      expect(page).to have_content("Annulé")
+      expect(page).to have_content(/Annulé/i)
     end
   end
 
@@ -200,13 +200,13 @@ RSpec.describe "Adding a user to a collective RDV" do
         fill_in(:letter1, with: "N")
         fill_in(:letter2, with: "V")
 
-        expect(page).to have_content("Annulé")
+        expect(page).to have_content(/Annulé/i)
         create(:participation, rdv: rdv2, user: user, status: "revoked")
         rdv2.status = "revoked"
         rdv2.save
 
         visit users_rdv_path(rdv2, invitation_token: rdv2.participation_token(user.id))
-        expect(page).to have_content("Annulé")
+        expect(page).to have_content(/Annulé/i)
       end
 
       it "doesnt send notifications email to user if notif is unchecked" do
@@ -356,13 +356,13 @@ RSpec.describe "Adding a user to a collective RDV" do
 
         visit users_rdv_path(rdv)
 
-        expect(page).to have_content("Annulé")
+        expect(page).to have_content(/Annulé/i)
         create(:participation, rdv: rdv2, user: user, status: "revoked")
         rdv2.status = "revoked"
         rdv2.save
 
         visit users_rdv_path(rdv2)
-        expect(page).to have_content("Annulé")
+        expect(page).to have_content(/Annulé/i)
       end
 
       it "doesnt send notifications email to user if notif is unchecked" do

--- a/spec/features/users/user_can_manage_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_rdv_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "User can manage their rdvs" do
         click_on("Annuler le RDV")
         expect(page).to have_content("Confirmation")
         click_link("Oui, annuler le rendez-vous")
-        expect(page).to have_selector(".badge", text: "Annulé")
+        expect(page).to have_selector(".fr-badge", text: "ANNULÉ")
       end
     end
 


### PR DESCRIPTION
# Contexte

On continue à se débarasser des icônes font awesome dans l’interface usager.

# Solution

- On change tous les icônes
- On en profite pour remplacer un bouton Bootstrap par un bouton DSFR
- On utilise des badges DSFR pour les tags « À venir » et « Annulé »

À discuter dans une autre PR avec le trio, est-ce qu’on n'afficherait pas des intitulés plutôt qu'uniquement les pictos ?

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/58589317-b042-4eb8-93ab-5cd616509b03) | ![image](https://github.com/user-attachments/assets/8bd01c54-c93a-4e53-beb0-1ea074430c38)
![image](https://github.com/user-attachments/assets/753ad3c8-75c4-4d34-9552-143cdef35aff) | ![image](https://github.com/user-attachments/assets/c4944807-79eb-45b4-a60d-a7a90efa164f)


