### PR TITLE
Passage d’un meeting_point_id vide à l’appel API ANTS status

### DIFF
--- a/app/lib/ants_api.rb
+++ b/app/lib/ants_api.rb
@@ -21,8 +21,11 @@ class AntsApi
 
   class << self
     def status(ants_pre_demande_number:, timeout: nil)
-      response_body = request(:get, "status", params: { application_ids: ants_pre_demande_number }, timeout: timeout)
-
+      params = {
+        application_ids: ants_pre_demande_number,
+        meeting_point_id: nil, # required but unused cf https://github.com/betagouv/rdv-service-public/pull/4940
+      }
+      response_body = request(:get, "status", params:, timeout:)
       response_body.fetch(ants_pre_demande_number)
     end
 

--- a/app/validators/ants_pre_demande_number_validation.rb
+++ b/app/validators/ants_pre_demande_number_validation.rb
@@ -30,6 +30,7 @@ class AntsPreDemandeNumberValidation < ActiveModel::Validator
     # Si l'API de l'ANTS est fiable, donc si elle renvoie une erreur ou un timeout,
     # on préfère bloquer la réservation et logguer l'erreur.
     record.errors.add(:ants_pre_demande_number, "n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.")
+    Rails.logger.error e
     Sentry.capture_exception(e)
   end
 

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_in_rdv_mairie_spec.rb
@@ -124,10 +124,9 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
   context "ANTS responds with an unexpected error" do
     before do
-      stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=1122334455").to_return(
-        status: 500,
-        body: "Internal Server Error"
-      )
+      stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status")
+        .with(query: hash_including(application_ids: "1122334455"))
+        .to_return(status: 500, body: "Internal Server Error")
     end
 
     it "prevents from creating the user / RDV" do

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -224,10 +224,9 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
     context "ANTS responds with an unexpected error" do
       before do
-        stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=5544332211").to_return(
-          status: 500,
-          body: "Internal Server Error"
-        )
+        stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status")
+          .with(query: hash_including(application_ids: "5544332211"))
+          .to_return(status: 500, body: "Internal Server Error")
       end
 
       it "detects wrong format without calling ANTS API an warns user" do

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
@@ -103,7 +103,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(
           status: 200,
           body: {
@@ -155,7 +155,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(
           status: 200,
           body: {
@@ -208,7 +208,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(
           status: 200,
           body: { "A123456789" => { status: "consumed", appointments: [] } }.to_json
@@ -236,7 +236,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(
           status: 200,
           body: {
@@ -305,7 +305,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "AABBCCDDEE" }, headers:)
+        .with(query: hash_including(application_ids: "AABBCCDDEE"), headers:)
         .to_return(status: 200, body: { "AABBCCDDEE" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
@@ -345,7 +345,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
@@ -385,7 +385,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(status: 200, body: { "A123456789" => { status: "validated", appointments: [] } }.to_json)
     end
     let!(:create_stub) do
@@ -425,7 +425,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
 
     let!(:status_stub) do
       stub_request(:get, "#{api_url}/status")
-        .with(query: { application_ids: "A123456789" }, headers:)
+        .with(query: hash_including(application_ids: "A123456789"), headers:)
         .to_return(
           status: 200,
           body: {

--- a/spec/services/ants_api_spec.rb
+++ b/spec/services/ants_api_spec.rb
@@ -4,14 +4,16 @@ RSpec.describe AntsApi, type: :service do
   describe ".status" do
     context "when credentials are incorrect" do
       before do
-        stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=1122334455").to_return(
-          status: 401,
-          body: <<~JSON
-            {
-              "detail": "X-RDV-OPT-AUTH-TOKEN header invalid"
-            }
-          JSON
-        )
+        stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status")
+          .with(query: hash_including(application_ids: "1122334455"))
+          .to_return(
+            status: 401,
+            body: <<~JSON
+              {
+                "detail": "X-RDV-OPT-AUTH-TOKEN header invalid"
+              }
+            JSON
+          )
       end
 
       it "raises an error" do

--- a/spec/support/ants_stubs.rb
+++ b/spec/support/ants_stubs.rb
@@ -1,8 +1,10 @@
 def stub_ants_status(application_id, status: "validated", appointments: [])
-  stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status?application_ids=#{application_id}").to_return(
-    status: 200,
-    body: { application_id => { status: status, appointments: appointments } }.to_json
-  )
+  stub_request(:get, "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api/status")
+    .with(query: hash_including(application_ids: application_id))
+    .to_return(
+      status: 200,
+      body: { application_id => { status: status, appointments: appointments } }.to_json
+    )
 end
 
 def stub_ants_create(application_id)


### PR DESCRIPTION
# Contexte

Je m’apprête à faire des modifications dans le parcours de prise de RDV pour les motifs ANTS (dans un premier temps, l’ajout de la validation des numéros ANTS passés pour les proches).

On a été informés le 23/12/2024 par l’ANTS que le `meeting_point_id` devient obligatoire sur leur endpoint d’API `status`. 
On ne comprend pas à quoi il sert et comment l’utiliser sur cet endpoint, on leur a posé la question cf [ce ticket gitlab](https://gitlab.com/france-titres/rendez-vous-mairie/interaction-avec-les-editeurs/-/issues/101).

Cette obligation est déjà effective sur l’environnement de preprod. 
Notre implémentation actuelle échoue, on ne peut pas passer l’étape de validation du numéro ANTS en local et en démo. 
Les specs passent car on stubbe les requêtes.

J’ai vérifié et ce n’est pas le cas en prod, le param `meeting_point_id` est toujours facultatif et notre implémentation continue de fonctionner, heureusement 😅 

# Solution

Je propose ici de simplement débloquer la situation en passant un `meeting_point_id` vide lors de nos appels au endpoint `status`. 
Cela fonctionne 🤷 

Si on doit effectivement passer le `meeting_point_id` ça va demander des changements un peu plus compliqués car notre validation se fait sur le user et pas sur le RDV donc compliqué de retrouver l’ID du lieu.

J’ai vérifié que passer une valeur vide en prod ne changeait pas les résultats.

# Code

- Dans un premier commit on générise les `stub_request("/status?appointment_ids=2345")` en `stub_request("/status").with(query: hash_including(appointment_ids: "2345"))` 
- Dans le secon commit on rajoute le paramètre ignoré `meeting_point_id=nil` et je ne le rajoute pas dans les tests, comme ça on pourra le supprimer le cas échéant

# Comment tester

Le plus simple est de tester en local : 
- dans votre fichier `.env` définir `ANTS_RDV_API_URL=https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api`
- toujours dans votre fichier `.env` définir `ANTS_RDV_OPT_AUTH_TOKEN` en récupérant sa valeur sur vaultwarden **pour l’env d’intégration / preprod**
- aller sur http://www.rdv-mairie.localhost:3000/
- chercher un rdv de passeport à sannois
- renseigner un numéro de prédemande comme `RDVSPUB001` cf https://github.com/betagouv/rdv-service-public/blob/production/docs/interconnexions/ants.md