### PR TITLE
Utilisation de boutons DSFR dans le déplacement de RDV

### DIFF
--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -4,7 +4,7 @@ div id="creneaux-lieu-#{lieu&.id}"
     - if date_range.begin > Time.zone.today
       .col-12.col-md-auto.mb-2.mb-md-0.d-flex.align-items-center.justify-content-center
         = link_to "", prendre_rdv_path(query_params.merge(date: previous_from_date)), class: "fr-btn fr-icon-arrow-left-s-line fr-hidden fr-unhidden-md", aria: { label: "Semaine précédente" }
-        = link_to "sem. précédente", prendre_rdv_path(query_params.merge(date: previous_from_date)), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md fr-hidden-lg", aria: { label: "Semaine précédente" }
+        = link_to "sem. précédente", prendre_rdv_path(query_params.merge(date: previous_from_date)), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md", aria: { label: "Semaine précédente" }
 
     .col
       .row
@@ -43,4 +43,4 @@ div id="creneaux-lieu-#{lieu&.id}"
     - if params[:date].blank? || !context.after_max_public_booking_delay?(params[:date].to_date + 6.days)
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
         = link_to "", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class: "fr-btn fr-icon-arrow-right-s-line fr-hidden fr-unhidden-md", aria: { label: "semaine suivante"}
-        = link_to "sem. prochaine", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class:  "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md fr-hidden-lg", aria: { label: "semaine suivante"}
+        = link_to "sem. prochaine", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class:  "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md", aria: { label: "semaine suivante"}

--- a/app/views/users/rdvs/_creneaux.html.slim
+++ b/app/views/users/rdvs/_creneaux.html.slim
@@ -1,7 +1,7 @@
 - if @all_creneaux.blank?
   .bg-info.rdv-color-white.p-2.mb-3 Malheureusement, tous les créneaux sont pris. Vous recevrez d'autres propositions si un créneau se libère. La date de votre RDV reste le #{I18n.l(@rdv.starts_at, format: :human)}.
   .py-4.border-bottom.rdv-text-align-center
-    = link_to "Retour au RDV", users_rdv_path(@rdv), class: "btn btn-primary"
+    = link_to "Retour au RDV", users_rdv_path(@rdv), class: "fr-btn"
 - else
   .card
     .card-body
@@ -10,7 +10,7 @@
         - if @date_range.begin > Time.zone.today
           .col-12.col-md-auto.mb-2.mb-md-0.d-flex.align-items-center.justify-content-center
             = link_to "", creneaux_users_rdv_path(@rdv, date: previous_from_date), class: "fr-btn fr-icon-arrow-left-s-line fr-hidden fr-unhidden-md", aria: { label: "Semaine précédente" }
-            = link_to "sem. précédente", creneaux_users_rdv_path(@rdv, date: previous_from_date), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md fr-hidden-lg", aria: { label: "Semaine précédente" }
+            = link_to "sem. précédente", creneaux_users_rdv_path(@rdv, date: previous_from_date), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md", aria: { label: "Semaine précédente" }
 
         .col
           .row
@@ -34,7 +34,7 @@
         - if @date_range.end < @all_creneaux.last.starts_at.to_date
           .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
             = link_to "", creneaux_users_rdv_path(@rdv, date: @date_range.end + 1.day), class: "fr-btn fr-icon-arrow-right-s-line fr-hidden fr-unhidden-md", aria: { label: "semaine suivante"}
-            = link_to "sem. prochaine", creneaux_users_rdv_path(@rdv, date: @date_range.end + 1.day), class: "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md fr-hidden-lg", aria: { label: "semaine suivante"}
+            = link_to "sem. prochaine", creneaux_users_rdv_path(@rdv, date: @date_range.end + 1.day), class: "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md", aria: { label: "semaine suivante"}
 
       .row
         .col.pt-4

--- a/app/views/users/rdvs/_creneaux.html.slim
+++ b/app/views/users/rdvs/_creneaux.html.slim
@@ -1,7 +1,7 @@
 - if @all_creneaux.blank?
   .bg-info.rdv-color-white.p-2.mb-3 Malheureusement, tous les créneaux sont pris. Vous recevrez d'autres propositions si un créneau se libère. La date de votre RDV reste le #{I18n.l(@rdv.starts_at, format: :human)}.
   .py-4.border-bottom.rdv-text-align-center
-      = link_to "Retour au RDV", users_rdv_path(@rdv), class: "btn btn-primary"
+    = link_to "Retour au RDV", users_rdv_path(@rdv), class: "btn btn-primary"
 - else
   .card
     .card-body
@@ -9,10 +9,8 @@
         - previous_from_date = @date_range.begin - 7.days
         - if @date_range.begin > Time.zone.today
           .col-12.col-md-auto.mb-2.mb-md-0.d-flex.align-items-center.justify-content-center
-            = link_to creneaux_users_rdv_path(@rdv, date: previous_from_date), remote: true, class: "btn btn-primary", data: { disable_with: "..." } do
-              i.fa.fa-chevron-left
-              span.d-md-none.ml-1<
-                | sem. précédente
+            = link_to "", creneaux_users_rdv_path(@rdv, date: previous_from_date), class: "fr-btn fr-icon-arrow-left-s-line fr-hidden fr-unhidden-md", aria: { label: "Semaine précédente" }
+            = link_to "sem. précédente", creneaux_users_rdv_path(@rdv, date: previous_from_date), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md fr-hidden-lg", aria: { label: "Semaine précédente" }
 
         .col
           .row
@@ -24,16 +22,19 @@
                   = l(date, format: "%d %b")
                 - creneaux_for_date = @creneaux.group_by { |c| c.starts_at.to_date }.select { |k, v| k == date }
 
-                - creneaux_for_date.each_value do |creneaux|
-                  - creneaux.sort.each do |creneau|
-                    = link_to l(creneau.starts_at, format: "%H:%M"), edit_users_rdv_path(@rdv, starts_at: creneau.starts_at, agent_id: creneau.agent.id), class: "btn btn-light mr-1 mb-1 w-100"
+                - if creneaux_for_date.any?
+                  .fr-grid-row
+                    - creneaux_for_date.each_value do |creneaux|
+                      - creneaux.sort.each do |creneau|
+                        = link_to l(creneau.starts_at, format: "%H:%M"), edit_users_rdv_path(@rdv, starts_at: creneau.starts_at, agent_id: creneau.agent.id), class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center"
+                - else
+                  p.rdv-text-align-center.fr-text--sm
+                      | Pas de créneau disponible
 
         - if @date_range.end < @all_creneaux.last.starts_at.to_date
           .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
-            = link_to creneaux_users_rdv_path(@rdv, date: @date_range.end + 1.day), remote: true, class: "btn btn-primary", data: { disable_with: "..." } do
-              span.d-md-none.mr-1
-                | sem. prochaine
-              i.fa.fa-chevron-right
+            = link_to "", creneaux_users_rdv_path(@rdv, date: @date_range.end + 1.day), class: "fr-btn fr-icon-arrow-right-s-line fr-hidden fr-unhidden-md", aria: { label: "semaine suivante"}
+            = link_to "sem. prochaine", creneaux_users_rdv_path(@rdv, date: @date_range.end + 1.day), class: "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md fr-hidden-lg", aria: { label: "semaine suivante"}
 
       .row
         .col.pt-4


### PR DESCRIPTION
# Contexte

Comme cela a été fait pour la recherche de RDV, on utilise des boutons DSFR pour le déplacement de RDV.
Voir https://github.com/betagouv/rdv-service-public/pull/4929

# Solution

> [!NOTE]
> Ici on a pris le parti de changer uniquement les boutons sans revoir l’UX. Des propositions sont en train d’être étudiées pour améliorer l’UX de la sélection de créneau. Cela sera traité dans d’autres PR.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/3ee4de25-bf3b-44f7-9f87-54ccbb1d1e1e) | ![image](https://github.com/user-attachments/assets/56b12f6a-fc89-4114-ba89-376296026e46)
![image](https://github.com/user-attachments/assets/61bc4538-9c2a-4cee-953c-8601fc06493b) | ![image](https://github.com/user-attachments/assets/d1372874-aab8-46c7-b52b-95c1458ba949)
