### PR TITLE
Utiliser `Agent::TeamPolicy` dans le filtre du formulaire "Trouver un RDV"

### DIFF
--- a/app/controllers/admin/creneaux_search_controller.rb
+++ b/app/controllers/admin/creneaux_search_controller.rb
@@ -59,9 +59,9 @@ class Admin::CreneauxSearchController < AgentAuthController
 
   def prepare_form
     @motifs = Agent::MotifPolicy::Scope.apply(current_agent, current_organisation.motifs).active.ordered_by_name
-    @services = Service.where(id: @motifs.pluck(:service_id).uniq)
+    @services = Service.where(id: @motifs.map(&:service_id).uniq)
     @form.service_id = @services.first.id if @services.count == 1
-    @teams = current_organisation.territory.teams
+    @teams = Agent::TeamPolicy::Scope.apply(current_agent, current_territory.teams)
     @agents = policy_scope(Agent, policy_scope_class: Agent::AgentPolicy::Scope)
       .joins(:organisations).where(organisations: { id: current_organisation.id })
       .complete.active.ordered_by_last_name

--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -19,11 +19,11 @@ class AgentCreneauxSearchForm
   end
 
   def users
-    organisation.users.where(id: user_ids) if user_ids.present?
+    organisation.users.where(id: user_ids)
   end
 
   def teams
-    organisation.territory.teams.where(id: team_ids) if team_ids.present?
+    organisation.territory.teams.where(id: team_ids)
   end
 
   def date_range

--- a/app/form_models/agent_creneaux_search_form.rb
+++ b/app/form_models/agent_creneaux_search_form.rb
@@ -7,23 +7,23 @@ class AgentCreneauxSearchForm
   validates :organisation_id, :motif, presence: true
 
   def organisation
-    Organisation.find_by(id: organisation_id)
+    Organisation.find_by(id: organisation_id) if organisation_id.present?
   end
 
   def service
-    Service.find_by(id: service_id)
+    Service.find_by(id: service_id) if service_id.present?
   end
 
   def motif
-    organisation.motifs.find_by(id: motif_id)
+    organisation.motifs.find_by(id: motif_id) if motif_id.present?
   end
 
   def users
-    organisation.users.where(id: user_ids)
+    organisation.users.where(id: user_ids) if user_ids.present?
   end
 
   def teams
-    organisation.territory.teams.where(id: team_ids)
+    organisation.territory.teams.where(id: team_ids) if team_ids.present?
   end
 
   def date_range

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -69,7 +69,7 @@ h1
         = t(".agent_teams_legend")
       = simple_form_for @agent, url: update_teams_admin_territory_agent_path(current_territory, @agent) do |f|
         .card-body
-          = f.input :team_ids, collection: current_territory.teams.ordered_by_name,
+          = f.input :team_ids, collection: Agent::TeamPolicy::Scope.apply(current_agent, current_territory.teams).ordered_by_name,
                 label: t(".teams"),
                 label_method: :name,
                 input_html: { \

--- a/spec/controllers/admin/creneaux_search_controller_spec.rb
+++ b/spec/controllers/admin/creneaux_search_controller_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Admin::CreneauxSearchController do
   let(:organisation) { create(:organisation) }
 
   context "with a secretaire signed_in" do
-    let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }
+    let(:agent) { create(:agent, :secretaire, :with_territory_access_rights, basic_role_in_organisations: [organisation]) }
 
     before { sign_in agent }
 
@@ -12,7 +12,7 @@ RSpec.describe Admin::CreneauxSearchController do
       expect(response).to render_template("index")
     end
 
-    it "assignses form with user_ids" do
+    it "assigns form with user_ids" do
       user = create(:user)
       get :index, params: { organisation_id: organisation.id, user_ids: [user.id] }
       expect(assigns(:form).user_ids).to eq([user.id.to_s])


### PR DESCRIPTION
Suite à [une discussion sur le sens et l'usage de la policy des équipes](https://github.com/betagouv/rdv-service-public/pull/4938/files#r1900969201), je propose ici d'utiliser `Agent::TeamPolicy::Scope` pour déterminer quelles équipes afficher dans :
- le filtre de l'interface "Trouver un RDV"
- le filtre de la liste des agents de l'admin de territoire