### PR TITLE
[Perf] Précharger les associations de la liste de RDVs de l'API

### DIFF
--- a/app/controllers/api/v1/rdvs_controller.rb
+++ b/app/controllers/api/v1/rdvs_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::RdvsController < Api::V1::AgentAuthBaseController
     rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).where(params.permit(:organisation_id))
     rdvs = rdvs.starts_after(Time.zone.parse(params[:starts_after])) if params[:starts_after].present?
     rdvs = rdvs.starts_before(Time.zone.parse(params[:starts_before])) if params[:starts_before].present?
+    rdvs = rdvs.includes(:organisation, :motif, :lieu, :agents, :users, participations: [:user], motif: [:motif_category])
     render_collection(rdvs)
   end
 end


### PR DESCRIPTION
J'ai remarqué sur Skylight que tous nos appels vers l'API de liste des RDVs prennent entre 1100-1500ms, alors qu'il s'agit d'une page de 100 RDVs.

Certes le blueprint inclus beaucoup d'associations (les users sont inclus un fois à travers les participations et une second fois à la racine...), mais la raison principale est les requêtes N+1.

Testé en local, ce préchargement devrait dramatiquement réduire le temps d'exécution de cet endpoint.

# Avant (6 janvier 2025)

https://www.skylight.io/app/applications/RgR7i58P67xN/recent/6h/endpoints/Api::V1::RdvsController%23index?responseType=json

![image](https://github.com/user-attachments/assets/c3c51ea8-b04a-48b6-8e7e-deecb6af8644)

# Après (11 janvier 2025)

![image](https://github.com/user-attachments/assets/39bbff00-6126-4185-8483-e1568cfb24e2)
