### PR TITLE
amélioration de la validation des emails via Devise

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -221,10 +221,15 @@ Devise.setup do |config|
   # Range for password length.
   config.password_length = 12..128
 
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/
+  # Email regex used to validate email formats.
+  config.email_regexp = /\A
+    [A-Za-z0-9_%+-]     # the first letter cannot be a dot
+    [A-Za-z0-9._%+-]+   # the rest can include dots
+    @
+    [A-Za-z0-9-]+
+    (\.[A-Za-z0-9-]+)*  # subdomains
+    \.[A-Za-z]{2,}      # TLD cannot be shorter than 2 letters
+  \z/x # x = extended mode = whitespaces ignored + allow comments
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/spec/form_models/users/registration_form_spec.rb
+++ b/spec/form_models/users/registration_form_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe Users::RegistrationForm, type: :form_model do
       expect(form.errors.attribute_names).to contain_exactly(:email)
     end
 
+    it "does not allow invalid email with single letter domain name" do
+      form = described_class.new(first_name: "Jean", last_name: "Jacques", email: "jean@j.f")
+      expect(form.valid?).to be(false)
+      expect(form.user.errors.count).to eq 1
+      expect(form.user.errors.first.attribute).to eq :email
+      expect(form.user.errors.first.type).to eq :invalid
+    end
+
+    it "does not allow invalid email that starts with a dot" do
+      form = described_class.new(first_name: "Jean", last_name: "Jacques", email: ".jean@jacques.fr")
+      expect(form.valid?).to be(false)
+      expect(form.user.errors.count).to eq 1
+      expect(form.user.errors.first.attribute).to eq :email
+      expect(form.user.errors.first.type).to eq :invalid
+    end
+
     it "also validates user model errors" do
       form = described_class.new(attributes.except(:first_name))
       form.save


### PR DESCRIPTION
# Contexte

[Cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/140291) correspond à une adresse email destinataire qui commence par un `.` : `.nom@sfr.fr`.

# Solution

Je propose d’adapter la regexp pour interdire les points en début d’email.

J’en profite pour passer la regexp existante sur plusieurs lignes et rajouter un test pour un cas existant déjà traité mais non testé (à ma connaissance).