### PR TITLE
Ne pas exclure les jours fériés pour Visioplainte

### DIFF
--- a/app/controllers/api/visioplainte/base_controller.rb
+++ b/app/controllers/api/visioplainte/base_controller.rb
@@ -14,7 +14,7 @@ class Api::Visioplainte::BaseController < ActionController::Base # rubocop:disab
     return unless ENV["VISIOPLAINTE_API_KEY"].start_with?("visioplainte-staging-api-key-")
     return unless ENV["FRANCECONNECT_HOST"] == "fcp.integ01.dev-franceconnect.fr"
 
-    territory = Territory.find_by(name: Territory::VISIOPLAINTE_NAME)
+    territory = Territory.visioplainte.first
 
     territory.organisations.find_each do |organisation|
       organisation.plage_ouvertures.delete_all

--- a/app/controllers/api/visioplainte/creneaux_controller.rb
+++ b/app/controllers/api/visioplainte/creneaux_controller.rb
@@ -38,7 +38,7 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
   end
 
   def self.find_motif
-    Motif.joins(organisation: :territory).where(territories: { name: Territory::VISIOPLAINTE_NAME })
+    Motif.joins(organisation: :territory).merge(Territory.visioplainte)
       .joins(:service).find_by(service: { name: GENDARMERIE_SERVICE_NAME })
   end
 

--- a/app/controllers/api/visioplainte/guichets_controller.rb
+++ b/app/controllers/api/visioplainte/guichets_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::Visioplainte::GuichetsController < Api::Visioplainte::BaseController
   def self.guichets
-    Agent.joins(roles: { organisation: :territory }).where(territories: { name: Territory::VISIOPLAINTE_NAME })
+    Agent.joins(roles: { organisation: :territory }).merge(Territory.visioplainte)
       .where(roles: { access_level: AgentRole::ACCESS_LEVEL_INTERVENANT })
       .joins(:services).where(services: { name: GENDARMERIE_SERVICE_NAME })
   end

--- a/app/controllers/api/visioplainte/rdvs_controller.rb
+++ b/app/controllers/api/visioplainte/rdvs_controller.rb
@@ -89,7 +89,7 @@ class Api::Visioplainte::RdvsController < Api::Visioplainte::BaseController
   end
 
   def authorized_rdv_scope
-    Rdv.joins(organisation: :territory).where(territories: { name: Territory::VISIOPLAINTE_NAME })
+    Rdv.joins(organisation: :territory).merge(Territory.visioplainte)
   end
 
   def motif

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -68,6 +68,7 @@ class Territory < ApplicationRecord
     where(id: Organisation.with_upcoming_rdvs.distinct.select(:territory_id))
   }
   scope :ordered_by_name, -> { order(Arel.sql("unaccent(LOWER(territories.name))")) }
+  scope :visioplainte, -> { where(name: VISIOPLAINTE_NAME) }
 
   ## -
 
@@ -100,6 +101,10 @@ class Territory < ApplicationRecord
 
   def cn?
     name == CNFS_NAME
+  end
+
+  def visioplainte?
+    name == VISIOPLAINTE_NAME
   end
 
   def sectorized?

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -14,7 +14,7 @@ module CreneauxSearch::Calculator
       scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
-        .includes(:agent)
+        .includes(:agent, :organisation, organisation: :territory)
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?
       scope
@@ -173,6 +173,8 @@ module CreneauxSearch::Calculator
     end
 
     def busy_times_from_off_days
+      return [] if @plage_ouverture.organisation.territory.visioplainte?
+
       OffDays.all_in_date_range(range).map do |off_day|
         BusyTime.new(off_day.beginning_of_day, off_day.end_of_day)
       end

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -14,7 +14,8 @@ module CreneauxSearch::Calculator
       scope = PlageOuverture.not_expired
         .merge(motif.plage_ouvertures)
         .in_range(datetime_range)
-        .includes(:agent, :organisation, organisation: :territory)
+        .includes(:agent)
+      scope = scope.includes(:organisation, organisation: :territory) if motif.organisation.territory.visioplainte?
       scope = scope.where(agent: agents) if agents&.any?
       scope = scope.where(lieu: lieu) if lieu.present?
       scope

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -49,6 +49,7 @@
       - else
         = t(".create_absence_for", full_name: @agent.full_name_or_email)
 
-.alert.alert-dismissible.alert-info
-  i.fa.fa-info-circle
-  = " Les jours fériés sont automatiquement considérés comme indisponibles."
+- unless current_territory.visioplainte?
+  .alert.alert-dismissible.alert-info
+    i.fa.fa-info-circle
+    = " Les jours fériés sont automatiquement considérés comme indisponibles."

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -11,12 +11,13 @@
   = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: current_organisation
 
 ruby:
-  sources = [
+  event_sources = [
     admin_api_agenda_rdvs_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json),
     admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json),
     admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, in_background: true, format: :json),
   ]
-  sources.push(OffDays.to_full_calendar_array) unless current_territory.visioplainte?
+  event_sources.push(OffDays.to_full_calendar_array) unless current_territory.visioplainte?
+
 #calendar[
   data-default-date-json="#{@date&.to_json}"
   data-agent-id="#{@agent.id}"
@@ -24,7 +25,7 @@ ruby:
   data-organisation-id="#{@organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
   data-display-sundays="#{current_territory.visioplainte?}"
-  data-event-sources-json="#{sources.to_json}"
+  data-event-sources-json="#{event_sources.to_json}"
   data-sign-in-path="#{new_agent_session_path}"
 ]
 .mt-3.flex-grow-1.text-right

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -16,7 +16,7 @@
   data-selected-event-id="#{@selected_event_id}"
   data-organisation-id="#{@organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
-  data-display-sundays="#{current_territory.name == Territory::VISIOPLAINTE_NAME}"
+  data-display-sundays="#{current_territory.visioplainte?}"
   data-event-sources-json="#{[admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json), admin_api_agenda_rdvs_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json), admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, in_background: true, format: :json), OffDays.to_full_calendar_array].to_json}"
   data-sign-in-path="#{new_agent_session_path}"
 ]

--- a/app/views/admin/agent_agendas/show.html.slim
+++ b/app/views/admin/agent_agendas/show.html.slim
@@ -10,6 +10,13 @@
 - content_for :breadcrumb do
   = render "layouts/rdv_a_renseigner", agent: current_agent, organisation: current_organisation
 
+ruby:
+  sources = [
+    admin_api_agenda_rdvs_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json),
+    admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json),
+    admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, in_background: true, format: :json),
+  ]
+  sources.push(OffDays.to_full_calendar_array) unless current_territory.visioplainte?
 #calendar[
   data-default-date-json="#{@date&.to_json}"
   data-agent-id="#{@agent.id}"
@@ -17,7 +24,7 @@
   data-organisation-id="#{@organisation.id}"
   data-display-saturdays="#{current_agent.display_saturdays}"
   data-display-sundays="#{current_territory.visioplainte?}"
-  data-event-sources-json="#{[admin_api_agenda_absences_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json), admin_api_agenda_rdvs_path(agent_id: @agent, organisation_id: current_organisation.id, format: :json), admin_api_agenda_plage_ouvertures_path(agent_id: @agent, organisation_id: current_organisation.id, in_background: true, format: :json), OffDays.to_full_calendar_array].to_json}"
+  data-event-sources-json="#{sources.to_json}"
   data-sign-in-path="#{new_agent_session_path}"
 ]
 .mt-3.flex-grow-1.text-right

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -24,7 +24,7 @@
 
       .weekly-select
         - weekdays = { Lundi: "monday", Mardi: "tuesday", Mercredi: "wednesday", Jeudi: "thursday", Vendredi: "friday", Samedi: "saturday" }
-        - weekdays[:Dimanche] = "sunday" if current_territory.name == Territory::VISIOPLAINTE_NAME
+        - weekdays[:Dimanche] = "sunday" if current_territory.visioplainte?
         = n.input :on, as: :check_boxes, label: "Répéter les", collection: weekdays, include_blank: false, input_html: { data: { target: "recurrence.on", action: "recurrence#updateRecurrence" }, class: "js-recurrence-on js-recurrence-input" }
 
       .monthly-select.form-group

--- a/spec/services/creneaux_search/calculator_spec.rb
+++ b/spec/services/creneaux_search/calculator_spec.rb
@@ -358,6 +358,19 @@ RSpec.describe CreneauxSearch::Calculator, type: :service do
       expected_ranges = [prev_rdv.ends_at..rdv.starts_at, rdv.ends_at..ends_at]
       expect(described_class.calculate_free_times(plage_ouverture, range)).to eq(expected_ranges)
     end
+
+    it "truncates off days (jours féries) from the ranges" do
+      xmas_week = Date.new(2024, 12, 23)..Date.new(2024, 12, 27)
+      plage_ouverture = create(:plage_ouverture, :weekdays, first_day: Date.new(2024, 12, 23), start_time: Tod::TimeOfDay.new(9), end_time: Tod::TimeOfDay.new(11))
+      computed_dates = proc { described_class.calculate_free_times(plage_ouverture, xmas_week).map(&:begin).map(&:to_date) }
+
+      # Par défaut les jours fériés ne sont pas travaillés
+      expect(computed_dates.call).to eq(xmas_week.to_a - [Date.new(2024, 12, 25)])
+
+      # Les agents de visioplainte travaillent les jours fériés
+      plage_ouverture.organisation.territory.update_columns(name: Territory::VISIOPLAINTE_NAME) # rubocop:disable Rails/ SkipsModelValidations
+      expect(computed_dates.call).to eq(xmas_week.to_a)
+    end
   end
 
   describe "#split_range_recursively" do

--- a/spec/services/off_days_spec.rb
+++ b/spec/services/off_days_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe OffDays, type: :service do
   it "is up to date" do
     # Il faut ajouter de nouveaux jours fériés si cette spec échoue
-    expect(described_class::JOURS_FERIES.to_a.last).to be > 3.months.from_now
+    expect(described_class::JOURS_FERIES.max).to be > 3.months.from_now
   end
 
   describe ".all_in_date_range" do


### PR DESCRIPTION
Closes #4946

# Contexte

Tout le contexte est dans l'issue. :ok_hand: 

# Solution

Peu de surprise sur les implémentation, c'est un switch sur le nom du territoire.

J'ai choisi d'introduire des helpers sur la classe `Territory` pour encapsuler la notion de "territoire Visioplainte". On commençait à avoir beaucoup d'usages de `Territory::VISIOPLAINTE_NAME`, je me suis dit que c'était plus concis d'encapsuler, même si le gain en lisibilité est discutable (surtout la scope qui est étrange car elle ne peut matcher qu'un record :shrug: ).

## Captures d'écran

### Avant

![image](https://github.com/user-attachments/assets/10231377-cb46-4263-9865-4a26fa1d2988)

### Après

![image](https://github.com/user-attachments/assets/a73b7e8d-0a6f-46f8-8b4d-ff72c3d17efa)

### Avant

![image](https://github.com/user-attachments/assets/f4b3cccd-c43a-4dab-a620-4f661ebe7214)

### Après

![image](https://github.com/user-attachments/assets/4c039641-d8e9-487a-8046-6d488e742a0c)
