### PR TITLE
Migration de la barre de recherche d’adresse au DSFR

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -23,8 +23,8 @@ $(document).on('turbolinks:load', function() {
   if (departementInput) {
     departementInput.addEventListener('change', event => {
       const valid = [2, 3].includes(departementInput.value.length)
-      whereInput.classList.toggle('is-valid', valid)
-      whereInput.classList.toggle('is-invalid', !valid)
+      whereInput.classList.toggle('fr-input--valid', valid)
+      whereInput.classList.toggle('fr-input--error', !valid)
       $(submitButton).attr('disabled', !valid)
     })
   }

--- a/app/javascript/stylesheets/components/_autocomplete.scss
+++ b/app/javascript/stylesheets/components/_autocomplete.scss
@@ -8,6 +8,7 @@
 .algolia-autocomplete .aa-input,
 .algolia-autocomplete .aa-hint {
   width: 100%;
+  line-height: 2rem;
 }
 .algolia-autocomplete .aa-hint {
   color: #999;

--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -1,7 +1,7 @@
-section.rdv-background-color-flat-blue-ecume.fr-py-4w
-  .fr-container.mb-4
-    .d-flex.justify-content-center
-      = link_to("https://cartographie.societenumerique.gouv.fr/", target: "_blank", class: "btn btn-outline-light btn-lg") do
+section.rdv-background-color-alt-blue-ecume.fr-py-4w
+  .fr-container.fr-mb-4w
+    .d-flex.rdv-justify-content-center
+      = link_to("https://cartographie.societenumerique.gouv.fr/", target: "_blank", class: "fr-btn fr-btn--lg") do
         | Consulter la carte des lieux d'inclusion numérique
 section.fr-py-4w
   .fr-container

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -1,16 +1,16 @@
 section.rdv-background-color-alt-blue-ecume.fr-pt-4w.fr-pb-8w
   .fr-container
     #search_form.fr-col-lg-10.fr-col-offset-lg-1
-      = form_with url: prendre_rdv_path, method: :get do |f|
-        = hidden_field :search, :departement, value: context.departement, name: "departement"
+      = form_with url: prendre_rdv_path, method: :get, scope: :search do |f|
+        = f.hidden_field :departement, value: context.departement, name: "departement"
         - if context.prescripteur?
-          = hidden_field :search, :prescripteur, name: "prescripteur", value: 1
-        = hidden_field :search, :city_code, name: "city_code", value: context.city_code
-        = hidden_field :search, :street_ban_id, name: "street_ban_id", value: context.street_ban_id
-        = hidden_field :search, :latitude, name: "latitude", value: context.latitude
-        = hidden_field :search, :longitude, name: "longitude", value: context.longitude
+          = f.hidden_field :prescripteur, name: "prescripteur", value: 1
+        = f.hidden_field :city_code, name: "city_code", value: context.city_code
+        = f.hidden_field :street_ban_id, name: "street_ban_id", value: context.street_ban_id
+        = f.hidden_field :latitude, name: "latitude", value: context.latitude
+        = f.hidden_field :longitude, name: "longitude", value: context.longitude
         / TODO: change input name to address and change whereInput in application.js
         .fr-search-bar.fr-search-bar--lg[role="search"]
-          = text_field_tag :search_where, context.address, label: false, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input places-js-container"
-          = button_tag :button, id: "search_submit", class: "fr-btn", disabled: true do
+          = f.text_field :where, label: false, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input places-js-container", required: true, value: context.address
+          = button_tag :button, id: "search_submit", class: "fr-btn" do
             | Rechercher

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -1,18 +1,16 @@
-section.rdv-background-color-flat-blue-ecume.fr-pt-4w.fr-pb-8w
+section.rdv-background-color-alt-blue-ecume.fr-pt-4w.fr-pb-8w
   .fr-container
-    #search_form
-      = simple_form_for :search, url: prendre_rdv_path, method: :get do |f|
-        = f.input :departement, as: :hidden, input_html: { name: "departement", value: context.departement }
+    #search_form.fr-col-lg-10.fr-col-offset-lg-1
+      = form_with url: prendre_rdv_path, method: :get do |f|
+        = hidden_field :search, :departement, value: context.departement, name: "departement"
         - if context.prescripteur?
-          = f.input :prescripteur, as: :hidden, input_html: { name: "prescripteur", value: 1 }
-        = f.input :city_code, as: :hidden, input_html: { name: "city_code", value: context.city_code }
-        = f.input :street_ban_id, as: :hidden, input_html: { name: "street_ban_id", value: context.street_ban_id }
-        = f.input :latitude, as: :hidden, input_html: { name: "latitude", value: context.latitude }
-        = f.input :longitude, as: :hidden, input_html: { name: "longitude", value: context.longitude }
-        .form-row.d-flex.justify-content-md-center
-          / TODO: change input name to address and change whereInput in application.js
-          .col-lg-9= f.input :where, label: "Votre adresse", placeholder: "ex : 21 rue Anatole France, Calais", input_html: { value: context.address, name: "address", class: "form-control-lg places-js-container" }, wrapper_html: { class: "mb-1 mb-lg-0" }
-          .col-lg-3.align-self-end
-            = f.button :button, id: "search_submit", class: "btn-white btn-lg w-100 text-center", disabled: true do
-              span.fr-icon-search-line.fr-mr-1w[aria-hidden="true"]
-              | Rechercher
+          = hidden_field :search, :prescripteur, name: "prescripteur", value: 1
+        = hidden_field :search, :city_code, name: "city_code", value: context.city_code
+        = hidden_field :search, :street_ban_id, name: "street_ban_id", value: context.street_ban_id
+        = hidden_field :search, :latitude, name: "latitude", value: context.latitude
+        = hidden_field :search, :longitude, name: "longitude", value: context.longitude
+        / TODO: change input name to address and change whereInput in application.js
+        .fr-search-bar.fr-search-bar--lg[role="search"]
+          = text_field_tag :search_where, context.address, label: false, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input places-js-container"
+          = button_tag :button, id: "search_submit", class: "fr-btn", disabled: true do
+            | Rechercher

--- a/app/views/search/search_rdv.html.slim
+++ b/app/views/search/search_rdv.html.slim
@@ -1,15 +1,12 @@
 = render "prescription_banner"
 
+= render "banner", context: @context
+
 / Adress selection partials have multiple sections
 - if @context.current_step == :address_selection
   // On fait du spécifique pour la bannière de la page de sélection d'adresse en attendant qu’on fasse la refonte au DSFR
-  section.py-2.rdv-background-color-flat-blue-ecume
-    .fr-container
-      h1.mb-3.rdv-color-white
-        = render(current_domain.search_banner_template_name, context: @context)
   = render(current_domain.address_selection_template_name, context: @context)
 - else
-  = render("banner", context: @context)
   .fr-container
     section.py-4.fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
       = render @context, context: @context


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4953.osc-secnum-fr1.scalingo.io/)

# Contexte

Dans le cadre de la migration des composants au DSFR, on migre la barre de recherche de la page d’accueil de RDVS.
On en profite également pour uniformiser la couleur du bandeau avec les étapes suivantes.

> [!NOTE]
> Le bandeau de couleur, ainsi que la mise en page sera retravaillé dans un prochain build. L’idée ici est uniquement de passer le champ de recherche au DSFR.

# Solution

- Utilisation de la partial du bandeau
- Ajustement du bouton côté RDV Aide Numérique pour le passer au DSFR

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/945d3f59-44bc-4643-a63f-602723fe4f5b) | ![image](https://github.com/user-attachments/assets/dda70368-d36e-4271-940e-fc00fd03cfc7)
![image](https://github.com/user-attachments/assets/188d5a87-c749-4b2b-91c6-1797f7db2b20) | ![image](https://github.com/user-attachments/assets/3eebb8e6-1ca4-4486-9035-1a123ad8ec7f)
![image](https://github.com/user-attachments/assets/b0c4f0d1-9bcb-4fe9-a1c2-919473f2ad53) | ![image](https://github.com/user-attachments/assets/a9b9f5f4-c2d8-40b1-801d-493cb8cde048)
![image](https://github.com/user-attachments/assets/09b13744-f3a3-4677-a8b2-5ebb7b0bdddc) | ![image](https://github.com/user-attachments/assets/420e0889-7535-4079-bb46-5bc746cec303)


