### PR TITLE
La fin des font awesome côté usager 🧹

### DIFF
--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -6,39 +6,39 @@ main.container
       .card
         .card-body
           h3
-            i.fa.fa-check-circle
+            span.fr-icon--lg.fr-icon-success-fill[aria-hidden="true"]
             |< Rendez-vous confirmé
           - rdv = @prescripteur.rdv
           ul.list-group.list-group-flush
             li.list-group-item
-              .fa.fa-calendar>
+              span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
               = rdv_title(rdv)
               = rdv_tag(rdv)
 
             - if rdv.public_office?
               li.list-group-item
-                .fa.fa-map-marker-alt>
+                span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
                 = human_location(rdv)
                 - if rdv.lieu&.phone_number
-                  span>
-                  span.fa.fa-phone>
+                  br
+                  span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
                   = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
             - elsif rdv.phone?
               li.list-group-item
-                .fa.fa-phone>
+                span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
                 | RDV Téléphonique
 
             li.list-group-item
-              .fa.fa-user>
+              span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
               = @prescripteur.user.full_name
               = " (#{@prescripteur.user.phone_number})" if @prescripteur.user.phone_number.present?
             li.list-group-item
-              i.fa.fa-info-circle>
+              span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
               = rdv.motif.name
             - if rdv.motif.instruction_for_rdv.present?
               li.list-group-item
-                i.fa.fa-exclamation-triangle>
+                span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
                 strong Informations supplémentaires&nbsp;:
                 .pl-3.pt-1
                   = instruction_for_rdv_to_html(rdv.motif)

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -10,19 +10,17 @@ main.container
           / Incitation à l'utilisation de la prescription interne
           - if @rdv_wizard.present? && show_agent_prescription_incitation?
             - territory = @rdv_wizard.motif.organisation.territory
-            .alert.alert-success
-              p.mb-0
-                i.fas.fa-lightbulb>
-                | Nouvelle fonctionnalité&nbsp;: Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
-                / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
-                - if !territory.sectorized?
-                  / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire
-                  = link_to user_selection_admin_organisation_prescription_path( \
-                      current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
-                    ) do
-                    | &nbsp;en cliquant ici.
-                - else
-                  | .
+            .fr-alert.fr-alert--info.fr-mb-2w
+              | Nouvelle fonctionnalité&nbsp;: Pour ne pas avoir à remplir ce formulaire pour chaque nouveau rendez-vous et réduire les doublons, vous pouvez utiliser la prescription dans l'espace agent
+              / TODO: faire sauter ce unless une fois que nous avons implémenté la saisie d'adresse dans la prescription interne sans usager selectionnée
+              - if !territory.sectorized?
+                / Le lien de prescription interne redirige vers la premiére organisation de l'agent dans le même territoire
+                = link_to user_selection_admin_organisation_prescription_path( \
+                    current_agent.organisations.find_by(territory: territory), session[:rdv_wizard_attributes].merge(prescripteur: "interne") \
+                  ) do
+                  | &nbsp;en cliquant ici.
+              - else
+                | .
 
               p.mb-0
               span> Pour en savoir plus consultez

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -6,7 +6,7 @@
         = link_to path_to_lieu_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du lieu" do
           .row
             .col-auto.align-self-center
-              i.fa.fa-chevron-left
+              span.fr-icon-arrow-left-line
             .col
               h2.pb-1.mb-1.card-title= context.lieu.name
               .card-subtitle= context.lieu.address
@@ -16,7 +16,7 @@
         = link_to path_to_organisation_selection(params), class: "d-block stretched-link", title: "Retour à la sélection de l’organisation" do
           .row
             .col-auto.align-self-center
-              i.fa.fa-chevron-left
+              span.fr-icon-arrow-left-line
             .col
               h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
               = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -3,7 +3,7 @@
     = link_to path_to_service_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du service" do
       .row
         .col-auto.align-self-center
-          i.fa.fa-chevron-left
+          span.fr-icon-arrow-left-line
         .col
           h2.fr-pb-0.fr-mb-0 = context.service.name
 - if context.unique_motifs_by_name_and_location_type.empty?

--- a/app/views/search/_nothing_to_show_invitation.html.slim
+++ b/app/views/search/_nothing_to_show_invitation.html.slim
@@ -13,7 +13,5 @@
 = mail_to email,
   subject: "[Problème Invitation. Créneaux Indisponibles, motif : #{context.motif_category_name}]",
   cc: "#{'support@rdv-insertion.fr' unless context.organisations_emails.empty?}",
-  class: "btn btn-primary" do
-  span>
-    i.fa.fa-envelope
+  class: "fr-btn fr-btn--icon-left fr-icon-mail-line" do
   | Envoyer une demande d'ouverture de créneaux

--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -5,8 +5,7 @@
         .m-2
           | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
           span>
-          = link_to users_rdvs_path do
-            | vos rendez-vous
+          = link_to "vos rendez-vous", users_rdvs_path
   - else
     - if context.follow_up_motifs?
       .card

--- a/app/views/search/_referent_booking_card.html.slim
+++ b/app/views/search/_referent_booking_card.html.slim
@@ -6,8 +6,6 @@
           | Pour prendre un RDV avec un de vos agents référent, allez sur la page de
           span>
           = link_to users_rdvs_path do
-            i.far.fa-calendar
-            span>
             | vos rendez-vous
   - else
     - if context.follow_up_motifs?

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -3,7 +3,7 @@
     = link_to path_to_motif_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du motif" do
       .row
         .col-auto.align-self-center
-          i.fa.fa-chevron-left
+          span.fr-icon-arrow-left-line
         .col
           h2.pb-1.mb-1
             = motif_name_and_location_type(context.first_matching_motif)

--- a/app/views/users/participations/index.html.slim
+++ b/app/views/users/participations/index.html.slim
@@ -2,42 +2,42 @@
 
 ul.list-group.fr-mb-3w
   li.list-group-item
-    span.fr-icon.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
+    span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
     = @rdv.motif_name
 
   li.list-group-item
-    span.fr-icon.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
+    span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
     = rdv_title(@rdv)
     = rdv_tag(@rdv)
 
   - if @rdv.home?
     li.list-group-item
-      span.fr-icon.fr-icon-home-4-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-home-4-fill.fr-mr-1w[aria-hidden="true"]
       | Ce RDV se déroulera à domicile
 
   - elsif @rdv.public_office?
     li.list-group-item
-      span.fr-icon.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(@rdv)
       - if @rdv.lieu&.phone_number
         br
-        span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+        span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
         = link_to @rdv.lieu.phone_number, "tel:#{@rdv.lieu.phone_number_formatted}"
 
   - elsif @rdv.phone?
     li.list-group-item
-      span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
       | RDV Téléphonique
 
   - if @rdv.motif.instruction_for_rdv.present?
     li.list-group-item
-      span.fr-icon.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
       strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(@rdv.motif)
 
   li.list-group-item
-    span.fr-icon.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
+    span.fr-icon-team-fill.fr-mr-1w[aria-hidden="true"]
     | Participant
 
     = form_tag users_rdv_participations_path(@rdv) do

--- a/app/views/users/rdvs/_file_attente.html.slim
+++ b/app/views/users/rdvs/_file_attente.html.slim
@@ -1,6 +1,6 @@
 - if rdv.available_to_file_attente?
   li.list-group-item
-    span.fr-icon.fr-icon-notification-3-fill.fr-mr-1w[aria-hidden="true"]
+    span.fr-icon-notification-3-fill.fr-mr-1w[aria-hidden="true"]
     | Vous souhaitez prendre RDV plus tôt ?
     - fa = rdv.file_attentes.where(user: current_user).first || FileAttente.new(user: current_user, rdv: rdv)
     = simple_form_for fa, url: users_file_attente_path, html: { method: :post, class: "form-inline" }, wrapper: :inline_form, remote: false  do |f|

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -1,31 +1,31 @@
 ul.list-group.list-group-flush.fr-mb-3w
   li.list-group-item.fr-pl-0.fr-pb-2w
-    span.fr-icon.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
+    span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
     = rdv_title(rdv)
     = rdv_tag(rdv)
 
   - if rdv.motif.restriction_for_rdv.present?
     li.list-group-item.fr-pl-0.fr-py-2w.alert.alert-warning
-      span.fr-icon.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
       = restriction_for_rdv_to_html(rdv.motif)
 
   - if rdv.home?
     li.list-group-item.fr-pl-0.fr-py-2w
-      span.fr-icon.fr-icon-home-4-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-home-4-fill.fr-mr-1w[aria-hidden="true"]
       | Ce RDV se déroulera à domicile
 
   - elsif rdv.public_office?
     li.list-group-item.fr-pl-0.fr-py-2w
-      span.fr-icon.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-building-fill.fr-mr-1w[aria-hidden="true"]
       = human_location(rdv)
       - if rdv.lieu&.phone_number
         br
-        span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+        span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
         = link_to rdv.lieu.phone_number, "tel:#{rdv.lieu.phone_number_formatted}"
 
   - elsif rdv.phone?
     li.list-group-item.fr-pl-0.fr-py-2w
-      span.fr-icon.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-phone-fill.fr-mr-1w[aria-hidden="true"]
       | RDV Téléphonique
       p.fr-mb-1v
         - if current_user.signed_in_with_invitation_token?
@@ -35,14 +35,14 @@ ul.list-group.list-group-flush.fr-mb-3w
 
   - elsif rdv.motif.visio?
     li.list-group-item.fr-pl-0.fr-py-2w
-      span.fr-icon.fr-icon-mac-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-mac-fill.fr-mr-1w[aria-hidden="true"]
       |> RDV par visioconférence
       = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
 
   li.list-group-item.fr-pl-0.fr-py-2w
     .row
       .col
-        span.fr-icon.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
+        span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
         = users_to_sentence(rdv.users)
     - if policy(rdv, policy_class: User::RdvPolicy).can_change_participants?
       .col-auto
@@ -50,12 +50,12 @@ ul.list-group.list-group-flush.fr-mb-3w
         = link_to "modifier", users_rdv_participations_path(rdv)
   - if @can_see_rdv_motif
     li.list-group-item.fr-pl-0.fr-py-2w
-      span.fr-icon.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-draft-fill.fr-mr-1w[aria-hidden="true"]
       = rdv.motif_name
 
   - if rdv.motif.instruction_for_rdv.present?
     li.list-group-item.fr-pl-0.fr-py-2w
-      span.fr-icon.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-warning-fill.fr-mr-1w[aria-hidden="true"]
       strong Informations supplémentaires&nbsp;:
       .pl-3.pt-1
         = instruction_for_rdv_to_html(rdv.motif)
@@ -83,7 +83,7 @@ ul.list-group.list-group-flush.fr-mb-3w
       rdv.in_the_past?
 
     li.list-group-item.font-italic
-      span.fr-icon.fr-icon-close-circle-fill.fr-mr-1w[aria-hidden="true"]
+      span.fr-icon-close-circle-fill.fr-mr-1w[aria-hidden="true"]
       | Ce rendez-vous n'est pas annulable en ligne. Prenez contact avec le secrétariat.
 
 ul.fr-btns-group.fr-btns-group--inline.fr-mb-0


### PR DESCRIPTION
# Contexte

On en termine enfin avec les font awesome côté usagers ! 
Une autre PR arrive pour retirer les imports.

# Solution

L’utilisation de rg pour vérifier qu’on a tout retiré

```bash
cd app/views
rg --pcre2 -i '(?<![a-zA-Z])fa[-\s.]' -g '!admin/' -g '!agents/'
```

## Captures d'écran

Avant | Après
:- | -:
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/f26780b0-9a81-4fb9-bb5f-0a794e1f140f" /> | <img width="1058" alt="image" src="https://github.com/user-attachments/assets/eca48998-ef4b-474e-9403-999042e52e8c" />
![image](https://github.com/user-attachments/assets/638be7a0-d6d8-42cb-bfab-c8f4e254144b) | ![image](https://github.com/user-attachments/assets/48cf9bcc-1a8b-4651-8f9b-a12fa131f5dd)
![image](https://github.com/user-attachments/assets/d3f48bab-68b7-47f4-a20d-74804235a39b) | ![image](https://github.com/user-attachments/assets/cddce7be-bb3f-4d8d-a949-d48aeaefb910)
<img width="998" alt="image" src="https://github.com/user-attachments/assets/16f4e793-639b-40b1-a1b4-1366b12b8345" /> | <img width="996" alt="image" src="https://github.com/user-attachments/assets/6d9dc1cc-7179-46c2-867f-153adebe699a" />




