### PR TITLE
Filet de sécurité pour l’affichage du bandeau rdv à renseigner

### DIFF
--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -1,6 +1,10 @@
 / locals(organisation: nil)
 - if current_agent.unknown_past_rdv_count > 0 && !current_agent.conseiller_numerique? # See https://github.com/betagouv/rdv-solidarites.fr/issues/2245
-  li.list-inline-item.fr-mr-2w
-    = link_to a_renseigner_admin_organisation_rdvs_path(organisation || current_agent.rdvs.a_renseigner.first.organisation_id), class: "btn text-primary-blue link-dsfr" do
-      span.fr-icon--sm.fr-mr-1v.fr-icon-warning-fill[aria-hidden="true"]
-      = "#{current_agent.unknown_past_rdv_count} RDV à renseigner"
+  / la condition ci-dessous permet de gérer les cas où le compteur en cache unknown_past_rdv_count
+  / est supérieur 0 mais qu’on ne retrouve aucun RDV effectivement à renseigner
+  - organisation_id = organisation&.id || current_agent.rdvs.a_renseigner.first.organisation_id
+  - if organisation_id
+    li.list-inline-item.fr-mr-2w
+      = link_to a_renseigner_admin_organisation_rdvs_path(organisation_id), class: "btn text-primary-blue link-dsfr" do
+        span.fr-icon--sm.fr-mr-1v.fr-icon-warning-fill[aria-hidden="true"]
+        = "#{current_agent.unknown_past_rdv_count} RDV à renseigner"


### PR DESCRIPTION
# Contexte

https://sentry.incubateur.net/organizations/betagouv/issues/141662/?project=74&referrer=webhooks_plugin

Il me semble que cette erreur a déjà été traitée en partie par Victor en réinitialisant les caches.

Peut-être que l’erreur persiste uniquement sur certains autres environnements parce qu’on n’a pas réinitialisé les caches ? 

# Solution

Je propose ici une solution ceinture et bretelle : on ne fait pas confiance au compteur en cache et on vérifie qu’il reste bien au moins un RDV à renseigner avant d’afficher la bannière.

Ça n’aura pas d’impact sur les perfs puisque cette vérification est déjà faite (mais fait une 500 dans le cas où c’est 0 aujourd’hui).

En revanche ça rendra ce problème de cache pas à jour invisible, ce qui n’est probablement pas une super idée non plus ?