### PR TITLE
Ajout d'un indicateur d'heure courante au calendrier

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -69,6 +69,7 @@ class CalendarRdvSolidarites {
       eventSourceFailure: this.handleAjaxError,
       defaultDate: this.getDefaultDate(),
       allDaySlot: false,
+      nowIndicator: true,
       defaultView: this.getDefaultView(),
       viewSkeletonRender: function (info) {
         localStorage.setItem("calendarDefaultView", info.view.type);


### PR DESCRIPTION

Avant | Après
:- | -:
<img width="522" alt="Screenshot 2025-01-13 at 16 13 57" src="https://github.com/user-attachments/assets/217eb1e9-45f1-4e63-badc-e3fb94d9ae21" /> | <img width="543" alt="Screenshot 2025-01-13 at 16 13 46" src="https://github.com/user-attachments/assets/9d2c228c-2b73-4ad6-8e16-797317b602cb" />




Je me suis rendu compte en bossant sur https://github.com/betagouv/rdv-service-public/pull/4966
 que c'était trivial d'ajouter un indicateur d'heure courante sur le calendrier.

C'est utile notamment pour retrouver rapidement le rendez-vous qui commence maintenant ou très prochainement (je pense que ça rendra service aux secrétaires).

C'est aussi une fonctionnalité présente sur Google Calendar et Outlook : 

<img width="619" alt="Screenshot 2025-01-13 at 16 09 52" src="https://github.com/user-attachments/assets/aa6e4797-a87b-41c1-9637-63f5788241b1" />
<img width="716" alt="Screenshot 2025-01-13 at 16 09 16" src="https://github.com/user-attachments/assets/f6e65af6-48bc-446a-9687-3c84fb07348a" />
