### PR TITLE
Migration user form au DSFR

### DIFF
--- a/app/views/application/_model_errors.html.slim
+++ b/app/views/application/_model_errors.html.slim
@@ -8,7 +8,7 @@
 
   - if local_assigns[:f]
     .collapse.show.js-collapse-warning-confirmation
-      = f.input :ignore_benign_errors, as: :hidden, input_html: {class: "js-ignore-benign-errors", value: "1" }
+      = f.hidden_field :ignore_benign_errors, class: "js-ignore-benign-errors", value: "1"
       .d-flex.justify-content-between.align-items-center
         div
           a.fr-btn.fr-btn--secondary[

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -6,13 +6,13 @@ ruby:
 
 = form_for user, url: form_url, method: form_method, builder: Dsfr::FormBuilder do |f|
   = render "model_errors", model: user, f: f
-  .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
-    .fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?
-    .fr-col-md-6= f.dsfr_text_field :last_name
-  .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
     - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
-      .fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
-      .fr-col-md-6= f.dsfr_text_field :birth_date, as: :string, type: "date", disabled: user.logged_once_with_franceconnect?
+      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
+      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, as: :string, type: "date", disabled: user.logged_once_with_franceconnect?
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
     = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), style: "text-transform: uppercase;"
   - if user.logged_once_with_franceconnect?
@@ -39,11 +39,11 @@ ruby:
 
   - if local_assigns[:service].nil? || service.user_field_groups.include?(:social)
     - if territories.map(&:enable_caisse_affiliation_field).any? || territories.map(&:enable_affiliation_number_field).any?
-      .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+      .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
         - if territories.map(&:enable_caisse_affiliation_field).any?
-          .fr-col-md-6= f.dsfr_select :caisse_affiliation, User.human_attribute_values(:caisse_affiliation), include_blank: true
+          .fr-col-12.fr-col-md-6= f.dsfr_select :caisse_affiliation, User.human_attribute_values(:caisse_affiliation), include_blank: true
         - if territories.map(&:enable_affiliation_number_field).any?
-          .fr-col-md-6= f.dsfr_text_field :affiliation_number
+          .fr-col-12.fr-col-md-6= f.dsfr_text_field :affiliation_number
 
     - if rdv_wizard
       ruby:

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -12,7 +12,7 @@ ruby:
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
     - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
-      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, as: :string, type: "date", disabled: user.logged_once_with_franceconnect?
+      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, type: "date", disabled: user.logged_once_with_franceconnect?
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
     = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), style: "text-transform: uppercase;"
   - if user.logged_once_with_franceconnect?

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -4,65 +4,58 @@ ruby:
   form_method = rdv_wizard.present? ? "post" : "patch"
   territories = Territory.joins(organisations: :user_profiles).where(user_profiles: { user_id: user.id }).to_a
 
-= simple_form_for user, url: form_url, method: form_method  do |f|
+= form_for user, url: form_url, method: form_method, builder: DsfrFormBuilder do |f|
   = render "model_errors", model: user, f: f
-  .form-row
-    .col-md-6= f.input :first_name, placeholder: "Prénom", disabled: user.logged_once_with_franceconnect?
-    .col-md-6= f.input :last_name, placeholder: "Nom"
-  .form-row
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+    .fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?
+    .fr-col-md-6= f.dsfr_text_field :last_name
+  .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
     - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
-      .col-md-6= f.input :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
-      .col-md-6= f.input :birth_date, as: :string, input_html: { type: "date" }, disabled: user.logged_once_with_franceconnect?
+      .fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
+      .fr-col-md-6= f.dsfr_text_field :birth_date, as: :string, type: "date", disabled: user.logged_once_with_franceconnect?
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
-    = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
+    = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), style: "text-transform: uppercase;"
   - if user.logged_once_with_franceconnect?
     .fr-alert.fr-alert--info.fr-mb-1w
       = I18n.t("users.franceconnect_frozen_fields")
   - if current_user.signed_in_with_invitation_token?
-    = f.input :email, disabled: user.email.present? && !user.email_changed?, required: true
-  = f.input :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
+    = f.dsfr_email_field :email, disabled: user.email.present? && !user.email_changed?, required: true
+  = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
   - if user.phone_number.present? && !user.phone_number_mobile?
     .fr-alert.fr-alert--warning.fr-mb-1w Vous ne recevrez pas de SMS avec ce numéro non-mobile
   div.mb-2 Préférences de notifications
-  div= f.input :notify_by_email
-  div= f.input :notify_by_sms
+  div= f.dsfr_check_box :notify_by_email
+  div= f.dsfr_check_box :notify_by_sms
   - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
-    = f.input :address, input_html: {value: address_value, data: { "address-autocomplete": "on" } }, required: rdv_wizard&.motif&.home?
+    = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }
 
   - if territories.map(&:enable_address_details).any?
-    = f.input :address_details, input_html: { data: { "address-autocomplete": "on" } }
+    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }
 
-  = f.input :city_code, as: :hidden
-  = f.input :post_code, as: :hidden
-  = f.input :city_name, as: :hidden
+  = f.hidden_field :city_code
+  = f.hidden_field :post_code
+  = f.hidden_field :city_name
 
   - if local_assigns[:service].nil? || service.user_field_groups.include?(:social)
     - if territories.map(&:enable_caisse_affiliation_field).any? || territories.map(&:enable_affiliation_number_field).any?
-      .form-row
+      .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
         - if territories.map(&:enable_caisse_affiliation_field).any?
-          .col-md-6= f.input :caisse_affiliation, collection: User.human_attribute_values(:caisse_affiliation)
+          .fr-col-md-6= f.dsfr_select :caisse_affiliation, User.human_attribute_values(:caisse_affiliation), include_blank: true
         - if territories.map(&:enable_affiliation_number_field).any?
-          .col-md-6= f.input :affiliation_number
-
-    - if territories.map(&:enable_family_situation_field).any? || territories.map(&:enable_number_of_children_field).any?
-      .form-row
-        - if territories.map(&:enable_family_situation_field).any?
-          .col-md-6= f.input :family_situation, collection: User.human_attribute_values(:family_situation)
-        - if territories.map(&:enable_number_of_children_field).any?
-          .col-md-6= f.input :number_of_children, input_html: { min: "0", max: "15", step: "any" }
+          .fr-col-md-6= f.dsfr_text_field :affiliation_number
 
     - if rdv_wizard
       ruby:
         current_organisation = Motif.find(rdv_wizard.to_query[:motif_id]).organisation
       - if current_organisation.territory.enable_logement_field
-        = f.input :logement, collection: User.human_attribute_values(:logement)
+        = f.dsfr_select :logement, User.human_attribute_values(:logement), include_blank: true
     - elsif territories.map(&:enable_logement_field).any?
-      = f.input :logement, collection: User.human_attribute_values(:logement)
+      = f.dsfr_select :logement, User.human_attribute_values(:logement), include_blank: true
 
   - if rdv_wizard.present?
     - rdv_wizard.to_query.each do |wizard_key, wizard_value|
       = hidden_field_tag "rdv[#{wizard_key}]", wizard_value
 
   .rdv-text-align-right
-    = f.button :submit, (rdv_wizard.present? ? "Continuer" : "Modifier")
+    = f.submit (rdv_wizard.present? ? "Continuer" : "Modifier"), class: "fr-btn"

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -4,7 +4,7 @@ ruby:
   form_method = rdv_wizard.present? ? "post" : "patch"
   territories = Territory.joins(organisations: :user_profiles).where(user_profiles: { user_id: user.id }).to_a
 
-= form_for user, url: form_url, method: form_method, builder: DsfrFormBuilder do |f|
+= form_for user, url: form_url, method: form_method, builder: Dsfr::FormBuilder do |f|
   = render "model_errors", model: user, f: f
   .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
     .fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4969.osc-secnum-fr1.scalingo.io/) 

# Contexte

On continue de passer au DSFR les formulaires côté usager.

# Solution

Utilisation du DSFR Form builder. 

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/f83e0091-febb-4229-bb61-0ccf0e162e02) | ![image](https://github.com/user-attachments/assets/bd587331-fc54-49dd-8042-cb6c2b970e8f)
![image](https://github.com/user-attachments/assets/040cbd93-23e5-45d7-8e43-bdece03f2ab1) | ![image](https://github.com/user-attachments/assets/84065b45-23f7-439a-8d3d-dd2e028d8345)


