### PR TITLE
Amélioration des motifs créés par défaut lors de l'ouverture d'un compte

### DIFF
--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -39,7 +39,7 @@ class Compte
         create_mairie_motifs!
         add_mairie_motifs_categories!
       else
-        create_example_motif!
+        create_example_motifs!
       end
 
       AgentTerritorialRole.create!(agent: agent, territory: territory)
@@ -92,15 +92,17 @@ class Compte
     end
   end
 
-  def create_example_motif!
-    Motif.create!(
+  def create_example_motifs!
+    default_motif_attributes = {
       organisation: organisation,
-      name: "Mon premier motif",
+      name: "Suivi de dossier",
       color: "#99CC99",
-      location_type: :public_office,
       default_duration_in_min: 30,
       bookable_by: :agents,
-      service: agent.services.first
-    )
+      service: agent.services.first,
+    }
+    Motif.create!(default_motif_attributes.merge(location_type: :phone))
+    Motif.create!(default_motif_attributes.merge(location_type: :visio))
+    Motif.create!(default_motif_attributes.merge(location_type: :public_office))
   end
 end

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
 
     new_motif = new_organisation.motifs.first
     expect(new_motif).to have_attributes(
-      name: "Mon premier motif"
+      name: "Suivi de dossier"
     )
 
     perform_enqueued_jobs


### PR DESCRIPTION
## Captures d'écran

Avant | Après
:- | -:
<img width="1045" alt="Screenshot 2025-01-14 at 12 25 07" src="https://github.com/user-attachments/assets/f3c92aa1-4baa-491a-bb2b-f6e02d19648c" /> | <img width="1073" alt="Screenshot 2025-01-14 at 12 24 42" src="https://github.com/user-attachments/assets/a90b2b23-7461-42c9-9b6c-16e0ee977c62" />

# Contexte

Suite aux discussion autour de l'onboarding, on propose ici de créer des motifs par défaut qui ont un peu plus de sens, et qui mettent mieux en avant les différentes fonctionnalités de l'application.
Lors de l'onboarding, ça permettra de faire une première prise de rdv un peu plus réaliste avant de former le nouvel agent sur le fonctionnement des motifs



# Solution

Plutôt que "Mon premier motif", on propose les trois motifs "Suivi de dossier" (un nom assez générique pour s'appliquer à beaucoup de cas), avec les location_type sur place, par téléphone, et en visio

