### PR TITLE
Correctif modification préférences de notifications usagers par un agent

### DIFF
--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -31,13 +31,11 @@
 .mb-2
   div= f.input( \
     :notify_by_email,  \
-    include_hidden: false, \
     wrapper: false, \
     **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
   )
   div= f.input( \
     :notify_by_sms,  \
-    include_hidden: false, \
     wrapper: false, \
     **input_opts.deep_merge(user.confirmed? ? { disabled: true, input_html: { class: "js-force-disabled" } } : {}) \
   )

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe "Agent can create user" do
       expect(existing_user.reload.organisations).to include(organisation)
     end
   end
+
+  it "permet de désactiver les préférences de notifications mails et SMS" do
+    fill_in :user_first_name, with: "Marco"
+    fill_in :user_last_name, with: "Lebreton"
+    fill_in "Email", with: "marco@lebreton.bzh"
+    fill_in "Téléphone", with: "0606060606"
+    uncheck "Accepte les notifications par email"
+    uncheck "Accepte les notifications par SMS"
+    click_button "Créer"
+    expect(find("span", text: /Accepte les notifications par email/).ancestor("li")).to have_content("Désactivées")
+    expect(find("span", text: /Accepte les notifications par SMS/).ancestor("li")).to have_content("Désactivées")
+  end
 end

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -64,4 +64,28 @@ RSpec.describe "Agent can update user" do
       expect(current_email.subject).to eq "Vous avez été invité sur RDV Solidarités"
     end
   end
+
+  context "usager n’a pas encore confirmé son compte" do
+    # lorsqu’un usager a confirmé son compte, l’agent n’a plus la main sur ses préférences de notifs
+    let!(:user) { create(:user, :unconfirmed, organisations: [organisation]) }
+
+    it "permet de désactiver et réactiver les préférences de notifications SMS et email" do
+      expect(page).to have_content("Modifier l'usager")
+      expect(page).to have_checked_field("Accepte les notifications par email")
+      expect(page).to have_checked_field("Accepte les notifications par SMS")
+      uncheck "Accepte les notifications par email"
+      uncheck "Accepte les notifications par SMS"
+      click_button "Enregistrer"
+      expect(find("span", text: /Accepte les notifications par email/).ancestor("li")).to have_content("Désactivées")
+      expect(find("span", text: /Accepte les notifications par SMS/).ancestor("li")).to have_content("Désactivées")
+      within("#spec-primary-user-card") { click_link "Modifier" }
+      expect(page).to have_unchecked_field("Accepte les notifications par email")
+      expect(page).to have_unchecked_field("Accepte les notifications par SMS")
+      check "Accepte les notifications par email"
+      check "Accepte les notifications par SMS"
+      click_button "Enregistrer"
+      expect(find("span", text: /Accepte les notifications par email/).ancestor("li")).to have_content("Activées")
+      expect(find("span", text: /Accepte les notifications par SMS/).ancestor("li")).to have_content("Activées")
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Problème remonté par une agent cf https://zammad10.ethibox.fr/#ticket/zoom/20324

On arrive à reproduire le bug facilement : 

- Se connecter en tant qu’agent
- Commencer à créer un usager
- (Renseigner email et tel)
- Décocher les cases notifs SMS / emails
- Enregistrer

=> les préférences de notifs restent  activées 😢 

On peut aussi reproduire ce problème lors de l’édition d’un usager (il faut que cet usager n’ait pas encore confirmé son compte)

J’ai rapidement creusé l’historique mais je n’ai pas vu de changement récent pouvant expliquer ce bug. Il semble qu’il date de longtemps 😿 .

# Solution

- Mise en place de failing specs
- Correction