### PR TITLE
Ajout de helpers pour les icônes dsfr

### DIFF
--- a/app/helpers/dsfr_helper.rb
+++ b/app/helpers/dsfr_helper.rb
@@ -7,6 +7,34 @@ module DsfrHelper
     end
   end
 
+  def icon(icon_name, html_options = {})
+    tag.span("", class: "#{icon_name} #{html_options.delete(:class)}", "aria-hidden": "true", **html_options)
+  end
+
+  def motif_icon(html_options = {})
+    icon("fr-icon-draft-fill", html_options)
+  end
+
+  def lieu_icon(html_options = {})
+    icon("fr-icon-building-fill", html_options)
+  end
+
+  def visio_icon(html_options = {})
+    icon("fr-icon-mac-fill", html_options)
+  end
+
+  def phone_icon(html_options = {})
+    icon("fr-icon-phone-fill", html_options)
+  end
+
+  def back_icon(html_options = {})
+    icon("fr-icon-arrow-left-line", html_options)
+  end
+
+  def home_icon(html_options = {})
+    icon("fr-icon-home-4-fill", html_options)
+  end
+
   def external_link_to(name, url, html_options = {})
     link_to(name, url, { target: "_blank", rel: "noopener", title: "#{name} - nouvel onglet" }.merge(html_options))
   end

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -74,11 +74,11 @@ nav.left-side-menu-wrapper
         - unless current_agent_role.admin?
           li
             = active_link_to admin_organisation_lieux_path(current_organisation), class: "side-menu__item"
-              span.fr-icon-building-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
+              = lieu_icon(class: "fr-icon--sm fr-mr-1w")
               | Lieux
           li
             = active_link_to admin_organisation_motifs_path(current_organisation), class: "side-menu__item"
-              span.fr-icon-draft-fill.fr-icon--sm.fr-mr-1w[aria-hidden="true"]
+              = motif_icon(class: "fr-icon--sm fr-mr-1w")
               | Motifs
 
         - if current_agent_role.admin?

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -39,7 +39,7 @@ ul.list-group.list-group-flush.fr-mb-3w
   - elsif rdv.motif.visio?
     li.list-group-item.fr-pl-0.fr-py-2w
       .fr-mb-1w
-        span.fr-icon-mac-fill.fr-mr-1w[aria-hidden="true"]
+        = visio_icon(class: "fr-mr-1w")
         = "RDV par visioconférence "
       .fr-ml-4w
         = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)


### PR DESCRIPTION
Cette PR introduit quelques helpers d'icônes DSFR qui m'ont été assez utile pour accélérer sur https://github.com/betagouv/rdv-service-public/pull/4966/files.

Elle ajoute aussi un peu de sémantique pour nous permettre de ne pas nous tromper sur les icône utilisées.

J'ai pas encore fait le travail de remplacement de toutes les icônes, mais peut-être qu'on peut déjà introduire les helpers et commencer à s'en servir.