### PR TITLE
Correctif sur le flash rdvs à renseigner

### DIFF
--- a/app/views/layouts/_rdv_a_renseigner.html.slim
+++ b/app/views/layouts/_rdv_a_renseigner.html.slim
@@ -2,7 +2,7 @@
 - if current_agent.unknown_past_rdv_count > 0 && !current_agent.conseiller_numerique? # See https://github.com/betagouv/rdv-solidarites.fr/issues/2245
   / la condition ci-dessous permet de gérer les cas où le compteur en cache unknown_past_rdv_count
   / est supérieur 0 mais qu’on ne retrouve aucun RDV effectivement à renseigner
-  - organisation_id = organisation&.id || current_agent.rdvs.a_renseigner.first.organisation_id
+  - organisation_id = organisation&.id || current_agent.rdvs.a_renseigner.first&.organisation_id
   - if organisation_id
     li.list-inline-item.fr-mr-2w
       = link_to a_renseigner_admin_organisation_rdvs_path(organisation_id), class: "btn text-primary-blue link-dsfr" do


### PR DESCRIPTION
# Contexte

Salma nous remonte un cas d’un·e agent admin de territoire qui a encore des soucis pour accéder à l’espace admin de territoire en demo [cf mattermost thread](https://mattermost.incubateur.net/betagouv/pl/6r1npx9h4i8mppn17wf8i31tfc)

[issue sentry correspondante](https://sentry.incubateur.net/organizations/betagouv/issues/142739/?environment=staging&project=74&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0)

Il semble que cela se produise quand le compteur de nombre de rdvs à renseigner en cache n’est pas à jour.
Le correctif précédent (https://github.com/betagouv/rdv-service-public/pull/4963) avait raté un cas.

# Solution

Corriger le cas avec un safe operator, un peu à l’aveugle mais je suis assez confiant