### PR TITLE
Syncro CRM : utilisation du capture de message Sentry au lieu de raise

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -36,7 +36,7 @@ class CronJob::SynchronizeCrm < ApplicationJob
     elsif account_url.match('organisations/(\d+)')
       [account_url.match('organisations/(\d+)')[1]]
     else
-      raise "Unrecognized account URL: #{account_url}"
+      Sentry.capture_message("Unrecognized account URL: #{account_url}", fingerprint: ["CronJob::SynchronizeCrm"])
     end
   end
 


### PR DESCRIPTION
# Contexte

Dans le cadre du job de synchro avec Notion, j’avais raise quand le format de l’URL ne permettait pas de déterminer le territoire ou l’organisation.
En faisant cela, le job s’arrête et n’essaye pas d’aller synchroniser les éléments restants.

# Solution

On utilise un capture message Sentry pour avoir l’info sans pour autant arrêter la synchro.

