### PR TITLE
Prise de rdv par api : calendrier

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -6,7 +6,9 @@ class Agents::RdvPlansController < AgentAuthController
     redirect_to edit_starts_at_agents_rdv_plan_path(@rdv_plan)
   end
 
-  def edit_starts_at; end
+  def edit_starts_at
+    @rdv_plan.starts_at = nil
+  end
 
   def update_starts_at
     @rdv_plan.update!(params.require(:rdv_plan).permit(:starts_at).merge(rdv_agent: current_agent))

--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -1,0 +1,28 @@
+class Agents::RdvPlansController < AgentAuthController
+  layout "application"
+  before_action :find_rdv_plan
+
+  def show
+    redirect_to edit_starts_at_agents_rdv_plan_path(@rdv_plan)
+  end
+
+  def edit_starts_at; end
+
+  def update_starts_at
+    @rdv_plan.update!(params.require(:rdv_plan).permit(:starts_at).merge(rdv_agent: current_agent))
+    redirect_to show_starts_at_agents_rdv_plan_path(@rdv_plan)
+  end
+
+  def show_starts_at; end
+
+  private
+
+  def find_rdv_plan
+    @rdv_plan = RdvPlan.find(params[:id])
+    authorize @rdv_plan, :edit?, policy_class: Agent::RdvPlanPolicy
+  end
+
+  def pundit_user
+    current_agent
+  end
+end

--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -2,8 +2,8 @@ import { Calendar } from '@fullcalendar/core';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import listPlugin from '@fullcalendar/list';
-import frLocale from '@fullcalendar/core/locales/fr';
 import interactionPlugin from '@fullcalendar/interaction';
+import { defaultFullCalendarConfig, eventRenderer } from  './calendar/utils'
 
 import Bowser from "bowser";
 const browser = Bowser.getParser(window.navigator.userAgent);
@@ -62,21 +62,16 @@ class CalendarRdvSolidarites {
     if (this.data.displaySundays !== "true") {
       hiddenDays.push(0);
     }
-    return new Calendar(this.calendarEl, {
+    const options = {
       plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin],
-      locale: frLocale,
       eventSources: JSON.parse(this.data.eventSourcesJson),
       eventSourceFailure: this.handleAjaxError,
       defaultDate: this.getDefaultDate(),
-      allDaySlot: false,
-      nowIndicator: true,
       defaultView: this.getDefaultView(),
       viewSkeletonRender: function (info) {
         localStorage.setItem("calendarDefaultView", info.view.type);
       },
       hiddenDays: hiddenDays,
-      height: "auto",
-      selectable: true,
       select: this.selectEvent,
       header: {
         center: 'dayGridMonth,timeGridWeek,timeGridOneDay,listWeek'
@@ -88,29 +83,10 @@ class CalendarRdvSolidarites {
           buttonText: 'Journée'
         }
       },
-      businessHours: {
-        // days of week. an array of zero-based day of week integers (0=Sunday)
-        daysOfWeek: [1, 2, 3, 4, 5, 6, 0],
-        startTime: '07:00',
-        endTime: '19:00',
-      },
-      minTime: '07:00:00',
-      maxTime: '20:00:00',
       datesRender: this.datesRender,
-      eventRender: this.eventRender,
-      eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
-      timeZone: "Europe/Paris" // This is a hack to make sure that the events will be shown at the proper time in the calendar.
-      // If this is removed, there is a bug that causes the events in the calendar to be show at the wrong
-      // time for agents that are not in the Paris timezone.
-      // The proper fix for this would be to make sure we store all rdvs with the right timezone, but that's a much bigger project.
-      // The timezone is forced to paris on the server side, so if we make sure that we also force it to the same timezone here,
-      // we always have a consistent result.
-      // We're always assuming that people are interested in their local time.
-      //
-      // There is one case for which this fix would fail: if the local time of the user and the agent is not the same (for example the agent is
-      // in the métropole and the user is at la réunion), they will not see the same time
-      // see the same time for the rdv. This seems unlikely for now.
-    });
+      eventRender: eventRenderer(this.data.selectedEventId),
+    }
+    return new Calendar(this.calendarEl, { ...defaultFullCalendarConfig(), ...options });
   }
 
   getDefaultView = () => {
@@ -166,85 +142,6 @@ class CalendarRdvSolidarites {
 
       printLinkElt.href = url.toString()
     }
-  }
-
-  eventRender = (info) => {
-    let $el = $(info.el);
-    let extendedProps = info.event.extendedProps;
-
-    if (extendedProps.past == true) {
-      $el.addClass("fc-event-past");
-    };
-    if (extendedProps.duration <= 30) {
-      $el.addClass("fc-event-small");
-    };
-    if (extendedProps.unauthorizedRdvExplanation) {
-      $el.addClass("fc-unauthorized-rdv");
-    };
-
-    if (this.data.selectedEventId && info.event.id == this.data.selectedEventId)
-      $el.addClass("selected");
-
-    $el.addClass("fc-event-" + extendedProps.status);
-
-    if (extendedProps.userInWaitingRoom == true) {
-      $el.addClass("fc-event-waiting");
-    }
-
-    if (extendedProps.jour_feries == true) {
-      return
-    }
-
-    let title = ``;
-    const start = Intl.DateTimeFormat("fr", { timeZone: 'UTC', hour: 'numeric', minute: 'numeric' }).format(info.event.start);
-    const end = Intl.DateTimeFormat("fr", { timeZone: 'UTC', hour: 'numeric', minute: 'numeric' }).format(info.event.end);
-
-    if (info.isStart && info.isEnd) {
-      title += `${start} - ${end}`;
-    } else if (info.isStart) {
-      title += `À partir de ${start}`;
-    } else if (info.isEnd) {
-      title += `Jusqu'à ${end}`;
-    } else {
-      title += `Toute la journée`;
-    }
-
-    if (info.event.rendering == 'background') {
-      $el.append("<div class=\"fc-title\" style=\"color: white; padding: 2px 4px; font-size: 12px; font-weight: bold;\">" + info.event.title + "</div>");
-
-      if (extendedProps.organisationName) {
-        title += `<br>${extendedProps.organisationName}`;
-      }
-      title += `<br><strong>${info.event.title}</strong>`;
-      if (extendedProps.lieu) {
-        title += `<br> <small>Lieu : ${extendedProps.lieu}</small>`;
-      }
-    } else {
-      if (extendedProps.duration) {
-        title += ` <small>(${extendedProps.duration} min)</small>`;
-        title += ` <br>${extendedProps.motif}`;
-      }
-
-      title += `<br><strong>${info.event.title}</strong>`;
-
-      if (extendedProps.organisationName) {
-        title += `<br>${extendedProps.organisationName}`;
-      }
-      if (extendedProps.lieu) {
-        title += `<br><strong>Lieu:</strong> ${extendedProps.lieu}`;
-      }
-      if (extendedProps.readableStatus) {
-        title += `<br><strong>Statut:</strong> ${extendedProps.readableStatus}`;
-      }
-      if (extendedProps.unauthorizedRdvExplanation) {
-        title += `<br>${extendedProps.unauthorizedRdvExplanation}`;
-      }
-    }
-
-    $el.attr("title", title);
-    $el.attr("data-toggle", "tooltip");
-    $el.attr("data-html", "true");
-    $el.tooltip()
   }
 
   isTodayVisible = ({ activeStart, activeEnd }) => {

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -1,0 +1,113 @@
+import frLocale from '@fullcalendar/core/locales/fr';
+
+const defaultFullCalendarConfig = () => ({
+  locale: frLocale,
+  allDaySlot: false,
+  height: "auto",
+  selectable: true,
+  nowIndicator: true,
+  businessHours: {
+    // days of week. an array of zero-based day of week integers (0=Sunday)
+    daysOfWeek: [1, 2, 3, 4, 5, 6, 0],
+      startTime: '07:00',
+      endTime: '19:00',
+  },
+  minTime: '07:00:00',
+  maxTime: '20:00:00',
+  eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
+    timeZone: "Europe/Paris" // This is a hack to make sure that the events will be shown at the proper time in the calendar.
+  // If this is removed, there is a bug that causes the events in the calendar to be show at the wrong
+  // time for agents that are not in the Paris timezone.
+  // The proper fix for this would be to make sure we store all rdvs with the right timezone, but that's a much bigger project.
+  // The timezone is forced to paris on the server side, so if we make sure that we also force it to the same timezone here,
+  // we always have a consistent result.
+  // We're always assuming that people are interested in their local time.
+  //
+  // There is one case for which this fix would fail: if the local time of the user and the agent is not the same (for example the agent is
+  // in the métropole and the user is at la réunion), they will not see the same time
+  // for the rdv. This seems unlikely for now.
+})
+
+function eventRenderer(selectedEventId) {
+  // On renvoie une fonction qui aura le bon selectedEventId
+  return (info) => {
+    let $el = $(info.el);
+    let extendedProps = info.event.extendedProps;
+
+    if (extendedProps.past == true) {
+      $el.addClass("fc-event-past");
+    };
+    if (extendedProps.duration <= 30) {
+      $el.addClass("fc-event-small");
+    };
+    if (extendedProps.unauthorizedRdvExplanation) {
+      $el.addClass("fc-unauthorized-rdv");
+    };
+
+    if (selectedEventId && info.event.id == selectedEventId)
+      $el.addClass("selected");
+
+    $el.addClass("fc-event-" + extendedProps.status);
+
+    if (extendedProps.userInWaitingRoom == true) {
+      $el.addClass("fc-event-waiting");
+    }
+
+    if (extendedProps.jour_feries == true) {
+      return
+    }
+
+    let title = ``;
+    const start = Intl.DateTimeFormat("fr", { timeZone: 'UTC', hour: 'numeric', minute: 'numeric' }).format(info.event.start);
+    const end = Intl.DateTimeFormat("fr", { timeZone: 'UTC', hour: 'numeric', minute: 'numeric' }).format(info.event.end);
+
+    if (info.isStart && info.isEnd) {
+      title += `${start} - ${end}`;
+    } else if (info.isStart) {
+      title += `À partir de ${start}`;
+    } else if (info.isEnd) {
+      title += `Jusqu'à ${end}`;
+    } else {
+      title += `Toute la journée`;
+    }
+
+    if (info.event.rendering == 'background') {
+      $el.append("<div class=\"fc-title\" style=\"color: white; padding: 2px 4px; font-size: 12px; font-weight: bold;\">" + info.event.title + "</div>");
+
+      if (extendedProps.organisationName) {
+        title += `<br>${extendedProps.organisationName}`;
+      }
+      title += `<br><strong>${info.event.title}</strong>`;
+      if (extendedProps.lieu) {
+        title += `<br> <small>Lieu : ${extendedProps.lieu}</small>`;
+      }
+    } else {
+      if (extendedProps.duration) {
+        title += ` <small>(${extendedProps.duration} min)</small>`;
+        title += ` <br>${extendedProps.motif}`;
+      }
+
+      title += `<br><strong>${info.event.title}</strong>`;
+
+      if (extendedProps.organisationName) {
+        title += `<br>${extendedProps.organisationName}`;
+      }
+      if (extendedProps.lieu) {
+        title += `<br><strong>Lieu:</strong> ${extendedProps.lieu}`;
+      }
+      if (extendedProps.readableStatus) {
+        title += `<br><strong>Statut:</strong> ${extendedProps.readableStatus}`;
+      }
+      if (extendedProps.unauthorizedRdvExplanation) {
+        title += `<br>${extendedProps.unauthorizedRdvExplanation}`;
+      }
+    }
+
+    $el.attr("title", title);
+    $el.attr("data-toggle", "tooltip");
+    $el.attr("data-html", "true");
+    $el.tooltip()
+  }
+}
+
+export { defaultFullCalendarConfig, eventRenderer }

--- a/app/javascript/components/rdv-plan-calendar.js
+++ b/app/javascript/components/rdv-plan-calendar.js
@@ -1,0 +1,52 @@
+import 'bootstrap';
+
+import { Calendar } from '@fullcalendar/core';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import { defaultFullCalendarConfig, eventRenderer } from  './calendar/utils'
+
+class RdvPlanCalendar {
+
+  constructor() {
+    const calendarEl = document.getElementById('rdvPlanCalendar');
+    if (calendarEl == null || calendarEl.innerHTML !== "")
+      return
+
+    return new Calendar(calendarEl, this.calendarConfig(calendarEl.dataset)).render();
+  }
+
+  calendarConfig = (dataset) => {
+    const options = {
+      plugins: [timeGridPlugin, interactionPlugin],
+      eventSources: JSON.parse(dataset.eventSourcesJson),
+      defaultDate: JSON.parse(dataset.defaultDateJson),
+      defaultView: dataset.singleDay === "true" ? 'timeGridDay' : 'timeGridWeek',
+      hiddenDays: [],
+      header: { left:  '', center: '', right:  '' },
+      select: this.selectEvent,
+      minTime: dataset.minTime || '07:00:00',
+      maxTime: dataset.maxTime || '20:00:00',
+      eventRender: eventRenderer(),
+    }
+
+    if (dataset.displaySaturdays !== "true") {
+      options.hiddenDays.push(6);
+    }
+    if (dataset.singleDay !== "true") {
+      options.header.right = 'prev,next';
+    }
+
+    return { ...defaultFullCalendarConfig(), ...options };
+  }
+
+  selectEvent = (info) => {
+    const field = document.getElementById('rdvPlanCalendarField')
+    field.value = info.startStr
+    const form = document.getElementById('rdvPlanCalendarForm')
+    form.submit()
+  }
+}
+
+document.addEventListener('turbolinks:load', function () {
+  new RdvPlanCalendar()
+});

--- a/app/javascript/components/rdv-plan-calendar.js
+++ b/app/javascript/components/rdv-plan-calendar.js
@@ -21,7 +21,7 @@ class RdvPlanCalendar {
       eventSources: JSON.parse(dataset.eventSourcesJson),
       defaultDate: JSON.parse(dataset.defaultDateJson),
       defaultView: dataset.singleDay === "true" ? 'timeGridDay' : 'timeGridWeek',
-      hiddenDays: [],
+      hiddenDays: [0],
       header: { left:  '', center: '', right:  '' },
       select: this.selectEvent,
       minTime: dataset.minTime || '07:00:00',
@@ -40,10 +40,8 @@ class RdvPlanCalendar {
   }
 
   selectEvent = (info) => {
-    const field = document.getElementById('rdvPlanCalendarField')
-    field.value = info.startStr
-    const form = document.getElementById('rdvPlanCalendarForm')
-    form.submit()
+    document.getElementById('rdvPlanCalendarField').value = info.startStr
+    document.getElementById('rdvPlanCalendarForm').submit()
   }
 }
 

--- a/app/javascript/rdv_plan.js
+++ b/app/javascript/rdv_plan.js
@@ -1,0 +1,3 @@
+import './stylesheets/rdv_plan';
+
+import './components/rdv-plan-calendar';

--- a/app/javascript/stylesheets/rdv_plan.scss
+++ b/app/javascript/stylesheets/rdv_plan.scss
@@ -1,0 +1,19 @@
+@import "@fullcalendar/core/main";
+@import "@fullcalendar/daygrid/main";
+@import "@fullcalendar/timegrid/main";
+
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "./variables";
+@import "./components/calendar";
+
+.fc-widget-content {
+  // On suit l'exemple de Google Calendar : dans le calendrier principal même si on peut cliquer n'importe où dans le calendrier
+  // pour créer un evènement, on ne passe habituellement le cursor en point que sur les évènements,
+  // parce qu'on considère que par défaut on est en train de consulter le calendrier plutôt que de vouloir
+  // ajouter un évènement
+  // Cependant, dans le cadre du rdv_plan, on sait qu'on et en train de chercher à créer un nouvel évènement
+  // donc on explicite que le calendrier est cliquable avec un cursor pointer.
+  cursor: pointer;
+}

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -17,8 +17,12 @@ class RdvPlan < ApplicationRecord
     return if return_url.blank?
 
     uri = URI.parse(return_url)
-    return if uri.host&.end_with?(".gouv.fr")
 
-    errors.add(:return_url, "N'est pas un nom de domaine autorisé")
+    unless uri.scheme.in(%w[http https])
+      errors.add(:return_url, "Doit utiliser http ou https")
+    end
+    unless uri.host&.end_with?(".gouv.fr")
+      errors.add(:return_url, "N'est pas un nom de domaine autorisé")
+    end
   end
 end

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -18,7 +18,7 @@ class RdvPlan < ApplicationRecord
 
     uri = URI.parse(return_url)
 
-    unless uri.scheme.in(%w[http https])
+    unless uri.scheme&.in?(%w[http https])
       errors.add(:return_url, "Doit utiliser http ou https")
     end
     unless uri.host&.end_with?(".gouv.fr")

--- a/app/policies/agent/rdv_plan_policy.rb
+++ b/app/policies/agent/rdv_plan_policy.rb
@@ -2,7 +2,7 @@ class Agent::RdvPlanPolicy < ApplicationPolicy
   def create?
     pundit_user == record.planning_agent
   end
-  alias show? create?
+  alias edit? create?
 
   class Scope < Scope
     def resolve

--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -1,5 +1,5 @@
 / Include the charts pack in the <head> section
-- content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
+- content_for(:additional_scripts) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for(:menu_item) { "menu-organisation-stats" }
 

--- a/app/views/agents/rdv_plans/_calendar.html.slim
+++ b/app/views/agents/rdv_plans/_calendar.html.slim
@@ -1,0 +1,33 @@
+/ locals(rdv_plan:, single_day: false)
+ruby:
+  organisation = current_agent.organisations.first
+  event_sources = [
+    admin_api_agenda_rdvs_path(agent_id: current_agent, organisation_id: organisation.id, format: :json),
+    admin_api_agenda_absences_path(agent_id: current_agent, organisation_id: organisation.id, format: :json),
+    admin_api_agenda_plage_ouvertures_path(agent_id: current_agent, organisation_id: organisation.id, in_background: true, format: :json),
+    OffDays.to_full_calendar_array,
+  ]
+
+  if rdv_plan.starts_at && single_day
+    event_sources << [{
+      title: rdv_plan.user.full_name,
+      start: rdv_plan.starts_at.as_json,
+      end: (rdv_plan.starts_at + (rdv_plan.duration_in_minutes || 30).minutes).as_json,
+      textColor: "white",
+      backgroundColor: "#6a6af4",
+    }]
+  end
+
+#rdvPlanCalendar[
+  data-default-date-json="#{(rdv_plan.starts_at&.to_date || Time.zone.today).to_json}"
+  data-display-saturdays="#{current_agent.display_saturdays}"
+  data-display-sundays="false"
+  data-event-sources-json="#{event_sources.to_json}"
+  data-min-time="#{I18n.l(rdv_plan.starts_at - 2.hours, format: "%H:%M:%S") if single_day}"
+  data-max-time="#{I18n.l(rdv_plan.starts_at + 3.hours, format: "%H:%M:%S") if single_day}"
+  data-single-day="#{single_day}"
+  style="margin-top: -60px; margin-bottom: 24px;"
+]
+
+= simple_form_for rdv_plan, url: update_starts_at_agents_rdv_plan_path(rdv_plan),html: { id: "rdvPlanCalendarForm"} do |f|
+  = f.hidden_field :starts_at, id: "rdvPlanCalendarField"

--- a/app/views/agents/rdv_plans/_calendar.html.slim
+++ b/app/views/agents/rdv_plans/_calendar.html.slim
@@ -8,7 +8,7 @@ ruby:
     OffDays.to_full_calendar_array,
   ]
 
-  if rdv_plan.starts_at && single_day
+  if rdv_plan.starts_at
     event_sources << [{
       title: rdv_plan.user.full_name,
       start: rdv_plan.starts_at.as_json,

--- a/app/views/agents/rdv_plans/_header.html.slim
+++ b/app/views/agents/rdv_plans/_header.html.slim
@@ -1,0 +1,6 @@
+/ locals(rdv_plan:, current_step:, step_title:, next_step_title:)
+- content_for(:additional_scripts) { javascript_include_tag "rdv_plan", "data-turbolinks-track": "reload" }
+- content_for(:additional_stylesheets) { stylesheet_link_tag "rdv_plan", media: "all", "data-turbolinks-track": "reload" }
+h1.fr-h2
+  | Nouveau rendez-vous avec #{rdv_plan.user.full_name}
+= render "common/stepper", step_count: 3, current_step:, step_title:, next_step_title:

--- a/app/views/agents/rdv_plans/edit_starts_at.html.slim
+++ b/app/views/agents/rdv_plans/edit_starts_at.html.slim
@@ -1,0 +1,9 @@
+.fr-row.fr-mb-16w
+  .fr-col-12
+    = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 1, step_title: "Créneau", next_step_title: "Motif"
+
+    h2.fr-h3 Calendrier de #{current_agent.full_name}
+    p Cliquez sur l'horaire auquel vous voulez faire le rendez-vous :
+    = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: false
+    - if @rdv_plan.return_url
+      = link_to "retour", @rdv_plan.return_url

--- a/app/views/agents/rdv_plans/show_starts_at.html.slim
+++ b/app/views/agents/rdv_plans/show_starts_at.html.slim
@@ -1,0 +1,7 @@
+.fr-row
+  .fr-col-12
+    = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 1, step_title: "Créneau", next_step_title: "Motif"
+
+.fr-row.fr-mb-16w
+  .fr-col-4
+    = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: true

--- a/app/views/common/_head_agent.html.slim
+++ b/app/views/common/_head_agent.html.slim
@@ -7,4 +7,4 @@
 = javascript_include_tag "#{dsfr_path}/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
 = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
 
-= content_for(:charts_script)
+= content_for(:additional_scripts)

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -5,6 +5,8 @@ html lang="fr"
     = stylesheet_link_tag "#{dsfr_path}/dsfr.min.css", "data-turbo-track": "reload"
     = stylesheet_link_tag "#{dsfr_path}/utility/icons/icons.min.css", "data-turbo-track": "reload"
     = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": "reload"
+    = content_for(:additional_stylesheets)
+
     = javascript_include_tag "application", "data-turbolinks-track": "reload"
     = javascript_include_tag "#{dsfr_path}/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
@@ -21,6 +23,9 @@ html lang="fr"
           header.with_tool_link title: "Vos informations", path: users_informations_path
           header.with_tool_link title: "Votre compte", path: edit_user_registration_path
           header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, classes: "fr-icon-lock-fill", html_attributes: { "data-method": "delete" }
+        elsif current_agent
+          header.with_tool_link title: "Espace Agent", path: root_path
+          header.with_tool_link title: current_agent.full_name, path: edit_agent_registration_path
         elsif current_domain == Domain::RDV_MAIRIE && request.path == "/"
           header.with_tool_link title: "Centre d’aide", path: "https://aide.rdv-service-public.fr", classes: "fr-icon-questionnaire-line"
           header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, classes: "fr-icon-admin-line"

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -8,7 +8,7 @@ html lang="fr"
     = javascript_include_tag "application", "data-turbolinks-track": "reload"
     = javascript_include_tag "#{dsfr_path}/dsfr.module.min.js", "data-turbo-track": "reload", type: "module", defer: true
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
-    = content_for(:charts_script)
+    = content_for(:additional_scripts)
 
   body
     = render "layouts/rdv_solidarites_instance_name"

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -1,5 +1,5 @@
 / Include the charts pack in the <head> section
-- content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
+- content_for(:additional_scripts) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for :title do
   | Statistiques

--- a/app/views/stats/notifications_index.html.slim
+++ b/app/views/stats/notifications_index.html.slim
@@ -1,5 +1,5 @@
 / Include the charts pack in the <head> section
-- content_for(:charts_script) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
+- content_for(:additional_scripts) { javascript_include_tag "charts", "data-turbolinks-track": "reload" }
 
 - content_for :title do
   | Statistiques de notifications

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,39 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "b96d8c613cd055c2962f67120dcbe2aef94766bd6c03784624afd356adc0adaf",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/agents/rdv_plans/edit_starts_at.html.slim",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"retour\", RdvPlan.find(params[:id]).return_url)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Agents::RdvPlansController",
+          "method": "edit_starts_at",
+          "line": 10,
+          "file": "app/controllers/agents/rdv_plans_controller.rb",
+          "rendered": {
+            "name": "agents/rdv_plans/edit_starts_at",
+            "file": "app/views/agents/rdv_plans/edit_starts_at.html.slim"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "agents/rdv_plans/edit_starts_at"
+      },
+      "user_input": "RdvPlan.find(params[:id]).return_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    }
+  ],
+  "brakeman_version": "7.0.0"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,7 +116,14 @@ Rails.application.routes.draw do
         resource :webcal_sync, only: %i[show update], controller: :webcal_sync
         resource :outlook_sync, only: %i[show destroy], controller: :outlook_sync
       end
-      resources :rdv_plans, only: %i[show]
+      resources :rdv_plans, only: %i[show] do
+        member do
+          get :edit_starts_at
+          patch :update_starts_at
+
+          get :show_starts_at # Route temporaire qui sera supprimée quand on implémentera la suite du parcours
+        end
+      end
       resources :users, only: [] do
         collection do
           get "search"

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'interface de rdv_plan" do
+  let!(:organisation) { create(:organisation) }
+  let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+  let!(:motif) { create(:motif, service: agent.services.first, organisation: organisation, location_type: :public_office) }
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+
+  let!(:user) do
+    create(:user, organisations: [organisation]) # créé par appel d'api par l'appli qui s'intègre avec nous
+  end
+  let(:rdv_plan) do
+    create(:rdv_plan, user: user, planning_agent: agent)
+  end
+
+  before { login_as(agent, scope: :agent) }
+
+  it "permet de prendre un rendez-vous", js: true do
+    visit agents_rdv_plan_path(rdv_plan.id)
+    find(".fc-widget-content", match: :first).click
+    expect(page).to have_content "Nouveau"
+    expect(rdv_plan.reload.starts_at).to be_present
+  end
+end

--- a/spec/models/rdv_plan_spec.rb
+++ b/spec/models/rdv_plan_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe RdvPlan do
   describe "#return_url" do
-    it "can only be ina a whitelisted domain name" do
+    it "can only be in a a whitelisted domain name" do
       rdv_plan = build(:rdv_plan)
       rdv_plan.return_url = "nimportequoi.fr/asdf"
       expect(rdv_plan).not_to be_valid
@@ -10,6 +10,14 @@ RSpec.describe RdvPlan do
 
       rdv_plan.return_url = "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123"
       expect(rdv_plan).to be_valid
+    end
+
+    it "needs to be a http url" do
+      rdv_plan = build(:rdv_plan, return_url: "javascript:alert(1)")
+      expect(rdv_plan).not_to be_valid
+
+      rdv_plan.return_url = "ssh://test.gouv.fr"
+      expect(rdv_plan).not_to be_valid
     end
   end
 end

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     application_agent: "./app/javascript/application_agent",
     application_agent_config: "./app/javascript/application_agent_config",
     charts: "./app/javascript/charts",
+    rdv_plan: "./app/javascript/rdv_plan",
     mail: "./app/javascript/mail",
     instance_name: "./app/javascript/instance_name",
   },


### PR DESCRIPTION

![www rdv-mairie localhost_3000_agents_rdv_plans_27_edit_starts_at](https://github.com/user-attachments/assets/202622e1-657e-4b03-a24b-81442f94ce31)

<img width="702" alt="Screenshot 2025-01-17 at 15 27 11" src="https://github.com/user-attachments/assets/361caf53-229f-4116-8cb6-285a64c8ba6c" />

# Contexte

Dans la suite de https://github.com/betagouv/rdv-service-public/pull/4966 et de https://github.com/betagouv/rdv-service-public/pull/4981, cette PR ajoute la première page de prise de rendez-vous via les intégrations, et plus particulièrement le calendrier correspondant.

# Solution

## Ajout d'un nouveau composant de calendrier

On ajoute ici un nouveau composant de calendrier qui sert à la fois pour la vue à la semaine, et pour la vue "zoomée" sur le rendez-vous qu'on est en train de prendre.

Pour la vue "zoomée", on passe dans les data attributes le paramètre `singleDay` pour changer plusieurs des options qu'on passe à fullcalendar.

Pour la vue à la semaine le principal changement de comportement est celui au clic.
Le calendrier "classique" fait principalement un changement de `window.location`, pour aller vers le rdv_wizard de l'organisation courante. Cette nouvelle version utilise un petit `form` caché dans le html du partial : on a un champs `starts_at` dont on sette la valeur puis on valide le formulaire.

Ces deux ajouts semblaient ajouter trop de complexité au composant calendrier qui est déjà assez complexe. Je suis donc parti sur une extraction de deux fonctions (les options full calendar de base, et la function pour rendrer les évènements du calendrier.

L'avantage d'avoir un calendrier spécialisé utilisé juste transitoirement pour la prise de rdv est qu'on n'est pas obligés de gérer le refresh long terme du calendrier, ce qui simplifie énormément le code.

## Ajout d'un nouveau bundle js et css

On est dans le layout principal (sans current_organisation et avec le dsfr) en tant qu'agent, ce qui est un cas qui n'arrivait pas avant.
J'ai préféré ne pas ajouter tout le js et css de full calendar au bundle qu'on affiche aux usagers (et qui aurait donc été inutile ici), et donc créer un nouveau bundle qui est ajouté à ces vues.
L'inconvénient de cette approche est qu'on est obligés de charger le js de bootstrap pour avoir les tooltips dans le calendrier.

## Découpage des commits

Les deux premiers commits sont des refactos. Le deuxième extrait la logique qui semble raisonnable à partager entre les deux composants de calendrier

## Hors scope de cette pr

- Le changement d'agent
- La validation sur le starts_at
