### PR TITLE
Fix - Synchro CRM - ID Territoire ou Organisation invalide

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -20,28 +20,36 @@ class CronJob::SynchronizeCrm < ApplicationJob
 
     client.database_query(database_id: NOTION_DATABASE_ID, filter:) do |page|
       page.results.each do |notion_page|
-        rdv_count = Rdv.where(organisation: organisations_ids(notion_page.properties["COMPTE PROD"].url)).count
-        client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count })
+        ids = organisations_ids(notion_page.properties["COMPTE PROD"].url)
+        if ids.blank?
+          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => nil })
+        else
+          rdv_count = Rdv.where(organisation: ids).count
+          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count })
+        end
       end
     end
   end
 
   private
 
+  # Prends une URL de compte au format '/organisations/1' ou '/territories/1' et retourne les IDs des organisations correspondantes
+  # On ne retourne les IDs que si les organisations existent dans la base de données
   def organisations_ids(account_url)
     if account_url.match('territories/(\d+)')
       territory_id = account_url.match('territories/(\d+)')[1]
-      territory = Territory.find(territory_id)
+      territory = Territory.find_by(id: territory_id)
       Organisation.where(territory: territory).pluck(:id)
     elsif account_url.match('organisations/(\d+)')
-      [account_url.match('organisations/(\d+)')[1]]
+      Organisation.where(id: account_url.match('organisations/(\d+)')[1]).pluck(:id)
     else
       Sentry.capture_message("Unrecognized account URL: #{account_url}", fingerprint: ["CronJob::SynchronizeCrm"])
+      []
     end
   end
 
   def instance_hostname
-    ENV["HOST"].sub("https://", "")
+    ENV["HOST"]
   end
 
   def client

--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -21,19 +21,15 @@ class CronJob::SynchronizeCrm < ApplicationJob
     client.database_query(database_id: NOTION_DATABASE_ID, filter:) do |page|
       page.results.each do |notion_page|
         ids = organisations_ids(notion_page.properties["COMPTE PROD"].url)
-        if ids.blank?
-          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => nil })
-        else
-          rdv_count = Rdv.where(organisation: ids).count
-          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count })
-        end
+        rdv_count = ids.blank? ? nil : Rdv.where(organisation: ids).count
+        client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count })
       end
     end
   end
 
   private
 
-  # Prends une URL de compte au format '/organisations/1' ou '/territories/1' et retourne les IDs des organisations correspondantes
+  # Prend une URL de compte au format '/organisations/1' ou '/territories/1' et retourne les IDs des organisations correspondantes
   # On ne retourne les IDs que si les organisations existent dans la base de données
   def organisations_ids(account_url)
     if account_url.match('territories/(\d+)')

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -50,5 +50,15 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
         expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 1 })
       end
     end
+
+    context "quand la variable COMPTE PROD de la page Notion est une organisation inconnue" do
+      let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/26739" }
+
+      it "retourne un compte nul" do
+        described_class.new.perform
+
+        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => nil })
+      end
+    end
   end
 end


### PR DESCRIPTION
# Contexte

Le job de synchro CRM s’arrêtait lorsqu’il y avait un territoire dont l’ID n’existait plus en base.

# Solution

Pour résoudre ceci, on fait un `find_by` pour récupérer une valeur `nil` plutôt que de raise.
On en profite pour vérifier que si l’URL contient un ID d’organisation, celle-ci existe en base afin de renvoyer un compte nul dans le CRM plutôt que 0.
