### PR TITLE
Ajout buildpacks Scalingo

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/ruby-buildpack.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/Scalingo/nodejs-buildpack.git
-https://github.com/Scalingo/ruby-buildpack.git
+https://github.com/adipasquale/ruby-buildpack.git#precompile-manifest-js

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # Assets are already compiled by default by the nodejs-buildpack
+  config.assets.enabled = false
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,9 +30,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Assets are already compiled by default by the nodejs-buildpack
-  config.assets.enabled = false
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Assets are already compiled by default by the nodejs-buildpack
-  config.assets.enabled = false
+  Rake::Task["assets:precompile"].clear
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # On Scalingo, assets are already compiled by default by the nodejs-buildpack
+  config.assets.enabled = false
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Assets are already compiled by default by the nodejs-buildpack
-  Rake::Task["assets:precompile"].clear
+  config.assets.enabled = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr4987.osc-secnum-fr1.scalingo.io/) 

# Contexte

Actuellement Scalingo affiche des warnings lors de nos deploys sur les versions de Node et Yarn qui ne sont pas pinnés.

# Solution

Comme recommandé dans les logs de deploy Scalingo on spécifie explicitement le multi buildpack node + ruby