### PR TITLE
Débloquer les jobs de synchro ANTS dont le num de dossier finit par un espace

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -10,10 +10,11 @@ module Ants
     # discard_on(StandardError) { |_job, ex| raise ex }
 
     def perform(ants_pre_demande_number:)
-      # Nous avons parfois dans les jobs des numéros qui finissent par un espace
-      ants_pre_demande_number = ants_pre_demande_number.strip
+      # Nous avons parfois dans les jobs des numéros qui finissent par un espace.
+      # Le temps d'investiguer, nous évitons ici que les jobs soient bloqués à cause d'un espace.
+      stripped_ants_pre_demande_number = ants_pre_demande_number.strip
 
-      ants_status = AntsApi.status(ants_pre_demande_number:, timeout: 4)
+      ants_status = AntsApi.status(ants_pre_demande_number: stripped_ants_pre_demande_number, timeout: 4)
 
       return false unless ants_status["status"] == "validated"
 
@@ -27,7 +28,7 @@ module Ants
         .joins(:users)
         .joins(motif: [:motif_category])
         .merge(MotifCategory.requires_ants_predemande_number)
-        .where(users: { ants_pre_demande_number: ants_pre_demande_number })
+        .where(users: { ants_pre_demande_number: [stripped_ants_pre_demande_number, ants_pre_demande_number] })
         .where.not(status: Rdv::CANCELLED_STATUSES)
         .where("starts_at >= ?", Time.zone.now)
         .order(id: :desc) # choix arbitraire pour éviter un comportement aléatoire
@@ -40,7 +41,7 @@ module Ants
       # en effet l’API de l’ANTS ne permet pas de faire de mises à jour, on fait donc un delete puis un update
       ants_appointments.each do |appointment|
         AntsApi.delete(
-          ants_pre_demande_number:,
+          ants_pre_demande_number: stripped_ants_pre_demande_number,
           **appointment.symbolize_keys.slice(:meeting_point, :appointment_date, :meeting_point_id)
         )
       end
@@ -48,7 +49,7 @@ module Ants
       # S’il n’y a aucun RDV non-annulé dans notre DB, on s’arrête ici. Il n’y a plus aucun appointment ANTS
       return unless rdv
 
-      AntsApi.create(ants_pre_demande_number:, **rdv.serialize_for_ants_api)
+      AntsApi.create(ants_pre_demande_number: stripped_ants_pre_demande_number, **rdv.serialize_for_ants_api)
     end
   end
 end

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -10,6 +10,9 @@ module Ants
     # discard_on(StandardError) { |_job, ex| raise ex }
 
     def perform(ants_pre_demande_number:)
+      # Nous avons parfois dans les jobs des numéros qui finissent par un espace
+      ants_pre_demande_number = ants_pre_demande_number.strip
+
       ants_status = AntsApi.status(ants_pre_demande_number:, timeout: 4)
 
       return false unless ants_status["status"] == "validated"

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -9,20 +9,7 @@ module Ants
     # useful to debug tests and avoid retries
     # discard_on(StandardError) { |_job, ex| raise ex }
 
-    def perform(rdv_attributes: nil, ants_pre_demande_number: nil, **_kwargs)
-      return perform_for_ants_pre_demande_number(ants_pre_demande_number) if ants_pre_demande_number
-
-      # Ce code gère la rétrocompatibilité avec l'ancienne signature de ce job
-      # TODO: supprimer ce code 2 semaines après le merge
-      raise ArgumentError("missing ants_pre_demande_number or rdv_attributes") if rdv_attributes.blank?
-
-      (
-        User.where(id: rdv_attributes[:users_ids]).pluck(:ants_pre_demande_number) +
-        [rdv_attributes[:obsolete_ants_pre_demande_number]]
-      ).compact_blank.each { self.class.perform_later(ants_pre_demande_number: _1) }
-    end
-
-    def perform_for_ants_pre_demande_number(ants_pre_demande_number)
+    def perform(ants_pre_demande_number:)
       ants_status = AntsApi.status(ants_pre_demande_number:, timeout: 4)
 
       return false unless ants_status["status"] == "validated"

--- a/spec/jobs/ants/sync_appointment_job_spec.rb
+++ b/spec/jobs/ants/sync_appointment_job_spec.rb
@@ -1,22 +1,4 @@
 RSpec.describe Ants::SyncAppointmentJob do
-  context "job mis en attente avec des arguments dépréciés" do
-    let!(:user1) { create(:user, ants_pre_demande_number: "AABBCCDDEE") }
-    let!(:user2) { create(:user, ants_pre_demande_number: nil) }
-    let!(:user3) { create(:user, ants_pre_demande_number: "1020304050") }
-
-    it "met en attente de nouveaux jobs avec les nouveaux arguments" do
-      expect(described_class).to receive(:perform_later).with(ants_pre_demande_number: "AABBCCDDEE")
-      expect(described_class).not_to receive(:perform_later).with(ants_pre_demande_number: nil)
-      expect(described_class).to receive(:perform_later).with(ants_pre_demande_number: "1020304050")
-      expect(described_class).to receive(:perform_later).with(ants_pre_demande_number: "FOOBARFOO1")
-
-      described_class.perform_now(
-        rdv_attributes: { id: 10, status: "canceled", users_ids: [user1.id, user2.id, user3.id], obsolete_ants_pre_demande_number: "FOOBARFOO1" },
-        appointment_data: { meeting_point: "gare du nord" }
-      )
-    end
-  end
-
   context "Nouveau RDV ANTS" do
     let!(:organisation) { create(:organisation, verticale: :rdv_mairie) }
     let!(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }


### PR DESCRIPTION
À lire commit par commit. :wink: 

# Contexte

Nous avons actuellement une grande quantité de jobs de synchro ANTS qui échouent car le numéro de dossier finit par un espace, par ex. `ABCDEFGHIJ `. 

Nous avons suffisamment de jobs dans cet état pour déclencher l'alerte Sentry "More than 50 occurrences in an hour" :

https://sentry.incubateur.net/organizations/betagouv/issues/93299

Ces remontées font du bruit inutilement et surtout elles empêchent la synchro avec l'ANTS, alors que les numéros de dossiers sont probablement valides.

# Solution

Solution en profondeur qui demande du temps : comprendre comment on a en base des numéros non conformes au format.

Solution simple qui débloque le problème rapidement : ignorer le whitespace dans le job de synchro

Je pars ici sur la solution simple et rapide.

## Au passage

Du code transitoire avait été ajouté dans la job, je le supprime.