### PR TITLE
Visioplainte : correctif pour des créneaux en double

### DIFF
--- a/app/controllers/api/visioplainte/creneaux_controller.rb
+++ b/app/controllers/api/visioplainte/creneaux_controller.rb
@@ -10,12 +10,12 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
     creneaux = CreneauxSearch::ForUser.new(
       motif: motif,
       date_range: date_range
-    ).creneaux
+    ).unique_creneaux
 
     render json: {
       creneaux: creneaux.map do |creneau|
         creneau_to_hash(creneau)
-      end.uniq,
+      end,
     }
   end
 

--- a/app/controllers/api/visioplainte/creneaux_controller.rb
+++ b/app/controllers/api/visioplainte/creneaux_controller.rb
@@ -10,7 +10,7 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
     creneaux = CreneauxSearch::ForUser.new(
       motif: motif,
       date_range: date_range
-    ).unique_creneaux
+    ).creneaux
 
     render json: {
       creneaux: creneaux.map do |creneau|

--- a/app/controllers/api/visioplainte/creneaux_controller.rb
+++ b/app/controllers/api/visioplainte/creneaux_controller.rb
@@ -15,7 +15,7 @@ class Api::Visioplainte::CreneauxController < Api::Visioplainte::BaseController
     render json: {
       creneaux: creneaux.map do |creneau|
         creneau_to_hash(creneau)
-      end,
+      end.uniq,
     }
   end
 

--- a/app/services/creneaux_search/for_user.rb
+++ b/app/services/creneaux_search/for_user.rb
@@ -27,6 +27,11 @@ class CreneauxSearch::ForUser
     CreneauxSearch::NextAvailability.find(motif, @lieu, attributed_agents, from: from, to: @motif.end_booking_delay)
   end
 
+  def unique_creneaux
+    # On n'affiche qu'un créneau par horaire, même si plusieurs agents sont dispos
+    creneaux.uniq(&:starts_at)
+  end
+
   def creneaux
     return available_collective_rdvs if motif.collectif?
 

--- a/app/services/creneaux_search/for_user.rb
+++ b/app/services/creneaux_search/for_user.rb
@@ -27,17 +27,10 @@ class CreneauxSearch::ForUser
     CreneauxSearch::NextAvailability.find(motif, @lieu, attributed_agents, from: from, to: @motif.end_booking_delay)
   end
 
-  def unique_creneaux
-    # On n'affiche qu'un créneau par horaire, même si plusieurs agents sont dispos
-    creneaux.uniq(&:starts_at)
-  end
-
   def creneaux
-    return available_collective_rdvs if motif.collectif?
-
-    return [] if reduced_date_range.blank?
-
-    CreneauxSearch::Calculator.available_slots(motif, @lieu, reduced_date_range, attributed_agents)
+    # On n'affiche qu'un créneau par horaire, même si plusieurs agents sont dispos
+    # car on ne propose pas à l'usager de choisir un agent en particulier
+    all_creneaux.uniq(&:starts_at)
   end
 
   def available_collective_rdvs
@@ -50,6 +43,14 @@ class CreneauxSearch::ForUser
   end
 
   private
+
+  def all_creneaux
+    return available_collective_rdvs if motif.collectif?
+
+    return [] if reduced_date_range.blank?
+
+    CreneauxSearch::Calculator.available_slots(motif, @lieu, reduced_date_range, attributed_agents)
+  end
 
   attr_reader :motif, :date_range
 

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -17,7 +17,7 @@ class SearchContext
   end
 
   def creneaux
-    @creneaux ||= creneaux_search.unique_creneaux
+    @creneaux ||= creneaux_search.creneaux
   end
 
   def available_collective_rdvs

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -17,8 +17,7 @@ class SearchContext
   end
 
   def creneaux
-    @creneaux ||= creneaux_search.creneaux
-      .uniq(&:starts_at) # On n'affiche qu'un créneau par horaire, même si plusieurs agents sont dispos
+    @creneaux ||= creneaux_search.unique_creneaux
   end
 
   def available_collective_rdvs

--- a/spec/requests/api/visioplainte/creneaux_spec.rb
+++ b/spec/requests/api/visioplainte/creneaux_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Visioplainte Creneaux" do
     load Rails.root.join("db/seeds/visioplainte.rb")
     create(:plage_ouverture,
            organisation: orga_gendarmerie,
-           agent: orga_gendarmerie.agents.first,
+           agent: Agent.find_by(last_name: "Guichet 1"),
            motifs: orga_gendarmerie.motifs,
            first_day: Date.tomorrow,
            start_time: Tod::TimeOfDay.new(14),
@@ -32,7 +32,18 @@ RSpec.describe "Visioplainte Creneaux" do
       }
     end
 
-    it "returns a list of creneaux" do
+    before do
+      create(:plage_ouverture,
+             organisation: orga_gendarmerie,
+             agent: Agent.find_by(last_name: "Guichet 2"),
+             motifs: orga_gendarmerie.motifs,
+             first_day: Date.tomorrow,
+             start_time: Tod::TimeOfDay.new(14),
+             end_time: Tod::TimeOfDay.new(18),
+             recurrence: Montrose.every(:week, day: [1, 2, 3, 4, 5], interval: 1, starts: Date.tomorrow, on: %i[monday tuesday thursday friday]))
+    end
+
+    it "returns a list of creneaux without duplicates" do
       creneaux = get_request[:creneaux]
       expect(creneaux.first).to eq(
         {
@@ -40,6 +51,12 @@ RSpec.describe "Visioplainte Creneaux" do
           duration_in_min: 30,
         }
       )
+
+      creneaux_starting_at_2pm = creneaux.select do |c|
+        c[:starts_at] == "2024-08-19T14:00:00+02:00"
+      end
+
+      expect(creneaux_starting_at_2pm.count).to eq 1
     end
   end
 

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
       agent2 = create(:agent, basic_role_in_organisations: [organisation])
       motif = create(:motif, :sectorisation_level_agent, organisation: organisation)
       mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: { organisation => Agent.where(id: [agent1.id, agent2.id]) })
-      expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, contain_exactly(agent1, agent2)).and_return([creneau_double])
+      allow(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, contain_exactly(agent1, agent2)).and_return([creneau_double])
       creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
       expect(creneaux).to eq [creneau_double]
     end

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe CreneauxSearch::ForUser, type: :service do
   let(:organisation) { create(:organisation) }
+  let(:creneau_double) { instance_double(Creneau, starts_at: 1.hour.from_now) }
   let(:lieu) { create(:lieu, organisation: organisation) }
   let(:date_range) { (Date.parse("2020-10-20")..Date.parse("2020-10-23")) }
   let(:now) { Time.zone.parse("2020-10-19 15:34") }
@@ -11,23 +12,26 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
   it "call builder without special options" do
     user = create(:user)
     motif = create(:motif, name: "Coucou", organisation: organisation, location_type: :public_office)
-    expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, [])
-    described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
+    allow(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, []).and_return([creneau_double])
+    creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
+    expect(creneaux).to eq [creneau_double]
   end
 
   it "call with referent as filter when follow_up motif" do
     motif = create(:motif, follow_up: true, organisation: organisation)
     agent = create(:agent, basic_role_in_organisations: [organisation])
     user = create(:user, organisations: [organisation], referent_agents: [agent])
-    expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, [agent])
-    described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
+    allow(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, [agent]).and_return([creneau_double])
+    creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
+    expect(creneaux).to eq [creneau_double]
   end
 
   it "call without referents when user without referents" do
     motif = create(:motif, follow_up: true, organisation: organisation)
     user = create(:user, referent_agents: [])
-    expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, [])
-    described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
+    allow(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, []).and_return([creneau_double])
+    creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range).creneaux
+    expect(creneaux).to eq [creneau_double]
   end
 
   context "with geo search" do
@@ -37,15 +41,17 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
       it "calls without agents filter" do
         mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: {})
         motif = create(:motif, :sectorisation_level_agent, organisation: organisation)
-        expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, [])
-        described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+        allow(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, []).and_return([creneau_double])
+        creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+        expect(creneaux).to eq [creneau_double]
       end
 
       it "calls without agents filter when no attributed agents" do
         mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: { organisation => Agent.none })
         motif = create(:motif, organisation: organisation)
-        expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, [])
-        described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+        allow(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, []).and_return([creneau_double])
+        creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+        expect(creneaux).to eq [creneau_double]
       end
 
       context "when the lieu is nil" do
@@ -55,7 +61,8 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
         it "doesn't crash" do
           expect do
             mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: { organisation => Agent.none })
-            described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+            creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+            expect(creneaux).to eq []
           end.not_to raise_error
         end
       end
@@ -66,8 +73,9 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
       agent2 = create(:agent, basic_role_in_organisations: [organisation])
       motif = create(:motif, :sectorisation_level_agent, organisation: organisation)
       mock_geo_search = instance_double(Users::GeoSearch, attributed_agents_by_organisation: { organisation => Agent.where(id: [agent1.id, agent2.id]) })
-      expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, contain_exactly(agent1, agent2))
-      described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+      expect(CreneauxSearch::Calculator).to receive(:available_slots).with(motif, lieu, date_range, contain_exactly(agent1, agent2)).and_return([creneau_double])
+      creneaux = described_class.new(user: user, motif: motif, lieu: lieu, date_range: date_range, geo_search: mock_geo_search).creneaux
+      expect(creneaux).to eq [creneau_double]
     end
   end
 


### PR DESCRIPTION
# Contexte

Sensiolabs nous a remonté un petit bug : les créneaux envoyés par l'api s'affichent en double si on a plusieurs agents qui ouvrent des plage d'ouverture.

Dans le cas des recherches de créneaux par les usagers, on ne donne jamais le détail de l'agent qui propose le créneau, souvent parce que ce n'est pas pertinent, mais aussi parce qu'on n'a pas particulièrement envie de donner les infos personnelles de l'agent (même si c'est juste l'identité).

# Solution

Dans le cas de la recherche de créneaux par usagers, on fait un `uniq(&:starts_at)` dans l'objet SearchContext. Ici on rentre cette abstraction dans le service object pour éviter de reproduire ce bug la prochaine fois qu'on expose les résultats du service object via une api.

