### PR TITLE
Ne pas remonter les timeouts du job ANTS dans Sentry

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -51,5 +51,13 @@ module Ants
 
       AntsApi.create(ants_pre_demande_number: stripped_ants_pre_demande_number, **rdv.serialize_for_ants_api)
     end
+
+    def capture_sentry_warning_for_retry?(exception)
+      if exception.is_a?(Typhoeus::Errors::TimeoutError)
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -9,8 +9,9 @@ module DefaultJobBehaviour
     # "retry 20 times with an exponential backoff, then mark job as discarded"
     #
     # Exponential backoff is n^4, so wait times between retries will be as follows:
-    # attempt:  1   2    3    4   5    6    7    8    9     10    11  12  13  14   15   16   17   18   19   20
-    # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m, 109m, 166m, 4h, 6h, 8h, 11h, 14h, 18h, 23h, 29h, 36h, 44h
+    # attempt:  1   2    3    4   5    6    7    8     9     10    11   12   13  14     15   16     17     18   19     20
+    # backoff:  1s, 16s, 81s, 4m, 10m, 21m, 40m, 68m,  109m, 166m, 4h,  6h,  8h, 11h,   14h, 18h,   23h,   29h, 36h,   44h
+    # total:    1s, 17s, 98s, 6m, 16m, 38m, 78m, 146m ,4h,   7h,   11h, 16h, 1d, 1d11h, 2d,  2d19h, 3d18h, 5d,  6d12h, 8d8h
     # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8 days
     # it therefore takes more than 8 days for a job to be discarded
     retry_on(StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)


### PR DESCRIPTION
# Contexte

Nous avons beaucoup de remontées de timeouts ANTS dans Sentry :
1. lors du job de synchro `Ants::SyncAppointmentJob`
2. lorsque les usagers ou agents saisissent des numéros de dossier (création de RDV, mise à jour du numéro sur la fiche usager)

# Solution

Cette PR s'attaque au point 1 : elle fait en sorte de ne pas remonter les timeouts dans le job de synchro.

Risque : nous ne sommes plus informé lorsque l'API ANTS n'est pas disponible. Ce risque semble très faible, puisque les erreurs synchrones du point 2 nous informerons bien assez tôt, ainsi que le support !