### PR TITLE
Fixup #4824

### DIFF
--- a/app/form_models/relative_user_form.rb
+++ b/app/form_models/relative_user_form.rb
@@ -1,5 +1,6 @@
 class RelativeUserForm
   include ActiveModel::Model
+  include BenignErrors
 
   attr_reader :user, :ants_pre_demande_number_required
 


### PR DESCRIPTION
Dans #4824 on introduit un nouveau form object qui utilise `validates_with AntsPreDemandeNumberValidation`. Or, ce validateur a besoin du concern `BenignErrors`.

https://sentry.incubateur.net/organizations/betagouv/issues/144081

> undefined method `ignore_benign_errors' for an instance of RelativeUserForm