### PR TITLE
[Draft] Test de non régression pour #4824

### DIFF
--- a/app/validators/ants_pre_demande_number_validation.rb
+++ b/app/validators/ants_pre_demande_number_validation.rb
@@ -7,6 +7,8 @@
 
 class AntsPreDemandeNumberValidation < ActiveModel::Validator
   def validate(record)
+    raise "You need to include BenignErrors to use #{self.class}" unless record.respond_to?(:add_benign_error)
+
     ants_pre_demande_number = record.ants_pre_demande_number.upcase
 
     unless ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)

--- a/app/views/users/relatives/new.html.slim
+++ b/app/views/users/relatives/new.html.slim
@@ -2,7 +2,7 @@
   h1.rdv-color-white Ajouter un proche
 
 = simple_form_for @form, url: relatives_path, remote: true, data: { modal: true } do |f|
-  = render "model_errors", model: @form
+  = render "model_errors", model: @form, f: f
   = render "form_fields", f: f
   .row
     .col.rdv-text-align-right

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -62,7 +62,7 @@ fr:
     warnings:
       models:
         user:
-          ants_pre_demande_number_already_used_html: Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de %{meeting_point}. Veuillez <a href='%{management_url}' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
+          ants_pre_demande_number_already_used_html: Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de %{meeting_point}. Veuillez <a href="%{management_url}" target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
 
   simple_form:
     hints:

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Users::RelativesController, type: :controller do
         expect { subject }.not_to change(User, :count)
         expect(response.body).to include(%(Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.))
         expect(response.body).to include(%(Veuillez <a href="https://rdvsympa.fr/123" target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.))
+        expect(response.body).to include(%(Confirmer en ignorant les avertissements))
       end
     end
 

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -93,20 +93,13 @@ RSpec.describe Users::RelativesController, type: :controller do
 
       include_context "rdv_mairie_api_authentication"
       before do
-        appointments = [
-          {
-            management_url: "https://gerer-rdv.com/1234",
-            meeting_point: "Mairie de Sannois",
-            appointment_date: "2023-04-03T08:45:00",
-          },
-        ]
-        stub_ants_status_ok("VALID12345", status: "validated", appointments:)
+        stub_ants_status_ok("VALID12345", status: "validated", appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "https://rdvsympa.fr/123" }])
       end
 
       it "créé le proche avec le numéro de pré-demande" do
         expect { subject }.not_to change(User, :count)
-        expect(response.body).to include(%(Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Sannois.))
-        expect(response.body).to include(%(Veuillez <a href='https://gerer-rdv.com/1234' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.))
+        expect(response.body).to include(%(Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.))
+        expect(response.body).to include(%(Veuillez <a href="https://rdvsympa.fr/123" target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.))
       end
     end
 

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -86,6 +86,30 @@ RSpec.describe Users::RelativesController, type: :controller do
       end
     end
 
+    context "quand le numéro de pré-demande ANTS est requis et passé et valide mais qu'il existe déjà des RDVs pris ailleurs pour ce numéro" do
+      let(:attributes) do
+        { relative_user_form: { first_name: "Eliott", last_name: "Le Dragon", ants_pre_demande_number: "VALID12345", ants_pre_demande_number_required: "true" } }
+      end
+
+      include_context "rdv_mairie_api_authentication"
+      before do
+        appointments = [
+          {
+            management_url: "https://gerer-rdv.com/1234",
+            meeting_point: "Mairie de Sannois",
+            appointment_date: "2023-04-03T08:45:00",
+          },
+        ]
+        stub_ants_status_ok("VALID12345", status: "validated", appointments:)
+      end
+
+      it "créé le proche avec le numéro de pré-demande" do
+        expect { subject }.not_to change(User, :count)
+        expect(response.body).to include(%(Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Sannois.))
+        expect(response.body).to include(%(Veuillez <a href='https://gerer-rdv.com/1234' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.))
+      end
+    end
+
     context "quand le numéro de pré-demande ANTS est requis mais pas passé" do
       let(:attributes) do
         { relative_user_form: { first_name: "Eliott", last_name: "Le Dragon", ants_pre_demande_number_required: "true" } }

--- a/spec/controllers/users/relatives_controller_spec.rb
+++ b/spec/controllers/users/relatives_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Users::RelativesController, type: :controller do
 
     context "quand le numéro de pré-demande ANTS est requis et passé et valide" do
       let(:attributes) do
-        { relative_user_form: { first_name: "Eliott", last_name: "Le Dragon", ants_pre_demande_number: "VALID12345" }, ants_pre_demande_number_required: "true" }
+        { relative_user_form: { first_name: "Eliott", last_name: "Le Dragon", ants_pre_demande_number: "VALID12345", ants_pre_demande_number_required: "true" } }
       end
 
       include_context "rdv_mairie_api_authentication"

--- a/spec/form_models/admin/user_form_spec.rb
+++ b/spec/form_models/admin/user_form_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Admin::UserForm, type: :form do
         expect(subject.errors.first.message).to eq(
           <<-TXT.squish
             Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.
-            Veuillez <a href='http://rdvsympa.fr/123' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
+            Veuillez <a href="http://rdvsympa.fr/123" target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
         TXT
         )
       end

--- a/spec/form_models/beneficiaire_form_spec.rb
+++ b/spec/form_models/beneficiaire_form_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe BeneficiaireForm do
         expect(form.errors.first.message).to eq(
           <<-TXT.squish
             Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.
-            Veuillez <a href='http://rdvsympa.fr/123' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
+            Veuillez <a href="http://rdvsympa.fr/123" target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
           TXT
         )
       end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe UserRdvWizard do
           expect(form.errors.first.message).to eq(
             <<-TXT.squish
               Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.
-              Veuillez <a href='http://rdvsympa.fr/123' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
+              Veuillez <a href="http://rdvsympa.fr/123" target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
           TXT
           )
         end


### PR DESCRIPTION
Un fixup de #4824 a été fait dans #4991 dans l'urgence mais sans test de non-régression.

J'ajoute ici un test de non régression (ajout d'un proche, validation sur l'existence de RDVs sur d'autres plateformes).

La spec vérifie aussi qu'il y a bien un bouton qui me permet de skipper cet avertissement, mais je n'ai pas pris le temps de transformer la controller spec en feature spec.