### PR TITLE
Correction du choix aléatoire de créneau

### DIFF
--- a/app/services/creneaux_search/for_user.rb
+++ b/app/services/creneaux_search/for_user.rb
@@ -16,7 +16,7 @@ class CreneauxSearch::ForUser
       geo_search: geo_search
     )
 
-    search.creneaux.select { _1.starts_at == starts_at }.sample
+    search.all_creneaux.select { _1.starts_at == starts_at }.sample
   end
 
   def next_availability
@@ -42,8 +42,6 @@ class CreneauxSearch::ForUser
     rdvs
   end
 
-  private
-
   def all_creneaux
     return available_collective_rdvs if motif.collectif?
 
@@ -51,6 +49,8 @@ class CreneauxSearch::ForUser
 
     CreneauxSearch::Calculator.available_slots(motif, @lieu, reduced_date_range, attributed_agents)
   end
+
+  private
 
   attr_reader :motif, :date_range
 

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -170,6 +170,40 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
       it { is_expected.to eq(mock_creneaux[0]) }
     end
 
+    context "when there are multiple creneaux with the same starts_at" do
+      let(:agent1) { create(:agent) }
+      let(:agent2) { create(:agent) }
+
+      let(:mock_creneaux) do
+        [
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 09:30"), agent: agent1),
+          build(:creneau, starts_at: Time.zone.parse("2020-10-20 09:30"), agent: agent2),
+        ]
+      end
+
+      it "randomly picks one" do
+        allow(mock_creneaux).to receive(:sample).and_return(mock_creneaux.first)
+
+        creneau = described_class.creneau_for(
+          user: user,
+          motif: motif,
+          lieu: lieu,
+          starts_at: starts_at
+        )
+        expect(creneau.agent).to eq agent1
+
+        allow(mock_creneaux).to receive(:sample).and_return(mock_creneaux.last)
+
+        creneau = described_class.creneau_for(
+          user: user,
+          motif: motif,
+          lieu: lieu,
+          starts_at: starts_at
+        )
+        expect(creneau.agent).to eq agent2
+      end
+    end
+
     context "no matching creneaux" do
       let(:mock_creneaux) do
         [

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -181,6 +181,8 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
         ]
       end
 
+      before { allow(mock_creneaux).to receive(:select).and_return(mock_creneaux) }
+
       it "randomly picks one" do
         allow(mock_creneaux).to receive(:sample).and_return(mock_creneaux.first)
 


### PR DESCRIPTION
# Contexte

Je me suis rendu compte que j'ai introduit un petit bug dans https://github.com/betagouv/rdv-service-public/pull/4989/files : le choix des créneaux n'est plus aléatoire, mais prend le premier agent disponible

# Solution

On passe à nouveau la liste de tous les créneaux pour en choisir un au hasard.
Les tests sont pas très élégants, mais il me semble qu'ils sont déterministes grâce aux stubs.


