### PR TITLE
Retirer tag “Inactif” pour les intervenants

### DIFF
--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -7,6 +7,15 @@ module AgentsHelper
     tag.span("Vous", class: "badge badge-info") if current_agent?(agent)
   end
 
+  def inactive_tag(agent)
+    # les intervenants ne peuvent pas se connecter, il est inutile de les afficher comme "Inactif".
+    return if agent.is_an_intervenant?
+
+    if agent.last_sign_in_at.nil? || agent.last_sign_in_at <= 1.month.ago
+      tag.span("Inactif", class: "badge badge-warning")
+    end
+  end
+
   def build_link_to_rdv_wizard_params(creneau, form)
     params = {}
     params[:step] = 2

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -145,10 +145,6 @@ class Agent < ApplicationRecord
     invitation_sent_at.nil? || invitation_accepted_at.present?
   end
 
-  def inactive?
-    last_sign_in_at.nil? || last_sign_in_at <= 1.month.ago
-  end
-
   def soft_delete
     raise SoftDeleteError, "agent still has attached orgs: #{organisations.ids.inspect}" if organisations.any?
 

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -5,8 +5,7 @@ tr id="agent_#{agent.id}"
   td
     - if agent_policy.edit?
       = link_to agent.reverse_full_name, edit_admin_organisation_agent_path(current_organisation, agent), class: "mr-2"
-      - if agent.inactive? && agent.complete?
-        = tag.span("Inactif", class: "badge badge-warning")
+      = inactive_tag(agent)
     - else
       span.mr-2= agent.reverse_full_name
     = me_tag(agent)


### PR DESCRIPTION
Fiche Notion : 
https://www.notion.so/rdvs/Retirer-tag-Inactif-pour-les-intervenants-1762b05ced41800581f2ccc675c84915

# Contexte

Les agents intervenants (utilisés pour les comptes nominatifs mais aussi pour des ressources comme des salles de réunion) portent toujours le tag “Inactif”, qui n'apporte aucun info mais plutôt de la confusion.

# Solution

La méthode `inactive?` n'est utilisée que dans le cadre de l'affichage de ce tag, je pense donc qu'elle a davantage sa place dans un helper plutôt que le modèle.

Je me suis inspiré de la méthode `me_tag`.

# Avant

![image](https://github.com/user-attachments/assets/126bb2ba-4ad1-454e-94cd-f47c1723297f)

# Après

![image](https://github.com/user-attachments/assets/28c5ce40-ffa1-4bc1-92e0-2ce92a33c9b1)
