### PR TITLE
Vérifie les IDs usagers passés au /edit de RDV collectif

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -44,11 +44,11 @@ class Admin::RdvsCollectifsController < AgentAuthController
   def edit
     @rdv = Rdv.find(params[:id])
 
-    authorize(@rdv, policy_class: Agent::RdvPolicy)
-
     @add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
-    users_to_add = User.where(id: @add_user_ids)
+    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: @add_user_ids)).resolve
     @participations_to_add = users_to_add.ids.map { @rdv.participations.build(user_id: _1, created_by: current_agent) }
+
+    authorize(@rdv, policy_class: Agent::RdvPolicy)
   end
 
   def update

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -78,7 +78,7 @@ class Admin::RdvsController < AgentAuthController
 
   def edit
     add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
-    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.all).resolve.where(id: add_user_ids)
+    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: add_user_ids)).resolve
     users_to_add.ids.each { @rdv.participations.build(user_id: _1) }
 
     @rdv_form = Admin::EditRdvForm.new(@rdv, pundit_user)

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -56,8 +56,9 @@ class Agent::RdvPolicy < ApplicationPolicy
   def users_authorized?
     return @users_authorized if defined?(@users_authorized)
 
+    participation_user_ids = record.participations.map(&:user_id)
     @users_authorized = Agent::UserPolicy::TerritoryScope.new(pundit_user, User).resolve
-      .where(id: record.user_ids).pluck(:id).to_set == record.user_ids.to_set
+      .where(id: participation_user_ids).pluck(:id).to_set == participation_user_ids.to_set
   end
 
   def notify_agents_unauthorized

--- a/config/locales/pundit.fr.yml
+++ b/config/locales/pundit.fr.yml
@@ -5,10 +5,14 @@ fr:
       show?: Vous n’avez pas les droits suffisants pour accéder à cette organisation
     agent/agent_agenda_policy:
       show?: Vous n’avez pas les droits suffisants pour accéder à l’agenda de cet agent
+    agent/rdv_policy:
+      create?: Vous n’avez pas les droits suffisants pour créer ce RDV.
+      edit?: Vous n’avez pas les droits suffisants pour modifier ce RDV.
+      update?: Vous n’avez pas les droits suffisants pour modifier ce RDV.
+      destroy?: Vous devez être admin de l'organisation pour pouvoir supprimer un RDV.
     agent/user_policy:
       show?: Vous n’avez pas les droits suffisants pour voir cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
       edit?: Vous n’avez pas les droits suffisants pour modifier cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
       update?: Vous n’avez pas les droits suffisants pour modifier cette fiche usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
       invite?: Vous n’avez pas les droits suffisants pour inviter cet usager.
       destroy?: Vous n’avez pas les droits suffisants pour supprimer cet usager. Une raison fréquente est que cet usager ne fait pas partie d’une de vos organisations.
-      

--- a/spec/features/agents/rdvs_collectifs/editing_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/editing_spec.rb
@@ -3,10 +3,6 @@ RSpec.describe "Agent can edit a Rdv collectif" do
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, service: service, admin_role_in_organisations: [organisation]) }
   let!(:motif) { create(:motif, :collectif, service: service, organisation: organisation, name: "Atelier Collectif") }
-
-  let(:user) do
-    create(:user, phone_number: "+33611223344", email: "test@exemple.fr", organisations: [organisation])
-  end
   let(:rdv) do
     create(:rdv,
            :without_users,
@@ -16,21 +12,55 @@ RSpec.describe "Agent can edit a Rdv collectif" do
            lieu: create(:lieu, organisation: organisation))
   end
 
-  before do
-    create(:participation, user: user, rdv: rdv, send_lifecycle_notifications: true)
+  describe "doesn't send a cancellation notification if the notifications for the participant are removed" do
+    let!(:user) { create(:user, phone_number: "+33611223344", email: "test@exemple.fr", organisations: [organisation]) }
+
+    # js: true is necessary for the lieu selection
+    it "works on common RDV edit page (edit_admin_organisation_rdv_path)", js: true do
+      create(:participation, user: user, rdv: rdv, send_lifecycle_notifications: true)
+      login_as(agent, scope: :agent)
+      visit edit_admin_organisation_rdv_path(organisation, rdv)
+      find(:label, text: "Notifications de création et modification").click
+
+      expect do
+        click_button "Enregistrer"
+        expect(page).to have_content("Atelier Collectif") # to wait for the request to complete before checking sent emails
+      end.not_to change { ActionMailer::Base.deliveries.size }
+
+      expect(rdv.reload.participations.first.send_lifecycle_notifications).to be false
+    end
+
+    it "works on RDV collectif edit page (edit_admin_organisation_rdvs_collectif_path)" do
+      login_as(agent, scope: :agent)
+      visit edit_admin_organisation_rdvs_collectif_path(organisation, rdv, add_user: [user.id])
+      find(:label, text: "Notifications de création et modification").click
+
+      expect { click_button "Enregistrer" }.not_to change { ActionMailer::Base.deliveries.size }
+      expect(rdv.reload.participations.first.send_lifecycle_notifications).to be false
+    end
   end
 
-  # js: true is necessary for the lieu selection
-  it "doesn't send a cancellation notification if the notifications for the participant are removed", js: true do
-    login_as(agent, scope: :agent)
-    visit edit_admin_organisation_rdv_path(organisation, rdv)
-    find(:label, text: "Notifications de création et modification").click
+  describe "injecting the ID of a user outside of the territory" do
+    let!(:user) do
+      create(:user, organisations: [organisation], first_name: "Francis", last_name: "Factice")
+    end
+    let(:organisation_from_other_territory) { create(:organisation, territory: create(:territory)) }
+    let(:user_from_other_territory) do
+      create(:user, organisations: [organisation_from_other_territory], first_name: "Gaston", last_name: "Bidon")
+    end
 
-    expect do
-      click_button "Enregistrer"
-      expect(page).to have_content("Atelier Collectif") # to wait for the request to complete before checking sent emails
-    end.not_to change { ActionMailer::Base.deliveries.size }
+    it "does not show injected user on page" do
+      login_as(agent, scope: :agent)
 
-    expect(rdv.reload.participations.first.send_lifecycle_notifications).to be false
+      visit edit_admin_organisation_rdvs_collectif_path(organisation, rdv, add_user: [user.id])
+      expect(page).to have_content("Francis")
+
+      visit edit_admin_organisation_rdvs_collectif_path(organisation, rdv, add_user: [user_from_other_territory.id])
+      expect(page).not_to have_content("Gaston")
+
+      visit edit_admin_organisation_rdvs_collectif_path(organisation, rdv, add_user: [user.id, user_from_other_territory.id])
+      expect(page).to have_content("Francis")
+      expect(page).not_to have_content("Gaston")
+    end
   end
 end

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, organisation: organisation, agents: [agent], motif: motif) }
     let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
-    context "when users are arleady saved in database" do
+    context "when users are already saved in database" do
       before do
         user_from_other_territory = create(:user)
         rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
@@ -122,6 +122,9 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
       it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
     end
 
+    # Certains controllers ajoutent des usagers à un RDV à travers
+    # `@rdv.participations.build(...)`, puis appellent cette policy.
+    # Cette section teste ce cas de figure.
     context "when users are added as participations but not yet persisted" do
       before do
         user_from_other_territory = create(:user)

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -103,5 +103,35 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     end
   end
 
+  context "users from outside the current agent's territory" do
+    let(:organisation) { create(:organisation) }
+    let(:service) { create(:service) }
+    let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+    let(:motif) { create(:motif, organisation: organisation, service: service) }
+    let(:rdv) { create(:rdv, organisation: organisation, agents: [agent], motif: motif) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
+
+    context "when users are arleady saved in database" do
+      before do
+        user_from_other_territory = create(:user)
+        rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
+        rdv.save!
+      end
+
+      it_behaves_like "permit actions", :rdv, :destroy?
+      it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
+    end
+
+    context "when users are added as participations but not yet persisted" do
+      before do
+        user_from_other_territory = create(:user)
+        rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
+      end
+
+      it_behaves_like "permit actions", :rdv, :destroy?
+      it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
+    end
+  end
+
   # TODO: write cases for :new? and create? which
 end


### PR DESCRIPTION
https://www.notion.so/rdvs/1832b05ced41805e82a9cb0e2567cfc9

L'usage de `Agent::UserPolicy::TerritoryScope` dans le controller fait en sorte de filtrer les IDs que l'on passe finalement à la policy, et donc la feature spec ne teste pas vraiment un cas où la policy examine des usagers externes. C'est pourquoi j'ai ajouté des tests unitaires sur la policy.

J'ai aussi découvert l'existence de `config/locales/pundit.fr.yml` (il n'est jamais trop tard), et j'entame une amélioration des messages d'erreurs sur les permissions afin d'améliorer l'UX (conjointement avec l'amélioration proposée dans #5007).