### PR TITLE
anonymiser les noms et adresses de lieux dans l’ETL

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -217,16 +217,16 @@ tables:
     anonymized_column_names:
       - phone_number
       - phone_number_formatted
+      - name # on pourrait probablement anonymiser le nom uniquement pour les lieux dont availability == single_use
+      - address # idem
     non_anonymized_column_names:
       - created_at
       - updated_at
-      - name
       - old_address
       - latitude
       - longitude
       - old_enabled
       - availability
-      - address
 
   - table_name: participations
     anonymized_column_names:


### PR DESCRIPTION
Comme indiqué par Victor dans https://mattermost.incubateur.net/betagouv/pl/5aauxmux97f4jmh1pkypgpb49e on a des noms de lieux qui contiennent des données sensibles.