### PR TITLE
Notifier sentry en cas de mauvaise autorisation sur les users

### DIFF
--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -39,9 +39,6 @@ class Agent::RdvPolicy < ApplicationPolicy
   private
 
   def users_and_agents_authorized?
-    notify_agents_unauthorized unless agents_authorized?
-    notify_users_unauthorized unless users_authorized?
-
     users_authorized? && agents_authorized?
   end
 
@@ -53,6 +50,10 @@ class Agent::RdvPolicy < ApplicationPolicy
     return @agents_authorized if defined?(@agents_authorized)
 
     @agents_authorized = (authorized_agent_ids_via_scope + authorized_agent_ids_via_motif).to_set == record.agent_ids.to_set
+
+    notify_agents_unauthorized unless @agents_authorized
+
+    @agents_authorized
   end
 
   def authorized_agent_ids_via_scope
@@ -73,6 +74,10 @@ class Agent::RdvPolicy < ApplicationPolicy
 
     @users_authorized = Agent::UserPolicy::TerritoryScope.new(agent_organisation_context, User).resolve
       .where(id: participation_user_ids).pluck(:id).to_set == participation_user_ids.to_set
+
+    notify_users_unauthorized unless @users_authorized
+
+    @users_authorized
   end
 
   def agent_organisation_context


### PR DESCRIPTION
## Contexte

Le but de cette pr est de nous notifier en cas de problème d'autorisation sur les usagers pour nous aider à débugger un incident en cours sur l'inscription des usagers aux rendez-vous collectif.

## Solution

On envoie une notif sentry si nécessaire lors de tous les appels à users_authorised?, et pas juste lors du create.

Au passage j'ai fais pareil pour les agents.