### PR TITLE
Bugfix : corriger l'inscription d'usager à un RDV collectif

### DIFF
--- a/app/controllers/admin/rdvs_collectifs_controller.rb
+++ b/app/controllers/admin/rdvs_collectifs_controller.rb
@@ -45,7 +45,7 @@ class Admin::RdvsCollectifsController < AgentAuthController
     @rdv = Rdv.find(params[:id])
 
     @add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
-    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: @add_user_ids)).resolve
+    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: @add_user_ids)).resolve.distinct
     @participations_to_add = users_to_add.ids.map { @rdv.participations.build(user_id: _1, created_by: current_agent) }
 
     authorize(@rdv, policy_class: Agent::RdvPolicy)

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -78,7 +78,7 @@ class Admin::RdvsController < AgentAuthController
 
   def edit
     add_user_ids = params[:add_user].to_a + params[:user_ids].to_a
-    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: add_user_ids)).resolve
+    users_to_add = Agent::UserPolicy::TerritoryScope.new(pundit_user, User.where(id: add_user_ids)).resolve.distinct
     users_to_add.ids.each { @rdv.participations.build(user_id: _1) }
 
     @rdv_form = Admin::EditRdvForm.new(@rdv, pundit_user)

--- a/spec/features/agents/rdvs_collectifs/editing_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/editing_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe "Agent can edit a Rdv collectif" do
     end
   end
 
+  describe "adding a user that belongs to several organisations" do
+    it "works" do
+      multi_org_user = create(:user, organisations: [organisation, create(:organisation, territory: organisation.territory)])
+      login_as(agent, scope: :agent)
+
+      visit edit_admin_organisation_rdvs_collectif_path(organisation, rdv, add_user: [multi_org_user.id])
+      expect { click_on "Enregistrer" }.to change { rdv.reload.user_ids }.from([]).to([multi_org_user.id])
+    end
+  end
+
   describe "injecting the ID of a user outside of the territory" do
     let!(:user) do
       create(:user, organisations: [organisation], first_name: "Francis", last_name: "Factice")


### PR DESCRIPTION
La scope faisait une jointure sur les orgas et donc les usagers qui sont sur plusieurs orgas étaient ajoutés plusieurs fois au formulaire.