### PR TITLE
Bugfix : les RDVs avec des usagers soft deleted ne sont pas visibles ni modifiables

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -180,6 +180,10 @@ class Agent < ApplicationRecord
     deleted_at ? :deleted_account : super
   end
 
+  def soft_deleted?
+    deleted_at.present?
+  end
+
   def name_for_paper_trail
     "[Agent] #{full_name}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,10 @@ class User < ApplicationRecord
     deleted_at ? :deleted_account : super
   end
 
+  def soft_deleted?
+    deleted_at.present?
+  end
+
   def user_to_notify
     relative? ? responsible : self
   end

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -49,28 +49,29 @@ class Agent::RdvPolicy < ApplicationPolicy
   def agents_authorized?
     return @agents_authorized if defined?(@agents_authorized)
 
-    @agents_authorized = (authorized_agent_ids_via_scope + authorized_agent_ids_via_motif).to_set == record.agent_ids.to_set
+    rdv_agent_ids = record.agents_rdvs.map(&:agent).reject(&:soft_deleted?).map(&:id)
+    @agents_authorized = (authorized_agent_ids_via_scope(rdv_agent_ids) + authorized_agent_ids_via_motif(rdv_agent_ids)).to_set == rdv_agent_ids.to_set
 
     notify_agents_unauthorized unless @agents_authorized
 
     @agents_authorized
   end
 
-  def authorized_agent_ids_via_scope
+  def authorized_agent_ids_via_scope(rdv_agent_ids)
     Agent::AgentPolicy::Scope.new(pundit_user, Agent).resolve
-      .where(id: record.agent_ids).pluck(:id)
+      .where(id: rdv_agent_ids).pluck(:id)
   end
 
-  def authorized_agent_ids_via_motif
+  def authorized_agent_ids_via_motif(rdv_agent_ids)
     return [] if record.motif.blank?
 
-    record.motif.authorized_agents.where(id: record.agent_ids).pluck(:id)
+    record.motif.authorized_agents.where(id: rdv_agent_ids).pluck(:id)
   end
 
   def users_authorized?
     return @users_authorized if defined?(@users_authorized)
 
-    participation_user_ids = record.participations.map(&:user_id)
+    participation_user_ids = record.participations.map(&:user).reject(&:soft_deleted?).map(&:id)
 
     @users_authorized = Agent::UserPolicy::TerritoryScope.new(agent_organisation_context, User).resolve
       .where(id: participation_user_ids).pluck(:id).to_set == participation_user_ids.to_set

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -136,5 +136,24 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     end
   end
 
+  context "any participating user is soft deleted" do
+    let(:organisation) { create(:organisation) }
+    let(:service) { create(:service) }
+    let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+    let(:motif) { create(:motif, organisation: organisation, service: service) }
+
+    let(:live_user)         { create(:user, deleted_at: 2.weeks.ago) }
+    let(:soft_deleted_user) { create(:user, deleted_at: 2.weeks.ago) }
+
+    let(:live_agent)          { create(:agent, admin_role_in_organisations: [organisation], service: service, deleted_at: 2.weeks.ago) }
+    let(:soft_deleted_agent)  { create(:agent, admin_role_in_organisations: [organisation], service: service, deleted_at: nil) }
+
+    let(:rdv) { create(:rdv, organisation: organisation, agents: [live_agent, soft_deleted_agent], users: [live_user, soft_deleted_user], motif: motif) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
+
+    it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?
+    it_behaves_like "not permit actions", :rdv
+  end
+
   # TODO: write cases for :new? and create? which
 end


### PR DESCRIPTION
# Contexte

Dans #5008 on a introduit un bug : si un RDV a des participations d'usagers qui ont été soft deleted, `#users_authorized?` renvoie toujours `false` car les IDs des usagers supprimés apparaissent dans `participation_user_ids` mais pas dans les requêtes de scopes (car on a `default_scope { where(deleted_at: nil) } ` dans notre modèles `User`).

# Solution

(je traite le problème pour les usagers, mais aussi pour les agents par la même occasion)

Je pense qu'on peut considérer que le fait qu'un usager soit supprimé ne devrait pas interféré avec les droits d'accès au RDV. En conséquence, j'ignore les IDs des usagers soft deleted les logiques de la policy.

Désormais je fais en sorte de considérer les IDs des usagers / agents qui ne sont pas soft deleted, et c'est ces IDs là que je compare aux IDs trouvés en base.

Note : Une fois encore les soft deletes nous donnent du fil à retordre, si vous avez des idées miracle, moi j'en ai pas.
