### PR TITLE
Correction création user profile lors de la modification des participants d’un RDV par l’usager

### DIFF
--- a/app/models/concerns/participation/creatable.rb
+++ b/app/models/concerns/participation/creatable.rb
@@ -5,6 +5,7 @@ module Participation::Creatable
     Participation.transaction do
       empty_rdv_from_relatives
       save!
+      user.add_organisation(organisation)
       notify_create!(author)
     end
   end

--- a/spec/models/concerns/participation/creatable_spec.rb
+++ b/spec/models/concerns/participation/creatable_spec.rb
@@ -66,5 +66,29 @@ RSpec.describe Participation::Creatable, type: :concern do
         expect(rdv.reload.participations).to eq([participation_relative])
       end
     end
+
+    describe "l’usager ajouté n’appartient pas encore à l’organisation" do
+      let!(:organisation) { create(:organisation, rdvs: [rdv]) }
+      let(:participation) { build(:participation, rdv:, user:) }
+
+      it "ajoute l’orga à l’usager" do
+        expect(user.organisations).to be_empty
+        participation.create_and_notify!(user)
+        expect(user.organisations).to contain_exactly(organisation)
+      end
+    end
+
+    describe "l’usager ajouté appartient déjà à l’organisation" do
+      let!(:organisation) { create(:organisation, rdvs: [rdv]) }
+      let!(:user) { create(:user, organisations: [organisation]) }
+      let(:participation) { build(:participation, rdv:, user:) }
+
+      it "ne ré-ajoute pas l’orga à l’usager" do
+        expect(user.organisations).to contain_exactly(organisation)
+        participation.create_and_notify!(user)
+        expect(user.organisations).to contain_exactly(organisation)
+        expect(user.organisations.count).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Contexte

On cherche les sources des cas où l’usager participe à un RDV d’une orga mais n’a pas de user profile dans cette orga.

J’ai trouvé une manière (un peu tordue) de se retrouver dans cette situation : 

- Commencer le flow de prise de rdv
- Se créer un compte usager, le confirmer
- Dans l’étape « pour qui prenez vous RDV » créer 2 proches, mais sélectionner SEULEMENT le premier comme participant
- confirmer le rdv
- modifier le rdv créé pour utiliser le 2e proche plutôt que le premier

cas illustré :

-    je suis Sylvie j’ai deux enfants Jeanne et Antoinette
-   je créé un rdv pour Jeanne dans l’orga A
-    alors: Jeanne et Sylvie sont dans l’orga A mais pas Antoinette

# Solution

Pour corriger le problème j’aurais pu régler ça à deux endroits :  
1. lors de la création du RDV s’assurer que tous les usagers d’une « famille » appartiennent à l’orga
2. lors de la modification du participant d’un usager, s’assurer que le nouveau participant appartient à l’orga

J’ai choisi la deuxième piste sans justification particulière 🤷 
J’ai préféré ne pas écrire un `after_create` pour éviter les effets de bords indésirables. 
J’ai modifié une méthode appelé par le contrôleur côté usager : `create_and_notify!`

Côté agent, il n’y a à ma connaissance pas de problème similaire, les usagers sont « importés » dans l’orga avant d’être ajoutés à un RDV. 