### PR TITLE
Avertissement Sentry lorsqu’un usager participe à un RDV mais n’a pas de user profile pour l’orga

### DIFF
--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -30,6 +30,7 @@ class Participation < ApplicationRecord
   before_create :set_status_from_rdv
   after_save :update_counter_cache
   after_destroy :update_counter_cache
+  after_commit :warn_missing_user_profile, on: %i[create update]
   # voir Outlook::EventSerializerAndListener pour d'autres callbacks
 
   # Scopes
@@ -99,5 +100,14 @@ class Participation < ApplicationRecord
 
   def prescription?
     created_by_prescripteur? || created_by_agent_prescripteur?
+  end
+
+  def warn_missing_user_profile
+    return if user.organisations.include?(rdv.organisation)
+
+    Sentry.capture_message(
+      "Avertissement : un usager participe à un RDV sans appartenir à l'organisation",
+      extra: { rdv_id: rdv.id, participation_id: id, user_id: user_id, organisation_id: rdv.organisation_id }
+    )
   end
 end


### PR DESCRIPTION
# Contexte

On investigue avec François les sources introduisant des usagers participant à des RDV mais n’appartenant pas aux orgas à travers un user profile.

On ne pense pas encore avoir trouvé tous les cas menant à cette situation.

# Solution

je propose de rajouter un after_commit hook sur les participations pour vérifier qu’il y a un user profile correspondant.

Dans le cas contraire je propose d’envoyer un message à Sentry qui nous permettra, je l’espère, de comprendre les sources des problèmes en regardant les stacktraces.

[Exemple d’erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/145459/?environment=development&project=74&query=&referrer=issue-stream&sort=trends&statsPeriod=24h&stream_index=0) qui serait levée (depuis le dev) 
