### PR TITLE
Bugfix : RDV interdit car un usager n'est dans aucune orga

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -280,6 +280,9 @@ Style/ComparableClamp:
 Style/SafeNavigationChainLength:
   Enabled: false
 
+Style/MapToSet:
+  Enabled: false
+
 # cette vérification serait bien à mettre en place mais il y plus de 20 specs qui ne la respectent pas aujourd’hui
 RSpec/NoExpectationExample:
   Enabled: false

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -71,17 +71,21 @@ class Agent::RdvPolicy < ApplicationPolicy
   def users_authorized?
     return @users_authorized if defined?(@users_authorized)
 
-    participation_user_ids = record.participations.map(&:user).reject(&:soft_deleted?).map(&:id).to_set
+    participants = record.participations.map(&:user).reject(&:soft_deleted?).map(&:id).to_set
 
-    users_i_can_create_rdv_for = Agent::UserPolicy::TerritoryScope.new(agent_organisation_context, User).resolve
-      .where(id: participation_user_ids).pluck(:id).to_set
+    territory_scope_users = Agent::UserPolicy::TerritoryScope.new(agent_organisation_context, User).resolve
+      .where(id: participants).pluck(:id).to_set
 
-    users_i_cannot_create_rdv_for = participation_user_ids.difference(users_i_can_create_rdv_for)
-    @users_authorized = if users_i_cannot_create_rdv_for.empty?
+    participants_not_in_territory_scope = participants.difference(territory_scope_users)
+    @users_authorized = if participants_not_in_territory_scope.empty?
+                          # Tous les participants sont dans mon périmètre
                           true
                         else
-                          users_of_rdvs_i_can_see = Scope.new(current_agent, Rdv.joins(:participations).where(participations: { user_id: users_i_cannot_create_rdv_for })).resolve
-                          users_of_rdvs_i_can_see.pluck(:id).to_set == users_i_cannot_create_rdv_for
+                          # Temporaire : si un usager n'est pas dans mon périmètre (orga / territoire)
+                          # mais qu'il participe à des RDV que je peux voir, c'est OK.
+                          # Voir : https://github.com/betagouv/rdv-service-public/pull/5023
+                          users_of_rdvs_i_can_see = Scope.new(current_agent, Rdv.joins(:participations).where(participations: { user_id: participants_not_in_territory_scope })).resolve
+                          users_of_rdvs_i_can_see.pluck(:id).to_set == participants_not_in_territory_scope
                         end
 
     notify_users_unauthorized unless @users_authorized

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -71,10 +71,18 @@ class Agent::RdvPolicy < ApplicationPolicy
   def users_authorized?
     return @users_authorized if defined?(@users_authorized)
 
-    participation_user_ids = record.participations.map(&:user).reject(&:soft_deleted?).map(&:id)
+    participation_user_ids = record.participations.map(&:user).reject(&:soft_deleted?).map(&:id).to_set
 
-    @users_authorized = Agent::UserPolicy::TerritoryScope.new(agent_organisation_context, User).resolve
-      .where(id: participation_user_ids).pluck(:id).to_set == participation_user_ids.to_set
+    users_i_can_create_rdv_for = Agent::UserPolicy::TerritoryScope.new(agent_organisation_context, User).resolve
+      .where(id: participation_user_ids).pluck(:id).to_set
+
+    users_i_cannot_create_rdv_for = participation_user_ids.difference(users_i_can_create_rdv_for)
+    @users_authorized = if users_i_cannot_create_rdv_for.empty?
+                          true
+                        else
+                          users_of_rdvs_i_can_see = Scope.new(current_agent, Rdv.joins(:participations).where(participations: { user_id: users_i_cannot_create_rdv_for })).resolve
+                          users_of_rdvs_i_can_see.pluck(:id).to_set == users_i_cannot_create_rdv_for
+                        end
 
     notify_users_unauthorized unless @users_authorized
 

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -85,7 +85,7 @@ class Agent::RdvPolicy < ApplicationPolicy
                           # mais qu'il participe à des RDV que je peux voir, c'est OK.
                           # Voir : https://github.com/betagouv/rdv-service-public/pull/5023
                           users_of_rdvs_i_can_see = Scope.new(current_agent, Rdv.joins(:participations).where(participations: { user_id: participants_not_in_territory_scope })).resolve
-                          users_of_rdvs_i_can_see.pluck(:id).to_set == participants_not_in_territory_scope
+                          users_of_rdvs_i_can_see.pluck("participations.user_id").to_set == participants_not_in_territory_scope
                         end
 
     notify_users_unauthorized unless @users_authorized

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -103,7 +103,10 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     end
   end
 
-  context "users from outside the current agent's territory" do
+  # Certains controllers ajoutent des usagers à un RDV à travers
+  # `@rdv.participations.build(...)`, puis appellent cette policy.
+  # Cette section teste ce cas de figure.
+  context "adding users from outside the current agent's territory" do
     let(:organisation) { create(:organisation) }
     let(:service) { create(:service) }
     let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
@@ -111,29 +114,13 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     let(:rdv) { create(:rdv, organisation: organisation, agents: [agent], motif: motif) }
     let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
 
-    context "when users are already saved in database" do
-      before do
-        user_from_other_territory = create(:user)
-        rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
-        rdv.save!
-      end
-
-      it_behaves_like "permit actions", :rdv, :destroy?
-      it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
+    before do
+      user_from_other_territory = create(:user)
+      rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
     end
 
-    # Certains controllers ajoutent des usagers à un RDV à travers
-    # `@rdv.participations.build(...)`, puis appellent cette policy.
-    # Cette section teste ce cas de figure.
-    context "when users are added as participations but not yet persisted" do
-      before do
-        user_from_other_territory = create(:user)
-        rdv.participations.build(user_id: user_from_other_territory.id, created_by: agent)
-      end
-
-      it_behaves_like "permit actions", :rdv, :destroy?
-      it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
-    end
+    it_behaves_like "permit actions", :rdv, :destroy?
+    it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
   end
 
   context "any participating user is soft deleted" do

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -167,8 +167,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
 
     before do
       # On s'assure que l'usager du RDV est sans orga
-      UserProfile.where(user: user).destroy_all
-      rdv.reload
+      user.user_profiles.destroy_all
     end
 
     it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
 
     it_behaves_like "permit actions", :rdv, :destroy?
     it_behaves_like "not permit actions", :rdv, :new?, :create?, :edit?
+    it_behaves_like "included in scope"
   end
 
   context "any participating user is soft deleted" do
@@ -140,6 +141,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
 
     it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?
     it_behaves_like "not permit actions", :rdv
+    it_behaves_like "included in scope"
   end
 
   context "the participating user belongs to no organisation but already has a RDV in my orgs" do
@@ -159,6 +161,7 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
 
     it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?
     it_behaves_like "not permit actions", :rdv
+    it_behaves_like "included in scope"
   end
 
   # TODO: write cases for :new? and create? which

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -155,5 +155,25 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     it_behaves_like "not permit actions", :rdv
   end
 
+  context "the participating user belongs to no organisation but already has a RDV in my orgs" do
+    let(:organisation) { create(:organisation) }
+    let(:service) { create(:service) }
+    let(:agent) { create(:agent, admin_role_in_organisations: [organisation], service: service) }
+    let(:motif) { create(:motif, organisation: organisation, service: service) }
+
+    let(:user) { create(:user) }
+    let!(:rdv) { create(:rdv, organisation: organisation, agents: [agent], users: [user], motif: motif) }
+    let(:pundit_context) { AgentOrganisationContext.new(agent, organisation) }
+
+    before do
+      # On s'assure que l'usager du RDV est sans orga
+      UserProfile.where(user: user).destroy_all
+      rdv.reload
+    end
+
+    it_behaves_like "permit actions", :rdv, :new?, :create?, :show?, :edit?, :update?, :destroy?
+    it_behaves_like "not permit actions", :rdv
+  end
+
   # TODO: write cases for :new? and create? which
 end


### PR DESCRIPTION
# Contexte

Nous constatons que certains usagers de la base ne sont liés à aucune orga. Nous ne savons pas pourquoi exactement, et nous tentons de boucher les trous dans #5021 et de monitorer la création de données incohérentes dans #5022.

Nous avons récemment modifié `RdvPolicy` pour qu'elle interdise à un agent d'ajouter à un RDV un usager "en dehors de son périmètre". Le périmètre étant calculé à travers une [intersection des orgas / territoires de l'agent et de l'usager](https://github.com/betagouv/rdv-service-public/blob/c98bf2ceca2b0e5b14064aa467be7b2d4b411ad7/app/policies/agent/user_policy.rb#L50), il est alors devenu interdit de voir / modifier un RDV si il a un usagers sans orga.

# Solution

Le problème est causé par une incohérence des données : des usagers participent à des RDVs mais n'appartiennent à aucune orga.

Il y a donc deux axes de correction : 
1. Correctif paliatif : débloquer les agents qui n'ont pas accès à des RDVs légitimes
2. Trouver la cause de l'incohérence de données (à travers des outils comme #5022)

Cette PR est s'attaque au premier axe, en modifiant la policy pour qu'elle considère qu'on peut gérer un RDV si un usager n'est pas dans l'orga mais que l'usager a déjà des RDVs auxquels on a accès.

Nous prévoyons de retirer ce code une fois les sources d'incohérence identifiées, car il est ajoute de la complexité dans la policy, la rendant difficile à comprendre.
