### PR TITLE
Migration pour créer les user profiles manquants des participations de RDV

### DIFF
--- a/db/migrate/20250127140407_create_missing_user_profiles.rb
+++ b/db/migrate/20250127140407_create_missing_user_profiles.rb
@@ -1,0 +1,21 @@
+class CreateMissingUserProfiles < ActiveRecord::Migration[7.1]
+  def up
+    participations = Participation
+      .joins(:user, :rdv)
+      .joins("LEFT JOIN user_profiles ON user_profiles.user_id = participations.user_id AND user_profiles.organisation_id = rdvs.organisation_id")
+      .where(user_profiles: { id: nil }) # on veut les participations qui n'ont pas de user_profile associé
+      .where(users: { deleted_at: nil }) # on exclut les usagers soft deleted
+      .select("participations.user_id, rdvs.organisation_id") # ces trois lignes permettent de récupérer des paires uniques de user_id et organisation_id
+      .order("participations.user_id, rdvs.organisation_id")
+      .distinct
+      .pluck("participations.user_id, rdvs.organisation_id")
+    Rails.logger.info "\n\n---\n\nCréation de #{participations.size} user_profiles manquants...\n\n---\n\n"
+    participations.each do |user_id, organisation_id|
+      user = User.find(user_id)
+      organisation = Organisation.find(organisation_id)
+      Rails.logger.info "Création du user_profile pour #{user.full_name} (#{user.id}) dans l’orga #{organisation.name} (#{organisation.id})..."
+      user.add_organisation(organisation)
+    end
+    Rails.logger.info "\n\n---\n\nFin !\n\n---\n\n"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_08_115309) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_27_140407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"


### PR DESCRIPTION
# Contexte

On s’intéresse aux cas d’usagers participant à un RDV dans une orga A mais n’ayant pas de user profile dans cette orga.

On vient de déployer une mitigation (#5021 ) qui devrait combler une partie des sources de ces situations.

On voudrait maintenant nettoyer l’existant.

# Solution

Je propose dans cette PR une migration up only qui effectue le nettoyage en parcourant les Participations qui n’ont pas de user profiles correspondant.
On exclut les user qui sont soft deleted pour ne pas les ré-associer à tort aux orgas existantes

# Tests

En local j’ai testé sur un dump semi anonymisé de la prod de RDV SP. Ça créé 177 user profiles sans encombre. Le re-lancement en créé 0, ce qui est attendu.

