### PR TITLE
Vérifier les agents passés à l'update de RDV

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -162,7 +162,6 @@ class Admin::RdvsController < AgentAuthController
 
   def rdv_update_params
     allowed_params = params.require(:rdv).permit(:motif_id, :status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors, :max_participants_count, :name,
-                                                 agent_ids: [],
                                                  participations_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy],
                                                  lieu_attributes: %i[name address latitude longitude id])
 
@@ -171,6 +170,12 @@ class Admin::RdvsController < AgentAuthController
     if allowed_params[:lieu_attributes].present?
       allowed_params[:lieu_attributes][:organisation] = current_organisation
       allowed_params[:lieu_attributes][:availability] = :single_use
+    end
+
+    if params[:rdv][:agent_ids].present?
+      # La méthode Motif#authorized_agents est aussi utilisée pour lister les agents du select
+      # de l'edit, c'est donc cohérent de l'utiliser ici pour sanitizer les IDs d'agent.
+      allowed_params[:agent_ids] = @rdv.motif.authorized_agents.where(id: params[:rdv][:agent_ids]).pluck(:id)
     end
 
     allowed_params

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -72,7 +72,6 @@ class Admin::RdvsController < AgentAuthController
   end
 
   def show
-    @uncollapsed_section = params[:uncollapsed_section]
     authorize(@rdv, policy_class: Agent::RdvPolicy)
   end
 

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -88,7 +88,7 @@ class Admin::RdvsController < AgentAuthController
     authorize(@rdv, policy_class: Agent::RdvPolicy)
 
     @rdv_form = Admin::EditRdvForm.new(@rdv, pundit_user)
-    @success = @rdv_form.submit(rdv_params)
+    @success = @rdv_form.submit(rdv_update_params)
 
     respond_to do |format|
       format.js do
@@ -160,7 +160,7 @@ class Admin::RdvsController < AgentAuthController
     @rdv = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).find(params[:id])
   end
 
-  def rdv_params
+  def rdv_update_params
     allowed_params = params.require(:rdv).permit(:motif_id, :status, :lieu_id, :duration_in_min, :starts_at, :context, :ignore_benign_errors, :max_participants_count, :name,
                                                  agent_ids: [],
                                                  participations_attributes: %i[user_id send_lifecycle_notifications send_reminder_notification id _destroy],
@@ -190,7 +190,7 @@ class Admin::RdvsController < AgentAuthController
 
   def rdv_success_flash
     {
-      notice: if rdv_params[:status].in?(Rdv::CANCELLED_STATUSES)
+      notice: if rdv_update_params[:status].in?(Rdv::CANCELLED_STATUSES)
                 I18n.t("admin.rdvs.message.success.cancel")
               else
                 I18n.t("admin.rdvs.message.success.update")

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -129,6 +129,18 @@ RSpec.describe Admin::RdvsController, type: :controller do
         end.not_to change { rdv.reload.user_ids }
       end
     end
+
+    context "when injecting the ID of an agent that is outside of the organisation (same territory)" do
+      it "doesn't allow updating the RDV with this agent" do
+        other_org_of_territory = create(:organisation, territory: organisation.territory)
+        agent_from_other_org_of_my_territory = create(:agent, :with_territory_access_rights, basic_role_in_organisations: [other_org_of_territory])
+        rdv = create(:rdv, motif: motif, agents: [agent], users: [user], organisation: organisation)
+        new_attributes = { agent_ids: [agent.id, agent_from_other_org_of_my_territory.id] }
+        expect do
+          put :update, params: { organisation_id: organisation.id, id: rdv.to_param, rdv: new_attributes }
+        end.not_to change { rdv.reload.agent_ids }
+      end
+    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
https://www.notion.so/rdvs/1832b05ced41805e82a9cb0e2567cfc9

Détail important : j'ai découvert que quand on fait `rdv.assign_attributes(agent_ids: [1, 2, 3])`, ActiveRecord déclenche une création de `agents_rdvs`, alors qu'on pourrait supposer que la méthode `assign_attributes` ne lance aucune écriture en base ! C'est pour ça que j'ai jugé judicieux de retirer `agent_ids: []` des permitted params. :wink: 