### PR TITLE
application de la policy scope Motif sur admin/rdvs#index

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -36,7 +36,10 @@ class Admin::RdvsController < AgentAuthController
 
     @form = Admin::RdvSearchForm.new(parsed_params.merge(pundit_user:))
     @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).enabled.ordered_by_name
-    @motifs = Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).ordered_by_name
+    @motifs = Agent::MotifPolicy::Scope.new(
+      current_agent,
+      Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).ordered_by_name
+    ).resolve
   end
 
   def a_renseigner

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -36,7 +36,7 @@ class Admin::RdvsController < AgentAuthController
 
     @form = Admin::RdvSearchForm.new(parsed_params.merge(pundit_user:))
     @lieux = Lieu.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).enabled.ordered_by_name
-    @motifs = Agent::MotifPolicy::Scope.new(
+    @motifs = Agent::MotifPolicy::ScopeForRdvsList.new(
       current_agent,
       Motif.joins(:organisation).where(organisations: { id: @scoped_organisations.select(:id) }).ordered_by_name
     ).resolve

--- a/app/policies/agent/motif_policy.rb
+++ b/app/policies/agent/motif_policy.rb
@@ -56,4 +56,26 @@ class Agent::MotifPolicy < ApplicationPolicy
 
     alias current_agent pundit_user
   end
+
+  class ScopeForRdvsList < Scope
+    # on veut permettre aux agents de filtrer sur les motifs d’autres services pour lesquels ils ont des RDV en binôme
+    def resolve
+      super.or(
+        scope.where(
+          organisation: current_agent.basic_orgs + current_agent.admin_orgs,
+          id: motif_ids_from_other_services
+        )
+      )
+    end
+
+    private
+
+    def motif_ids_from_other_services
+      # L’exclusion des services de l’agent ci-dessous n’est pas nécessaire mais évite de retourner de nombreux motif ids dans cette sous-requête
+      AgentsRdv.joins(rdv: [:motif])
+        .where(agent: current_agent)
+        .where.not(motifs: { service_id: current_agent.service_ids })
+        .select("rdvs.motif_id")
+    end
+  end
 end

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe Admin::RdvsController, type: :controller do
   let(:now) { Time.zone.parse("19/07/2019 15:00") }
-  let!(:organisation) { create(:organisation) }
-  let!(:territory) { organisation.territory }
+  let!(:territory) { create(:territory) }
+  let!(:organisation) { create(:organisation, territory:) }
   let!(:service) { create(:service) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation], service: service) }
   let!(:user) { create(:user, first_name: "Marie", last_name: "Denis") }
   let!(:motif) { create(:motif, name: "Suivi", organisation: organisation, service: service, color: "#1010FF") }
+  let!(:motif_from_other_orga) { create(:motif, name: "Suivi", organisation: create(:organisation, territory:), service: service, color: "#1010FF") }
+  let!(:motif_from_other_service) { create(:motif, name: "Suivi", organisation: organisation, service: create(:service), color: "#1010FF") }
 
   before do
     travel_to(now)
@@ -32,6 +34,12 @@ RSpec.describe Admin::RdvsController, type: :controller do
       get(:index, params: { organisation_id: organisation.id, agent_id: agent.id, start: Time.zone.parse("20/07/2019 08:00"), end: Time.zone.parse("27/07/2019 09:00") })
 
       expect(assigns(:form)).not_to be_nil
+    end
+
+    it "assigns motifs" do
+      get(:index, params: { organisation_id: organisation.id })
+
+      expect(assigns(:motifs)).to eq([motif])
     end
 
     context "with invalid dates" do

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe Admin::RdvsController, type: :controller do
   let!(:user) { create(:user, first_name: "Marie", last_name: "Denis") }
   let!(:motif) { create(:motif, name: "Suivi", organisation: organisation, service: service, color: "#1010FF") }
   let!(:motif_from_other_orga) { create(:motif, name: "Suivi", organisation: create(:organisation, territory:), service: service, color: "#1010FF") }
-  let!(:motif_from_other_service) { create(:motif, name: "Suivi", organisation: organisation, service: create(:service), color: "#1010FF") }
+  let!(:other_service) { create(:service) }
+  let!(:motif_from_other_service_without_rdv) { create(:motif, name: "Rencontre", organisation: organisation, service: other_service, color: "#1010FF") }
+  let!(:motif_from_other_service_with_rdv_binome) { create(:motif, name: "Parcours", organisation: organisation, service: other_service, color: "#1010FF") }
+  let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation], service: other_service) }
+  let!(:rdv_binome) { create(:rdv, motif: motif_from_other_service_with_rdv_binome, agents: [agent2, agent], users: [user], organisation: organisation) }
 
   before do
     travel_to(now)
@@ -27,7 +31,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
       rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
       get(:index, params: { organisation_id: organisation.id })
 
-      expect(assigns(:rdvs)).to eq([rdv])
+      expect(assigns(:rdvs)).to contain_exactly(rdv, rdv_binome)
     end
 
     it "assign form" do
@@ -39,7 +43,7 @@ RSpec.describe Admin::RdvsController, type: :controller do
     it "assigns motifs" do
       get(:index, params: { organisation_id: organisation.id })
 
-      expect(assigns(:motifs)).to eq([motif])
+      expect(assigns(:motifs)).to contain_exactly(motif, motif_from_other_service_with_rdv_binome)
     end
 
     context "with invalid dates" do


### PR DESCRIPTION
# Contexte

Actuellement, un agent peut voir les motifs de services auxquels il n’a pas accès sur la page `admin/rdvs#index`.

Cependant, il ne peut pas voir les RDV de ces motifs, la scope sur les RDV est bien appliquée.

# Solution

Appliquer la policy scope des Motifs sur cette route.

J’ai vérifié que ça n’impacte pas les agents admin et les agents secrétaires qui, eux, peuvent voir tous les motifs.

# Captures d’écran

<img width="2623" alt="SCR-20250129-ikhi" src="https://github.com/user-attachments/assets/6389a032-e973-48d5-a88e-f8520f297644" />