### PR TITLE
Pinning des versions node et yarn pour Scalingo

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/ruby-buildpack.git

--- a/.env.sample
+++ b/.env.sample
@@ -110,3 +110,6 @@ SCALINGO_TIMEOUT_ERROR_URL=https://rawcdn.githack.com/betagouv/rdv-service-publi
 
 # Notion
 NOTION_API_SECRET=change_me
+
+# disable npm run build during scalingo build, it will be done by rails assets:precompile
+NPM_NO_BUILD=true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "scripts": {
     "build": "webpack --config webpack.config.js"
   },
+  "engines": {
+    "node": "18.16.1",
+    "yarn": "1.22.21"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@fullcalendar/core": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "build": "webpack --config webpack.config.js"
   },
   "engines": {
-    "node": "18.16.1",
-    "yarn": "1.22.21"
+    "node": "20.9.0",
+    "yarn": "1.22.22"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "select2": "^4.0.8",
     "select2-bootstrap4-theme": "^1.0.0",
     "turbolinks": "^5.2.0",
-    "whatwg-fetch": "^3.0.0"
-  },
-  "devDependencies": {
+    "whatwg-fetch": "^3.0.0",
     "css-loader": "^6.7.1",
     "fstream": "^1.0.12",
     "mini-css-extract-plugin": "^2.6.0",


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5028.osc-secnum-fr1.scalingo.io/) 

# Contexte

Actuellement Scalingo affiche des warnings lors de nos deploys sur les versions de Node et Yarn qui ne sont pas pinnés.

Des tentatives précédentes ont été abandonnées cf #4987 et #3969

# Solution

Comme recommandé dans les logs de deploy Scalingo on spécifie explicitement le multi buildpack node + ruby

On définit aussi `NPM_NO_BUILD=true` sur les envs scalingo pour éviter que le script js `npm run build` soit éxecuté deux fois : par le buildpack node et par le buildpack ruby au travers de `assets:precompile`.

Enfin j’ai du faire un autre changement : déplacer toutes les dépendances JS « dev » dans les dépendances « normales ». C’était nécessaire car le buildpack node fait un « pruning » des dépendances dev que je n’ai pas réussi à désactiver. Lorsque `assets:precompile` se lançait, il manquait alors les dépendances dev comme `webpacker`.

Dans notre cas, quasiment tous les packages Node qu’on installe sont en fait « dev » c’est à dire qu’on ne les utilise que lors du build webpacker mais pas au runtime. Il n’y a que le `dsfr` qu’on installe via node puis dont on expose les assets via un lien symbolique depuis `/public` au runtime.

# Problème restant

l’image buildée par scalingo a l’air de faire 30mb de plus :(