### PR TITLE
Correction mise à jour des agents d’un RDV

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -178,7 +178,7 @@ class Admin::RdvsController < AgentAuthController
     if params[:rdv][:agent_ids].present?
       # La méthode Motif#authorized_agents est aussi utilisée pour lister les agents du select
       # de l'edit, c'est donc cohérent de l'utiliser ici pour sanitizer les IDs d'agent.
-      allowed_params[:agent_ids] = @rdv.motif.authorized_agents.where(id: params[:rdv][:agent_ids]).pluck(:id)
+      allowed_params[:agent_ids] = @rdv.motif.authorized_agents.where(id: params[:rdv][:agent_ids]).pluck(:id).uniq
     end
 
     allowed_params


### PR DESCRIPTION
# Contexte

Cette erreur est apparue après le déploiement de la PR #5026 :
https://sentry.incubateur.net/organizations/betagouv/issues/145875/?referrer=webhooks_plugin

Après investigation, il semble que le pluck(:id) puisse renvoyer des ids doublons.

# Solution

Ce hotfix rajoute juste un `.uniq` pour s’assurer de l’unicité des agent_ids et débloquer le problème.

Il faudrait peut-être rajouter une spec pour éviter une future régression