### PR TITLE
Éviter les doubles-clics sur des boutons de création

### DIFF
--- a/app/views/admin/creneaux_search/index.html.slim
+++ b/app/views/admin/creneaux_search/index.html.slim
@@ -63,7 +63,7 @@
         .col-md-4
           = f.input :lieu_ids, collection: @lieux, label: "Lieu(x)", input_html: { multiple: true, class: "select2-input" }
       .text-right
-        = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux..."}
+        = f.submit "Afficher les créneaux", class: "btn btn-primary", data: { disable_with: "Récupération des créneaux…"}
 
 #creneaux
   .rdv-text-align-center

--- a/app/views/admin/merge_users/_user_selection.html.slim
+++ b/app/views/admin/merge_users/_user_selection.html.slim
@@ -5,7 +5,7 @@
         b>= user.reverse_full_name
         span>= relative_tag(user)
         span>= user_logged_franceconnect_tag(user)
-        = link_to "changer...", ".collapse-#{attribute}", data: { toggle: "collapse" }
+        = link_to "changer…", ".collapse-#{attribute}", data: { toggle: "collapse" }
 
     = f.input attribute, as: :hidden, input_html: { id: attribute }, wrapper: false
 

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -77,7 +77,7 @@
                 .col-md-6.rdv-text-align-center.my-5
                   - if current_organisation.motifs.none?
                     p.mb-2.lead Vous n'avez pas encore créé de motif.
-                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc...
+                    p Les motifs sont les types de RDV que vous proposez dans votre organisation. Chaque motif a des options indépendantes : durée, format (à domicile, par téléphone, sur place), prise de RDV en ligne activée etc…
                   - else
                     p.mb-2.lead Aucun motif ne correspond à votre filtre
                   span.fa-stack.fa-4x

--- a/app/views/admin/prescription/recapitulatif.html.slim
+++ b/app/views/admin/prescription/recapitulatif.html.slim
@@ -29,4 +29,4 @@ main.container
 
           .row.mt-2
             .col.text-right
-              = button_to("Confirmer le rdv", create_rdv_admin_organisation_prescription_path(@rdv_wizard.query_params), method: :post, class: "btn btn-primary")
+              = button_to("Confirmer le rdv", create_rdv_admin_organisation_prescription_path(@rdv_wizard.query_params), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patientez..."})

--- a/app/views/admin/prescription/recapitulatif.html.slim
+++ b/app/views/admin/prescription/recapitulatif.html.slim
@@ -29,4 +29,4 @@ main.container
 
           .row.mt-2
             .col.text-right
-              = button_to("Confirmer le rdv", create_rdv_admin_organisation_prescription_path(@rdv_wizard.query_params), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patientez..."})
+              = button_to("Confirmer le rdv", create_rdv_admin_organisation_prescription_path(@rdv_wizard.query_params), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"})

--- a/app/views/admin/rdvs/_waiting_room.html.slim
+++ b/app/views/admin/rdvs/_waiting_room.html.slim
@@ -4,4 +4,4 @@
     - if rdv.user_in_waiting_room?
       | Usager en salle d'attente
     - else
-      = link_to "Salle d'attente", admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv), method: :post, class: "btn btn-primary", remote: true
+      = link_to "Salle d'attente", admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv), method: :post, class: "btn btn-primary", remote: true, data: { disable_with: "Veuillez patientez..."}

--- a/app/views/admin/rdvs/_waiting_room.html.slim
+++ b/app/views/admin/rdvs/_waiting_room.html.slim
@@ -4,4 +4,4 @@
     - if rdv.user_in_waiting_room?
       | Usager en salle d'attente
     - else
-      = link_to "Salle d'attente", admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv), method: :post, class: "btn btn-primary", remote: true, data: { disable_with: "Veuillez patientez..."}
+      = link_to "Salle d'attente", admin_organisation_rdv_user_in_waiting_room_path(rdv.organisation, rdv), method: :post, class: "btn btn-primary", remote: true, data: { disable_with: "Veuillez patienter…"}

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -33,10 +33,10 @@
     - if @rdvs.total_count > 0
       .card-footer
         div.d-flex.justify-content-end.align-items-center
-          = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "..." do
+          = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
             span> Exporter les RDVs par usager en XLS
             i.fa.fa-download>
-          = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "..." do
+          = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
             span> Exporter les #{@rdvs.total_count} RDVs en XLS
             i.fa.fa-download>
 

--- a/app/views/admin/receipts/_receipts.html.slim
+++ b/app/views/admin/receipts/_receipts.html.slim
@@ -9,7 +9,7 @@
       = render "admin/receipts/receipts_table", receipts: rdv.receipts.most_recent_first
     .card-footer
       - if rdv.starts_at > Time.zone.now
-        = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "btn btn-outline-primary", data: { disable_with: "Veuillez patientez..."}
+        = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "btn btn-outline-primary", data: { disable_with: "Veuillez patienter…"}
       - else
         = link_to t("admin.receipts.send_reminder_manually"), nil, class: "btn btn-light", disabled: true
         .mt-2

--- a/app/views/admin/receipts/_receipts.html.slim
+++ b/app/views/admin/receipts/_receipts.html.slim
@@ -9,7 +9,7 @@
       = render "admin/receipts/receipts_table", receipts: rdv.receipts.most_recent_first
     .card-footer
       - if rdv.starts_at > Time.zone.now
-        = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "btn btn-outline-primary"
+        = link_to t("admin.receipts.send_reminder_manually"), send_reminder_manually_admin_organisation_rdv_path(current_organisation, @rdv), method: :post, class: "btn btn-outline-primary", data: { disable_with: "Veuillez patientez..."}
       - else
         = link_to t("admin.receipts.send_reminder_manually"), nil, class: "btn btn-light", disabled: true
         .mt-2

--- a/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
+++ b/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
@@ -10,6 +10,6 @@ tr id="agent_#{agent.id}"
           span> Retirer
           i.fa.fa-angle-right
       - elsif action == :add
-        = link_to admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patientez..."} do
+        = link_to admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"} do
           span> Ajouter
           i.fa.fa-angle-right

--- a/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
+++ b/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
@@ -10,6 +10,6 @@ tr id="agent_#{agent.id}"
           span> Retirer
           i.fa.fa-angle-right
       - elsif action == :add
-        = link_to admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary" do
+        = link_to admin_organisation_user_referent_assignations_path(current_organisation, @user, agent_id: agent.id),  method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patientez..."} do
           span> Ajouter
           i.fa.fa-angle-right

--- a/app/views/admin/territories/agents/edit.html.slim
+++ b/app/views/admin/territories/agents/edit.html.slim
@@ -57,7 +57,7 @@ h1
           span>
           = label_tag :territorial_admin, "Administrateur du territoire"
           small.form-text.text-muted
-            | Ce status d'agent ouvre un large accès à la création d'organisation, la gestion de la sectorisation, la gestion des webhook, la configuration de ce qui est visible dans une fiche usager, une fiche RDV, la visiblité des catégories de motif, ...
+            | Ce status d'agent ouvre un large accès à la création d'organisation, la gestion de la sectorisation, la gestion des webhook, la configuration de ce qui est visible dans une fiche usager, une fiche RDV, la visiblité des catégories de motif, …
 
         .card-footer
           .row

--- a/app/views/admin/territories/zone_imports/new.html.slim
+++ b/app/views/admin/territories/zone_imports/new.html.slim
@@ -59,7 +59,7 @@
           td Rue des casernes
           td 62080_0180
         tr
-          td.rdv-text-align-center[colspan=3] ...
+          td.rdv-text-align-center[colspan=3] …
     .rdv-text-align-center
       .mb-1.w-75.m-auto.text-muted 3 premières lignes: communes entières, 2 dernières lignes: 2 rues spécifiques
       ul.list-inline

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -25,7 +25,7 @@
               - if @user.invitation_sent_at
                 p.small.m-0 Invitation envoyée il y a #{distance_of_time_in_words_to_now(@user.invitation_sent_at)}
             .col-md-4.text-right
-              = link_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white", data: { disable_with: "Veuillez patientez..."}
+              = link_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white", data: { disable_with: "Veuillez patienter…"}
 
         - if @user.invited_through == "external" && @user.invitation_accepted_at.nil?
           .row.bg-info.text-white.p-2.mb-3

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -25,7 +25,7 @@
               - if @user.invitation_sent_at
                 p.small.m-0 Invitation envoyée il y a #{distance_of_time_in_words_to_now(@user.invitation_sent_at)}
             .col-md-4.text-right
-              = link_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white"
+              = link_to "Inviter", invite_admin_organisation_user_path(current_organisation, @user), method: :post, class: "btn btn-outline-white", data: { disable_with: "Veuillez patientez..."}
 
         - if @user.invited_through == "external" && @user.invitation_accepted_at.nil?
           .row.bg-info.text-white.p-2.mb-3

--- a/app/views/common/_recurrence.html.slim
+++ b/app/views/common/_recurrence.html.slim
@@ -13,7 +13,7 @@
   = f.input :recurrence, as: :hidden, input_html: { value: model.recurrence ? model.recurrence.as_json.to_json : "", "data-target": "recurrence.recurrenceComputed", class: "js-recurrence-computed" }
 
   = simple_fields_for :recurrence do |n|
-    = n.input :has_recurrence, as: :boolean, label: "Répéter...", input_html: { data: { target: "recurrence.hasRecurrence", action: "recurrence#updateRecurrence" }, class: "js-recurrence-toggle js-recurrence-input" }
+    = n.input :has_recurrence, as: :boolean, label: "Répéter…", input_html: { data: { target: "recurrence.hasRecurrence", action: "recurrence#updateRecurrence" }, class: "js-recurrence-toggle js-recurrence-input" }
 
     .all-select
       .form-group

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -34,7 +34,7 @@ div id="creneaux-lieu-#{lieu&.id}"
 
         - if next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center
-            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at)), class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-s-line", data: { disable_with: "..." } do
+            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at)), class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-s-line", data: { disable_with: "Veuillez patienter…" } do
               .d-flex.align-items-center
                 div
                   | Prochaine disponibilité le

--- a/app/views/static_pages/mds.html.slim
+++ b/app/views/static_pages/mds.html.slim
@@ -10,7 +10,7 @@
     .fr-col-12.fr-col-lg-8
       h2 L'insertion sociale
       .small-divider
-      p.lead Les professionnels des MDS aident les publics en difficulté (bénéficiaires de minima sociaux, demandeurs d'emploi) dans leurs démarches administratives ou la constitution de dossiers. En cas de gros problèmes financiers ou de difficultés à se loger, ils peuvent vous aider dans la recherche de solutions d'urgence provisoires&nbsp;: hébergement d'urgence, démarches auprès des banques...
+      p.lead Les professionnels des MDS aident les publics en difficulté (bénéficiaires de minima sociaux, demandeurs d'emploi) dans leurs démarches administratives ou la constitution de dossiers. En cas de gros problèmes financiers ou de difficultés à se loger, ils peuvent vous aider dans la recherche de solutions d'urgence provisoires&nbsp;: hébergement d'urgence, démarches auprès des banques…
     .fr-col-12.fr-col-lg-4.rdv-text-align-center
       = image_tag "static_pages/social.svg", class: "rdv-max-width-60 rdv-max-width-md-100 p-3", alt: ""
 

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -4,7 +4,7 @@ header.main-content__header role="banner"
     = content_for(:title)
   div
     - if page.resource.invitation_accepted_at.nil? && page.resource.password.nil?
-      => link_to "Inviter", invite_super_admins_agent_path(page.resource), method: :post, class: "button" if accessible_action?(page.resource, :invite)
+      => link_to "Inviter", invite_super_admins_agent_path(page.resource), method: :post, class: "button", data: { disable_with: "Veuillez patientez..."} if accessible_action?(page.resource, :invite)
     - if sign_in_as_allowed?
       => link_to "Se logger en tant que", sign_in_as_super_admins_agent_path(page.resource), class: "button" if accessible_action?(page.resource, :sign_in_as)
     => link_to(t("administrate.actions.edit_resource", name: page.page_title), [:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -4,7 +4,7 @@ header.main-content__header role="banner"
     = content_for(:title)
   div
     - if page.resource.invitation_accepted_at.nil? && page.resource.password.nil?
-      => link_to "Inviter", invite_super_admins_agent_path(page.resource), method: :post, class: "button", data: { disable_with: "Veuillez patientez..."} if accessible_action?(page.resource, :invite)
+      => link_to "Inviter", invite_super_admins_agent_path(page.resource), method: :post, class: "button", data: { disable_with: "Veuillez patienter…"} if accessible_action?(page.resource, :invite)
     - if sign_in_as_allowed?
       => link_to "Se logger en tant que", sign_in_as_super_admins_agent_path(page.resource), class: "button" if accessible_action?(page.resource, :sign_in_as)
     => link_to(t("administrate.actions.edit_resource", name: page.page_title), [:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -7,6 +7,6 @@
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body.rdv-text-align-right
         - if @rdv_wizard.rdv.collectif?
-          = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary"
+          = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patientez..."}
         - else
-          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary"
+          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter..."}

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -7,6 +7,6 @@
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body.rdv-text-align-right
         - if @rdv_wizard.rdv.collectif?
-          = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patientez..."}
+          = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"}
         - else
-          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter..."}
+          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"}

--- a/app/views/users/rdvs/edit.html.slim
+++ b/app/views/users/rdvs/edit.html.slim
@@ -12,4 +12,4 @@
       .col
         = link_to "Retour à la liste des créneaux", creneaux_users_rdv_path(@rdv)
       .col.rdv-text-align-right
-        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :put, data: { disable_with: "Veuillez patientez..."}
+        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :put, data: { disable_with: "Veuillez patienter…"}

--- a/app/views/users/rdvs/edit.html.slim
+++ b/app/views/users/rdvs/edit.html.slim
@@ -12,4 +12,4 @@
       .col
         = link_to "Retour à la liste des créneaux", creneaux_users_rdv_path(@rdv)
       .col.rdv-text-align-right
-        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :put
+        = link_to "Confirmer le nouveau créneau", users_rdv_path(@rdv, starts_at: @starts_at.to_s), class: "btn btn-primary", method: :put, data: { disable_with: "Veuillez patientez..."}

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -83,7 +83,7 @@ fr:
         public_office: Sur place
         visio: Par visioconférence
       motif/location_types/hint:
-        public_office: L'agent reçoit l'usager sur place, au lieu sélectionné (MDS...).
+        public_office: L'agent reçoit l'usager sur place, au lieu sélectionné (MDS…).
         visio: L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV. L'agent se connecte au <a href="https://www.numerique.gouv.fr/outils-agents/webconference-etat/" target="_blank">service de webconférence de l'État</a> avec ProConnect pour démarrer la visioconférence.
         phone: L’agent appelle le numéro indiqué sur la fiche de l'usager.
         home: L’agent se rend à l'adresse indiquée sur la fiche de l'usager.

--- a/config/locales/models/motif_category.fr.yml
+++ b/config/locales/models/motif_category.fr.yml
@@ -4,4 +4,4 @@ fr:
       motif_category: Catégorie
     attributes:
       motif_category:
-        category_hint: La catégorie de motifs n’est pas visible par l’usager. Elle peut être utile pour filtrer les motifs proposés dans certains contextes, ou permettre d’avoir un référentiel partagé avec un système externe (API de l’ANTS pour les mairies...)
+        category_hint: La catégorie de motifs n’est pas visible par l’usager. Elle peut être utile pour filtrer les motifs proposés dans certains contextes, ou permettre d’avoir un référentiel partagé avec un système externe (API de l’ANTS pour les mairies…)

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -80,7 +80,7 @@ fr:
         revoked: Annulé
       rdv/statuses/collective_rdv_explanation:
         unknown: Pour corriger l’état du rendez-vous et de toutes les participations.
-        revoked: Le rendez-vous a du être annulé (raison administrative, manque de participants...).
+        revoked: Le rendez-vous a du être annulé (raison administrative, manque de participants…).
         seen: Le rendez-vous collectif a eu lieu.
       rdv/statuses/collective_rdv_explanation_notif:
         unknown: Une notification de nouveau RDV sera envoyée aux usagers.


### PR DESCRIPTION
# Contexte

Nous avons eu à deux reprises de remontées de RDV-I qui nous informent qu'un usager a pris un RDV en double (même agent, même heure, tout pareil).

Et en effet, je constate que le bouton "Confirmer mon RDV" peut être cliqué plusieurs fois de suite, ce qui pour effet de créer plusieurs fois le RDV.

# Solution

Il y a deux niveaux de solutions :
- éviter que l'usager puisse re-cliquer sur un bouton qu'il vient de cliquer (pendant le temps de chargement de la page suivante)
- étendre le mécanisme actuel de détection de créneau déjà pris afin qu'il soit transactionnel (usage d'un mutex ?)

Je pense que le premier point répond à 99 % du problème avec un très petit effort.

## Au passage

J'ai cherché nos usages de `link_to` et `button_to` qui n'utilisaient pas `disable_with`, et je l'ai ajouté pour ceux qui étaient importants (création de RDV, renvoi manuel d'invitation, invitation d'un agent).

Le choix du message "Veuillez patientez..." est discutable, mais je pense que c'est déjà mieux qu'avant.

## Considérations techniques

J'ai découvert que l'option `disable_with` était automatiquement ajoutée lorsque l'on utilise la méthode `submit` fournie par Rails ([voir source](https://github.com/rails/rails/blob/8c39c74b185fcc3d9155791b5932ce993ce3519b/actionview/lib/action_view/helpers/form_tag_helper.rb)). En revanche, lorsque l'on utilise `link_to` ou `button_to`, il faut penser à spécifier `disable_with` si on veut profiter de cette feature de `rails-ujs`.


# Captures d'écran

## Avant

![image](https://github.com/user-attachments/assets/209073e1-2f7a-4a1f-a918-a96370d96dd1)

## Après

![image](https://github.com/user-attachments/assets/986a3ba4-a150-4af7-a16f-f99c82154b1b)
