### PR TITLE
Ne pas mettre à jour l'email d'un usager via l'api quand le compte devise est activé

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,6 +23,15 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   end
 
   def update
+    if @user.confirmed? && user_params[:email].present?
+      render_error :unprocessable_entity, {
+        success: false,
+        errors: {},
+        error_messages: [I18n.t("users.can_not_update_email_of_confirmed_user")],
+      }
+      return
+    end
+
     @user.skip_reconfirmation!
     @user.update!(user_params)
     render_record @user

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   private
 
   def email_change_not_allowed?
-    @user.confirmed? && user_params[:email].present? && @user.email != user_params[:email]
+    @user.confirmed? && user_params.key?(:email) && @user.email != user_params[:email]
   end
 
   def set_organisation

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   end
 
   def update
-    if @user.confirmed? && user_params[:email].present?
+    if email_change_not_allowed?
       render_error :unprocessable_entity, {
         success: false,
         errors: {},
@@ -43,6 +43,10 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   end
 
   private
+
+  def email_change_not_allowed?
+    @user.confirmed? && user_params[:email].present? && @user.email != user_params[:email]
+  end
 
   def set_organisation
     @organisation = params[:organisation_id].present? ? Organisation.find(params[:organisation_id]) : nil

--- a/config/locales/users.fr.yml
+++ b/config/locales/users.fr.yml
@@ -1,6 +1,7 @@
 fr:
   users:
     can_not_delete_because_has_future_rdvs: L'usager ou ses proches ont des rendez-vous programmés, vous ne pouvez pas le supprimer.
+    can_not_update_email_of_confirmed_user: Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte.
     soft_delete_confirm_message:
       relatives:
         one: ⚠️ Cet usager a un proche qui sera aussi supprimé

--- a/spec/requests/api/v1/swagger_doc/users_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/users_request_spec.rb
@@ -188,17 +188,15 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
 
         run_test!
 
-        it "returns error message" do
+        it {
           expect(parsed_response_body).to include(
             success: false,
             errors: {},
             error_messages: ["Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte."]
           )
-        end
+        }
 
-        it "doesn't update the email" do
-          expect(user.reload.email).not_to eq(email)
-        end
+        it { expect(user.reload.email).not_to eq(email) }
       end
 
       response 422, "can't nullify email of confirmed user" do
@@ -207,17 +205,15 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
 
         run_test!
 
-        it "returns error message" do
+        it {
           expect(parsed_response_body).to include(
             success: false,
             errors: {},
             error_messages: ["Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte."]
           )
-        end
+        }
 
-        it "doesn't update the email" do
-          expect(user.reload.email).not_to eq(email)
-        end
+        it { expect(user.reload.email).not_to eq(email) }
       end
 
       it_behaves_like "an endpoint that returns 401 - unauthorized"

--- a/spec/requests/api/v1/swagger_doc/users_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/users_request_spec.rb
@@ -201,6 +201,25 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         end
       end
 
+      response 422, "can't nullify email of confirmed user" do
+        let(:user) { create(:user, organisations: [organisation]) }
+        let(:email) { "" }
+
+        run_test!
+
+        it "returns error message" do
+          expect(parsed_response_body).to include(
+            success: false,
+            errors: {},
+            error_messages: ["Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte."]
+          )
+        end
+
+        it "doesn't update the email" do
+          expect(user.reload.email).not_to eq(email)
+        end
+      end
+
       it_behaves_like "an endpoint that returns 401 - unauthorized"
 
       it_behaves_like "an endpoint that returns 422 - unprocessable_entity", "des paramètres sont manquants ou mal formés ou impossibles", true do

--- a/spec/requests/api/v1/swagger_doc/users_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/users_request_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
       let(:uid) { auth_headers["uid"].to_s }
       let(:client) { auth_headers["client"].to_s }
 
-      let(:user) { create(:user, first_name: "Jean", last_name: "JACQUES", organisations: [organisation]) }
+      let(:user) { create(:user, :unconfirmed, first_name: "Jean", last_name: "JACQUES", organisations: [organisation]) }
       let(:user_id) { user.id }
 
       response 200, "Met à jour et renvoie un·e usager·ère" do
@@ -179,6 +179,25 @@ RSpec.describe "Users API", swagger_doc: "v1/api.json" do
         it "updates non frozen attributes" do
           expect(user.reload.first_name).not_to eq(first_name)
           expect(user.address).to eq(address)
+        end
+      end
+
+      response 422, "can't update email of confirmed user" do
+        let(:user) { create(:user, organisations: [organisation]) }
+        let(:email) { "new@email.fr" }
+
+        run_test!
+
+        it "returns error message" do
+          expect(parsed_response_body).to include(
+            success: false,
+            errors: {},
+            error_messages: ["Vous ne pouvez pas modifier l'email d'un usager ayant validé son compte."]
+          )
+        end
+
+        it "doesn't update the email" do
+          expect(user.reload.email).not_to eq(email)
         end
       end
 


### PR DESCRIPTION
Je me suis rendu compte d'un comportement anormal dans l'api :

**On peut modifier l'email d'un usager ayant activé son compte, il ne reçoit pas d'email lui demandant de valider son nouveau compte, rendant son compte (via l'ancien email) définitivement inaccessible pour lui.**

On a plusieurs pistes pour résoudre ce problème :
- On désactive la possibilité de modifier l'email d'un usager via l'api quand celui ci a activé son compte.
- On garde le même comportement que dans l'interface, c'est à dire que l'email n'est pas modifié directement mais l'usager reçoit un email de devise lui demandant d'activer son nouveau compte. Ce qui peut être un peu perturbant pour l'agent qui fait le changement d'email dans la fiche usager car il n'y a pas de message lui expliquant la situation et l'email n'est pas modifié (il le sera plus tard quand le compte sera de nouveau validé)

Je suis parti sur la première solution mais on peut faire autrement si vous le souhaitez.