### PR TITLE
Désactivation de la signature Chrome dans les specs E2E JS

### DIFF
--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -9,7 +9,7 @@ Capybara.register_driver :selenium do |app|
   chrome_bin = ENV.fetch("GOOGLE_CHROME_SHIM", nil)
   binary = chrome_bin if chrome_bin
   # these args seem to reduce test flakyness
-  args = %w[no-sandbox disable-gpu disable-dev-shm-usage window-size=1500,1000 disable-search-engine-choice-screen]
+  args = %w[no-sandbox disable-gpu disable-dev-shm-usage window-size=1500,1000 disable-search-engine-choice-screen disable-features=MacAppCodeSignClone]
   args.prepend("headless") if ENV["HEADLESS"] != "false"
   options = Selenium::WebDriver::Chrome::Options.new(args:, "goog:loggingPrefs": { browser: "ALL" }, binary:)
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)


### PR DESCRIPTION
Je me demandais pourquoi mon mac me disait que je n’avais plus d’espace disque quand soudain 

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/12675553-f751-4f4f-bf2b-f9958d254ec4" />

À chaque lancement e2e chrome js: true en désactivant headless, une copie du binaire chrome est créée et n’est jamais nettoyée.

J’ai découvert cette solution ici https://issues.chromium.org/issues/379125944