### PR TITLE
Filtrer les agents référents passés via /api/v1/users

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -15,11 +15,12 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
   def create
     params.require(:organisation_ids)
 
-    user = User.new(user_params.merge(created_through: "agent_creation_api"))
-    authorize(user, policy_class: Agent::UserPolicy)
-    user.skip_confirmation_notification!
-    user.save!
-    render_record user
+    @user = User.new
+    @user.assign_attributes(user_params.merge(created_through: "agent_creation_api"))
+    authorize(@user, policy_class: Agent::UserPolicy)
+    @user.skip_confirmation_notification!
+    @user.save!
+    render_record @user
   end
 
   def update

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -55,10 +55,14 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
 
     attrs -= User::FranceconnectFrozenFieldsConcern::FROZEN_FIELDS if @user&.logged_once_with_franceconnect?
 
-    params.permit(*attrs, organisation_ids: []).merge(referent_agent_ids: safe_referent_ids)
+    referents_i_can_modify = Agent::AgentPolicy::Scope.new(pundit_user, @user.referent_agents).resolve
+    referents_i_cant_modify = @user.referent_agents - referents_i_can_modify
+
+    permitted_params = params.permit(*attrs, organisation_ids: [])
+    permitted_params.merge(referent_agent_ids: authorized_referent_ids + referents_i_cant_modify.map(&:id))
   end
 
-  def safe_referent_ids
+  def authorized_referent_ids
     policy_scope(
       Agent.where(id: params[:referent_agent_ids]),
       policy_scope_class: Agent::AgentPolicy::Scope

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -55,6 +55,13 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
 
     attrs -= User::FranceconnectFrozenFieldsConcern::FROZEN_FIELDS if @user&.logged_once_with_franceconnect?
 
-    params.permit(attrs, organisation_ids: [], referent_agent_ids: [])
+    params.permit(*attrs, organisation_ids: []).merge(referent_agent_ids: safe_referent_ids)
+  end
+
+  def safe_referent_ids
+    policy_scope(
+      Agent.where(id: params[:referent_agent_ids]),
+      policy_scope_class: Agent::AgentPolicy::Scope
+    ).ids
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe "/api/v1/users" do
+  let(:my_organisation) { create(:organisation) }
+  let(:myself) { create(:agent, basic_role_in_organisations: [my_organisation]) }
+
+  let(:headers) { api_auth_headers_for_agent(myself) }
+
+  describe "POST #create" do
+    context "simple case, create a user in my org" do
+      let(:params) do
+        {
+          first_name: "Francis",
+          last_name: "Factice",
+          organisation_ids: [my_organisation.id],
+        }
+      end
+
+      it "creates the user" do
+        expect do
+          post "/api/v1/users", headers:, params:, as: :json
+        end.to change(User, :count).by(1)
+        expect(User.last).to have_attributes(
+          first_name: "Francis",
+          last_name: "Factice",
+          organisations: [my_organisation]
+        )
+      end
+    end
+
+    context "when passing arbitrary referent_agent_ids" do
+      let(:agent_from_my_org) { create(:agent, basic_role_in_organisations: [my_organisation]) }
+      let(:agent_from_other_org) { create(:agent) }
+
+      let(:params) do
+        {
+          first_name: "Francis",
+          last_name: "Factice",
+          organisation_ids: [my_organisation.id],
+          referent_agent_ids: [agent_from_other_org.id, myself.id],
+        }
+      end
+
+      it "agent ids outside my orgs are ignored" do
+        post "/api/v1/users", headers:, params:, as: :json
+        expect(User.last.referent_agents).to eq([myself])
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    let(:existing_user) { create(:user, organisations: [my_organisation]) }
+
+    context "simple case, update last name" do
+      let(:params) do
+        {
+          last_name: "Fastoche"
+        }
+      end
+
+      it "updates successfully" do
+        expect do
+          put "/api/v1/users/#{existing_user.id}", headers:, params:, as: :json
+        end.to change { existing_user.reload.last_name }
+        expect(existing_user.reload.last_name).to eq("Fastoche")
+      end
+    end
+
+    context "when passing arbitrary referent_agent_ids" do
+      let(:agent_from_other_org) { create(:agent) }
+
+      let(:params) do
+        {
+          referent_agent_ids: [agent_from_other_org.id, myself.id]
+        }
+      end
+
+      it "filters out external agents" do
+        expect(existing_user.reload.referent_agents).to be_empty
+        put "/api/v1/users/#{existing_user.id}", headers:, params:, as: :json
+        expect(existing_user.reload.referent_agents).to eq([myself])
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -79,5 +79,23 @@ RSpec.describe "/api/v1/users" do
         expect(existing_user.reload.referent_agents).to eq([myself])
       end
     end
+
+    context "quand un usager a un référent auquel je n'ai pas accès en tant qu'agent" do
+      let(:agent_from_other_org) { create(:agent) }
+      let(:params) do
+        {
+          referent_agent_ids: [myself.id],
+        }
+      end
+
+      before do
+        existing_user.referent_agents << agent_from_other_org
+      end
+
+      it "permet de modifier les référents sans supprimer ceux auxquels je n'ai pas accès" do
+        put "/api/v1/users/#{existing_user.id}", headers:, params:, as: :json
+        expect(existing_user.reload.referent_agents).to contain_exactly(myself, agent_from_other_org)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "/api/v1/users" do
     context "simple case, update last name" do
       let(:params) do
         {
-          last_name: "Fastoche"
+          last_name: "Fastoche",
         }
       end
 
@@ -69,7 +69,7 @@ RSpec.describe "/api/v1/users" do
 
       let(:params) do
         {
-          referent_agent_ids: [agent_from_other_org.id, myself.id]
+          referent_agent_ids: [agent_from_other_org.id, myself.id],
         }
       end
 


### PR DESCRIPTION
# Contexte

Anomalie détectée lors de la review de #5047

# Solution

Dans la continuité de #4981 j'ai préféré créer des specs **non swagger** pour ces edge cases, car les specs swagger sont difficiles à lire, lancer et modifier.