### PR TITLE
Changement du query selector pour les autocomplete d’adresse

### DIFF
--- a/app/javascript/components/places-inputs.js
+++ b/app/javascript/components/places-inputs.js
@@ -104,7 +104,7 @@ class PlacesInput {
 
 class PlacesInputs {
   constructor() {
-    document.querySelectorAll('.places-js-container').forEach(elt => new PlacesInput(elt))
+    document.querySelectorAll('input[data-address-autocomplete="on"]').forEach(elt => new PlacesInput(elt))
   }
 }
 

--- a/app/views/admin/lieux/_lieu_fields.html.slim
+++ b/app/views/admin/lieux/_lieu_fields.html.slim
@@ -14,7 +14,7 @@
 = f.input :name, required: true
 - unless is_nested_form
   = f.input :phone_number, hint: I18n.t("simple_form.hints.lieu.phone_number", app_name: current_domain.name)
-= f.input :address, input_html: { class: "places-js-container" }
+= f.input :address, input_html: { data: { "address-autocomplete": "on" } }
 = f.hidden_field :latitude
 = f.hidden_field :longitude
 

--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -32,8 +32,8 @@ ruby:
             small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
               = t(".existing_lieu_hint_html")
       - elsif @rdv.home?
-        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", input_html: { class: "places-js-container" }
+        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", input_html: { data: { "address-autocomplete": "on" } }
       - elsif @rdv.phone?
-        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", input_html: { class: "places-js-container" }
+        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", input_html: { data: { "address-autocomplete": "on" } }
       = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input", data: { "auto-select-sole-option": true } }
       = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -54,7 +54,7 @@
                     = t(".existing_lieu_hint_html")
 
             - elsif @rdv_form.motif.home?
-              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { class: "places-js-container" }
+              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { data: { "address-autocomplete": "on" } }
             = f.association :agents,
               collection: @rdv_form.motif.authorized_agents,
               label_method: :full_name_and_service,

--- a/app/views/admin/territories/sectorisation_tests/search.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/search.html.slim
@@ -14,7 +14,7 @@ do |f|
         :where, \
         label: "Adresse", \
         placeholder: "ex : 21 rue Anatole France, Calais", \
-        input_html: { class: "places-js-container" }
+        input_html: { data: { "address-autocomplete": "on" } }
       .row.align-items-center.bg-light.py-2.mb-2
         .col-lg-2 Infos de la Base Adresse
         .col-lg-2= f.input :departement, readonly: true, label: "Département"

--- a/app/views/admin/territories/zones/_form.html.slim
+++ b/app/views/admin/territories/zones/_form.html.slim
@@ -29,15 +29,13 @@
     = f.input :city_label, \
       label: "Rechercher une commune", \
       input_html: { \
-        class: "places-js-container", \
-        data: { "address-type": "municipality" }, \
+        data: { "address-type": "municipality", "address-autocomplete": "on" }, \
       }
   - elsif zone.level_street?
     = f.input :street_label, \
       label: "Rechercher une rue", \
       input_html: { \
-        class: "places-js-container", \
-        data: { "address-type": "street" }, \
+        data: { "address-type": "street", "address-autocomplete": "on" }, \
       }
   .row
     .col-6

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -44,14 +44,14 @@
     | L'usager ayant validé son compte, vous ne pouvez plus modifier ses préférences
 
 - unless current_domain == Domain::RDV_MAIRIE
-  = f.input :address, **(input_opts.deep_merge(input_html: { class: "places-js-container" }))
+  = f.input :address, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" } }))
 
   = f.input :city_code, as: :hidden, **input_opts
   = f.input :post_code, as: :hidden, **input_opts
   = f.input :city_name, as: :hidden, **input_opts
 
 - if current_territory.enable_address_details
-  = f.input :address_details, **(input_opts.deep_merge(input_html: { class: "places-js-container" }))
+  = f.input :address_details, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" } }))
 
 - if current_territory.enable_case_number
   = f.input :case_number, **input_opts

--- a/app/views/fields/places_field/_form.html.slim
+++ b/app/views/fields/places_field/_form.html.slim
@@ -1,4 +1,4 @@
 .field-unit__label
   = f.label field.attribute
 .field-unit__field
-  = f.text_field field.attribute, class: "places-js-container"
+  = f.text_field field.attribute, data: { "address-autocomplete": "on" }

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -11,6 +11,6 @@ section.rdv-background-color-alt-blue-ecume.fr-pt-4w.fr-pb-8w
         = f.hidden_field :longitude, name: "longitude", value: context.longitude
         / TODO: change input name to address and change whereInput in application.js
         .fr-search-bar.fr-search-bar--lg[role="search"]
-          = f.text_field :where, label: false, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input places-js-container", required: true, value: context.address
+          = f.text_field :where, label: false, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input", required: true, value: context.address, data: { "address-autocomplete": "on" }
           = button_tag :button, id: "search_submit", class: "fr-btn" do
             | Rechercher

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -23,7 +23,7 @@ section.main-content__body
         = ff.input :ants_connectable, as: :boolean, label: "Autoriser le branchement au moteur de recherche de l'ANTS", hint: "En cochant cette case, vous permettrez à cette organisation (probablement une mairie) d'apparaitre sur https://rendezvouspasseport.ants.gouv.fr/"
 
     = f.simple_fields_for :lieu do |ff|
-      = ff.input :address, label: "Adresse du premier lieu", hint: "", input_html: { class: "places-js-container"}
+      = ff.input :address, label: "Adresse du premier lieu", hint: "", input_html: { data: { "address-autocomplete": "on" } }
       = ff.input :latitude, as: :hidden
       = ff.input :longitude, as: :hidden
 

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -28,10 +28,10 @@ ruby:
   div= f.input :notify_by_sms
   - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
-    = f.input :address, input_html: {value: address_value, class: "places-js-container" }, required: rdv_wizard&.motif&.home?
+    = f.input :address, input_html: {value: address_value, data: { "address-autocomplete": "on" } }, required: rdv_wizard&.motif&.home?
 
   - if territories.map(&:enable_address_details).any?
-    = f.input :address_details, input_html: {class: "places-js-container" }
+    = f.input :address_details, input_html: { data: { "address-autocomplete": "on" } }
 
   = f.input :city_code, as: :hidden
   = f.input :post_code, as: :hidden


### PR DESCRIPTION
# Contexte

Durant la rédaction de : https://github.com/betagouv/rdv-service-public/pull/4969
Je me suis rendu compte que nous utilisions une classe CSS comme sélecteur pour activer l’autocomplétion d’adresse.
J’ai une préférence pour que nous gardions les classes pour leur usage original, c-à-d styliser des éléments.

# Solution

Vu que sur d’autres paramètres de l’autocomplete on utilise l’attribut `data-address-` je propose donc de changer le sélecteur par `data-address-autocomplete`

