### PR TITLE
Ajout d'un script pour extraire une mairie de son territoire

### DIFF
--- a/scripts/extract_mairie_from_territory.rb
+++ b/scripts/extract_mairie_from_territory.rb
@@ -41,7 +41,7 @@ class ExtractMairieFromTerritory
       end
 
       MotifCategory.requires_ants_predemande_number.each do |motif_category|
-        MotifCategoriesTerritory.create(
+        MotifCategoriesTerritory.create!(
           motif_category: motif_category,
           territory: @new_territory
         )
@@ -49,8 +49,8 @@ class ExtractMairieFromTerritory
 
       # On ne met que les services des agents de la mairie
       # Le territoire mairies a beaucoup de services utilisés par une seule mairie
-      organisation.agents.map(&:services).flatten.each do |service|
-        TerritoryService.create(
+      organisation.agents.map(&:services).flatten.uniq.each do |service|
+        TerritoryService.create!(
           territory: @new_territory,
           service: service
         )
@@ -58,7 +58,7 @@ class ExtractMairieFromTerritory
       AgentTerritorialRole.find_or_initialize_by(
         territory: @new_territory,
         agent_id: @admin_agent_id
-      ).save
+      ).save!
     end
   end
 

--- a/scripts/extract_mairie_from_territory.rb
+++ b/scripts/extract_mairie_from_territory.rb
@@ -1,0 +1,81 @@
+# Ce script permet de sortir une mairie du territory historique des mairies, pour lui donner son propre territoire.
+
+# exemple pour une mairie a juste une organisation dans le territoire existant:
+# ExtractMairieFromTerritory.run(110, 155)
+#
+# exemple pour une mairie qui a une organisation dans le territoire mairie et une autre organisation dans un autre territoire
+# on peut déplacer l'organisation du territoire mairie en faisant:
+# ExtractMairieFromTerritory.run(454, 952, new_territory_id: 265)
+
+class MotifCategoriesTerritory < ApplicationRecord
+  belongs_to :motif_category
+  belongs_to :territory
+end
+
+class ExtractMairieFromTerritory
+  # organisation_id : l'id de l'organisation d'origine de la mairie
+  def self.run(organisation_id, admin_agent_id, new_territory_id: nil)
+    new(organisation_id, admin_agent_id, new_territory_id:).run
+  end
+
+  def initialize(organisation_id, admin_agent_id, new_territory_id:)
+    @organisation_id = organisation_id
+    @admin_agent_id = admin_agent_id
+    @new_territory = Territory.find_by(id: new_territory_id)
+  end
+
+  def run
+    ActiveRecord::Base.logger = Logger.new($stdout)
+
+    ActiveRecord::Base.transaction do
+      @new_territory ||= Territory.create!(
+        name: organisation.name,
+        departement_number: departement_number
+      )
+      organisation.update!(territory: @new_territory)
+
+      organisation.agents.each do |agent|
+        agent.agent_territorial_access_rights.where(territory_id: mairies_territory.id).each do |rights|
+          rights.update!(territory: @new_territory)
+        end
+      end
+
+      MotifCategory.requires_ants_predemande_number.each do |motif_category|
+        MotifCategoriesTerritory.create(
+          motif_category: motif_category,
+          territory: @new_territory
+        )
+      end
+
+      # On ne met que les services des agents de la mairie
+      # Le territoire mairies a beaucoup de services utilisés par une seule mairie
+      organisation.agents.map(&:services).flatten.each do |service|
+        TerritoryService.create(
+          territory: @new_territory,
+          service: service
+        )
+      end
+      AgentTerritorialRole.find_or_initialize_by(
+        territory: @new_territory,
+        agent_id: @admin_agent_id
+      ).save
+    end
+  end
+
+  private
+
+  def departement_number
+    zipcode_regex = /\d{5}/
+    zipcode = organisation.lieux.first.address[zipcode_regex]
+
+    zipcode[0..1]
+  end
+
+  def mairies_territory
+    @mairies_territory ||= Territory.find_by(name: Territory::MAIRIES_NAME)
+  end
+
+  def organisation
+    @organisation ||= Organisation.find(@organisation_id)
+  end
+end


### PR DESCRIPTION
# Contexte

Pour permettre aux communes de proposer des rendez-vous pour des motifs autres que les papiers d'identité, on veut permettre à chaque commune de disposer de son propre "territoire", ce qui permettra aux admins de communes de créer une nouvelle organisation, par exemple pour un CCAS.
On a eu le besoin de faire cette manipulation pour deux communes différentes :
- Gattieres, qui avait juste une organisation dans le territoire "mairies" partagée entre toutes les communes
- Sèvres, qui avait une organisation dans son propre territoire, et une organisation dans le territoire "mairies".

Ce script a permis de faire l'opération pour ces deux communes, et cette PR propose de commiter le code pour pouvoir le réutiliser


# Solution

Le script s'inspire de `scripts/split_territory.rb`, avec l'avantage de proposer des simplifications puisque les orga des mairies ont moins d'options.

# Prochaines étapes

On va sans doute vouloir le faire tourner sur les 87 communes groupées dans le territoire mairies, en se synchronisant avec l'équipe déploiement.
Ça veut aussi dire qu'on va amener plus d'agents à avoir accès à un espace admin de territoire. C'est une bonne motivation pour faire un peu de ménage dedans, et enlever la possibilité d'activer le champs "remarques".