### PR TITLE
Amélioration des textes affichés lors de la connexion agent et de l'oauth

### DIFF
--- a/app/helpers/deprecated_path_helper.rb
+++ b/app/helpers/deprecated_path_helper.rb
@@ -1,8 +1,4 @@
 module DeprecatedPathHelper
-  def agent_path?
-    request.path =~ /(agents|admin)/ || (request.path == "/" && current_agent.present?)
-  end
-
   def stats_path?
     request.path.match(%r{^/stats.*})
   end

--- a/app/views/doorkeeper/authorizations/new.html.slim
+++ b/app/views/doorkeeper/authorizations/new.html.slim
@@ -13,7 +13,6 @@ h2.rdv-text-align-center.mt-0.font-weight-bold.mb-4 Validation de permissions
 
     p
       |> En continuant, vous allez permettre à <b>#{@pre_auth.client.application.name}</b> d'accéder à votre compte <b>#{current_domain.name}</b>
-      |> lié à l'adresse #{current_agent.email}
 
     - @pre_auth.scopes.each do |scope|
       / Quand on affinera les scopes, il faudra ajouter des textes d'explication pour les permissions données ici

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -24,12 +24,23 @@ html lang="fr"
               |< Retour à l'accueil
           .align-items-center.d-flex.mt-2.mt-lg-4
             .p-1.p-lg-3.flex-grow-1.mt-lg-4
-              - if agent_path? && current_agent.nil?
-                p.lead.mb-3 Terminé l'agenda papier, moins de temps perdu.
-              - elsif agent_path? && current_agent.present?
-                = render "agents/preferences_menu"
+              - if current_agent
+                / Lors de la connexion par Oauth, on affiche juste les informations qui indiquent à l'agent qu'iel est connecté.e, et avec quel compte
+                / On ne propose pas tout le menu, parce que ce n'est pas pertinent de faire sortir l'agent du flow d'Oauth
+                - if controller.instance_of?(Doorkeeper::AuthorizationsController)
+                  .d-flex.flex-row.justify-content-center
+                    div.text-left
+                      h3 = current_agent.full_name
+                      p = current_agent.email
+                - else
+                  = render "agents/preferences_menu"
               - else
-                h4.mb-3 Prenez RDV en ligne avec votre département !
+                p.lead.mb-3
+                  ' Faciliter
+                  span.rdv-color-blue-ecume-sun-247-moon-675-hover
+                    ' la gestion et la prise de rendez‑vous
+                    / on utilise un non-breaking hyphen dans rendez-vous pour éviter le retour à la ligne
+                  | dans votre administration
 
         .auth-fluid-form-box.col-xs-12.col-md-8
           / Permet de centrer les formulaire de login, et d'aligner en haut de l'écran les formulaires de préférences

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "OAuth provider", ignore_js_errors: true, js: true do
     click_on "Se connecter"
 
     expect(page).to have_content("Connexion réussie")
-    expect(page).to have_content("En continuant, vous allez permettre à Démarches Simplifiées d'accéder à votre compte RDV Solidarités lié à l'adresse francis@factice.org")
+    expect(page).to have_content("En continuant, vous allez permettre à Démarches Simplifiées d'accéder à votre compte RDV Solidarités")
     click_on "Continuer"
     expect(page).to have_content("Votre email est francis@factice.org")
 
@@ -101,7 +101,8 @@ RSpec.describe "OAuth provider", ignore_js_errors: true, js: true do
     click_on "Se connecter"
 
     expect(page).to have_content("Connexion réussie")
-    expect(page).to have_content("En continuant, vous allez permettre à Démarches Simplifiées d'accéder à votre compte RDV Solidarités lié à l'adresse francis@factice.org")
+    expect(page).to have_content("En continuant, vous allez permettre à Démarches Simplifiées d'accéder à votre compte RDV Solidarités")
+    expect(page).to have_content(agent.email) # On indique à l'agent le compte utilisé pour la connexion
     click_on "Continuer"
 
     expect(page).to have_content("Votre email est francis@factice.org")


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1309" alt="Screenshot 2025-02-07 at 11 49 43" src="https://github.com/user-attachments/assets/c41a6ada-0e0e-44c2-8714-b7cd1336e82a" />|<img width="1321" alt="Screenshot 2025-02-07 at 11 56 53" src="https://github.com/user-attachments/assets/2d4aade3-5efe-49e3-82f6-0ac5641466d7" />
<img width="1311" alt="Screenshot 2025-02-07 at 11 49 29" src="https://github.com/user-attachments/assets/f406658a-8963-45cc-91a6-dc276624fcda" />|<img width="1298" alt="Screenshot 2025-02-07 at 11 57 26" src="https://github.com/user-attachments/assets/286a49cc-fbea-4fb3-b530-0257ae996228" />

# Contexte

On a plusieurs partenaires qui se préparent à mettre en prod la connexion par Oauth, donc c'est l'occasion de faire des petites améliorations cosmétiques.

# Changements

- Le vieux texte "Terminé l'agenda papier, moins de temps perdu." est remplacé par notre nouvelle proposition de valeur utilisée sur la landing page "Faciliter la gestion et la prise de rendez‑vous dans votre administration" (validé avec Léa). Ce changement est pour toutes les connexions des agents, pas juste l'oauth
- Pour l'oauth on enlève la tagline encore plus ancienne et maintenant obsolète. Pour clarifier à l'agent que la connexion à RDV Service Public est faite, et le compte qui est utilisé, on reprend l'affichage habituel du layout agent config, mais avec moins d'éléments. On met uniquement l'email qui permet de comprendre quel compte est utilisé (pratique pour les agents qui ont plusieurs comptes avec des emails différents), et on n'affiche pas les entrées de menus classique, parce qu'on ne veut pas que l'agent sorte du parcours d'oauth.

# Prochaines étapes

On pourrait faire d'autres petites améliorations visuelles, notamment transformer le premier flash d'erreur en un flash d'infos moins agressif, mais ça sera dans une autre pr.