### PR TITLE
Fix - Update Microsoft refresh token

### DIFF
--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -92,13 +92,10 @@ module Outlook
 
       if refresh_token_response["error"].present?
         raise RefreshTokenError, refresh_token_response["error"]
+      elsif refresh_token_response["access_token"].present? && refresh_token_response["refresh_token"].present?
+        @agent.update!(microsoft_graph_token: refresh_token_response["access_token"], refresh_microsoft_graph_token: refresh_token_response["refresh_token"])
       else
-        if refresh_token_response["access_token"].present?
-          @agent.update!(microsoft_graph_token: refresh_token_response["access_token"])
-        end
-        if refresh_token_response["refresh_token"].present?
-          @agent.update!(refresh_microsoft_graph_token: refresh_token_response["refresh_token"])
-        end
+        raise RefreshTokenError, "Could not refresh token, invalid response (does not contain access_token and refresh_token)"
       end
     end
 

--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -92,8 +92,13 @@ module Outlook
 
       if refresh_token_response["error"].present?
         raise RefreshTokenError, refresh_token_response["error"]
-      elsif refresh_token_response["access_token"].present?
-        @agent.update!(microsoft_graph_token: refresh_token_response["access_token"])
+      else
+        if refresh_token_response["access_token"].present?
+          @agent.update!(microsoft_graph_token: refresh_token_response["access_token"])
+        end
+        if refresh_token_response["refresh_token"].present?
+          @agent.update!(refresh_microsoft_graph_token: refresh_token_response["refresh_token"])
+        end
       end
     end
 

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -136,7 +136,15 @@ RSpec.describe Outlook::ApiClient do
           .with(
             body: { "client_id" => "fake_client_id", "client_secret" => "fake_client_secret", "grant_type" => "refresh_token", "refresh_token" => "refresh_token" }
           )
-          .to_return(status: 200, body: { access_token: "abc", refresh_token: "123" }.to_json, headers: {})
+          .to_return(status: 200, body: {
+            token_type: "Bearer",
+            scope: "email openid profile https://graph.microsoft.com/Calendars.ReadWrite https://graph.microsoft.com/User.Read",
+            access_token: "abc",
+            refresh_token: "123",
+            expires_in: 4365,
+            ext_expires_in: 4365,
+            id_token: "id_token",
+          }.to_json, headers: {})
 
         stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
           .with(body: expected_body, headers: expected_updated_headers)

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Outlook::ApiClient do
           .with(
             body: { "client_id" => "fake_client_id", "client_secret" => "fake_client_secret", "grant_type" => "refresh_token", "refresh_token" => "refresh_token" }
           )
-          .to_return(status: 200, body: { access_token: "abc" }.to_json, headers: {})
+          .to_return(status: 200, body: { access_token: "abc", refresh_token: "123" }.to_json, headers: {})
 
         stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
           .with(body: expected_body, headers: expected_updated_headers)
@@ -150,6 +150,7 @@ RSpec.describe Outlook::ApiClient do
                          "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_body)).to have_been_made.twice
 
         expect(agent.reload.microsoft_graph_token).to eq("abc")
+        expect(agent.reload.refresh_microsoft_graph_token).to eq("123")
       end
     end
 


### PR DESCRIPTION
# Contexte

Nous avons des agents qui ont synchronisé leur compte RDV-S avec leur compte Outlook. Au bout de 90 jours, la synchronisation s’est arrêtée. Ce nombre de jours correspond avec la validité du refresh token.
Aujourd’hui il semble que nous ne mettions jamais à jour ce token. Comme indiqué dans la documentation de Microsoft Graph, un nouveau refresh token est envoyé à chaque utilisation :  https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens.

# Solution

On met donc à jour le refresh token en même temps que l’accès token.

Note : j’ai testé les points d’API manuellement et le refresh token est bien mis à jour à chaque appel.

# À suivre

- Débloquer les agents qui sont bloqués actuellement. Ils ne peuvent pas à ce jour supprimer eux-mêmes la synchronisation pour la remettre en place, car lors de la suppression, nous essayons de supprimer les éléments présents dans les agendas.
- Trouver une solution pour éviter ce blocage parce que cette situation peut se reproduire dans certains cas. Voir : https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens
