### PR TITLE
Permettre des redirections vers des applications oauth autre que Mon Suivi Social

### DIFF
--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
       RdvPlan.create!(
         planning_agent: current_agent,
         user: user,
+        oauth_application: doorkeeper_token&.application,
         return_url: params[:return_url]
       )
     end

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -6,6 +6,7 @@ class RdvPlan < ApplicationRecord
   belongs_to :motif, optional: true
   belongs_to :lieu, optional: true
   belongs_to :rdv, optional: true
+  belongs_to :oauth_application, class_name: "Doorkeeper::Application", optional: true
 
   delegate :organisation, to: :motif
 
@@ -57,13 +58,17 @@ class RdvPlan < ApplicationRecord
   def return_url_is_authorized
     return if return_url.blank?
 
-    uri = URI.parse(return_url)
+    return_uri = URI.parse(return_url)
 
-    unless uri.scheme&.in?(%w[http https])
+    unless return_uri.scheme&.in?(%w[http https])
       errors.add(:return_url, "Doit utiliser http ou https")
     end
-    unless uri.host&.end_with?(".gouv.fr")
-      errors.add(:return_url, "N'est pas un nom de domaine autorisé")
+
+    authorized_domain_names = oauth_application.redirect_uri.split("\n").map do |uri|
+      URI.parse(uri).host
+    end
+    unless return_uri.host&.in?(authorized_domain_names)
+      errors.add(:return_url, "n'est pas un nom de domaine autorisé")
     end
   end
 end

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -6,6 +6,9 @@ class RdvPlan < ApplicationRecord
   belongs_to :motif, optional: true
   belongs_to :lieu, optional: true
   belongs_to :rdv, optional: true
+  # Le `optional: true` sur les oauth_application est un peu anticipé : on pourra avoir ce cas quand des
+  # rdv_plans seront créés en natif depuis l'application, probablement pour enregistrer un brouillon de rdv
+  # TODO: il faudrait mettre à jour la spec swagger pour utiliser de l'oauth pour pouvoir enlever le `optional: true`
   belongs_to :oauth_application, class_name: "Doorkeeper::Application", optional: true
 
   delegate :organisation, to: :motif

--- a/app/views/agents/rdv_plans/rdv.html.slim
+++ b/app/views/agents/rdv_plans/rdv.html.slim
@@ -30,4 +30,4 @@
         .fr-mt-4w
           = link_to "Modifier", edit_admin_organisation_rdv_path(@rdv.organisation, @rdv), class: "fr-btn fr-btn--secondary", target: :blank
     - if @rdv_plan.return_url
-      = link_to "Retour sur Mon Suivi Social", @rdv_plan.return_url, class: "float-right"
+      = link_to "Retour sur #{@rdv_plan.oauth_application.name}", @rdv_plan.return_url, class: "float-right"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,40 +3,6 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "2747f988c20b0979bf7fe9339e5ba78a0f118f9f87ba443060f1ee2bd0cd52c6",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/agents/rdv_plans/rdv.html.slim",
-      "line": 33,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Retour sur Mon Suivi Social\", RdvPlan.find(params[:id]).return_url, :class => \"float-right\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Agents::RdvPlansController",
-          "method": "rdv",
-          "line": 82,
-          "file": "app/controllers/agents/rdv_plans_controller.rb",
-          "rendered": {
-            "name": "agents/rdv_plans/rdv",
-            "file": "app/views/agents/rdv_plans/rdv.html.slim"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "agents/rdv_plans/rdv"
-      },
-      "user_input": "RdvPlan.find(params[:id]).return_url",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
       "fingerprint": "b96d8c613cd055c2962f67120dcbe2aef94766bd6c03784624afd356adc0adaf",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
@@ -60,6 +26,40 @@
       "location": {
         "type": "template",
         "template": "agents/rdv_plans/edit_starts_at"
+      },
+      "user_input": "RdvPlan.find(params[:id]).return_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "eb06341fb0ece8eb672553f39d23c6f20622a266bd155402f243287541ba2f19",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/agents/rdv_plans/rdv.html.slim",
+      "line": 33,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Retour sur #{RdvPlan.find(params[:id]).oauth_application.name}\", RdvPlan.find(params[:id]).return_url, :class => \"float-right\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Agents::RdvPlansController",
+          "method": "rdv",
+          "line": 82,
+          "file": "app/controllers/agents/rdv_plans_controller.rb",
+          "rendered": {
+            "name": "agents/rdv_plans/rdv",
+            "file": "app/views/agents/rdv_plans/rdv.html.slim"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "agents/rdv_plans/rdv"
       },
       "user_input": "RdvPlan.find(params[:id]).return_url",
       "confidence": "Weak",

--- a/db/migrate/20250210110923_add_oauth_applications_to_rdv_plans.rb
+++ b/db/migrate/20250210110923_add_oauth_applications_to_rdv_plans.rb
@@ -1,0 +1,6 @@
+class AddOauthApplicationsToRdvPlans < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rdv_plans, :oauth_application_id, :bigint
+    add_foreign_key :rdv_plans, :oauth_applications, validate: false
+  end
+end

--- a/db/migrate/20250210110923_add_oauth_applications_to_rdv_plans.rb
+++ b/db/migrate/20250210110923_add_oauth_applications_to_rdv_plans.rb
@@ -1,6 +1,9 @@
 class AddOauthApplicationsToRdvPlans < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
   def change
     add_column :rdv_plans, :oauth_application_id, :bigint
+    add_index :rdv_plans, :oauth_application_id, algorithm: :concurrently
     add_foreign_key :rdv_plans, :oauth_applications, validate: false
   end
 end

--- a/db/migrate/20250210111401_validate_rdv_plan_oauth_app_foreign_key.rb
+++ b/db/migrate/20250210111401_validate_rdv_plan_oauth_app_foreign_key.rb
@@ -1,0 +1,5 @@
+class ValidateRdvPlanOauthAppForeignKey < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :rdv_plans, :oauth_applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_21_133641) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_10_111401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -595,6 +595,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_133641) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.enum "location_type", enum_type: "location_type"
+    t.bigint "oauth_application_id"
     t.index ["lieu_id"], name: "index_rdv_plans_on_lieu_id"
     t.index ["motif_id"], name: "index_rdv_plans_on_motif_id"
     t.index ["planning_agent_id"], name: "index_rdv_plans_on_planning_agent_id"
@@ -898,6 +899,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_133641) do
   add_foreign_key "rdv_plans", "agents", column: "rdv_agent_id"
   add_foreign_key "rdv_plans", "lieux"
   add_foreign_key "rdv_plans", "motifs"
+  add_foreign_key "rdv_plans", "oauth_applications"
   add_foreign_key "rdv_plans", "rdvs"
   add_foreign_key "rdv_plans", "users"
   add_foreign_key "rdvs", "lieux"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -598,6 +598,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_10_131404) do
     t.bigint "oauth_application_id"
     t.index ["lieu_id"], name: "index_rdv_plans_on_lieu_id"
     t.index ["motif_id"], name: "index_rdv_plans_on_motif_id"
+    t.index ["oauth_application_id"], name: "index_rdv_plans_on_oauth_application_id"
     t.index ["planning_agent_id"], name: "index_rdv_plans_on_planning_agent_id"
     t.index ["rdv_agent_id"], name: "index_rdv_plans_on_rdv_agent_id"
     t.index ["rdv_id"], name: "index_rdv_plans_on_rdv_id"

--- a/spec/factories/oauth_application.rb
+++ b/spec/factories/oauth_application.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     name { "Démarches Simplifiées" }
     uid { "fake_app_id" }
     logo_base64 { "" }
+    redirect_uri { "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttps://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback" }
   end
 end

--- a/spec/factories/oauth_application.rb
+++ b/spec/factories/oauth_application.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :oauth_application, class: Doorkeeper::Application do
+    name { "Démarches Simplifiées" }
+    uid { "fake_app_id" }
+    logo_base64 { "" }
+  end
+end

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -1,13 +1,9 @@
 RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'interface de rdv_plan" do
   let!(:organisation) { create(:organisation) }
   let(:application) do
-    Doorkeeper::Application.create!(
-      name: "Démarches Simplifiées",
-      uid: "fake_app_id",
-      redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttp://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback",
-      post_logout_redirect_uri: "http://localhost:4567/",
-      logo_base64: ""
-    )
+    create(:oauth_application,
+           name: "Démarches Simplifiées",
+           redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttp://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback")
   end
   let!(:agent) do
     create(:agent, basic_role_in_organisations: [organisation], rdv_notifications_level: :all)

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -1,5 +1,14 @@
 RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'interface de rdv_plan" do
   let!(:organisation) { create(:organisation) }
+  let(:application) do
+    Doorkeeper::Application.create!(
+      name: "Démarches Simplifiées",
+      uid: "fake_app_id",
+      redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttp://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback",
+      post_logout_redirect_uri: "http://localhost:4567/",
+      logo_base64: ""
+    )
+  end
   let!(:agent) do
     create(:agent, basic_role_in_organisations: [organisation], rdv_notifications_level: :all)
   end
@@ -10,7 +19,11 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     create(:user, :unregistered, organisations: [organisation]) # créé par appel d'api par l'appli qui s'intègre avec nous
   end
   let(:rdv_plan) do
-    create(:rdv_plan, user: user, planning_agent: agent)
+    create(:rdv_plan,
+           user: user,
+           planning_agent: agent,
+           return_url: "https://demo.demarches-simplifiees.fr/callback/123",
+           oauth_application: application)
   end
 
   before do
@@ -54,5 +67,7 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     expect(emails.size).to eq(2)
     expect(emails.map { [_1.to, _1.subject] }).to include([["newaddress@exemple.com"], a_string_matching(/RDV confirmé le/)])
     expect(emails.map { [_1.to, _1.subject] }).to include([[agent.email], a_string_matching(/Nouveau RDV ajouté sur votre agenda/)])
+
+    expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
 end

--- a/spec/models/rdv_plan_spec.rb
+++ b/spec/models/rdv_plan_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe RdvPlan do
       rdv_plan.return_url = "http://localhost:4567/beneficiaires/123"
       expect(rdv_plan).to be_valid
 
-      rdv_plan.return_url = "demo.demarches-simplifiees.fr/beneficiaires/123"
+      rdv_plan.return_url = "https://demo.demarches-simplifiees.fr/beneficiaires/123"
       expect(rdv_plan).to be_valid
     end
 
     it "needs to be a http url" do
-      rdv_plan = build(:rdv_plan, return_url: "javascript:alert(1)")
+      rdv_plan = build(:rdv_plan, oauth_application: application, return_url: "javascript:alert(1)")
       expect(rdv_plan).not_to be_valid
 
       rdv_plan.return_url = "ssh://test.gouv.fr"

--- a/spec/models/rdv_plan_spec.rb
+++ b/spec/models/rdv_plan_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe RdvPlan do
   describe "#return_url" do
-    it "can only be in a a whitelisted domain name" do
-      rdv_plan = build(:rdv_plan)
+    let(:application) do
+      create(:oauth_application,
+             redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttps://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback")
+    end
+
+    it "can only be in a a whitelisted domain name from the corresponding oauth application" do
+      rdv_plan = build(:rdv_plan, oauth_application: application)
       rdv_plan.return_url = "nimportequoi.fr/asdf"
       expect(rdv_plan).not_to be_valid
 
       rdv_plan.return_url = "https://nimportequoi.fr/asdf#test.gouv.fr"
       expect(rdv_plan).not_to be_valid
 
-      rdv_plan.return_url = "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123"
+      rdv_plan.return_url = "http://localhost:4567/beneficiaires/123"
+      expect(rdv_plan).to be_valid
+
+      rdv_plan.return_url = "demo.demarches-simplifiees.fr/beneficiaires/123"
       expect(rdv_plan).to be_valid
     end
 

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "RDV Plan API" do
     Doorkeeper::Application.create!(
       name: "Démarches Simplifiées",
       uid: "fake_app_id",
-      redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback",
+      redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttp://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback",
       post_logout_redirect_uri: "http://localhost:4567/",
       logo_base64: ""
     )
@@ -105,7 +105,7 @@ RSpec.describe "RDV Plan API" do
             address: "21 rue des Ardennes, 75019 Paris",
             birth_date: "1990-12-31",
           },
-          return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/callback/123",
+          return_url: "https://demo.demarches-simplifiees.fr/callback/123",
         }
       end
 
@@ -114,8 +114,11 @@ RSpec.describe "RDV Plan API" do
           post "/api/v1/rdv_plans", headers: headers, params: params, as: :json
         end.to change(User, :count).by(1)
         rdv_plan = RdvPlan.last
-        expect(rdv_plan.planning_agent).to eq agent
-        expect(rdv_plan.return_url).to eq "https://monsuivisocial.incubateur.anct.gouv.fr/callback/123"
+        expect(rdv_plan).to have_attributes(
+          agent: agent,
+          return_url: "https://demo.demarches-simplifiees.fr/callback/123",
+          oauth_application_id: application.id
+        )
 
         expect(rdv_plan.user).to have_attributes(
           first_name: "Francis",

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "RDV Plan API" do
         end.to change(User, :count).by(1)
         rdv_plan = RdvPlan.last
         expect(rdv_plan).to have_attributes(
-          agent: agent,
+          planning_agent: agent,
           return_url: "https://demo.demarches-simplifiees.fr/callback/123",
           oauth_application_id: application.id
         )

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -9,13 +9,10 @@ RSpec.describe "RDV Plan API" do
     }
   end
   let(:application) do
-    Doorkeeper::Application.create!(
-      name: "Démarches Simplifiées",
-      uid: "fake_app_id",
-      redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttp://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback",
-      post_logout_redirect_uri: "http://localhost:4567/",
-      logo_base64: ""
-    )
+    create(:oauth_application,
+           name: "Démarches Simplifiées",
+           redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttp://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback",
+           post_logout_redirect_uri: "http://localhost:4567/")
   end
 
   let(:agent) do

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
   path "/api/v1/rdv_plans" do
     post "Créer un brouillon de rendez-vous" do
-      with_authentication
+      with_oauth_authentication
       description "Permet de créer un brouillon de rendez-vous"
 
       parameter(
@@ -63,7 +63,6 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
               phone_number: "0611223344",
               address: "21 rue des Ardennes, 75019 Paris",
             },
-            return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123",
           }
         end
 
@@ -85,8 +84,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
             address: "21 rue des Ardennes, 75019 Paris"
           )
           expect(rdv_plan).to have_attributes(
-            planning_agent: agent,
-            return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123"
+            planning_agent: agent
           )
         end
       end

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
   path "/api/v1/rdv_plans" do
     post "Créer un brouillon de rendez-vous" do
-      with_oauth_authentication
+      with_authentication
       description "Permet de créer un brouillon de rendez-vous"
 
       parameter(


### PR DESCRIPTION
# Contexte

Cette Pr est une petite amélioration sur le parcours de prise de rdv par Oauth. En fin de parcours on avait mis en dur le lien "Retour vers Mon Suivi Social", et ce n'est plus pertinent maintenant que Démarches Simplifiées s'en sert aussi.

# Solution

On ajoute un lien entre l'appli oauth utilisée, et le rdv plan, ce qui permet d'avoir une liste des noms de domaines autorisés.
C'est aussi une amélioration facile par rapport au système de whitelist précédent qui autorisait juste les noms en `.gouv.fr` (ce qui ne marche pas pour DS)

En petit bonus, ça nous permettra de sortir facilement des stats sur l'usage de cette fonctionnalité par application.

