### PR TITLE
migration: nettoyage des numéros ANTS invalides existants

### DIFF
--- a/db/migrate/20250210131404_clear_invalid_ants_pre_demande_numbers.rb
+++ b/db/migrate/20250210131404_clear_invalid_ants_pre_demande_numbers.rb
@@ -1,0 +1,13 @@
+class ClearInvalidAntsPreDemandeNumbers < ActiveRecord::Migration[7.1]
+  def up
+    users = User.where.not(ants_pre_demande_number: [nil, ""]).select(:id, :ants_pre_demande_number).to_a
+    Rails.logger.info "Found #{users.size} users with an ANTS pre-demande number…"
+    users_with_invalid_numbers = users.reject { _1.ants_pre_demande_number.strip.upcase.match?(/\A[A-Z0-9]{10}\z/) }
+    Rails.logger.info "Found #{users_with_invalid_numbers.size} users with an invalid ANTS pre-demande number…"
+    Rails.logger.info "Batch update these users to clear their ANTS numbers…"
+    User
+      .where(id: users_with_invalid_numbers.map(&:id))
+      .update_all(ants_pre_demande_number: nil)
+    Rails.logger.info "Success ✅"
+  end
+end

--- a/db/migrate/20250210131404_clear_invalid_ants_pre_demande_numbers.rb
+++ b/db/migrate/20250210131404_clear_invalid_ants_pre_demande_numbers.rb
@@ -1,8 +1,11 @@
 class ClearInvalidAntsPreDemandeNumbers < ActiveRecord::Migration[7.1]
   def up
-    users = User.where.not(ants_pre_demande_number: [nil, ""]).select(:id, :ants_pre_demande_number).to_a
+    users = User
+      .where.not(ants_pre_demande_number: [nil, ""])
+      .select(:id, :ants_pre_demande_number)
+      .to_a
     Rails.logger.info "Found #{users.size} users with an ANTS pre-demande number…"
-    users_with_invalid_numbers = users.reject { _1.ants_pre_demande_number.strip.upcase.match?(/\A[A-Z0-9]{10}\z/) }
+    users_with_invalid_numbers = users.reject { valid_ants_number?(_1.ants_pre_demande_number) }
     Rails.logger.info "Found #{users_with_invalid_numbers.size} users with an invalid ANTS pre-demande number…"
     Rails.logger.info "Batch update these users to clear their ANTS numbers…"
     User
@@ -10,4 +13,8 @@ class ClearInvalidAntsPreDemandeNumbers < ActiveRecord::Migration[7.1]
       .update_all(ants_pre_demande_number: nil)
     Rails.logger.info "Success ✅"
   end
+
+  private
+
+  def valid_ants_number?(number) = number.strip.upcase.match?(/\A[A-Z0-9]{10}\z/)
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_21_133641) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_10_131404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"


### PR DESCRIPTION
# Contexte

Ici nous parlons de validité du numéro de prédemande ANTS uniquement en terme de format (10 caractères alphanumériques).

Depuis #4824 nous n’insérons normalement plus dans notre DB de numéros ANTS invalides.

Cependant il en reste un certain nombre d’existants en DB.

sujet relancé à juste titre par Mr. FF [cf ce fil Mattermost](https://mattermost.incubateur.net/betagouv/pl/iz3jfn6ttpdmxkq1otd8rcdpqa)

# Solution

Une migration itère tous les users ayant un numéro ANTS, teste la regex et nettoie sans plus de précaution tous les numéros invalides.

J’ai dupliqué la regex dans le fichier de migration car le validateur `AntsPreDemandeNumberValidation` lance aussi des tests sur l’API distante, ce qui ne concerne pas cette PR. 

J’ai aussi préféré une migration qu’un script pour : 
- reviewer et committer ce code
- être sûr qu’il a été éxecuté sur tous les environnements (dev de tous les devs et prod) et toutes les instances (même s’il ne devrait pas y avoir de numéros ANTS sur RDVS).

# Tests en local

J’ai téléchargé et anonymisé un dump de RDVSP et lancé la migration dessus avec succès, il y en a environ 220 qui sont nettoyés. 
