### PR TITLE
Utiliser des flashes de type info plutôt que d'erreur si l'utilisateur a besoin de se connecter

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -1,6 +1,17 @@
 class Agents::SessionsController < Devise::SessionsController
   before_action :exclude_signed_in_users, only: [:new]
 
+  def new
+    if flash[:alert] == I18n.t("devise.failure.unauthenticated")
+      # Contrairement aux usagers, les agents ne peuvent pas créer de compte
+      # On n'utilise donc pas `I18n.t("devise.failure.unauthenticated")`, mais une variante
+      flash[:notice] = "Vous devez vous connecter pour continuer"
+      flash[:alert] = nil
+    end
+
+    super
+  end
+
   def create
     super
 

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -2,7 +2,7 @@ class Agents::SessionsController < Devise::SessionsController
   before_action :exclude_signed_in_users, only: [:new]
 
   def new
-    # Le flash d'erreur est trop aggressif pour le cas d'un agent non connecté.
+    # Le flash d'erreur est trop agressif pour le cas d'un agent non connecté.
     # Un flash de style info est plus adapté.
     if flash[:alert] == I18n.t("devise.failure.unauthenticated")
       # Contrairement aux usagers, les agents ne peuvent pas créer de compte

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -2,6 +2,8 @@ class Agents::SessionsController < Devise::SessionsController
   before_action :exclude_signed_in_users, only: [:new]
 
   def new
+    # Le flash d'erreur est trop aggressif pour le cas d'un agent non connecté.
+    # Un flash de style info est plus adapté.
     if flash[:alert] == I18n.t("devise.failure.unauthenticated")
       # Contrairement aux usagers, les agents ne peuvent pas créer de compte
       # On n'utilise donc pas `I18n.t("devise.failure.unauthenticated")`, mais une variante

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -6,6 +6,15 @@ class Users::SessionsController < Devise::SessionsController
   before_action :exclude_signed_in_agents, only: [:new]
   after_action :allow_iframe
 
+  def new
+    if flash[:alert] == I18n.t("devise.failure.unauthenticated")
+      flash[:notice] = flash[:alert]
+      flash[:alert] = nil
+    end
+
+    super
+  end
+
   def create
     if auth_options[:scope] == :user && (self.resource = Agent.find_by(email: params[:user]["email"])) && resource.valid_password?(params[:user]["password"])
       set_flash_message!(:notice, :signed_in)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -7,6 +7,8 @@ class Users::SessionsController < Devise::SessionsController
   after_action :allow_iframe
 
   def new
+    # Le flash d'erreur est trop aggressif pour le cas d'un usager non connecté.
+    # Un flash de style info est plus adapté.
     if flash[:alert] == I18n.t("devise.failure.unauthenticated")
       flash[:notice] = flash[:alert]
       flash[:alert] = nil

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe "OAuth provider", ignore_js_errors: true, js: true do
     visit "http://localhost:4567/"
     click_button "Se connecter avec RDV Service Public"
 
-    expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
+    expect(page).to have_content("Vous devez vous connecter pour continuer")
+    find(".fr-alert--info") # On vérifie que le flash est une info et pas une alerte
+
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"

--- a/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
+++ b/spec/features/users/account/user_is_redirected_back_after_login_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "User is redirected back to requested page after login" do
     visit "/users/rdvs"
     expect(page).to have_current_path("/users/sign_in")
     expect(page).to have_content("Vous devez vous connecter ou vous inscrire pour continuer")
+    find(".fr-alert--info") # On vérifie que le flash est une info et pas une alerte
 
     fill_in("user_email", with: user.email)
     fill_in("user_password", with: user.password)


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1416" alt="Screenshot 2025-02-10 at 18 04 41" src="https://github.com/user-attachments/assets/4d0d7733-ede5-4d4c-9f49-55294ec64076" />|<img width="1426" alt="Screenshot 2025-02-10 at 18 05 01" src="https://github.com/user-attachments/assets/bcabf754-83d1-4b9d-ab88-c5de309cd6ed" />
<img width="1427" alt="Screenshot 2025-02-10 at 18 05 22" src="https://github.com/user-attachments/assets/95fb72a4-a261-416d-a435-119809cdd5ea" />|<img width="1436" alt="Screenshot 2025-02-10 at 18 05 37" src="https://github.com/user-attachments/assets/4c63ffc8-96be-4566-8350-b66f7dde7fa5" />

# Contexte

Vu avec Téo : la manière dont on affiche le message qui indique aux usagers et aux agents de se connecter est un peu trop intense. C'est pas une véritable erreur, mais juste une étape (relativement facile) à passer.
On préfère donc afficher un flash de type info que d'erreur pour inciter à la connexion.

Au passage, on corrige le texte côté agent, puisque l'inscription pour les agents n'est pas encore possible (et si elle le devient, ça sera probablement uniquement via proconnect).

# Solution

Ça a pas l'air possible de changer ce comportement directement dans devise, donc la manière la plus simple que j'ai trouvé de faire ça c'est de motifier le flash dans le controller de la classe fille.

