### PR TITLE
ANTS: ré-autoriser la suppression d’appointment sans meeting_point_id

### DIFF
--- a/app/lib/ants_api.rb
+++ b/app/lib/ants_api.rb
@@ -40,7 +40,7 @@ class AntsApi
       )
     end
 
-    def delete(ants_pre_demande_number:, meeting_point:, appointment_date:, meeting_point_id:)
+    def delete(ants_pre_demande_number:, meeting_point:, appointment_date:, meeting_point_id: nil)
       request(
         :delete,
         "appointments",


### PR DESCRIPTION
# Contexte

des erreurs se produisent sur les `AntsApi#delete` suite à #5056 
https://sentry.incubateur.net/organizations/betagouv/issues/149393/?project=74&referrer=webhooks_plugin

il semble que l’endpoint status de l’ANTS ne renvoie pas (toujours) les meeting_point_id des appointments

# Solution

Ceci est un quick fix qui devrait permettre de revenir à la situation précédente où on déclenchait les appels à #delete sans `meeting_point_id`

Cela mérite une vérification plus en détail : 
- créer un appointment avec un meeting_point_id
- appeler status
- vérifier si le meeting_point_id est bien retourné ou non

voir si on arrive bien à supprimer un appointmenet sans passer le meeting_point_id ou en passant un autre

