### PR TITLE
ANTS: corrections du job de synchro liés au meeting_point_id

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -41,7 +41,7 @@ module Ants
       @ants_appointments.each do |appointment|
         AntsApi.delete(
           ants_pre_demande_number: stripped_ants_pre_demande_number,
-          meeting_point_id:,
+          meeting_point_id:, # les appointments retournés par status ne contiennent pas le meeting_point_id
           **appointment.symbolize_keys.slice(:meeting_point, :appointment_date)
         )
       end

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -30,16 +30,15 @@ module Ants
 
       # on n’utilise pas de regex ci-dessous pour éviter un faux-positif de Brakeman
       protocol = Rails.env.production? ? "https" : "http"
-      ants_appointments = ants_status["appointments"].select do |appointment|
+      @ants_appointments = ants_status["appointments"].select do |appointment|
         appointment["management_url"].start_with?("#{protocol}://#{Domain::RDV_MAIRIE.host_name}")
       end
 
-      # on ne fait rien si les infos sont déjà identiques (chacune des deux listes peut être vide ici)
-      return true if ants_appointments == [upcoming_rdv_serialized_to_ants_appointment].compact
+      return true unless needs_synchronization?
 
       # on déclenche la suppression des appointments existants dans tous les cas, qu’il s’agisse d’une mise à jour ou d’une suppression
       # en effet l’API de l’ANTS ne permet pas de faire de mises à jour, on fait donc un delete puis un create
-      ants_appointments.each do |appointment|
+      @ants_appointments.each do |appointment|
         AntsApi.delete(
           ants_pre_demande_number: stripped_ants_pre_demande_number,
           meeting_point_id:,
@@ -105,6 +104,19 @@ module Ants
             &.id
             &.to_s
         end
+    end
+
+    def needs_synchronization?
+      return false if @ants_appointments.empty? && upcoming_rdv.nil?
+
+      return true if
+        @ants_appointments.size > 1 || # ça ne devrait jamais arriver
+        (@ants_appointments.empty? && upcoming_rdv.present?) || # il faut créer un rdv
+        (@ants_appointments.present? && upcoming_rdv.nil?) # il faut supprimer l’appointment
+
+      compared_attributes = %i[management_url appointment_date meeting_point]
+      @ants_appointments.first.symbolize_keys.slice(*compared_attributes) !=
+        upcoming_rdv_serialized_to_ants_appointment.slice(*compared_attributes)
     end
   end
 end

--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -12,12 +12,17 @@ module Ants
     # useful to debug tests and avoid retries
     # discard_on(StandardError) { |_job, ex| raise ex }
 
-    def perform(ants_pre_demande_number:, meeting_point_id: nil)
+    def perform(ants_pre_demande_number:, obsolete_meeting_point_id: nil)
       @ants_pre_demande_number = ants_pre_demande_number
+      @obsolete_meeting_point_id = obsolete_meeting_point_id
+
+      if meeting_point_id.nil?
+        raise MissingMeetingPointId, "aucun RDV trouvé pour le numéro ANTS '#{ants_pre_demande_number}'"
+      end
 
       ants_status = AntsApi.status(
         ants_pre_demande_number: stripped_ants_pre_demande_number,
-        meeting_point_id: meeting_point_id || find_meeting_point_id,
+        meeting_point_id:,
         timeout: 4
       )
 
@@ -37,7 +42,8 @@ module Ants
       ants_appointments.each do |appointment|
         AntsApi.delete(
           ants_pre_demande_number: stripped_ants_pre_demande_number,
-          **appointment.symbolize_keys.slice(:meeting_point, :appointment_date, :meeting_point_id)
+          meeting_point_id:,
+          **appointment.symbolize_keys.slice(:meeting_point, :appointment_date)
         )
       end
 
@@ -82,22 +88,23 @@ module Ants
       @stripped_ants_pre_demande_number ||= ants_pre_demande_number.strip
     end
 
-    def find_meeting_point_id
-      return upcoming_rdv.lieu_id.to_s if upcoming_rdv&.lieu_id.present?
-
-      # On se replie sur n’importe quel RDV associé à ce numéro, même dans le passé
-      fallback_id = Lieu
-        .joins(rdvs: { users: [], motif: { motif_category: [] } })
-        .merge(MotifCategory.requires_ants_predemande_number)
-        .where(users: { ants_pre_demande_number: [stripped_ants_pre_demande_number, ants_pre_demande_number].uniq })
-        .order("rdvs.id DESC") # choix arbitraire pour éviter un comportement aléatoire
-        .first
-        &.id
-        &.to_s
-
-      return fallback_id if fallback_id.present?
-
-      raise MissingMeetingPointId, "aucun RDV trouvé pour le numéro ANTS '#{ants_pre_demande_number}'"
+    def meeting_point_id
+      @meeting_point_id ||=
+        if @obsolete_meeting_point_id.present?
+          @obsolete_meeting_point_id # utilisé pour les suppressions de participations
+        elsif upcoming_rdv&.lieu_id.present?
+          return upcoming_rdv.lieu_id.to_s
+        else
+          # On se replie sur le lieu de n’importe quel RDV associé à ce numéro, même dans le passé
+          Lieu
+            .joins(rdvs: { users: [], motif: { motif_category: [] } })
+            .merge(MotifCategory.requires_ants_predemande_number)
+            .where(users: { ants_pre_demande_number: [stripped_ants_pre_demande_number, ants_pre_demande_number].uniq })
+            .order("rdvs.id DESC") # choix arbitraire pour éviter un comportement aléatoire
+            .first
+            &.id
+            &.to_s
+        end
     end
   end
 end

--- a/app/models/concerns/ants/appointment_serializer_and_listener.rb
+++ b/app/models/concerns/ants/appointment_serializer_and_listener.rb
@@ -72,7 +72,7 @@ module Ants
         if rdv.obsolete_ants_data.present?
           Ants::SyncAppointmentJob.perform_later(
             ants_pre_demande_number: rdv.obsolete_ants_data[:pre_demande_number],
-            meeting_point_id: rdv.obsolete_ants_data[:meeting_point_id]
+            obsolete_meeting_point_id: rdv.obsolete_ants_data[:meeting_point_id]
           )
         end
         rdv.assign_attributes(needs_sync_to_ants: false)

--- a/spec/jobs/ants/sync_appointment_job_spec.rb
+++ b/spec/jobs/ants/sync_appointment_job_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Ants::SyncAppointmentJob do
               {
                 "management_url" => "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
                 "meeting_point" => "Mairie de Saumur",
-                "meeting_point_id" => lieu.id.to_s,
                 "appointment_date" => "2020-04-20 08:00:00",
               },
             ],

--- a/spec/jobs/ants/sync_appointment_job_spec.rb
+++ b/spec/jobs/ants/sync_appointment_job_spec.rb
@@ -84,4 +84,76 @@ RSpec.describe Ants::SyncAppointmentJob do
       expect { described_class.new.perform(ants_pre_demande_number: "A123456789") }.to raise_error Ants::MissingMeetingPointId
     end
   end
+
+  context "Synchro pour un RDV déjà existant en tant qu’appointment ANTS qui n’a pas changé" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let!(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
+    let!(:motif) { create(:motif, motif_category: create(:motif_category, :passeport), organisation:) }
+    let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 08:00:00")) }
+
+    before { travel_to(Time.zone.parse("2020-02-10")) } # le RDV est dans le futur
+
+    it "ne fait rien" do
+      allow(AntsApi).to receive(:status)
+        .with(hash_including(ants_pre_demande_number: "A123456789", meeting_point_id: lieu.id.to_s))
+        .and_return(
+          {
+            "status" => "validated",
+            "appointments" => [{
+              "management_url" => "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+              "meeting_point" => "Mairie de Saumur",
+              "appointment_date" => "2020-04-20 08:00:00",
+            }],
+          }
+        )
+      expect(AntsApi).not_to receive(:delete)
+      expect(AntsApi).not_to receive(:create)
+      described_class.perform_now(ants_pre_demande_number: "A123456789")
+    end
+  end
+
+  context "Synchro pour un RDV déjà existant en tant qu’appointment ANTS dont l’heure a changé" do
+    let!(:organisation) { create(:organisation, verticale: :rdv_mairie) }
+    let!(:lieu) { create(:lieu, organisation:, name: "Mairie de Saumur") }
+    let!(:motif) { create(:motif, motif_category: create(:motif_category, :passeport), organisation:) }
+    let!(:user) { create(:user, ants_pre_demande_number: "A123456789", organisations: [organisation]) }
+    let!(:rdv) { create(:rdv, motif:, users: [user], lieu:, organisation:, starts_at: Time.zone.parse("2020-04-20 12:00:00")) }
+
+    before { travel_to(Time.zone.parse("2020-02-10")) } # le RDV est dans le futur
+
+    it "ne fait rien" do
+      allow(AntsApi).to receive(:status)
+        .with(hash_including(ants_pre_demande_number: "A123456789", meeting_point_id: lieu.id.to_s))
+        .and_return(
+          {
+            "status" => "validated",
+            "appointments" => [{
+              "management_url" => "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+              "meeting_point" => "Mairie de Saumur",
+              "appointment_date" => "2020-04-20 08:00:00", # c’est différent de l’heure du RDV !
+            }],
+          }
+        )
+      expect(AntsApi).to receive(:delete)
+        .with(
+          {
+            ants_pre_demande_number: "A123456789",
+            meeting_point: "Mairie de Saumur",
+            meeting_point_id: lieu.id.to_s,
+            appointment_date: "2020-04-20 08:00:00",
+          }
+        )
+      expect(AntsApi).to receive(:create).with(
+        {
+          ants_pre_demande_number: "A123456789",
+          meeting_point: "Mairie de Saumur",
+          meeting_point_id: lieu.id.to_s,
+          appointment_date: "2020-04-20 12:00:00",
+          management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
+        }
+      )
+      described_class.perform_now(ants_pre_demande_number: "A123456789")
+    end
+  end
 end

--- a/spec/jobs/ants/sync_appointment_job_spec.rb
+++ b/spec/jobs/ants/sync_appointment_job_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Ants::SyncAppointmentJob do
 
     before { travel_to(Time.zone.parse("2020-02-10")) } # le RDV est dans le futur
 
-    it "ne fait rien" do
+    it "ne fait pas de mise à jour de l’appointment" do
       allow(AntsApi).to receive(:status)
         .with(hash_including(ants_pre_demande_number: "A123456789", meeting_point_id: lieu.id.to_s))
         .and_return(
@@ -122,7 +122,7 @@ RSpec.describe Ants::SyncAppointmentJob do
 
     before { travel_to(Time.zone.parse("2020-02-10")) } # le RDV est dans le futur
 
-    it "ne fait rien" do
+    it "met à jour l’appointment" do
       allow(AntsApi).to receive(:status)
         .with(hash_including(ants_pre_demande_number: "A123456789", meeting_point_id: lieu.id.to_s))
         .and_return(

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -231,29 +231,10 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
         body: {
           "A123456789" => {
             status: "validated",
-            appointments: [
-              {
-                management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
-                meeting_point: "Mairie de Saumur",
-                appointment_date: "2020-04-20 08:00:00",
-              },
-            ],
+            appointments: [],
           },
         }.to_json
       )
-    end
-    let!(:delete_stub) do
-      stub_request(:delete, "#{api_url}/appointments")
-        .with(
-          query: {
-            application_id: "A123456789",
-            appointment_date: "2020-04-20 08:00:00",
-            meeting_point: "Mairie de Saumur",
-            meeting_point_id: rdv.lieu.id,
-          },
-          headers:
-        )
-        .to_return(status: 200, body: { rowcount: 1 }.to_json)
     end
     let!(:create_stub) do
       stub_request(:post, "#{api_url}/appointments")
@@ -279,7 +260,7 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
       end
 
       expect(status_stub).to have_been_requested.at_least_once
-      expect(delete_stub).to have_been_requested.at_least_once
+      expect(WebMock).not_to have_requested(:delete, "#{api_url}/appointments")
       expect(create_stub).to have_been_requested.at_least_once
     end
   end

--- a/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
+++ b/spec/models/concerns/ants/appointment_serializer_and_listener_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               {
                 management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
-                meeting_point_id: rdv.lieu.id,
                 appointment_date: "2020-04-20 08:00:00",
               },
             ],
@@ -160,7 +159,6 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               {
                 management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
-                meeting_point_id: rdv.lieu.id,
                 appointment_date: "2020-04-20 08:00:00",
               },
             ],
@@ -237,7 +235,6 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               {
                 management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
-                meeting_point_id: rdv.lieu.id,
                 appointment_date: "2020-04-20 08:00:00",
               },
             ],
@@ -421,7 +418,6 @@ RSpec.describe Ants::AppointmentSerializerAndListener do
               {
                 management_url: "http://www.rdv-mairie-test.localhost/users/rdvs/#{rdv.id}",
                 meeting_point: "Mairie de Saumur",
-                meeting_point_id: rdv.lieu.id,
                 appointment_date: "2020-04-20 08:00:00",
               },
             ],


### PR DESCRIPTION
> [!NOTE]
> Cette PR peut se lire commit par commit

# Contexte

Suite de #5056 et #5063 

Après des tests sur l’API d’intégration de l’ANTS, l’endpoint status ne renvoie finalement pas le `meeting_point_id`.
Je ne sais pas si c’était une fausse hypothèse ou si ça a changé.

Ça a deux conséquences sur notre code :

- la comparaison permettant de décider s’il faut faire un cycle de delete-create renvoie toujours true
- on ne peut pas s’appuyer sur le `meeting_point_id` renvoyé par `status` pour supprimer l’appointment pré-existant.

# Solution


Dans les deux premiers commits je fais en sorte que l’appel à `AntsApi#delete` passe le `meeting_point_id` trouvé dans l’upcoming RDV, dans un RDV passé ou bien celui passé volontairement par `obsolete_meeting_point_id`.

```
- red: correction des request stubs dans les tests : status ne renvoie pas de meeting_point_id
- green: correction du passage de meeting_point_id à AntsApi#delete
```

Dans les deux commits suivants je corrige la condition de mise à jour des appointments. Je rajoute un failing test qui montre le problème actuel puis je corrige en extrayant une méthode `needs_synchronizing?`

```
- red: nouvelles specs de MàJ des appointments ANTS
- green: correction de la comparaison entre appointment et upcoming_rdv
```