### PR TITLE
Ajoute du logging pour détecter les IDs Outlook "malformed"

### DIFF
--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -13,7 +13,14 @@ module Outlook
     # @return [String] the outlook_id of the created event
     def create_event!(payload)
       outlook_event = call_events_api("POST", "me/Events", payload)
-      outlook_event["id"]
+      id = outlook_event["id"]
+
+      # Ce logging permet d'enquêter sur https://github.com/betagouv/rdv-service-public/issues/3539
+      if id.to_s.size < 10
+        Sentry.capture_message("ID outlook suspicieux: #{id}", extra: { outlook_response: outlook_event })
+      end
+
+      id
     rescue AlreadyExistsError => e
       Rails.logger.error("Outlook error while creating event: #{e.message}")
     end

--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -17,7 +17,8 @@ module Outlook
 
       # Ce logging permet d'enquêter sur https://github.com/betagouv/rdv-service-public/issues/3539
       if id.to_s.size < 10
-        Sentry.capture_message("ID outlook suspicieux: #{id}", extra: { outlook_response: outlook_event })
+        Sentry.set_extras({ outlook_response: outlook_event })
+        raise "ID outlook suspicieux: #{id}"
       end
 
       id

--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -17,8 +17,7 @@ module Outlook
 
       # Ce logging permet d'enquêter sur https://github.com/betagouv/rdv-service-public/issues/3539
       if id.to_s.size < 10
-        Sentry.set_extras({ outlook_response: outlook_event })
-        raise "ID outlook suspicieux: #{id}"
+        Sentry.capture_message("ID outlook suspicieux: #{id}", extra: { outlook_response: outlook_event })
       end
 
       id

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
     perform_enqueued_jobs { example.run }
   end
 
+  let(:event_id) { "AAMkAGY3YjViMzE2LTgyMDYtNDhiNi04ZTI0LTYxMjg1ZjBjNjMwOABGAAAAAABJYMQ==" }
   let(:agent) { create(:agent, microsoft_graph_token: "token") }
   let(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, name: "Super Motif", location_type: :phone, organisation:) }
@@ -35,7 +36,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
     it "sends requests to the Outlook api for every change on the objects that are included in the Outlook event" do
       create_request_stub = stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
-        .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
+        .to_return(status: 200, body: { id: event_id }.to_json, headers: {})
 
       rdv = create(:rdv, agents: [agent], users: [user], motif: motif, organisation: organisation,
                          starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30)
@@ -62,7 +63,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
       expect(create_request_stub.with(headers: expected_headers, body: expected_create_body)).to have_been_requested.once
 
-      expect(rdv.reload.agents_rdvs.first.outlook_id).to eq "event_id"
+      expect(rdv.reload.agents_rdvs.first.outlook_id).to eq(event_id)
     end
   end
 
@@ -96,18 +97,18 @@ RSpec.describe Outlook::EventSerializerAndListener do
       end
 
       before do
-        rdv.agents_rdvs.first.update!(outlook_id: "event_id")
+        rdv.agents_rdvs.first.update!(outlook_id: event_id)
         agent.update!(microsoft_graph_token: "token")
-        stub_request(:patch, "https://graph.microsoft.com/v1.0/me/Events/event_id")
+        stub_request(:patch, "https://graph.microsoft.com/v1.0/me/Events/#{event_id}")
           .with(body: expected_body, headers: expected_headers)
-          .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
+          .to_return(status: 200, body: { id: event_id.to_s }.to_json, headers: {})
       end
 
       it "updates the Outlook Event" do
         rdv.update(duration_in_min: 40)
 
         expect(a_request(:patch,
-                         "https://graph.microsoft.com/v1.0/me/Events/event_id").with(body: expected_body)).to have_been_made.once
+                         "https://graph.microsoft.com/v1.0/me/Events/#{event_id}").with(body: expected_body)).to have_been_made.once
         expect(sentry_events).to be_empty
       end
     end
@@ -158,7 +159,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
         stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
           .with(body: expected_updated_body, headers: expected_headers)
-          .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
+          .to_return(status: 200, body: { id: event_id.to_s }.to_json, headers: {})
       end
 
       it "creates the Outlook Event" do
@@ -167,7 +168,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
         expect(a_request(:post,
                          "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_updated_body)).to have_been_made.once
 
-        expect(agents_rdv.reload.outlook_id).to eq("event_id")
+        expect(agents_rdv.reload.outlook_id).to eq(event_id.to_s)
       end
     end
 

--- a/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_integration_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Outlook::EventSerializerAndListener do
     perform_enqueued_jobs { example.run }
   end
 
-  let(:event_id) { "AAMkAGY3YjViMzE2LTgyMDYtNDhiNi04ZTI0LTYxMjg1ZjBjNjMwOABGAAAAAABJYMQ==" }
   let(:agent) { create(:agent, microsoft_graph_token: "token") }
   let(:organisation) { create(:organisation) }
   let(:motif) { create(:motif, name: "Super Motif", location_type: :phone, organisation:) }
@@ -36,7 +35,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
     it "sends requests to the Outlook api for every change on the objects that are included in the Outlook event" do
       create_request_stub = stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
-        .to_return(status: 200, body: { id: event_id }.to_json, headers: {})
+        .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
 
       rdv = create(:rdv, agents: [agent], users: [user], motif: motif, organisation: organisation,
                          starts_at: Time.zone.parse("2023-01-01 11h00"), duration_in_min: 30)
@@ -63,7 +62,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
       expect(create_request_stub.with(headers: expected_headers, body: expected_create_body)).to have_been_requested.once
 
-      expect(rdv.reload.agents_rdvs.first.outlook_id).to eq(event_id)
+      expect(rdv.reload.agents_rdvs.first.outlook_id).to eq "event_id"
     end
   end
 
@@ -97,18 +96,18 @@ RSpec.describe Outlook::EventSerializerAndListener do
       end
 
       before do
-        rdv.agents_rdvs.first.update!(outlook_id: event_id)
+        rdv.agents_rdvs.first.update!(outlook_id: "event_id")
         agent.update!(microsoft_graph_token: "token")
-        stub_request(:patch, "https://graph.microsoft.com/v1.0/me/Events/#{event_id}")
+        stub_request(:patch, "https://graph.microsoft.com/v1.0/me/Events/event_id")
           .with(body: expected_body, headers: expected_headers)
-          .to_return(status: 200, body: { id: event_id.to_s }.to_json, headers: {})
+          .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
       end
 
       it "updates the Outlook Event" do
         rdv.update(duration_in_min: 40)
 
         expect(a_request(:patch,
-                         "https://graph.microsoft.com/v1.0/me/Events/#{event_id}").with(body: expected_body)).to have_been_made.once
+                         "https://graph.microsoft.com/v1.0/me/Events/event_id").with(body: expected_body)).to have_been_made.once
         expect(sentry_events).to be_empty
       end
     end
@@ -159,7 +158,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
         stub_request(:post, "https://graph.microsoft.com/v1.0/me/Events")
           .with(body: expected_updated_body, headers: expected_headers)
-          .to_return(status: 200, body: { id: event_id.to_s }.to_json, headers: {})
+          .to_return(status: 200, body: { id: "event_id" }.to_json, headers: {})
       end
 
       it "creates the Outlook Event" do
@@ -168,7 +167,7 @@ RSpec.describe Outlook::EventSerializerAndListener do
         expect(a_request(:post,
                          "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_updated_body)).to have_been_made.once
 
-        expect(agents_rdv.reload.outlook_id).to eq(event_id.to_s)
+        expect(agents_rdv.reload.outlook_id).to eq("event_id")
       end
     end
 


### PR DESCRIPTION
Closes #3539

# Contexte

Tout est dans l'issue #3539 (créée le 16 mai 2023 :grimacing:  )

# Solution

Ajout d'une remontée Sentry qui permet de logger quand on a un ID suspect.