### PR TITLE
ANTS: ne plus valider le statut des dossiers inutilement côté agent

### DIFF
--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -7,7 +7,7 @@ class Admin::UserForm
 
   delegate :ants_pre_demande_number, :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :user
   validate :warn_duplicates
-  validates_with AntsPreDemandeNumberValidation, if: -> { @user.ants_pre_demande_number.present? }
+  validates_with AntsPreDemandeNumberStatusValidation, if: -> { @user.ants_pre_demande_number.present? }
 
   delegate :errors, to: :user
 

--- a/app/form_models/admin/user_form.rb
+++ b/app/form_models/admin/user_form.rb
@@ -7,7 +7,6 @@ class Admin::UserForm
 
   delegate :ants_pre_demande_number, :ignore_benign_errors, :ignore_benign_errors=, :add_benign_error, :benign_errors, :not_benign_errors, :errors_are_all_benign?, to: :user
   validate :warn_duplicates
-  validates_with AntsPreDemandeNumberStatusValidation, if: -> { @user.ants_pre_demande_number.present? }
 
   delegate :errors, to: :user
 

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -15,6 +15,7 @@ class BeneficiaireForm
   validates_presence_of :first_name, :last_name
   validate :warn_no_contact_information
   validate :validate_phone_number
+  validates :ants_pre_demande_number, presence: true, ants_pre_demande_number_format: true, if: :requires_ants_predemande_number?
   validates_with AntsPreDemandeNumberStatusValidation, if: :requires_ants_predemande_number?
 
   def warn_no_contact_information

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -15,7 +15,7 @@ class BeneficiaireForm
   validates_presence_of :first_name, :last_name
   validate :warn_no_contact_information
   validate :validate_phone_number
-  validates_with AntsPreDemandeNumberValidation, if: :requires_ants_predemande_number?
+  validates_with AntsPreDemandeNumberStatusValidation, if: :requires_ants_predemande_number?
 
   def warn_no_contact_information
     return if ignore_benign_errors

--- a/app/form_models/relative_user_form.rb
+++ b/app/form_models/relative_user_form.rb
@@ -11,7 +11,8 @@ class RelativeUserForm
 
   validate :validate_user
   validates :ants_pre_demande_number, presence: true, if: :ants_pre_demande_number_required
-  validates_with AntsPreDemandeNumberStatusValidation, if: -> { ants_pre_demande_number_required && user.ants_pre_demande_number.present? }
+  # la validation du format du numéro de pré-demande ANTS est déjà faite au niveau du modèle user
+  validates_with AntsPreDemandeNumberStatusValidation, if: :ants_pre_demande_number_required
 
   def initialize(user:, ants_pre_demande_number_required: false)
     @user = user

--- a/app/form_models/relative_user_form.rb
+++ b/app/form_models/relative_user_form.rb
@@ -11,7 +11,7 @@ class RelativeUserForm
 
   validate :validate_user
   validates :ants_pre_demande_number, presence: true, if: :ants_pre_demande_number_required
-  validates_with AntsPreDemandeNumberValidation, if: -> { ants_pre_demande_number_required && user.ants_pre_demande_number.present? }
+  validates_with AntsPreDemandeNumberStatusValidation, if: -> { ants_pre_demande_number_required && user.ants_pre_demande_number.present? }
 
   def initialize(user:, ants_pre_demande_number_required: false)
     @user = user

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -98,10 +98,10 @@ module UserRdvWizard
       @user.skip_reconfirmation! if @user.email_was.blank?
 
       # dans la vue on appelle form_for(user) plutôt que form_for(user_rdv_wizard) les erreurs doivent donc être
-      # définies sur le user et on ne peut pas simplement appeler `validates_with AntsPreDemandeNumberValidation`
+      # définies sur le user et on ne peut pas simplement appeler `validates_with AntsPreDemandeNumberStatusValidation`
       # dans ce form model
       if rdv.requires_ants_predemande_number?
-        @user.singleton_class.validates_with(AntsPreDemandeNumberValidation)
+        @user.singleton_class.validates_with(AntsPreDemandeNumberStatusValidation)
       end
 
       valid? && @user.save

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -101,6 +101,7 @@ module UserRdvWizard
       # définies sur le user et on ne peut pas simplement appeler `validates_with AntsPreDemandeNumberStatusValidation`
       # dans ce form model
       if rdv.requires_ants_predemande_number?
+        @user.singleton_class.validates(:ants_pre_demande_number, presence: true)
         @user.singleton_class.validates_with(AntsPreDemandeNumberStatusValidation)
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,7 @@ class User < ApplicationRecord
   # Validations
   validates :last_name, :first_name, :created_through, presence: true
   validates :number_of_children, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :ants_pre_demande_number, ants_pre_demande_number_format: true
 
   validate :birth_date_validity
 

--- a/app/validators/ants_pre_demande_number_format_validator.rb
+++ b/app/validators/ants_pre_demande_number_format_validator.rb
@@ -1,0 +1,7 @@
+class AntsPreDemandeNumberFormatValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank? || value.upcase.match?(/\A[A-Z0-9]{10}\z/)
+
+    record.errors.add(attribute, :invalid_format)
+  end
+end

--- a/app/validators/ants_pre_demande_number_format_validator.rb
+++ b/app/validators/ants_pre_demande_number_format_validator.rb
@@ -1,6 +1,11 @@
 class AntsPreDemandeNumberFormatValidator < ActiveModel::EachValidator
+  REGEX = /\A[A-Z0-9]{10}\z/
+
   def validate_each(record, attribute, value)
-    return if value.blank? || value.upcase.match?(/\A[A-Z0-9]{10}\z/)
+    return if record.errors[attribute]&.include?(:invalid_format)
+    # évite les doublons d’erreurs si la validation est appellée plusieurs fois
+
+    return if value.blank? || value.upcase.match?(REGEX)
 
     record.errors.add(attribute, :invalid_format)
   end

--- a/app/validators/ants_pre_demande_number_status_validation.rb
+++ b/app/validators/ants_pre_demande_number_status_validation.rb
@@ -5,7 +5,7 @@
 #
 # cf /docs/interconnexions/ants.md
 
-class AntsPreDemandeNumberValidation < ActiveModel::Validator
+class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
   def validate(record)
     raise "You need to include BenignErrors to use #{self.class}" unless record.respond_to?(:add_benign_error)
 

--- a/app/validators/ants_pre_demande_number_status_validation.rb
+++ b/app/validators/ants_pre_demande_number_status_validation.rb
@@ -15,9 +15,10 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
       record.ants_pre_demande_number.blank? ||
       !record.ants_pre_demande_number.upcase.match?(AntsPreDemandeNumberFormatValidator::REGEX)
 
-    ants_pre_demande_number = record.ants_pre_demande_number.upcase
-
-    status, appointments = AntsApi.status(ants_pre_demande_number:, timeout: 4).values_at("status", "appointments")
+    status, appointments = AntsApi.status(
+      ants_pre_demande_number: record.ants_pre_demande_number.upcase,
+      timeout: 4
+    ).values_at("status", "appointments")
 
     return unless validate_status_validated(status, record)
 

--- a/app/validators/ants_pre_demande_number_status_validation.rb
+++ b/app/validators/ants_pre_demande_number_status_validation.rb
@@ -9,9 +9,9 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
   def validate(record)
     raise "You need to include BenignErrors to use #{self.class}" unless record.respond_to?(:add_benign_error)
 
-    ants_pre_demande_number = record.ants_pre_demande_number.upcase
+    return true if record.errors[:ants_pre_demande_number].present? # skip status checks when there are format errors
 
-    return unless validate_format(ants_pre_demande_number, record)
+    ants_pre_demande_number = record.ants_pre_demande_number.upcase
 
     status, appointments = AntsApi.status(ants_pre_demande_number:, timeout: 4).values_at("status", "appointments")
 
@@ -24,13 +24,6 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
     record.errors.add(:ants_pre_demande_number, "n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.")
     Rails.logger.error e
     Sentry.capture_exception(e)
-  end
-
-  def validate_format(ants_pre_demande_number, record)
-    return true if ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)
-
-    record.errors.add(:ants_pre_demande_number, "doit comporter 10 chiffres et lettres")
-    false
   end
 
   def validate_status_validated(status, record)

--- a/app/validators/ants_pre_demande_number_status_validation.rb
+++ b/app/validators/ants_pre_demande_number_status_validation.rb
@@ -9,7 +9,11 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
   def validate(record)
     raise "You need to include BenignErrors to use #{self.class}" unless record.respond_to?(:add_benign_error)
 
-    return true if record.errors[:ants_pre_demande_number].present? # skip status checks when there are format errors
+    # filet de sécurité : on ne lance pas les vérifications API si le numéro n’est pas présent et valide
+    return if
+      record.errors[:ants_pre_demande_number].present? ||
+      record.ants_pre_demande_number.blank? ||
+      !record.ants_pre_demande_number.upcase.match?(AntsPreDemandeNumberFormatValidator::REGEX)
 
     ants_pre_demande_number = record.ants_pre_demande_number.upcase
 
@@ -25,6 +29,8 @@ class AntsPreDemandeNumberStatusValidation < ActiveModel::Validator
     Rails.logger.error e
     Sentry.capture_exception(e)
   end
+
+  private
 
   def validate_status_validated(status, record)
     return true if status == "validated"

--- a/app/validators/ants_pre_demande_number_validation.rb
+++ b/app/validators/ants_pre_demande_number_validation.rb
@@ -11,23 +11,13 @@ class AntsPreDemandeNumberValidation < ActiveModel::Validator
 
     ants_pre_demande_number = record.ants_pre_demande_number.upcase
 
-    unless ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)
-      record.errors.add(:ants_pre_demande_number, "doit comporter 10 chiffres et lettres")
-      return
-    end
+    return unless validate_format(ants_pre_demande_number, record)
 
-    application_hash = AntsApi.status(ants_pre_demande_number:, timeout: 4)
+    status, appointments = AntsApi.status(ants_pre_demande_number:, timeout: 4).values_at("status", "appointments")
 
-    status = application_hash["status"]
+    return unless validate_status_validated(status, record)
 
-    if status == "validated"
-      if application_hash["appointments"].any?
-        appointment = OpenStruct.new(application_hash["appointments"].first)
-        record.add_benign_error(warning_message(appointment)) unless record.ignore_benign_errors
-      end
-    else
-      record.errors.add(:ants_pre_demande_number, AntsApi::ERROR_STATUSES.fetch(status))
-    end
+    validate_empty_appointments(appointments, record)
   rescue AntsApi::ApiRequestError, Typhoeus::Errors::TimeoutError => e
     # Si l'API de l'ANTS est fiable, donc si elle renvoie une erreur ou un timeout,
     # on préfère bloquer la réservation et logguer l'erreur.
@@ -36,11 +26,30 @@ class AntsPreDemandeNumberValidation < ActiveModel::Validator
     Sentry.capture_exception(e)
   end
 
-  def warning_message(appointment)
-    I18n.t(
-      "activerecord.warnings.models.user.ants_pre_demande_number_already_used_html",
-      management_url: appointment.management_url,
-      meeting_point: appointment.meeting_point
-    ).html_safe
+  def validate_format(ants_pre_demande_number, record)
+    return true if ants_pre_demande_number.match?(/\A[A-Z0-9]{10}\z/)
+
+    record.errors.add(:ants_pre_demande_number, "doit comporter 10 chiffres et lettres")
+    false
+  end
+
+  def validate_status_validated(status, record)
+    return true if status == "validated"
+
+    record.errors.add(:ants_pre_demande_number, AntsApi::ERROR_STATUSES.fetch(status))
+    false
+  end
+
+  def validate_empty_appointments(appointments, record)
+    return true if appointments.empty? || record.ignore_benign_errors
+
+    record.add_benign_error(
+      I18n.t(
+        "activerecord.warnings.models.user.ants_pre_demande_number_already_used_html",
+        management_url: appointments.first["management_url"],
+        meeting_point: appointments.first["meeting_point"]
+      ).html_safe
+    )
+    false
   end
 end

--- a/config/locales/models/user.fr.yml
+++ b/config/locales/models/user.fr.yml
@@ -54,6 +54,7 @@ fr:
               too_short:
                 other: "Pour assurer la sécurité de votre compte, votre mot de passe doit faire au moins %{count} caractères"
             ants_pre_demande_number: &ants_pre_demande_number_errors
+              blank: doit être renseigné
               invalid_format: doit comporter 10 chiffres et lettres
               unexpected_api_error: n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.
             phone_number:

--- a/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_for_rdv_mairie_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "Agent can create user" do
-  include_context "rdv_mairie_api_authentication"
-
   let!(:organisation) { create(:organisation, name: "Mairie de Romainville") }
   let!(:cni_motif_category) { create(:motif_category, name: Api::Ants::EditorController::CNI_MOTIF_CATEGORY_NAME) }
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
@@ -18,11 +16,7 @@ RSpec.describe "Agent can create user" do
     expect_page_title("Nouvel usager")
   end
 
-  context "ants_pre_demander number is validated and has no appointment declared yet" do
-    before do
-      stub_ants_status_ok("1122334455")
-    end
-
+  context "ants_pre_demander number has the valid format" do
     it "creates user with no warning" do
       fill_in :user_first_name, with: "Marco"
       fill_in :user_last_name, with: "Lebreton"
@@ -35,58 +29,12 @@ RSpec.describe "Agent can create user" do
   end
 
   context "when using a pre-demande number in lowercase" do
-    let!(:call_to_status_with_upcased_number) { stub_ants_status_ok("ABCD1234EF", appointments: []) }
-
     it "considers it as uppercase when calling ANTS API and saving it in user" do
       fill_in :user_first_name, with: "Marco"
       fill_in :user_last_name, with: "Lebreton"
       fill_in :user_ants_pre_demande_number, with: "abcd1234ef"
       expect { click_button "Créer" }.to change(User, :count).by(1)
       expect(User.last.ants_pre_demande_number).to eq("ABCD1234EF")
-      expect(call_to_status_with_upcased_number).to have_been_requested.at_least_once
-    end
-  end
-
-  context "ants_pre_demander number is validated but already has appointments" do
-    before do
-      stub_ants_status_ok(
-        "1122334455",
-        appointments: [
-          {
-            management_url: "https://gerer-rdv.com",
-            meeting_point: "Mairie de Sannois",
-            appointment_date: "2023-04-03T08:45:00",
-          },
-        ]
-      )
-    end
-
-    it "displays a warning but allows user creation" do
-      fill_in :user_first_name, with: "Marco"
-      fill_in :user_last_name, with: "Lebreton"
-      fill_in :user_ants_pre_demande_number, with: ants_pre_demande_number
-      click_button "Créer"
-      expect(page).to have_content(
-        "Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Sannois. Veuillez annuler ce RDV avant d'en prendre un nouveau"
-      )
-      click_button("Confirmer en ignorant les avertissements")
-      expect_page_title("Marco LEBRETON")
-      expect(User.exists?(first_name: "Marco", last_name: "Lebreton")).to be(true)
-    end
-  end
-
-  context "ants_pre_demander number is consumed (dossier déjà envoyé et instruit en préfecture)" do
-    before do
-      stub_ants_status_ok("1122334455", status: "consumed")
-    end
-
-    it "prevents agent from creating the user / RDV" do
-      fill_in :user_first_name, with: "Marco"
-      fill_in :user_last_name, with: "Lebreton"
-      fill_in :user_ants_pre_demande_number, with: ants_pre_demande_number
-      click_button "Créer"
-      expect(page).to have_content("Numéro de pré-demande ANTS correspond à un dossier déjà instruit")
-      expect(page).not_to have_content("Confirmer en ignorant les avertissements")
     end
   end
 end

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe "User can search rdv on rdv mairie" do
 
         fill_in("user_ants_pre_demande_number", with: "  ")
         click_button("Continuer")
-        expect(page).to have_content("Numéro de pré-demande ANTS doit comporter 10 chiffres et lettres")
+        expect(page).to have_content("Numéro de pré-demande ANTS doit être renseigné")
       end
     end
 

--- a/spec/form_models/admin/user_form_spec.rb
+++ b/spec/form_models/admin/user_form_spec.rb
@@ -149,75 +149,10 @@ RSpec.describe Admin::UserForm, type: :form do
     end
 
     context "numéro de pré-demande ANTS valide" do
-      before { stub_ants_status_ok("VALID12345", status: "validated", appointments: []) }
-
       let(:user) { build(:user, ants_pre_demande_number: "VALID12345") }
 
       specify do
         expect(subject).to be_valid
-      end
-    end
-
-    context "numéro de pré-demande ANTS non-reconnu (unknown)" do
-      before { stub_ants_status_ok("VALID12345", status: "unknown", appointments: []) }
-
-      let(:user) { build(:user, ants_pre_demande_number: "VALID12345") }
-
-      specify do
-        expect(subject.valid?).to be false
-        expect(subject.errors.first.full_message).to eq("Numéro de pré-demande ANTS n'est pas reconnu par l'ANTS")
-      end
-    end
-
-    context "numéro de pré-demande ANTS a déjà un appointment" do
-      before do
-        stub_ants_status_ok(
-          "VALID12345",
-          status: "validated",
-          appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "http://rdvsympa.fr/123" }]
-        )
-      end
-
-      let(:user) { build(:user, ants_pre_demande_number: "VALID12345") }
-
-      specify do
-        expect(subject.valid?).to be false
-        expect(subject.errors.first.attribute).to eq(:_benign)
-        expect(subject.errors.first.message).to eq(
-          <<-TXT.squish
-            Ce numéro de pré-demande ANTS est déjà utilisé pour un RDV auprès de Mairie de Montrouge.
-            Veuillez <a href='http://rdvsympa.fr/123' target="_blank">annuler ce RDV<a> avant d'en prendre un nouveau.
-        TXT
-        )
-      end
-    end
-
-    context "numéro de pré-demande ANTS a déjà un appointment mais les avertissements sont ignorés" do
-      subject { described_class.new(user, ignore_benign_errors: true, view_locals: { current_organisation: organisation }) }
-
-      before do
-        stub_ants_status_ok(
-          "VALID12345",
-          status: "validated",
-          appointments: [{ "meeting_point" => "Mairie de Montrouge", "management_url" => "http://rdvsympa.fr/123" }]
-        )
-      end
-
-      let(:user) { build(:user, ants_pre_demande_number: "VALID12345") }
-
-      specify do
-        expect(subject.valid?).to be true
-      end
-    end
-
-    context "l’API ANTS timeoute" do
-      before { allow(AntsApi).to receive(:status).and_raise(Typhoeus::Errors::TimeoutError) }
-
-      let(:user) { build(:user, ants_pre_demande_number: "VALID12345") }
-
-      specify do
-        expect(subject.valid?).to be false
-        expect(subject.errors.first.full_message).to eq("Numéro de pré-demande ANTS n'a pas pu être validé à cause d'une erreur inattendue. Merci de réessayer dans 30 secondes.")
       end
     end
   end

--- a/spec/form_models/beneficiaire_form_spec.rb
+++ b/spec/form_models/beneficiaire_form_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe BeneficiaireForm do
 
       specify do
         expect(form).to be_invalid
-        expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS doit comporter 10 chiffres et lettres")
+        expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS doit être renseigné")
       end
     end
 

--- a/spec/form_models/relative_user_form_spec.rb
+++ b/spec/form_models/relative_user_form_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RelativeUserForm do
         expect { form.submit(first_name: "Jean", last_name: "Jacques", ants_pre_demande_number: "notval") }.not_to change(User, :count)
         expect(form.errors.count).to eq 1
         expect(form.errors.first.attribute).to eq :ants_pre_demande_number
-        expect(form.errors.first.type).to eq "doit comporter 10 chiffres et lettres"
+        expect(form.errors.first.type).to eq :invalid_format
       end
     end
   end

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -115,9 +115,8 @@ RSpec.describe UserRdvWizard do
           expect(res).to be false
           expect(form.errors.count).to eq(1)
           expect(form.errors.first.attribute).to eq(:ants_pre_demande_number)
-          expect(form.errors.first.message).to eq("doit comporter 10 chiffres et lettres")
           # le message affiché est en fait celui sur le user
-          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS doit comporter 10 chiffres et lettres")
+          expect(form.errors.first.full_message).to eq("Numéro de pré-demande ANTS doit être renseigné")
         end
       end
 


### PR DESCRIPTION
# Contexte 

On est en train de rajouter le `meeting_point_id` à tous nos appels à l’API ANTS comme demandé

# Solution

Cette PR ne rajoute pas de `meeting_point_id` mais elle prépare le terrain pour le rajouter dans les appels faits depuis le validateur de numéro.

L’idée est ici de séparer la validation du format du numéro et la validation distante via l’API ANTS du statut du dossier.

Actuellement, côté agent, lors de l’édition d’une fiche usager comportant un numéro ANTS, on revalide le statut du dossier via l’API distante. Ça n’a pas de sens dans la majorité des cas.

# Description commit par commit

1er commit :  `refactor AntsPreDemandeNumberValidation`

pur refacto de la validation existante pour la manipuler plus simplement ensuite

---

2e commit :  `rename AntsPreDemandeNumberStatusValidation`
 
`AntsPreDemandeNumberValidation` => `AntsPreDemandeNumberStatusValidation`

---

3e commit :  `ANTS: isolation de la validation de format de numéro`

On isole `AntsPreDemandeNumberFormatValidator`. 
On appelle les bonnes validations selon les endroits : juste le format ou bien format + statut via API.

---

4e commit :  `ajout d’un filet de sécurité pour réappliquer les validations avant les vérifications de statut` 

Le validateur de statut via API dépend maintenant de 2 validations précédentes : presence et ants_format.
Il « faut » que ces validations soient appelés en amont de la validation de statut.
Comme c’est à peu près sûr qu’on va oublier ou se tromper , ce commit met en place un filet de sécurité : on réapplique quand ça n’a pas été fait les validations prérequises.

---

5e commit : `minor refactor` 

Un rien du tout pour préparer du diff futur ✨ 