### PR TITLE
Suppression des headers des logs d'appels à l'api

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -73,6 +73,7 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
     else
       doorkeeper_authorize!
       if doorkeeper_token
+        @authentication_type = "OAuth"
         @current_agent = Agent.find(doorkeeper_token.resource_owner_id)
       end
     end

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -68,8 +68,8 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       # Bypass DeviseTokenAuth
       authenticate_agent_with_shared_secret
     elsif request.headers["HTTP_ACCESS_TOKEN"] && request.headers["HTTP_UID"]
-      # Use DeviseTokenAuth
       authenticate_api_v1_agent_with_token_auth!
+      @authentication_type = "DeviseTokenAuth"
     else
       doorkeeper_authorize!
       if doorkeeper_token
@@ -115,15 +115,14 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       method: request.method,
       path: request.fullpath,
       host: request.host,
-      # We only keep headers that are uppercase (convention for HTTP headers)
-      headers: request.headers.select { |key, _| key == key.upcase }.to_h.transform_values { |value| value.is_a?(String) ? value : value.inspect },
     }
 
     ApiCall.create!(
       raw_http: raw_http,
       controller_name: controller_name,
       action_name: action_name,
-      agent_id: current_agent.id
+      agent_id: current_agent.id,
+      authentication_type: @authentication_type
     )
   rescue StandardError => e
     Sentry.capture_exception(e, extra: {

--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -65,7 +65,6 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
 
   def authenticate_agent
     if request.headers.include?("X-Agent-Auth-Signature")
-      # Bypass DeviseTokenAuth
       authenticate_agent_with_shared_secret
     elsif request.headers["HTTP_ACCESS_TOKEN"] && request.headers["HTTP_UID"]
       authenticate_api_v1_agent_with_token_auth!
@@ -82,6 +81,7 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   def authenticate_agent_with_shared_secret
     if shared_secret_is_valid?
       @current_agent = Agent.find_by(email: request.headers["uid"])
+      @authentication_type = "SharedSecret"
     else
       Sentry.capture_message("API authentication agent was called with an invalid signature !", fingerprint: ["api_agent_invalid_sig"])
       render(

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -413,6 +413,7 @@ tables:
       - controller_name
       - action_name
       - agent_id
+      - authentication_type
 
   - table_name: exports
     non_anonymized_column_names:

--- a/db/migrate/20250212125817_add_api_call_auth_type.rb
+++ b/db/migrate/20250212125817_add_api_call_auth_type.rb
@@ -1,0 +1,5 @@
+class AddApiCallAuthType < ActiveRecord::Migration[7.1]
+  def change
+    add_column :api_calls, :authentication_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_10_131404) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_12_125817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -267,6 +267,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_10_131404) do
     t.string "controller_name", null: false
     t.string "action_name", null: false
     t.bigint "agent_id", null: false
+    t.string "authentication_type"
   end
 
   create_table "exports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -197,8 +197,6 @@ RSpec.describe "Available Creneaux Count for Invitation" do
               received_at: now
             )
             expect(ApiCall.first.raw_http["method"]).to eq("GET")
-            expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
-            expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
           end
         end
 

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -121,16 +121,16 @@ RSpec.describe "Available Creneaux Count for Invitation" do
         end
 
         it "logs the API call" do
-          expect(ApiCall.first.attributes.symbolize_keys).to include(
+          api_call = ApiCall.first
+          expect(api_call).to have_attributes(
             controller_name: "invitations",
             action_name: "creneau_availability",
             agent_id: agent.id,
-            received_at: now
+            received_at: now,
+            authentication_type: "DeviseTokenAuth"
           )
-          expect(ApiCall.first.raw_http["method"]).to eq("GET")
-          expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
-          expect(ApiCall.first.raw_http["headers"]).not_to include("rack.session.options")
-          expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
+          expect(api_call.raw_http["method"]).to eq("GET")
+          expect(api_call.raw_http["headers"]).to be_blank
         end
 
         context "Si le lieu n'existe pas" do

--- a/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/referent_assignations_request_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe "Referent Assignation authentified API" do
           expect(ApiCall.first.attributes.symbolize_keys).to include(
             controller_name: "referent_assignations",
             action_name: "create_many",
-            agent_id: agent1.id
+            agent_id: agent1.id,
+            authentication_type: "SharedSecret"
           )
         end
       end

--- a/spec/requests/api/v1/api_call_logging_spec.rb
+++ b/spec/requests/api/v1/api_call_logging_spec.rb
@@ -9,11 +9,14 @@ RSpec.describe "On enregistre les appels à l'api pour mieux comprendre qui s'en
         Authorization: "Bearer #{oauth_token.plaintext_token}",
       }
     end
-    let(:application) do
-      raise "utiliser la bonne factory"
+    let(:application) { create(:oauth_application) }
+    let(:agent) do
+      create(:agent, basic_role_in_organisations: [create(:organisation)])
     end
 
     it "records the correct authentication type" do
+      get "/api/v1/absences", headers: headers, as: :json
+      expect(ApiCall.last.authentication_type).to eq "OAuth"
     end
   end
 end

--- a/spec/requests/api/v1/api_call_logging_spec.rb
+++ b/spec/requests/api/v1/api_call_logging_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "On enregistre les appels à l'api pour mieux comprendre qui s'en sert et comment" do
+  context "with OAuth authentication" do
+    let!(:oauth_token) do
+      create(:access_token, resource_owner_id: agent.id, application:)
+    end
+    let(:headers) do
+      {
+        "Content-Type": "application/json",
+        Authorization: "Bearer #{oauth_token.plaintext_token}",
+      }
+    end
+    let(:application) do
+      raise "utiliser la bonne factory"
+    end
+
+    it "records the correct authentication type" do
+    end
+  end
+end

--- a/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
@@ -100,8 +100,6 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
             received_at: be_within(10.seconds).of(Time.zone.now)
           )
           expect(ApiCall.first.raw_http["method"]).to eq("POST")
-          expect(ApiCall.first.raw_http["headers"]).to include("HTTP_ACCEPT")
-          expect(ApiCall.first.raw_http["headers"]["HTTP_ACCEPT"]).to eq("application/json")
         end
       end
 

--- a/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/absences_request_spec.rb
@@ -72,25 +72,24 @@ RSpec.describe "Absence authentified API", swagger_doc: "v1/api.json" do
         let(:end_time) { "15:00" }
 
         let!(:absence_count_before) { Absence.count }
-        let(:created_absence) { Absence.find(parsed_response_body["absence"]["id"]) }
 
         schema "$ref" => "#/components/schemas/absence_with_root"
 
         run_test!
 
-        it { expect(Absence.count).to eq(absence_count_before + 1) }
+        specify do
+          expect(Absence.count).to eq(absence_count_before + 1)
 
-        it { expect(created_absence.agent).to eq(agent) }
-
-        it { expect(created_absence.title).to eq(title) }
-
-        it { expect(created_absence.first_day).to eq(Date.new(2023, 11, 20)) }
-
-        it { expect(created_absence.start_time).to eq(Tod::TimeOfDay.new(8, 0)) }
-
-        it { expect(created_absence.end_day).to eq(Date.new(2023, 11, 20)) }
-
-        it { expect(created_absence.end_time).to eq(Tod::TimeOfDay.new(15, 0)) }
+          created_absence = Absence.find(parsed_response_body["absence"]["id"])
+          expect(created_absence).to have_attributes(
+            agent: agent,
+            title: title,
+            first_day: Date.new(2023, 11, 20),
+            start_time: Tod::TimeOfDay.new(8, 0),
+            end_day: Date.new(2023, 11, 20),
+            end_time: Tod::TimeOfDay.new(15, 0)
+          )
+        end
 
         it "logs the API call" do
           expect(ApiCall.first.attributes.symbolize_keys).to include(


### PR DESCRIPTION
En inspectant des ApiCall, je me suis rendu compte qu'en enregistrant les headers http, on écrit en clair en base des headers qui servent à l'authentification, ce qui introduit un risque d'escalade de privilège si un acteur malveillant avait accès à ces records.

Par ailleurs, il n'y a pas vraiment d'informations utiles ni exploitables dans ces headers.

On en a discuté avec Romain, et on préfère donc ne pas les enregistrer du tout, mais d'ajotuer une nouvelle colonne pour tracker le type d'authentification utilisé (ce qui va être beaucoup plus utile comme information maintenant qu'on essaye d'uniformiser l'authentification pour privilégier l'oauth).

Il faudra aussi nettoyer/backfiller les ApiCall existants (plus 1.5 millions sur l'instance principale !), mais je ferai ça dans une autre PR.

Vu qu'on ajoute une colonne sur une assez grosse table, je préfère déployer ça en dehors des horaires de bureau.
