### PR TITLE
Séparer les remarques par territoire (étape 1)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -247,6 +247,9 @@ Style/DateTime:
 Naming/BlockForwarding:
   Enabled: false
 
+Naming/VariableNumber:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,0 +1,6 @@
+class Annotation < ApplicationRecord
+  belongs_to :user
+  belongs_to :territory
+
+  validates :content, presence: true
+end

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -3,4 +3,5 @@ class Annotation < ApplicationRecord
   belongs_to :territory
 
   validates :content, presence: true
+  validates :territory_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@ class User < ApplicationRecord
   has_many :relatives, foreign_key: "responsible_id", class_name: "User", inverse_of: :responsible, dependent: :nullify
   has_many :file_attentes, dependent: :destroy
   has_many :receipts, dependent: :destroy
+  has_many :annotations, dependent: :destroy
 
   # Through relations
   # we specify dependent: :destroy because by default user_profiles and referent_assignations
@@ -72,6 +73,8 @@ class User < ApplicationRecord
 
   # Hooks
   before_save :set_email_to_null_if_blank
+  after_create :create_annotations  # backfill temporaire, première étape de migration
+  after_update :sync_annotations    # backfill temporaire, première étape de migration
 
   # Scopes
   default_scope { where(deleted_at: nil) }
@@ -279,6 +282,34 @@ class User < ApplicationRecord
     self.email = nil if email.blank?
   end
 
+  def create_annotations
+    return if notes.blank?
+
+    find_or_initialize_annotations.each do |annotation|
+      annotation.content = notes
+      annotation.save!
+    end
+  end
+
+  def sync_annotations
+    return unless notes_previously_changed?
+
+    if notes.present?
+      find_or_initialize_annotations.each do |annotation|
+        annotation.content = notes
+        annotation.save!
+      end
+    else
+      annotations.destroy_all
+    end
+  end
+
+  def find_or_initialize_annotations
+    territories.map do |territory|
+      Annotation.find_or_initialize_by(user: self, territory:)
+    end
+  end
+
   def birth_date_validity
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
@@ -296,6 +327,7 @@ class User < ApplicationRecord
     Anonymizer.anonymize_record!(self)
     receipts.each { |r| Anonymizer.anonymize_record!(r) }
     rdvs.each { |r| Anonymizer.anonymize_record!(r) }
+    annotations.destroy_all
     versions.destroy_all
     update_columns(
       first_name: "Usager supprimé",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -289,7 +289,8 @@ class User < ApplicationRecord
   def create_annotations
     return if notes.blank?
 
-    find_or_initialize_annotations.each do |annotation|
+    territories.distinct.map.each do |territory|
+      annotation = annotations.find_or_initialize_by(territory:)
       annotation.content = notes
       annotation.save!
     end
@@ -299,18 +300,13 @@ class User < ApplicationRecord
     return unless notes_previously_changed?
 
     if notes.present?
-      find_or_initialize_annotations.each do |annotation|
+      territories.distinct.map.each do |territory|
+        annotation = annotations.find_or_initialize_by(territory:)
         annotation.content = notes
         annotation.save!
       end
     else
       annotations.destroy_all
-    end
-  end
-
-  def find_or_initialize_annotations
-    territories.distinct.map do |territory|
-      annotations.find_or_initialize_by(territory:)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -249,6 +249,10 @@ class User < ApplicationRecord
     super(value&.upcase)
   end
 
+  def cleanup_annotations
+    annotations.where.not(territory: territories.reload).each(&:destroy!)
+  end
+
   protected
 
   def generate_rdv_invitation_token
@@ -305,8 +309,8 @@ class User < ApplicationRecord
   end
 
   def find_or_initialize_annotations
-    territories.map do |territory|
-      Annotation.find_or_initialize_by(user: self, territory:)
+    territories.distinct.map do |territory|
+      annotations.find_or_initialize_by(territory:)
     end
   end
 

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -17,4 +17,7 @@ class UserProfile < ApplicationRecord
 
   # Delegations
   delegate :territory, :territory_id, to: :organisation, allow_nil: true
+
+  # Callbacks
+  after_destroy { user.cleanup_annotations }
 end

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -19,6 +19,8 @@ tables:
     truncated: true
   - table_name: user_profiles
     truncated: true
+  - table_name: annotations
+    truncated: true
   - table_name: motif_categories_territories
     truncated: true
   - table_name: schema_migrations

--- a/db/migrate/20250213094124_create_annotations.rb
+++ b/db/migrate/20250213094124_create_annotations.rb
@@ -1,7 +1,7 @@
 class CreateAnnotations < ActiveRecord::Migration[7.1]
   def change
     create_table :annotations do |t|
-      t.references :user, foreign_key: true, index: true, null: false
+      t.references :user, foreign_key: true, index: false, null: false
       t.references :territory, foreign_key: true, index: true, null: false
 
       t.string :content, null: false
@@ -9,22 +9,21 @@ class CreateAnnotations < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    reversible do |direction|
-      direction.up do
-        User.where.not(notes: nil).where.not(notes: "").includes(:territories).find_each do |user|
-          next if user.notes.blank? # pas la peine de migrer "   "
+    add_index :annotations, %i[user_id territory_id], unique: true
 
-          user.territories.each do |territory|
-            Annotation.create!(
-              user: user,
-              territory: territory,
-              content: user.notes,
-              created_at: user.updated_at,
-              updated_at: user.updated_at
-            )
-          end
-        end
-      end
-    end
+    # Migration de données à lancer séparément pour ne pas que la migration timeout
+    # User.where.not(notes: nil).where.not(notes: "").includes(:territories).find_each do |user|
+    #   next if user.notes.blank? # pas la peine de migrer "   "
+    #
+    #   user.territories.each do |territory|
+    #     Annotation.create!(
+    #       user: user,
+    #       territory: territory,
+    #       content: user.notes,
+    #       created_at: user.updated_at,
+    #       updated_at: user.updated_at
+    #     )
+    #   end
+    # end
   end
 end

--- a/db/migrate/20250213094124_create_annotations.rb
+++ b/db/migrate/20250213094124_create_annotations.rb
@@ -20,13 +20,11 @@ class CreateAnnotations < ActiveRecord::Migration[7.1]
       next if user.notes.blank? # pas la peine de migrer "   "
 
       user.territories.distinct.each do |territory|
-        Annotation.create!(
-          user: user,
-          territory: territory,
-          content: user.notes,
-          created_at: user.updated_at,
-          updated_at: user.updated_at
-        )
+        annotation = user.annotations.find_or_initialize_by(territory:)
+        annotation.content = user.notes
+        annotation.created_at = user.updated_at
+        annotation.updated_at = user.updated_at
+        annotation.save!
       end
     end
   end

--- a/db/migrate/20250213094124_create_annotations.rb
+++ b/db/migrate/20250213094124_create_annotations.rb
@@ -1,0 +1,30 @@
+class CreateAnnotations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :annotations do |t|
+      t.references :user, foreign_key: true, index: true, null: false
+      t.references :territory, foreign_key: true, index: true, null: false
+
+      t.string :content, null: false
+
+      t.timestamps
+    end
+
+    reversible do |direction|
+      direction.up do
+        User.where.not(notes: nil).where.not(notes: "").includes(:territories).find_each do |user|
+          next if user.notes.blank? # pas la peine de migrer "   "
+
+          user.territories.each do |territory|
+            Annotation.create!(
+              user: user,
+              territory: territory,
+              content: user.notes,
+              created_at: user.updated_at,
+              updated_at: user.updated_at
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250213094124_create_annotations.rb
+++ b/db/migrate/20250213094124_create_annotations.rb
@@ -10,20 +10,24 @@ class CreateAnnotations < ActiveRecord::Migration[7.1]
     end
 
     add_index :annotations, %i[user_id territory_id], unique: true
+  end
 
-    # Migration de données à lancer séparément pour ne pas que la migration timeout
-    # User.where.not(notes: nil).where.not(notes: "").includes(:territories).find_each do |user|
-    #   next if user.notes.blank? # pas la peine de migrer "   "
-    #
-    #   user.territories.each do |territory|
-    #     Annotation.create!(
-    #       user: user,
-    #       territory: territory,
-    #       content: user.notes,
-    #       created_at: user.updated_at,
-    #       updated_at: user.updated_at
-    #     )
-    #   end
-    # end
+  private
+
+  # Migration de données à lancer séparément pour ne pas que la migration timeout :
+  def a_lancer_manuellement
+    User.where.not(notes: nil).where.not(notes: "").includes(:territories).find_each do |user|
+      next if user.notes.blank? # pas la peine de migrer "   "
+
+      user.territories.distinct.each do |territory|
+        Annotation.create!(
+          user: user,
+          territory: territory,
+          content: user.notes,
+          created_at: user.updated_at,
+          updated_at: user.updated_at
+        )
+      end
+    end
   end
 end

--- a/db/migrate/20250213094124_create_annotations.rb
+++ b/db/migrate/20250213094124_create_annotations.rb
@@ -14,7 +14,8 @@ class CreateAnnotations < ActiveRecord::Migration[7.1]
 
   private
 
-  # Migration de données à lancer séparément pour ne pas que la migration timeout :
+  # Cette migration de données a pris 11 minutes sur une copie locale de la prod, c'est
+  # pourquoi on la lance séparément pour ne pas que la migration timeout lors du deploy Scalingo.
   def a_lancer_manuellement
     User.where.not(notes: nil).where.not(notes: "").includes(:territories).find_each do |user|
       next if user.notes.blank? # pas la peine de migrer "   "

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_12_125817) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_13_094124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -259,6 +259,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_12_125817) do
     t.index ["agent_id", "rdv_id"], name: "index_agents_rdvs_on_agent_id_and_rdv_id", unique: true
     t.index ["agent_id"], name: "index_agents_rdvs_on_agent_id"
     t.index ["rdv_id"], name: "index_agents_rdvs_on_rdv_id"
+  end
+
+  create_table "annotations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "territory_id", null: false
+    t.string "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["territory_id"], name: "index_annotations_on_territory_id"
+    t.index ["user_id"], name: "index_annotations_on_user_id"
   end
 
   create_table "api_calls", force: :cascade do |t|
@@ -563,6 +573,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_12_125817) do
     t.bigint "lieu_id"
     t.boolean "expired_cached", default: false
     t.datetime "recurrence_ends_at"
+    t.time "secondary_start_time"
+    t.time "secondary_end_time"
     t.index "tsrange((first_day)::timestamp without time zone, recurrence_ends_at, '[]'::text)", name: "index_plage_ouvertures_on_tsrange_first_day_recurrence_ends_at", using: :gist
     t.index ["agent_id"], name: "index_plage_ouvertures_on_agent_id"
     t.index ["expired_cached"], name: "index_plage_ouvertures_on_expired_cached"
@@ -875,6 +887,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_12_125817) do
   add_foreign_key "agent_territorial_roles", "territories"
   add_foreign_key "agents_rdvs", "agents"
   add_foreign_key "agents_rdvs", "rdvs"
+  add_foreign_key "annotations", "territories"
+  add_foreign_key "annotations", "users"
   add_foreign_key "api_calls", "agents"
   add_foreign_key "exports", "agents"
   add_foreign_key "file_attentes", "rdvs"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -573,8 +573,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_13_094124) do
     t.bigint "lieu_id"
     t.boolean "expired_cached", default: false
     t.datetime "recurrence_ends_at"
-    t.time "secondary_start_time"
-    t.time "secondary_end_time"
     t.index "tsrange((first_day)::timestamp without time zone, recurrence_ends_at, '[]'::text)", name: "index_plage_ouvertures_on_tsrange_first_day_recurrence_ends_at", using: :gist
     t.index ["agent_id"], name: "index_plage_ouvertures_on_agent_id"
     t.index ["expired_cached"], name: "index_plage_ouvertures_on_expired_cached"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -268,7 +268,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_13_094124) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["territory_id"], name: "index_annotations_on_territory_id"
-    t.index ["user_id"], name: "index_annotations_on_user_id"
+    t.index ["user_id", "territory_id"], name: "index_annotations_on_user_id_and_territory_id", unique: true
   end
 
   create_table "api_calls", force: :cascade do |t|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     affiliation_number { "39012093812038" }
     family_situation { "divorced" }
     number_of_children { 12 }
-    notes { "Super note" }
+    notes { nil }
     logement { :locataire }
     responsible { nil }
     created_through { "user_sign_up" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -364,4 +364,52 @@ RSpec.describe User, type: :model do
       expect(user.reload.ants_pre_demande_number).to eq "ABCDE12345"
     end
   end
+
+  describe "#sync_annotations" do
+    describe "user creation" do
+      it "creates an annotation if needed" do
+        organisation = create(:organisation)
+        user_with_notes = create(:user, notes: "Lorem ipsum", organisations: [organisation])
+        expect(user_with_notes.notes).to eq("Lorem ipsum")
+        expect(Annotation.where(user: user_with_notes).sole).to have_attributes(territory: organisation.territory, content: "Lorem ipsum")
+
+        expect { create(:user, notes: "", organisations: [organisation]) }.not_to change(Annotation, :count)
+      end
+    end
+
+    describe "user update" do
+      it "creates an annotation if notes appear" do
+        organisation = create(:organisation)
+        user = create(:user, notes: nil, organisations: [organisation])
+        expect(Annotation.count).to eq(0)
+
+        expect { user.update!(notes: "Lorem ipsum") }.to change(Annotation, :count).by(1)
+        expect(Annotation.where(user: user).sole).to have_attributes(territory: organisation.territory, content: "Lorem ipsum")
+      end
+
+      it "updates the annotation if the notes change" do
+        organisation = create(:organisation)
+        user = create(:user, notes: "Lorem ipsum", organisations: [organisation])
+        expect { user.update!(notes: "dolor sit amet") }.to change { Annotation.where(user: user).sole.reload.updated_at }
+        expect(Annotation.where(user: user).sole.content).to eq("dolor sit amet")
+      end
+
+      it "deletes the annotation if the notes become blank" do
+        organisation = create(:organisation)
+        user = create(:user, notes: "Lorem ipsum", organisations: [organisation])
+        expect { user.update!(notes: "") }.to change { Annotation.where(user: user).first }.to(nil)
+      end
+    end
+
+    describe "user anonymization" do
+      it "deletes the annotations" do
+        organisation = create(:organisation)
+        user = create(:user, notes: "Lorem ipsum", organisations: [organisation])
+        expect(Annotation.where(user: user).sole.content).to eq("Lorem ipsum")
+
+        user.soft_delete
+        expect(Annotation.where(user: user)).to be_empty
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "#sync_annotations" do
+  describe "annotations" do
     describe "user creation" do
       it "creates an annotation if needed" do
         organisation = create(:organisation)
@@ -409,6 +409,24 @@ RSpec.describe User, type: :model do
 
         user.soft_delete
         expect(Annotation.where(user: user)).to be_empty
+      end
+    end
+
+    describe "removing user from organisation" do
+      it "removes annotations for the org's territory" do
+        territory_a = create(:territory)
+        territory_b = create(:territory)
+        organisation_a_1 = create(:organisation, territory: territory_a)
+        organisation_a_2 = create(:organisation, territory: territory_a)
+        organisation_b_1 = create(:organisation, territory: territory_b)
+        organisation_b_2 = create(:organisation, territory: territory_b)
+
+        user = create(:user, notes: "Lorem ipsum", organisations: [organisation_a_1, organisation_a_2, organisation_b_1, organisation_b_2])
+        expect(Annotation.where(user: user).count).to eq(2)
+
+        expect { UserProfile.find_by!(user: user, organisation: organisation_a_1).destroy! }.not_to change(Annotation, :count)
+        expect { UserProfile.find_by!(user: user, organisation: organisation_a_2).destroy! }.to change(Annotation, :count).by(-1)
+        expect(Annotation.where(user: user).sole.territory).to eq(territory_b)
       end
     end
   end


### PR DESCRIPTION
# Contexte

Actuellement, nous avons un champs "Remarques" (nom technique : `notes`) présent sur chaque usager. Il s'agit d'un champ libre qui peut être utilisé pour stocker des informations sur l'usager. Ces informations sont alors disponibles en lecture et écriture à tous les agents des organisations de l'usager.

En parallèle, si un agent tape l'adresse e-mail d'un usager existant qui n'est pas dans ses orgas ni territoire, on lui signale que la fiche existe dans notre base, et on lui propose de l'importer.

Le problème est donc que les informations saisies dans le champ "Remarques" sont globales à toute la base, ce qui pose des problèmes évidents de confidentialité.

Note : Par le passé, ce champ était stocké dans la table de jointure entre un usager et une organisation, mais il a été rapatrié sur l'usager, probablement parce que certains agents devaient collaborer entre plusieurs orgas d'un territoire.

# Solution

Au vu des informations de contexte, le fait de cloisonner les remarques par territoire semble un bon premier pas. Nous pourrons ensuite aller plus loin (permettre à un agent de partager une remarque avec un orga spécifique, un agent, un service, ajouter du versionnage, etc).

Cette PR consiste en la 1ère étape de migration des données : 
- créer une table pour stocker les remarques, qui fait la jointure entre usagers et territoire
- écrire aux deux endroits (`users.notes` et `annotations.content`)

Dans une seconde étape nous pourrons modifier les formulaires pour qu'ils utilisent l'annotation du territoire courant.

J'ai choisi le nom "Annotation" car je pense qu'il décrit mieux la nature de l'objet : nous avons une fiche usager, nous souhaitons y ajouter une information, nous pouvons donc l'annoter. D'autres agents peuvent l'annoter de leur côté, plusieurs annotations peuvent exister en même temps.
