### PR TITLE
Ajout d'infos de rdv via l'api de rdv_plans

### DIFF
--- a/app/blueprints/rdv_plan_blueprint.rb
+++ b/app/blueprints/rdv_plan_blueprint.rb
@@ -8,11 +8,15 @@ class RdvPlanBlueprint < Blueprinter::Base
   end
 
   field :rdv do |rdv_plan, _options|
-    next if rdv_plan.rdv.nil?
+    rdv = rdv_plan.rdv
+
+    next if rdv.nil?
 
     {
-      id: rdv_plan.rdv_id,
-      status: rdv_plan.rdv.status,
+      id: rdv.id,
+      status: rdv.status,
+      starts_at: rdv.starts_at.iso8601,
+      location_type: rdv.motif.location_type,
     }
   end
 end

--- a/app/blueprints/rdv_plan_blueprint.rb
+++ b/app/blueprints/rdv_plan_blueprint.rb
@@ -17,7 +17,7 @@ class RdvPlanBlueprint < Blueprinter::Base
     {
       id: rdv.id,
       status: rdv.status,
-      starts_at: rdv.starts_at.iso8601,
+      starts_at: rdv.starts_at,
       location_type: rdv.motif.location_type,
     }
   end

--- a/app/blueprints/rdv_plan_blueprint.rb
+++ b/app/blueprints/rdv_plan_blueprint.rb
@@ -8,6 +8,8 @@ class RdvPlanBlueprint < Blueprinter::Base
   end
 
   field :rdv do |rdv_plan, _options|
+    # L'appli partenaire a besoin des infos de base sur le rendez-vous pour permettre à l'agent
+    # de savoir quand et comment il aura lieu.
     rdv = rdv_plan.rdv
 
     next if rdv.nil?

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -130,22 +130,6 @@ RSpec.describe "RDV Plan API" do
   end
 
   describe "#show" do
-    context "when there is a rdv" do
-      let(:rdv_plan) do
-        create(:rdv_plan, rdv: create(:rdv), planning_agent: agent)
-      end
-
-      it "returns the minimum information about the rdv" do
-        get "/api/v1/rdv_plans/#{rdv_plan.id}", headers: headers, params: {}, as: :json
-        expect(parsed_response_body.dig("rdv_plan", "rdv")).to match(
-          {
-            id: rdv_plan.rdv_id,
-            status: "unknown",
-          }
-        )
-      end
-    end
-
     context "when the rdv_plan belongs to a different user" do
       let(:rdv_plan) do
         create(:rdv_plan, planning_agent: create(:agent))

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           expect(parsed_response_body.dig("rdv_plan", "url")).to eq "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/#{rdv_plan.id}"
           expect(parsed_response_body.dig("rdv_plan", "rdv").symbolize_keys).to include(
             id: rdv.id,
-            starts_at: rdv.starts_at,
             status: rdv.status,
+            starts_at: rdv.starts_at.iso8601,
             location_type: rdv.motif.location_type
           )
         end

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -112,10 +112,19 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
         run_test!
 
         let(:rdv_plan_id) { rdv_plan.id }
-        let!(:rdv_plan) { create(:rdv_plan, planning_agent: agent) }
+        let!(:rdv_plan) do
+          create(:rdv_plan, planning_agent: agent, rdv: rdv)
+        end
+        let(:rdv) { create(:rdv) }
 
         specify do
           expect(parsed_response_body.dig("rdv_plan", "url")).to eq "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/#{rdv_plan.id}"
+          expect(parsed_response_body.dig("rdv_plan", "rdv").symbolize_keys).to include(
+            id: rdv.id,
+            starts_at: rdv.starts_at,
+            status: rdv.status,
+            location_type: rdv.motif.location_type
+          )
         end
       end
     end

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -122,9 +122,9 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
           expect(parsed_response_body.dig("rdv_plan", "rdv").symbolize_keys).to include(
             id: rdv.id,
             status: rdv.status,
-            starts_at: rdv.starts_at.iso8601,
             location_type: rdv.motif.location_type
           )
+          expect(Time.zone.parse(parsed_response_body.dig("rdv_plan", "rdv", "starts_at"))).to be_within(1.second).of(rdv.reload.starts_at)
         end
       end
     end

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1335,14 +1335,14 @@
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Savinien",
+                          "first_name": "Arthur",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Paris"
+                          "last_name": "Fournier"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084713Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084843Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
                           "id": 20,
@@ -1521,14 +1521,14 @@
                         "agent": {
                           "id": 31,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Nadine",
+                          "first_name": "Bertille",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Boulanger"
+                          "last_name": "Lopez"
                         },
                         "end_day": "2025-02-15",
                         "end_time": "15:30:00",
                         "first_day": "2025-02-15",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084714Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084844Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
                           "id": 34,
@@ -1728,14 +1728,14 @@
                         "agent": {
                           "id": 43,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Zacharie",
+                          "first_name": "Aubertine",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Jacob"
+                          "last_name": "Pierre"
                         },
                         "end_day": "2025-02-15",
                         "end_time": "15:30:00",
                         "first_day": "2025-02-15",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084714Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084844Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
                           "id": 46,
@@ -2024,9 +2024,9 @@
                         {
                           "id": 67,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Josselin",
+                          "first_name": "Alphée",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Huet"
+                          "last_name": "Lopéz"
                         }
                       ],
                       "meta": {
@@ -2799,9 +2799,9 @@
                     "value": {
                       "rdv_plan": {
                         "id": 7,
-                        "created_at": "2025-02-14 09:47:20 +0100",
+                        "created_at": "2025-02-14 09:48:50 +0100",
                         "rdv": null,
-                        "updated_at": "2025-02-14 09:47:20 +0100",
+                        "updated_at": "2025-02-14 09:48:50 +0100",
                         "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/7",
                         "user_id": 17
                       }
@@ -2913,14 +2913,14 @@
                     "value": {
                       "rdv_plan": {
                         "id": 9,
-                        "created_at": "2025-02-14 09:47:20 +0100",
+                        "created_at": "2025-02-14 09:48:50 +0100",
                         "rdv": {
                           "id": 8,
                           "status": "unknown",
-                          "starts_at": "2025-02-17T09:47:20+01:00",
+                          "starts_at": "2025-02-17 09:48:50 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2025-02-14 09:47:20 +0100",
+                        "updated_at": "2025-02-14 09:48:50 +0100",
                         "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/9",
                         "user_id": 21
                       }
@@ -3023,15 +3023,15 @@
                             {
                               "id": 152,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Tristan",
+                              "first_name": "Athanase",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "André"
+                              "last_name": "Hubert"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-02-14 09:47:20 +0100",
+                          "created_at": "2025-02-14 09:48:50 +0100",
                           "created_by": "agent",
                           "created_by_id": 152,
                           "created_by_type": "Agent",
@@ -3091,20 +3091,20 @@
                                 "birth_name": null,
                                 "caisse_affiliation": "caf",
                                 "case_number": null,
-                                "created_at": "2025-02-14 09:47:20 +0100",
+                                "created_at": "2025-02-14 09:48:50 +0100",
                                 "email": "usager_1@lapin.fr",
                                 "family_situation": "divorced",
-                                "first_name": "Enguerrand",
+                                "first_name": "Anceline",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "ROGER",
+                                "last_name": "FABRE",
                                 "logement": "locataire",
                                 "notes": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
                                 "number_of_children": 12,
-                                "phone_number": "0615482424",
-                                "phone_number_formatted": "+33615482424",
+                                "phone_number": "0792963238",
+                                "phone_number_formatted": "+33792963238",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3123,27 +3123,27 @@
                               "birth_name": null,
                               "caisse_affiliation": "caf",
                               "case_number": null,
-                              "created_at": "2025-02-14 09:47:20 +0100",
+                              "created_at": "2025-02-14 09:48:50 +0100",
                               "email": "usager_1@lapin.fr",
                               "family_situation": "divorced",
-                              "first_name": "Enguerrand",
+                              "first_name": "Anceline",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "ROGER",
+                              "last_name": "FABRE",
                               "logement": "locataire",
                               "notes": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
                               "number_of_children": 12,
-                              "phone_number": "0615482424",
-                              "phone_number_formatted": "+33615482424",
+                              "phone_number": "0792963238",
+                              "phone_number_formatted": "+33792963238",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "fd044c67-efd8-428a-acdf-434bb9c54d9f"
+                          "uuid": "e11bad5c-e0d3-4935-aabb-92c1ebe0b6a8"
                         }
                       ],
                       "meta": {
@@ -3258,9 +3258,9 @@
                         "agent": {
                           "id": 253,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Titien",
+                          "first_name": "Assomption",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Dumas"
+                          "last_name": "Leblanc"
                         },
                         "user": {
                           "id": 101,
@@ -3271,20 +3271,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-14 09:47:26 +0100",
+                          "created_at": "2025-02-14 09:48:56 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Agapet",
+                          "first_name": "Juste",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LUCAS",
+                          "last_name": "PONS",
                           "logement": "locataire",
                           "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 11 23 27 81",
-                          "phone_number_formatted": "+33611232781",
+                          "phone_number": "6 49 57 92 65",
+                          "phone_number_formatted": "+33649579265",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3540,26 +3540,26 @@
                             {
                               "id": 285,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Philothée",
+                              "first_name": "Dieudonné",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Fernandez"
+                              "last_name": "Perrin"
                             },
                             {
                               "id": 286,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Honorine",
+                              "first_name": "Gilles",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Hoarau"
+                              "last_name": "Paul"
                             },
                             {
                               "id": 287,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Félicie",
+                              "first_name": "Hippolyte",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Gauthier"
+                              "last_name": "Faure"
                             }
                           ],
-                          "name": "Alsace monkeys 84afb394",
+                          "name": "Picardie vampires ab2afca8",
                           "territory": {
                             "id": 240,
                             "departement_number": "01",
@@ -3693,20 +3693,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-14 09:47:27 +0100",
+                          "created_at": "2025-02-14 09:48:57 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Vigile",
+                          "first_name": "Madeleine",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MULLER",
+                          "last_name": "PAUL",
                           "logement": "locataire",
                           "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 33 34 08 44",
-                          "phone_number_formatted": "+33633340844",
+                          "phone_number": "0761744406",
+                          "phone_number_formatted": "+33761744406",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4001,7 +4001,7 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-14 09:47:28 +0100",
+                        "created_at": "2025-02-14 09:48:58 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -4013,8 +4013,8 @@
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "6 30 86 01 64",
-                        "phone_number_formatted": "+33630860164",
+                        "phone_number": "0795230612",
+                        "phone_number_formatted": "+33795230612",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
@@ -4306,7 +4306,7 @@
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-14 09:47:30 +0100",
+                        "created_at": "2025-02-14 09:49:00 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Alain",
@@ -4329,20 +4329,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-14 09:47:30 +0100",
+                          "created_at": "2025-02-14 09:49:00 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Eustache",
+                          "first_name": "Mélissandre",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MILLET",
+                          "last_name": "JACQUET",
                           "logement": "locataire",
                           "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 20 86 22 62",
-                          "phone_number_formatted": "+33620862262",
+                          "phone_number": "07 69 06 07 42",
+                          "phone_number_formatted": "+33769060742",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4477,7 +4477,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "9A10LLRT"
+                      "invitation_token": "328RGN6N"
                     }
                   }
                 },
@@ -4618,20 +4618,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-14 09:47:32 +0100",
+                          "created_at": "2025-02-14 09:49:02 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Brigitte",
+                          "first_name": "Lionel",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "BRETON",
+                          "last_name": "MORIN",
                           "logement": "locataire",
                           "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "790439624",
-                          "phone_number_formatted": "+33790439624",
+                          "phone_number": "0663399854",
+                          "phone_number_formatted": "+33663399854",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4896,7 +4896,7 @@
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-14 09:47:32 +0100",
+                        "created_at": "2025-02-14 09:49:02 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Johnny",
@@ -4919,20 +4919,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-14 09:47:32 +0100",
+                          "created_at": "2025-02-14 09:49:02 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Ludolphe",
+                          "first_name": "Fulbert",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEMAIRE",
+                          "last_name": "FABRE",
                           "logement": "locataire",
                           "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "6 16 18 77 68",
-                          "phone_number_formatted": "+33616187768",
+                          "phone_number": "07 65 48 22 14",
+                          "phone_number_formatted": "+33765482214",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5086,20 +5086,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-14 09:47:33 +0100",
+                          "created_at": "2025-02-14 09:49:03 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Avigaëlle",
+                          "first_name": "Zélie",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GILLET",
+                          "last_name": "GUERIN",
                           "logement": "locataire",
                           "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "7 87 63 72 40",
-                          "phone_number_formatted": "+33787637240",
+                          "phone_number": "742944531",
+                          "phone_number_formatted": "+33742944531",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5224,7 +5224,7 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-14 09:47:33 +0100",
+                        "created_at": "2025-02-14 09:49:03 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -5236,8 +5236,8 @@
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "0617321062",
-                        "phone_number_formatted": "+33617321062",
+                        "phone_number": "06 62 76 28 33",
+                        "phone_number_formatted": "+33662762833",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -1331,21 +1331,21 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 18,
+                        "id": 12,
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Philippine",
+                          "first_name": "Savinien",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Simon"
+                          "last_name": "Paris"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250212T135810Z\r\nUID:absence_18@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_18@RDV Solidarités",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084713Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
-                          "id": 27,
+                          "id": 20,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1517,21 +1517,21 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 27,
+                        "id": 21,
                         "agent": {
-                          "id": 32,
+                          "id": 31,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Hermine",
+                          "first_name": "Nadine",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Roche"
+                          "last_name": "Boulanger"
                         },
-                        "end_day": "2025-02-13",
+                        "end_day": "2025-02-15",
                         "end_time": "15:30:00",
-                        "first_day": "2025-02-13",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250212T135811Z\r\nUID:absence_27@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250213T100000\r\nDTEND;TZID=Europe/Paris:20250213T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_27@RDV Solidarités",
+                        "first_day": "2025-02-15",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084714Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
-                          "id": 41,
+                          "id": 34,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1724,21 +1724,21 @@
                   "example": {
                     "value": {
                       "absence": {
-                        "id": 39,
+                        "id": 33,
                         "agent": {
-                          "id": 44,
+                          "id": 43,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Innocent",
+                          "first_name": "Zacharie",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Lévêque"
+                          "last_name": "Jacob"
                         },
-                        "end_day": "2025-02-13",
+                        "end_day": "2025-02-15",
                         "end_time": "15:30:00",
-                        "first_day": "2025-02-13",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250212T135811Z\r\nUID:absence_39@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250213T100000\r\nDTEND;TZID=Europe/Paris:20250213T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
-                        "ical_uid": "absence_39@RDV Solidarités",
+                        "first_day": "2025-02-15",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084714Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
-                          "id": 53,
+                          "id": 46,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2022,11 +2022,11 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 68,
+                          "id": 67,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Amandine",
+                          "first_name": "Josselin",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Meunier"
+                          "last_name": "Huet"
                         }
                       ],
                       "meta": {
@@ -2169,6 +2169,24 @@
                     "value": {
                       "motifs": [
                         {
+                          "id": 7,
+                          "bookable_by": "everyone",
+                          "bookable_publicly": true,
+                          "collectif": false,
+                          "deleted_at": null,
+                          "follow_up": false,
+                          "instruction_for_rdv": null,
+                          "location_type": "public_office",
+                          "motif_category": {
+                            "id": 7,
+                            "name": "Catégorie de motif n°1",
+                            "short_name": "1_motif_cat"
+                          },
+                          "name": "Motif 1",
+                          "organisation_id": 87,
+                          "service_id": 90
+                        },
+                        {
                           "id": 8,
                           "bookable_by": "everyone",
                           "bookable_publicly": true,
@@ -2179,30 +2197,12 @@
                           "location_type": "public_office",
                           "motif_category": {
                             "id": 8,
-                            "name": "Catégorie de motif n°1",
-                            "short_name": "1_motif_cat"
-                          },
-                          "name": "Motif 1",
-                          "organisation_id": 94,
-                          "service_id": 97
-                        },
-                        {
-                          "id": 9,
-                          "bookable_by": "everyone",
-                          "bookable_publicly": true,
-                          "collectif": false,
-                          "deleted_at": null,
-                          "follow_up": false,
-                          "instruction_for_rdv": null,
-                          "location_type": "public_office",
-                          "motif_category": {
-                            "id": 9,
                             "name": "Catégorie de motif n°2",
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 94,
-                          "service_id": 97
+                          "organisation_id": 87,
+                          "service_id": 90
                         }
                       ],
                       "meta": {
@@ -2327,35 +2327,35 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 127,
+                          "id": 120,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 128,
+                          "id": 121,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 129,
+                          "id": 122,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 130,
+                          "id": 123,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 131,
+                          "id": 124,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -2473,7 +2473,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 138,
+                        "id": 131,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -2582,7 +2582,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 142,
+                        "id": 135,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -2673,15 +2673,15 @@
                       "public_links": [
                         {
                           "external_id": "ext_id_A",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/188"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/181"
                         },
                         {
                           "external_id": "ext_id_B",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/189"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/182"
                         },
                         {
                           "external_id": "ext_id_C",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/190"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/183"
                         }
                       ]
                     }
@@ -2798,12 +2798,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 8,
-                        "created_at": "2025-02-12 14:58:16 +0100",
+                        "id": 7,
+                        "created_at": "2025-02-14 09:47:20 +0100",
                         "rdv": null,
-                        "updated_at": "2025-02-12 14:58:16 +0100",
-                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/8",
-                        "user_id": 19
+                        "updated_at": "2025-02-14 09:47:20 +0100",
+                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/7",
+                        "user_id": 17
                       }
                     }
                   }
@@ -2912,11 +2912,16 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 10,
-                        "created_at": "2025-02-12 14:58:16 +0100",
-                        "rdv": null,
-                        "updated_at": "2025-02-12 14:58:16 +0100",
-                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/10",
+                        "id": 9,
+                        "created_at": "2025-02-14 09:47:20 +0100",
+                        "rdv": {
+                          "id": 8,
+                          "status": "unknown",
+                          "starts_at": "2025-02-17T09:47:20+01:00",
+                          "location_type": "public_office"
+                        },
+                        "updated_at": "2025-02-14 09:47:20 +0100",
+                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/9",
                         "user_id": 21
                       }
                     }
@@ -3012,37 +3017,37 @@
                     "value": {
                       "rdvs": [
                         {
-                          "id": 11,
+                          "id": 12,
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 151,
+                              "id": 152,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Reybaud",
+                              "first_name": "Tristan",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Henry"
+                              "last_name": "André"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-02-12 14:58:17 +0100",
+                          "created_at": "2025-02-14 09:47:20 +0100",
                           "created_by": "agent",
-                          "created_by_id": 151,
+                          "created_by_id": 152,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
                           "lieu": {
-                            "id": 26,
+                            "id": 27,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "name": "Lieu n°1",
-                            "organisation_id": 201,
+                            "organisation_id": 196,
                             "phone_number": null,
                             "single_use": false
                           },
                           "max_participants_count": null,
                           "motif": {
-                            "id": 65,
+                            "id": 66,
                             "bookable_by": "everyone",
                             "bookable_publicly": true,
                             "collectif": false,
@@ -3051,17 +3056,17 @@
                             "instruction_for_rdv": null,
                             "location_type": "public_office",
                             "motif_category": {
-                              "id": 65,
+                              "id": 66,
                               "name": "Catégorie de motif n°1",
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 201,
-                            "service_id": 189
+                            "organisation_id": 196,
+                            "service_id": 184
                           },
                           "name": null,
                           "organisation": {
-                            "id": 201,
+                            "id": 196,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3069,10 +3074,10 @@
                           },
                           "participations": [
                             {
-                              "id": 14,
+                              "id": 15,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 151,
+                              "created_by_id": 152,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
@@ -3086,20 +3091,20 @@
                                 "birth_name": null,
                                 "caisse_affiliation": "caf",
                                 "case_number": null,
-                                "created_at": "2025-02-12 14:58:17 +0100",
+                                "created_at": "2025-02-14 09:47:20 +0100",
                                 "email": "usager_1@lapin.fr",
                                 "family_situation": "divorced",
-                                "first_name": "Pascale",
+                                "first_name": "Enguerrand",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "MÉUNIER",
+                                "last_name": "ROGER",
                                 "logement": "locataire",
-                                "notes": "Super note",
+                                "notes": null,
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
                                 "number_of_children": 12,
-                                "phone_number": "0769046672",
-                                "phone_number_formatted": "+33769046672",
+                                "phone_number": "0615482424",
+                                "phone_number_formatted": "+33615482424",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3118,27 +3123,27 @@
                               "birth_name": null,
                               "caisse_affiliation": "caf",
                               "case_number": null,
-                              "created_at": "2025-02-12 14:58:17 +0100",
+                              "created_at": "2025-02-14 09:47:20 +0100",
                               "email": "usager_1@lapin.fr",
                               "family_situation": "divorced",
-                              "first_name": "Pascale",
+                              "first_name": "Enguerrand",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "MÉUNIER",
+                              "last_name": "ROGER",
                               "logement": "locataire",
-                              "notes": "Super note",
+                              "notes": null,
                               "notify_by_email": true,
                               "notify_by_sms": true,
                               "number_of_children": 12,
-                              "phone_number": "0769046672",
-                              "phone_number_formatted": "+33769046672",
+                              "phone_number": "0615482424",
+                              "phone_number_formatted": "+33615482424",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "8d671758-47fc-4c00-b09a-58c152922d45"
+                          "uuid": "fd044c67-efd8-428a-acdf-434bb9c54d9f"
                         }
                       ],
                       "meta": {
@@ -3251,11 +3256,11 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 252,
+                          "id": 253,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Judicaël",
+                          "first_name": "Titien",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Arnaud"
+                          "last_name": "Dumas"
                         },
                         "user": {
                           "id": 101,
@@ -3266,20 +3271,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-12 14:58:22 +0100",
+                          "created_at": "2025-02-14 09:47:26 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Catherine",
+                          "first_name": "Agapet",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MARTY",
+                          "last_name": "LUCAS",
                           "logement": "locataire",
-                          "notes": "Super note",
+                          "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "0732816032",
-                          "phone_number_formatted": "+33732816032",
+                          "phone_number": "06 11 23 27 81",
+                          "phone_number_formatted": "+33611232781",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3533,30 +3538,30 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 284,
-                              "email": "agent_2@lapin.fr",
-                              "first_name": "Éric",
-                              "inclusion_connect_open_id_sub": null,
-                              "last_name": "Huet"
-                            },
-                            {
                               "id": 285,
-                              "email": "agent_3@lapin.fr",
-                              "first_name": "Ludivine",
+                              "email": "agent_2@lapin.fr",
+                              "first_name": "Philothée",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Renaud"
+                              "last_name": "Fernandez"
                             },
                             {
                               "id": 286,
-                              "email": "agent_4@lapin.fr",
-                              "first_name": "Gautier",
+                              "email": "agent_3@lapin.fr",
+                              "first_name": "Honorine",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Colin"
+                              "last_name": "Hoarau"
+                            },
+                            {
+                              "id": 287,
+                              "email": "agent_4@lapin.fr",
+                              "first_name": "Félicie",
+                              "inclusion_connect_open_id_sub": null,
+                              "last_name": "Gauthier"
                             }
                           ],
-                          "name": "Basse-Normandie oracles 18219804",
+                          "name": "Alsace monkeys 84afb394",
                           "territory": {
-                            "id": 245,
+                            "id": 240,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Territoire n°1"
@@ -3673,7 +3678,7 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 264,
+                          "id": 259,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -3688,20 +3693,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-12 14:58:24 +0100",
+                          "created_at": "2025-02-14 09:47:27 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Manassé",
+                          "first_name": "Vigile",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEMOINE",
+                          "last_name": "MULLER",
                           "logement": "locataire",
-                          "notes": "Super note",
+                          "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 10 82 77 82",
-                          "phone_number_formatted": "+33610827782",
+                          "phone_number": "06 33 34 08 44",
+                          "phone_number_formatted": "+33633340844",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3996,7 +4001,7 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-12 14:58:25 +0100",
+                        "created_at": "2025-02-14 09:47:28 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -4004,18 +4009,18 @@
                         "invitation_created_at": null,
                         "last_name": "JACQUES",
                         "logement": "locataire",
-                        "notes": "Super note",
+                        "notes": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "7 70 83 17 08",
-                        "phone_number_formatted": "+33770831708",
+                        "phone_number": "6 30 86 01 64",
+                        "phone_number_formatted": "+33630860164",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 285,
+                              "id": 280,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -4301,7 +4306,7 @@
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-12 14:58:26 +0100",
+                        "created_at": "2025-02-14 09:47:30 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Alain",
@@ -4309,7 +4314,7 @@
                         "invitation_created_at": null,
                         "last_name": "Verse",
                         "logement": "locataire",
-                        "notes": "Super note",
+                        "notes": null,
                         "notify_by_email": false,
                         "notify_by_sms": false,
                         "number_of_children": 3,
@@ -4324,20 +4329,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-12 14:58:26 +0100",
+                          "created_at": "2025-02-14 09:47:30 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Vincent",
+                          "first_name": "Eustache",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PHILIPPE",
+                          "last_name": "MILLET",
                           "logement": "locataire",
-                          "notes": "Super note",
+                          "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "6 41 41 04 11",
-                          "phone_number_formatted": "+33641410411",
+                          "phone_number": "06 20 86 22 62",
+                          "phone_number_formatted": "+33620862262",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4472,7 +4477,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "RDRTUUAD"
+                      "invitation_token": "9A10LLRT"
                     }
                   }
                 },
@@ -4613,20 +4618,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-12 14:58:28 +0100",
+                          "created_at": "2025-02-14 09:47:32 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Scholastique",
+                          "first_name": "Brigitte",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LEMOINE",
+                          "last_name": "BRETON",
                           "logement": "locataire",
-                          "notes": "Super note",
+                          "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "06 27 14 71 75",
-                          "phone_number_formatted": "+33627147175",
+                          "phone_number": "790439624",
+                          "phone_number_formatted": "+33790439624",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4891,7 +4896,7 @@
                         "birth_name": "Fripouille",
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-12 14:58:28 +0100",
+                        "created_at": "2025-02-14 09:47:32 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "single",
                         "first_name": "Johnny",
@@ -4914,20 +4919,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-12 14:58:28 +0100",
+                          "created_at": "2025-02-14 09:47:32 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Alaïs",
+                          "first_name": "Ludolphe",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "LOPEZ",
+                          "last_name": "LEMAIRE",
                           "logement": "locataire",
-                          "notes": "Super note",
+                          "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "07 79 19 96 51",
-                          "phone_number_formatted": "+33779199651",
+                          "phone_number": "6 16 18 77 68",
+                          "phone_number_formatted": "+33616187768",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5081,20 +5086,20 @@
                           "birth_name": null,
                           "caisse_affiliation": "caf",
                           "case_number": null,
-                          "created_at": "2025-02-12 14:58:29 +0100",
+                          "created_at": "2025-02-14 09:47:33 +0100",
                           "email": "usager_1@lapin.fr",
                           "family_situation": "divorced",
-                          "first_name": "Lothaire",
+                          "first_name": "Avigaëlle",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "SCHNEIDER",
+                          "last_name": "GILLET",
                           "logement": "locataire",
-                          "notes": "Super note",
+                          "notes": null,
                           "notify_by_email": true,
                           "notify_by_sms": true,
                           "number_of_children": 12,
-                          "phone_number": "6 13 55 08 84",
-                          "phone_number_formatted": "+33613550884",
+                          "phone_number": "7 87 63 72 40",
+                          "phone_number_formatted": "+33787637240",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5219,7 +5224,7 @@
                         "birth_name": null,
                         "caisse_affiliation": "caf",
                         "case_number": null,
-                        "created_at": "2025-02-12 14:58:29 +0100",
+                        "created_at": "2025-02-14 09:47:33 +0100",
                         "email": "jean@jacques.fr",
                         "family_situation": "divorced",
                         "first_name": "Jean",
@@ -5227,18 +5232,18 @@
                         "invitation_created_at": null,
                         "last_name": "JACQUES",
                         "logement": "locataire",
-                        "notes": "Super note",
+                        "notes": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
                         "number_of_children": 12,
-                        "phone_number": "665707573",
-                        "phone_number_formatted": "+33665707573",
+                        "phone_number": "0617321062",
+                        "phone_number_formatted": "+33617321062",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 361,
+                              "id": 356,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -5545,7 +5550,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 26,
-                        "organisation_id": 381,
+                        "organisation_id": 376,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -5743,7 +5748,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 28,
-                        "organisation_id": 388,
+                        "organisation_id": 383,
                         "subscriptions": [
                           "rdv",
                           "user",


### PR DESCRIPTION
# Contexte

Suite aux discussions avec les équipes techniques de Mon Suivi Social et Démarches Simplifiées, on a eu confirmation qu'il y a besoin d'infos basiques sur le rdv via l'endpoint d'api du rdv_plan.

On avait commencé par faire une version très restreinte des infos sur le rdv, pour être sûrs de ne pas ajouter de champs inutiles qui seraient difficiles à supprimer par la suite.

# Solution

On ajoute les champs nécessaires à l'api.
voir aussi https://pad.numerique.gouv.fr/aZatuVU5Sj-bJskWabazaQ