### PR TITLE
Utilisation d’une variable d’environnement pour la DB du CRM

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -2,7 +2,7 @@ class CronJob::SynchronizeCrm < ApplicationJob
   # Base de données "Activation"
   # ID récupéré dans l’URL de la page
   # Cf: https://developers.notion.com/reference/retrieve-a-database
-  NOTION_DATABASE_ID = "81a35c7b2490464590a408bbbb78ca2e".freeze
+  NOTION_DATABASE_ID = ENV["NOTION_DATABASE_ID"].freeze
 
   def perform
     return unless ENV["NOTION_API_SECRET"]


### PR DESCRIPTION
# Contexte

Suite à une modification dans Notion de la part de l’équipe déploiement, leur base de données à changé d’ID.

# Solution

Afin d’éviter de changer le code tous les 4 matins, je suggère d’utiliser une variable d’environnement.

