### PR TITLE
correction typo ceux - celles dans les stats

### DIFF
--- a/app/views/stats/territories.html.slim
+++ b/app/views/stats/territories.html.slim
@@ -14,10 +14,10 @@
 
     .fr-callout.fr-my-8w
       - if ENV["APP"] == "production-rdv-solidarites"
-        | Les structures dont les statistiques sont accessibles ici sont ceux de RDV Solidarités et RDV Aide Numérique.&#32;
+        | Les structures dont les statistiques sont accessibles ici sont celles de RDV Solidarités et RDV Aide Numérique.&#32;
         | Vous pouvez consulter les statistiques des structures de l'instance RDV Service Public sur&#32;
         = link_to "rdv.anct.gouv.fr/stats/territories", "https://rdv.anct.gouv.fr/stats/territories", title: "Page de statistiques RDV Service Public - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"
       - else
-        | Les structures dont les statistiques sont accessibles ici sont ceux de RDV Service Public.&#32;
+        | Les structures dont les statistiques sont accessibles ici sont celles de RDV Service Public.&#32;
         | Vous pouvez consulter les statistiques des structures de RDV Solidarités et RDV Aide Numérique sur&#32;
         = link_to "rdv-solidarites.fr/stats/territories", "https://rdv-solidarites.fr/stats/territories", title: "Page de statistiques RDV Solidarités et RDV Aide Némurique - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"


### PR DESCRIPTION
Une petite faute d’accord sur les pages de stats