### PR TITLE
forcer required:false sur les champs ANTS côté agent

### DIFF
--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -29,7 +29,7 @@
     )
 
     - if current_organisation.motifs.requires_ants_predemande_number.any?
-      = f.input :ants_pre_demande_number, **input_opts, hint: t("simple_form.hints.agent.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
+      = f.input :ants_pre_demande_number, **input_opts, hint: t("simple_form.hints.agent.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}, required: false
 
     div *div_opts[:responsible]
       = render "responsible_form_fields", f: f, input_opts: input_opts[:responsible]

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -30,7 +30,7 @@
 
     - if current_organisation.motifs.requires_ants_predemande_number.any?
       = f.input :ants_pre_demande_number, **input_opts, hint: t("simple_form.hints.agent.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}, required: false
-
+      / le required est important cf https://github.com/betagouv/rdv-service-public/pull/5079
     div *div_opts[:responsible]
       = render "responsible_form_fields", f: f, input_opts: input_opts[:responsible]
 


### PR DESCRIPTION
# Contexte

Un bug semble avoir été introduit avec #5067 

Des agents nous font remonter que le numéro de dossier ANTS est devenu obligatoire côté agent. En effet on arrive à reproduire ça en prod.

Malheureusement, impossible de comprendre d’où vient le problème ou de le reproduire en local. 
J’ai tenté de charger un dump de la prod mais le bug ne s’est toujours pas reproduit, le champ apparait facultatif en local.
J’ai aussi tenté de reproduire en env de démo.

Ce `required: true` est très probablement rajouté par simple_form qui le fait sur tous les champs ayant une validation de presence. 
Or, je ne vois pas comment c’est possible qu’une validation de présence ait été rajoutée sur le champ ANTS dans le formulaire `Admin::UserForm`. 
Je pense que c’est un faux positif de la détection de simple_form mais qui ne se produit qu’en prod pour une certaine raison 🤷 

# Solution

Je propose une solution de contournement temporaire dans ce fix : forcer le `required: false` dans la vue `admin/users/_form`. 

J’ai fait un test en prod pour m’assurer que cela devrait corriger le problème : 
- dans l’inspecteur enlever `required: true` du champ ANTS et du champ first_name
- remplir un last name
- soumettre le formulaire
- le formulaire revient avec UNE SEULE erreur : il manque un `first_name`

Cela semble confirmer que la présence n’est effectivement pas requise sur le champ ANTS mais que c’est simple_form qui rajoute le required à tort. Cette solution de contournement devrait corriger le problème le temps qu’on comprenne d’où ça vient.