### PR TITLE
Add script to backfill api calls

### DIFF
--- a/scripts/backfill_agent_territorial_access_rights.rb
+++ b/scripts/backfill_agent_territorial_access_rights.rb
@@ -1,6 +1,0 @@
-# usage: rails runner scripts/backfill_agent_territorial_access_rights.rb
-Agent.joins("left outer join agent_territorial_access_rights on agents.id = agent_territorial_access_rights.agent_id")
-  .where(agent_territorial_access_rights: { id: nil })
-  .find_each do |agent|
-    AgentTerritorialAccessRight.create(agent: agent, territory: agent.organisations.first.territory)
-  end

--- a/scripts/backfill_api_calls_auth.rb
+++ b/scripts/backfill_api_calls_auth.rb
@@ -7,7 +7,7 @@ ApiCall.where(authentication_type: nil).find_each do |api_call|
     api_call.authentication_type = "OAuth"
   elsif headers["HTTP_ACCESS_TOKEN"] && headers["HTTP_UID"]
     api_call.authentication_type = "DeviseTokenAuth"
-  elsif headers["X-Agent-Auth-Signature"]
+  elsif headers["HTTP_X_AGENT_AUTH_SIGNATURE"]
     api_call.authentication_type = "SharedSecret"
   end
 

--- a/scripts/backfill_api_calls_auth.rb
+++ b/scripts/backfill_api_calls_auth.rb
@@ -1,0 +1,15 @@
+# usage: bundle exec rails runner scripts/backfill_api_calls_auth.rb
+
+ApiCall.where(authentication_type: nil).find_each do |api_call|
+  headers = api_call.raw_http.delete("headers")
+
+  if headers["HTTP_AUTHORIZATION"]
+    api_call.authentication_type = "OAuth"
+  elsif headers["HTTP_ACCESS_TOKEN"] && headers["HTTP_UID"]
+    api_call.authentication_type = "DeviseTokenAuth"
+  elsif headers["X-Agent-Auth-Signature"]
+    api_call.authentication_type = "SharedSecret"
+  end
+
+  api_call.save
+end


### PR DESCRIPTION
# Contexte

Suite de https://github.com/betagouv/rdv-service-public/pull/5068 : cette PR corrige rétroactivement les données des ApiCall. On supprime les headers, et on enregistre le type d'authentification.

# Solution

On a plus d'un million d'ApiCall sur la base principale, donc je préfère ne pas mettre ce script dans une migration qui risquerait de faire un timeout.
Le script est écrit pour pouvoir être relancé après un échec.
Je le lancerai en soirée, en dehors des horaires de traffic important.
