### PR TITLE
Correction du hover sur les boutons full calendar

### DIFF
--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -71,6 +71,10 @@
   height: auto;
 }
 
+.fc-button:hover {
+  color: $black;
+}
+
 .fc-text-arrow {
   font-family: inherit;
   font-size: 1rem;


### PR DESCRIPTION
# Contexte

Suite à #4914 

# Solution

Dans un premier temps on corrige juste le hover pour des questions d’accessibilités.
Après la màj full calendar on pourra envisager les composants DSFR pour full calendar.

## Captures d'écran

Avant | Après
:- | -:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/789604de-2704-4b16-8ca7-7e2afdf2dd1b" /> | <img width="492" alt="image" src="https://github.com/user-attachments/assets/44e3897b-d7f9-4b24-90b7-77b3250620bb" />
