### PR TITLE
Diminution de la quantité de données personnelles accessibles via l'api et les webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,12 @@ generate_db_diagram: ## Generate docs/domain_model.svg from Rails models
 	bundle exec erd
 
 rswag: ## Re-generate swagger/v1/api.json by running API specs
-	SWAGGER_DRY_RUN=0 RAILS_ENV=test rake rswag:specs:swaggerize PATTERN="spec/requests/api/**/*_spec.rb"
+	SWAGGER_DRY_RUN=0 RAILS_ENV=test FAKER_SEED=1 rake rswag:specs:swaggerize PATTERN="spec/requests/api/**/*_spec.rb"
+
+rswag_api_v1: ## Re-generate swagger/v1/api.json by running API specs
+	SWAGGER_DRY_RUN=0 RAILS_ENV=test FAKER_SEED=1 rake rswag:specs:swaggerize PATTERN="spec/requests/api/v1/swagger_doc/**/*_spec.rb"
+	git checkout swagger/conseillers_numeriques/api.json
+	git checkout swagger/visioplainte/api.json
 
 .PHONY: install run lint lint_rubocop lint_brakeman test test_unit test_features autocorrect clean generate_db_diagram help
 .DEFAULT_GOAL := help

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -2,9 +2,8 @@ class UserBlueprint < Blueprinter::Base
   identifier :id
 
   fields  :first_name, :birth_name, :last_name, :email, :address, :phone_number, :phone_number_formatted, :birth_date,
-          :responsible_id, :caisse_affiliation, :affiliation_number, :family_situation, :number_of_children, :notify_by_sms,
-          :notify_by_email, :invitation_created_at, :invitation_accepted_at, :created_at, :case_number, :address_details,
-          :logement, :notes
+          :responsible_id, :affiliation_number, :notify_by_sms, :notify_by_email, :invitation_created_at,
+          :invitation_accepted_at, :created_at, :address_details
 
   association :responsible, blueprint: UserBlueprint
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -1,7 +1,7 @@
 class Rdv < ApplicationRecord
   # Mixins
   has_paper_trail(
-    only: %w[user_ids agent_ids status starts_at ends_at lieu_id notes context participations],
+    only: %w[user_ids agent_ids status starts_at ends_at lieu_id context participations],
     meta: { virtual_attributes: :virtual_attributes_for_paper_trail }
   )
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,6 +54,11 @@ RSpec.configure do |config|
   config.include DeviseRequestSpecHelpers, type: :request
   config.include NotificationsHelper
 
+  # Permet d'avoir des données générées de manière déterministe pour les specs swagger
+  if ENV["FAKER_SEED"]
+    Faker::Config.random = Random.new(ENV["FAKER_SEED"].to_i)
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -180,21 +180,16 @@ RSpec.configure do |config|
               bith_date: { type: "string", format: "date", nullable: true },
               bith_name: { type: "string", nullable: true },
               caisse_affiliation: { type: "string", enum: %w[aucun caf msa], nullable: true },
-              case_number: { type: "string", nullable: true },
               created_at: { type: "string" },
               email: { type: "string", nullable: true },
-              family_situation: { type: "string", enum: %w[single in_a_relationship divorced], nullable: true },
               first_name: { type: "string" },
               invitation_accepted_at: { type: "string", nullable: true },
               invitation_created_at: { type: "string", nullable: true },
               last_name: { type: "string" },
               notify_by_email: { type: "boolean" },
               notify_by_sms: { type: "boolean" },
-              number_of_children: { type: "integer", nullable: true },
               phone_number: { type: "string", nullable: true },
               phone_number_formatted: { type: "string", nullable: true },
-              logement: { type: "string", enum: %w[sdf heberge en_accession_propriete proprietaire autre locataire], nullable: true },
-              notes: { type: "string", nullable: true },
               responsible: { type: "object", nullable: true },
               responsible_id: { type: "integer", nullable: true },
               user_profiles: {
@@ -203,7 +198,7 @@ RSpec.configure do |config|
                 items: { "$ref" => "#/components/schemas/user_profile" },
               },
             },
-            required: %w[id address address_details affiliation_number birth_date birth_name case_number created_at first_name invitation_accepted_at
+            required: %w[id address address_details affiliation_number birth_date birth_name created_at first_name invitation_accepted_at
                          invitation_created_at last_name notify_by_email notify_by_sms phone_number phone_number_formatted responsible responsible_id user_profiles],
           },
           user_profile_with_root: {

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -282,24 +282,11 @@
             ],
             "nullable": true
           },
-          "case_number": {
-            "type": "string",
-            "nullable": true
-          },
           "created_at": {
             "type": "string"
           },
           "email": {
             "type": "string",
-            "nullable": true
-          },
-          "family_situation": {
-            "type": "string",
-            "enum": [
-              "single",
-              "in_a_relationship",
-              "divorced"
-            ],
             "nullable": true
           },
           "first_name": {
@@ -322,31 +309,11 @@
           "notify_by_sms": {
             "type": "boolean"
           },
-          "number_of_children": {
-            "type": "integer",
-            "nullable": true
-          },
           "phone_number": {
             "type": "string",
             "nullable": true
           },
           "phone_number_formatted": {
-            "type": "string",
-            "nullable": true
-          },
-          "logement": {
-            "type": "string",
-            "enum": [
-              "sdf",
-              "heberge",
-              "en_accession_propriete",
-              "proprietaire",
-              "autre",
-              "locataire"
-            ],
-            "nullable": true
-          },
-          "notes": {
             "type": "string",
             "nullable": true
           },
@@ -373,7 +340,6 @@
           "affiliation_number",
           "birth_date",
           "birth_name",
-          "case_number",
           "created_at",
           "first_name",
           "invitation_accepted_at",
@@ -1335,17 +1301,17 @@
                         "agent": {
                           "id": 12,
                           "email": "agent@example.com",
-                          "first_name": "Arthur",
+                          "first_name": "Angilbe",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Fournier"
+                          "last_name": "Reynaud"
                         },
                         "end_day": "2023-11-20",
                         "end_time": "15:00:00",
                         "first_day": "2023-11-20",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084843Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20240331T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20231029T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250217T111218Z\r\nUID:absence_12@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20231120T080000\r\nDTEND;TZID=Europe/Paris:20231120T150000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Super absence\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_12@RDV Solidarités",
                         "organisation": {
-                          "id": 20,
+                          "id": 12,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1519,19 +1485,19 @@
                       "absence": {
                         "id": 21,
                         "agent": {
-                          "id": 31,
+                          "id": 23,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Bertille",
+                          "first_name": "Paulette",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Lopez"
+                          "last_name": "Hubert"
                         },
-                        "end_day": "2025-02-15",
+                        "end_day": "2025-02-18",
                         "end_time": "15:30:00",
-                        "first_day": "2025-02-15",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084844Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "first_day": "2025-02-18",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250217T111219Z\r\nUID:absence_21@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250218T100000\r\nDTEND;TZID=Europe/Paris:20250218T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Indisponibilité 1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_21@RDV Solidarités",
                         "organisation": {
-                          "id": 34,
+                          "id": 26,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -1726,19 +1692,19 @@
                       "absence": {
                         "id": 33,
                         "agent": {
-                          "id": 43,
+                          "id": 35,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Aubertine",
+                          "first_name": "Serge",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Pierre"
+                          "last_name": "Jacquet"
                         },
-                        "end_day": "2025-02-15",
+                        "end_day": "2025-02-18",
                         "end_time": "15:30:00",
-                        "first_day": "2025-02-15",
-                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250214T084844Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250215T100000\r\nDTEND;TZID=Europe/Paris:20250215T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
+                        "first_day": "2025-02-18",
+                        "ical": "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:RDV Solidarités\r\nCALSCALE:GREGORIAN\r\nMETHOD:PUBLISH\r\nBEGIN:VTIMEZONE\r\nTZID:Europe/Paris\r\nBEGIN:DAYLIGHT\r\nDTSTART:20250330T030000\r\nTZOFFSETFROM:+0100\r\nTZOFFSETTO:+0200\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=3\r\nTZNAME:CEST\r\nEND:DAYLIGHT\r\nBEGIN:STANDARD\r\nDTSTART:20241027T020000\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nRRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10\r\nTZNAME:CET\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nDTSTAMP:20250217T111220Z\r\nUID:absence_33@RDV Solidarités\r\nDTSTART;TZID=Europe/Paris:20250218T100000\r\nDTEND;TZID=Europe/Paris:20250218T153000\r\nORGANIZER:mailto:secretariat-auto@rdv-solidarites.fr\r\nSEQUENCE:0\r\nSUMMARY:RDV Solidarités Nouveau titre\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n",
                         "ical_uid": "absence_33@RDV Solidarités",
                         "organisation": {
-                          "id": 46,
+                          "id": 38,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
@@ -2022,11 +1988,11 @@
                     "value": {
                       "agents": [
                         {
-                          "id": 67,
+                          "id": 59,
                           "email": "agent_1@lapin.fr",
-                          "first_name": "Alphée",
+                          "first_name": "Faustine",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Lopéz"
+                          "last_name": "Da silva"
                         }
                       ],
                       "meta": {
@@ -2183,8 +2149,8 @@
                             "short_name": "1_motif_cat"
                           },
                           "name": "Motif 1",
-                          "organisation_id": 87,
-                          "service_id": 90
+                          "organisation_id": 79,
+                          "service_id": 82
                         },
                         {
                           "id": 8,
@@ -2201,8 +2167,8 @@
                             "short_name": "2_motif_cat"
                           },
                           "name": "Motif 2",
-                          "organisation_id": 87,
-                          "service_id": 90
+                          "organisation_id": 79,
+                          "service_id": 82
                         }
                       ],
                       "meta": {
@@ -2327,35 +2293,35 @@
                     "value": {
                       "organisations": [
                         {
-                          "id": 120,
+                          "id": 112,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 121,
+                          "id": 113,
                           "email": null,
                           "name": "Organisation n°2",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 122,
+                          "id": 114,
                           "email": null,
                           "name": "Organisation n°3",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 123,
+                          "id": 115,
                           "email": null,
                           "name": "Organisation n°4",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         {
-                          "id": 124,
+                          "id": 116,
                           "email": null,
                           "name": "Organisation n°5",
                           "phone_number": null,
@@ -2473,7 +2439,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 131,
+                        "id": 123,
                         "email": null,
                         "name": "Organisation n°1",
                         "phone_number": null,
@@ -2582,7 +2548,7 @@
                   "example": {
                     "value": {
                       "organisation": {
-                        "id": 135,
+                        "id": 127,
                         "email": "pole@parcours.fr",
                         "name": "Pole parcours",
                         "phone_number": "33100008012",
@@ -2673,15 +2639,15 @@
                       "public_links": [
                         {
                           "external_id": "ext_id_A",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/181"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/173"
                         },
                         {
                           "external_id": "ext_id_B",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/182"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/174"
                         },
                         {
                           "external_id": "ext_id_C",
-                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/183"
+                          "public_link": "http://www.rdv-aide-numerique-test.localhost/org/175"
                         }
                       ]
                     }
@@ -2798,12 +2764,12 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 7,
-                        "created_at": "2025-02-14 09:48:50 +0100",
+                        "id": 2,
+                        "created_at": "2025-02-17 12:12:25 +0100",
                         "rdv": null,
-                        "updated_at": "2025-02-14 09:48:50 +0100",
-                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/7",
-                        "user_id": 17
+                        "updated_at": "2025-02-17 12:12:25 +0100",
+                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/2",
+                        "user_id": 11
                       }
                     }
                   }
@@ -2912,17 +2878,17 @@
                   "example": {
                     "value": {
                       "rdv_plan": {
-                        "id": 9,
-                        "created_at": "2025-02-14 09:48:50 +0100",
+                        "id": 4,
+                        "created_at": "2025-02-17 12:12:25 +0100",
                         "rdv": {
                           "id": 8,
                           "status": "unknown",
-                          "starts_at": "2025-02-17 09:48:50 +0100",
+                          "starts_at": "2025-02-20 12:12:25 +0100",
                           "location_type": "public_office"
                         },
-                        "updated_at": "2025-02-14 09:48:50 +0100",
-                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/9",
-                        "user_id": 21
+                        "updated_at": "2025-02-17 12:12:25 +0100",
+                        "url": "http://www.rdv-solidarites-test.localhost/agents/rdv_plans/4",
+                        "user_id": 15
                       }
                     }
                   }
@@ -3021,19 +2987,19 @@
                           "address": "1 rue de l'adresse, Ville, 12345",
                           "agents": [
                             {
-                              "id": 152,
+                              "id": 144,
                               "email": "agent_1@lapin.fr",
-                              "first_name": "Athanase",
+                              "first_name": "Amaranthe",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Hubert"
+                              "last_name": "Guyot"
                             }
                           ],
                           "cancelled_at": null,
                           "collectif": false,
                           "context": null,
-                          "created_at": "2025-02-14 09:48:50 +0100",
+                          "created_at": "2025-02-17 12:12:26 +0100",
                           "created_by": "agent",
-                          "created_by_id": 152,
+                          "created_by_id": 144,
                           "created_by_type": "Agent",
                           "duration_in_min": 45,
                           "ends_at": "2022-01-01 08:45:00 +0100",
@@ -3041,7 +3007,7 @@
                             "id": 27,
                             "address": "1 rue de l'adresse, Ville, 12345",
                             "name": "Lieu n°1",
-                            "organisation_id": 196,
+                            "organisation_id": 188,
                             "phone_number": null,
                             "single_use": false
                           },
@@ -3061,12 +3027,12 @@
                               "short_name": "1_motif_cat"
                             },
                             "name": "Motif 1",
-                            "organisation_id": 196,
-                            "service_id": 184
+                            "organisation_id": 188,
+                            "service_id": 176
                           },
                           "name": null,
                           "organisation": {
-                            "id": 196,
+                            "id": 188,
                             "email": null,
                             "name": "Organisation n°1",
                             "phone_number": null,
@@ -3077,34 +3043,28 @@
                               "id": 15,
                               "created_by": "agent",
                               "created_by_agent_prescripteur": false,
-                              "created_by_id": 152,
+                              "created_by_id": 144,
                               "created_by_type": "Agent",
                               "send_lifecycle_notifications": true,
                               "send_reminder_notification": true,
                               "status": "unknown",
                               "user": {
-                                "id": 25,
+                                "id": 19,
                                 "address": "20 avenue de Ségur, Paris, 75012",
                                 "address_details": null,
                                 "affiliation_number": "39012093812038",
                                 "birth_date": "1985-07-20",
                                 "birth_name": null,
-                                "caisse_affiliation": "caf",
-                                "case_number": null,
-                                "created_at": "2025-02-14 09:48:50 +0100",
+                                "created_at": "2025-02-17 12:12:26 +0100",
                                 "email": "usager_1@lapin.fr",
-                                "family_situation": "divorced",
-                                "first_name": "Anceline",
+                                "first_name": "Charlaine",
                                 "invitation_accepted_at": null,
                                 "invitation_created_at": null,
-                                "last_name": "FABRE",
-                                "logement": "locataire",
-                                "notes": null,
+                                "last_name": "PERRIER",
                                 "notify_by_email": true,
                                 "notify_by_sms": true,
-                                "number_of_children": 12,
-                                "phone_number": "0792963238",
-                                "phone_number_formatted": "+33792963238",
+                                "phone_number": "797892255",
+                                "phone_number_formatted": "+33797892255",
                                 "responsible": null,
                                 "responsible_id": null,
                                 "user_profiles": null
@@ -3115,35 +3075,29 @@
                           "status": "unknown",
                           "users": [
                             {
-                              "id": 25,
+                              "id": 19,
                               "address": "20 avenue de Ségur, Paris, 75012",
                               "address_details": null,
                               "affiliation_number": "39012093812038",
                               "birth_date": "1985-07-20",
                               "birth_name": null,
-                              "caisse_affiliation": "caf",
-                              "case_number": null,
-                              "created_at": "2025-02-14 09:48:50 +0100",
+                              "created_at": "2025-02-17 12:12:26 +0100",
                               "email": "usager_1@lapin.fr",
-                              "family_situation": "divorced",
-                              "first_name": "Anceline",
+                              "first_name": "Charlaine",
                               "invitation_accepted_at": null,
                               "invitation_created_at": null,
-                              "last_name": "FABRE",
-                              "logement": "locataire",
-                              "notes": null,
+                              "last_name": "PERRIER",
                               "notify_by_email": true,
                               "notify_by_sms": true,
-                              "number_of_children": 12,
-                              "phone_number": "0792963238",
-                              "phone_number_formatted": "+33792963238",
+                              "phone_number": "797892255",
+                              "phone_number_formatted": "+33797892255",
                               "responsible": null,
                               "responsible_id": null,
                               "user_profiles": null
                             }
                           ],
                           "users_count": 1,
-                          "uuid": "e11bad5c-e0d3-4935-aabb-92c1ebe0b6a8"
+                          "uuid": "0817d940-1b21-4d97-a428-1dda09597348"
                         }
                       ],
                       "meta": {
@@ -3256,35 +3210,29 @@
                     "value": {
                       "referent_assignation": {
                         "agent": {
-                          "id": 253,
+                          "id": 245,
                           "email": "agent_2@lapin.fr",
-                          "first_name": "Assomption",
+                          "first_name": "Alexanne",
                           "inclusion_connect_open_id_sub": null,
-                          "last_name": "Leblanc"
+                          "last_name": "Daniel"
                         },
                         "user": {
-                          "id": 101,
+                          "id": 95,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "caisse_affiliation": "caf",
-                          "case_number": null,
-                          "created_at": "2025-02-14 09:48:56 +0100",
+                          "created_at": "2025-02-17 12:12:31 +0100",
                           "email": "usager_1@lapin.fr",
-                          "family_situation": "divorced",
-                          "first_name": "Juste",
+                          "first_name": "Judith",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PONS",
-                          "logement": "locataire",
-                          "notes": null,
+                          "last_name": "RÉMY",
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "number_of_children": 12,
-                          "phone_number": "6 49 57 92 65",
-                          "phone_number_formatted": "+33649579265",
+                          "phone_number": "6 99 48 91 27",
+                          "phone_number_formatted": "+33699489127",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3538,30 +3486,30 @@
                           "id": 5,
                           "agents": [
                             {
-                              "id": 285,
+                              "id": 277,
                               "email": "agent_2@lapin.fr",
-                              "first_name": "Dieudonné",
+                              "first_name": "Angadrême",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Perrin"
+                              "last_name": "Monnier"
                             },
                             {
-                              "id": 286,
+                              "id": 278,
                               "email": "agent_3@lapin.fr",
-                              "first_name": "Gilles",
+                              "first_name": "Séraphin",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Paul"
+                              "last_name": "Da silva"
                             },
                             {
-                              "id": 287,
+                              "id": 279,
                               "email": "agent_4@lapin.fr",
-                              "first_name": "Hippolyte",
+                              "first_name": "Mauricette",
                               "inclusion_connect_open_id_sub": null,
-                              "last_name": "Faure"
+                              "last_name": "Lopez"
                             }
                           ],
-                          "name": "Picardie vampires ab2afca8",
+                          "name": "Midi-Pyrénées dogs 6c94a3f3",
                           "territory": {
-                            "id": 240,
+                            "id": 232,
                             "departement_number": "01",
                             "motif_categories": [],
                             "name": "Territoire n°1"
@@ -3678,35 +3626,29 @@
                     "value": {
                       "user_profile": {
                         "organisation": {
-                          "id": 259,
+                          "id": 251,
                           "email": null,
                           "name": "Organisation n°1",
                           "phone_number": null,
                           "verticale": "rdv_solidarites"
                         },
                         "user": {
-                          "id": 117,
+                          "id": 111,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "caisse_affiliation": "caf",
-                          "case_number": null,
-                          "created_at": "2025-02-14 09:48:57 +0100",
+                          "created_at": "2025-02-17 12:12:33 +0100",
                           "email": "usager_1@lapin.fr",
-                          "family_situation": "divorced",
-                          "first_name": "Madeleine",
+                          "first_name": "Quitterie",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "PAUL",
-                          "logement": "locataire",
-                          "notes": null,
+                          "last_name": "NOËL",
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "number_of_children": 12,
-                          "phone_number": "0761744406",
-                          "phone_number_formatted": "+33761744406",
+                          "phone_number": "6 42 59 26 54",
+                          "phone_number_formatted": "+33642592654",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -3993,34 +3935,28 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 134,
+                        "id": 128,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "caisse_affiliation": "caf",
-                        "case_number": null,
-                        "created_at": "2025-02-14 09:48:58 +0100",
+                        "created_at": "2025-02-17 12:12:34 +0100",
                         "email": "jean@jacques.fr",
-                        "family_situation": "divorced",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
                         "invitation_created_at": null,
                         "last_name": "JACQUES",
-                        "logement": "locataire",
-                        "notes": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "number_of_children": 12,
-                        "phone_number": "0795230612",
-                        "phone_number_formatted": "+33795230612",
+                        "phone_number": "6 19 39 78 95",
+                        "phone_number_formatted": "+33619397895",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 280,
+                              "id": 272,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -4298,56 +4234,44 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 169,
+                        "id": 163,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "caisse_affiliation": "caf",
-                        "case_number": null,
-                        "created_at": "2025-02-14 09:49:00 +0100",
+                        "created_at": "2025-02-17 12:12:36 +0100",
                         "email": "jean@jacques.fr",
-                        "family_situation": "single",
                         "first_name": "Alain",
                         "invitation_accepted_at": null,
                         "invitation_created_at": null,
                         "last_name": "Verse",
-                        "logement": "locataire",
-                        "notes": null,
                         "notify_by_email": false,
                         "notify_by_sms": false,
-                        "number_of_children": 3,
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 168,
+                          "id": 162,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "caisse_affiliation": "caf",
-                          "case_number": null,
-                          "created_at": "2025-02-14 09:49:00 +0100",
+                          "created_at": "2025-02-17 12:12:35 +0100",
                           "email": "usager_1@lapin.fr",
-                          "family_situation": "divorced",
-                          "first_name": "Mélissandre",
+                          "first_name": "Nathanaël",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "JACQUET",
-                          "logement": "locataire",
-                          "notes": null,
+                          "last_name": "RICHARD",
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "number_of_children": 12,
-                          "phone_number": "07 69 06 07 42",
-                          "phone_number_formatted": "+33769060742",
+                          "phone_number": "6 99 13 73 84",
+                          "phone_number_formatted": "+33699137384",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 168,
+                        "responsible_id": 162,
                         "user_profiles": null
                       }
                     }
@@ -4477,7 +4401,7 @@
                 "examples": {
                   "example": {
                     "value": {
-                      "invitation_token": "328RGN6N"
+                      "invitation_token": "IGQ3G79Y"
                     }
                   }
                 },
@@ -4610,28 +4534,22 @@
                     "value": {
                       "users": [
                         {
-                          "id": 193,
+                          "id": 187,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "caisse_affiliation": "caf",
-                          "case_number": null,
-                          "created_at": "2025-02-14 09:49:02 +0100",
+                          "created_at": "2025-02-17 12:12:37 +0100",
                           "email": "usager_1@lapin.fr",
-                          "family_situation": "divorced",
-                          "first_name": "Lionel",
+                          "first_name": "Charline",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "MORIN",
-                          "logement": "locataire",
-                          "notes": null,
+                          "last_name": "SANCHEZ",
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "number_of_children": 12,
-                          "phone_number": "0663399854",
-                          "phone_number_formatted": "+33663399854",
+                          "phone_number": "772533338",
+                          "phone_number_formatted": "+33772533338",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -4888,56 +4806,44 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 204,
+                        "id": 198,
                         "address": "10 rue du Havre, Paris, 75016",
                         "address_details": null,
                         "affiliation_number": "101010",
                         "birth_date": "1976-10-01",
                         "birth_name": "Fripouille",
-                        "caisse_affiliation": "caf",
-                        "case_number": null,
-                        "created_at": "2025-02-14 09:49:02 +0100",
+                        "created_at": "2025-02-17 12:12:37 +0100",
                         "email": "jean@jacques.fr",
-                        "family_situation": "single",
                         "first_name": "Johnny",
                         "invitation_accepted_at": null,
                         "invitation_created_at": null,
                         "last_name": "Silverhand",
-                        "logement": null,
-                        "notes": null,
                         "notify_by_email": false,
                         "notify_by_sms": false,
-                        "number_of_children": 3,
                         "phone_number": "33600008012",
                         "phone_number_formatted": "+33600008012",
                         "responsible": {
-                          "id": 203,
+                          "id": 197,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "caisse_affiliation": "caf",
-                          "case_number": null,
-                          "created_at": "2025-02-14 09:49:02 +0100",
+                          "created_at": "2025-02-17 12:12:37 +0100",
                           "email": "usager_1@lapin.fr",
-                          "family_situation": "divorced",
-                          "first_name": "Fulbert",
+                          "first_name": "Guillemette",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "FABRE",
-                          "logement": "locataire",
-                          "notes": null,
+                          "last_name": "MARCHAND",
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "number_of_children": 12,
-                          "phone_number": "07 65 48 22 14",
-                          "phone_number_formatted": "+33765482214",
+                          "phone_number": "7 98 69 30 57",
+                          "phone_number_formatted": "+33798693057",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
                         },
-                        "responsible_id": 203,
+                        "responsible_id": 197,
                         "user_profiles": null
                       }
                     }
@@ -5078,28 +4984,22 @@
                     "value": {
                       "users": [
                         {
-                          "id": 213,
+                          "id": 207,
                           "address": "20 avenue de Ségur, Paris, 75012",
                           "address_details": null,
                           "affiliation_number": "39012093812038",
                           "birth_date": "1985-07-20",
                           "birth_name": null,
-                          "caisse_affiliation": "caf",
-                          "case_number": null,
-                          "created_at": "2025-02-14 09:49:03 +0100",
+                          "created_at": "2025-02-17 12:12:38 +0100",
                           "email": "usager_1@lapin.fr",
-                          "family_situation": "divorced",
-                          "first_name": "Zélie",
+                          "first_name": "Mélodie",
                           "invitation_accepted_at": null,
                           "invitation_created_at": null,
-                          "last_name": "GUERIN",
-                          "logement": "locataire",
-                          "notes": null,
+                          "last_name": "BESSON",
                           "notify_by_email": true,
                           "notify_by_sms": true,
-                          "number_of_children": 12,
-                          "phone_number": "742944531",
-                          "phone_number_formatted": "+33742944531",
+                          "phone_number": "0789995364",
+                          "phone_number_formatted": "+33789995364",
                           "responsible": null,
                           "responsible_id": null,
                           "user_profiles": null
@@ -5216,34 +5116,28 @@
                   "example": {
                     "value": {
                       "user": {
-                        "id": 218,
+                        "id": 212,
                         "address": "20 avenue de Ségur, Paris, 75012",
                         "address_details": null,
                         "affiliation_number": "39012093812038",
                         "birth_date": "1985-07-20",
                         "birth_name": null,
-                        "caisse_affiliation": "caf",
-                        "case_number": null,
-                        "created_at": "2025-02-14 09:49:03 +0100",
+                        "created_at": "2025-02-17 12:12:38 +0100",
                         "email": "jean@jacques.fr",
-                        "family_situation": "divorced",
                         "first_name": "Jean",
                         "invitation_accepted_at": null,
                         "invitation_created_at": null,
                         "last_name": "JACQUES",
-                        "logement": "locataire",
-                        "notes": null,
                         "notify_by_email": true,
                         "notify_by_sms": true,
-                        "number_of_children": 12,
-                        "phone_number": "06 62 76 28 33",
-                        "phone_number_formatted": "+33662762833",
+                        "phone_number": "06 77 99 38 67",
+                        "phone_number_formatted": "+33677993867",
                         "responsible": null,
                         "responsible_id": null,
                         "user_profiles": [
                           {
                             "organisation": {
-                              "id": 356,
+                              "id": 348,
                               "email": null,
                               "name": "Organisation n°1",
                               "phone_number": null,
@@ -5550,7 +5444,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 26,
-                        "organisation_id": 376,
+                        "organisation_id": 368,
                         "subscriptions": [
                           "rdv",
                           "user",
@@ -5748,7 +5642,7 @@
                     "value": {
                       "webhook_endpoint": {
                         "id": 28,
-                        "organisation_id": 383,
+                        "organisation_id": 375,
                         "subscriptions": [
                           "rdv",
                           "user",


### PR DESCRIPTION
closes https://github.com/betagouv/rdv-service-public/issues/5073

Il y a un petit risque que certains département se plaignent de la disparition de ces champs de l'api et des webhooks, mais on est prêts à accepter ça.

Au passage, j'ai ajouté une option pour rendre les données générées par Faker plus déterministes lorsqu'on génère les fichiers swagger (ça permettrait de diminuer légèrement le bruit lié à ces spec).