### PR TITLE
Correction des Outlook ID vides

### DIFF
--- a/app/models/outlook/api_client.rb
+++ b/app/models/outlook/api_client.rb
@@ -48,7 +48,6 @@ module Outlook
     #                 for POST or PATCH.
 
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def call_events_api(method, path, event_payload = {})
       headers = {
         "Authorization" => "Bearer #{@agent.microsoft_graph_token}",
@@ -73,7 +72,8 @@ module Outlook
       body_response = response.body == "" ? {} : JSON.parse(response.body)
       if body_response["error"].present?
         if @agent.connected_to_outlook? && response.response_code == 401 # token expired
-          refresh_outlook_token && call_events_api(method, path, event_payload)
+          refresh_outlook_token!
+          body_response = call_events_api(method, path, event_payload)
         else
           raise_exception(error_code: body_response["error"]["code"], error_message: body_response["error"]["message"])
         end
@@ -81,9 +81,8 @@ module Outlook
       response.response_code == 204 ? "" : body_response
     end
     # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
-    def refresh_outlook_token
+    def refresh_outlook_token!
       refresh_token_query =
         Typhoeus.post(
           # voir https://docs.microsoft.com/en-us/graph/use-the-api?view=graph-rest-1.0

--- a/spec/models/outlook/api_client_spec.rb
+++ b/spec/models/outlook/api_client_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Outlook::ApiClient do
       end
 
       it "refreshes it and retries, and saves the refresh token on the agent" do
-        described_class.new(agent).create_event!(expected_body)
+        expect(described_class.new(agent).create_event!(expected_body)).to eq("event_id")
 
         expect(a_request(:post,
                          "https://graph.microsoft.com/v1.0/me/Events").with(body: expected_body)).to have_been_made.twice


### PR DESCRIPTION
# Contexte

Lié à [LAPINS-267](https://sentry.incubateur.net/organizations/betagouv/issues/149692/)

Suite à l’introduction d’un « capture message » pour détecter les ID étranges que nous récupérons d’Outlook, je me suis rendu compte que le code n’était pas correct. Quand on arrive au moment où nous rafraîchissons le token MS Graph, la méthode `call_events_api` ne retourne pas le bon body. Nous n’engistrons alors pas l’ID de l’événement Outlook dans notre base (et donc nous ne sommes pas en mesure de supprimer ou modifier l’événement).

# Solution

- J’ai corrigé le test pour vérifier qu’on récupère correctement l’ID
- J’ai ensuite corrigé le code pour récupérer le bon body et pas le body de la première requête dont le résultat est une 401.
