### PR TITLE
Amélioration du texte pour la prise de rdv par intégration

### DIFF
--- a/app/views/agents/rdv_plans/edit_starts_at.html.slim
+++ b/app/views/agents/rdv_plans/edit_starts_at.html.slim
@@ -3,7 +3,7 @@
     = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 1, step_title: "Créneau", next_step_title: "Motif"
 
     h2.fr-h3 Calendrier de #{current_agent.full_name}
-    p Cliquez sur l'horaire auquel vous voulez faire le rendez-vous :
+    p Convenez d'un horaire avec #{@rdv_plan.user.full-name}, et cliquez dessus dans le calendrier
     = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: false
     - if @rdv_plan.return_url
       = link_to "retour", @rdv_plan.return_url

--- a/app/views/agents/rdv_plans/edit_starts_at.html.slim
+++ b/app/views/agents/rdv_plans/edit_starts_at.html.slim
@@ -3,7 +3,7 @@
     = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 1, step_title: "Créneau", next_step_title: "Motif"
 
     h2.fr-h3 Calendrier de #{current_agent.full_name}
-    p Convenez d'un horaire avec #{@rdv_plan.user.full-name}, et cliquez dessus dans le calendrier
+    p Convenez d'un horaire avec #{@rdv_plan.user.full_name}, et cliquez dessus dans le calendrier
     = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: false
     - if @rdv_plan.return_url
       = link_to "retour", @rdv_plan.return_url


### PR DESCRIPTION
Un tout petit détail dans le contexte de la prise de rdv par intégration, j'ai trouvé une formulation pour expliciter à l'agent qu'il a besoin de convenir d'une date de rendez-vous avec l'usager.

Avant | Après
:- | -:
<img width="706" alt="Screenshot 2025-02-17 at 14 45 29" src="https://github.com/user-attachments/assets/3f87a3d6-42c8-4797-b027-7b41ad280800" /> | <img width="710" alt="Screenshot 2025-02-17 at 14 45 13" src="https://github.com/user-attachments/assets/ab9e206f-84c8-4d65-ac45-6f4a730efc5e" />

### Contexte 
<img width="1265" alt="Screenshot 2025-02-17 at 14 45 09" src="https://github.com/user-attachments/assets/163926d6-9211-4bfb-a2ad-1bd322c75a94" />
