### PR TITLE
Parcours usager: migration des formulaires prescripteur au DSFR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,7 @@ gem "rails_autolink"
 # ActionView helper to render currently active links
 gem "active_link_to"
 gem "dsfr-view-components"
-gem "dsfr-form_builder", "= 0.0.2" # On fixe la version tant qu’on est pas en 1.0
+gem "dsfr-form_builder", "= 0.0.3" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.
 gem "premailer-rails" # Mail formatting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.1)
     dsfr-assets (1.13.0.1)
-    dsfr-form_builder (0.0.2)
+    dsfr-form_builder (0.0.3)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
@@ -769,7 +769,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   drb
-  dsfr-form_builder (= 0.0.2)
+  dsfr-form_builder (= 0.0.3)
   dsfr-view-components
   factory_bot
   faker

--- a/app/form_models/beneficiaire_form.rb
+++ b/app/form_models/beneficiaire_form.rb
@@ -30,7 +30,7 @@ class BeneficiaireForm
     return if phone_number.blank?
 
     errors.add(:phone_number, :invalid) if PhoneNumberValidation.parsed_number(phone_number).blank?
-    errors.add(:phone_number, "ne permet pas de recevoir des SMS") unless PhoneNumberValidation.number_is_mobile?(phone_number)
+    errors.add(:phone_number, "doit être un numéro de mobile") unless PhoneNumberValidation.number_is_mobile?(phone_number)
   end
 
   def requires_ants_predemande_number?

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -16,7 +16,7 @@ main.container
               - if @rdv_wizard.rdv.requires_ants_predemande_number?
                 .fr-col-12= f.dsfr_text_field :ants_pre_demande_number, required: true, input_html: {style: "text-transform: uppercase;"}
 
-              .fr-col-12= f.dsfr_phone_field :phone_number, hint: "Format attendu : 0122334455. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
+              .fr-col-12= f.dsfr_phone_field :phone_number, label: "Téléphone mobile", hint: "Format attendu : 0639980130. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
 
             = render("model_errors", model: @beneficiaire, f: f)
 

--- a/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_beneficiaire.html.slim
@@ -9,24 +9,16 @@ main.container
           h3 Bénéficiaire
           p Indiquez les coordonnées de la personne qui viendra au rendez-vous
 
-          = simple_form_for @beneficiaire, url: prescripteur_create_rdv_path do |f|
-            .form-group
-              .row
-                .col-6
-                  = f.input :first_name, required: true
-                .col-6
-                  = f.input :last_name, required: true
-            - if @rdv_wizard.rdv.requires_ants_predemande_number?
-              .row
-                .col-12
-                  = f.input :ants_pre_demande_number, required: true, input_html: {style: "text-transform: uppercase;"}
+          = form_for @beneficiaire, url: prescripteur_create_rdv_path, builder: Dsfr::FormBuilder do |f|
+            .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
+              .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, required: true
+              .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, required: true
+              - if @rdv_wizard.rdv.requires_ants_predemande_number?
+                .fr-col-12= f.dsfr_text_field :ants_pre_demande_number, required: true, input_html: {style: "text-transform: uppercase;"}
 
-            .form-group
-              .row
-                .col-12
-                  = f.input :phone_number, as: :tel, placeholder: "06134567890", hint: "Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
+              .fr-col-12= f.dsfr_phone_field :phone_number, hint: "Format attendu : 0122334455. Un SMS de confirmation et un SMS de rappel seront envoyés à ce numéro"
 
             = render("model_errors", model: @beneficiaire, f: f)
 
-            .form-group.mb-0.rdv-text-align-center
-              = f.submit "Confirmer le rendez-vous", class: "btn btn-primary"
+            .rdv-text-align-right
+              = f.submit "Confirmer le rendez-vous", class: "fr-btn"

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -30,22 +30,12 @@ main.container
             |> Ces informations permettront à l'agent qui assure le rendez-vous de savoir qui l'a planifié,
             | et de vous contacter s'il y a une erreur sur le type de rendez-vous.
 
-          = simple_form_for @prescripteur, url: prescripteur_store_prescripteur_in_session_path do |f|
-            .form-group
-              .row
-                .col-6
-                  = f.input :first_name, required: true, label: "Votre prénom"
-                .col-6
-                  = f.input :last_name, required: true, label: "Votre nom"
+          = form_for @prescripteur, url: prescripteur_store_prescripteur_in_session_path, builder: Dsfr::FormBuilder do |f|
+            .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
+              .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, required: true, label: "Votre prénom"
+              .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, required: true, label: "Votre nom"
+              .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : nom@domaine.fr"
+              .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455"
 
-            .form-group
-              .row
-                .col-12
-                  = f.input :email, as: :email, placeholder: "prenom.prescripteur@departement.fr", required: true, label: "Votre email professionnel", hint: ""
-            .form-group
-              .row
-                .col-12
-                  = f.input :phone_number, as: :tel, placeholder: "0122334455", label: "Votre numéro de téléphone professionnel", hint: ""
-
-            .form-group.mb-0.rdv-text-align-center
-              = f.submit "Continuer", class: "btn btn-primary"
+            .rdv-text-align-right
+              = f.submit "Continuer", class: "fr-btn"

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -34,7 +34,7 @@ main.container
             .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
               .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, required: true, label: "Votre prénom"
               .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, required: true, label: "Votre nom"
-              .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : nom@domaine.fr"
+              .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : prenom.prescripteur@departement.fr"
               .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455"
 
             .rdv-text-align-right

--- a/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
+++ b/app/views/prescripteur_rdv_wizard/new_prescripteur.html.slim
@@ -34,7 +34,7 @@ main.container
             .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
               .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, required: true, label: "Votre prénom"
               .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, required: true, label: "Votre nom"
-              .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : prenom.prescripteur@departement.fr"
+              .fr-col-12= f.dsfr_email_field :email, required: true, label: "Votre email professionnel", hint: "Format attendu : prenom.prescripteur@domaine.fr"
               .fr-col-12= f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone professionnel", hint: "Format attendu : 0122334455"
 
             .rdv-text-align-right

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
     fill_in "Téléphone", with: "0123456789"
     click_on "Confirmer le rendez-vous"
 
-    expect(page).to have_content("Téléphone ne permet pas de recevoir des SMS")
+    expect(page).to have_content("Téléphone doit être un numéro de mobile")
     fill_in "Téléphone", with: "0611223344"
 
     expect { click_on "Confirmer le rendez-vous" }.to change { rdv_collectif.users.count }.by(1).and(change(User, :count).by(1))

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
     fill_in "Téléphone", with: "0123456789"
 
     click_on "Confirmer le rendez-vous"
-    expect(page).to have_content("Téléphone ne permet pas de recevoir des SMS")
+    expect(page).to have_content("Téléphone doit être un numéro de mobile")
     fill_in "Téléphone", with: "0611223344"
 
     expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1).and(change(User, :count).by(1))

--- a/spec/form_models/beneficiaire_form_spec.rb
+++ b/spec/form_models/beneficiaire_form_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe BeneficiaireForm do
 
     specify do
       expect(form).to be_invalid
-      expect(form.errors.first.full_message).to eq("Téléphone ne permet pas de recevoir des SMS")
+      expect(form.errors.first.full_message).to eq("Téléphone doit être un numéro de mobile")
     end
   end
 


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5088.osc-secnum-fr1.scalingo.io/) 

# Contexte

Dans la continuité du passage au DSFR on migre les formulaires du parcours usager côté prescripteur.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/66c06231-9db1-4aaa-a6f0-82a7f916b277) | ![image](https://github.com/user-attachments/assets/60765e64-6059-44c7-91a1-ae82dd413efc)
![image](https://github.com/user-attachments/assets/41d741ff-12f6-462c-888d-8909f764d74f) | ![image](https://github.com/user-attachments/assets/898dc6b4-ad92-4972-ac6f-5dafa3038155)
![image](https://github.com/user-attachments/assets/6a2b751b-d7eb-48cd-8b9f-443fad71d901) | ![image](https://github.com/user-attachments/assets/20f31d12-a508-4d6d-a579-9dc3c4aea5da)
![image](https://github.com/user-attachments/assets/e8d7e2f0-286f-4397-8155-4fce1e46a8b6) | ![image](https://github.com/user-attachments/assets/c0488d79-91c0-4e42-8c74-49007aefaa38)


