### PR TITLE
correction de doublons renvoyés par Agent::RdvPolicy::Scope : DISTINCT

### DIFF
--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -142,6 +142,7 @@ class Agent::RdvPolicy < ApplicationPolicy
       if current_agent.secretaire?
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
           .where(agent_roles: { agent_id: current_agent.id }) # RDV des organisations dans lesquelles j'ai un role
+          .distinct
 
       else
 
@@ -154,6 +155,7 @@ class Agent::RdvPolicy < ApplicationPolicy
               OR (agent_roles.access_level = 'admin')",
             current_agent.id, current_agent.service_ids
           )
+          .distinct
       end
     end
   end

--- a/spec/policies/agent/rdv_policy_spec.rb
+++ b/spec/policies/agent/rdv_policy_spec.rb
@@ -163,6 +163,34 @@ RSpec.describe Agent::RdvPolicy, type: :policy do
     it_behaves_like "not permit actions", :rdv
     it_behaves_like "included in scope"
   end
+end
 
-  # TODO: write cases for :new? and create? which
+RSpec.describe Agent::RdvPolicy::Scope do
+  describe "#resolve" do
+    subject(:policy_scope) { described_class.new(current_agent, Rdv) }
+
+    context "l’agent courant est admin d’orga" do
+      let!(:organisation) { create(:organisation) }
+      let!(:rdv) { create(:rdv, organisation:) }
+      let!(:rdv_other_orga) { create(:rdv, organisation: create(:organisation)) }
+      let(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+      specify do
+        expect(policy_scope.resolve.map(&:id)).to contain_exactly(rdv.id)
+      end
+    end
+
+    context "l’agent courant est admin d’orga, un RDV a deux agents attachés" do
+      let!(:organisation) { create(:organisation) }
+      let!(:agent1) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:rdv1) { create(:rdv, organisation:, agents: [agent1]) }
+      let!(:agent2) { create(:agent, basic_role_in_organisations: [organisation]) }
+      let!(:rdv2) { create(:rdv, organisation:, agents: [agent1, agent2]) }
+      let(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+
+      specify do
+        expect(policy_scope.resolve.map(&:id)).to contain_exactly(rdv1.id, rdv2.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Ce ticket https://zammad10.ethibox.fr/#ticket/zoom/21168 nous signale une différence de 10% entre le nombre de RDV totaux affichés sur la liste de RDV agents et sur le nombre de lignes effectivement exportées.

Note: Il y a 10% moins de lignes dans le fichier exporté que dans le total affiché, heureusement 😅 

On peut reproduire le problème en mettant simplement deux agents à un RDV puis en allant voir la liste des RDV : le compteur indique un de trop.

En creusant je me suis rendu compte que : 

1. on n’applique pas la policy scope RDV dans le job, c’est probablement un problème
2. l’application de la policy scope RDV génère des doublons 

Cette PR tente de résoudre le sujet 2. 

Je suppose que c’est l’application de `inner joins` dans la policy scope qui génère ces RDV doublons. Ça a l’air d’avoir bougé il y a 4 mois avec cette PR https://github.com/betagouv/rdv-service-public/pull/4692

# Solution

J’ai introduit une spec qui permet de reproduire le problème

Je ne sais pas trop comment corriger ça efficacement 🙄 si quelqu’un a envie de le faire, qu’il se signale please ! 