### PR TITLE
Autoriser des délais minimums plus courts pour visioplainte

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -60,7 +60,7 @@ class Motif < ApplicationRecord
   validates :sectorisation_level, inclusion: { in: SECTORISATION_TYPES }
   validates :name, presence: true
   validates :color, :default_duration_in_min, :min_public_booking_delay, :max_public_booking_delay, presence: true
-  validates :min_public_booking_delay, numericality: { greater_than_or_equal_to: 5.minutes, less_than_or_equal_to: 1.year.minutes } # On a besoin de 5mn pour la staging de Visioplainte, mais on propose 30mn minimum dans l'interface
+  validates :min_public_booking_delay, numericality: { greater_than_or_equal_to: 5.minutes, less_than_or_equal_to: 1.year.minutes } # On a besoin de 5mn pour la staging de Visioplainte, mais on propose 30mn minimum dans l'interface # rubocop:disable Layout/LineLength
   validates :max_public_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
   validate :booking_delay_validation
   validate :not_associated_with_secretariat

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -60,7 +60,7 @@ class Motif < ApplicationRecord
   validates :sectorisation_level, inclusion: { in: SECTORISATION_TYPES }
   validates :name, presence: true
   validates :color, :default_duration_in_min, :min_public_booking_delay, :max_public_booking_delay, presence: true
-  validates :min_public_booking_delay, numericality: { greater_than_or_equal_to: 5.minutes, less_than_or_equal_to: 1.year.minutes }
+  validates :min_public_booking_delay, numericality: { greater_than_or_equal_to: 5.minutes, less_than_or_equal_to: 1.year.minutes } # On a besoin de 5mn pour la staging de Visioplainte, mais on propose 30mn minimum dans l'interface
   validates :max_public_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
   validate :booking_delay_validation
   validate :not_associated_with_secretariat

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -60,7 +60,7 @@ class Motif < ApplicationRecord
   validates :sectorisation_level, inclusion: { in: SECTORISATION_TYPES }
   validates :name, presence: true
   validates :color, :default_duration_in_min, :min_public_booking_delay, :max_public_booking_delay, presence: true
-  validates :min_public_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
+  validates :min_public_booking_delay, numericality: { greater_than_or_equal_to: 5.minutes, less_than_or_equal_to: 1.year.minutes }
   validates :max_public_booking_delay, numericality: { greater_than_or_equal_to: 30.minutes, less_than_or_equal_to: 1.year.minutes }
   validate :booking_delay_validation
   validate :not_associated_with_secretariat


### PR DESCRIPTION
# Contexte

En production, le délai minimum de prise de rendez-vous pour visioplainte sera de quelques heures, donc le système actuel fonctionne bien.
En revanche, pour les tests sur l'environnement de staging, ils nous ont demandé de diminuer ce délai à 5mn, pour pouvoir faire des tests efficacement.

Pour aller au plus simple, j'ai donc changé la valeur du `min_public_booking_delay` en staging, en overridant les validations métiers, qui demandent au moins 30 minutes de délai minimum.

L'inconvénient de cette approche est que le motif est maintenant invalide, et ça empêche donc de créer des plages d'ouvertures : apparemment AR fait tourner les validations du motifs, et lors de la tentative de création de plage d'ouverture on a l'erreur mystérieuse "Motifs n'est pas valide".

Tout ça pour dire que finalement on a un seul cas où on a besoin d'autoriser les `min_public_booking_delay` : la staging de visioplainte.

Comment résoudre ça ? C'est très spécifique, mais en même temps, je vois assez peu d'inconvénient à alléger les validations back-end dans tous les cas pour autoriser 5 minutes (les valeurs proposées dans le front sont indépendantes des règles de validation, et donc le comportement normal de l'application ne change pas).

# Solution

Je suis donc parti sur une approche la plus simple possible : assouplir la règle de validation, et expliquer le contexte dans un commentaire et surtout dans cette magnifique pull request.

Je suis très preneur d'un deuxième avis sur cette approche !