### PR TITLE
retrait de code temporaire dans admin/rdvs_controller

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -4,14 +4,6 @@ class Admin::RdvsController < AgentAuthController
   respond_to :html, :json
 
   before_action :set_rdv, :set_optional_agent, except: %i[index a_renseigner export participations_export]
-  # Ce mécanisme temporaire est mis en place afin d'assurer une rétro-compatibilité du fait
-  # du changement de noms (ou ajout des s) aux paramètres motif_id, lieu_id et scoped_organisation_id
-  # Pour plus de contexte, voir https://github.com/betagouv/rdv-service-public/pull/4054#discussion_r1489720373
-  before_action do
-    params[:motif_ids] ||= Array(params[:motif_id])
-    params[:lieu_ids] ||= Array(params[:lieu_id])
-    params[:scoped_organisation_ids] ||= Array(params[:scoped_organisation_id])
-  end
 
   def index
     set_scoped_organisations


### PR DESCRIPTION
# Contexte

Je suis en train de travailler sur un sujet connexe #5091
Je suis tombé sur ce vieux code temporaire pour gérer d’anciennes URL. cf https://github.com/betagouv/rdv-service-public/commit/6ff368d39354b7a829f45c5c445478f5ab9f2814

Un commentaire de FF signale qu’il est déjà probablement temps de le supprimer en juin 2024 https://github.com/betagouv/rdv-service-public/pull/4054#discussion_r1654763868

# Solution

Je le supprime