### PR TITLE
Permettre aux agents de se créer un compte sans organisation via Proconnect

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -2,7 +2,6 @@ class Admin::OrganisationsController < AgentAuthController
   respond_to :html, :json
 
   before_action :set_organisation, except: :index
-  before_action :follow_unique, only: :index
 
   def index
     @organisations_by_territory = policy_scope(current_agent.organisations, policy_scope_class: Agent::OrganisationPolicy::Scope)
@@ -72,12 +71,5 @@ class Admin::OrganisationsController < AgentAuthController
 
   def new_organisation_params
     params.require(:organisation).permit(:name, :territory_id)
-  end
-
-  def follow_unique
-    accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
-    return if params[:follow_unique].blank? || accessible_organisations.count != 1
-
-    redirect_to admin_organisation_agent_agenda_path(accessible_organisations.first, current_agent)
   end
 end

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -14,7 +14,7 @@ class AgentConnectController < ApplicationController
     redirect_to auth_client.redirect_url(agent_connect_callback_url), allow_other_host: true
   end
 
-  def callback
+  def callback # rubocop:disable Metrics/PerceivedComplexity
     callback_client = AgentConnectOpenIdClient::Callback.new(
       session_state: session.delete(:agent_connect_state),
       params_state: params[:state],
@@ -32,6 +32,10 @@ class AgentConnectController < ApplicationController
     # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
     # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub
     agent = Agent.active.find_by(email: callback_client.user_email)
+
+    if current_domain.allow_agent_creation_with_agent_connect
+      agent ||= Agent.new(email: callback_client.user_email, password: SecureRandom.base64(32))
+    end
 
     if agent
       agent.update!(

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -11,7 +11,7 @@ class Agents::PagesController < AgentAuthController
     if accessible_organisations.count == 1
       redirect_to admin_organisation_agent_agenda_path(accessible_organisations.first, current_agent)
     elsif accessible_organisations.count > 1
-      redirect_to agents_organisations_path
+      redirect_to admin_organisations_path
     end
   end
 

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -1,6 +1,8 @@
 class Agents::PagesController < AgentAuthController
   layout "application"
 
+  CONTACT_TEAM_URL = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5"
+
   def home
     skip_authorization
 

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -1,4 +1,6 @@
 class Agents::PagesController < AgentAuthController
+  layout "application"
+
   def home
     skip_authorization
 
@@ -6,7 +8,7 @@ class Agents::PagesController < AgentAuthController
 
     if accessible_organisations.count == 1
       redirect_to admin_organisation_agent_agenda_path(accessible_organisations.first, current_agent)
-    else
+    elsif accessible_organisations.count > 1
       redirect_to agents_organisations_path
     end
   end

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -1,7 +1,7 @@
 class Agents::PagesController < AgentAuthController
   layout "application"
 
-  CONTACT_TEAM_URL = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5"
+  CONTACT_TEAM_URL = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5".freeze
 
   def home
     skip_authorization

--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -1,0 +1,19 @@
+class Agents::PagesController < AgentAuthController
+  def home
+    skip_authorization
+
+    accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
+
+    if accessible_organisations.count == 1
+      redirect_to admin_organisation_agent_agenda_path(accessible_organisations.first, current_agent)
+    else
+      redirect_to agents_organisations_path
+    end
+  end
+
+  private
+
+  def pundit_user
+    AgentContext.new(current_agent)
+  end
+end

--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -33,7 +33,7 @@ module SuperAdmins
         territory: %i[name departement_number],
         organisation: %i[name ants_connectable],
         lieu: %i[address latitude longitude],
-        agent: %i[first_name last_name email service_ids]
+        agent: %i[id first_name last_name email service_ids]
       )
     end
   end

--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -1,5 +1,14 @@
 module SuperAdmins
   class ComptesController < SuperAdmins::ApplicationController
+    def new
+      @agent = Agent.find(params[:agent_id])
+      if @agent
+        authorize_resource(@agent)
+      end
+
+      super
+    end
+
     def create
       compte_params[:agent][:invited_by] = current_super_admin
       compte = Compte.new(compte_params, current_domain)

--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -1,7 +1,7 @@
 module SuperAdmins
   class ComptesController < SuperAdmins::ApplicationController
     def new
-      @agent = Agent.find(params[:agent_id])
+      @agent = Agent.find_by(params[:agent_id])
       if @agent
         authorize_resource(@agent)
       end

--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -1,7 +1,7 @@
 module SuperAdmins
   class ComptesController < SuperAdmins::ApplicationController
     def new
-      @agent = Agent.find_by(params[:agent_id])
+      @agent = Agent.find_by(id: params[:agent_id])
       if @agent
         authorize_resource(@agent)
       end

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -26,10 +26,7 @@ class Compte
       organisation.save!
       lieu.save!
 
-      self.agent = Agent.invite!(@attributes[:agent].merge(
-                                   password: SecureRandom.base64(32),
-                                   roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
-                                 ))
+      self.agent = find_or_invite_agent(organisation)
 
       agent.services.each do |service|
         TerritoryService.create!(service: service, territory: territory)
@@ -64,6 +61,19 @@ class Compte
   end
 
   private
+
+  def find_or_invite_agent(organisation)
+    if @attributes.dig(:agent, :id)
+      Agent.find(@attributes.dig(:agent, :id)).tap do |agent|
+        AgentRole.create(agent: agent, organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
+      end
+    else
+      Agent.invite!(@attributes[:agent].merge(
+                      password: SecureRandom.base64(32),
+                      roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
+                    ))
+    end
+  end
 
   def create_mairie_motifs!
     service = Service.find_by(name: Service::MAIRIE)

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -65,12 +65,16 @@ class Compte
   def find_or_invite_agent(organisation)
     if @attributes.dig(:agent, :id)
       Agent.find(@attributes.dig(:agent, :id)).tap do |agent|
-        AgentRole.create(agent: agent, organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN)
+        agent.update(
+          @attributes[:agent].merge(
+            roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
+          )
+        )
       end
     else
       Agent.invite!(@attributes[:agent].merge(
-                      password: SecureRandom.base64(32),
-                      roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
+                      roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
+                      password: SecureRandom.base64(32)
                     ))
     end
   end

--- a/app/javascript/stylesheets/administrate/base/_forms.scss
+++ b/app/javascript/stylesheets/administrate/base/_forms.scss
@@ -107,3 +107,7 @@ select {
     outline-offset: $focus-outline-offset;
   }
 }
+
+.form-group {
+  margin: 8px 0;
+}

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -100,7 +100,7 @@ class Agent < ApplicationRecord
   # * it validates :email (the invite_key) specifically with Devise.email_regexp.
   validates :first_name, presence: true, unless: -> { allow_blank_name || is_an_intervenant? }
   validates :last_name, presence: true, unless: -> { allow_blank_name }
-  validates :agent_services, presence: true
+  validates :agent_services, presence: true, unless: -> { roles.none? }
 
   # Hooks
   before_destroy :prevent_destroy_if_rdvs

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -16,6 +16,7 @@ Domain = Struct.new(
   :support_email,
   :secretariat_email,
   :verticale,
+  :allow_agent_creation_with_agent_connect,
   keyword_init: true
 )
 
@@ -36,6 +37,9 @@ class Domain
       france_connect_enabled: true,
       support_email: "support@rdv-solidarites.fr",
       verticale: :rdv_solidarites,
+      # TODO: décommenter cette ligne après les tests
+      # allow_agent_creation_with_agent_connect: false,
+      allow_agent_creation_with_agent_connect: true,
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"
       # secretariat_email est utilisé comme adresse de "Reply-To" pour les e-mails
       # qui contiennent des ICS. Lorsque l'événement ICS est acceptée par le
@@ -58,6 +62,7 @@ class Domain
       france_connect_enabled: false,
       support_email: "support@rdv-aide-numerique.fr",
       verticale: :rdv_aide_numerique,
+      allow_agent_creation_with_agent_connect: false,
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"
     ),
 
@@ -76,6 +81,7 @@ class Domain
       france_connect_enabled: true,
       support_email: "support@rdv-service-public.fr",
       verticale: :rdv_mairie,
+      allow_agent_creation_with_agent_connect: true,
       secretariat_email: "secretariat-auto@rdv-service-public.fr"
     ),
   ].freeze

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -37,9 +37,7 @@ class Domain
       france_connect_enabled: true,
       support_email: "support@rdv-solidarites.fr",
       verticale: :rdv_solidarites,
-      # TODO: décommenter cette ligne après les tests
-      # allow_agent_creation_with_agent_connect: false,
-      allow_agent_creation_with_agent_connect: true,
+      allow_agent_creation_with_agent_connect: false,
       secretariat_email: "secretariat-auto@rdv-solidarites.fr"
       # secretariat_email est utilisé comme adresse de "Reply-To" pour les e-mails
       # qui contiennent des ICS. Lorsque l'événement ICS est acceptée par le

--- a/app/services/admin_creates_agent.rb
+++ b/app/services/admin_creates_agent.rb
@@ -12,6 +12,9 @@ class AdminCreatesAgent
       @agent = find_agent
 
       if @agent
+        if @agent.services.none?
+          @agent.update(service_ids: @agent_params[:service_ids])
+        end
         add_agent_to_organisations
         @warning_message = self.class.check_agent_service(@agent, @agent_params[:service_ids])
       elsif @access_level == "intervenant"

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -8,4 +8,4 @@
 
   ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-8w
     li
-      = link_to "Contacter notre équipe", Agents::PagesController::CONTACT_TEAM_URL, class: "fr-btn"
+      = link_to "Contacter notre équipe", "https://cal.com/team/rdv-service-public/temps-d-echanges", class: "fr-btn"

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -1,15 +1,11 @@
-- contact_team_url = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5"
-
 .fr-container.fr-py-8w
-  h1.fr-h3.fr-pb-2w Bienvenue ! 
+  h1.fr-h3.fr-pb-2w Bienvenue !
   p.fr-py-1w Pour commencer, aidez-nous à reconnaitre votre organisation.
 
-  p.fr-py-1w Si vos collègues utilisent déjà RDV Service Public, vous pouvez leur demander de vous inviter dans leur espace via le menu “Paramètres > Agents > Ajouter un agent”.
+  p.fr-py-1w Si vos collègues utilisent déjà #{current_domain.name}, vous pouvez leur demander de vous inviter dans leur espace via le menu “Paramètres > Agents > Ajouter un agent”.
 
-  p.fr-py-1w Si vous souhaitez ouvrir un nouvel espace sur RDV Service Public pour votre organisation, notre équipe est là vous aider.
+  p.fr-py-1w Si vous souhaitez ouvrir un nouvel espace sur #{current_domain.name} pour votre organisation, notre équipe est là vous aider.
 
-  ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-0
+  ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-8w
     li
-      = link_to "Contacter notre équipe", contact_team_url, class: "fr-btn fr-mb-0"
-
-
+      = link_to "Contacter notre équipe", Agents::PagesController::CONTACT_TEAM_URL, class: "fr-btn"

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -1,10 +1,16 @@
-.fr-container.fr-py-8w
+.fr-container.fr-pb-8w
   h1.fr-h3.fr-pb-2w Bienvenue !
-  p.fr-py-1w Pour commencer, aidez-nous à reconnaître votre organisation.
+  p.fr-py-1w Pour commencer, aidez-nous à en savoir plus :
 
-  p.fr-py-1w Si vos collègues utilisent déjà #{current_domain.name}, ils peuvent vous inviter dans leur espace via le menu <b>“Paramètres > Agents > Ajouter un agent”</b>.
+  p.fr-pt-1w.fr-pb-2w
+    | Votre structure <b>utilise déjà #{current_domain.name}</b> et vous souhaitez disposer d’un accès ?
+    br
+    | Vos collègues peuvent vous inviter depuis le menu <b>“Paramètres > Agents > Ajouter un agent”</b>.
 
-  p.fr-py-1w Si vous souhaitez ouvrir un nouvel espace sur #{current_domain.name} pour votre organisation, notre équipe est là vous aider.
+  p.fr-py-1w
+    | Votre structure <b>n’utilise pas #{current_domain.name}</b> et vous souhaitez créer un compte ?
+    br
+    | Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et créer le compte de votre structure.
 
   ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-8w
     li

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -1,0 +1,15 @@
+- contact_team_url = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5"
+
+.fr-container.fr-py-8w
+  h1.fr-h3.fr-pb-2w Bienvenue ! 
+  p.fr-py-1w Pour commencer, aidez-nous à reconnaitre votre organisation.
+
+  p.fr-py-1w Si vos collègues utilisent déjà RDV Service Public, vous pouvez leur demander de vous inviter dans leur espace via le menu “Paramètres > Agents > Ajouter un agent”.
+
+  p.fr-py-1w Si vous souhaitez ouvrir un nouvel espace sur RDV Service Public pour votre organisation, notre équipe est là vous aider.
+
+  ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-0
+    li
+      = link_to "Contacter notre équipe", contact_team_url, class: "fr-btn fr-mb-0"
+
+

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -1,8 +1,8 @@
 .fr-container.fr-py-8w
   h1.fr-h3.fr-pb-2w Bienvenue !
-  p.fr-py-1w Pour commencer, aidez-nous à reconnaitre votre organisation.
+  p.fr-py-1w Pour commencer, aidez-nous à reconnaître votre organisation.
 
-  p.fr-py-1w Si vos collègues utilisent déjà #{current_domain.name}, vous pouvez leur demander de vous inviter dans leur espace via le menu “Paramètres > Agents > Ajouter un agent”.
+  p.fr-py-1w Si vos collègues utilisent déjà #{current_domain.name}, ils peuvent vous inviter dans leur espace via le menu <b>“Paramètres > Agents > Ajouter un agent”</b>.
 
   p.fr-py-1w Si vous souhaitez ouvrir un nouvel espace sur #{current_domain.name} pour votre organisation, notre équipe est là vous aider.
 

--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -1,4 +1,4 @@
-- contact_team_url = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5"
+- contact_team_url = Agents::PagesController::CONTACT_TEAM_URL
 
 .fr-py-8w.rdv-background-color-alt-blue-ecume
   .fr-container

--- a/app/views/super_admins/agents/show.html.slim
+++ b/app/views/super_admins/agents/show.html.slim
@@ -7,8 +7,11 @@ header.main-content__header role="banner"
       => link_to "Inviter", invite_super_admins_agent_path(page.resource), method: :post, class: "button", data: { disable_with: "Veuillez patienter…"} if accessible_action?(page.resource, :invite)
     - if sign_in_as_allowed?
       => link_to "Se logger en tant que", sign_in_as_super_admins_agent_path(page.resource), class: "button" if accessible_action?(page.resource, :sign_in_as)
-    => link_to(t("administrate.actions.edit_resource", name: page.page_title), [:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)
+    => link_to("Modifier", [:edit, namespace, page.resource], class: "button") if accessible_action?(page.resource, :edit)
     => link_to("Migrer", new_super_admins_agent_migration_path(agent_id: page.resource.id), class: "button")
+    - if page.resource.roles.none?
+      = link_to("Ouvrir un compte", new_super_admins_compte_path(agent_id: page.resource.id), class: "button")
+
 section.main-content__body
   dl
     - page.attributes.each do |attribute|

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -42,7 +42,7 @@ section.main-content__body
         = ff.input :last_name, label: "Nom"
         = ff.input :email, label: "Adresse mail", hint: "Une invitation sera envoyée automatiquement"
       - # rubocop:disable Rails/OutputSafety
-      = ff.input :service_ids, label: "Service", collection: Service.all, hint: "Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}".html_safe
+      = ff.input :service_ids, label: "Service", collection: Service.all, hint: sanitize("Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}")
     - # rubocop:enable Rails/OutputSafety
 
     = f.submit

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -36,7 +36,7 @@ section.main-content__body
       - if @agent
         p = @agent.full_name
         p = @agent.email
-        = ff.hidden_field :agent_id, value: @agent.id
+        = ff.hidden_field :id, value: @agent.id
       - else
         = ff.input :first_name, label: "Prénom"
         = ff.input :last_name, label: "Nom"

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -41,8 +41,6 @@ section.main-content__body
         = ff.input :first_name, label: "Prénom"
         = ff.input :last_name, label: "Nom"
         = ff.input :email, label: "Adresse mail", hint: "Une invitation sera envoyée automatiquement"
-      - # rubocop:disable Rails/OutputSafety
       = ff.input :service_ids, label: "Service", collection: Service.all, hint: sanitize("Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}")
-    - # rubocop:enable Rails/OutputSafety
 
     = f.submit

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -12,13 +12,14 @@ section.main-content__body
   p
     | Ce formulaire vous permet de créer un territoire, une organisation, et un lieu pour un agent qui en sera admin (généralement la personne référente du projet).
   p
-    | Un motif d'exemple "Mon premier motif" sera créé, sauf s'il s'agit d'une ouverture de compte pour une mairie.
+    | Des motifs "Suivi de dossier" seront créés par défaut
   = simple_form_for([namespace, page.resource], html: { class: "form" }) do |f|
     = f.simple_fields_for :territory do |ff|
       = ff.input :name, label: "Nom du territoire"
 
     = f.simple_fields_for :organisation do |ff|
-      = ff.input :name, label: "Nom de la première organisation et du premier lieu"
+      div[style="margin: 8px 0"]
+        = ff.input :name, label: "Nom de la première organisation et du premier lieu"
       div[style="margin: 16px 0 8px 0"]
         = ff.input :ants_connectable, as: :boolean, label: "Autoriser le branchement au moteur de recherche de l'ANTS", hint: "En cochant cette case, vous permettrez à cette organisation (probablement une mairie) d'apparaitre sur https://rendezvouspasseport.ants.gouv.fr/"
 
@@ -32,9 +33,14 @@ section.main-content__body
 
     h2[style="margin: 32px 0 16px 0"] Admin de territoire
     = f.simple_fields_for :agent do |ff|
-      = ff.input :first_name, label: "Prénom"
-      = ff.input :last_name, label: "Nom"
-      = ff.input :email, label: "Adresse mail", hint: "Une invitation sera envoyée automatiquement"
+      - if @agent
+        p = @agent.full_name
+        p = @agent.email
+        = ff.hidden_field :agent_id, value: @agent.id
+      - else
+        = ff.input :first_name, label: "Prénom"
+        = ff.input :last_name, label: "Nom"
+        = ff.input :email, label: "Adresse mail", hint: "Une invitation sera envoyée automatiquement"
       - # rubocop:disable Rails/OutputSafety
       = ff.input :service_ids, label: "Service", collection: Service.all, hint: "Si nécessaire, vous pouvez #{link_to('créer un nouveau service', new_super_admins_service_path, target: :blank)}".html_safe
     - # rubocop:enable Rails/OutputSafety

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,7 +290,7 @@ Rails.application.routes.draw do
     end
   end
   authenticated :agent do
-    root to: "agents/pages#home", as: :authenticated_agents_root
+    root to: "agents/pages#home", as: :authenticated_agent_root
   end
 
   scope path: "prescripteur", as: "prescripteur", controller: "prescripteur_rdv_wizard" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,7 +290,7 @@ Rails.application.routes.draw do
     end
   end
   authenticated :agent do
-    root to: "admin/organisations#index", as: :authenticated_agent_root, defaults: { follow_unique: "1" }
+    root to: "agents/pages#home", as: :agents_root
   end
 
   scope path: "prescripteur", as: "prescripteur", controller: "prescripteur_rdv_wizard" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,7 +290,7 @@ Rails.application.routes.draw do
     end
   end
   authenticated :agent do
-    root to: "agents/pages#home", as: :agents_root
+    root to: "agents/pages#home", as: :authenticated_agents_root
   end
 
   scope path: "prescripteur", as: "prescripteur", controller: "prescripteur_rdv_wizard" do

--- a/db/seeds/ccas.rb
+++ b/db/seeds/ccas.rb
@@ -49,3 +49,18 @@ user = User.new(
 
 user.skip_confirmation!
 user.save!
+
+# Un agent pour tester l'absence d'orga et de services
+agent = Agent.new(
+  email: "bob-sans-orga@demo.rdv-solidarites.fr",
+  uid: "bob-sans-orga@demo.rdv-solidarites.fr",
+  first_name: "Bob",
+  last_name: "Sans Organisation",
+  password: "Rdvservicepublictest1!",
+  services: [],
+  invitation_accepted_at: 1.day.ago,
+  roles_attributes: [],
+  agent_territorial_access_rights_attributes: []
+)
+agent.skip_confirmation!
+agent.save!

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -12,8 +12,17 @@ FactoryBot.define do
 
     transient do
       service { build(:service) }
+      no_services { false }
+
+      trait :no_services do
+        no_services { true }
+      end
     end
     after(:build) do |agent, evaluator|
+      next if evaluator.no_services
+      next if agent.agent_services.any?
+      next if agent.services.any?
+
       if agent.agent_services.empty? && agent.services.empty?
         agent.services = if evaluator.service
                            [evaluator.service]

--- a/spec/features/agents/account/agent_can_reset_his_password_spec.rb
+++ b/spec/features/agents/account/agent_can_reset_his_password_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Agent resets his password spec" do
     fill_in "Mot de passe", with: "correct H0rse battery! staple"
     expect { click_on "Enregistrer" }.to change { agent.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
-    expect(page).to have_link("Vos organisations")
   end
 
   it "works when using the user's password reset form" do
@@ -39,6 +38,5 @@ RSpec.describe "Agent resets his password spec" do
     fill_in "Mot de passe", with: "correct H0rse battery! staple"
     expect { click_on "Enregistrer" }.to change { agent.reload.encrypted_password }
     expect(page).to have_content("Votre mot de passe a été édité avec succès")
-    expect(page).to have_link("Vos organisations")
   end
 end

--- a/spec/services/admin_creates_agent_spec.rb
+++ b/spec/services/admin_creates_agent_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe AdminCreatesAgent do
   context "when inviting an agent that doesn't have any services" do
     let(:agent) do
-      create(:agent, services: [], organisations: [])
+      create(:agent, :no_services, organisations: [])
     end
     let(:service1) { create(:service) }
     let(:service2) { create(:service) }
@@ -10,10 +10,6 @@ RSpec.describe AdminCreatesAgent do
     end
     let(:admin) do
       create(:agent, admin_role_in_organisations: [organisation])
-    end
-
-    before do
-      agent.services.delete_all
     end
 
     it "adds the services to the agent" do

--- a/spec/services/admin_creates_agent_spec.rb
+++ b/spec/services/admin_creates_agent_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe AdminCreatesAgent do
+  context "when inviting an agent that doesn't have any services" do
+    let(:agent) do
+      create(:agent, services: [], organisations: [])
+    end
+    let(:service1) { create(:service) }
+    let(:service2) { create(:service) }
+    let(:organisation) do
+      create(:organisation)
+    end
+    let(:admin) do
+      create(:agent, admin_role_in_organisations: [organisation])
+    end
+
+    before do
+      agent.services.delete_all
+    end
+
+    it "adds the services to the agent" do
+      described_class.new(
+        agent_params: { email: agent.email, service_ids: [service1.id, service2.id] },
+        current_agent: admin,
+        organisations: [organisation],
+        access_level: :basic
+      ).call
+
+      expect(agent.reload.services).to contain_exactly(service1, service2)
+      expect(agent.organisations).to eq [organisation]
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/betagouv/rdv-service-public/issues/5060


# Contexte

voir https://github.com/betagouv/rdv-service-public/issues/5060

On a 3 objectifs : 
- éviter les agents bloqués par une connexion au mauvais compte proconnect
- permettre la création de compte via proconnect pour ne pas bloquer l'oauth dans le cadre des intégrations
- expliquer aux agents qui cherchent à rejoindre une organisation comment faire

# Solution

On autorise la création de comptes via proconnect, mais uniquement pour le domaine RDV Service Public.
On met à jour le formulaire d'ouverture de compte dans le super admin pour ajouter un agent (optionnel), et on permet de faire cette ouverture si un agent n'a pas d'organisation.

Dans la "state machine" des agents, c'est possible de ne pas avoir de compte dans l'état initial, mais pas dans un état intermédiaire ou final, parce que le compte de l'agent est supprimé s'il est retiré de toutes ses organisations.

L'agent créé ainsi n'a pas de service. On autorise l'ajout de services lorsque l'agent est créé par un super admin ou invité par un autre admin d'orga ou de territoire.

On va voir avec l'équipe déploiement comment on ajoute ces agents à leur crm.

## Captures d'écran

Avant | Après
:- | -:
<img width="1368" alt="Screenshot 2025-03-03 at 12 24 17" src="https://github.com/user-attachments/assets/b674ed87-ef08-4c4e-ab54-a53d4157c5c0" />|<img width="1422" alt="Screenshot 2025-03-03 at 12 14 29" src="https://github.com/user-attachments/assets/ca03b7b6-5622-4f72-b19d-39c5dbc34e47" />
<img width="1493" alt="Screenshot 2025-03-03 at 12 26 03" src="https://github.com/user-attachments/assets/9cfc1257-8329-434e-8878-c1f8e69f72f2" />|<img width="1501" alt="Screenshot 2025-03-03 at 12 26 44" src="https://github.com/user-attachments/assets/de37f356-a34f-4aea-b401-0486b74a584b" />

