### PR TITLE
Fix - Correction d’un lien mort RDVS présentation agent

### DIFF
--- a/app/views/static_pages/rdv_solidarites_presentation_for_agents.html.slim
+++ b/app/views/static_pages/rdv_solidarites_presentation_for_agents.html.slim
@@ -1,4 +1,5 @@
-- generic_team_meeting_url = "https://meet.brevo.com/-1918/-rencontre-temps-dechanges"
+- generic_team_meeting_url = "https://cal.com/forms/937585aa-48a4-4efd-a642-961fad79c9c5"
+
 section.py-5.rdv-background-color-flat-blue-ecume
   .fr-container
     .row


### PR DESCRIPTION
# Contexte

En faisant la liste des boutons qui ne sont pas encore au DSFR, je me suis rendu compte que nous avions des liens morts ici sur les boutons « Contactez-nous » : https://www.rdv-solidarites.fr/presentation_agent

# Solution

On utilise le même CTA que sur la page d’accueil rdv.anct.gouv.fr

