### PR TITLE
WIP - Parcours usager, stepper DSFR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,19 +153,20 @@ jobs:
           POSTGRES_USER: lapin_test
           POSTGRES_PASSWORD: lapin_test
           POSTGRES_DB: lapin_test
-  test_features:
-    name: Feature Tests
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # cette strategy permet de lancer deux jobs de feature specs en parallèle pour accélérer l’exécution
-        dirname: [agents, "*"]
-        include: 
-          - dirname: agents
-            command: "parallel:spec[spec/features/agents]"
-          - dirname: "*"
-            command: "parallel:spec['spec/features/(?!agents)']"
+  # NE PAS MERGER ! SKIP TEST POUR POUVOIR VOIR LA REVIEW APP
+#  test_features:
+#    name: Feature Tests
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        # cette strategy permet de lancer deux jobs de feature specs en parallèle pour accélérer l’exécution
+#        dirname: [agents, "*"]
+#        include:
+#          - dirname: agents
+#            command: "parallel:spec[spec/features/agents]"
+#          - dirname: "*"
+#            command: "parallel:spec['spec/features/(?!agents)']"
     services:
       postgres:
         image: postgres

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,32 +1,47 @@
 .fr-container
-  = render "search/selected_motif_recap", context: context
-  - if context.lieu.present?
-    .card
-      .card-body
-        = link_to path_to_lieu_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du lieu" do
-          .row
-            .col-auto.align-self-center
-              span.fr-icon-arrow-left-line
-            .col
-              h2.pb-1.mb-1.card-title= context.lieu.name
-              .card-subtitle= context.lieu.address
-  - elsif context.user_selected_organisation.present?
-    .card
-      .card-body
-        = link_to path_to_organisation_selection(params), class: "d-block stretched-link", title: "Retour à la sélection de l’organisation" do
-          .row
-            .col-auto.align-self-center
-              span.fr-icon-arrow-left-line
-            .col
-              h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
-              = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
   - if context.no_availability?
     = render "search/nothing_to_show", context: context
   - else
     - if context.first_matching_motif.collectif?
-      h3 = "Inscrivez-vous à l'atelier de votre choix :"
+      = dsfr_stepper(title: "Inscrivez-vous à l’atelier de votre choix", value: 3, max: 6, next_title: "Identifiez-vous")
     - else
-      h3 Sélectionnez un créneau&nbsp;:
+      = dsfr_stepper(title: "Sélectionnez un créneau de RDV", value: 3, max: 6, next_title: "Identifiez-vous")
+
+      .card
+        ul.list-group.list-group-flush
+          li.list-group-item
+            .row
+              .col
+                span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+                | Motif :&nbsp;
+                = context.first_matching_motif.name
+              .col-auto
+                = link_to "modifier", path_to_service_selection(params)
+          - case context.first_matching_motif.location_type
+          - when Motif.location_types[:phone]
+            li.list-group-item
+              span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+              | RDV téléphonique
+          - when Motif.location_types[:home]
+            li.list-group-item
+              span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+              | RDV à domicile
+          - when Motif.location_types[:visio]
+            li.list-group-item
+              span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+              | RDV par visioconférence
+          - when Motif.location_types[:public_office]
+            li.list-group-item
+              .row
+                .col
+                  span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+                  | Lieu :&nbsp;
+                  = context.lieu.full_name
+                .col-auto
+                  = link_to "modifier", path_to_organisation_selection(params)
+          - else
+            = raise "unrecognized location_type: #{rdv_wizard.motif.location_type.inspect}"
+
     - if context.first_matching_motif.collectif?
       ul.fr-raw-list
         - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -1,7 +1,7 @@
 - if context.shown_lieux.empty?
   = render "search/nothing_to_show", context: context
 - else
-  = dsfr_stepper(title: "Sélectionnez un lieu de RDV", value: 3, max: 6, next_title: "Sélectionnez un créneau de RDV")
+  = dsfr_stepper(title: "Sélectionnez un lieu de RDV", value: 2, max: 6, next_title: "Sélectionnez un créneau de RDV")
   .card
     ul.list-group.list-group-flush
       li.list-group-item

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -1,8 +1,17 @@
-= render "search/selected_motif_recap", context: context
 - if context.shown_lieux.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h3 = t(".select_lieu")
+  = dsfr_stepper(title: "Sélectionnez un lieu de RDV", value: 3, max: 6, next_title: "Sélectionnez un créneau de RDV")
+  .card
+    ul.list-group.list-group-flush
+      li.list-group-item
+        .row
+          .col
+            span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+            | Motif :&nbsp;
+            = context.first_matching_motif.name
+          .col-auto
+            = link_to "modifier", path_to_service_selection(params)
   p = t(".lieu_available", count: context.shown_lieux.count)
   ul.fr-raw-list
     - context.next_availability_by_lieux.each do |lieu, next_availability|

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,3 +1,5 @@
+//TODO: Si on retient la fusion service/motif, supprimer cette étape
+
 = dsfr_stepper(title: "Sélectionnez le motif de votre RDV", value: 2, max: 7, next_title: "Sélectionnez la structure avec laquelle prendre RDV")
 .card
   ul.list-group.list-group-flush

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,16 +1,4 @@
-//TODO: Si on retient la fusion service/motif, supprimer cette étape
-
-= dsfr_stepper(title: "Sélectionnez le motif de votre RDV", value: 2, max: 7, next_title: "Sélectionnez la structure avec laquelle prendre RDV")
-.card
-  ul.list-group.list-group-flush
-    li.list-group-item
-      .row
-        .col
-          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
-          | Service :&nbsp;
-          = context.service.name
-        .col-auto
-          = link_to "modifier", path_to_service_selection(params)
+= dsfr_stepper(title: "Sélectionnez le motif de votre RDV", value: 1, max: 6, next_title: "Sélectionnez le lieu de RDV")
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,15 +1,17 @@
+= dsfr_stepper(title: "Sélectionnez le motif de votre RDV", value: 2, max: 7, next_title: "Sélectionnez la structure avec laquelle prendre RDV")
 .card
-  .card-body
-    = link_to path_to_service_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du service" do
+  ul.list-group.list-group-flush
+    li.list-group-item
       .row
-        .col-auto.align-self-center
-          span.fr-icon-arrow-left-line
         .col
-          h2.fr-pb-0.fr-mb-0 = context.service.name
+          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+          | Service :&nbsp;
+          = context.service.name
+        .col-auto
+          = link_to "modifier", path_to_service_selection(params)
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2 Sélectionnez le motif de votre RDV&nbsp;:
   ul.fr-raw-list
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -1,8 +1,18 @@
-= render "search/selected_motif_recap", context: context
 - if context.next_availability_by_motifs_organisations.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h3 Sélectionnez la structure avec laquelle prendre RDV&nbsp;:
+  = dsfr_stepper(title: "Sélectionnez la structure avec laquelle prendre RDV", value: 2, max: 6, next_title: "Sélectionnez un créneau de RDV")
+
+  .card
+    ul.list-group.list-group-flush
+      li.list-group-item
+        .row
+          .col
+            span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+            | Motif :&nbsp;
+            = context.first_matching_motif.name
+          .col-auto
+            = link_to "modifier", path_to_service_selection(params)
   ul.fr-raw-list
     - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
       li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -1,7 +1,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2 Sélectionnez le service avec qui vous voulez prendre un RDV&nbsp;:
+  = dsfr_stepper(title: "Sélectionnez le service avec qui vous voulez prendre un RDV", value: 1, max: 7, next_title: "Sélectionnez le motif de votre RDV")
   - context.services.each do |service|
     .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
       .fr-card__body

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -1,11 +1,33 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  = dsfr_stepper(title: "Sélectionnez le service avec qui vous voulez prendre un RDV", value: 1, max: 7, next_title: "Sélectionnez le motif de votre RDV")
-  - context.services.each do |service|
-    .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
-      .fr-card__body
-        .fr-card__content
-          .fr-card__title
-            = link_to service.name, prendre_rdv_path(context.query_params.merge(service_id: service.id))
+  = dsfr_stepper(title: "Sélectionnez le service avec lequel vous voulez prendre RDV puis le motif", value: 1, max: 6, next_title: "Sélectionnez le motif de votre RDV")
+  = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
+    - context.services.each do |service|
+      = accordion.with_section(title: service.name) do
+        ul.fr-raw-list
+          - context.unique_motifs_by_name_and_location_type.each do |motif|
+            // TODO: Changer cette manière d’afficher les motifs par service. C’est pas très propre et pas très efficient mais c’est juste pour prototyper.
+            - if motif.service_id == service.id
+              li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
+                .fr-card__body
+                  .fr-card__content
+                    .fr-card__title
+                      = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))
+                    .fr-card__start
+                      ul.fr-badges-group
+                        - case motif.location_type
+                        - when "phone"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-phone-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - when "home"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-home-4-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - when "public_office"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-building-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - when "visio"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-mac-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - else
+                          li.fr-badge.fr-badge--blue-cumulus = motif.human_attribute_value(:location_type)
+                          - if motif.collectif?
+                            li.fr-badge.fr-badge--purple-glycine.fr-icon-team-fill.fr-badge--icon-left = "RDV collectif"
+
 = render "search/referent_booking_card", context: context

--- a/app/views/search/search_rdv.html.slim
+++ b/app/views/search/search_rdv.html.slim
@@ -1,10 +1,8 @@
 = render "prescription_banner"
 
-= render "banner", context: @context
-
 / Adress selection partials have multiple sections
 - if @context.current_step == :address_selection
-  // On fait du spécifique pour la bannière de la page de sélection d'adresse en attendant qu’on fasse la refonte au DSFR
+  = render "banner", context: @context
   = render(current_domain.address_selection_template_name, context: @context)
 - else
   .fr-container

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -1,9 +1,7 @@
 .fr-container
   .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
-    = dsfr_stepper(title: "Vos informations", value: 5, max: 7, next_title: "Choix de l’usager")
+    = dsfr_stepper(title: "Vos informations", value: 5, max: 6, next_title: "Confirmation")
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
         = render "users/users/form", user: current_user, rdv_wizard: @rdv_wizard, service: @rdv_wizard.service
-        .col
-          = link_to "Revenir en arrière", prendre_rdv_path(@rdv_wizard.to_query), class: "btn btn-link"

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -1,8 +1,6 @@
-= render "/users/rdv_wizard_steps/stepper", step_title: t(".title")
-
-.row.justify-content-center
-  .col-lg-7.col-md-10.col-sm-11
-    h3.rdv-text-align-center.mb-3 Vos informations
+.fr-container
+  .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
+    = dsfr_stepper(title: "Vos informations", value: 5, max: 7, next_title: "Choix de l’usager")
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -1,8 +1,6 @@
-= render "stepper", step_title: t(".title")
-
-.row.justify-content-center
-  .col-lg-7.col-md-10.col-sm-11
-    h3.rdv-text-align-center.mb-3 Choix de l'usager
+.fr-container
+  .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
+    = dsfr_stepper(title: "Choix de l’usager", value: 6, max: 7, next_title: "Confirmation")
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -1,6 +1,6 @@
 .fr-container
   .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
-    = dsfr_stepper(title: "Choix de l’usager", value: 6, max: 7, next_title: "Confirmation")
+    = dsfr_stepper(title: "Vos informations", value: 5, max: 6, next_title: "Confirmation")
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
@@ -31,8 +31,5 @@
                 input_html: { name: "rdv[user_ids][]" }
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
-          .row
-            .col
-              = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "btn btn-link"
-            .col
-              = f.button :submit, "Continuer"
+          .rdv-text-align-right
+            = f.button :submit, "Continuer"

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -1,6 +1,6 @@
 .fr-container
   .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
-    = dsfr_stepper(title: "Confirmation", value: 7, max: 7)
+    = dsfr_stepper(title: "Confirmation", value: 6, max: 6)
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body.rdv-text-align-right

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -1,8 +1,6 @@
-= render "stepper", step_title: t(".title")
-
-.row.justify-content-center
-  .col-lg-7.col-md-10.col-sm-11
-    h3.rdv-text-align-center.mb-3 Confirmation
+.fr-container
+  .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
+    = dsfr_stepper(title: "Confirmation", value: 7, max: 7)
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body.rdv-text-align-right


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5106.osc-secnum-fr1.scalingo.io/) 

> [!Warning]
> NE PAS MERGER ~SANS RETIRER LE SKIP TEST~ DU TOUT

Suite aux retours que nous avons eu pendant la DM, nous allons découper cette PR en plusieurs petites : 

- Une PR pour l’ajout du résumé de RDV dans les premières étapes : #5154 
- Une PR pour supprimer le bandeau bleu et ajouter le stepper : #5168 (migration de l’ancien stepper vers le stepper DSFR)
- Une PR pour fusionner le choix du service et le choix du motif : https://github.com/betagouv/rdv-service-public/pull/5185
