### PR TITLE
correction d’un lien cassé dans les liens du fil d’ariane 

### DIFF
--- a/app/views/stats/territory_notifications.html.slim
+++ b/app/views/stats/territory_notifications.html.slim
@@ -6,7 +6,7 @@
     = b.with_breadcrumb label: "Accueil", href: "/"
     = b.with_breadcrumb label: "Statistiques globales", href: stats_path
     = b.with_breadcrumb label: "Statistiques par structure", href: stats_territories_path
-    = b.with_breadcrumb label: @territory.to_s, href: stats_territory_path(@territory)
+    = b.with_breadcrumb label: @territory.to_s, href: stats_territory_path(territory: @territory)
     = b.with_breadcrumb label: "Statistiques de notifications"
 
 h2= @territory


### PR DESCRIPTION
# Contexte

J’ai introduit un bug dans #5043 : un lien est cassé dans le fil d’ariane de la page de stats présentant les notifications d’un territoire.
On voit l’erreur se produire lors de scrappings : https://sentry.incubateur.net/organizations/betagouv/issues/150535

# Solution

Correction de l’URL générée.

je n’ai pas rajouté de spec car c’est un peu trop bénin pour décrire ça spécifiquement dans les specs il me semble.