### PR TITLE
correction de doublons renvoyés par Agent::RdvPolicy::Scope : DISTINCT ON

### DIFF
--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -9,9 +9,10 @@ class Admin::RdvsController < AgentAuthController
     set_scoped_organisations
     @breadcrumb_page = params[:breadcrumb_page]
 
-    order = { starts_at: :asc }
+    order = [{ starts_at: :asc }, { id: :asc }]
+    distinct_on = "rdvs.starts_at, rdvs.id" # les clauses ORDER BY et DISTINCT ON doivent utiliser les mêmes colonnes
     @rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
-      .select("DISTINCT ON (rdvs.id) rdvs.*") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
+      .select("DISTINCT ON (#{distinct_on}) rdvs.*") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
       .search_for(@scoped_organisations, parsed_params)
       .order(order).page(page_number).per(10)
 

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -10,14 +10,14 @@ class Admin::RdvsController < AgentAuthController
     @breadcrumb_page = params[:breadcrumb_page]
 
     order = { starts_at: :asc }
-    @rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
-      .select("DISTINCT ON (rdvs.id) rdvs.*") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
+    @rdvs_ids_paginated = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
+      .select("DISTINCT ON (rdvs.id) rdvs.id") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
       .search_for(@scoped_organisations, parsed_params)
       .order(order).page(page_number).per(10)
 
     # On fait cette requête en deux temps pour éviter de faire un `order` et un `include` sur le même scope,
     # parce que ça fait un sort et beaucoup de left outer joins
-    @rdvs_in_page = Rdv.where(id: @rdvs.pluck(:id)).order(order).includes(
+    @rdvs_in_page = Rdv.where(id: @rdvs_ids_paginated.pluck(:id)).order(order).includes(
       [
         :agents_rdvs, :organisation, :lieu, :motif,
         {

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -10,14 +10,14 @@ class Admin::RdvsController < AgentAuthController
     @breadcrumb_page = params[:breadcrumb_page]
 
     order = { starts_at: :asc }
-    @rdvs_ids_paginated = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
-      .select("DISTINCT ON (rdvs.id) rdvs.id") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
+    @rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
+      .select("DISTINCT ON (rdvs.id) rdvs.*") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
       .search_for(@scoped_organisations, parsed_params)
       .order(order).page(page_number).per(10)
 
     # On fait cette requête en deux temps pour éviter de faire un `order` et un `include` sur le même scope,
     # parce que ça fait un sort et beaucoup de left outer joins
-    @rdvs_in_page = Rdv.where(id: @rdvs_ids_paginated.pluck(:id)).order(order).includes(
+    @rdvs_in_page = Rdv.where(id: @rdvs.pluck(:id)).order(order).includes(
       [
         :agents_rdvs, :organisation, :lieu, :motif,
         {

--- a/app/controllers/admin/rdvs_controller.rb
+++ b/app/controllers/admin/rdvs_controller.rb
@@ -10,7 +10,9 @@ class Admin::RdvsController < AgentAuthController
     @breadcrumb_page = params[:breadcrumb_page]
 
     order = { starts_at: :asc }
-    @rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).search_for(@scoped_organisations, parsed_params)
+    @rdvs = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope)
+      .select("DISTINCT ON (rdvs.id) rdvs.*") # dédoublonnage des RDV renvoyés par Agent::RdvPolicy::Scope
+      .search_for(@scoped_organisations, parsed_params)
       .order(order).page(page_number).per(10)
 
     # On fait cette requête en deux temps pour éviter de faire un `order` et un `include` sur le même scope,

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -139,12 +139,11 @@ class Agent::RdvPolicy < ApplicationPolicy
     include CurrentAgentInPolicyConcern
 
     def resolve
+      # NOTE: IMPORTANTE: Ce scope peut renvoyer des RDV doublons à cause des INNER JOIN vers les participations et les agents.
       if current_agent.secretaire?
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
           .where(agent_roles: { agent_id: current_agent.id }) # RDV des organisations dans lesquelles j'ai un role
-
       else
-
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
           .where(agent_roles: { agent_id: current_agent.id }) # RDV des organisations dans lesquelles j'ai un role
           .joins(:motif, :agents_rdvs)

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -142,7 +142,7 @@ class Agent::RdvPolicy < ApplicationPolicy
       if current_agent.secretaire?
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
           .where(agent_roles: { agent_id: current_agent.id }) # RDV des organisations dans lesquelles j'ai un role
-          .select("DISTINCT ON (rdvs.id) rdvs.*")
+
       else
 
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
@@ -154,7 +154,6 @@ class Agent::RdvPolicy < ApplicationPolicy
               OR (agent_roles.access_level = 'admin')",
             current_agent.id, current_agent.service_ids
           )
-          .select("DISTINCT ON (rdvs.id) rdvs.*")
       end
     end
   end

--- a/app/policies/agent/rdv_policy.rb
+++ b/app/policies/agent/rdv_policy.rb
@@ -142,7 +142,7 @@ class Agent::RdvPolicy < ApplicationPolicy
       if current_agent.secretaire?
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
           .where(agent_roles: { agent_id: current_agent.id }) # RDV des organisations dans lesquelles j'ai un role
-
+          .select("DISTINCT ON (rdvs.id) rdvs.*")
       else
 
         scope.joins("INNER JOIN agent_roles on agent_roles.organisation_id = rdvs.organisation_id")
@@ -154,6 +154,7 @@ class Agent::RdvPolicy < ApplicationPolicy
               OR (agent_roles.access_level = 'admin')",
             current_agent.id, current_agent.service_ids
           )
+          .select("DISTINCT ON (rdvs.id) rdvs.*")
       end
     end
   end

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -30,7 +30,7 @@
     .card-body
       = render "rdv_search_form", form: @form
 
-    - if @rdvs_ids_paginated.total_count > 0
+    - if @rdvs.total_count > 0
       .card-footer
         div.d-flex.justify-content-end.align-items-center
           = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
@@ -38,10 +38,10 @@
             i.fa.fa-download>
           = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
             span
-              - if @rdvs_ids_paginated.total_count == 1
+              - if @rdvs.total_count == 1
                 |> Exporter le RDV en XLS
               - else
-                |> Exporter les #{@rdvs_ids_paginated.total_count} RDV en XLS
+                |> Exporter les #{@rdvs.total_count} RDV en XLS
 
             i.fa.fa-download>
 
@@ -51,18 +51,18 @@
 
   = render "admin/rdvs/rdv_visibility"
 
-  - if @rdvs_ids_paginated.total_count > 0
+  - if @rdvs.total_count > 0
     .mb-2
-      h4>= "#{@rdvs_ids_paginated.total_count} rendez-vous"
+      h4>= "#{@rdvs.total_count} rendez-vous"
       .custom-control.custom-switch
         input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
         label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
 
     .row.justify-content-center.pb-3
       .col-md-12.col-lg-8
-        .d-flex.justify-content-center= paginate @rdvs_ids_paginated, theme: "twitter-bootstrap-4"
+        .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
-        .d-flex.justify-content-center= paginate @rdvs_ids_paginated, theme: "twitter-bootstrap-4"
+        .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
   - else
     .row.justify-content-center.pb-3
       .col-md-12.col-lg-8

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -37,7 +37,12 @@
             span> Exporter les RDVs par usager en XLS
             i.fa.fa-download>
           = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
-            span> Exporter les #{@rdvs.total_count} RDVs en XLS
+            span
+              - if @rdvs.total_count == 1
+                |> Exporter le RDV en XLS
+              - else
+                |> Exporter les #{@rdvs.total_count} RDV en XLS
+
             i.fa.fa-download>
 
           .btn.btn-sm.btn-link.d-print-none role="button" onclick="window.print();return;"

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -30,7 +30,7 @@
     .card-body
       = render "rdv_search_form", form: @form
 
-    - if @rdvs.total_count > 0
+    - if @rdvs_ids_paginated.total_count > 0
       .card-footer
         div.d-flex.justify-content-end.align-items-center
           = button_to participations_export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
@@ -38,10 +38,10 @@
             i.fa.fa-download>
           = button_to export_admin_organisation_rdvs_path(**@form.to_query), method: :post, class: "btn btn-sm btn-link d-print-none", disable_with: "Veuillez patienter…" do
             span
-              - if @rdvs.total_count == 1
+              - if @rdvs_ids_paginated.total_count == 1
                 |> Exporter le RDV en XLS
               - else
-                |> Exporter les #{@rdvs.total_count} RDV en XLS
+                |> Exporter les #{@rdvs_ids_paginated.total_count} RDV en XLS
 
             i.fa.fa-download>
 
@@ -51,18 +51,18 @@
 
   = render "admin/rdvs/rdv_visibility"
 
-  - if @rdvs.total_count > 0
+  - if @rdvs_ids_paginated.total_count > 0
     .mb-2
-      h4>= "#{@rdvs.total_count} rendez-vous"
+      h4>= "#{@rdvs_ids_paginated.total_count} rendez-vous"
       .custom-control.custom-switch
         input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
         label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
 
     .row.justify-content-center.pb-3
       .col-md-12.col-lg-8
-        .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+        .d-flex.justify-content-center= paginate @rdvs_ids_paginated, theme: "twitter-bootstrap-4"
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
-        .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+        .d-flex.justify-content-center= paginate @rdvs_ids_paginated, theme: "twitter-bootstrap-4"
   - else
     .row.justify-content-center.pb-3
       .col-md-12.col-lg-8

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -28,10 +28,9 @@ RSpec.describe Admin::RdvsController, type: :controller do
     end
 
     it "assign RDVS" do
-      rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
+      _rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
       get(:index, params: { organisation_id: organisation.id })
-
-      expect(assigns(:rdvs)).to contain_exactly(rdv, rdv_binome)
+      expect(assigns(:rdvs).total_count).to eq(2) # rdv & rdv_binome
     end
 
     it "assign form" do

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Admin::RdvsController, type: :controller do
     end
 
     it "assign RDVS" do
-      rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
+      _rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
       get(:index, params: { organisation_id: organisation.id })
-      expect(assigns(:rdvs_ids_paginated).pluck(:id)).to contain_exactly(rdv.id, rdv_binome.id) # rdv & rdv_binome
+      expect(assigns(:rdvs).total_count).to eq(2) # rdv & rdv_binome
     end
 
     it "assign form" do

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe Admin::RdvsController, type: :controller do
     end
 
     it "assign RDVS" do
-      _rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
+      rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
       get(:index, params: { organisation_id: organisation.id })
-      expect(assigns(:rdvs).total_count).to eq(2) # rdv & rdv_binome
+      expect(assigns(:rdvs_ids_paginated).pluck(:id)).to contain_exactly(rdv.id, rdv_binome.id) # rdv & rdv_binome
     end
 
     it "assign form" do

--- a/spec/controllers/admin/rdvs_controller_spec.rb
+++ b/spec/controllers/admin/rdvs_controller_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe Admin::RdvsController, type: :controller do
     end
 
     it "assign RDVS" do
-      _rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
+      rdv = create(:rdv, agents: [agent], organisation: organisation, motif: motif)
       get(:index, params: { organisation_id: organisation.id })
-      expect(assigns(:rdvs).total_count).to eq(2) # rdv & rdv_binome
+
+      expect(assigns(:rdvs)).to contain_exactly(rdv, rdv_binome)
     end
 
     it "assign form" do

--- a/spec/features/agents/agent_can_export_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_export_rdvs_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "agent can export RDVs" do
 
   it "displays export list" do
     visit admin_organisation_rdvs_url(organisation, agent)
-    click_on "Exporter les 1 RDVs en XLS"
+    click_on "Exporter le RDV en XLS"
     perform_enqueued_jobs
 
     login_as(agent, scope: :agent)
@@ -26,7 +26,7 @@ RSpec.describe "agent can export RDVs" do
   it "exports by RDV" do
     visit admin_organisation_rdvs_url(organisation, agent)
     perform_enqueued_jobs do
-      click_on "Exporter les 1 RDVs en XLS"
+      click_on "Exporter le RDV en XLS"
     end
 
     open_email(agent.email)

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -103,19 +103,6 @@ RSpec.describe "Agent can list RDVs" do
       end
     end
 
-    context "un seul RDV avec deux users" do
-      let!(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
-      let!(:user1) { create(:user) }
-      let!(:user2) { create(:user) }
-      let!(:rdv) { create(:rdv, users: [user1, user2], organisation: organisation, agents: [current_agent]) }
-
-      it "devrait afficher des compteurs de RDV égaux à 1" do
-        visit admin_organisation_rdvs_path(organisation, current_agent)
-        expect(page).to have_content("Exporter le RDV en XLS")
-        expect(find("h4", text: /1 rendez-vous/)).to be_present
-      end
-    end
-
     context "panaché de RDV" do
       let!(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
       let!(:other_agent) { create(:agent, organisations: [organisation]) }

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -89,4 +89,37 @@ RSpec.describe "Agent can list RDVs" do
       expect(page).to have_content(motif.name) # Permet de vérifier que le rdv est bien affiché
     end
   end
+
+  describe "cohérence du compteur pour les RDV avec plusieurs agents" do
+    context "un seul RDV avec deux agents" do
+      let!(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, organisations: [organisation]) }
+      let!(:rdv) { create(:rdv, organisation: organisation, agents: [current_agent, other_agent]) }
+
+      it "devrait afficher des compteurs de RDV égaux à 1" do
+        visit admin_organisation_rdvs_path(organisation, current_agent)
+        expect(page).to have_content("Exporter le RDV en XLS")
+        expect(find("h4", text: /1 rendez-vous/)).to be_present
+      end
+    end
+
+    context "panaché de RDV" do
+      let!(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:other_agent) { create(:agent, organisations: [organisation]) }
+      let!(:other_agent2) { create(:agent, organisations: [organisation]) }
+
+      before do
+        create(:rdv, organisation: organisation, agents: [current_agent, other_agent])
+        create(:rdv, organisation: organisation, agents: [current_agent])
+        create(:rdv, organisation: organisation, agents: [other_agent])
+        create(:rdv, organisation: organisation, agents: [current_agent, other_agent, other_agent2])
+      end
+
+      it "devrait afficher le bon nombre de RDV" do
+        visit admin_organisation_rdvs_path(organisation, current_agent)
+        expect(page).to have_content("Exporter les 4 RDV en XLS")
+        expect(find("h4", text: /4 rendez-vous/)).to be_present
+      end
+    end
+  end
 end

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -103,6 +103,19 @@ RSpec.describe "Agent can list RDVs" do
       end
     end
 
+    context "un seul RDV avec deux users" do
+      let!(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+      let!(:user1) { create(:user) }
+      let!(:user2) { create(:user) }
+      let!(:rdv) { create(:rdv, users: [user1, user2], organisation: organisation, agents: [current_agent]) }
+
+      it "devrait afficher des compteurs de RDV égaux à 1" do
+        visit admin_organisation_rdvs_path(organisation, current_agent)
+        expect(page).to have_content("Exporter le RDV en XLS")
+        expect(find("h4", text: /1 rendez-vous/)).to be_present
+      end
+    end
+
     context "panaché de RDV" do
       let!(:current_agent) { create(:agent, admin_role_in_organisations: [organisation]) }
       let!(:other_agent) { create(:agent, organisations: [organisation]) }


### PR DESCRIPTION
> [!NOTE]
> ne pas lire commit par commit, je suis passé par plusieurs pistes différentes !

# Contexte

Ce ticket https://zammad10.ethibox.fr/#ticket/zoom/21168 nous signale une différence de 10% entre le nombre de RDV totaux affichés sur la liste de RDV agents et sur le nombre de lignes effectivement exportées.

Note: Il y a 10% moins de lignes dans le fichier exporté que dans le total affiché, heureusement 😅 

On peut reproduire le problème en mettant simplement deux agents à un RDV puis en allant voir la liste des RDV : le compteur indique un de trop.

En creusant je me suis rendu compte que : 

1. on n’applique pas la policy scope RDV dans le job, c’est probablement un problème
2. l’application de la policy scope RDV génère des doublons 

Cette PR tente de résoudre 2. 

# Solution

J’utilise une clause `DISTINCT ON` pour dédoublonner les RDV retournés par la scope. Je l’ai introduite au niveau de l’action `admin/rdvs#index` uniquement. 

> [!WARNING]
> Je n’ai pas encore réussi à tester sur des données de prod, l’anonymisation des données de RDVS est trop lente sur ma machine…

## Piste alternative : DISTINCT ON mais au niveau du Scope

Une tentative d’introduire au niveau de la policy elle même amenait à de nombreuses erreurs de specs cf [ce run GH](https://github.com/betagouv/rdv-service-public/actions/runs/13482497889/job/37669472565). 

Je n’étais pas prêt à investir le temps nécessaire pour corriger ce problème et j’ai peur que ça suscite d’autres problèmes non couverts par les specs.

## Piste alternative : DISTINCT (sans ON)

Un distinct simple causait des problèmes de compatibilité des colonnes avec le `ORDER BY` effectué dans un second temps sur cette relation AR cf #5091 
cf https://www.slingacademy.com/article/ways-to-select-distinct-rows-in-postgresql/

## Piste alternative : Monkey patch `total_count`

Une autre manière de résoudre le problème est de monkey patcher `total_count` sur @rdvs comme

```rb
rdvs_before_pagination = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).search_for(@scoped_organisations, parsed_params)
@rdvs = rdvs_before_pagination.order(order).page(page_number).per(10)
define_singleton_method(@rdvs, :total_count) { rdvs_before_pagination.count } 
# define_singleton_method ouvre une closure, pratique pour appeler la variable locale rdvs_before_pagination
```

En effet, `total_count` est quasiment la seule méthode appelée sur `@rdvs`. Les RDV effectivement affichés sur la page le sont dans une requête successive qui utilise `@rdvs.pluck(:id)`

ça fonctionne très bien aussi il me semble et c’est peut-être moins risqué que la solution que je propose dans cette PR. à discuter ?

## Piste alternative : sous-requête

J’aurais aimé faire en sorte que le Scope lui même arrête de renvoyer des doublons.
La seule piste qui me paraisse robuste serait de faire une sous query : 

```sql
SELECT * FROM rdvs 
WHERE rdvs.id IN (
  SELECT DISTINCT rdvs.* 
  FROM rdvs
  INNER JOIN agents ...
)
```

mais j’ai peur que ça introduise des problèmes : 
- de performances
- de dépendances à corriger : je suppose que des bouts de code utilisant ce `Scope` s’appuie sur les joins qu’il fait déjà. 