### PR TITLE
Diminution du nombre de connexions à la base de données

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,9 +25,19 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   # And also GoodJob doc: https://github.com/bensheldon/good_job#database-connections
-  # For web containers, pool size is puma's default number of threads, plus the number of threads defined by global_executor_concurrency
+  #
+  # Pour les containers web, on ouvre une connexion par thread puma.
+  # On utilise `load_async` à certains endroits, ce qui veut dire qu'un thread peut utiliser plusieurs connexions à la fois (voir global_executor_concurrency).
+  # Dans le scénario du pire, il est possible que tous les thread soient en train d'accéder à la base de données, et que certains d'entre eux soient en plus en train d'exécuter du code qui utilise `load_async`. Cependant, ce cas ne se produit jamais ou quasiment jamais. S'il a lieu, les thread attendront d'avoir une connexion disponible, ce qui peut causer un ralentissement de l'application, mais probablement pas assez pour générer un timeout.
+  # Les connexions ont un cout au niveau du server de base de données : chaque connexion utilise de la RAM, donc on essaye de ne pas trop en ouvrir.
+  # Pour savoir combien de connexions on utilise, on peut vérifier sur Scalingo via la page "Running queries" du dashboard postgres
+  # par exemple https://dashboard.scalingo.com/apps/osc-secnum-fr1/production-rdv-solidarites/db/postgresql/running-queries
+  #
+  # On pourrait même mieux utiliser le mécanisme de connection pool, et avoir moins de connexions que de threads.
+  #
+  #
   # For GoodJob container, pool size is GOOD_JOB_MAX_THREADS (5) + 3 (1 for LISTEN/NOTIFY, 2 for CRON)
-  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : (ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 4) %>
+  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : (ENV.fetch("RAILS_MAX_THREADS", 5).to_i) %>
 
 development:
   <<: *default

--- a/docs/decisions/2023-04-24-politique-maj-gems.md
+++ b/docs/decisions/2023-04-24-politique-maj-gems.md
@@ -1,6 +1,6 @@
 ---
 title: Notre politique de mise à jour des gems (et libs JS)
-date: 2023-02-24
+date: 2023-04-24
 status: proposition
 ---
 

--- a/docs/decisions/2025-02-24-diminution-du-nombre-de-connexions-pg.md
+++ b/docs/decisions/2025-02-24-diminution-du-nombre-de-connexions-pg.md
@@ -1,0 +1,32 @@
+---
+title: Diminution du nombre de connexions Postgres
+date: 2025-02-24
+status: approuvée
+---
+
+## Problème
+
+<img width="775" alt="Un exemple d'incident d'effondrement de ram" src="https://github.com/user-attachments/assets/86df4529-e83a-4eb4-a95b-38bb1ec1c26f" />
+
+On a eu plusieurs incidents pendant des mises en productions lors desquels on avait des "effondrements de RAM".
+Après beaucoup de temps d'investigation par l'équipe SRE de Scalingo, et en interne chez nous, l'explication qui semble la plus plausible était qu'il y avait une contention mémoire lorsque les connexions de la nouvelle version de l'app sont ouvertes, et cette de l'ancienne ne sont pas fermées (et que l'OS met en cache dans la RAM les fichiers correspondant aux tables que Postgres lit fréquemment).
+Ça arrive quand la nouvelle app répond aux requêtes, mais que l'ancienne ne s'est pas encore fermé.
+A ce moment là, l'OS commence à swapper, et même si la mémoire est libérée sur les connexions qui sont fermées, il semble qu'il mette du temps à remettre en RAM la mémoire qui a été mise dans le disque.
+
+Pour rappel :
+- chaque connexion à postgres prend un peu de mémoire (je pense que c'est un petit process, similaire à un serveur web en fait), et quand on fait un déploy on ouvre plein de nouvelles connexions d'un coup
+- le swap n'est pas parfait : quand il y a toutes ces connexions qui se créent, et toutes les autre qui se ferment, il y a quand même de la "contention mémoire", c'est à dire que l'os doit arbitrer qui garder en ram et qui swapper, et cet arbitrage peut mener à ce que les nouvelles connexions soient en swap même après que les anciennes ont libéré leur ram.
+
+## Solution
+
+Le nombre de connexions avait été augmenté dans https://github.com/betagouv/rdv-service-public/pull/4695
+L'intention était d'éviter que les serveurs web attendent pour obtenir une connexion dans le cas où tous les thread d'un process sont en train de faire une requête, mais ce cas est très rare.
+
+Au final, l'intérêt d'un connexion pool est de partager les connexions, pour avoir moins de connexions que de clients qui peuvent les utiliser. Ce n'est pas du tout ce qu'on fait actuellement, puisqu'on prévoit une connexion par thread, en plus des connexions partagées pour `load_async`.
+
+Un grand merci à l'équipe Scalingo, qui nous a aidé à comprendre ce problème et à trouver une solution !
+
+Autres fun facts qu'on a appris :
+- Contrairement à mysql ou d'autres rdbms, Postgres ne charge pas les tables en mémoire, mais il compte sur l'os pour mettre en ram les fichiers des tables qui sont lus fréquemment. C'est à dire que l'OS met en ram des parties du disque (c'est un peu l'inverse du swap), pour que les lectures soient plus rapide (et les écritures aussi je crois).
+- le graphe de mémoire de postgres affiché par scalingo montre la mémoire allouée par les process pg et par le cache en ram fait par l'os.
+- peut-être que le nombre de connexions maximum proposé par Scalingo est un peu ambitieux sur le plan 8G 🤔

--- a/spec/models/active_record_configuration_spec.rb
+++ b/spec/models/active_record_configuration_spec.rb
@@ -1,7 +1,0 @@
-RSpec.describe "ActiveRecord configuration" do # rubocop:disable RSpec/DescribeClass
-  it "has enough connections" do
-    # voir https://guides.rubyonrails.org/configuring.html#config-active-record-global-executor-concurrency
-    pool_size = ActiveRecord::Base.connection.pool.stat[:size]
-    expect(pool_size).to eq(ENV.fetch("RAILS_MAX_THREADS", 5) + Rails.configuration.active_record.global_executor_concurrency)
-  end
-end


### PR DESCRIPTION
Cette PR ajuste le nombre de connexions à la db pour éviter de saturer notre serveur postgres de connexions inutilisées qui saturent la mémoire.

## Problème

<img width="775" alt="Un exemple d'incident d'effondrement de ram" src="https://github.com/user-attachments/assets/86df4529-e83a-4eb4-a95b-38bb1ec1c26f" />

On a eu plusieurs incidents pendant des mises en productions lors desquels on avait des "effondrements de RAM".
Après beaucoup de temps d'investigation par l'équipe SRE de Scalingo, et en interne chez nous, l'explication qui semble la plus plausible était qu'il y avait une contention mémoire lorsque les connexions de la nouvelle version de l'app sont ouvertes, et cette de l'ancienne ne sont pas fermées (et que l'OS met en cache dans la RAM les fichiers correspondant aux tables que Postgres lit fréquemment).
Ça arrive quand la nouvelle app répond aux requêtes, mais que l'ancienne ne s'est pas encore fermé.
A ce moment là, l'OS commence à swapper, et même si la mémoire est libérée sur les connexions qui sont fermées, il semble qu'il mette du temps à remettre en RAM la mémoire qui a été mise dans le disque.

Pour rappel :
- chaque connexion à postgres prend un peu de mémoire (je pense que c'est un petit process, similaire à un serveur web en fait), et quand on fait un déploy on ouvre plein de nouvelles connexions d'un coup
- le swap n'est pas parfait : quand il y a toutes ces connexions qui se créent, et toutes les autre qui se ferment, il y a quand même de la "contention mémoire", c'est à dire que l'os doit arbitrer qui garder en ram et qui swapper, et cet arbitrage peut mener à ce que les nouvelles connexions soient en swap même après que les anciennes ont libéré leur ram.

## Solution

Le nombre de connexions avait été augmenté dans https://github.com/betagouv/rdv-service-public/pull/4695
L'intention était d'éviter que les serveurs web attendent pour obtenir une connexion dans le cas où tous les thread d'un process sont en train de faire une requête, mais ce cas est très rare.

Au final, l'intérêt d'un connexion pool est de partager les connexions, pour avoir moins de connexions que de clients qui peuvent les utiliser. Ce n'est pas du tout ce qu'on fait actuellement, puisqu'on prévoit une connexion par thread, en plus des connexions partagées pour `load_async`.

Un grand merci à l'équipe Scalingo, qui nous a aidé à comprendre ce problème et à trouver une solution !

Autres fun facts qu'on a appris :
- Contrairement à mysql ou d'autres rdbms, Postgres ne charge pas les tables en mémoire, mais il compte sur l'os pour mettre en ram les fichiers des tables qui sont lus fréquemment. C'est à dire que l'OS met en ram des parties du disque (c'est un peu l'inverse du swap), pour que les lectures soient plus rapide (et les écritures aussi je crois).
- le graphe de mémoire de postgres affiché par scalingo montre la mémoire allouée par les process pg et par le cache en ram fait par l'os.
- peut-être que le nombre de connexions maximum proposé par Scalingo est un peu ambitieux sur le plan 8G 🤔 