### PR TITLE
Bugfix: répare la recherche agent par e-mail

### DIFF
--- a/app/models/concerns/text_search.rb
+++ b/app/models/concerns/text_search.rb
@@ -38,8 +38,11 @@ module TextSearch
 
       term = clean_search_term(term)
 
-      if columns.map(&:name).any? { |column| column =~ /email/i } && looks_like_email(term)
-        where("\"#{table_name}\".\"email\" LIKE ? OR \"#{table_name}\".\"notification_email\" LIKE ?", "#{term}%", "#{term}%")
+      email_columns = columns.map(&:name).intersection(%w[email notification_email])
+      if email_columns.any? && looks_like_email(term)
+        email_columns.map do |email_column|
+          where("\"#{table_name}\".\"#{email_column}\" LIKE ?", "#{term}%")
+        end.reduce(:or)
       else
         full_text_search(term)
       end

--- a/spec/models/concerns/text_search_spec.rb
+++ b/spec/models/concerns/text_search_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe TextSearch, type: :concern do
       expect(described_class.search_by_text("patoche@dur")).to eq([patricia])
     end
 
-    it "returns users that match with email" do
+    it "returns users that match with exact email" do
       create(:user, email: "jean@moustache.fr")
       patricia = create(:user, email: "patoche@duroy.fr")
       expect(described_class.search_by_text("patoche@duroy.fr")).to eq([patricia])
@@ -51,6 +51,26 @@ RSpec.describe TextSearch, type: :concern do
       match_in_first_name = create(:user, first_name: "Nicolas", last_name: "Marie")
       match_in_email = create(:user, first_name: "Frédéric", last_name: "Petit", email: "nicolas@example.com")
       expect(described_class.search_by_text("nicolas")).to eq([match_in_last_name, match_in_first_name, match_in_email])
+    end
+  end
+
+  describe(Agent) do
+    it "returns agents that match with first name" do
+      create(:agent, first_name: "jean")
+      martine = create(:agent, first_name: "martine")
+      expect(described_class.search_by_text("martine")).to eq([martine])
+    end
+
+    it "returns agent that match with partial email" do
+      create(:agent, email: "jean@moustache.fr")
+      martine = create(:agent, email: "martine@validay.fr")
+      expect(described_class.search_by_text("martine@val")).to eq([martine])
+    end
+
+    it "returns agent that match with exact email" do
+      create(:agent, email: "jean@moustache.fr")
+      martine = create(:agent, email: "martine@validay.fr")
+      expect(described_class.search_by_text("martine@validay.fr")).to eq([martine])
     end
   end
 end


### PR DESCRIPTION
Dans #5101 on a oublié qu'on impactait aussi la recherche agent.

J'ajoute donc des specs pour la recherche agent : 
- recherche libre, qui utiliser `pg_search` (oh, on dirait qu'il manque un index pour cette recherche... mais en fait avec 40 agents par orga c'est pas un problème)
- recherche qui ressemble à un e-mail -> on recherche uniquement sur la colonne `email`