### PR TITLE
Ajout du nombre de créneaux à l'API rdvi

### DIFF
--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -18,7 +18,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def number_of_creneaux_available
-    invitation_search_context.matching_motifs.sum do |motif|
+    @number_of_creneaux_available ||= invitation_search_context.matching_motifs.sum do |motif|
       if motif.phone?
         creneaux_available_for_motif(motif).size
       else

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -2,7 +2,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
 
   def creneau_availability
-    render json: { creneau_availability: creneau_available? }
+    render json: { creneau_availability: creneau_available?, creneau_availability_count: number_of_creneaux_available }
   rescue StandardError => e
     render json: { error: e.message }, status: :internal_server_error
   end
@@ -14,22 +14,35 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def creneau_available?
-    invitation_search_context.matching_motifs.any? do |motif|
-      if motif.phone?
-        creneaux_available_for_motif?(motif)
-      else
-        motif.lieux.any? { |lieu| creneaux_available_for_motif?(motif, lieu) }
-      end
+    creneaux_available.any? { |creneau| creneau[:creneau_available] }
+  end
+
+  def number_of_creneaux_available
+    creneaux_available.sum { |creneau| creneau[:number_of_creneaux] }
+  end
+
+  def creneaux_available
+    @creneaux_available ||= invitation_search_context.matching_motifs.map do |motif|
+      number_of_creneaux = if motif.phone?
+                             creneaux_available_for_motif(motif).size
+                           else
+                             motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
+                           end
+
+      {
+        number_of_creneaux:,
+        creneau_available: number_of_creneaux > 0,
+      }
     end
   end
 
-  def creneaux_available_for_motif?(motif, lieu = nil)
+  def creneaux_available_for_motif(motif, lieu = nil)
     CreneauxSearch::ForUser.new(
       user: user,
       motif: motif,
       lieu: lieu,
       geo_search: invitation_search_context.geo_search
-    ).creneaux.any?
+    ).creneaux
   end
 
   def invitation_search_context

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -14,25 +14,16 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def creneau_available?
-    creneaux_available.any? { |creneau| creneau[:creneau_available] }
+    number_of_creneaux_available > 0
   end
 
   def number_of_creneaux_available
-    creneaux_available.sum { |creneau| creneau[:number_of_creneaux] }
-  end
-
-  def creneaux_available
-    @creneaux_available ||= invitation_search_context.matching_motifs.map do |motif|
-      number_of_creneaux = if motif.phone?
-                             creneaux_available_for_motif(motif).size
-                           else
-                             motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
-                           end
-
-      {
-        number_of_creneaux:,
-        creneau_available: number_of_creneaux > 0,
-      }
+    invitation_search_context.matching_motifs.sum do |motif|
+      if motif.phone?
+        creneaux_available_for_motif(motif).size
+      else
+        motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
+      end
     end
   end
 

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe "Available Creneaux Count for Invitation" do
           let!(:"organisation_ids[]") { [organisation1.id] }
 
           it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
+          it { expect(parsed_response_body["creneau_availability_count"]).to eq(5) }
         end
 
         context "Quand le user est spécifié" do


### PR DESCRIPTION
Comme évoqué lors de notre point tech jeudi dernier, cette PR a vocation à rendre disponible le comptage du nombre de créneaux disponibles côté rdvi. 

Grâce à cette PR nous allons pouvoir mettre en place une CRON que nous lancerons tous les matins pour compter les créneaux disponibles pour tous les combos organisation_id/motif_category_id que nous avons chez nous (927). 

Merci d'avance ! 🙏 

Ticket relié chez nous : https://github.com/gip-inclusion/rdv-insertion/issues/2580