### PR TITLE
Permettre de configurer le idle_timeout depuis une variable d'environnement

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -39,6 +39,10 @@ default: &default
   # For GoodJob container, pool size is GOOD_JOB_MAX_THREADS (5) + 3 (1 for LISTEN/NOTIFY, 2 for CRON)
   pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : (ENV.fetch("RAILS_MAX_THREADS", 5).to_i) %>
 
+  # idle_timeout permet de définir au bout de combien de secondes une connexion inactive est fermée
+  # On espère qu'en diminuant cette valeur par rapport au default de Rails (300 secondes), on aura moins de connexions inutilisées, donc moins d'usage mémoire sur la DB
+  idle_timeout: <%=ENV.fetch("RAILS_IDLE_TIMEOUT", 300).to_i %>
+
 development:
   <<: *default
   database: lapin_development


### PR DESCRIPTION
On a essayé de diminuer le nombre de connexions à la db dans https://github.com/betagouv/rdv-service-public/pull/5112, mais ça n'a pas été très efficace (comme anticipé dans https://github.com/betagouv/rdv-service-public/pull/5112#issuecomment-2679395572).

On était à 150 connexions, et on est maintenant entre 132 et 137. Si on ne fait pas d'opération, ça oscille entre ces deux nombres, donc ça confirme que des connexions sont ouvertes et fermées périodiquement.

Par défaut, le reaper du connexion pool tourne toutes les 60 secondes, et ferme toutes les connexions qui ont été inutilisées pendant `idle_timeout`, qui est à 300 secondes (voir  `lib/active_record/connection_adapters/abstract/connection_pool.rb` et `lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb`).

On espère pouvoir diminuer le nombre de connexions inactives en diminuant la valeur de `idle_timeout`, donc on le rend configurable par une variable d'environnement.
Quand on aura trouvé une valeur qui marche bien, on pourra la commiter.