### PR TITLE
Fix : Prendre en compte le `notification_email` dans l'interface pour les mention de notification usager

### DIFF
--- a/app/form_models/admin/rdv_wizard_form/step2.rb
+++ b/app/form_models/admin/rdv_wizard_form/step2.rb
@@ -16,7 +16,7 @@ class Admin::RdvWizardForm::Step2
     return unless rdv.motif.visio?
 
     can_receive_notifications = users.map(&:user_to_notify).any? do |user|
-      user.email.present? ||
+      user.valid_email? ||
         (user.phone_number.present? && PhoneNumberValidation.number_is_mobile?(user.phone_number))
     end
     return if can_receive_notifications

--- a/app/mailers/users/file_attente_mailer.rb
+++ b/app/mailers/users/file_attente_mailer.rb
@@ -16,7 +16,7 @@ class Users::FileAttenteMailer < ApplicationMailer
   private
 
   def save_receipt(subject)
-    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.email, content: subject)
+    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.preferred_email, content: subject)
   end
 
   def domain

--- a/app/mailers/users/rdv_mailer.rb
+++ b/app/mailers/users/rdv_mailer.rb
@@ -47,7 +47,7 @@ class Users::RdvMailer < ApplicationMailer
   private
 
   def save_receipt(subject)
-    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.email, content: subject)
+    Receipt.create!(rdv: @rdv, user: @user, event: action_name, channel: :mail, result: :processed, email_address: @user.preferred_email, content: subject)
   end
 
   def domain

--- a/app/models/file_attente.rb
+++ b/app/models/file_attente.rb
@@ -53,7 +53,7 @@ class FileAttente < ApplicationRecord
           event: :new_creneau_available,
           channel: :mail,
           result: :processed,
-          email_address: user.email
+          email_address: user.preferred_email
         )
       end
 

--- a/app/views/admin/participations/_form.html.slim
+++ b/app/views/admin/participations/_form.html.slim
@@ -12,7 +12,7 @@ div id=element_id
       = render "common/destroy_button", form: form, id: element_id
   .ml-3
     = render "admin/users/notifications_preferences", user: participation.user.user_to_notify
-    - if participation.user.user_to_notify.email.present? || participation.user.user_to_notify.phone_number.present?
+    - if participation.user.user_to_notify.valid_email? || participation.user.user_to_notify.phone_number.present?
       h6= t("admin.participations.notifications_overrides")
       = form.input :send_lifecycle_notifications, wrapper: false
       - if current_organisation.rdv_insertion?

--- a/app/views/admin/participations/_notifications_email.html.slim
+++ b/app/views/admin/participations/_notifications_email.html.slim
@@ -1,8 +1,8 @@
-- if participation.user.user_to_notify.email.present?
+- if participation.user.user_to_notify.valid_email?
   - if participation.user.user_to_notify.notify_by_email?
     span.mr-1
       i.fa.fa-envelope.text-primary-blue.mr-2
-      strong.word-break-all = participation.user.user_to_notify.email
+      strong.word-break-all = participation.user.user_to_notify.preferred_email
   - else
     span.mr-1
       i.fa.fa-times.text-primary-blue.mr-2

--- a/app/views/admin/rdv_wizard_steps/_participation_form.html.slim
+++ b/app/views/admin/rdv_wizard_steps/_participation_form.html.slim
@@ -21,7 +21,7 @@ div id=element_id
         i.fa.fa-edit
   .ml-3
     = render "admin/users/notifications_preferences", user: user.user_to_notify
-    - if participation.user.user_to_notify.email.present? || participation.user.user_to_notify.phone_number.present?
+    - if participation.user.user_to_notify.valid_email? || participation.user.user_to_notify.phone_number.present?
       h6= t("admin.participations.notifications_overrides")
       = form.input :send_lifecycle_notifications, wrapper: false
       - if current_organisation.rdv_insertion?

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -24,7 +24,7 @@
           ruby:
             user = participation.user
             phone_number = user.user_to_notify&.phone_number
-            email = user.user_to_notify&.email
+            email = user.user_to_notify&.preferred_email
           div
             span.font-weight-bold.lead
               = user

--- a/app/views/admin/users/_notifications_preferences.html.slim
+++ b/app/views/admin/users/_notifications_preferences.html.slim
@@ -1,15 +1,15 @@
 / Component: display the user notification settings
   depending on :email :phone_number :notify_by_email and :notify_by_sms
 
-- if user.email.present?
+- if user.valid_email?
   - if user.notify_by_email?
     = boolean_tag(true) do
       div= t(".email_present_and_enabled")
-      code= user.email
+      code= user.preferred_email
   - else
     = boolean_tag(false) do
       div= t(".email_disabled")
-      code= user.email
+      code= user.preferred_email
 - else
   = boolean_tag(false) do
     = t(".email_absent")

--- a/app/views/admin/users/_user.html.slim
+++ b/app/views/admin/users/_user.html.slim
@@ -4,4 +4,4 @@ tr
     span>= relative_tag(user)
   td= birth_date_and_age(user)
   td= user.phone_number
-  td.word-break-all= user.email
+  td.word-break-all= user.preferred_email

--- a/app/views/agents/rdv_plans/rdv.html.slim
+++ b/app/views/agents/rdv_plans/rdv.html.slim
@@ -24,7 +24,7 @@
         .fr-mt-2w
           span.fr-icon-user-fill.fr-mr-1w[aria-hidden="true"]
           = @rdv_plan.user.full_name
-          .fr-ml-4w= @rdv_plan.user.email
+          .fr-ml-4w= @rdv_plan.user.preferred_email
           .fr-ml-4w= @rdv_plan.user.phone_number
 
         .fr-mt-4w

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -59,7 +59,7 @@ ul.list-group.list-group-flush
       .row
         .col.ml-3
           span> ✉️ Email&nbsp;:
-          b>= current_user.email
+          b>= current_user.preferred_email
           span>= "(notifications par email #{current_user.notify_by_email? ? 'activées' :  'désactivées'})"
       .row
         .col.ml-3

--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Agent can create a Rdv with wizard" do
     # create user with mail
     fill_in :user_first_name, with: "Jean-Paul"
     fill_in :user_last_name, with: "Orvoir"
-    expect(page).to have_selector(".user_email")
+    fill_in :user_email, with: "jporvoir@bidule.com"
     click_button("Créer usager")
 
     # create user without email
@@ -171,6 +171,21 @@ RSpec.describe "Agent can create a Rdv with wizard" do
         expect(WebMock).to(have_requested(:post, "https://example.com/").with do |req|
           JSON.parse(req.body)["data"]["users"].pluck("id") == [user.id]
         end)
+      end
+    end
+
+    describe "with a user with a notification email" do
+      let(:user_with_notification_email) { create(:user, :without_devise_email, notification_email: "user_with_notif_email@test.com", organisations: [organisation]) }
+
+      it "works", js: true do
+        step1
+        select_user(user_with_notification_email)
+        click_button("Continuer")
+        step3(:enabled)
+        expect(page).to have_content("Reçoit les notifications par email")
+        expect(page).to have_content("user_with_notif_email@test.com")
+        click_button("Confirmer le RDV")
+        expect(user_with_notification_email.rdvs.count).to eq(1)
       end
     end
   end

--- a/spec/features/agents/rdv_details_spec.rb
+++ b/spec/features/agents/rdv_details_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe "Agent can see RDV details correctly" do
       expect(page).to have_text(user.phone_number)
     end
 
+    it "show good notification preferences when user has a notification_email" do
+      user.update(email: nil, notification_email: "test@test.fr")
+      visit admin_organisation_rdv_path(organisation, rdv)
+      expect(page).to have_text(user.notification_email)
+      expect(page).not_to have_text(I18n.t("admin.users.notifications_preferences.email_absent"))
+    end
+
     context "The rdv has multiple users" do
       let(:user2) { create(:user, :without_devise_email, :with_no_phone_number, organisations: [organisation]) }
 

--- a/spec/models/concerns/participation/creatable_spec.rb
+++ b/spec/models/concerns/participation/creatable_spec.rb
@@ -7,10 +7,14 @@ RSpec.describe Participation::Creatable, type: :concern do
   describe "Participation create" do
     let(:agent) { create :agent }
     let(:user) { create :user }
+    let(:user2) { create :user, :without_devise_email, notification_email: "notif@email.fr" }
     let(:user3) { create :user }
     let!(:organisation) { create(:organisation) }
     let(:relative) do
       create(:user, :relative, :without_devise_email, responsible: user, first_name: "Petit", last_name: "Bébé")
+    end
+    let(:relative2) do
+      create(:user, :relative, :without_devise_email, responsible: user2, first_name: "Grand", last_name: "Bébé")
     end
     let(:rdv) { create :rdv, :collectif, :without_users, starts_at: Time.zone.tomorrow, agents: [agent], organisation: }
 
@@ -25,7 +29,7 @@ RSpec.describe Participation::Creatable, type: :concern do
       end
     end
 
-    describe "with notifications" do
+    describe "with notifications for devise email" do
       let(:participation1) { build(:participation, rdv: rdv, user: user) }
       let(:participation_relative) { build(:participation, rdv: rdv, user: relative) }
 
@@ -41,6 +45,28 @@ RSpec.describe Participation::Creatable, type: :concern do
         participation1.save!
         participation_relative.create_and_notify!(user)
         expect_notifications_sent_for(rdv, user, :rdv_created)
+        expect_notifications_sent_for(rdv, agent, :rdv_created)
+        expect(rdv.reload.participations).to eq([participation_relative])
+        expect(participation1.participation_token).to be_nil
+      end
+    end
+
+    describe "with notifications for a notification email" do
+      let(:participation1) { build(:participation, rdv: rdv, user: user2) }
+      let(:participation_relative) { build(:participation, rdv: rdv, user: relative2) }
+
+      it "for self (user2)" do
+        participation1.create_and_notify!(user2)
+        expect_notifications_sent_for(rdv, user2, :rdv_created)
+        expect_notifications_sent_for(rdv, agent, :rdv_created)
+        expect(rdv.reload.participations).to eq([participation1])
+        expect(participation1.participation_token).to eq("12345")
+      end
+
+      it "for a relative with existing participations" do
+        participation1.save!
+        participation_relative.create_and_notify!(user2)
+        expect_notifications_sent_for(rdv, user2, :rdv_created)
         expect_notifications_sent_for(rdv, agent, :rdv_created)
         expect(rdv.reload.participations).to eq([participation_relative])
         expect(participation1.participation_token).to be_nil

--- a/spec/support/notifications_helper.rb
+++ b/spec/support/notifications_helper.rb
@@ -32,7 +32,7 @@ module NotificationsHelper
 
   def expect_no_notifications_for_user(user)
     perform_enqueued_jobs
-    expect(ActionMailer::Base.deliveries.map(&:to).flatten).not_to include(user.email)
+    expect(ActionMailer::Base.deliveries.map(&:to).flatten).not_to include(user.preferred_email)
     expect(Receipt.where(user_id: user.id, channel: "sms", result: "delivered").count).to eq 0
   end
 
@@ -45,18 +45,19 @@ module NotificationsHelper
   private
 
   def expect_email_sent_for(rdv, person, event)
-    expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(person.email)
     if person.instance_of?(User)
-      expect(email_sent_to(person.email).subject).to include(email_title_for_user(rdv, event))
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(person.preferred_email)
+      expect(email_sent_to(person.preferred_email).subject).to include(email_title_for_user(rdv, event))
     elsif person.instance_of?(Agent)
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(person.email)
       expect(email_sent_to(person.email).subject).to include(email_title_for_agent(rdv, person, event))
     end
   end
 
   def expect_no_email_sent_for(rdv, person, event)
     if person.instance_of?(User)
-      if ActionMailer::Base.deliveries.map(&:to).flatten.include?(person.email)
-        expect(email_sent_to(person.email).subject).not_to include(email_title_for_user(rdv, event))
+      if ActionMailer::Base.deliveries.map(&:to).flatten.include?(person.preferred_email)
+        expect(email_sent_to(person.preferred_email).subject).not_to include(email_title_for_user(rdv, event))
       end
     elsif person.instance_of?(Agent)
       if ActionMailer::Base.deliveries.map(&:to).flatten.include?(person.email)


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-service-public/pull/5003
Nous avons eu des retours d'agent qui nous ont remonté des problèmes d'affichage de l'email dans l'interface rdvsp.
En effet plusieurs oublie dans la PR précédente font que l'usager s'affiche sans email et sans notification email activé dans le front alors qu'il a bien un email de notification renseigné et qu'il reçoit bien les emails de notification. Il s'agit uniquement d'un problème d'affichage.
Je règle ici les cas que j'ai identifié. J'ajoute également quelques tests manquants pour la logique d'envoi de mail vers le `notification_email` et le bon affichage dans le front.