### PR TITLE
Éviter de compter les créneaux pour rien

### DIFF
--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -2,7 +2,13 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
 
   def creneau_availability
-    render json: { creneau_availability: creneau_available?, creneau_availability_count: number_of_creneaux_available }
+    payload = if params[:total_count] == "true"
+                { creneau_availability_count: }
+              else
+                { creneau_availability: creneau_available? }
+              end
+
+    render json: payload
   rescue StandardError => e
     render json: { error: e.message }, status: :internal_server_error
   end
@@ -13,16 +19,22 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
     @user ||= Invitation.new(invitation_link_hash).user
   end
 
-  def creneau_available?
-    number_of_creneaux_available > 0
+  def creneau_availability_count
+    invitation_search_context.matching_motifs.sum do |motif|
+      if motif.phone?
+        creneaux_available_for_motif(motif)
+      else
+        motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu) }
+      end
+    end
   end
 
-  def number_of_creneaux_available
-    @number_of_creneaux_available ||= invitation_search_context.matching_motifs.sum do |motif|
+  def creneau_available?
+    invitation_search_context.matching_motifs.any? do |motif|
       if motif.phone?
-        creneaux_available_for_motif(motif).size
+        creneaux_available_for_motif(motif).any?
       else
-        motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
+        motif.lieux.any? { |lieu| creneaux_available_for_motif(motif, lieu).any? }
       end
     end
   end

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -22,9 +22,9 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   def creneau_availability_count
     invitation_search_context.matching_motifs.sum do |motif|
       if motif.phone?
-        creneaux_available_for_motif(motif)
+        creneaux_available_for_motif(motif).size
       else
-        motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu) }
+        motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
       end
     end
   end

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "Available Creneaux Count for Invitation" do
       parameter name: "lieu_id", in: :query, type: :string, description: "L'ID du lieu de recherche", example: "1", required: false
       parameter name: "organisation_ids[]", in: :query, schema: { type: :array, items: { type: :string } }, description: "Les IDs des organisations de recherche", example: %w[1 2 3], required: false
       parameter name: "referent_ids[]", in: :query, schema: { type: :array, items: { type: :string } }, description: "Les IDs des référents de recherche", example: %w[1 2 3], required: false
+      parameter name: "total_count", in: :query, type: :string, description: "Est-ce que l'endpoint doit renvoyer le total ou un booléen", example: "true", required: false
 
       let!(:user) { create(:user, organisations: [organisation1], rdv_invitation_token: "user_token") }
       let!(:user_with_referent) { create(:user, referent_agents: [agent], organisations: [organisation1], rdv_invitation_token: "user_with_referent_token") }
@@ -214,6 +215,7 @@ RSpec.describe "Available Creneaux Count for Invitation" do
 
         context "Avec un motif_category_shortname" do
           let!(:motif_category_short_name) { "rsa_orientation" }
+          let!(:total_count) { "true" }
           let!(:"organisation_ids[]") { [organisation1.id] }
 
           it { expect(parsed_response_body["creneau_availability"]).to be_truthy }

--- a/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
+++ b/spec/requests/api/rdvinsertion/creneau_availability_request_spec.rb
@@ -215,11 +215,15 @@ RSpec.describe "Available Creneaux Count for Invitation" do
 
         context "Avec un motif_category_shortname" do
           let!(:motif_category_short_name) { "rsa_orientation" }
-          let!(:total_count) { "true" }
           let!(:"organisation_ids[]") { [organisation1.id] }
 
           it { expect(parsed_response_body["creneau_availability"]).to be_truthy }
-          it { expect(parsed_response_body["creneau_availability_count"]).to eq(5) }
+
+          context "Avec le paramètre total_count" do
+            let!(:total_count) { "true" }
+
+            it { expect(parsed_response_body["creneau_availability_count"]).to eq(5) }
+          end
         end
 
         context "Quand le user est spécifié" do


### PR DESCRIPTION
Comme évoqué tout à l'heure, cette PR est un revert partiel permettant d'éviter de compter les créneaux dans des cas où l'on ne s'en servirait pas. 
En effet l'endpoint en prod devenait trop lent pour notre cas principal (check à l'envoi d'invitation pour éviter d'envoyer pour rien). 

Le code se répète pas mal mais je pense qu'il est clair en l'état et ne mérite pas plus de séparation selon moi. 
