### PR TITLE
Diminution du nombre de threads

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -37,11 +37,7 @@ default: &default
   #
   #
   # For GoodJob container, pool size is GOOD_JOB_MAX_THREADS (5) + 3 (1 for LISTEN/NOTIFY, 2 for CRON)
-  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : (ENV.fetch("RAILS_MAX_THREADS", 5).to_i) %>
-
-  # idle_timeout permet de définir au bout de combien de secondes une connexion inactive est fermée
-  # On espère qu'en diminuant cette valeur par rapport au default de Rails (300 secondes), on aura moins de connexions inutilisées, donc moins d'usage mémoire sur la DB
-  idle_timeout: <%=ENV.fetch("RAILS_IDLE_TIMEOUT", 300).to_i %>
+  pool: <%= $PROGRAM_NAME.include?("good_job") ? ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i + 3 : (ENV.fetch("RAILS_MAX_THREADS", 4).to_i) %>
 
 development:
   <<: *default

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -6,7 +6,7 @@ class Redis
   POOL_TIMEOUT = 5 # amount of time to wait for a connection if none currently available in the pool
   REDIS_TIMEOUT = 5 # timeout for each individual connection, see https://github.com/redis/redis-rb?tab=readme-ov-file#timeouts
 
-  CONNECTION_POOL = ConnectionPool.new(size: ENV.fetch("RAILS_MAX_THREADS", 5), timeout: POOL_TIMEOUT) do
+  CONNECTION_POOL = ConnectionPool.new(size: ENV.fetch("RAILS_MAX_THREADS", 4), timeout: POOL_TIMEOUT) do
     redis_connection = new(url: Rails.configuration.x.redis_url, timeout: REDIS_TIMEOUT)
     Redis::Namespace.new(Rails.configuration.x.redis_namespace, redis: redis_connection)
   end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 3 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 4)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 3 }
+workers ENV.fetch("WEB_CONCURRENCY", 3)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/5116 et https://github.com/betagouv/rdv-service-public/pull/5112


# Contexte

On essaye de diminuer le nombre de connexions inutiles à la db, pour éviter la contention mémoire au moment de l'ouverture de nouvelles connexions lors des déploiement, ce qui cause du swap qui entraine du downtime.

## Retour sur les tentatives précédentes

Les deux approches essayées précedemment n'ont pas eu beaucoup d'impact.
On a commencé avec environ 150 connexions pendant les périodes de charge (horaires de bureau)

### Diminution de la taille du pool (#5112 )

Cette PR a fait passer le nombre de connexions d'environ 150 à environ 135 : elle diminue la taille du pool, mais en faisant le calcul du nombre maximum de connexions (nombre de worker webs scalingo * nombre de process puma * valeur de connexion pool dans le database.yml), on s'est rendu compte qu'on ouvrait très rarement le nombre de connexions maximum autorisées.

Ça nous a appris qu'on pourrait sans doute mieux tirer avantage du connection pool en ayant moins de connexions que de threads (si ça arrive que toutes les connexions du pool sont utilisées en même temps, c'est apparemment très bref).

### Diminution du  délai de fermeture des connexions inutilisées (`idle_timeout`, #5116)

On a passé le idle_timeout de 300  à 180 secondes, mais ça n'a pas eu d'impact : le nombre de connexions en période de charge n'a pas changé. Ça veut dire qu'environ au moins une fois toutes les 3 minutes toutes les connexions du pool sont utilisées.
C'est important de noter que chaque pool est assez petit : puisqu'il est par process, on a en fait 24 pools de 5 connexions (le 24 vient de 8 workers scalingos qui ont chacun 3 process puma, le 5 vient de la valeur indiquée dans le database.yml).
Peut-être que si on avait des plus gros pool on verrait un effet, mais ça pose d'autre questions d'équilibrage nombre de process/nombre de thread (notamment d'usage mémoire)

# Solution

On a fait avec Adrien un calcul très approximatif : en période de charge on a environ 5K requêtes par minute. On n'a pas d'information sur la durée moyenne d'une requête (seulement la médiane, et on est sur le genre de distribution où la médiane est largement en dessous de la moyenne), mais on pourrait supposer qu'elle est de 250ms.
On a donc environ 80 requêtes par seconde, qui durent 0.25 secondes, donc chaque seconde on passe 20 secondes à répondre à des requêtes, donc on pourrait avoir 20 threads (tous workers confondus), et être capable de répondre à toutes les requêtes.

Evidemment, ce n'est pas aussi simple que ça, mais c'est intéressant de voir ce résultat par rapport aux 120 threads qu'on a actuellement 🙃 

En tout cas à ça nous a rassurés sur le fait que c'est sans doute raisonnable de passer le nombre de threads par process de 5 à 4, ce qui veut dire que le nombre de threads total sera de 96.

En manipulant la variable d'env, on a pu voir que ça n'avait pas d'influence sur les temps de réponse, et que ça limitait le nombre maximum de connexions à la base à 112, ce qui est une nette amélioration.

Par ailleurs, on a tendance à avoir du swap sur les workers web depuis quelques temps, donc c'est peut-être pas une mauvaise chose d'avoir un peu moins de threads.


### Configuration dans le code vs dans les variables d'env

C'est pratique de pouvoir manipuler les variables d'env, mais en attendant d'avoir du vrai infrastructure as code c'est aussi pratique d'avoir un historique sur la date de modification de la config. On garde donc la possiblité de faire des override avec les variables d'env, mais on préfère les utiliser ponctuellement pour faire des tests.

J'en profite pour expliciter notre nombre de workers puma qui était difficile à comprendre sans aller voir notre config de production jusqu'à maintenant.