### PR TITLE
Suppression des colonnes `invitations_count` (étape 1)

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,7 +1,7 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  self.ignored_columns += [:inclusion_connect_open_id_sub]
+  self.ignored_columns += %i[inclusion_connect_open_id_sub invitations_count]
   # Mixins
   has_paper_trail(
     only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  self.ignored_columns += %i[invitations_count]
+
   # Mixins
   has_paper_trail(
     only: %w[


### PR DESCRIPTION
En travaillant sur les index superflus dans #5045, j'ai constaté que cette colonne était toujours à 0, que ce soit dans la table `agents` comme la table `users`.

```ruby
User.where("invitations_count > 0").count
# => 0

Agent.where("invitations_count > 0").count
# => 0
```