### PR TITLE
Utilisation DSFR radio/checkbox parcours usager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ gem "rails_autolink"
 # ActionView helper to render currently active links
 gem "active_link_to"
 gem "dsfr-view-components"
-gem "dsfr-form_builder", "= 0.0.3" # On fixe la version tant qu’on est pas en 1.0
+gem "dsfr-form_builder", "= 0.0.5" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.
 gem "premailer-rails" # Mail formatting

--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ gem "rails_autolink"
 # ActionView helper to render currently active links
 gem "active_link_to"
 gem "dsfr-view-components"
-gem "dsfr-form_builder", "= 0.0.5" # On fixe la version tant qu’on est pas en 1.0
+gem "dsfr-form_builder", "= 0.0.6" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.
 gem "premailer-rails" # Mail formatting

--- a/Gemfile
+++ b/Gemfile
@@ -133,7 +133,7 @@ gem "rails_autolink"
 # ActionView helper to render currently active links
 gem "active_link_to"
 gem "dsfr-view-components"
-gem "dsfr-form_builder", "= 0.0.6" # On fixe la version tant qu’on est pas en 1.0
+gem "dsfr-form_builder", "= 0.0.7" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.
 gem "premailer-rails" # Mail formatting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.1)
     dsfr-assets (1.13.0.1)
-    dsfr-form_builder (0.0.5)
+    dsfr-form_builder (0.0.6)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
@@ -787,7 +787,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   drb
-  dsfr-form_builder (= 0.0.5)
+  dsfr-form_builder (= 0.0.6)
   dsfr-view-components
   factory_bot
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.1)
     dsfr-assets (1.13.0.1)
-    dsfr-form_builder (0.0.6)
+    dsfr-form_builder (0.0.7)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
@@ -787,7 +787,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   drb
-  dsfr-form_builder (= 0.0.6)
+  dsfr-form_builder (= 0.0.7)
   dsfr-view-components
   factory_bot
   faker

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
       railties (>= 3.2)
     drb (2.2.1)
     dsfr-assets (1.13.0.1)
-    dsfr-form_builder (0.0.3)
+    dsfr-form_builder (0.0.5)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
@@ -350,7 +350,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.5)
+    logger (1.6.6)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -787,7 +787,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   drb
-  dsfr-form_builder (= 0.0.3)
+  dsfr-form_builder (= 0.0.5)
   dsfr-view-components
   factory_bot
   faker

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -17,7 +17,7 @@
               - current_user.available_users_for_rdv.each do |user|
                 = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: (user.id.in?(@rdv.user_ids)), name: "rdv[user_ids][]" }, user.id, nil
           - else
-            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: (user.id.in?(@rdv.user_ids))} }
+            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: (user.id.in?(@rdv.user_ids) || current_user.id == user.id)} }
             = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "rdv[user_ids][]"
 
           .form-group

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -22,4 +22,5 @@
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
           .rdv-text-align-right
+            = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-btn fr-btn--secondary fr-mr-2w"
             = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -6,35 +6,20 @@
     .card
       = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
       .card-body
-        = simple_form_for(@rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv)), method: :post) do |f|
+        = form_for @rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv)), method: :post, builder: Dsfr::FormBuilder do |f|
 
-          = f.association :motif, as: :hidden, wrapper_html: { class: "mb-0" }
-          = f.input :starts_at, as: :hidden, wrapper_html: { class: "mb-0" }
+          = f.hidden_field :motif_id
+          = f.hidden_field :starts_at
 
           div Pour qui prenez-vous rendez-vous ?
           - if current_domain == Domain::RDV_MAIRIE
-            .custom-control.custom-checkbox
-              .form-group
-                - current_user.available_users_for_rdv.each do |user|
-                  div
-                    = f.check_box :user_ids, { multiple: true, class: "form-check-input" }, user.id, false
-                    = f.label "user_ids_#{user.id}", full_name_and_birthdate(user), class: "form-check-label"
+            - current_user.available_users_for_rdv.each do |user|
+              = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: user.id == current_user.id, name: "rdv[user_ids][]" }, user.id, nil
           - else
-            / https://blog.bigbinary.com/2016/05/18/rails-5-add-a-hidden-field-on-collection-radio-buttons.html
-            = f.association \
-                :users,
-                label: "",
-                as: :radio_buttons,
-                include_hidden: false,
-                collection: current_user.available_users_for_rdv,
-                checked: (current_user.participation_for(@rdv)&.user&.id || current_user.id),
-                label_method: lambda { |user| full_name_and_birthdate(user) },
-                wrapper_html: { class: "mb-0" },
-                input_html: { name: "rdv[user_ids][]" }
+            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: user.id == current_user.id} }
+            = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true
+
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
-          .row
-            .col
-              = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "btn btn-link"
-            .col
-              = f.button :submit, "Continuer"
+          .rdv-text-align-right
+            = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -13,11 +13,12 @@
 
           div Pour qui prenez-vous rendez-vous ?
           - if current_domain == Domain::RDV_MAIRIE
-            - current_user.available_users_for_rdv.each do |user|
-              = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: user.id == current_user.id, name: "rdv[user_ids][]" }, user.id, nil
+            .fr-mt-2w
+              - current_user.available_users_for_rdv.each do |user|
+                = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: (user.id.in?(@rdv.user_ids)), name: "rdv[user_ids][]" }, user.id, nil
           - else
-            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: user.id == current_user.id} }
-            = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true
+            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: (user.id.in?(@rdv.user_ids))} }
+            = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "rdv[user_ids][]"
 
           .form-group
             = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }

--- a/spec/features/users/online_booking/on_rdv_mairie_spec.rb
+++ b/spec/features/users/online_booking/on_rdv_mairie_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe "User can search rdv on rdv mairie" do
       alain = User.find_by(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211")
       expect(alain).to be_present
 
-      check "Marco POLO"
-      check "Alain MAIRIE"
+      check("Marco POLO", allow_label_click: true)
+      check("Alain MAIRIE", allow_label_click: true)
       click_button "Continuer"
 
       click_link "Confirmer mon RDV"
@@ -221,8 +221,8 @@ RSpec.describe "User can search rdv on rdv mairie" do
       # on attend que le proche soit bien enregistré dans la DB pour éviter une flaky spec (causée par l'animation CSS de la modale ?)
       wait_for { User.exists?(first_name: "Alain", last_name: "Mairie", ants_pre_demande_number: "5544332211") }.to be(true)
 
-      check "Marco POLO"
-      check "Alain MAIRIE"
+      check("Marco POLO", allow_label_click: true)
+      check("Alain MAIRIE", allow_label_click: true)
       click_button "Continuer"
 
       click_link "Confirmer mon RDV"


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5124.osc-secnum-fr1.scalingo.io/) 

# Contexte

Dans la continuité du passage de l’interface usagers au DSFR, on migre les radios buttons et les checkbox de la sélection d’usager.

# Solution

Les développements spécifiques au DSFR ont été fait dans `dsfr-form_builder`. On met donc à jour la Gem et on l’utilise.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/e9fe29f9-a0d1-45df-ae8e-50a7a040ff05) | ![image](https://github.com/user-attachments/assets/6c488706-cc20-48b2-a7bc-0cf124028b0b)
![image](https://github.com/user-attachments/assets/5bd483f0-d10b-404a-af78-d062d068e0f8) | ![image](https://github.com/user-attachments/assets/08e910a8-9152-4ab2-af76-9fc7a6f481ae)

