### PR TITLE
Permettre d’utiliser Crisp dans le formulaire de contact

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -113,5 +113,11 @@ NOTION_API_SECRET=change_me
 # Zammad
 ZAMMAD_API_TOKEN="voir https://zammad10.ethibox.fr/#profile/token_access (clé rattachée à un compte individuel Agent Zammad)"
 
+# Crisp
+CRISP_ENABLED=false
+CRISP_WEBSITE_ID="voir app.crisp.chat > Paramètres > Mise en place et intégration"
+CRISP_IDENTIFIER="voir le plugin dans Crisp Marketplace"
+CRISP_KEY="voir le plugin dans Crisp Marketplace"
+
 # Metabase, pour la carte géographique des lieux sur la page stats
 METABASE_API_KEY="voir dans Admin settings > Authentication depuis https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/"

--- a/.env.sample
+++ b/.env.sample
@@ -118,6 +118,7 @@ CRISP_ENABLED=false
 CRISP_WEBSITE_ID="voir app.crisp.chat > Paramètres > Mise en place et intégration"
 CRISP_IDENTIFIER="voir le plugin dans Crisp Marketplace"
 CRISP_KEY="voir le plugin dans Crisp Marketplace"
+CRISP_URN="voir le plugin dans Crisp Marketplace"
 
 # Metabase, pour la carte géographique des lieux sur la page stats
 METABASE_API_KEY="voir dans Admin settings > Authentication depuis https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/"

--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,7 @@ gem "typhoeus"
 
 # External services
 gem "notion-ruby-client", "~> 1.2"
+gem "crisp-api", "~> 1.1"
 
 # API documentation
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    crisp-api (1.1.12)
+      rest-client (~> 2.0)
     css_parser (1.16.0)
       addressable
     csv (3.3.0)
@@ -230,6 +232,7 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 7.3)
     diff-lcs (1.5.0)
+    domain_name (0.6.20240107)
     doorkeeper (5.7.1)
       railties (>= 5)
     doorkeeper-i18n (5.2.7)
@@ -291,6 +294,9 @@ GEM
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
+    http-accept (1.7.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     icalendar (2.8.0)
@@ -361,6 +367,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2025.0220)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
@@ -383,6 +393,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.3)
     nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
@@ -554,6 +565,11 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.4.0)
     rouge (4.5.1)
     rspec (3.13.0)
@@ -760,6 +776,7 @@ DEPENDENCIES
   common_french_passwords
   connection_pool
   coverband
+  crisp-api (~> 1.1)
   csv
   database_cleaner
   devise!

--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -23,13 +23,25 @@ class DemandeSupportForm
   def submit
     return unless valid?
 
-    CreateZammadTicketJob.perform_later(
-      sender_role: role,
-      email:,
-      subject: ticket_subject,
-      body: ticket_body,
-      tags: [current_domain.to_s]
-    )
+    if ENV.fetch("CRISP_ENABLED", false)
+      CreateCrispTicketJob.perform_later(
+        nickname: "#{first_name} #{last_name}",
+        email: email,
+        phone: phone_number,
+        subject: ticket_subject,
+        message: message,
+        role: role,
+        domain: current_domain.to_s
+      )
+    else
+      CreateZammadTicketJob.perform_later(
+        sender_role: role,
+        email:,
+        subject: ticket_subject,
+        body: ticket_body,
+        tags: [current_domain.to_s]
+      )
+    end
   end
 
   private

--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -28,7 +28,7 @@ class DemandeSupportForm
         nickname: "#{first_name} #{last_name}",
         email: email,
         phone: phone_number,
-        subject: ticket_subject,
+        subject: subject,
         message: message,
         role: role,
         domain: current_domain.to_s
@@ -46,10 +46,14 @@ class DemandeSupportForm
 
   private
 
+  # Nous utilisons cette méthode uniquement pour Zammad car Crisp permet de stocker les inforations de contact
+  # dans les métadonnées de la conversation
   def ticket_subject
     "Demande Support #{role.to_s.capitalize} - #{first_name} #{last_name} - #{sujet}"
   end
 
+  # Nous utilisons cette méthode uniquement pour Zammad car Crisp permet de stocker les informations de contact
+  # dans les métadonnées de la conversation
   def ticket_body
     <<~BODY
       #{message}

--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -28,7 +28,7 @@ class DemandeSupportForm
         nickname: "#{first_name} #{last_name}",
         email: email,
         phone: phone_number,
-        subject: subject,
+        subject: sujet,
         message: message,
         role: role,
         domain: current_domain.to_s

--- a/app/jobs/create_crisp_ticket_job.rb
+++ b/app/jobs/create_crisp_ticket_job.rb
@@ -1,6 +1,6 @@
 class CreateCrispTicketJob < ApplicationJob
   def perform(nickname:, email:, phone:, subject:, message:, role:, domain:)
-    response = client.website.create_new_conversation(website_id)
+    conversation = client.website.create_new_conversation(website_id)
 
     message = <<~MESSAGE
       #{message}
@@ -9,27 +9,31 @@ class CreateCrispTicketJob < ApplicationJob
       Message envoyé depuis le formulaire de contact
     MESSAGE
 
-    query = {
-      "type" => "text",
-      "from" => "user",
-      "origin" => ENV.fetch("CRISP_URN"), # Permet de savoir que le message provient de notre application
-      "content" => message,
-    }
+    client.website.send_message_in_conversation(
+      website_id,
+      conversation["session_id"],
+      {
+        "type" => "text",
+        "from" => "user",
+        "origin" => ENV.fetch("CRISP_URN"), # Permet de savoir que le message provient de notre application
+        "content" => message,
+      }
+    )
 
-    client.website.send_message_in_conversation(website_id, response["session_id"], query)
-
-    data = {
-      nickname:,
-      email:,
-      phone:,
-      segments: [
-        role,
-        domain,
-      ],
-      subject:,
-    }
-
-    client.website.update_conversation_metas(website_id, response["session_id"], data)
+    client.website.update_conversation_metas(
+      website_id,
+      conversation["session_id"],
+      {
+        nickname:,
+        email:,
+        phone:,
+        segments: [
+          role,
+          domain,
+        ],
+        subject:,
+      }
+    )
   end
 
   private

--- a/app/jobs/create_crisp_ticket_job.rb
+++ b/app/jobs/create_crisp_ticket_job.rb
@@ -2,10 +2,17 @@ class CreateCrispTicketJob < ApplicationJob
   def perform(nickname:, email:, phone:, subject:, message:, role:, domain:)
     response = client.website.create_new_conversation(website_id)
 
+    message = <<~MESSAGE
+      #{message}
+
+      ---
+      Message envoyé depuis le formulaire de contact
+    MESSAGE
+
     query = {
       "type" => "text",
       "from" => "user",
-      "origin" => "email",
+      "origin" => ENV.fetch("CRISP_URN"), # Permet de savoir que le message provient de notre application
       "content" => message,
     }
 

--- a/app/jobs/create_crisp_ticket_job.rb
+++ b/app/jobs/create_crisp_ticket_job.rb
@@ -1,0 +1,42 @@
+class CreateCrispTicketJob < ApplicationJob
+  def perform(nickname:, email:, phone:, subject:, message:, role:, domain:)
+    response = client.website.create_new_conversation(website_id)
+
+    query = {
+      "type" => "text",
+      "from" => "user",
+      "origin" => "email",
+      "content" => message,
+    }
+
+    client.website.send_message_in_conversation(website_id, response["session_id"], query)
+
+    data = {
+      nickname:,
+      email:,
+      phone:,
+      segments: [
+        role,
+        domain,
+      ],
+      subject:,
+    }
+
+    client.website.update_conversation_metas(website_id, response["session_id"], data)
+  end
+
+  private
+
+  def client
+    @client ||= begin
+      client = Crisp::Client.new
+      client.set_tier("plugin")
+      client.authenticate(ENV.fetch("CRISP_IDENTIFIER"), ENV.fetch("CRISP_KEY"))
+      client
+    end
+  end
+
+  def website_id
+    ENV.fetch("CRISP_WEBSITE_ID")
+  end
+end

--- a/spec/form_models/demande_support_form_spec.rb
+++ b/spec/form_models/demande_support_form_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe DemandeSupportForm do
   subject(:form) { described_class.new(**attributes) }
 
+  before { allow(ENV).to receive(:fetch).with("CRISP_ENABLED", false).and_return(false) }
+
   context "tous les attributs présents" do
     let(:attributes) do
       {
@@ -19,7 +21,18 @@ RSpec.describe DemandeSupportForm do
 
     it "appele CreateZammadTicket" do
       expect(CreateZammadTicketJob).to receive(:perform_later)
+      expect(CreateCrispTicketJob).not_to receive(:perform_later)
       form.submit
+    end
+
+    context "CRISP_ENABLED est activé" do
+      before { allow(ENV).to receive(:fetch).with("CRISP_ENABLED", false).and_return(true) }
+
+      it "appele CreateCrispTicket" do
+        expect(CreateCrispTicketJob).to receive(:perform_later)
+        expect(CreateZammadTicketJob).not_to receive(:perform_later)
+        form.submit
+      end
     end
   end
 
@@ -41,6 +54,7 @@ RSpec.describe DemandeSupportForm do
 
     it "n’appele pas CreateZammadTicket" do
       expect(CreateZammadTicketJob).not_to receive(:perform_later)
+      expect(CreateCrispTicketJob).not_to receive(:perform_later)
       form.submit
     end
   end
@@ -63,6 +77,7 @@ RSpec.describe DemandeSupportForm do
 
     it "n’appele pas CreateZammadTicket" do
       expect(CreateZammadTicketJob).not_to receive(:perform_later)
+      expect(CreateCrispTicketJob).not_to receive(:perform_later)
       form.submit
     end
   end

--- a/spec/form_models/demande_support_form_spec.rb
+++ b/spec/form_models/demande_support_form_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe DemandeSupportForm do
   subject(:form) { described_class.new(**attributes) }
 
-  before { allow(ENV).to receive(:fetch).with("CRISP_ENABLED", false).and_return(false) }
+  stub_env_with(CRISP_ENABLED: nil)
 
   context "tous les attributs présents" do
     let(:attributes) do
@@ -26,7 +26,7 @@ RSpec.describe DemandeSupportForm do
     end
 
     context "CRISP_ENABLED est activé" do
-      before { allow(ENV).to receive(:fetch).with("CRISP_ENABLED", false).and_return(true) }
+      stub_env_with(CRISP_ENABLED: "true")
 
       it "appele CreateCrispTicket" do
         expect(CreateCrispTicketJob).to receive(:perform_later)


### PR DESCRIPTION
# Contexte

Suite à l’arrivée de Crisp, notre nouvel outil de service client, on y branche notre formulaire de contact.

# Solution

Le branchement est activé par une variable d’environnement afin que nous puissions l’activer par instance et rollback au besoin. 
Une fois que cela sera en place, nous pourrons supprimer le code Zammad. 

