### PR TITLE
Supprimer la colonne `users.notes`

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -49,7 +49,6 @@ tables:
       - city_name
       - case_number
       - logement
-      - notes
       - ants_pre_demande_number
       - franceconnect_openid_sub
       - encrypted_password

--- a/db/migrate/20250303104258_remove_users_notes.rb
+++ b/db/migrate/20250303104258_remove_users_notes.rb
@@ -1,0 +1,7 @@
+class RemoveUsersNotes < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured do
+      remove_column :users, :notes, :text
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_27_165927) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_03_104258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -795,7 +795,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_27_165927) do
     t.string "case_number"
     t.string "address_details"
     t.integer "logement"
-    t.text "notes"
     t.string "ants_pre_demande_number"
     t.string "rdv_invitation_token"
     t.virtual "text_search_terms", type: :tsvector, as: "(((((setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(last_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(first_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(birth_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'C'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(phone_number_formatted, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text)), 'D'::\"char\"))", stored: true


### PR DESCRIPTION
Suite de #5121, dans laquelle nous avons ajouté la colonne aux `self.ignored_columns +=` de `User`.

Je me dis que ça ne sert rien d'attendre, si la PR précédente fonctionne, on entre dans l'ère des annotations. Dans le pire des cas on a des backups de toute façon.

Prochaine PR : nettoyer les `self.ignored_columns +=`.