### PR TITLE
Migration au DSFR du formulaire d’ajout et d’édition de proche

### DIFF
--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,9 +1,9 @@
-.form-row
-  .col-md-6= f.input :first_name
-  .col-md-6= f.input :last_name
+.fr-grid-row.fr-grid-row--gutters.fr-mb-5v
+  .fr-col-md-6= f.dsfr_text_field :first_name
+  .fr-col-md-6= f.dsfr_text_field :last_name
 - if f.object.ants_pre_demande_number_required
-  = f.input :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
+  = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   = f.hidden_field :ants_pre_demande_number_required, value: "true"
-  = f.input :ants_meeting_point_id, as: :hidden
+  = f.hidden_field :ants_meeting_point_id
 - if current_domain != Domain::RDV_MAIRIE
-  = f.input :birth_date, as: :string, input_html: { type: "date" }
+  = f.dsfr_text_field :birth_date, type: :date, input_html: { type: "date" }

--- a/app/views/users/relatives/edit.html.slim
+++ b/app/views/users/relatives/edit.html.slim
@@ -2,12 +2,12 @@
 
 .card
   .card-body
-    = simple_form_for @form, url: relative_path(@form.user) do |f|
+    = form_for @form, url: relative_path(@form.user), builder: Dsfr::FormBuilder do |f|
       = render "model_errors", model: @form, f: f
       = render "form_fields", f: f
       .d-flex.justify-content-between
-        = link_to "Supprimer", relative_path(@form.user), method: :delete, class: "btn btn-outline-danger", data: { confirm: "Confirmez-vous la suppression de ce proche ?"}
+        = link_to "Supprimer", relative_path(@form.user), method: :delete, class: "fr-btn fr-btn--icon-left fr-btn--secondary fr-icon-delete-line", data: { confirm: "Confirmez-vous la suppression de ce proche ?"}
 
         .d-flex.justify-content-end
-          = link_to "Annuler", users_informations_path, class: "btn btn-link"
-          = f.button :submit, class: "btn"
+          = link_to "Annuler", users_informations_path, class: "fr-btn fr-btn--tertiary fr-mr-2v"
+          = f.button :submit, class: "fr-btn"

--- a/app/views/users/relatives/new.html.slim
+++ b/app/views/users/relatives/new.html.slim
@@ -1,10 +1,11 @@
 - content_for(:title) do
   h1.rdv-color-white Ajouter un proche
 
-= simple_form_for @form, url: relatives_path, remote: true, data: { modal: true } do |f|
+= form_for @form, url: relatives_path, remote: true, data: { modal: true }, builder: Dsfr::FormBuilder do |f|
   = render "model_errors", model: @form, f: f
   = render "form_fields", f: f
+  // Note : on laisse le row et le col pour le moment car on va passer la modale au DSFR dans une PR suivante
   .row
     .col.rdv-text-align-right
-      button.btn.btn-link data-dismiss="modal" type="button" Annuler
-      = f.button :submit
+      button.fr-btn.fr-btn--secondary.fr-mr-2v data-dismiss="modal" type="button" Annuler
+      = f.button :submit, class: "fr-btn fr-btn--primary"


### PR DESCRIPTION
# Contexte

Dans la continuité de notre passage au DSFR, on passe le formulaire d’ajout et de modification d’un proche au DSFR.

# Solution

Utilisation du DSFR Form Builder.

Dans un second temps, nous passerons la modale d’ajout de proche au DSFR.

## Captures d'écran

Avant | Après
:- | -:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/33744502-9b11-41d9-a510-39093c511c53" /> | <img width="824" alt="image" src="https://github.com/user-attachments/assets/0efb846f-0c85-46fa-80d0-00a264fd3a2b" />
<img width="821" alt="image" src="https://github.com/user-attachments/assets/db19693d-6cee-4d7c-ae2f-66480e2ed211" /> | <img width="828" alt="image" src="https://github.com/user-attachments/assets/030a800a-c440-4670-a229-6d4e7e3e62c1" />

