### PR TITLE
Passage de la connexion superadmin au DSFR

### DIFF
--- a/app/views/welcome/super_admin.html.slim
+++ b/app/views/welcome/super_admin.html.slim
@@ -1,15 +1,13 @@
 .fr-mb-3w
-  .row.justify-content-center.pt-6
-    .col-3
-      = link_to "Accéder à superadmin", "/omniauth/github", class: "btn btn-primary", method: :post
+  .rdv-text-align-center
+    = link_to "Accéder à superadmin", "/omniauth/github", class: "fr-btn", method: :post
 
   - if Rails.env.development?
-    .row.justify-content-center.mt-3
-      .col-3
-        h5 Liens utiles
-        ul
-          li = link_to "Letter Opener", letter_opener_web_path
-          li = link_to "Mailer Previews", "/rails/mailers"
-          li = link_to "SMS Previews", "/lapin/sms_preview"
-          li = link_to "Routes", "/rails/info/routes"
-          li = link_to "Rails properties", "/rails/info/properties"
+    .fr-col-lg-3.fr-col-offset-lg-5.fr-mt-3w
+      h5 Liens utiles
+      ul
+        li = link_to "Letter Opener", letter_opener_web_path
+        li = link_to "Mailer Previews", "/rails/mailers"
+        li = link_to "SMS Previews", "/lapin/sms_preview"
+        li = link_to "Routes", "/rails/info/routes"
+        li = link_to "Rails properties", "/rails/info/properties"


### PR DESCRIPTION
# Contexte

Objectif : on veut arrêter d’utiliser les boutons Bootstrap.

# Solution

- Passage du bouton de connexion au DSFR
- On en profite pour retirer l’usage du système de grille Bootstrap


