### PR TITLE
On renomme le bouton de prise de contact RDV SP

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -14,7 +14,7 @@
           | Éviter les rendez-vous non honorés, gagner du temps au quotidien et améliorer la relation entre les agents et les usagers
         ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-0
           li
-            = link_to "Contacter notre équipe", contact_team_url, class: "fr-btn fr-mb-0"
+            = link_to "Demander une démo", contact_team_url, class: "fr-btn fr-mb-0"
 
 .fr-container.fr-py-8w
   .fr-grid-row.fr-grid-row--gutters.fr-grid-row--center
@@ -417,5 +417,5 @@ hr
     h2 Plus de RDV, moins de lapins
     p
       | Votre agenda vous remerciera.
-    .fr-my-4w= link_to "Contacter notre équipe", contact_team_url, class: "fr-btn"
+    .fr-my-4w= link_to "Demander une démo", contact_team_url, class: "fr-btn"
     = link_to "Revenir en haut de la page", "#header", class: "fr-link fr-icon-arrow-up-line fr-link--icon-left"


### PR DESCRIPTION
# Contexte

À la lecture du Zammad, on se rend compte que le bouton de prise de contact de notre page d’accueil est peut-être mal compris. On change le texte pour mieux faire comprendre que c’est un bouton de prise de contact pour mettre en place le service dans son administration.

# Solution

« Contacter notre équipe » -> « Demander une démo »


