### PR TITLE
Répare la détection d'erreurs JS dans les specs

### DIFF
--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,6 +1,5 @@
 class PlageOuverture {
   constructor() {
-    tiens_tiens_mais_cette_fonction_nexiste_pas();
     this.toggleLieuSelectionField(true);
     $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("input", () => { this.toggleLieuSelectionField(); })
   }

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,5 +1,6 @@
 class PlageOuverture {
   constructor() {
+    tiens_tiens_mais_cette_fonction_nexiste_pas();
     this.toggleLieuSelectionField(true);
     $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("input", () => { this.toggleLieuSelectionField(); })
   }

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "OAuth provider", ignore_js_errors: true, js: true do
+RSpec.describe "OAuth provider", js: true do
   # On fait quelque chose d'un peu inhabituel dans cette spec pour avoir un test d'intégration sur l'oauth
   # dans un contexte où notre application est le fournisseur d'oauth : on démarre une petite application
   # Sinatra qui joue le rôle d'une application externe (comme Démarches Simplifiées) qui propose un

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -40,7 +40,9 @@ if ENV["HEADLESS"] == "false"
 end
 
 RSpec.configure do |config|
-  config.after(:each, ignore_js_errors: nil, js: true) do
+  config.after(:each, js: true) do |example|
+    next if example.metadata[:ignore_js_errors]
+
     logs = page.driver.browser.logs.get(:browser)
     aggregate_failures "javascript errors" do
       logs.each do |log|

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -40,9 +40,7 @@ if ENV["HEADLESS"] == "false"
 end
 
 RSpec.configure do |config|
-  config.after(:each, js: true) do |example|
-    next if example.metadata[:ignore_js_errors]
-
+  config.after(:each, js: true) do
     logs = page.driver.browser.logs.get(:browser)
     aggregate_failures "javascript errors" do
       logs.each do |log|

--- a/spec/support/fake_oauth_client.rb
+++ b/spec/support/fake_oauth_client.rb
@@ -43,4 +43,9 @@ class FakeOauthClient < Sinatra::Base
 
     redirect to(Capybara.app_host + OmniAuth::Strategies::RdvServicePublic.sign_out_path("fake_app_id"))
   end
+
+  get "/favicon.ico" do
+    status 204
+    body ""
+  end
 end


### PR DESCRIPTION
# Explication longue et incompréhensible

J'ai constaté que cette détection ne fonctionnait pas en rédigeant une spec JS sur un autre sujet (#5065).

Une fois la détection d'erreurs JS rétablie, j'ai constaté dans la CI ces erreurs : 

```
  1) Agent can delete user delete user
     Failure/Error: expect(log.level).not_to eq("SEVERE"), log.message
       http://localhost:4567/favicon.ico - Failed to load resource: the server responded with a status of 404 (Not Found)
     # ./spec/support/capybara_config.rb:49:in `block (4 levels) in <top (required)>'
     # [...]

[...]

Failed examples:

rspec ./spec/features/agents/users/agent_can_delete_user_spec.rb:11 # Agent can delete user delete user
```

sur des specs qui n'avaient rien à voir avec `localhost:4567`, qui correspond à l'URL du `FakeOauthClient` utilisé dans les specs sur l'OAuth.

En discutant avec Victor, j'ai appris que le paramètre `ignore_js_errors` avait été ajouté pour ignorer précisément cette erreur de `/favicon.ico` introuvable.

Et donc, le fix était simple : faire en sorte que `FakeOauthClient` serve une favicon, ce qui évite une erreur en console JS, ce qui permet de rétablir une détection des erreurs JS propre.

# Explication simple et sympa

C'était une mauvaise idée d'ajouter le flag RSpec `ignore_js_errors: true` pour mettre sous le tapis une erreur JS qu'on pouvais simplement corrigé en ajoutant un action Sinatra.