### PR TITLE
Ajout de Crisp à la déclaration de confidentialité et au DAT

### DIFF
--- a/app/views/static_pages/politique_de_confidentialite.html.slim
+++ b/app/views/static_pages/politique_de_confidentialite.html.slim
@@ -162,20 +162,25 @@
             th Garanties
         tbody
           tr
-            td Outscale SASU
+            td Scalingo
             td Hébergement
             td France
-            td = link_to "CGV Outscale", "https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf", target: "_blank"
+            td = link_to " Contrat de Gestion des Traitements de Données Personnelles Scalingo", "https://scalingo.com/fr/contrat-gestion-traitements-donnees-personnelles", target: "_blank"
           tr
-            td Sendinblue
+            td Brevo
             td Envoi de mails
             td France
-            td = link_to "RGPD Brevo", "https://fr.sendinblue.com/rgpd/", target: "_blank"
+            td = link_to "Politique de Confidentialité Brevo", "https://www.brevo.com/fr/legal/privacypolicy/", target: "_blank"
           tr
             td LinkMobility
             td Envoi de SMS
             td France
             td = link_to "Politique de confidentialité Link Mobility", "https://www.linkmobility.com/fr/legal/politique-de-confidentialite", target: "_blank"
+          tr
+            td Crisp
+            td Service support (email et formulaire de contact)
+            td Pays-Bas
+            td = link_to "Politique de confidentialité Crisp", "https://storage.crisp.chat/public/documents/Crisp%20Privacy%20Policy%20FR.pdf", target: "_blank"
 
     h3 Sécurité et confidentialité des données
 

--- a/docs/architecture-technique.md
+++ b/docs/architecture-technique.md
@@ -85,6 +85,7 @@ Ces choix techniques sont aussi influencés par la culture de la communauté Rub
 | Navigateur redirigé par App Rails | API Microsoft          | HTTPS (OAuth) | 443  | Amsterdam, Pays-Bas | login.microsoftonline.com                             |
 | App Rails                         | API dédoublonnage ANTS | HTTPS         | 443  | Paris, France       | api-coordination.rendezvouspasseport.ants.gouv.fr/api |
 | Moteur de recherche ANTS          | App Rails              | HTTPS         | 443  | Paris, France       | rdv.anct.gouv.fr/api/ants/availableTimeSlots          |
+| App Rails                         | Crisp                  | HTTPS         | 443  | Amsterdam, Pays-Bas | api.crisp.chat                                        |
 
 ##### Webhooks
 
@@ -111,11 +112,11 @@ plusieurs tables dans la base de données de RDV Insertion.
 
 ### Inventaire des dépendances
 
-| Nom de l’applicatif | Service          | Version   | Commentaires                                                    |
-|---------------------|------------------|-----------|-----------------------------------------------------------------|
-| Serveur web         | Rails @ Scalingo | Rails 7   | Voir ci-dessous pour le détail des librairies                   |
-| BDD métier          | PostgreSQL       | `14.10.0` | Stockage des données métier, voir [db/schema.rb](/db/schema.rb) |
-| BDD technique       | Redis            | `7.2.3`   | Stockage du cache                                               |
+| Nom de l’applicatif | Service          | Version  | Commentaires                                                    |
+|---------------------|------------------|----------|-----------------------------------------------------------------|
+| Serveur web         | Rails @ Scalingo | Rails 7  | Voir ci-dessous pour le détail des librairies                   |
+| BDD métier          | PostgreSQL       | `16.6.0` | Stockage des données métier, voir [db/schema.rb](/db/schema.rb) |
+| BDD technique       | Redis            | `7.2.5`  | Stockage du cache                                               |
 
 La liste des librairies Ruby est disponible dans :
 - [Gemfile](/Gemfile) pour la liste des dépendances directes et la description de la fonctionnalité de chacune des gems


### PR DESCRIPTION
# Contexte

Avec l’arrivée prochaine de Crisp, on l’ajoute au DAT et à la déclaration de confidentialité.

# Solution

J’en ai profité pour mettre à jour les infos sur Scalingo et Brevo ainsi que les versions de PG et Redis.
