### PR TITLE
[CI] Mettre en cache notre build JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,17 @@ jobs:
           path: node_modules
       - name: Install JS dependencies
         run: yarn install
+
+      - name: Cache precompiled assets
+        id: cache-precompiled-assets
+        uses: actions/cache@v4
+        with:
+          key: assets-${{ hashFiles('yarn.lock', 'app/javascript/**') }}
+          path: app/assets/builds
       - name: Precompile assets
+        if: steps.cache-precompiled-assets.outputs.cache-hit != 'true' # Skip if cache was restored
         run: yarn run build
+
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test unit spec runtime log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
           path: node_modules
       - name: Install JS dependencies
         run: yarn install
-
       - name: Cache precompiled assets
         id: cache-precompiled-assets
         uses: actions/cache@v4
@@ -144,7 +143,6 @@ jobs:
       - name: Precompile assets
         if: steps.cache-precompiled-assets.outputs.cache-hit != 'true' # Skip if cache was restored
         run: yarn run build
-
       - name: Prepare runtime log cache key
         run: ls spec/**/*.rb > tmp/spec_files.txt
       - name: Cache parallel test unit spec runtime log
@@ -211,7 +209,6 @@ jobs:
           path: node_modules
       - name: Install JS dependencies
         run: yarn install
-
       - name: Cache precompiled assets
         id: cache-precompiled-assets
         uses: actions/cache@v4
@@ -221,7 +218,6 @@ jobs:
       - name: Precompile assets
         if: steps.cache-precompiled-assets.outputs.cache-hit != 'true' # Skip if cache was restored
         run: yarn run build
-
       - name: Prepare runtime log cache key
         run: "ls spec/features/${{ matrix.dirname }}/**/*.rb > tmp/feature_spec_${{ matrix.dirname }}_files.txt"
       - name: Cache parallel test feature spec runtime log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,17 @@ jobs:
           path: node_modules
       - name: Install JS dependencies
         run: yarn install
+
+      - name: Cache precompiled assets
+        id: cache-precompiled-assets
+        uses: actions/cache@v4
+        with:
+          key: assets-${{ hashFiles('yarn.lock', 'app/javascript/**') }}
+          path: app/assets/builds
       - name: Precompile assets
+        if: steps.cache-precompiled-assets.outputs.cache-hit != 'true' # Skip if cache was restored
         run: yarn run build
+
       - name: Prepare runtime log cache key
         run: "ls spec/features/${{ matrix.dirname }}/**/*.rb > tmp/feature_spec_${{ matrix.dirname }}_files.txt"
       - name: Cache parallel test feature spec runtime log

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,5 +1,6 @@
 class PlageOuverture {
   constructor() {
+    // Essai pour changer la clé de cache de build JS en CI
     this.toggleLieuSelectionField(true);
     $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("input", () => { this.toggleLieuSelectionField(); })
   }

--- a/app/javascript/components/plage_ouverture.js
+++ b/app/javascript/components/plage_ouverture.js
@@ -1,6 +1,5 @@
 class PlageOuverture {
   constructor() {
-    // Essai pour changer la clé de cache de build JS en CI
     this.toggleLieuSelectionField(true);
     $(".plage-ouverture-form .form-check-input[name='plage_ouverture[motif_ids][]']").on("input", () => { this.toggleLieuSelectionField(); })
   }


### PR DESCRIPTION
On constate que la commande `yarn run build` (le build webpack) lancée à l'étape "Precompile assets" de la CI prend **25 secondes**. Avec l'usage du cache on gagne donc 25 précieuses secondes par build, et puis on va dire que c'est écolo. :thinking: 

À ma connaissance, notre build ne change que si on change quelque chose dans `app/javascript` ou dans `yarn.lock`. La clé de cache est donc calculée avec `hashFiles('yarn.lock', 'app/javascript/**')`.

On peut voir la liste des caches créés et leur usage ici : https://github.com/betagouv/rdv-service-public/actions/caches
On peut y voir la clé de notre cache actuel (`assets-6976c2b6e383b0f3eb90556adb3188feeca1b73efed5e60c5a41a10926992ddb`) et la clé générée par [ce commit](https://github.com/betagouv/rdv-service-public/pull/5142/commits/4ee517d5af8f6ac12559ec879376a176db48b3d0) que j'ai utilisé pour tester (`assets-54caa4cb1ee2f0fd124703cff766a490a0fbad89d59e134fb2a3a21540c88254`).

Note : si vous pensez que c'est le moment de factoriser des étapes dans notre ci.yml plutôt que de dupliquer, ça me va, mais bon, je n'ai pas l'impression que la duplication nous pose problème ici.