### PR TITLE
Forcer la locale FR pour la création de tickets Crisp

### DIFF
--- a/app/jobs/create_crisp_ticket_job.rb
+++ b/app/jobs/create_crisp_ticket_job.rb
@@ -32,6 +32,9 @@ class CreateCrispTicketJob < ApplicationJob
           domain,
         ],
         subject:,
+        device: {
+          locales: ["fr"],
+        },
       }
     )
   end


### PR DESCRIPTION
# Contexte

Par défaut les conversation Crisp sont annotés comme en langue anglaise. Cela nous pose un problème, car Crisp ajoute un petit footer dans les mails qui est par conséquent écrit en anglais.

# Solution

On force la locale FR pour tous les tickets Crisp ouvert grâce au formulaire de contact. Le jour où le site sera multilingue, nous pourrons changer ce comportement pour utiliser la locale courante.
