### PR TITLE
Deuxième vague de petits refactos sur les invitations

### DIFF
--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,6 +1,6 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
   # invitation_token sert uniquement à retrouver l'usager
-  INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
+  INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[invitation_token]).freeze
 
   def creneau_availability
     payload = if params[:total_count] == "true"

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,7 +1,4 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
-  # invitation_token sert uniquement à retrouver l'usager
-  INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[invitation_token]).freeze
-
   def creneau_availability
     payload = if params[:total_count] == "true"
                 { creneau_availability_count: }
@@ -61,6 +58,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def invitation_link_params
-    params.permit(INVITATION_LINK_PARAMS)
+    # invitation_token sert uniquement à retrouver l'usager
+    params.permit(InvitationSearchContext::INVITATION_PARAMS + %i[invitation_token])
   end
 end

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,4 +1,6 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
+  # TODO: address latitude longitude ne sont pas utilisés, mais quand même passés
+  # invitation_token sert uniquement à retrouver l'usager
   INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
 
   def creneau_availability

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,5 +1,4 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
-  # TODO: address latitude longitude ne sont pas utilisés, mais quand même passés
   # invitation_token sert uniquement à retrouver l'usager
   INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -101,9 +101,9 @@ class SearchController < ApplicationController
 
   def search_params
     params.permit(
-      :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
-      :service_id, :lieu_id, :date, :motif_name_with_location_type, :motif_category_short_name,
-      :motif_id, :public_link_organisation_id, :user_selected_organisation_id, :prescripteur,
+      *WebSearchContext::ADDRESS_SELECTION_PARAMS,
+      *WebSearchContext::USER_CHOICE_PARAMS,
+      :motif_category_short_name, :date, :public_link_organisation_id, :prescripteur,
       organisation_ids: [], referent_ids: [], external_organisation_ids: []
     ).to_h.deep_symbolize_keys
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,9 +31,9 @@ class SearchController < ApplicationController
       redirect_to search_creneau_admin_organisation_prescription_path(session[:agent_prescripteur_organisation_id], agent_search_params)
     else
       @context = if invitation?
-                   WebInvitationSearchContext.new(user: current_user, query_params: query_params)
+                   WebInvitationSearchContext.new(user: current_user, query_params: search_params.merge(invitation.query_params))
                  else
-                   WebSearchContext.new(user: current_user, query_params: query_params)
+                   WebSearchContext.new(user: current_user, query_params: search_params)
                  end
 
       if !current_domain.provides_address_selection? && @context.current_step == :address_selection
@@ -99,10 +99,6 @@ class SearchController < ApplicationController
     end
   end
 
-  def query_params
-    search_params.to_h.deep_symbolize_keys.merge(invitation? ? invitation.query_params : {})
-  end
-
   def invitation?
     invitation.present? && invitation.to_take_rdv?
   end
@@ -113,7 +109,7 @@ class SearchController < ApplicationController
       :service_id, :lieu_id, :date, :motif_name_with_location_type, :motif_category_short_name,
       :motif_id, :public_link_organisation_id, :user_selected_organisation_id, :prescripteur,
       organisation_ids: [], referent_ids: [], external_organisation_ids: []
-    )
+    ).to_h.deep_symbolize_keys
   end
 
   def agent_search_params

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -30,7 +30,7 @@ class SearchController < ApplicationController
     if current_agent && params[:prescripteur] == Prescripteur::INTERNE && session[:agent_prescripteur_organisation_id]
       redirect_to search_creneau_admin_organisation_prescription_path(session[:agent_prescripteur_organisation_id], agent_search_params)
     else
-      @context = if invitation?
+      @context = if invitation&.to_take_rdv?
                    WebInvitationSearchContext.new(user: current_user, query_params: search_params.merge(invitation.query_params))
                  else
                    WebSearchContext.new(user: current_user, query_params: search_params)
@@ -97,10 +97,6 @@ class SearchController < ApplicationController
       flash[:alert] = "Organisation non trouvée"
       redirect_to root_path
     end
-  end
-
-  def invitation?
-    invitation.present? && invitation.to_take_rdv?
   end
 
   def search_params

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -1,8 +1,8 @@
 class Users::RdvWizardStepsController < UserAuthController
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
-    :lieu_id, :departement, :where, :created_user_id, :latitude, :longitude, :city_code, :rdv_collectif_id,
-    :street_ban_id, :address, :user_selected_organisation_id,
+    *WebSearchContext::ADDRESS_SELECTION_PARAMS,
+    :lieu_id, :where, :created_user_id, :rdv_collectif_id, :user_selected_organisation_id,
     :public_link_organisation_id, :duration,
     { organisation_ids: [], referent_ids: [], external_organisation_ids: [] },
   ].freeze

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -55,17 +55,12 @@ module UserRdvWizard
         motif_id: rdv.motif.id, starts_at: rdv.starts_at.to_s, user_ids: rdv.users&.map(&:id), rdv_collectif_id: rdv.id,
       }.merge(
         @attributes.slice(
-          :where, :departement, :lieu_id, :latitude, :longitude, :city_code, :street_ban_id,
-          :address, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
+          *WebSearchContext::ADDRESS_SELECTION_PARAMS,
+          :where, :lieu_id,
+          :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
           :referent_ids, :external_organisation_ids, :duration
         )
       )
-    end
-
-    def to_search_query
-      @attributes
-        .slice(:departement, :latitude, :longitude, :motif_name_with_location_type, :where, :city_code, :street_ban_id)
-        .merge(service: @rdv.motif.service_id, motif_name_with_location_type: @rdv.motif.name_with_location_type)
     end
 
     def save

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -56,8 +56,7 @@ module UserRdvWizard
       }.merge(
         @attributes.slice(
           *WebSearchContext::ADDRESS_SELECTION_PARAMS,
-          :where, :lieu_id,
-          :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
+          :where, :lieu_id, :organisation_ids, :public_link_organisation_id, :user_selected_organisation_id,
           :referent_ids, :external_organisation_ids, :duration
         )
       )

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -51,12 +51,7 @@ module SearchContextHelper
 
   def service_selection_permitted_params_list
     [
-      :departement,
-      :city_code,
-      :longitude,
-      :latitude,
-      :street_ban_id,
-      :address,
+      *WebSearchContext::ADDRESS_SELECTION_PARAMS,
       :public_link_organisation_id,
       :prescripteur,
       :duration,

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -63,7 +63,7 @@ module SearchContextHelper
       {
         referent_ids: [],
         external_organisation_ids: [],
-        user_ids: [],
+        user_ids: [], # utilisés par les agents prescripteurs en prescription interne
       },
     ]
   end

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -1,40 +1,35 @@
 module SearchContextHelper
-  def path_to_motif_selection(params)
+  def path_to_service_selection(params)
     prendre_rdv_path(
-      service_selection(params).merge(
-        service_id: params[:service_id]
-      )
+      permit_hash_or_params(params, service_selection_permitted_params_list)
     )
   end
 
-  def path_to_service_selection(params)
-    prendre_rdv_path(service_selection(params))
+  def path_to_motif_selection(params)
+    prendre_rdv_path(
+      permit_hash_or_params(params, [:service_id] + service_selection_permitted_params_list)
+    )
   end
 
   def path_to_lieu_selection(params)
     prendre_rdv_path(
-      service_selection(params).merge(
-        motif_name_with_location_type: params[:motif_name_with_location_type],
-        service_id: params[:service_id]
-      )
+      permit_hash_or_params(params, %i[service_id motif_name_with_location_type] + service_selection_permitted_params_list)
     )
   end
 
   def path_to_organisation_selection(params)
     prendre_rdv_path(
-      service_selection(params).merge(
-        motif_name_with_location_type: params[:motif_name_with_location_type],
-        user_selected_organisation_id: nil
-      )
+      permit_hash_or_params(params, %i[service_id motif_name_with_location_type] + service_selection_permitted_params_list)
     )
   end
 
   def path_to_creneau_selection(params)
+    additional_params = %i[
+      service_id motif_name_with_location_type lieu_id user_selected_organisation_id
+    ]
+
     prendre_rdv_path(
-      service_selection(params).merge(
-        motif_name_with_location_type: params[:motif_name_with_location_type],
-        lieu_id: params[:lieu_id], user_selected_organisation_id: params[:user_selected_organisation_id]
-      )
+      permit_hash_or_params(params, additional_params + service_selection_permitted_params_list)
     )
   end
 

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -1,25 +1,31 @@
 module SearchContextHelper
   def path_to_service_selection(params)
-    prendre_rdv_path(
-      permit_hash_or_params(params, service_selection_permitted_params_list)
+    prendre_rdv_path_with_filtered_params(
+      params,
+      starting_permitted_params_list
     )
   end
 
   def path_to_motif_selection(params)
-    prendre_rdv_path(
-      permit_hash_or_params(params, [:service_id] + service_selection_permitted_params_list)
+    prendre_rdv_path_with_filtered_params(
+      params,
+      [:service_id] + starting_permitted_params_list
     )
   end
 
   def path_to_lieu_selection(params)
-    prendre_rdv_path(
-      permit_hash_or_params(params, %i[service_id motif_name_with_location_type] + service_selection_permitted_params_list)
+    prendre_rdv_path_with_filtered_params(
+      params,
+      %i[service_id motif_name_with_location_type] + starting_permitted_params_list
     )
   end
 
+  # C'est la même implémentation que #path_to_lieu_selection, et c'est en fonction des motifs disponibles
+  # que la logique de Users::CreneauxWizardConcern#current_step décidera entre lieu_selection et organisation_selection
   def path_to_organisation_selection(params)
-    prendre_rdv_path(
-      permit_hash_or_params(params, %i[service_id motif_name_with_location_type] + service_selection_permitted_params_list)
+    prendre_rdv_path_with_filtered_params(
+      params,
+      %i[service_id motif_name_with_location_type] + starting_permitted_params_list
     )
   end
 
@@ -28,15 +34,16 @@ module SearchContextHelper
       service_id motif_name_with_location_type lieu_id user_selected_organisation_id
     ]
 
-    prendre_rdv_path(
-      permit_hash_or_params(params, additional_params + service_selection_permitted_params_list)
+    prendre_rdv_path_with_filtered_params(
+      params,
+      additional_params + starting_permitted_params_list
     )
   end
 
   private
 
-  def service_selection(params)
-    permit_hash_or_params(params, service_selection_permitted_params_list)
+  def prendre_rdv_path_with_filtered_params(params, permitted_params_list)
+    prendre_rdv_path(permit_hash_or_params(params, permitted_params_list))
   end
 
   def permit_hash_or_params(hash_or_params, permitted_params_list)
@@ -49,7 +56,7 @@ module SearchContextHelper
     params.permit(*permitted_params_list)
   end
 
-  def service_selection_permitted_params_list
+  def starting_permitted_params_list
     [
       *WebSearchContext::ADDRESS_SELECTION_PARAMS,
       :public_link_organisation_id,

--- a/app/helpers/search_context_helper.rb
+++ b/app/helpers/search_context_helper.rb
@@ -41,19 +41,35 @@ module SearchContextHelper
   private
 
   def service_selection(params)
-    {
-      departement: params[:departement],
-      city_code: params[:city_code],
-      longitude: params[:longitude],
-      latitude: params[:latitude],
-      street_ban_id: params[:street_ban_id],
-      address: params[:address],
-      public_link_organisation_id: params[:public_link_organisation_id],
-      referent_ids: params[:referent_ids],
-      external_organisation_ids: params[:external_organisation_ids],
-      prescripteur: params[:prescripteur],
-      duration: params[:duration],
-      user_ids: params[:user_ids],
-    }
+    permit_hash_or_params(params, service_selection_permitted_params_list)
+  end
+
+  def permit_hash_or_params(hash_or_params, permitted_params_list)
+    params = if hash_or_params.is_a?(Hash)
+               ActionController::Parameters.new(hash_or_params)
+             else
+               hash_or_params
+             end
+
+    params.permit(*permitted_params_list)
+  end
+
+  def service_selection_permitted_params_list
+    [
+      :departement,
+      :city_code,
+      :longitude,
+      :latitude,
+      :street_ban_id,
+      :address,
+      :public_link_organisation_id,
+      :prescripteur,
+      :duration,
+      {
+        referent_ids: [],
+        external_organisation_ids: [],
+        user_ids: [],
+      },
+    ]
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,3 +1,6 @@
+# Les invitations peuvent servir dans plusieurs cas :
+# - inviter un usager à prendre un nouveau rendez-vous, suite à une notification envoyée par RDV Insertion
+# - permettre à un usager de modifier un rendez-vous existant, dont parfois de changer le créneau (parfois pour les Files d'attente)
 class Invitation
   attr_reader :attributes
 
@@ -31,10 +34,6 @@ class Invitation
 
   def to_take_rdv?
     user_by_rdv_invitation_token.present?
-  end
-
-  def to_edit_rdv?
-    participation_by_invitation_token.present?
   end
 
   def expired?

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -18,7 +18,7 @@ class Invitation
 
   def query_params
     # Dans le cas d'une invitation à prendre rdv, les clés du hash renvoyé par cette méthode
-    # devraient correspondre à Api::Rdvinsertion::InvitationsController::INVITATION_LINK_PARAMS
+    # devraient correspondre à InvitationSearchContext::INVITATION_PARAMS
     @attributes.except(:invitation_token, :expires_at)
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -17,6 +17,8 @@ class Invitation
   end
 
   def query_params
+    # Dans le cas d'une invitation à prendre rdv, les clés du hash renvoyé par cette méthode
+    # devraient correspondre à Api::Rdvinsertion::InvitationsController::INVITATION_LINK_PARAMS
     @attributes.except(:invitation_token, :expires_at)
   end
 

--- a/app/services/agent_prescription_search_context.rb
+++ b/app/services/agent_prescription_search_context.rb
@@ -1,8 +1,8 @@
 class AgentPrescriptionSearchContext < WebSearchContext
   STRONG_PARAMS_LIST = [
-    :latitude, :longitude, :address, :city_code, :departement, :street_ban_id,
-    :service_id, :lieu_id, :date, :motif_name_with_location_type, :motif_category_short_name,
-    :motif_id, :user_selected_organisation_id, :prescripteur,
+    *WebSearchContext::ADDRESS_SELECTION_PARAMS,
+    *WebSearchContext::USER_CHOICE_PARAMS,
+    :date, :motif_category_short_name, :prescripteur,
     :context,
     { # Paramètre supplémentaire qui n'apparait pas dans le WebSearchContext
       user_ids: [],

--- a/app/services/invitation_search_context.rb
+++ b/app/services/invitation_search_context.rb
@@ -1,7 +1,7 @@
 class InvitationSearchContext < SearchContext
-  attr_reader :departement, :city_code, :street_ban_id
+  attr_reader :departement, :city_code, :street_ban_id, :address, :latitude, :longitude
 
-  INVITATION_PARAMS = %i[city_code departement street_ban_id motif_category_short_name lieu_id].freeze + [
+  INVITATION_PARAMS = %i[city_code departement street_ban_id address latitude longitude motif_category_short_name lieu_id].freeze + [
     organisation_ids: [], referent_ids: [],
   ].freeze
 

--- a/app/services/web_invitation_search_context.rb
+++ b/app/services/web_invitation_search_context.rb
@@ -4,13 +4,24 @@ class WebInvitationSearchContext < InvitationSearchContext
 
   def initialize(user:, query_params: {})
     super
-    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
-    @motif_id = query_params[:motif_id]
-    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
     @service_id = query_params[:service_id]
     @address = query_params[:address]
     @latitude = query_params[:latitude]
     @longitude = query_params[:longitude]
+
+    # User choices
+    # motif_selection:
+    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
+
+    # lieu_selection: le lieu peut parfois être déterminé par l'invitation
+    # mais il peut aussi être choisi par l'usager.
+    # Dans les deux cas, la variable d'instance lieu_id est initialisée par la classe parente
+
+    # organisation_selection:
+    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
+
+    # creneau_selection
+    @motif_id = query_params[:motif_id]
   end
 
   # dupliqué de WebSearchContext

--- a/app/services/web_invitation_search_context.rb
+++ b/app/services/web_invitation_search_context.rb
@@ -4,12 +4,16 @@ class WebInvitationSearchContext < InvitationSearchContext
 
   def initialize(user:, query_params: {})
     super
-    @service_id = query_params[:service_id]
+
+    # Ces paramètres sont déterminés par l'invitation
     @address = query_params[:address]
     @latitude = query_params[:latitude]
     @longitude = query_params[:longitude]
 
     # User choices
+    # La plupart du temps il n'y a qu'un seul service qui propose des invitations, donc il n'est
+    # pas choisi explicitement, mais c'est techniquement possible
+    @service_id = query_params[:service_id]
     # motif_selection:
     @motif_name_with_location_type = query_params[:motif_name_with_location_type]
 

--- a/app/services/web_invitation_search_context.rb
+++ b/app/services/web_invitation_search_context.rb
@@ -1,14 +1,9 @@
 class WebInvitationSearchContext < InvitationSearchContext
   include Users::CreneauxWizardConcern
-  attr_reader :errors, :query_params, :address, :latitude, :longitude, :organisation_ids, :motif_category_short_name
+  attr_reader :errors, :query_params, :organisation_ids, :motif_category_short_name
 
   def initialize(user:, query_params: {})
     super
-
-    # Ces paramètres sont déterminés par l'invitation
-    @address = query_params[:address]
-    @latitude = query_params[:latitude]
-    @longitude = query_params[:longitude]
 
     # User choices
     # La plupart du temps il n'y a qu'un seul service qui propose des invitations, donc il n'est

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -2,32 +2,31 @@ class WebSearchContext < SearchContext
   include Users::CreneauxWizardConcern
   attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude
 
+  ADDRESS_SELECTION_PARAMS = %i[latitude longitude address departement city_code street_ban_id].freeze
+
+  USER_CHOICE_PARAMS = %i[service_id motif_name_with_location_type lieu_id user_selected_organisation_id motif_id].freeze
+
   def initialize(user:, query_params: {})
     super
-    @latitude = query_params[:latitude]
-    @longitude = query_params[:longitude]
-    @address = query_params[:address]
-    @city_code = query_params[:city_code]
-    @street_ban_id = query_params[:street_ban_id]
+
+    # Optional starting conditions
     @public_link_organisation_id = query_params[:public_link_organisation_id]
     @external_organisation_ids = query_params[:external_organisation_ids]
     @referent_ids = query_params[:referent_ids]
     @prescripteur = query_params[:prescripteur]
 
+    # Address selection:
+    @latitude = query_params[:latitude]
+    @longitude = query_params[:longitude]
+    @address = query_params[:address]
+    @city_code = query_params[:city_code]
+    @street_ban_id = query_params[:street_ban_id]
+
     # User choices
-    # service_selection:
     @service_id = query_params[:service_id]
-
-    # motif_selection:
     @motif_name_with_location_type = query_params[:motif_name_with_location_type]
-
-    # lieu_selection:
     @lieu_id = query_params[:lieu_id]
-
-    # organisation_selection:
     @user_selected_organisation_id = query_params[:user_selected_organisation_id]
-
-    # creneau_selection
     @motif_id = query_params[:motif_id]
   end
 

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -10,14 +10,25 @@ class WebSearchContext < SearchContext
     @city_code = query_params[:city_code]
     @street_ban_id = query_params[:street_ban_id]
     @public_link_organisation_id = query_params[:public_link_organisation_id]
-    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
     @external_organisation_ids = query_params[:external_organisation_ids]
-    @motif_id = query_params[:motif_id]
-    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
-    @service_id = query_params[:service_id]
-    @lieu_id = query_params[:lieu_id]
     @referent_ids = query_params[:referent_ids]
     @prescripteur = query_params[:prescripteur]
+
+    # User choices
+    # service_selection:
+    @service_id = query_params[:service_id]
+
+    # motif_selection:
+    @motif_name_with_location_type = query_params[:motif_name_with_location_type]
+
+    # lieu_selection:
+    @lieu_id = query_params[:lieu_id]
+
+    # organisation_selection:
+    @user_selected_organisation_id = query_params[:user_selected_organisation_id]
+
+    # creneau_selection
+    @motif_id = query_params[:motif_id]
   end
 
   def invitation?

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -2,7 +2,9 @@ class WebSearchContext < SearchContext
   include Users::CreneauxWizardConcern
   attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude
 
-  ADDRESS_SELECTION_PARAMS = %i[latitude longitude address departement city_code street_ban_id].freeze
+  # departement est un cas particulier parce qu'il est aussi utilisé en dehors de addresse selection pour
+  # passer cette première étape
+  ADDRESS_SELECTION_PARAMS = %i[latitude longitude address city_code street_ban_id departement].freeze
 
   USER_CHOICE_PARAMS = %i[service_id motif_name_with_location_type lieu_id user_selected_organisation_id motif_id].freeze
 

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -2,13 +2,13 @@ section.rdv-background-color-alt-blue-ecume.fr-pt-4w.fr-pb-8w
   .fr-container
     #search_form.fr-col-lg-10.fr-col-offset-lg-1
       = form_with url: prendre_rdv_path, method: :get, scope: :search do |f|
-        = f.hidden_field :departement, value: context.departement, name: "departement"
-        - if context.prescripteur?
-          = f.hidden_field :prescripteur, name: "prescripteur", value: 1
+        = f.hidden_field :departement, name: "departement", value: context.departement
         = f.hidden_field :city_code, name: "city_code", value: context.city_code
         = f.hidden_field :street_ban_id, name: "street_ban_id", value: context.street_ban_id
         = f.hidden_field :latitude, name: "latitude", value: context.latitude
         = f.hidden_field :longitude, name: "longitude", value: context.longitude
+        - if context.prescripteur?
+          = f.hidden_field :prescripteur, name: "prescripteur", value: 1
         / TODO: change input name to address and change whereInput in application.js
         = f.label :where, "Saisissez votre adresse", class: "fr-label"
         .fr-search-bar.fr-search-bar--lg[role="search"]


### PR DESCRIPTION
Suite de https://github.com/betagouv/rdv-service-public/pull/5137

Cette PR fait principalement du regroupement de "sacs de paramètres" pour commencer à faire sortir les notions métiers auxquelles ils correspondent, et clarifier les liens entre les différents endroits où ils sont utilisés.

J'espère que ça va aussi rendre visible des bugs possibles lorsqu'un paramètre manque à une certaine liste (on a eu beaucoup de variations de bugs de ce genre).

On pourrait continuer, mais je pense que c'est bien de merger au fur et à mesure, et ça commence à faire déjà pas mal de diff.
