### PR TITLE
Nettoyage des `ignored_columns` de colonnes déjà supprimées

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,7 +1,6 @@
 class SoftDeleteError < StandardError; end
 
 class Agent < ApplicationRecord
-  self.ignored_columns += %i[inclusion_connect_open_id_sub invitations_count]
   # Mixins
   has_paper_trail(
     only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at]

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,6 +1,4 @@
 class Participation < ApplicationRecord
-  self.ignored_columns += %i[invitations_count]
-
   # Mixins
   devise :invitable, invite_for: 12.weeks
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  self.ignored_columns += %i[invitations_count notes]
-
   # Mixins
   has_paper_trail(
     only: %w[


### PR DESCRIPTION
Nous avons récemment supprimé plusieurs colonnes en suivant les recommandations de `strong_migrations`.

Cette PR correspond à la dernière étape (étape 5) de cette procédure : 
https://github.com/ankane/strong_migrations?tab=readme-ov-file#removing-a-column