### PR TITLE
[CI] Ne pas afficher de warning inutile sur les artefacts Capybara

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
         with:
           name: artifacts-capybara
           path: tmp/capybara
+          if-no-files-found: ignore
   test_boot_without_db:
     name: Boot web server without database
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Problème

Lorsque nos jobs "Feature Tests" échouent : 
1. Capybara ajoute des artefacts (HTML, PNG) dans `tmp/capybara`
2. L'action `actions/upload-artifact@v4` upload ces artefacts pour que nous puissions y accéder
3. Nous sommes heureux

Lorsque nos jobs "Feature Tests" réussissent : 
1. Capybara n'enregistre rien dans `tmp/capybara`
2. L'action `actions/upload-artifact@v4` tente de trouver des artefacts mais ne trouve rien et donc elle lève un warning
3. Ces warning s'affichent alors que tout va bien :

![2025-03-05_11-19](https://github.com/user-attachments/assets/37a81b31-68ea-4022-b811-9fdaed295641)

![2025-03-05_11-18](https://github.com/user-attachments/assets/3fe8d1ba-1a07-4f8e-b726-a4ca8bdeffff)

# Solution

Configurer `actions/upload-artifact@v4` pour ne rien faire quand les artefacts sont absents.

La doc : https://github.com/actions/upload-artifact?tab=readme-ov-file#inputs

# Avant

![image](https://github.com/user-attachments/assets/7712768b-6fde-4da6-ad14-118a2f5b8399)

# Après

![image](https://github.com/user-attachments/assets/39dea41f-8e9f-4516-bcf4-7cbc7089c638)
