### PR TITLE
Inciter les agents qui se connectent via une intégration mais qui n'ont pas d'organisation à contacter notre équipe pour une ouverture de compte

### DIFF
--- a/app/controllers/agents/rdv_plans_controller.rb
+++ b/app/controllers/agents/rdv_plans_controller.rb
@@ -4,7 +4,11 @@ class Agents::RdvPlansController < AgentAuthController
   before_action :redirect_to_rdv, if: -> { @rdv_plan.rdv.present? }, except: [:rdv]
 
   def show
-    redirect_to edit_starts_at_agents_rdv_plan_path(@rdv_plan)
+    if current_agent.organisations.any?
+      redirect_to edit_starts_at_agents_rdv_plan_path(@rdv_plan)
+    else
+      redirect_to authenticated_agent_root_path
+    end
   end
 
   def edit_starts_at

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -66,4 +66,16 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
 
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
+
+  context "quand l'agent n'appartient à aucune organisation parce qu'il n'a pas encore fait d'ouverture de compte avec notre équipe déploiement, ou qu'il n'a pas été invité à rejoindre son organisation par ses collègues" do
+    let!(:agent) do
+      create(:agent, basic_role_in_organisations: [])
+    end
+
+    it "redirige vers la page qui permet de corriger cette situation" do
+      visit agents_rdv_plan_path(rdv_plan.id)
+      expect(page).to have_content("Vos collègues peuvent vous inviter")
+      expect(page).to have_content("Nous vous invitons à contacter notre équipe")
+    end
+  end
 end

--- a/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
+++ b/spec/features/agents/create_rdv_with_rdv_plan_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe "Les agents peuvent prendre un rendez-vous en passant par l'inter
     expect(page).to have_content("Retour sur Démarches Simplifiées")
   end
 
-  context "quand l'agent n'appartient à aucune organisation parce qu'il n'a pas encore fait d'ouverture de compte avec notre équipe déploiement, ou qu'il n'a pas été invité à rejoindre son organisation par ses collègues" do
+  context "quand l'agent n'appartient à aucune organisation" do
+    # Ça arrive s'il n'a pas encore fait d'ouverture de compte avec notre équipe déploiement, ou qu'il n'a pas été invité à rejoindre son organisation par ses collègues
     let!(:agent) do
       create(:agent, basic_role_in_organisations: [])
     end


### PR DESCRIPTION
corrige https://sentry.incubateur.net/organizations/betagouv/issues/154379/?project=74&referrer=webhooks_plugin

# Contexte

Si une intégration est activée sans que notre équipe ai fait une procédure de création de compte, aujourd'hui il y a une erreur lors de la tentative de prise de rdv.

Ça veut dire que si on ne se coordonne pas avec l'équipe partenaire (Démarches Simplifiées ou Mon Suivi Social), l'intégration est inutilisable.

# Solution

Cette PR propose un changement simple qui améliore la vie des agents et la nôtre :

Si un agent essaye de prendre un rendez-vous par intégration sans avoir de compte, il est redirigé vers la page qui incite à contacter notre équipe de déploiement ou à rejoindre une équipe.

Ça évite à l'agent d'être bloqué, et ça nous permet de faire des ouvertures de comptes pour les intégrations sans avoir à se synchroniser avec l'autre équipe.

Cette PR est rendue possible par le travail fait prédemment sur la création de compte via proconnect https://github.com/betagouv/rdv-service-public/pull/5102

## Captures d'écran

Avant | Après
:- | -:
![image (4)](https://github.com/user-attachments/assets/cb204dea-8e80-48dd-aa17-cce211268b82)|<img width="1422" alt="Screenshot 2025-03-04 at 09 48 23" src="https://github.com/user-attachments/assets/7e814082-9deb-4d0d-b0c8-f81e2525bd2b" />
