### PR TITLE
MAJ Rails 7.1 : `allow_deprecated_parameters_hash_equality = false`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -34,7 +34,7 @@ Rails.application.config.action_dispatch.default_headers = {
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
 #++
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.


### PR DESCRIPTION
Je continue le travail commencé dans #4935, j'y vais petit à petit, ça permet d'avancer malgré la peur.

Je pense que si les specs passent, on peut déployer en prod et prier pour qu'on ne fasse pa de comparaison de hash dans une chemin non testé (ce qui est bien possible, mais :shrug: ). :crossed_fingers: 