### PR TITLE
Rediriger vers la liste après une création / modif de plage d'ouverture

### DIFF
--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -58,7 +58,7 @@ class Admin::PlageOuverturesController < AgentAuthController
 
       Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_created.deliver_later if @agent.plage_ouverture_notification_level == "all"
       flash[:success] = "Plage d'ouverture créée"
-      redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
+      redirect_to admin_organisation_agent_plage_ouvertures_path(organisation_id: @plage_ouverture.organisation, agent_id: @plage_ouverture.agent_id)
     else
       render :new
     end
@@ -69,7 +69,7 @@ class Admin::PlageOuverturesController < AgentAuthController
     if @plage_ouverture.update(plage_ouverture_params)
       Agents::PlageOuvertureMailer.with(plage_ouverture: @plage_ouverture).plage_ouverture_updated.deliver_later if @agent.plage_ouverture_notification_level == "all"
       flash[:success] = "La plage d'ouverture a été modifiée."
-      redirect_to admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
+      redirect_to admin_organisation_agent_plage_ouvertures_path(organisation_id: @plage_ouverture.organisation, agent_id: @plage_ouverture.agent_id)
     else
       render :edit
     end

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -18,9 +18,13 @@ tr
     - else
       | Le #{l(plage_ouverture.first_day, format: :human)} #{display_time_range(plage_ouverture)}
     - if plage_ouverture.overlapping_plages_ouvertures?
-      .alert.alert-warning.py-1.px-2.mt-1 ⚠️ Conflit de dates
+      .alert.alert-warning.py-1.px-2.mt-1
+        span ⚠️ Conflit de dates
+        =< link_to("(voir détails)", admin_organisation_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id))
     - if plage_ouverture.overflow_motifs_duration?
-      .alert.alert-warning.py-1.px-2.mt-1 ⚠️ Certains motifs débordent sur la durée de la plage
+      .alert.alert-warning.py-1.px-2.mt-1
+        span ⚠️ Certains motifs débordent sur la durée de la plage
+        =< link_to("(voir détails)", admin_organisation_plage_ouverture_path(organisation_id: organisation.id, id: plage_ouverture.id))
   td
     .d-flex
       div.mr-3= link_to edit_admin_organisation_plage_ouverture_path(organisation, plage_ouverture),

--- a/spec/controllers/admin/plage_ouvertures_controller_spec.rb
+++ b/spec/controllers/admin/plage_ouvertures_controller_spec.rb
@@ -119,9 +119,9 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
         end
 
         it "creates it and redirects to the index" do
-          post(:create, params: valid_params)
-          expect(response).to redirect_to(admin_organisation_plage_ouverture_path(organisation, PlageOuverture.last))
-          expect(agent.plage_ouvertures.count).to eq 2
+          expect { post(:create, params: valid_params) }.to change { agent.plage_ouvertures.count }.by(1)
+          created_plage = PlageOuverture.last
+          expect(response).to redirect_to(admin_organisation_agent_plage_ouvertures_path(organisation_id: created_plage.organisation, agent_id: created_plage.agent_id))
         end
 
         it "send notification after create" do
@@ -176,7 +176,7 @@ RSpec.describe Admin::PlageOuverturesController, type: :controller do
       context "with valid params" do
         it "updates the requested plage_ouverture" do
           put :update, params: { organisation_id: organisation.id, id: plage_ouverture.to_param, plage_ouverture: { title: "Le nouveau nom" } }
-          expect(response).to redirect_to(admin_organisation_plage_ouverture_path(organisation, plage_ouverture))
+          expect(response).to redirect_to(admin_organisation_agent_plage_ouvertures_path(organisation_id: plage_ouverture.organisation, agent_id: plage_ouverture.agent_id))
         end
 
         it "send notification after update" do

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Libellé (facultatif)", with: "La belle plage"
       click_button("Enregistrer")
 
-      expect_page_title("La belle plage")
+      expect_page_title("Vos plages d'ouverture")
+      click_on("La belle plage")
       click_link("Supprimer")
 
       expect_page_title("Vos plages d'ouverture")
@@ -42,9 +43,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       select(lieu.full_name, from: "plage_ouverture_lieu_id") if lieu
       check "Suivi bonjour"
       click_button "Créer la plage d'ouverture"
-
-      expect_page_title("Accueil")
-      click_link "Modifier"
+      expect(PlageOuverture.last.title).to eq("Accueil")
+      expect_page_title("Vos plages d'ouverture")
     end
   end
 
@@ -111,7 +111,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Libellé (facultatif)", with: "La belle plage"
       click_button("Enregistrer")
 
-      expect_page_title("La belle plage")
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      click_on("La belle plage")
       accept_confirm do
         click_link("Supprimer")
       end
@@ -126,9 +127,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       check "Suivi bonjour"
       select(lieu.full_name, from: "plage_ouverture_lieu_id")
       click_button "Créer la plage d'ouverture"
-
-      expect_page_title("Accueil")
-      click_link "Modifier"
+      expect(PlageOuverture.last.title).to eq("Accueil")
+      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
     end
 
     context "when the motif doesn't require a lieu" do
@@ -148,7 +148,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         fill_in "Libellé (facultatif)", with: "La belle plage"
         click_button("Enregistrer")
 
-        expect_page_title("La belle plage")
+        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        click_on("La belle plage")
         click_link("Supprimer")
 
         expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
@@ -160,9 +161,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         fill_in "Libellé (facultatif)", with: "Accueil"
         check "Suivi bonjour"
         click_button "Créer la plage d'ouverture"
-
-        expect_page_title("Accueil")
-        click_link "Modifier"
+        expect(PlageOuverture.last.title).to eq("Accueil")
+        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
       end
     end
   end


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5151.osc-secnum-fr1.scalingo.io/) `martine@demo.rdv-solidarites.fr` / `Rdvservicepublictest1!`

# Contexte

Lors de la discovery, nous avons constaté que certaines personnes sont confuses en arrivant sur la page `#show` après une création de plage.

# Solution

Nous proposons de rediriger les agents vers la liste des plages après la création et l'édition.

## Les warnings

La page show montre deux types de warning : 
- quand il y a une autre plage en "conflit" (mêmes dates et mêmes motifs)
- quand la plage n'est pas assez longue pour assurer l'un des motifs (ajouté dans #2857)

![image](https://github.com/user-attachments/assets/24bb0a10-cd02-4a0c-afd7-db11c3979ec9)

Ces warnings sont affichés sur l'index également mais avec moins de détails : 

![image](https://github.com/user-attachments/assets/f2496b1d-7848-4b6b-8d1d-3d08a11790c5)

On ajoute donc un lien "(voir détails)" qui pointe vers le show, puisque celui-ci est désormais moins mis ne avant : 

![image](https://github.com/user-attachments/assets/314ec1da-a630-4a04-962a-097b369ecba0)

