### PR TITLE
Tentative de fix de flaky spec (`visioconference_spec.rb`)

### DIFF
--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe "Agent can CRUD motifs" do
       expect(editable_by_user_checkbox).not_to be_checked
       expect { click_on "Enregistrer" }.to change { motif.reload.bookable_by }.from("everyone").to("agents")
     end
+
+    it "allows changing the motif's location_type to :visio" do
+      motif = create(:motif, organisation: organisation, location_type: :public_office, service:)
+
+      visit admin_organisation_motifs_path(organisation)
+      click_on motif.name
+      click_on "Modifier"
+      expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
+      choose "Par visioconférence"
+      expect { click_on "Enregistrer" }.to change { motif.reload.location_type }.from("public_office").to("visio")
+    end
   end
 
   describe "archiving" do

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -1,3 +1,4 @@
+# Run 2
 RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   let(:organisation) { create(:organisation) }
   let(:service) { create(:service) }

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
-  let!(:motif) { create(:motif, organisation: organisation, location_type: :public_office, service: service, name: "Accompagnement RSA") }
   let(:organisation) { create(:organisation) }
   let(:service) { create(:service) }
 
@@ -12,17 +11,19 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
     login_as(agent, scope: :agent)
   end
 
-  it "allows changing the location type and adds validation when trying to create a rdv without email or phone number", js: true do
+  it "allows changing the motif location_type" do
+    motif = create(:motif, organisation: organisation, location_type: :public_office, service:)
+
     visit admin_organisation_motifs_path(organisation)
     click_on motif.name
     click_on "Modifier"
     expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
     choose "Par visioconférence"
-    click_on "Enregistrer"
-    wait_for { Motif.exists?(id: motif.id, location_type: :visio) }.to be(true)
+    expect { click_on "Enregistrer" }.to change { motif.reload.location_type }.from("public_office").to("visio")
+  end
 
-    expect(page).to have_content "RDV individuel par visioconférence"
-    expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
+  it "adds validation when trying to create a rdv without email or phone number", js: true do
+    motif = create(:motif, organisation: organisation, location_type: :visio, service: service, name: "Accompagnement RSA")
 
     visit new_admin_organisation_rdv_wizard_step_path(organisation_id: organisation.id)
     select(motif.name, from: "Motif du rendez-vous")

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -1,4 +1,3 @@
-# Run 5
 RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   let(:organisation) { create(:organisation) }
   let(:service) { create(:service) }

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -1,4 +1,4 @@
-# Run 3
+# Run 4
 RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   let(:organisation) { create(:organisation) }
   let(:service) { create(:service) }

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
     login_as(agent, scope: :agent)
   end
 
-  it "allows changing the motif location_type" do
-    motif = create(:motif, organisation: organisation, location_type: :public_office, service:)
-
-    visit admin_organisation_motifs_path(organisation)
-    click_on motif.name
-    click_on "Modifier"
-    expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
-    choose "Par visioconférence"
-    expect { click_on "Enregistrer" }.to change { motif.reload.location_type }.from("public_office").to("visio")
-  end
-
   it "adds validation when trying to create a rdv without email or phone number", js: true do
     motif = create(:motif, organisation: organisation, location_type: :visio, service: service, name: "Accompagnement RSA")
 

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -1,4 +1,4 @@
-# Run 2
+# Run 3
 RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   let(:organisation) { create(:organisation) }
   let(:service) { create(:service) }

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -13,17 +13,13 @@ RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   end
 
   it "allows changing the location type and adds validation when trying to create a rdv without email or phone number", js: true do
-    if Date.new(2024, 12, 19).future?
-      pending # rubocop:disable RSpec/Pending
-      raise "cette flaky spec a été désactivée le temps de travailler dessus"
-    end
-
     visit admin_organisation_motifs_path(organisation)
     click_on motif.name
     click_on "Modifier"
     expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
     choose "Par visioconférence"
     click_on "Enregistrer"
+    wait_for { Motif.exists?(id: motif.id, location_type: :visio) }.to be(true)
 
     expect(page).to have_content "RDV individuel par visioconférence"
     expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."

--- a/spec/features/agents/visioconference_spec.rb
+++ b/spec/features/agents/visioconference_spec.rb
@@ -1,4 +1,4 @@
-# Run 4
+# Run 5
 RSpec.describe "Les agents peuvent organiser des rdv par visioconférence" do
   let(:organisation) { create(:organisation) }
   let(:service) { create(:service) }


### PR DESCRIPTION
Cette spec a été désactivée jusqu'au 19 décembre 2024 "le temps de s'en occuper", puis elle est revenue sans qu'on s'en soit occupée.

Quand cette spec échoue, c'est parfois ligne 24, parfois ligne 29, quand on fait

```ruby
expect(page).to have_content "L'agent et l'usager se retrouvent sur un lien de visioconférence unique pour chaque RDV."
```

Voici le screenshot de fail capybara :

![screenshot_2025-03-05-16-02-42 671](https://github.com/user-attachments/assets/8d5b02da-08db-4cce-abd2-2bca9a1ed386)

# Solution

Cette spec fait deux choses assez différentes : 
1. elle modifie le motif pour qu'il passe de "Sur place" à "En visio"
2. elle fait le parcours de prise de RDV avec ce motif.

Elle plante durant l'étape 1.

Je suggère qu'on divise cette spec en deux :
1. une première spec **non JS** qui teste juste qu'on peut modifier le location type d'un motif
2. une autre spec **avec JS** qui fait le parcours de prise de RDV avec un motif en visio (déjà créé en base)

La première a peu de risque d'être flaky, et si elle l'est elle sera plus facile à débugger. Si la seconde est flaky, c'est un autre problème, mais au moins on aura avancé.

J'ai déplacé la première spec dans le fichier `agent_can_crud_motifs_spec.rb` qui me paraît être sa place.