### PR TITLE
Petites améliorations visuelles sur la landing pour les agents sans organisations

### DIFF
--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -7,7 +7,7 @@
     .card
       .card-body
         h2.fr-h6 Votre structure utilise déjà #{current_domain.name} et vous souhaitez disposer d’un accès ?
-        p Vos collègues peuvent vous inviter depuis le menu <b>“Paramètres > Agents > Ajouter un agent”</b>.
+        p Vos collègues peuvent vous inviter depuis le menu <b>Paramètres > Agents > Ajouter un agent</b>.
 
   .fr-col-6.fr-p-1w.fr-pb-8w
     .card

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -3,13 +3,13 @@
   p.fr-py-1w Pour commencer, aidez-nous à en savoir plus :
 
 .fr-grid-row
-  .fr-col-6.fr-p-1w
+  .fr-col-12.fr-col-md-6.fr-p-1w
     .card
       .card-body
         h2.fr-h6 Votre structure utilise déjà #{current_domain.name} et vous souhaitez disposer d’un accès ?
         p Vos collègues peuvent vous inviter depuis le menu <b>Paramètres > Agents > Ajouter un agent</b>.
 
-  .fr-col-6.fr-p-1w.fr-pb-8w
+  .fr-col-12.fr-col-md-6.fr-p-1w.fr-pb-8w
     .card
       .card-body
         h2.fr-h6 Votre structure n’utilise pas #{current_domain.name} et vous souhaitez créer un compte ?

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -1,17 +1,20 @@
-.fr-container.fr-pb-8w
+.fr-container
   h1.fr-h3.fr-pb-2w Bienvenue !
   p.fr-py-1w Pour commencer, aidez-nous à en savoir plus :
 
-  p.fr-pt-1w.fr-pb-2w
-    | Votre structure <b>utilise déjà #{current_domain.name}</b> et vous souhaitez disposer d’un accès ?
-    br
-    | Vos collègues peuvent vous inviter depuis le menu <b>“Paramètres > Agents > Ajouter un agent”</b>.
+.fr-grid-row
+  .fr-col-6.fr-p-1w
+    .card
+      .card-body
+        h2.fr-h6 Votre structure utilise déjà #{current_domain.name} et vous souhaitez disposer d’un accès ?
+        p Vos collègues peuvent vous inviter depuis le menu <b>“Paramètres > Agents > Ajouter un agent”</b>.
 
-  p.fr-py-1w
-    | Votre structure <b>n’utilise pas #{current_domain.name}</b> et vous souhaitez créer un compte ?
-    br
-    | Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et créer le compte de votre structure.
+  .fr-col-6.fr-p-1w.fr-pb-8w
+    .card
+      .card-body
+        h2.fr-h6 Votre structure n’utilise pas #{current_domain.name} et vous souhaitez créer un compte ?
+        p Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et créer le compte de votre structure.
 
-  ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md.fr-mb-8w
-    li
-      = link_to "Contacter notre équipe", "https://cal.com/team/rdv-service-public/temps-d-echanges", class: "fr-btn"
+        ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md
+          li
+            = link_to "Rencontrer notre équipe", "https://cal.com/team/rdv-service-public/temps-d-echanges", class: "fr-btn"

--- a/app/views/agents/rdv_plans/edit_modalites.html.slim
+++ b/app/views/agents/rdv_plans/edit_modalites.html.slim
@@ -5,6 +5,7 @@
   .col-12.col-md-4
     = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: true
     = link_to edit_starts_at_agents_rdv_plan_path(@rdv_plan) do
+      = back_icon(class: "fr-mr-1w")
       = "retour"
 
   .col-12.col-md-4

--- a/app/views/agents/rdv_plans/edit_starts_at.html.slim
+++ b/app/views/agents/rdv_plans/edit_starts_at.html.slim
@@ -6,4 +6,6 @@
     p Convenez d'un horaire avec #{@rdv_plan.user.full_name}, et cliquez dessus dans le calendrier
     = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: false
     - if @rdv_plan.return_url
-      = link_to "retour", @rdv_plan.return_url
+      = link_to @rdv_plan.return_url do
+        = back_icon(class: "fr-mr-1w")
+        = "Retour sur #{@rdv_plan.oauth_application.name}"

--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -13,7 +13,8 @@
       = render "agents/rdv_plans/summary/motif", rdv_plan: @rdv_plan
 
       hr.fr-mt-2w
-      h3= @rdv_plan.user.full_name
+      h3 Coordonnées de #{@rdv_plan.user.full_name}
+      p Des notifications seront envoyées par email et/ou par sms
       = simple_form_for @rdv_plan, url: create_rdv_agents_rdv_plan_path(@rdv_plan), method: :post do |f|
         = f.fields_for :user, @rdv_plan.user do |ff|
           .row

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,19 +3,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "b96d8c613cd055c2962f67120dcbe2aef94766bd6c03784624afd356adc0adaf",
+      "fingerprint": "dbe0369e2d4d1c53275ed53753eb214ac4f86b713b15cbe7035590a5fd0139ab",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/agents/rdv_plans/edit_starts_at.html.slim",
       "line": 9,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"retour\", RdvPlan.find(params[:id]).return_url)",
+      "code": "link_to(RdvPlan.find(params[:id]).return_url)",
       "render_path": [
         {
           "type": "controller",
           "class": "Agents::RdvPlansController",
           "method": "edit_starts_at",
-          "line": 12,
+          "line": 16,
           "file": "app/controllers/agents/rdv_plans_controller.rb",
           "rendered": {
             "name": "agents/rdv_plans/edit_starts_at",
@@ -49,7 +49,7 @@
           "type": "controller",
           "class": "Agents::RdvPlansController",
           "method": "rdv",
-          "line": 82,
+          "line": 86,
           "file": "app/controllers/agents/rdv_plans_controller.rb",
           "rendered": {
             "name": "agents/rdv_plans/rdv",


### PR DESCRIPTION
# Contexte

Suite à une discussion avec Marlène de DS, on a amélioré un peu l'UI de la page pour les agents qui n'ont pas d'organisation

# Solution

On met deux blocs côte à côté plutôt que l'un au dessus de l'autre pour mieux indiquer qu'il y a deux possibilités, et pour mieux grouper le CTA avec la situation correspondante.

On change le texte du CTA, parce que dans son état actuel on s'attend à ce qu'il amène vers un formulaire de contact et pas une prise de rdv.

Je corrige aussi au passage des icônes manquantes dans le parcours de prise de rdv par intégration.

## Captures d'écran

Avant | Après
:- | -:
<img width="1435" alt="Screenshot 2025-03-05 at 17 44 57" src="https://github.com/user-attachments/assets/76b5c8d0-e82d-4fcd-9c39-f450bc7489dd" />|<img width="1440" alt="Screenshot 2025-03-05 at 17 44 28" src="https://github.com/user-attachments/assets/f3e916b3-3800-4289-b015-a7fdff2d5eb1" />



