### PR TITLE
Ajout du récapitulatif de RDV dans la première partie du parcours usager

### DIFF
--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -1,25 +1,5 @@
 .fr-container
   = render "search/selected_motif_recap", context: context
-  - if context.lieu.present?
-    .card
-      .card-body
-        = link_to path_to_lieu_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du lieu" do
-          .row
-            .col-auto.align-self-center
-              span.fr-icon-arrow-left-line
-            .col
-              h2.pb-1.mb-1.card-title= context.lieu.name
-              .card-subtitle= context.lieu.address
-  - elsif context.user_selected_organisation.present?
-    .card
-      .card-body
-        = link_to path_to_organisation_selection(params), class: "d-block stretched-link", title: "Retour à la sélection de l’organisation" do
-          .row
-            .col-auto.align-self-center
-              span.fr-icon-arrow-left-line
-            .col
-              h2.pb-1.mb-1.card-title= context.user_selected_organisation.name
-              = render "search/organisation_card_subtitles", organisation: context.user_selected_organisation
   - if context.no_availability?
     = render "search/nothing_to_show", context: context
   - else

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -4,9 +4,9 @@
     = render "search/nothing_to_show", context: context
   - else
     - if context.first_matching_motif.collectif?
-      h3 = "Inscrivez-vous à l'atelier de votre choix :"
+      h1.fr-h3 = "Inscrivez-vous à l'atelier de votre choix :"
     - else
-      h3 Sélectionnez un créneau&nbsp;:
+      h1.fr-h3 Sélectionnez un créneau&nbsp;:
     - if context.first_matching_motif.collectif?
       ul.fr-raw-list
         - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -2,7 +2,7 @@
 - if context.shown_lieux.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h3 = t(".select_lieu")
+  h1.fr-h3 = t(".select_lieu")
   p = t(".lieu_available", count: context.shown_lieux.count)
   ul.fr-raw-list
     - context.next_availability_by_lieux.each do |lieu, next_availability|

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -4,7 +4,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2 Sélectionnez le motif de votre RDV&nbsp;:
+  h1.fr-h2 Sélectionnez le motif de votre RDV&nbsp;:
   ul.fr-raw-list
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,11 +1,6 @@
-.card
-  .card-body
-    = link_to path_to_service_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du service" do
-      .row
-        .col-auto.align-self-center
-          span.fr-icon-arrow-left-line
-        .col
-          h2.fr-pb-0.fr-mb-0 = context.service.name
+// Nous mettons un lien simple qui est beaucoup plus accessible en attendant la PR qui fusionne la sélection du service et du motif
+.fr-mb-4w
+  = link_to "Retour à la sélection du service", path_to_service_selection(params), class: "fr-link fr-icon-arrow-go-back-line fr-link--icon-left"
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -2,7 +2,7 @@
 - if context.next_availability_by_motifs_organisations.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h3 Sélectionnez la structure avec laquelle prendre RDV&nbsp;:
+  h1.fr-h3 Sélectionnez la structure avec laquelle prendre RDV&nbsp;:
   ul.fr-raw-list
     - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
       li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -1,10 +1,35 @@
 .card
-  .card-body
-    = link_to path_to_motif_selection(params), class: "d-block stretched-link", title: "Retour à la sélection du motif" do
+  ul.list-group.list-group-flush
+    li.list-group-item
       .row
-        .col-auto.align-self-center
-          span.fr-icon-arrow-left-line
         .col
-          h2.pb-1.mb-1
-            = motif_name_and_location_type(context.first_matching_motif)
-          = context.service.name
+          span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+          | Motif :&nbsp;
+          = context.first_matching_motif.name
+        .col-auto
+          = link_to "modifier", path_to_service_selection(params)
+    - case context.first_matching_motif.location_type
+    - when Motif.location_types[:phone]
+      li.list-group-item
+        span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+        | RDV téléphonique
+    - when Motif.location_types[:home]
+      li.list-group-item
+        span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+        | RDV à domicile
+    - when Motif.location_types[:visio]
+      li.list-group-item
+        span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+        | RDV par visioconférence
+    - when Motif.location_types[:public_office]
+      - if context.lieu
+        li.list-group-item
+          .row
+            .col
+              span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
+              | Lieu :&nbsp;
+              = context.lieu.full_name
+            .col-auto
+              = link_to "modifier", path_to_organisation_selection(params)
+    - else
+      = raise "unrecognized location_type: #{rdv_wizard.motif.location_type.inspect}"

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -258,7 +258,6 @@ RSpec.describe "agents can prescribe rdvs" do
       it "when sectorization is enabled on the user street level only it show the street leveled motif only" do
         expect(page).not_to have_content(motif_insertion.name)
         expect(page).not_to have_content(motif_autre_service.name)
-        expect(page).to have_content(motif_mds.service.name)
         expect(page).to have_content(motif_mds.name)
         click_on motif_mds.name
         find(".fr-card__title", text: /#{mds_paris_nord.name}/).ancestor(".fr-card__body").find("a").click

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
 
       expect(page).to have_content("Sélectionnez un créneau")
 
-      click_on(lieu.name)
+      find_all("a", text: "modifier").last.click # Retour en arrière au choix de lieu
 
       expect(page).to have_content("Sélectionnez un lieu de RDV")
       click_on lieu.name

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       click_on("Motif A") # choix du motif
       expect(page).to have_content("1 lieu est disponible")
       expect(page).to have_content(lieu_a.name)
-      expect(page).to have_content(motif_a.service.name)
       click_on(lieu_a.name)
 
       expect(page).to have_content("Sélectionnez un créneau")
@@ -83,10 +82,10 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
       visit "http://www.rdv-aide-numerique-test.localhost/org/#{organisation_a.id}"
       click_on("Motif C")
-      expect(page).to have_content("Motif C (Sur place)")
+      expect(page).to have_content("Motif C")
 
       # retour au choix de motif
-      click_on("Motif C")
+      click_on("modifier")
       expect(page).to have_content("Sélectionnez le motif de votre RDV")
     end
 
@@ -95,7 +94,6 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
       click_on("Motif A") # choix du motif
       expect(page).to have_content("1 lieu est disponible")
       expect(page).to have_content(lieu_a.name)
-      expect(page).to have_content(motif_a.service.name)
       click_on(lieu_a.name)
 
       expect(page).to have_content("Sélectionnez un créneau")

--- a/spec/features/users/online_booking/motif_selection_spec.rb
+++ b/spec/features/users/online_booking/motif_selection_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Motif selection" do
       click_link("premier contact")
       expect(page).to have_content("Sélectionnez un lieu de RDV")
       expect(page).to have_content("MDS Centre")
-      click_link("premier contact") # c’est le lien retour
+      click_link("modifier")
       expect(page).to have_content("Sélectionnez le motif")
     end
   end

--- a/spec/features/users/online_booking/resin_link_spec.rb
+++ b/spec/features/users/online_booking/resin_link_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Rés'In specific public link" do
 
   it "allows user to book a RDV" do
     visit "/resin/123,456"
-    expect(page).to have_content("Accompagnement individuel (Sur place)")
+    expect(page).to have_content("Accompagnement individuel")
     expect(page).to have_content("2 lieux sont disponibles")
     expect(page).to have_content(motif_a.name)
     expect(page).to have_content(motif_b.name)


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5154.osc-secnum-fr1.scalingo.io/) 

# Contexte

Afin de rendre plus accessible et plus claire la navigation dans la première partie du parcours usager, on adopte un récapitulatif de RDV similaire à celui de la seconde partie.

# Solution

- On utilise des éléments similaires à l’existant (mais adaptés au fait que nous n’ayons pas encore le rdv wizard)
- Pour l’étape de sélection de motif, on fait un lien simple vers la sélection de service car nous souhaitons fusionner ces deux étapes dans une PR suivante.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/1923bcef-e866-4a60-a2b5-d14f1ad81405) | ![image](https://github.com/user-attachments/assets/58314449-1513-4644-9c6a-c9290be8d262)
![image](https://github.com/user-attachments/assets/51dd32a6-bc34-42d3-bcd2-d6d176c05e27) | ![image](https://github.com/user-attachments/assets/b94f029b-1ad4-4de8-bdb4-73c0bb0845f3)
![image](https://github.com/user-attachments/assets/edbbc092-4810-4d54-b63f-452a16d6d127) | ![image](https://github.com/user-attachments/assets/a015ff9b-6f36-4ef3-85cf-8f010fc8c7ed)


