### PR TITLE
Améliorer le wording de création de première plage

### DIFF
--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -17,6 +17,7 @@ class Admin::PlageOuverturesController < AgentAuthController
     @plage_ouvertures = all_plage_ouvertures
       .where(expired_cached: filter_params[:current_tab] == "expired")
       .page(page_number)
+    @plage_ouvertures_before_text_search = @plage_ouvertures
     @plage_ouvertures = @plage_ouvertures.search_by_text(params[:search]) if params[:search].present?
     @display_tabs = all_plage_ouvertures.where(expired_cached: true).any? || params[:current_tab] == "expired"
   end

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -22,12 +22,13 @@
       li.nav-item
         = active_link_to t(".past"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id, current_tab: "expired", search: params[:search]), class: "nav-link", active: { current_tab: "expired" }
 
-  .m-2.d-flex.justify-content-end
-    div= link_to t("helpers.reset"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: class_names("btn", "btn-link", "d-none": params[:search].blank?)
-    = simple_form_for "", url: admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
-      = f.input :search, placeholder: t(".search_placeholder"), label: false, input_html: { autocomplete: "off", class: "search-form-control mr-2", value: params[:search] }, required: false
-      = f.hidden_field :current_tab, value: params[:current_tab]
-      = f.button :submit, t("helpers.search")
+  - if @plage_ouvertures_before_text_search.any?
+    .m-2.d-flex.justify-content-end
+      div= link_to t("helpers.reset"), admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), class: class_names("btn", "btn-link", "d-none": params[:search].blank?)
+      = simple_form_for "", url: admin_organisation_agent_plage_ouvertures_path(current_organisation, @agent.id), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
+        = f.input :search, placeholder: t(".search_placeholder"), label: false, input_html: { autocomplete: "off", class: "search-form-control mr-2", value: params[:search] }, required: false
+        = f.hidden_field :current_tab, value: params[:current_tab]
+        = f.button :submit, t("helpers.search")
 
   - if @plage_ouvertures.any?
     table.table

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -50,20 +50,18 @@
             = t(".no_results_for_your_search")
           - else
             - if current_agent == @agent
-              = t(".not_yet_created_plage_ouverture")
+              = t(".self.not_yet_created_plage_ouverture")
+              p = t(".self.explanation_plage_ouverture")
             - else
-              =t(".this_agent_not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
-            p = t(".explanation_plage_ouverture")
-            span.fa-stack.fa-4x
-              i.fa.fa-circle.fa-stack-2x.text-primary
-              i.far.fa-calendar.fa-stack-1x.text-white
+              = t(".other_agent.not_yet_created_plage_ouverture", full_name: @agent.full_name_or_email)
+              p = t(".other_agent.explanation_plage_ouverture")
 
             .mt-3
               = link_to new_admin_organisation_agent_plage_ouverture_path(current_organisation, @agent.id), class: "btn btn-primary" do
                 - if current_agent == @agent
-                  = t(".create_plage_ouverture")
+                  = t(".self.create_first_plage_cta")
                 - else
-                  = t(".create_plage_ouverture_for", full_name: @agent.full_name_or_email)
+                  = t(".other_agent.create_first_plage_cta", full_name: @agent.full_name_or_email)
 
   - if params[:current_tab] == "expired"
     .rdv-text-align-center.text-muted = t(".hint_delete_old")

--- a/config/locales/views/plage_ouvertures.fr.yml
+++ b/config/locales/views/plage_ouvertures.fr.yml
@@ -11,9 +11,16 @@ fr:
         in_progress: En cours
         past: "Passées"
         no_results_for_your_search: Il n'y a pas de résultat correspondant à votre recherche.
-        not_yet_created_plage_ouverture: Vous n'avez pas encore créé de plage d'ouverture.
-        this_agent_not_yet_created_plage_ouverture: "%{full_name} n'a pas encore créé de plage d'ouverture."
-        explanation_plage_ouverture: Les plages d'ouvertures affichent votre disponibilité à la prise de RDV, qu'elle soit faite par l'usager lui même (en ligne) ou par un autre agent de votre organisation. Chaque agent a ses propres plages d'ouvertures et peut y associer des motifs et un lieu. Les plages peuvent être récurrentes.
+
+        self:
+          not_yet_created_plage_ouverture: Vous n'avez pas encore créé de plage d'ouverture.
+          explanation_plage_ouverture: Vos plages d'ouverture sont votre vitrine de disponibilité. Elles permettent aux usagers de réserver un créneau avec vous (si l’option est activée) et facilitent la coordination avec vos collègues.
+          create_first_plage_cta: Renseigner mes disponibilités
+        other_agent:
+          not_yet_created_plage_ouverture: "%{full_name} n'a pas encore créé de plage d'ouverture."
+          explanation_plage_ouverture: Ses plages d'ouverture sont sa vitrine de disponibilité. Elles permettent aux usagers de réserver un créneau (si l’option est activée) et facilitent la coordination avec ses collègues.
+          create_first_plage_cta: Renseigner les disponibilités de %{full_name}
+
         title: Libellé
         motifs: Motifs
         place: Lieu

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
 
-      click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
+      click_link "Renseigner les disponibilités de Jane FAROU", match: :first
 
       expect_page_title("Nouvelle plage d'ouverture")
       fill_in "Libellé (facultatif)", with: "Accueil"
@@ -155,7 +155,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
         expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
 
-        click_link "Créer une plage d'ouverture pour Jane FAROU", match: :first
+        click_link "Renseigner les disponibilités de Jane FAROU", match: :first
 
         expect_page_title("Nouvelle plage d'ouverture")
         fill_in "Libellé (facultatif)", with: "Accueil"


### PR DESCRIPTION
# Contexte

Le trio des plages d'ouvertures a constaté que le message affiché lorsque l'agent n'a aucun plage est améliorable. Cette nouvelle formulation met l'accent sur ce que permettent de faire les plages, et non pas sur ce qu'elles sont.

L'icône géante est aussi inutile, donc on la retire.

Note : Nous sommes conscient que le terme "indisponibilité" devient un peu synonyme de "plage d'ouverture", et nous l'utilisons de manière très ciblée ici. Mais au fond, il faudrait renommer les plages en "disponibilités", ce qui est un autre chantier.


# Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/8e7b1741-e867-4fb7-a927-89dc0e697fa3) | ![image](https://github.com/user-attachments/assets/a70a0199-caa0-405b-bb6d-57ff3e44ce13)
![image](https://github.com/user-attachments/assets/1cc48795-4b4c-42d8-b377-82dc57602037) | ![image](https://github.com/user-attachments/assets/aa5a936d-59a8-42e4-bf15-20b262490a27)

