### PR TITLE
Contrôle des endpoints qui utilisent les invitations

### DIFF
--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -12,8 +12,6 @@ module TokenInvitable
   private
 
   def store_invitation_in_session_and_redirect
-    return true if params[:invitation_token].blank?
-
     invitation = Invitation.new(current_url_params)
     return redirect_with_error(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
     return redirect_with_error(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -7,12 +7,14 @@ module TokenInvitable
   included do
     # :store_invitation_in_session_and_redirect is called first, :sign_in_with_session_token after it
     prepend_before_action :sign_in_with_session_token, if: -> { session[:invitation].present? }
-    prepend_before_action :store_invitation_in_session_and_redirect, if: -> { params[:invitation_token].present? }
+    prepend_before_action :store_invitation_in_session_and_redirect
   end
 
   private
 
   def store_invitation_in_session_and_redirect
+    return true if params[:invitation_token].blank?
+
     invitation = Invitation.new(current_url_params)
     return redirect_with_error(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
     return redirect_with_error(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -7,7 +7,6 @@ module TokenInvitable
   included do
     # :store_invitation_in_session_and_redirect is called first, :sign_in_with_session_token after it
     prepend_before_action :sign_in_with_session_token, if: -> { session[:invitation].present? }
-    prepend_before_action :store_invitation_in_session_and_redirect
   end
 
   private

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,7 @@ class SearchController < ApplicationController
   layout "application_base"
 
   include TokenInvitable
+  prepend_before_action :store_invitation_in_session_and_redirect
 
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social
   after_action :allow_iframe

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -90,10 +90,10 @@ class SearchController < ApplicationController
   private
 
   def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return unless params[:invitation_token]
+    return true if params[:invitation_token].blank?
 
     if params[:action] != "search_rdv"
-      Sentry.capture_message("Invitation used on unexpected action")
+      Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
     end
     store_invitation_in_session_and_redirect
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,8 +2,7 @@ class SearchController < ApplicationController
   layout "application_base"
 
   include TokenInvitable
-  # ce before_action est utile uniquement pour search_rdv
-  prepend_before_action :store_invitation_in_session_and_redirect
+  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social
   after_action :allow_iframe
@@ -89,6 +88,15 @@ class SearchController < ApplicationController
   end
 
   private
+
+  def store_invitation_in_session_and_redirect_for_allowlisted_actions
+    return unless params[:invitation_token]
+
+    if params[:action] != "search_rdv"
+      Sentry.capture_message("Invitation used on unexpected action")
+    end
+    store_invitation_in_session_and_redirect
+  end
 
   def redirect_to_organisation_search(organisation)
     if organisation

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,6 +2,7 @@ class SearchController < ApplicationController
   layout "application_base"
 
   include TokenInvitable
+  # ce before_action est utile uniquement pour search_rdv
   prepend_before_action :store_invitation_in_session_and_redirect
 
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social

--- a/app/controllers/user_auth_controller.rb
+++ b/app/controllers/user_auth_controller.rb
@@ -28,10 +28,7 @@ class UserAuthController < ApplicationController
   end
 
   def should_verify_user_name_initials?
-    return false unless current_user.signed_in_with_invitation_token?
-    return false if cookies.encrypted[user_name_initials_cookie_name] == true
-
-    true
+    current_user.signed_in_with_invitation_token? && !cookies.encrypted[user_name_initials_cookie_name]
   end
 
   def verify_user_name_initials
@@ -41,6 +38,8 @@ class UserAuthController < ApplicationController
     redirect_to new_users_user_name_initials_verification_path
   end
 
+  # Cette méthode est appelée quand l'usager vérifie ses initiales au moment d'une première "connexion"
+  # ou s'il fait une action d'écriture sur une participation (dont une création de rdv)
   def set_user_name_initials_verified
     cookies.encrypted[user_name_initials_cookie_name] = {
       value: true, expires: 10.minutes.from_now,

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -22,9 +22,9 @@ class Users::ParticipationsController < UserAuthController
   private
 
   def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return unless params[:invitation_token]
+    return true if params[:invitation_token].blank?
 
-    Sentry.capture_message("Invitation used on unexpected action")
+    Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
     store_invitation_in_session_and_redirect
   end
 

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -4,6 +4,7 @@ class Users::ParticipationsController < UserAuthController
   layout "application_narrow"
 
   include TokenInvitable
+  prepend_before_action :store_invitation_in_session_and_redirect
 
   def index
     @rdv = policy_scope(Rdv, policy_scope_class: User::RdvPolicy::Scope).find(params[:rdv_id])

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -4,6 +4,7 @@ class Users::ParticipationsController < UserAuthController
   layout "application_narrow"
 
   include TokenInvitable
+  # je crois que le before action est inutile ici
   prepend_before_action :store_invitation_in_session_and_redirect
 
   def index

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -4,8 +4,7 @@ class Users::ParticipationsController < UserAuthController
   layout "application_narrow"
 
   include TokenInvitable
-  # je crois que le before action est inutile ici
-  prepend_before_action :store_invitation_in_session_and_redirect
+  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
   def index
     @rdv = policy_scope(Rdv, policy_scope_class: User::RdvPolicy::Scope).find(params[:rdv_id])
@@ -21,6 +20,13 @@ class Users::ParticipationsController < UserAuthController
   end
 
   private
+
+  def store_invitation_in_session_and_redirect_for_allowlisted_actions
+    return unless params[:invitation_token]
+
+    Sentry.capture_message("Invitation used on unexpected action")
+    store_invitation_in_session_and_redirect
+  end
 
   def set_rdv
     @rdv = Rdv.find(params[:rdv_id])

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -10,8 +10,7 @@ class Users::RdvWizardStepsController < UserAuthController
   before_action :set_step_titles
 
   include TokenInvitable
-  # je crois que ce before action est inutile ici
-  prepend_before_action :store_invitation_in_session_and_redirect
+  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
   def new
     @rdv_wizard = rdv_wizard_for(current_user, query_params)
@@ -37,6 +36,13 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   protected
+
+  def store_invitation_in_session_and_redirect_for_allowlisted_actions
+    return unless params[:invitation_token]
+
+    Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
+    store_invitation_in_session_and_redirect
+  end
 
   def current_step
     return UserRdvWizard::STEPS.first if params[:step].blank?

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -10,6 +10,7 @@ class Users::RdvWizardStepsController < UserAuthController
   before_action :set_step_titles
 
   include TokenInvitable
+  # je crois que ce before action est inutile ici
   prepend_before_action :store_invitation_in_session_and_redirect
 
   def new

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -38,7 +38,7 @@ class Users::RdvWizardStepsController < UserAuthController
   protected
 
   def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return unless params[:invitation_token]
+    return true if params[:invitation_token].blank?
 
     Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
     store_invitation_in_session_and_redirect

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -10,6 +10,7 @@ class Users::RdvWizardStepsController < UserAuthController
   before_action :set_step_titles
 
   include TokenInvitable
+  prepend_before_action :store_invitation_in_session_and_redirect
 
   def new
     @rdv_wizard = rdv_wizard_for(current_user, query_params)

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -9,6 +9,7 @@ class Users::RdvsController < UserAuthController
   layout "application_narrow", only: %i[show]
 
   include TokenInvitable
+  # ce before action semble nécessaire uniquement pour show et creneaux
   prepend_before_action :store_invitation_in_session_and_redirect
 
   def index

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -97,10 +97,10 @@ class Users::RdvsController < UserAuthController
   private
 
   def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return unless params[:invitation_token]
+    return true if params[:invitation_token].blank?
 
     unless params[:action].in?(%w[show creneaux])
-      Sentry.capture_message("Invitation used on unexpected action")
+      Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
     end
     store_invitation_in_session_and_redirect
   end

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -9,8 +9,7 @@ class Users::RdvsController < UserAuthController
   layout "application_narrow", only: %i[show]
 
   include TokenInvitable
-  # ce before action semble nécessaire uniquement pour show et creneaux
-  prepend_before_action :store_invitation_in_session_and_redirect
+  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
   def index
     authorize(Rdv, policy_class: User::RdvPolicy)
@@ -96,6 +95,15 @@ class Users::RdvsController < UserAuthController
   end
 
   private
+
+  def store_invitation_in_session_and_redirect_for_allowlisted_actions
+    return unless params[:invitation_token]
+
+    unless params[:action].in?(%w[show creneaux])
+      Sentry.capture_message("Invitation used on unexpected action")
+    end
+    store_invitation_in_session_and_redirect
+  end
 
   def build_creneau
     @starts_at = Time.zone.parse(params[:starts_at])

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -9,6 +9,7 @@ class Users::RdvsController < UserAuthController
   layout "application_narrow", only: %i[show]
 
   include TokenInvitable
+  prepend_before_action :store_invitation_in_session_and_redirect
 
   def index
     authorize(Rdv, policy_class: User::RdvPolicy)

--- a/app/controllers/users/user_name_initials_verification_controller.rb
+++ b/app/controllers/users/user_name_initials_verification_controller.rb
@@ -4,7 +4,6 @@ class Users::UserNameInitialsVerificationController < UserAuthController
   skip_after_action :verify_authorized
 
   include TokenInvitable
-  prepend_before_action :store_invitation_in_session_and_redirect
 
   def new; end
 

--- a/app/controllers/users/user_name_initials_verification_controller.rb
+++ b/app/controllers/users/user_name_initials_verification_controller.rb
@@ -4,6 +4,7 @@ class Users::UserNameInitialsVerificationController < UserAuthController
   skip_after_action :verify_authorized
 
   include TokenInvitable
+  prepend_before_action :store_invitation_in_session_and_redirect
 
   def new; end
 

--- a/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
+++ b/app/views/mailers/users/rdv_mailer/rdv_cancelled.html.slim
@@ -14,6 +14,7 @@ div
   - if @rdv.bookable_by_everyone?
     p= t(".reschedule_online")
     .btn-wrapper
+      / Il y a peut-être un bug ici : il manquerait le lieu_id, qui fait partie des choix de l'usager
       = link_to t(".reschedule_button"), prendre_rdv_url(\
         departement: @rdv.organisation.departement_number, \
         motif_name_with_location_type: @rdv.motif.name_with_location_type, \

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TokenInvitable, type: :controller do
       return unless params[:invitation_token]
 
       unless params[:action].in?(["fake_action"])
-        Sentry.capture_message("Invitation used on unexpected action")
+        Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
       end
       store_invitation_in_session_and_redirect
     end
@@ -213,11 +213,12 @@ RSpec.describe TokenInvitable, type: :controller do
 
       expect(request.session[:invitation]).to eq(params.merge(expires_at: Time.zone.parse("2022-08-03 10:32:00")))
 
-      expect(sentry_events.last.message).to eq "Invitation used on unexpected action"
+      expect(sentry_events.last.message).to eq "Invitation used unexpectedly on anonymous#fake_action_not_using_invitation"
     end
 
     it "doesn't notify Sentry if there is no invitation token" do
       get :fake_action_not_using_invitation
+      expect(response.body).to eq "ok"
 
       expect(sentry_events).to be_empty
     end

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TokenInvitable, type: :controller do
     private
 
     def store_invitation_in_session_and_redirect_for_allowlisted_actions
-      return unless params[:invitation_token]
+      return true if params[:invitation_token].blank?
 
       unless params[:action].in?(["fake_action"])
         Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe TokenInvitable, type: :controller do
   controller(ApplicationController) do
     include TokenInvitable
-    prepend_before_action :store_invitation_in_session_and_redirect
+    prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
     def fake_action
       render plain: "ok"
@@ -13,7 +13,12 @@ RSpec.describe TokenInvitable, type: :controller do
 
     private
 
-    def store_invitation_in_session_and_redirect_for_allowlisted_actions; end
+    def store_invitation_in_session_and_redirect_for_allowlisted_actions
+      store_invitation_in_session_and_redirect
+      unless params[:action].in?(["fake_action"])
+        Sentry.capture_message("Invitation used on unexpected action")
+      end
+    end
   end
 
   let!(:token) { "some-token" }
@@ -23,7 +28,10 @@ RSpec.describe TokenInvitable, type: :controller do
 
   before do
     travel_to(now)
-    routes.draw { get "fake_action" => "anonymous#fake_action" }
+    routes.draw do
+      get "fake_action" => "anonymous#fake_action"
+      get "fake_action_not_using_invitation" => "anonymous#fake_action_not_using_invitation"
+    end
   end
 
   describe "#store_invitation_in_session_and_redirect" do
@@ -191,6 +199,19 @@ RSpec.describe TokenInvitable, type: :controller do
           expect(flash[:error]).to eq("L’utilisateur connecté ne correspond pas à l’utilisateur invité. Déconnectez-vous et réessayez.")
         end
       end
+    end
+  end
+
+  context "when using an invitation on an unexpected action" do
+    let(:token) { user.set_rdv_invitation_token! }
+    let(:params) { { invitation_token: token } }
+
+    it "stores the token in the session and notifies Sentry" do
+      get :fake_action_not_using_invitation, params: params
+
+      expect(request.session[:invitation]).to eq(params.merge(expires_at: Time.zone.parse("2022-08-03 10:32:00")))
+
+      expect(sentry_events.last.message).to eq "Invitation used on unexpected action"
     end
   end
 end

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -14,10 +14,12 @@ RSpec.describe TokenInvitable, type: :controller do
     private
 
     def store_invitation_in_session_and_redirect_for_allowlisted_actions
-      store_invitation_in_session_and_redirect
+      return unless params[:invitation_token]
+
       unless params[:action].in?(["fake_action"])
         Sentry.capture_message("Invitation used on unexpected action")
       end
+      store_invitation_in_session_and_redirect
     end
   end
 
@@ -212,6 +214,12 @@ RSpec.describe TokenInvitable, type: :controller do
       expect(request.session[:invitation]).to eq(params.merge(expires_at: Time.zone.parse("2022-08-03 10:32:00")))
 
       expect(sentry_events.last.message).to eq "Invitation used on unexpected action"
+    end
+
+    it "doesn't notify Sentry if there is no invitation token" do
+      get :fake_action_not_using_invitation
+
+      expect(sentry_events).to be_empty
     end
   end
 end

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -1,10 +1,19 @@
 RSpec.describe TokenInvitable, type: :controller do
   controller(ApplicationController) do
     include TokenInvitable
+    prepend_before_action :store_invitation_in_session_and_redirect
 
     def fake_action
       render plain: "ok"
     end
+
+    def fake_action_not_using_invitation
+      render plain: "ok"
+    end
+
+    private
+
+    def store_invitation_in_session_and_redirect_for_allowlisted_actions; end
   end
 
   let!(:token) { "some-token" }


### PR DESCRIPTION
cette Pr est la suite de https://github.com/betagouv/rdv-service-public/pull/5145

# Contexte

j'essaye de découpler deux aspects du système actuel d'invitation :
- l'authentification limitée à un rdv
- l'authentification limitée à une prise de rdv avec ajout de contrainte lors du choix de créneaux.

Pour faire ça, j'essaye d'identifier les routes qui utilisent la logique de ces deux mécanismes.

Actuellement, toutes les actions des controllers qui incluent `TokenInvitable` peuvent prendre un paramètre `invitation_token` qui permet de faire un login limité à un rdv.
Après beaucoup de recherche dans le code, cette PR essaye de limiter cette possiblité aux actions pour lesquelles ce fonctionnement existe dans la pratique.

On aurait pu penser que c'est "pratique" de pouvoir utiliser l'authentification restreinte sur n'importe quelle route, mais ça ajoute pas mal de complexité, et je pense que le code sera plus compréhensible si on identifie clairement les endroits qui s'en servent.


# Solution

Plutôt que de bloquer complètement l'authentification pour les actions qui ne semblent pas être concernées, on notifie Sentry et on garde le fonctionnement actuel.
L'idée est de faire tourner ce code pendant une ou deux semaines avant de limiter l'usage du `invitation_token` sur les actions de manière stricte.

J'ai préféré dupliquer le code temporaire pour le rendre plus facile à comprendre plutôt que de faire de la métaprogrammation.

