### PR TITLE
Petite amélioration du calcul de créneaux

### DIFF
--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -24,14 +24,14 @@ class Users::RdvsController < UserAuthController
     # Nous modifions en mémoire la durée par défaut du motif
     # Cela permet d'effectuer une recherche de créneaux, avec une durée différente
     motif.default_duration_in_min = params[:duration] if params[:duration]
+    @creneau = CreneauxSearch::ForUser.creneau_for(
+      user: current_user,
+      starts_at: Time.zone.parse(rdv_params[:starts_at]),
+      motif: motif,
+      lieu: lieu,
+      geo_search: @geo_search
+    )
     ActiveRecord::Base.transaction do
-      @creneau = CreneauxSearch::ForUser.creneau_for(
-        user: current_user,
-        starts_at: Time.zone.parse(rdv_params[:starts_at]),
-        motif: motif,
-        lieu: lieu,
-        geo_search: @geo_search
-      )
       if @creneau.present?
         @rdv = build_rdv_from_creneau(@creneau)
         authorize(@rdv, policy_class: User::RdvPolicy)

--- a/app/form_models/prescripteur_rdv_wizard.rb
+++ b/app/form_models/prescripteur_rdv_wizard.rb
@@ -10,6 +10,7 @@ class PrescripteurRdvWizard < UserRdvWizard::Base
   end
 
   def create!
+    creneau # On précharge le créneau en dehors de la transaction pour éviter les erreurs  ActiveRecord::AsynchronousQueryInsideTransactionError lors des requêtes asynchrones
     ActiveRecord::Base.transaction do
       find_or_create_user
 

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -155,18 +155,7 @@ module CreneauxSearch::Calculator
 
       @absences = plage_ouverture.agent.absences.not_expired.in_range(range).load_async
 
-      rdv_scope = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
-
-      # Pour éviter l'erreur :
-      # ActiveRecord::AsynchronousQueryInsideTransactionError:
-      #   Asynchronous queries are not allowed inside transactions
-      # on exécute la requête de manière synchrone si on est dans une transaction,
-      # ce qui arrive pour certaines créations de rendez-vous
-      @rdvs_starts_and_ends_at = if ActiveRecord::Base.connection.open_transactions > 0
-                                   OpenStruct.new(value: rdv_scope.pluck(:starts_at, :ends_at))
-                                 else
-                                   rdv_scope.async_pluck(:starts_at, :ends_at)
-                                 end
+      @rdvs_starts_and_ends_at = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end).async_pluck(:starts_at, :ends_at)
     end
 
     def busy_times_from_absences

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -154,7 +154,19 @@ module CreneauxSearch::Calculator
       #        Le problème potentiel de cette approche est qu'il serait difficile d'éviter de charger des rdv et absences qui sont en dehors des ocurrences des plages d'ouverture
 
       @absences = plage_ouverture.agent.absences.not_expired.in_range(range).load_async
-      @rdvs_starts_and_ends_at = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end).async_pluck(:starts_at, :ends_at)
+
+      rdv_scope = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end)
+
+      # Pour éviter l'erreur :
+      # ActiveRecord::AsynchronousQueryInsideTransactionError:
+      #   Asynchronous queries are not allowed inside transactions
+      # on exécute la requête de manière synchrone si on est dans une transaction,
+      # ce qui arrive pour certaines créations de rendez-vous
+      @rdvs_starts_and_ends_at = if ActiveRecord::Base.connection.open_transactions > 0
+                                   OpenStruct.new(value: rdv_scope.pluck(:starts_at, :ends_at))
+                                 else
+                                   rdv_scope.async_pluck(:starts_at, :ends_at)
+                                 end
     end
 
     def busy_times_from_absences

--- a/app/services/creneaux_search/calculator.rb
+++ b/app/services/creneaux_search/calculator.rb
@@ -138,8 +138,8 @@ module CreneauxSearch::Calculator
       # On calcule les occurrences des absences en premier pour laisser aux rdvs le temps de finir de charger
       busy_times += busy_times_from_absences
 
-      busy_times += @rdvs.map do |rdv|
-        BusyTime.new(rdv.starts_at, rdv.ends_at)
+      busy_times += @rdvs_starts_and_ends_at.value.map do |rdv_starts_and_ends_at|
+        BusyTime.new(rdv_starts_and_ends_at.first, rdv_starts_and_ends_at.last)
       end
 
       # Le tri est nécessaire, surtout pour les surcharges.
@@ -154,7 +154,7 @@ module CreneauxSearch::Calculator
       #        Le problème potentiel de cette approche est qu'il serait difficile d'éviter de charger des rdv et absences qui sont en dehors des ocurrences des plages d'ouverture
 
       @absences = plage_ouverture.agent.absences.not_expired.in_range(range).load_async
-      @rdvs = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end).load_async
+      @rdvs_starts_and_ends_at = plage_ouverture.agent.rdvs.not_cancelled.where("tsrange(starts_at, ends_at, '[)') && tsrange(?, ?)", range.begin, range.end).async_pluck(:starts_at, :ends_at)
     end
 
     def busy_times_from_absences


### PR DESCRIPTION
Cette PR propose une petite amélioration de performance du calcul de créneaux : en utilisant la méthode `async_pluck` plutôt que `async_load`, on évite d'initialiser inutilement des objets `Rdv`, et donc d'exécuter du code ruby inutile.

# Contexte

On a des difficultés à calculer tous les créneaux pour les appels fait par RDV Insertion pour vérifier la validité des invitations.

# Solution

Vu qu'on n'utilise que `starts_at` et `ends_at` sur les rdv, cette amélioration locale est facile à faire.

Petite complication étonnante : ça a commencé à lever des erreurs `ActiveRecord::AsynchronousQueryInsideTransactionError: Asynchronous queries are not allowed inside transactions` lors de la création de rdv par l'usager.
Vu que le calcul de créneau ne fait pas d'écriture et n'acquiert pas de lock (ni sur des lignes ni sur des tables), je l'ai sorti de la transaction.