### PR TITLE
Bandeau d’avertissement quand un super-admin est connecté en tant qu’agent

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -42,9 +42,6 @@ class Agents::SessionsController < Devise::SessionsController
 
     sign_out(:agent)
 
-    # On efface cette clé de session qui nous permet de savoir qu’un super-admin s’est connecté en tant qu’agent
-    session.delete(:sign_in_as)
-
     # Si on redirige vers l'app cliente, on n'aura pas de render pendant lequel le flash s'affichera, donc on ne l'ajoute pas.
     if @oauth_client_app_post_logout_redirect_url
       # On est obligés de modifier la session ici puisque l'appel à `sign_out(:agent)` a effacé la session
@@ -53,7 +50,12 @@ class Agents::SessionsController < Devise::SessionsController
       set_flash_message!(:notice, :signed_out)
     end
 
-    if agent_connect_id_token
+    # Si un super-admin s'est connecté en tant qu'agent, on supprime la clef qui indique qu’il s’est connecté en tant que
+    # et on le redirige vers la liste des agents
+    if session[:sign_in_as]
+      session.delete(:sign_in_as)
+      redirect_to super_admins_agents_path
+    elsif agent_connect_id_token
       agent_connect_client = AgentConnectOpenIdClient::Logout.new(agent_connect_id_token)
 
       redirect_to agent_connect_client.agent_connect_logout_url(root_url), allow_other_host: true

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -42,6 +42,9 @@ class Agents::SessionsController < Devise::SessionsController
 
     sign_out(:agent)
 
+    # On efface cette clé de session qui nous permet de savoir qu’un super-admin s’est connecté en tant qu’agent
+    session.delete(:sign_in_as)
+
     # Si on redirige vers l'app cliente, on n'aura pas de render pendant lequel le flash s'affichera, donc on ne l'ajoute pas.
     if @oauth_client_app_post_logout_redirect_url
       # On est obligés de modifier la session ici puisque l'appel à `sign_out(:agent)` a effacé la session

--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -50,10 +50,8 @@ class Agents::SessionsController < Devise::SessionsController
       set_flash_message!(:notice, :signed_out)
     end
 
-    # Si un super-admin s'est connecté en tant qu'agent, on supprime la clef qui indique qu’il s’est connecté en tant que
-    # et on le redirige vers la liste des agents
-    if session[:sign_in_as]
-      session.delete(:sign_in_as)
+    if session[:super_admin_signed_in_as_agent]
+      session.delete(:super_admin_signed_in_as_agent)
       redirect_to super_admins_agents_path
     elsif agent_connect_id_token
       agent_connect_client = AgentConnectOpenIdClient::Logout.new(agent_connect_id_token)

--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -6,6 +6,8 @@ module SuperAdmins
       if sign_in_as_allowed?
         sign_out(:user)
         bypass_sign_in(agent, scope: :agent)
+        # On ajoute une clé de session pour savoir qu’un super-admin s’est connecté en tant qu’agent
+        session[:sign_in_as] = true
         redirect_to root_url
       else
         flash[:error] = "Fonctionnalité désactivée sur cet environnement."

--- a/app/controllers/super_admins/agents_controller.rb
+++ b/app/controllers/super_admins/agents_controller.rb
@@ -6,8 +6,7 @@ module SuperAdmins
       if sign_in_as_allowed?
         sign_out(:user)
         bypass_sign_in(agent, scope: :agent)
-        # On ajoute une clé de session pour savoir qu’un super-admin s’est connecté en tant qu’agent
-        session[:sign_in_as] = true
+        session[:super_admin_signed_in_as_agent] = true
         redirect_to root_url
       else
         flash[:error] = "Fonctionnalité désactivée sur cet environnement."

--- a/app/views/layouts/_agent_header.html.slim
+++ b/app/views/layouts/_agent_header.html.slim
@@ -28,3 +28,5 @@ header.header.bg-white
             li = link_to destroy_agent_session_path, method: :delete, class: "dropdown-item-dsfr dropdown-item" do
               span.fr-icon--sm.fr-mr-2v.fr-icon-logout-box-r-line[aria-hidden="true"]
               | Se déconnecter
+
+  = render "layouts/super_admin_sign_in_as_warning"

--- a/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
+++ b/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
@@ -3,6 +3,6 @@
     .fr-container
       .fr-notice__body
         p.fr-mb-0
-          span.fr-notice__title Attention
-          span.fr-notice__desc Vous êtes actuellement connecté en tant que #{current_agent.full_name}.
+          span.fr-notice__title Information importante
+          span.fr-notice__desc Vous êtes connecté en tant que #{current_agent.full_name}. Soyez attentif à vos manipulations.
           = link_to "Revenir au super admin", super_admins_agents_path, class: "fr-notice__link"

--- a/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
+++ b/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
@@ -5,4 +5,4 @@
         p.fr-mb-0
           span.fr-notice__title Information importante
           span.fr-notice__desc Vous êtes connecté en tant que #{current_agent.full_name}. Soyez attentif à vos manipulations.
-          = link_to "Revenir au super admin", super_admins_agents_path, class: "fr-notice__link"
+          = link_to "Se déconnecter et revenir au super admin", destroy_agent_session_path, method: :delete, class: "fr-notice__link"

--- a/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
+++ b/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
@@ -1,0 +1,8 @@
+- if session[:sign_in_as]
+  .fr-notice.fr-notice--warning
+    .fr-container
+      .fr-notice__body
+        p.fr-mb-0
+          span.fr-notice__title Attention
+          span.fr-notice__desc Vous êtes actuellement connecté en tant que #{current_agent.full_name}.
+          = link_to "Revenir au super admin", super_admins_agents_path, class: "fr-notice__link"

--- a/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
+++ b/app/views/layouts/_super_admin_sign_in_as_warning.html.slim
@@ -1,4 +1,4 @@
-- if session[:sign_in_as]
+- if session[:super_admin_signed_in_as_agent]
   .fr-notice.fr-notice--warning
     .fr-container
       .fr-notice__body

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -13,6 +13,7 @@ html lang="fr"
     = javascript_include_tag "#{dsfr_path}/dsfr.nomodule.min.js", "data-turbo-track": "reload", nomodule: true, defer: true
   main
     body.pb-0
+      = render "layouts/super_admin_sign_in_as_warning"
       = render "layouts/rdv_solidarites_instance_name"
       .auth-fluid.row
         .auth-fluid-left.text-center.col-xs-12.col-md-4 class="#{"auth-fluid-left--agent-preferences" if current_agent}"


### PR DESCRIPTION
# Contexte

En tant que super-admin, il est possible de se connecter en tant qu’agent. Je propose donc que nous ajoutions un bandeau qui permet de rappeler au super admin qu’il est connecté en tant qu’un agent et qu’il l’invite à revenir au super admin s'il le souhaite.

# Solution

Ajout d’une clé dans la session pour savoir qu’on a utilisé la fonctionnalité de « Connexion en tant que… »

## Captures d'écran

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/4c7c34f5-57ee-4c85-bb5a-c491c57f30d0" />
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/45bf5327-7ac1-44ef-96ac-89b2fc4cadc6" />

