### PR TITLE
Revert la détection d'occurrence invalide

### DIFF
--- a/app/models/recurrence/occurrence.rb
+++ b/app/models/recurrence/occurrence.rb
@@ -4,8 +4,6 @@ class Recurrence::Occurrence
   attr_reader :starts_at, :ends_at
 
   def initialize(starts_at:, ends_at:)
-    raise "Invalid times: #{starts_at} -> #{ends_at}" if starts_at >= ends_at
-
     @starts_at = starts_at
     @ends_at = ends_at
   end


### PR DESCRIPTION
Erreur Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/155630

Dans #5065 j'ai ajouté ce `raise` qui avait pour but de détecter les erreurs que je tente de corriger dans #4983. Je n'aurais pas dû tout mélanger. Je supprime ici ce `raise`.