### PR TITLE
Permettre l'utilisation de la date de naissance sur RDV Service Public

### DIFF
--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -13,15 +13,14 @@ module UserRdvWizard
     def initialize(user, attributes)
       @user = user
       @attributes = attributes.to_h.symbolize_keys
-      rdv_defaults = { user_ids: [user&.id] }
       if attributes[:rdv_collectif_id].present?
         @rdv = Rdv.collectif.bookable_by_everyone_or_agents_and_prescripteurs_or_invited_users.find(attributes[:rdv_collectif_id])
       else
-        @rdv = Rdv.new(
-          rdv_defaults
-            .merge(@attributes.slice(:starts_at, :user_ids, :motif_id))
-        )
+        @rdv = Rdv.new({
+          user_ids: [user&.id],
+        }.merge(@attributes.slice(:starts_at, :user_ids, :motif_id)))
         @rdv.duration_in_min = @attributes[:duration]&.to_i || @rdv.motif&.default_duration_in_min
+        @rdv.organisation_id = @rdv.motif.organisation_id
       end
     end
 

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -93,6 +93,7 @@ class Territory < ApplicationRecord
   OPTIONAL_FIELD_TOGGLES = {
     enable_notes_field: :annotation_content,
     enable_logement_field: :logement,
+    enable_birth_date_field: :birth_date,
   }.merge(SOCIAL_FIELD_TOGGLES).freeze
 
   def mairies?

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -38,7 +38,7 @@
       .form-row
         .col-md-6= f.input :first_name, **input_opts[:relative]
         .col-md-6= f.input :last_name, **input_opts[:relative]
-      - unless current_domain == Domain::RDV_MAIRIE
+      - if current_territory.enable_birth_date_field?
         = date_input(f, :birth_date, **input_opts[:relative])
       - if current_territory.enable_notes_field?
         = f.input :annotation_content, **input_opts[:relative].deep_merge(input_html: { rows: 6, value: user.annotation_for(current_territory) })

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -11,9 +11,10 @@
   .col-md-6= f.input :first_name, **input_opts.deep_merge(frozen_fields_opts)
   .col-md-6= f.input :last_name, **input_opts
 
-- unless current_domain == Domain::RDV_MAIRIE
-  .form-row
+.form-row
+  - if current_domain != Domain::RDV_MAIRIE
     .col-md-6= f.input :birth_name, **input_opts.deep_merge(frozen_fields_opts)
+  - if current_territory.enable_birth_date_field?
     .col-md-6= date_input(f, :birth_date, **input_opts.deep_merge(frozen_fields_opts))
 
 = f.input :phone_number, as: :tel, **input_opts

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -4,7 +4,8 @@ ul.list-unstyled.mb-5
   - if current_organisation.motifs.requires_ants_predemande_number.any?
     li.mb-2= object_attribute_tag(user, :ants_pre_demande_number)
   li.mb-2= object_attribute_tag(user, :birth_name)
-  li.mb-2= object_attribute_tag(user, :birth_date, birth_date_and_age(user))
+  - if current_territory.enable_birth_date_field?
+    li.mb-2= object_attribute_tag(user, :birth_date, birth_date_and_age(user))
   li.mb-2= object_attribute_tag(user, :address)
   li.mb-2= object_attribute_tag(user, :preferred_email, clickable_user_email(user))
   li.mb-2= object_attribute_tag(user, :notify_by_email, notify_by_email_description(user))

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -5,5 +5,5 @@
   = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   = f.hidden_field :ants_pre_demande_number_required, value: "true"
   = f.hidden_field :ants_meeting_point_id
-- if current_domain != Domain::RDV_MAIRIE
+- if current_domain != Domain::RDV_MAIRIE # TODO: trouver un moyen d'avoir le contexte du rdv_wizard, pour ensuite se baser sur current_territory.enable_birth_date_field?
   = f.dsfr_text_field :birth_date, type: :date, input_html: { type: "date" }

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -12,6 +12,7 @@ ruby:
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
     - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
+    - if !current_user.signed_in_with_invitation_token? && rdv_wizard&.rdv&.territory&.enable_birth_date_field?
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, type: "date", disabled: user.logged_once_with_franceconnect?
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
     = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), style: "text-transform: uppercase;"

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -294,6 +294,7 @@ tables:
       - enable_case_number
       - enable_address_details
       - enable_context_field
+      - enable_birth_date_field
       - enable_waiting_room_mail_field
       - enable_waiting_room_color_field
       - visible_users_throughout_the_territory

--- a/db/migrate/20250310112344_add_birth_date_option.rb
+++ b/db/migrate/20250310112344_add_birth_date_option.rb
@@ -1,0 +1,12 @@
+class AddBirthDateOption < ActiveRecord::Migration[7.1]
+  def change
+    add_column :territories, :enable_birth_date_field, :boolean, default: false
+
+    up_only do
+      # Pour la rétro-compatibilité, on active l'option sur tous les territoires de l'instance historique
+      if ENV["HOST"] == "https://www.rdv-solidarites.fr"
+        Territory.update_all(enable_birth_date_field: true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_03_104258) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_10_112344) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -735,6 +735,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_03_104258) do
     t.boolean "enable_waiting_room_mail_field", default: false
     t.boolean "enable_waiting_room_color_field", default: false
     t.boolean "visible_users_throughout_the_territory", default: false
+    t.boolean "enable_birth_date_field", default: false
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
   end
 

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe "Agent can CRUD intervenants" do
         fill_in "Nom", with: "Fictif", match: :smart
       end
       click_button("Enregistrer")
+      expect(page).to have_content "L’agent nouvel_agent@exemple.fr a été invité à rejoindre votre organisation."
 
       expect(agent_intervenant1.reload.roles.pluck(:access_level)).to eq ["basic"]
     end

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe "Agent can CRUD motifs" do
       visit edit_admin_organisation_motif_path(organisation_id: organisation.id, id: motif.id)
       find("#tab_resa_en_ligne").click
       check "Autoriser les agents du service Secrétariat à assurer ces RDV"
-      click_on "Enregistrer" and motif.reload
+      click_on "Enregistrer"
+      expect(page).to have_content "Le motif #{motif.name} a été modifié."
+      motif.reload
       expect(motif.for_secretariat).to be_truthy
       expect(motif.follow_up).to be_falsey
 
@@ -73,7 +75,9 @@ RSpec.describe "Agent can CRUD motifs" do
       find("#tab_resa_en_ligne").click
       check "Autoriser ces rendez-vous seulement aux usagers bénéficiant d'un suivi par un référent"
       expect(find("#motif_for_secretariat", visible: false)).not_to be_checked
-      click_on "Enregistrer" and motif.reload
+      click_on "Enregistrer"
+      expect(page).to have_content "Le motif #{motif.name} a été modifié."
+      motif.reload
       expect(motif.for_secretariat).to be_falsey
       expect(motif.follow_up).to be_truthy
     end

--- a/spec/features/agents/agent_can_crud_motifs_spec.rb
+++ b/spec/features/agents/agent_can_crud_motifs_spec.rb
@@ -100,13 +100,19 @@ RSpec.describe "Agent can CRUD motifs" do
       choose "Agents de l’organisation, prescripteurs et usagers"
       expect(editable_by_user_checkbox).to be_checked
 
-      expect { click_on "Enregistrer" }.to change { motif.reload.bookable_by }.to("everyone")
+      expect do
+        click_on "Enregistrer"
+        expect(page).to have_content "Le motif #{motif.name} a été modifié."
+      end.to change { motif.reload.bookable_by }.to("everyone")
 
       # On décoche la case "RDVs modifiables" et on enregistre
       click_on "Modifier"
       find("#tab_resa_en_ligne").click
       uncheck "motif_rdvs_editable_by_user"
-      expect { click_on "Enregistrer" }.to change { motif.reload.rdvs_editable_by_user }.from(true).to(false)
+      expect do
+        click_on "Enregistrer"
+        expect(page).to have_content "Le motif #{motif.name} a été modifié."
+      end.to change { motif.reload.rdvs_editable_by_user }.from(true).to(false)
 
       # On revient sur le formulaire, la case est bien décochée
       # et reste décochée lorsque l'on désactive la résa en ligne
@@ -115,7 +121,10 @@ RSpec.describe "Agent can CRUD motifs" do
       expect(editable_by_user_checkbox).not_to be_checked
       choose "Agents de l’organisation", id: "motif_bookable_by_agents"
       expect(editable_by_user_checkbox).not_to be_checked
-      expect { click_on "Enregistrer" }.to change { motif.reload.bookable_by }.from("everyone").to("agents")
+      expect do
+        click_on "Enregistrer"
+        expect(page).to have_content "Le motif #{motif.name} a été modifié." # On attend le chargement de cette page pour éviter une flaky spec
+      end.to change { motif.reload.bookable_by }.from("everyone").to("agents")
     end
 
     it "allows changing the motif's location_type to :visio" do

--- a/spec/features/agents/relatives/agent_can_create_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_create_relative_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe "Agent can create a relative" do
-  let!(:organisation) { create(:organisation) }
+  let!(:organisation) { create(:organisation, territory: territory) }
+  let(:territory) do
+    create(:territory, enable_birth_date_field: true)
+  end
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do
     create(:user, first_name: "Fiona", last_name: "LEGENDE", email: "jean@legende.com", organisations: [organisation])

--- a/spec/features/agents/relatives/agent_can_update_relative_spec.rb
+++ b/spec/features/agents/relatives/agent_can_update_relative_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe "Agent can update a relative" do
-  let!(:organisation) { create(:organisation) }
+  let!(:organisation) { create(:organisation, territory: territory) }
+  let(:territory) do
+    create(:territory, enable_birth_date_field: true)
+  end
   let!(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
   let!(:user) do
     create(:user, first_name: "Fiona", last_name: "LEGENDE", email: "jean@legende.com", organisations: [organisation])

--- a/spec/features/prescripteurs/motifs_for_invitation_only_spec.rb
+++ b/spec/features/prescripteurs/motifs_for_invitation_only_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe "motifs for invitation only" do
       choose("Agents de l’organisation et prescripteurs")
       expect(page).to have_field("Délai minimum avant le RDV", visible: :visible)
 
-      expect { click_button("Enregistrer") }.to change { motif.reload.bookable_by }.to("agents_and_prescripteurs")
+      expect do
+        click_button("Enregistrer")
+        expect(page).to have_content("Le motif Accompagnement individuel a été modifié.")
+      end.to change { motif.reload.bookable_by }.to("agents_and_prescripteurs")
     end
   end
 

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe "User can search for rdvs" do
   end
 
   describe "default" do
-    let!(:territory92) { create(:territory, departement_number: "92") }
+    let!(:territory92) do
+      create(:territory, departement_number: "92", enable_birth_date_field: true)
+    end
     let!(:organisation) { create(:organisation, :with_contact, territory: territory92) }
     let(:service) { create(:service) }
     let!(:motif) { create(:motif, name: "Vaccination", organisation: organisation, restriction_for_rdv: nil, service: service) }

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe "User can search for rdvs" do
 
   describe "Prise de RDV en ligne" do
     let!(:service) { create(:service) }
-    let!(:territory) { create(:territory, departement_number: "92") }
+    let!(:territory) do
+      create(:territory, departement_number: "92", enable_birth_date_field: true)
+    end
+
     let!(:first_organisation_with_po) { create(:organisation, :with_contact, territory: territory) }
     let!(:first_motif) do
       create(:motif, :by_phone, name: "RSA orientation par téléphone", organisation: first_organisation_with_po, restriction_for_rdv: nil, service: service)
@@ -181,7 +184,11 @@ RSpec.describe "User can search for rdvs" do
       end
     end
     let!(:agent2) { create(:agent) }
-    let!(:organisation) { create(:organisation, territory: create(:territory, departement_number: "92")) }
+    let!(:organisation) { create(:organisation, territory: territory) }
+    let!(:territory) do
+      create(:territory, departement_number: "92", enable_birth_date_field: true)
+    end
+
     let!(:service_social) { create(:service, name: "Service Social") }
     let!(:service_insertion) { create(:service, name: "Service Insertion") }
     let!(:lieu) { create(:lieu, organisation: organisation) }
@@ -470,6 +477,7 @@ RSpec.describe "User can search for rdvs" do
     fill_in("Adresse email", with: "michel@lapin.fr")
     fill_in("Numéro de téléphone", with: "0612345678")
     click_button("Je m’inscris")
+    expect(page).to have_content("Un message contenant un lien de confirmation a été envoyé à votre adresse email. Ouvrez ce lien pour activer votre compte.")
 
     # Confirmation email
     open_email("michel@lapin.fr")

--- a/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
+++ b/spec/features/users/online_booking/link_to_take_rdv_in_organisation_spec.rb
@@ -3,7 +3,9 @@ RSpec.describe "user can use a link that points to RDV search scoped to an organ
 
   around { |example| perform_enqueued_jobs { example.run } }
 
-  let!(:territory) { create(:territory, departement_number: Territory::CN_DEPARTEMENT_NUMBER) }
+  let!(:territory) do
+    create(:territory, departement_number: Territory::CN_DEPARTEMENT_NUMBER, enable_birth_date_field: true)
+  end
   let!(:organisation_a) { create(:organisation, territory: territory, external_id: "123") }
   let!(:organisation_b) { create(:organisation, territory: territory, external_id: "456") }
 


### PR DESCRIPTION
Une première PR pour https://github.com/betagouv/rdv-service-public/issues/5160

# Contexte

voir l'issue

# Solution

On passe le champs en optionnel comme les autres.

