### PR TITLE
Accessibilité: mise à jour de axe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -242,7 +242,7 @@ group :test do
   # Accessibility
 
   # Axe API utility methods
-  gem "axe-core-api", "4.3.2" # Fixed to 4.3.2 because recent versions of axe are more strict
+  gem "axe-core-api"
   # RSpec custom matchers for Axe
   gem "axe-core-rspec", "4.3.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,8 +146,9 @@ GEM
     attr_required (1.0.1)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    axe-core-api (4.3.2)
+    axe-core-api (4.10.2)
       dumb_delegator
+      ostruct
       virtus
     axe-core-rspec (4.3.2)
       axe-core-api
@@ -251,7 +252,7 @@ GEM
       dsfr-assets (~> 1.13)
       html-attributes-utils (~> 1)
       view_component (~> 3)
-    dumb_delegator (1.0.0)
+    dumb_delegator (1.1.0)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -756,7 +757,7 @@ DEPENDENCIES
   administrate
   anonymizer!
   auto_strip_attributes
-  axe-core-api (= 4.3.2)
+  axe-core-api
   axe-core-rspec (= 4.3.2)
   axiom-types!
   better_errors

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -113,7 +113,7 @@ module UsersHelper
   end
 
   def clickable_user_phone_number(user)
-    user.responsible_phone_number.present? ? link_to(user.responsible_phone_number, "tel:#{user.responsible_or_self.phone_number_formatted}") : nil
+    user.responsible_phone_number.present? ? link_to(user.responsible_phone_number, "tel:#{user.responsible_or_self.phone_number_formatted}", class: "fr-link") : nil
   end
 
   def formatted_user_annotation(user, current_territory)

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -108,7 +108,7 @@
 
 @import "./structure/bootstrap_overrides";
 
-a[href]:not(.fc-event-waiting) {
+a[href]:not(.fc-event-waiting):not(.fr-link) {
   background-image: none; // pour éviter le soulignement des liens
 }
 

--- a/spec/features/accessibility/agents_pages_spec.rb
+++ b/spec/features/accessibility/agents_pages_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "agents page", js: true do
     login_as(agent, scope: :agent)
 
     path = admin_organisation_agent_agenda_path(organisation, agent)
-    expect_page_to_be_axe_clean(path)
+    expect_page_to_be_axe_clean(path, excluding_selector: ".fc-axis") # Full calendar place une case de tableau vide pour laquelle nous ne voulons pas d’alerte
   end
 
   it "agenda with 3 rdvs is accessible" do
@@ -33,7 +33,7 @@ RSpec.describe "agents page", js: true do
     visit path
     expect(page).to have_current_path(path)
     expect(page).to have_content(Rdv.last.users.last.full_name)
-    expect(page).to be_axe_clean
+    expect(page).to be_axe_clean.excluding(".fc-axis") # Full calendar place une case de tableau vide pour laquelle nous ne voulons pas d’alerte
   end
 
   it "admin organisation plage_ouvertures path is accessible" do

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -51,8 +51,13 @@ RSpec.configure do |config|
   end
 end
 
-def expect_page_to_be_axe_clean(path)
+def expect_page_to_be_axe_clean(path, excluding_selector: nil)
   visit path
   expect(page).to have_current_path(path)
-  expect(page).to be_axe_clean
+
+  if excluding_selector
+    expect(page).to be_axe_clean.excluding(excluding_selector)
+  else
+    expect(page).to be_axe_clean
+  end
 end


### PR DESCRIPTION
# Contexte

Dans le cadre de l’amélioration de l’accessibilité, on met à jour axe pour être à jour sur les dernières régles.

# Solution

- Nous avions un problème d’accessibilité sur le lien téléphone de la fiche usager. J’ai profité de cette PR pour retirer l’overwrite qui a été fait sur les liens quand le lien a explicitement la classe `fr-link`.
- Dans l’agenda, nous avons la case d’en-tête de tableau tout en haut à gauche qui est vide. Cela l’élève une erreur axe qu’on souhaite ignorer car cela ne fait pas de sens de mettre quelque chose dedans et qu’en plus ceci est géré par Full Calendar.

