### PR TITLE
Fix: mise à jour de la liste des agents d’un RDV

### DIFF
--- a/app/form_models/admin/edit_rdv_form.rb
+++ b/app/form_models/admin/edit_rdv_form.rb
@@ -11,11 +11,15 @@ class Admin::EditRdvForm
   end
 
   def submit(rdv_attributes)
+    raise ArgumentError, "agent_ids est accepté mais pas agents" if rdv_attributes.key?(:agents)
+
+    agent_ids = rdv_attributes.delete(:agent_ids) # évite de sauvegarder les changements d’agents avant la validation
     @rdv.assign_attributes(rdv_attributes)
 
     authorize(@rdv, :update?, policy_class: Agent::RdvPolicy)
 
     if valid?
+      @rdv.agent_ids = agent_ids if agent_ids.present?
       @rdv.save_and_notify(agent_context.agent)
     else
       false

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -46,23 +46,37 @@ RSpec.describe Admin::EditRdvForm, type: :form do
       expect(rdv.status).to eq("unknown")
     end
 
-    context "lorsque le RDV est invalide" do
-      let(:rdv) { create(:rdv, agents: [agent], organisation: organisation) }
-      let(:another_rdv) { create(:rdv, agents: [agent], organisation: organisation, starts_at: rdv.starts_at) }
-      let(:another_agent) { create(:agent) }
-
-      it "on ne met pas à jour la liste des agents si l’agent n’a pas bypass l’avertissement" do
-        edit_rdv_form = described_class.new(rdv, agent_context)
-        edit_rdv_form.submit({ agents: [agent, another_agent] })
-
-        expect(rdv.reload.agents).to eq([agent])
+    context "ajout d’un agent à un RDV avec une erreur contournable" do
+      subject do
+        described_class.new(rdv2, agent_context).submit(attributes)
+        rdv2.reload.agents.map(&:full_name).sort.to_sentence
       end
 
-      it "on met à jour la liste des agents si l’agent a bypass l’avertissement" do
-        edit_rdv_form = described_class.new(rdv, agent_context)
-        edit_rdv_form.submit({ agents: [agent, another_agent], ignore_benign_errors: "1" })
+      let!(:organisation) { create(:organisation) }
+      let!(:agent_mayra) { create(:agent, first_name: "Mayra", last_name: "Castello", basic_role_in_organisations: [organisation]) }
+      let!(:agent_stefan) { create(:agent, first_name: "Stefan", last_name: "Hoyt", basic_role_in_organisations: [organisation]) }
+      let(:agent_context) { instance_double(AgentOrganisationContext, agent: agent_mayra, organisation:) }
+      let!(:rdv1) { create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-28 10:30")) }
+      let!(:rdv2) { create(:rdv, agents: [agent_mayra], organisation:, starts_at: Time.zone.parse("2025-04-29 18:00")) }
+      let(:base_attributes) do
+        {
+          starts_at: Time.zone.parse("2025-04-28 10:30"), # le même horaire que rdv1, déclenche une erreur contournable
+          agent_ids: [agent_mayra.id, agent_stefan.id],
+        }
+      end
 
-        expect(rdv.reload.agents).to eq([agent, another_agent])
+      before { travel_to Time.zone.parse("2025-04-24 10:00") }
+
+      context "l’avertissement est contourné" do
+        let(:attributes) { base_attributes.merge(ignore_benign_errors: "1") }
+
+        it { is_expected.to eq("Mayra CASTELLO et Stefan HOYT") }
+      end
+
+      context "l’avertissement n’est pas contourné" do
+        let(:attributes) { base_attributes }
+
+        it { is_expected.to eq("Mayra CASTELLO") }
       end
     end
   end

--- a/spec/form_models/admin/edit_rdv_form_spec.rb
+++ b/spec/form_models/admin/edit_rdv_form_spec.rb
@@ -45,5 +45,25 @@ RSpec.describe Admin::EditRdvForm, type: :form do
       expect(rdv.cancelled_at).to be_nil
       expect(rdv.status).to eq("unknown")
     end
+
+    context "lorsque le RDV est invalide" do
+      let(:rdv) { create(:rdv, agents: [agent], organisation: organisation) }
+      let(:another_rdv) { create(:rdv, agents: [agent], organisation: organisation, starts_at: rdv.starts_at) }
+      let(:another_agent) { create(:agent) }
+
+      it "on ne met pas à jour la liste des agents si l’agent n’a pas bypass l’avertissement" do
+        edit_rdv_form = described_class.new(rdv, agent_context)
+        edit_rdv_form.submit({ agents: [agent, another_agent] })
+
+        expect(rdv.reload.agents).to eq([agent])
+      end
+
+      it "on met à jour la liste des agents si l’agent a bypass l’avertissement" do
+        edit_rdv_form = described_class.new(rdv, agent_context)
+        edit_rdv_form.submit({ agents: [agent, another_agent], ignore_benign_errors: "1" })
+
+        expect(rdv.reload.agents).to eq([agent, another_agent])
+      end
+    end
   end
 end


### PR DESCRIPTION
# Contexte

En explorant un bug concernant les mails transactionnels qui ne partaient pas quand on ajoute un agent à un RDV, je me suis rendu compte d’un comportement anormal.

En tant qu’agent, si j’édite un RDV et que celui-ci n’est pas valide au moment de la soumission (et que je n’ignore pas l’avertissement), le RDV n’est pas sauvegardé mais la liste des agents oui. Le comportement est reproduit dans la spec du premier commit.

Le problème vient du `assign_attributes(attributes)` positionné avant le `valid?` et le `save`. Il déclenche un `self.agent_ids = new_agent_ids` qui écrit en db, ce qui est un comportement connu et documenté mais très surprenant de Rails.

# Solution

Je propose une solution qui améliore la situation mais ne la résoud pas à 100% : je décale ce `self.agent_ids =` plus bas, après la vérification du `valid?`. 

Il peut donc encore y avoir des états incohérents si le `.agent_ids=` passe mais pas le `.save` consécutif. C’est nettement moins probable.

A ma connaissance, il n’y a pas de validation sur les agents associés à un RDV au moment de l’update donc ça ne pose pas de soucis de décaler le `agent_ids=` après la vérification de la validité.
