### PR TITLE
Fix: flaky specs

### DIFF
--- a/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
+++ b/spec/features/agents/agent_can_create_rdv_with_wizard_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe "Agent can create a Rdv with wizard" do
       step2
       step3(:enabled)
       step4
+      expect(page).to have_content("Le rendez-vous a été créé.")
 
       expect(user.rdvs.count).to eq(1)
       rdv = user.rdvs.first
@@ -131,6 +132,7 @@ RSpec.describe "Agent can create a Rdv with wizard" do
 
         step3(:enabled)
         step4
+        expect(page).to have_content("Le rendez-vous a été créé.")
 
         expect(user_from_other_organisation.rdvs.count).to eq(1)
         expect(user_from_other_organisation.reload.organisations).to contain_exactly(organisation, other_organisation)
@@ -185,6 +187,8 @@ RSpec.describe "Agent can create a Rdv with wizard" do
         expect(page).to have_content("Reçoit les notifications par email")
         expect(page).to have_content("user_with_notif_email@test.com")
         click_button("Confirmer le RDV")
+        expect(page).to have_content("Le rendez-vous a été créé.")
+
         expect(user_with_notification_email.rdvs.count).to eq(1)
       end
     end
@@ -196,6 +200,8 @@ RSpec.describe "Agent can create a Rdv with wizard" do
       step2
       step3(:single_use)
       step4
+
+      expect(page).to have_content("Le rendez-vous a été créé.")
 
       expect(user.rdvs.count).to eq(1)
       rdv = user.rdvs.first

--- a/spec/features/agents/agent_can_crud_intervenants_spec.rb
+++ b/spec/features/agents/agent_can_crud_intervenants_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe "Agent can CRUD intervenants" do
       fill_in "Nom", with: "Fictif", match: :smart
     end
     click_button("Enregistrer")
+    expect(page).to have_content("L’agent ancien_intervenant1@invitation.com a été invité à rejoindre votre organisation.")
 
     expect(Agent.last.roles.pluck(:access_level)).to eq ["admin"]
 

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
 
       expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
       click_on("La belle plage")
+      expect(page).to have_content("La belle plage")
       accept_confirm do
         click_link("Supprimer")
       end
@@ -127,6 +128,8 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       check "Suivi bonjour"
       select(lieu.full_name, from: "plage_ouverture_lieu_id")
       click_button "Créer la plage d'ouverture"
+      expect(page).to have_content("Plage d'ouverture créée")
+
       expect(PlageOuverture.last.title).to eq("Accueil")
       expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
     end
@@ -215,6 +218,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       expect(page).to have_content("Lieu")
       select(lieu.full_name, from: "plage_ouverture_lieu_id")
       click_on "Créer la plage d'ouverture"
+      expect(page).to have_content("Plage d'ouverture créée")
       expect(PlageOuverture.last.motifs).to contain_exactly(motif_1_service_avocat, motif_2_service_avocat)
     end
   end
@@ -240,7 +244,10 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       select "17", from: "plage_ouverture_secondary_end_time_4i"
       select "45", from: "plage_ouverture_secondary_end_time_5i"
 
-      expect { click_on "Créer la plage d'ouverture" }.to change(PlageOuverture, :count).by(1)
+      expect do
+        click_on "Créer la plage d'ouverture"
+        expect(page).to have_content("Plage d'ouverture créée")
+      end.to change(PlageOuverture, :count).by(1)
       expected_attrs = {
         start_time: Tod::TimeOfDay.parse("09:30"),
         end_time: Tod::TimeOfDay.parse("12:00"),

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -86,7 +86,10 @@ RSpec.describe "agents can prescribe rdvs" do
       # deuxième passage page récap
       click_on "Continuer"
       expect(page).to have_content("L’usager est pressé il a besoin...")
-      expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)
+      expect do
+        click_button "Confirmer le rdv"
+        expect(page).to have_content("Rendez-vous confirmé")
+      end.to change(Rdv, :count).by(1)
       # Display Confirmation
       expect(page).to have_content("Rendez-vous confirmé")
       created_rdv = Rdv.last
@@ -134,7 +137,10 @@ RSpec.describe "agents can prescribe rdvs" do
         expect(page).to have_content("Lieu : #{mds_paris_nord.name}")
         expect(page).to have_content("Date du rendez-vous :")
         expect(page).to have_content("Usager : FACTICE Francis")
-        expect { click_button "Confirmer le rdv" }.to change(Rdv.last.reload.participations, :count).by(1)
+        expect do
+          click_button "Confirmer le rdv"
+          expect(page).to have_content("Rendez-vous confirmé")
+        end.to change(Rdv.last.reload.participations, :count).by(1)
         expect(Rdv.last.participations.where(user: existing_user).first.created_by_agent_prescripteur).to be(true)
       end
     end
@@ -196,7 +202,10 @@ RSpec.describe "agents can prescribe rdvs" do
       click_on "Créer usager"
       expect(page).to have_content("BONJOUR Jean-Pierre")
       click_on "Continuer"
-      expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)
+      expect do
+        click_button "Confirmer le rdv"
+        expect(page).to have_content("Rendez-vous confirmé")
+      end.to change(Rdv, :count).by(1)
       expect(Rdv.last.users.first.full_name).to eq("Jean-Pierre BONJOUR")
       expect(Rdv.last.participations.first.created_by_agent_prescripteur).to be(true)
     end
@@ -262,7 +271,10 @@ RSpec.describe "agents can prescribe rdvs" do
         click_on motif_mds.name
         find(".fr-card__title", text: /#{mds_paris_nord.name}/).ancestor(".fr-card__body").find("a").click
         first(:link, "11:00").click
-        expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)
+        expect do
+          click_button "Confirmer le rdv"
+          expect(page).to have_content("Rendez-vous confirmé")
+        end.to change(Rdv, :count).by(1)
       end
 
       context "when sectorization is enabled on the street level and on city level on 2 differents sectors" do
@@ -335,7 +347,10 @@ RSpec.describe "agents can prescribe rdvs" do
       # Display Récapitulatif
       # les infos de l'usager sont affichées dans le recap
       expect(page).to have_content("Usager : TERRE Miss - 20/07/1985 - 06 11 22 33 44 - miss_terre@example.com")
-      expect { click_button "Confirmer le rdv" }.to change(Rdv, :count).by(1)
+      expect do
+        click_button "Confirmer le rdv"
+        expect(page).to have_content("Rendez-vous confirmé")
+      end.to change(Rdv, :count).by(1)
       # Display Confirmation
       expect(page).to have_content("Rendez-vous confirmé")
       created_rdv = Rdv.last

--- a/spec/features/agents/oauth_provider_spec.rb
+++ b/spec/features/agents/oauth_provider_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe "OAuth provider", js: true do
     fill_in "Adresse email", with: agent.email
     fill_in "Mot de passe", with: agent.password
     click_on "Se connecter"
+    expect(page).to have_content("Connexion réussie")
 
     visit "http://localhost:4567/"
     click_button "Se connecter avec RDV Service Public"

--- a/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/agent_can_create_rdv_collectif_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe "Agent can create a Rdv collectif from the agenda" do
     add_user(user2)
     add_user(user3)
     click_button("Enregistrer")
+    expect(page).to have_content("Le rendez-vous a été modifié.")
     expect(rdv.reload.users.count).to eq 3
   end
 end

--- a/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
+++ b/spec/features/agents/rdvs_collectifs/full_lifecycle_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
     add_user(user1)
     add_new_user
     click_button "Enregistrer"
+    expect(page).to have_content("Participants mis à jour")
 
     expect(Receipt.where(user_id: user1.id, channel: "sms", result: "delivered").count).to eq 1
     expect(Receipt.where(user_id: user1.id, channel: "mail", result: "processed").count).to eq 1
@@ -66,6 +67,8 @@ RSpec.describe "Agent can organize a rdv collectif", js: true do
     add_user(user2)
     add_new_user({ with_phone: true })
     click_button "Enregistrer"
+    expect(page).to have_content("Participants mis à jour")
+
     user3 = User.last
 
     expect(user3).not_to eq user2

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -159,9 +159,11 @@ RSpec.describe "prescripteur can create RDV for a user" do
       # Le format du numéro de téléphone n'est pas exactement le même que celui en base
       fill_in "Téléphone", with: "06 11 22 33 44"
 
-      expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1)
-        .and(change(User, :count).by(0))
-        .and(change(UserProfile, :count).by(1))
+      expect do
+        click_on "Confirmer le rendez-vous"
+
+        expect(page).to have_content("Rendez-vous confirmé")
+      end.to change(Rdv, :count).by(1).and(change(User, :count).by(0)).and(change(UserProfile, :count).by(1))
 
       expect(UserProfile.last).to have_attributes(
         user: user,
@@ -190,7 +192,11 @@ RSpec.describe "prescripteur can create RDV for a user" do
         # Le format du numéro de téléphone n'est pas exactement le même que celui en base
         fill_in "Téléphone", with: "06 11 22 33 44"
 
-        expect { click_on "Confirmer le rendez-vous" }.to change(Rdv, :count).by(1).and(change(UserProfile, :count).by(0))
+        expect do
+          click_on "Confirmer le rendez-vous"
+
+          expect(page).to have_content("Rendez-vous confirmé")
+        end.to change(Rdv, :count).by(1).and(change(UserProfile, :count).by(0))
       end
     end
   end

--- a/spec/features/prescripteurs/motifs_for_invitation_only_spec.rb
+++ b/spec/features/prescripteurs/motifs_for_invitation_only_spec.rb
@@ -38,7 +38,10 @@ RSpec.describe "motifs for invitation only" do
       choose("Agents de l’organisation, prescripteurs et usagers via une invitation")
       expect(page).to have_content("Délai minimum avant le RDV")
 
-      expect { click_button("Enregistrer") }.to change { motif.reload.bookable_by }.to("agents_and_prescripteurs_and_invited_users")
+      expect do
+        click_button("Enregistrer")
+        expect(page).to have_content("Le motif Accompagnement individuel a été modifié.")
+      end.to change { motif.reload.bookable_by }.to("agents_and_prescripteurs_and_invited_users")
     end
   end
 end

--- a/spec/features/super_admin/use_correct_history_version_spec.rb
+++ b/spec/features/super_admin/use_correct_history_version_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Use correct history version when a super admin is logged in and 
     click_link "Vos informations"
     fill_in("Téléphone", with: "0612345678")
     click_on("Modifier")
+    expect(page).to have_content("Vos informations ont été mises à jour")
 
     expect(user.reload.versions.last.whodunnit).to eq "[Admin] #{super_admin.full_name} pour #{user.full_name}"
   end

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe "Adding a user to a collective RDV" do
         click_button("Continuer")
         stub_request(:post, "https://example.com/")
         click_on("Confirmer ma participation")
+        expect(page).to have_content("Participation confirmée")
+        expect(page).to have_content("modifier") # can_change_participants?
       end.to change { rdv.reload.users.count }.from(0).to(1)
-      expect(page).to have_content("Participation confirmée")
-      expect(page).to have_content("modifier") # can_change_participants?
 
       expect_notifications_sent_for(rdv, logged_user, :rdv_created)
       expect_webhooks_for(logged_user)


### PR DESCRIPTION
# Contexte

Nous avons récemment une salve de flaky spec qui est arrivé.
Nous supposons une mise à jour de `chromewebdriver` en cause.

Dans tous les cas, le comportement supposé est systématiquement le suivant : 
- On clique sur un bouton dans un test
- On vérifie les mises à jour des données en base, mais la requête n’est pas encore arrivé/traité par le serveur web

# Solution

On vérifie la présence d’élément sur la page.

Dans un second temps, ajouter un helper. Suggestion de @victormours 

> ça vaudrait peut-être le coup d'avoir une méthode de helper du genre wait_for_page_to_have_content pour rendre plus clair que c'est pour ça qu'on fait les expects.

```ruby
      click_on "Créer la plage d'ouverture"
      wait_for_page_to_have_content("Plage d'ouverture créée")
      expect(PlageOuverture.last.motifs).to contain_exactly(motif_1_service_avocat, motif_2_service_avocat)
 ```
