### PR TITLE
Refacto et cleanup de `PlageOuverturesHelper`

### DIFF
--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -1,16 +1,16 @@
 module PlageOuverturesHelper
-  def display_recurrence(plage_ouverture)
-    every_part = display_every(plage_ouverture)
+  def display_recurrence(recurrent_record)
+    every_part = display_every(recurrent_record)
 
-    time_part = display_time_range(plage_ouverture)
+    time_part = display_time_range(recurrent_record)
 
-    range_part = display_recurrence_range(plage_ouverture)
+    range_part = display_recurrence_range(recurrent_record)
 
     [every_part, time_part, range_part]
   end
 
-  def display_every(plage_ouverture)
-    recurrence_hash = plage_ouverture.recurrence.to_hash
+  def display_every(recurrent_record)
+    recurrence_hash = recurrent_record.recurrence.to_hash
 
     interval = "#{recurrence_hash[:interval]} " if recurrence_hash[:interval]&.>(1)
 
@@ -21,17 +21,17 @@ module PlageOuverturesHelper
       if recurrence_hash[:on].present?
         "#{every_part}, les #{recurrence_hash[:on].map { |d| "#{weekday_in_fr(d)}s" }.to_sentence}"
       else
-        "#{every_part}, le #{I18n.l(plage_ouverture.first_day, format: '%A')}"
+        "#{every_part}, le #{I18n.l(recurrent_record.first_day, format: '%A')}"
       end
     when :month
       "Tous les #{interval} mois, #{weekday_position_in_month(recurrence_hash[:day])}"
     end
   end
 
-  def display_time_range(plage_ouverture)
-    str = "de #{I18n.l(plage_ouverture.start_time, format: '%H:%M')} à #{I18n.l(plage_ouverture.end_time, format: '%H:%M')}"
-    if plage_ouverture.try(:secondary_start_time) && plage_ouverture.try(:secondary_end_time)
-      str += " et de #{I18n.l(plage_ouverture.secondary_start_time, format: '%H:%M')} à #{I18n.l(plage_ouverture.secondary_end_time, format: '%H:%M')}"
+  def display_time_range(recurrent_record)
+    str = "de #{I18n.l(recurrent_record.start_time, format: '%H:%M')} à #{I18n.l(recurrent_record.end_time, format: '%H:%M')}"
+    if recurrent_record.try(:secondary_start_time) && recurrent_record.try(:secondary_end_time)
+      str += " et de #{I18n.l(recurrent_record.secondary_start_time, format: '%H:%M')} à #{I18n.l(recurrent_record.secondary_end_time, format: '%H:%M')}"
     end
     str
   end
@@ -44,10 +44,10 @@ module PlageOuverturesHelper
     end
   end
 
-  def display_recurrence_range(plage_ouverture)
-    recurrence_hash = plage_ouverture.recurrence.to_hash
+  def display_recurrence_range(recurrent_record)
+    recurrence_hash = recurrent_record.recurrence.to_hash
 
-    range_part = "à partir du #{I18n.l(plage_ouverture.first_day, format: :human)}"
+    range_part = "à partir du #{I18n.l(recurrent_record.first_day, format: :human)}"
 
     range_part = "#{range_part}, jusqu'au #{I18n.l(recurrence_hash[:until].to_date, format: :human)}" if recurrence_hash[:until].present?
     range_part

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -72,8 +72,8 @@ module PlageOuverturesHelper
     weekdays[weekday]
   end
 
-  def po_exceptionnelle_tag(plage_ouverture)
-    tag.span("Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
+  def exceptionnelle_tag(recurrent_record)
+    tag.span("Exceptionnelle", class: "badge badge-info") if recurrent_record.exceptionnelle?
   end
 
   def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -36,11 +36,11 @@ module PlageOuverturesHelper
     str
   end
 
-  def plage_ouverture_occurrence_text(plage_ouverture)
-    if plage_ouverture.recurring?
-      display_recurrence(plage_ouverture).join(" ")
+  def occurrence_text(recurrent_record)
+    if recurrent_record.recurring?
+      display_recurrence(recurrent_record).join(" ")
     else
-      I18n.l(plage_ouverture.first_day, format: :human) + display_time_range(plage_ouverture)
+      I18n.l(recurrent_record.first_day, format: :human) + display_time_range(recurrent_record)
     end
   end
 

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -72,10 +72,6 @@ module PlageOuverturesHelper
     weekdays[weekday]
   end
 
-  def overflow_motif_duration(plage_ouverture, motif)
-    (motif.default_duration_in_min - plage_ouverture.daily_max_duration.in_minutes).to_i
-  end
-
   def po_exceptionnelle_tag(plage_ouverture)
     tag.span("Exceptionnelle", class: "badge badge-info") if plage_ouverture.exceptionnelle?
   end

--- a/app/helpers/plage_ouvertures_helper.rb
+++ b/app/helpers/plage_ouvertures_helper.rb
@@ -40,7 +40,7 @@ module PlageOuverturesHelper
     if recurrent_record.recurring?
       display_recurrence(recurrent_record).join(" ")
     else
-      I18n.l(recurrent_record.first_day, format: :human) + display_time_range(recurrent_record)
+      [I18n.l(recurrent_record.first_day, format: :human), display_time_range(recurrent_record)].join(" ")
     end
   end
 

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -1,4 +1,4 @@
-module PlageOuverturesHelper
+module RecurrenceHelper
   def display_recurrence(recurrent_record)
     every_part = display_every(recurrent_record)
 

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -75,4 +75,11 @@ module RecurrenceHelper
   def exceptionnelle_tag(recurrent_record)
     tag.span("Exceptionnelle", class: "badge badge-info") if recurrent_record.exceptionnelle?
   end
+
+  def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)
+    Agent::PlageOuverturePolicy::Scope
+      .new(pundit_user, PlageOuverture)
+      .resolve
+      .merge(plage_ouvertures)
+  end
 end

--- a/app/helpers/recurrence_helper.rb
+++ b/app/helpers/recurrence_helper.rb
@@ -75,11 +75,4 @@ module RecurrenceHelper
   def exceptionnelle_tag(recurrent_record)
     tag.span("Exceptionnelle", class: "badge badge-info") if recurrent_record.exceptionnelle?
   end
-
-  def filter_plage_ouvertures_in_departement_scope(plage_ouvertures)
-    Agent::PlageOuverturePolicy::Scope
-      .new(pundit_user, PlageOuverture)
-      .resolve
-      .merge(plage_ouvertures)
-  end
 end

--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -1,5 +1,5 @@
 class Agents::AbsenceMailer < ApplicationMailer
-  helper PlageOuverturesHelper
+  helper RecurrenceHelper
 
   before_action do
     @absence = params[:absence]

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -1,6 +1,6 @@
 class Agents::PlageOuvertureMailer < ApplicationMailer
   helper MotifsHelper
-  helper PlageOuverturesHelper
+  helper RecurrenceHelper
 
   before_action do
     @plage_ouverture = params[:plage_ouverture]

--- a/app/presenters/plage_ouverture_presenter.rb
+++ b/app/presenters/plage_ouverture_presenter.rb
@@ -21,7 +21,7 @@ class PlageOuverturePresenter
       attrs.merge!(
         path: admin_organisation_plage_ouverture_path(plage_ouverture.organisation, plage_ouverture),
         lieu_name: plage_ouverture.lieu_name,
-        occurrence_text: plage_ouverture_occurrence_text(plage_ouverture),
+        occurrence_text: occurrence_text(plage_ouverture),
         organisation_name: plage_ouverture.organisation.name
       )
     end

--- a/app/presenters/plage_ouverture_presenter.rb
+++ b/app/presenters/plage_ouverture_presenter.rb
@@ -1,5 +1,5 @@
 class PlageOuverturePresenter
-  include PlageOuverturesHelper
+  include RecurrenceHelper
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::TranslationHelper # allows getting a SafeBuffer instead of a String when using #translate (which a direct call to I18n.t doesn't do)
 

--- a/app/views/admin/plage_ouvertures/_motifs_duration_exceed.html.slim
+++ b/app/views/admin/plage_ouvertures/_motifs_duration_exceed.html.slim
@@ -1,4 +1,5 @@
-- model.overflow_motifs_duration.each do |motif|
+- plage_ouverture.overflow_motifs_duration.each do |motif|
+  - motif_duration_overflow = (motif.default_duration_in_min - plage_ouverture.daily_max_duration.in_minutes).to_i
   li.mb-1
-    span>= link_to("#{motif.name}", edit_admin_organisation_motif_path(model.organisation, motif))
-    span> déborde de #{overflow_motif_duration(model, motif)} minutes. Il ne sera pas possible de prendre rendez-vous pour ce motif en l'état.
+    span>= link_to("#{motif.name}", edit_admin_organisation_motif_path(plage_ouverture.organisation, motif))
+    span> déborde de #{motif_duration_overflow} minutes. Il ne sera pas possible de prendre rendez-vous pour ce motif en l'état.

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,4 +1,4 @@
-- in_scope = Agent::PlageOuverturePolicy::Scope.new(pundit_user, model.overlapping_plages_ouvertures).resolve
+- in_scope = filter_plage_ouvertures_in_departement_scope(model.overlapping_plages_ouvertures)
 
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -7,7 +7,7 @@
       span> de #{overlapping_plage_ouverture.agent.full_name_or_email}
     - if overlapping_plage_ouverture.lieu.present?
       span> à #{overlapping_plage_ouverture.lieu_name}
-    = plage_ouverture_occurrence_text(overlapping_plage_ouverture)
+    = occurrence_text(overlapping_plage_ouverture)
     - if overlapping_plage_ouverture.organisation != current_organisation
       span>= "(Organisation #{overlapping_plage_ouverture.organisation.name})"
 

--- a/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
+++ b/app/views/admin/plage_ouvertures/_overlapping_plage_ouvertures.html.slim
@@ -1,4 +1,4 @@
-- in_scope = filter_plage_ouvertures_in_departement_scope(model.overlapping_plages_ouvertures)
+- in_scope = Agent::PlageOuverturePolicy::Scope.new(pundit_user, model.overlapping_plages_ouvertures).resolve
 
 - in_scope.each do |overlapping_plage_ouverture|
   li.mb-1

--- a/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
+++ b/app/views/admin/plage_ouvertures/_plage_ouverture.html.slim
@@ -2,7 +2,7 @@ tr
   - organisation = plage_ouverture.organisation
   td
     = link_to plage_ouverture.title_with_default, admin_organisation_plage_ouverture_path(organisation, plage_ouverture)
-    = po_exceptionnelle_tag(plage_ouverture)
+    = exceptionnelle_tag(plage_ouverture)
     br
     small
       | modifiée le #{l(plage_ouverture.updated_at, format: :short)}

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -36,7 +36,7 @@
             span= @plage_ouverture.title
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Répétition&nbsp;:
-          span= @plage_ouverture.recurring? ? "Récurrente" : po_exceptionnelle_tag(@plage_ouverture)
+          span= @plage_ouverture.recurring? ? "Récurrente" : exceptionnelle_tag(@plage_ouverture)
         div.mt-2.d-flex
           .flex-shrink-0.mr-1.font-weight-bold Dates&nbsp;:
           - if @plage_ouverture.recurring?

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -58,7 +58,7 @@
               = @plage_ouverture.send(:warn_overflow_motifs_duration).type
             .border-left.border-right.border-bottom.rounded.border-warning
               ul.pl-3.py-2.mb-0
-                = render "motifs_duration_exceed", model: @plage_ouverture
+                = render "motifs_duration_exceed", plage_ouverture: @plage_ouverture
 
       .card-footer.d-flex.justify-content-between
         div

--- a/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
+++ b/app/views/mailers/agents/absence_mailer/_absence_overview.html.slim
@@ -10,7 +10,7 @@
     .clear
   div.row-result
     span.title Répétition :
-    span.float-right= @absence.recurring? ? "Récurrente" : po_exceptionnelle_tag(@absence)
+    span.float-right= @absence.recurring? ? "Récurrente" : exceptionnelle_tag(@absence)
     .clear
   div.row-result.no-border
     span.title Dates :

--- a/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
+++ b/app/views/mailers/agents/plage_ouverture_mailer/_plage_ouverture_overview.html.slim
@@ -21,7 +21,7 @@
     .clear
   div.row-result
     span.title Répétition :
-    span.float-right= plage_ouverture.recurring? ? "Récurrente" : po_exceptionnelle_tag(plage_ouverture)
+    span.float-right= plage_ouverture.recurring? ? "Récurrente" : exceptionnelle_tag(plage_ouverture)
     .clear
   div.row-result.no-border
     span.title Dates :

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -201,6 +201,18 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     end
   end
 
+  describe "detecting motif duration overflow" do
+    before do
+      plage_ouverture.update!(start_time: "09:00", end_time: "10:30") # plage de 1h30
+      motif.update!(default_duration_in_min: 120)                     # motif de 2h
+    end
+
+    it "works" do
+      visit admin_organisation_plage_ouverture_path(organisation, plage_ouverture)
+      expect(page).to have_content("Suivi bonjour déborde de 30 minutes. Il ne sera pas possible de prendre rendez-vous pour ce motif en l'état.")
+    end
+  end
+
   describe "selecting motifs for a plage" do
     let!(:avocat) { create(:service, name: "Avocat") }
     let!(:notaire) { create(:service, name: "Notaire") }

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PlageOuverturesHelper do
 
     it "returns" do
       plage_ouverture = build(:plage_ouverture)
-      expect(occurrence_text(plage_ouverture)).to eq("mardi 28 décembre 2021de 08:00 à 12:00")
+      expect(occurrence_text(plage_ouverture)).to eq("mardi 28 décembre 2021 de 08:00 à 12:00")
     end
   end
 

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -27,15 +27,15 @@ RSpec.describe PlageOuverturesHelper do
     end
   end
 
-  describe "#plage_ouverture_occurrence_text" do
+  describe "#occurrence_text" do
     it "returns occurrence text" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week))
-      expect(plage_ouverture_occurrence_text(plage_ouverture)).to eq("Toutes les  semaines, le mardi de 08:00 à 12:00 à partir du mardi 28 décembre 2021")
+      expect(occurrence_text(plage_ouverture)).to eq("Toutes les  semaines, le mardi de 08:00 à 12:00 à partir du mardi 28 décembre 2021")
     end
 
     it "returns" do
       plage_ouverture = build(:plage_ouverture)
-      expect(plage_ouverture_occurrence_text(plage_ouverture)).to eq("mardi 28 décembre 2021de 08:00 à 12:00")
+      expect(occurrence_text(plage_ouverture)).to eq("mardi 28 décembre 2021de 08:00 à 12:00")
     end
   end
 

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -39,15 +39,15 @@ RSpec.describe PlageOuverturesHelper do
     end
   end
 
-  describe "#po_exceptionnelle_tag" do
+  describe "#exceptionnelle_tag" do
     it "return exceptionnelle badge without recurrence" do
       plage_ouverture = build(:plage_ouverture)
-      expect(po_exceptionnelle_tag(plage_ouverture)).to eq(%(<span class="badge badge-info">Exceptionnelle</span>))
+      expect(exceptionnelle_tag(plage_ouverture)).to eq(%(<span class="badge badge-info">Exceptionnelle</span>))
     end
 
     it "return nil with recurrence" do
       plage_ouverture = build(:plage_ouverture, recurrence: Montrose.every(:week))
-      expect(po_exceptionnelle_tag(plage_ouverture)).to be_nil
+      expect(exceptionnelle_tag(plage_ouverture)).to be_nil
     end
   end
 end

--- a/spec/helpers/plage_ouvertures_helper_spec.rb
+++ b/spec/helpers/plage_ouvertures_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PlageOuverturesHelper do
   describe "#po_exceptionnelle_tag" do
     it "return exceptionnelle badge without recurrence" do
       plage_ouverture = build(:plage_ouverture)
-      expect(po_exceptionnelle_tag(plage_ouverture)).to eq("<span class=\"badge badge-info\">Exceptionnelle</span>")
+      expect(po_exceptionnelle_tag(plage_ouverture)).to eq(%(<span class="badge badge-info">Exceptionnelle</span>))
     end
 
     it "return nil with recurrence" do

--- a/spec/helpers/recurrence_helper_spec.rb
+++ b/spec/helpers/recurrence_helper_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PlageOuverturesHelper do
+RSpec.describe RecurrenceHelper do
   let(:now) { Time.zone.parse("2021-12-23 09:00") }
 
   before do

--- a/spec/presenters/plage_ouverture_presenter_spec.rb
+++ b/spec/presenters/plage_ouverture_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe PlageOuverturePresenter, type: :presenter do
       end
       let(:presenter) { described_class.new(plage_ouverture, agent1_context) }
 
-      it { is_expected.to match %r{Jeanne LONGO a <a href=.*>une plage d'ouverture</a> à MDS du coin mercredi 09 décembre 2020de 07:00 à 10:00} }
+      it { is_expected.to match %r{Jeanne LONGO a <a href=.*>une plage d'ouverture</a> à MDS du coin mercredi 09 décembre 2020 de 07:00 à 10:00} }
     end
   end
 end


### PR DESCRIPTION
En travaillant sur #5065, on a remarqué que la majorité des méthodes de `PlageOuverturesHelper` étaient utilisées aussi pour des absences.

Je fais donc ici du renommage, et un peu cleanup. La lecture se fait bien commit par commit. Voici notamment ceux qui méritent un peu d'explication :

https://github.com/betagouv/rdv-service-public/pull/5176/commits/ecb7794eabb4c42c0fc10131ede8d65ce8d4b09e
Ici j'inline un helper dans une vue car il est très simple et utilisé qu'une seule fois.

https://github.com/betagouv/rdv-service-public/pull/5176/commits/3817a600d989ff32239ed933527ae12e314e5a0a
Ici je renomme Renomme les variables `plage_ouverture` en `recurrent_record` : **je n'aime pas trop ce nouveau nom et je suis très preneur d'une meilleure proposition !** 

https://github.com/betagouv/rdv-service-public/pull/5176/commits/ac1684d4547fdcc308d1fc765b5eda6ac49b504a
On peut voir dans ce commit que je commets une erreur que j'avais déjà commise il y a 6 mois (voir #4732) mais comme j'ai été malin en ajoutant une spec, cette fois, je la revert poliment. :hatched_chick: 