### PR TITLE
Correctif pour l'ouverture de compte d'agents déjà existant

### DIFF
--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -63,20 +63,24 @@ class Compte
   private
 
   def find_or_invite_agent(organisation)
-    if @attributes.dig(:agent, :id)
-      Agent.find(@attributes.dig(:agent, :id)).tap do |agent|
-        agent.update(
-          @attributes[:agent].merge(
-            roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
-          )
+    agent = find_agent
+    if agent
+      agent.update!(
+        @attributes[:agent].merge(
+          roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }]
         )
-      end
+      )
+      agent
     else
       Agent.invite!(@attributes[:agent].merge(
                       roles_attributes: [{ organisation: organisation, access_level: AgentRole::ACCESS_LEVEL_ADMIN }],
                       password: SecureRandom.base64(32)
                     ))
     end
+  end
+
+  def find_agent
+    Agent.find_by(id: @attributes.dig(:agent, :id)) || Agent.find_by(email: @attributes.dig(:agent, :email))
   end
 
   def create_mairie_motifs!

--- a/spec/form_models/compte_spec.rb
+++ b/spec/form_models/compte_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Compte do
+  context "when the agent already has an account because they logged in with ProConnect" do
+    let!(:agent) { create(:agent, :no_services) }
+    let(:super_admin) { create(:super_admin) }
+    let(:service) { create(:service) }
+
+    it "creates the organisation and adds the agent" do
+      described_class.new(
+        {
+          territory: {
+            name: "Montreuil", departement_number: 93,
+          },
+          organisation: { name: "Mairie de Montreuil", ants_connectable: false },
+          lieu: { address: "1 rue de la république", latitude: 48.859, longitude: 2.347 },
+          agent: { first_name: "Francis", last_name: "Factice", email: agent.email, service_ids: [service.id] },
+        },
+        Domain::RDV_MAIRIE
+      )
+
+      expect(agent.reload.roles.last).to have_attributes(access_level: :admin)
+      expect(agent.organisations.last.name).to eq "Mairie de Montreuil"
+    end
+  end
+end

--- a/spec/form_models/compte_spec.rb
+++ b/spec/form_models/compte_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Compte do
           agent: { first_name: "Francis", last_name: "Factice", email: agent.email, service_ids: [service.id] },
         },
         Domain::RDV_MAIRIE
-      )
+      ).save!
 
-      expect(agent.reload.roles.last).to have_attributes(access_level: :admin)
+      expect(agent.reload.roles.last).to have_attributes(access_level: "admin")
       expect(agent.organisations.last.name).to eq "Mairie de Montreuil"
     end
   end


### PR DESCRIPTION
# Contexte

Il y a eu un bug lors de l'ouverture d'un compte par Matis pour agent qui s'était déjà connecté via ProConnect (rendu possible par https://github.com/betagouv/rdv-service-public/pull/5102) : tout a bien été créé, mais l'agent n'a pas été ajouté à son organisation.

# Solution

On corrige juste le service object pour prendre ce cas en compte.
