### PR TITLE
Redirection vers le chat Crisp

### DIFF
--- a/app/controllers/agents/pages_controller.rb
+++ b/app/controllers/agents/pages_controller.rb
@@ -6,6 +6,14 @@ class Agents::PagesController < AgentAuthController
   def home
     skip_authorization
 
+    # Crisp propose aux utilisateurs de répondre aux mails soit par réponse de mail soit par le chat
+    # Comme nous ne pouvons pas retirer la mention du chat et que nous ne souhaitons pas le proposer comme moyen de
+    # contact, nous redirigeons les utilisateurs vers le chat Crisp si ils cliquent sur le lien dans le footer du mail
+    if params[:crisp_sid]
+      redirect_to_crisp_chat(params[:crisp_sid])
+      return
+    end
+
     accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
 
     if accessible_organisations.count == 1
@@ -19,5 +27,9 @@ class Agents::PagesController < AgentAuthController
 
   def pundit_user
     AgentContext.new(current_agent)
+  end
+
+  def redirect_to_crisp_chat(crisp_sid)
+    redirect_to "https://go.crisp.chat/chat/embed/?website_id=#{ENV['CRISP_WEBSITE_ID']}&crisp_sid=#{crisp_sid}", allow_other_host: true
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,6 +18,14 @@ class SearchController < ApplicationController
       return
     end
 
+    # Crisp propose aux utilisateurs de répondre aux mails soit par réponse de mail soit par le chat
+    # Comme nous ne pouvons pas retirer la mention du chat et que nous ne souhaitons pas le proposer comme moyen de
+    # contact, nous redirigeons les utilisateurs vers le chat Crisp si ils cliquent sur le lien dans le footer du mail
+    if params[:crisp_sid]
+      redirect_to_crisp_chat(params[:crisp_sid])
+      return
+    end
+
     if current_domain == Domain::RDV_MAIRIE
       render "dsfr/rdv_mairie/homepage"
     else
@@ -120,5 +128,9 @@ class SearchController < ApplicationController
 
   def agent_search_params
     params.permit(AgentPrescriptionSearchContext::STRONG_PARAMS_LIST)
+  end
+
+  def redirect_to_crisp_chat(crisp_sid)
+    redirect_to "https://go.crisp.chat/chat/embed/?website_id=#{ENV['CRISP_WEBSITE_ID']}&crisp_sid=#{crisp_sid}", allow_other_host: true
   end
 end

--- a/spec/controllers/agents/pages_controller_spec.rb
+++ b/spec/controllers/agents/pages_controller_spec.rb
@@ -6,6 +6,37 @@ RSpec.describe Agents::PagesController, type: :controller do
       sign_in agent
     end
 
+    context "quand l’agent n’a pas d’organisation accessible" do
+      it "rend la page d’accueil" do
+        get :home
+        expect(response).to render_template("home")
+      end
+    end
+
+    context "quand l’agent a une seule organisation accessible" do
+      let(:organisation) { create(:organisation) }
+
+      before do
+        agent.organisations << organisation
+      end
+
+      it "redirige l’agent vers l’agenda de l’organisation" do
+        get :home
+        expect(response).to redirect_to(admin_organisation_agent_agenda_path(organisation, agent))
+      end
+    end
+
+    context "quand l’agent a plusieurs organisations accessibles" do
+      let(:organisation1) { create(:organisation) }
+      let(:organisation2) { create(:organisation) }
+      let(:agent) { create(:agent, admin_role_in_organisations: [organisation1, organisation2]) }
+
+      it "redirige l’agent vers la liste des organisations" do
+        get :home
+        expect(response).to redirect_to(admin_organisations_path)
+      end
+    end
+
     context "quand un id de session Crisp est présent" do
       stub_env_with(CRISP_WEBSITE_ID: "abcde")
 

--- a/spec/controllers/agents/pages_controller_spec.rb
+++ b/spec/controllers/agents/pages_controller_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Agents::PagesController, type: :controller do
+  describe "#home" do
+    let(:agent) { create(:agent) }
+
+    before do
+      sign_in agent
+    end
+
+    context "quand un id de session Crisp est présent" do
+      stub_env_with(CRISP_WEBSITE_ID: "abcde")
+
+      it "l’utilisateur est redirigé vers le chat Crisp" do
+        get :home, params: { crisp_sid: "123456" }
+        expect(response).to redirect_to("https://go.crisp.chat/chat/embed/?website_id=abcde&crisp_sid=123456")
+      end
+    end
+  end
+end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -55,9 +55,11 @@ RSpec.describe SearchController, type: :controller do
     end
 
     context "quand un id de session Crisp est présent" do
+      stub_env_with(CRISP_WEBSITE_ID: "abcde")
+
       it "l’utilisateur est redirigé vers le chat Crisp" do
         get :home, params: { crisp_sid: "123456" }
-        expect(response).to redirect_to("https://go.crisp.chat/chat/embed/?website_id=#{ENV['CRISP_WEBSITE_ID']}&crisp_sid=123456")
+        expect(response).to redirect_to("https://go.crisp.chat/chat/embed/?website_id=abcde&crisp_sid=123456")
       end
     end
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe SearchController, type: :controller do
       .and_return(geo_search)
   end
 
+  describe "#home" do
+    it "rend la page d’accueil" do
+      get :home
+      expect(response).to be_successful
+    end
+
+    context "quand un id de session Crisp est présent" do
+      it "l’utilisateur est redirigé vers le chat Crisp" do
+        get :home, params: { crisp_sid: "123456" }
+        expect(response).to redirect_to("https://go.crisp.chat/chat/embed/?website_id=#{ENV['CRISP_WEBSITE_ID']}&crisp_sid=123456")
+      end
+    end
+  end
+
   describe "#search_rdv" do
     context "invitation validation" do
       context "when the token is invalid" do


### PR DESCRIPTION
# Contexte

Depuis le passage à Crisp, nos utilisateurs reçoivent ceci dans le bas de mail de nos réponses de support.
<img width="329" alt="image" src="https://github.com/user-attachments/assets/546b900b-1496-4948-8275-c25637524ef8" />

Vu que nous n’utilisons pas la fonctionnalité de chat, nous avons demandé au support s'il était possible de retirer cette mention. Ils nous ont répondu que cela n’était pas possible.

Aujourd’hui, ce lien renvoi vers notre page d’accueil, avec en paramètre l’ID de la conversation. Afin d’éviter un côté déceptif et de perdre nos usagers, je propose donc que dans ce cas, nous les redirigions vers le chat.

# Solution

Si on reçoit un ID Crisp en paramètre, on craft simplement l’URL qui permet à l’usager de voir sa conversation dans le chat.

