### PR TITLE
Correctif pour le flash affiché en double lors d'une connexion ProConnect

### DIFF
--- a/app/controllers/agents/sessions_controller.rb
+++ b/app/controllers/agents/sessions_controller.rb
@@ -7,7 +7,8 @@ class Agents::SessionsController < Devise::SessionsController
     if flash[:alert] == I18n.t("devise.failure.unauthenticated")
       # Contrairement aux usagers, les agents ne peuvent pas créer de compte
       # On n'utilise donc pas `I18n.t("devise.failure.unauthenticated")`, mais une variante
-      flash[:notice] = "Vous devez vous connecter pour continuer"
+      # Il faut utiliser un flash.now pour éviter de réafficher le flash après la connexion si on utilise ProConnect
+      flash.now[:notice] = "Vous devez vous connecter pour continuer"
       flash[:alert] = nil
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,7 +10,8 @@ class Users::SessionsController < Devise::SessionsController
     # Le flash d'erreur est trop aggressif pour le cas d'un usager non connecté.
     # Un flash de style info est plus adapté.
     if flash[:alert] == I18n.t("devise.failure.unauthenticated")
-      flash[:notice] = flash[:alert]
+      # Il faut utiliser un flash.now pour éviter de réafficher le flash après la connexion si on utilise ProConnect
+      flash.now[:notice] = flash[:alert]
       flash[:alert] = nil
     end
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1709" alt="Screenshot 2025-03-17 at 11 28 21" src="https://github.com/user-attachments/assets/f65e5981-b92e-4937-856d-a1bb14389691" />|<img width="1721" alt="Screenshot 2025-03-17 at 11 28 30" src="https://github.com/user-attachments/assets/a41f15ea-2abd-40a3-a720-7546bc6a952c" />

# Contexte

Il y avait un petit bug dans #5061 : si on essaye d'accéder à une page, qu'on est redirigé vers le login, et qu'on se connecte avec ProConnect, le flash qui demande la connexion s'affiche une deuxième fois alors qu'on est connecté.
Ce bug est revenu souvent lors des tests de l'intégration avec DS ou MSS.

# Solution

Il suffit d'un `flash.now` plutôt que le flash classique. Par contre c'est assez galère à tester, donc j'ai préféré expliquer ce point avec un commentaire.
