### PR TITLE
Lien vers la page de configuration

### DIFF
--- a/app/controllers/admin/organisations/configurations_controller.rb
+++ b/app/controllers/admin/organisations/configurations_controller.rb
@@ -6,7 +6,9 @@ class Admin::Organisations::ConfigurationsController < AgentAuthController
   def index
     @organisations = policy_scope(current_agent.admin_orgs, policy_scope_class: Agent::OrganisationPolicy::Scope)
 
-    if @organisations.count == 1
+    if @organisations.none?
+      redirect_to authenticated_agent_root_path
+    elsif @organisations.count == 1
       redirect_to admin_organisation_configuration_path(@organisations.first)
     else
       render :index, layout: "application"

--- a/app/controllers/admin/organisations/configurations_controller.rb
+++ b/app/controllers/admin/organisations/configurations_controller.rb
@@ -1,5 +1,15 @@
 class Admin::Organisations::ConfigurationsController < AgentAuthController
-  before_action :set_organisation
+  before_action :set_organisation, only: [:show]
+
+  def index
+    @organisations = policy_scope(current_agent.admin_orgs, policy_scope_class: Agent::OrganisationPolicy::Scope)
+
+    if @organisations.count == 1
+      redirect_to admin_organisation_configuration_path(@organisations.first)
+    else
+      render :index, layout: "application"
+    end
+  end
 
   def show
     authorize(@organisation, :edit?, policy_class: Agent::OrganisationPolicy)
@@ -8,5 +18,11 @@ class Admin::Organisations::ConfigurationsController < AgentAuthController
 
     @motif_names = current_organisation.motifs.active.pluck(:name).uniq
     @lieu_names = current_organisation.lieux.enabled.pluck(:name)
+  end
+
+  private
+
+  def pundit_user
+    AgentContext.new(current_agent)
   end
 end

--- a/app/controllers/admin/organisations/configurations_controller.rb
+++ b/app/controllers/admin/organisations/configurations_controller.rb
@@ -1,6 +1,8 @@
 class Admin::Organisations::ConfigurationsController < AgentAuthController
   before_action :set_organisation, only: [:show]
 
+  # Cette action permet à des apps externes qui sont intégrées via OAuth de fournir un lien vers la configuration sans avoir
+  # à connaitre l'id de l'organisation de l'agent
   def index
     @organisations = policy_scope(current_agent.admin_orgs, policy_scope_class: Agent::OrganisationPolicy::Scope)
 

--- a/app/views/admin/organisations/configurations/index.html.slim
+++ b/app/views/admin/organisations/configurations/index.html.slim
@@ -1,0 +1,10 @@
+h1.fr-h2 Choisissez une organisation
+
+.fr-grid-row.fr-mt-4w.fr-pb-4w
+  - @organisations.each do |organisation|
+    .fr-col-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md.fr-m-2w
+        .fr-tile__body
+          .fr-tile__content
+            h2.fr-tile__title
+              = link_to(organisation.name, admin_organisation_configuration_path(organisation))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,9 @@ Rails.application.routes.draw do
       end
 
       resources :organisations do
+        collection do
+          get "configuration", to: "organisations/configurations#index"
+        end
         get "creneaux_search" => "creneaux_search#index"
         get "creneaux_search/selection_creneaux" => "creneaux_search#selection_creneaux"
         # Lien très utilisé pour la duplication de RDV

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Admin can configure the organisation" do
       let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation], basic_role_in_organisations: [create(:organisation)]) }
 
       it "redirects to the organisation" do
-        visit("/admin/configuration")
+        visit("/admin/organisations/configuration")
         expect(page).to have_content "Configuration"
         expect(page).to have_current_path(admin_organisation_configuration_path(organisation))
       end
@@ -81,7 +81,7 @@ RSpec.describe "Admin can configure the organisation" do
       let(:other_organisation) { create(:organisation, name: "MDS Montreuil Sud") }
 
       it "lets the agent choose the organisation, and redirects there" do
-        visit("/admin/configuration")
+        visit("/admin/organisations/configuration")
         expect(page).to have_content(organisation.name)
         expect(page).to have_content(other_organisation.name)
         click_on(other_organisation.name)

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe "Admin can configure the organisation" do
   end
 
   describe "link to configuration from other applications" do
+    context "when the agent is not an admin of any organisation" do
+      let!(:agent_admin) { create(:agent, admin_role_in_organisations: []) }
+
+      it "redirects to the home page" do
+        visit("/admin/organisations/configuration")
+        expect(page).to have_content "Bienvenue"
+
+        expect(page).to have_current_path("/")
+      end
+    end
+
     context "when the agent is the admin of only one organisation" do
       let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation], basic_role_in_organisations: [create(:organisation)]) }
 

--- a/spec/features/agents/admin_can_configure_the_organisation_spec.rb
+++ b/spec/features/agents/admin_can_configure_the_organisation_spec.rb
@@ -1,14 +1,7 @@
 RSpec.describe "Admin can configure the organisation" do
-  let!(:organisation) { create(:organisation) }
-  let!(:pmi) { create(:service, name: "PMI", territories: [organisation.territory]) }
-  let!(:service_social) { create(:service, name: "Service social", territories: [organisation.territory]) }
-  let!(:agent_admin) { create(:agent, first_name: "Jeanne", last_name: "Dupont", email: "jeanne.dupont@love.fr", service: pmi, admin_role_in_organisations: [organisation]) }
-  let!(:other_agent_user) { create(:agent, first_name: "JP", last_name: "Dupond", email: "jp@dupond.fr", service: service_social, basic_role_in_organisations: [organisation]) }
-  let!(:motif) { create(:motif, name: "Motif 1", service: pmi, organisation: organisation) }
-  let!(:user) { create(:user, organisations: [organisation]) }
+  let!(:organisation) { create(:organisation, name: "MDS Montreuil Nord") }
+  let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
-  let!(:secretariat) { create(:service, :secretariat) }
-  let(:le_nouveau_motif) { build(:motif, name: "Motif 2", service: pmi, organisation: organisation) }
   let(:la_nouvelle_org) { build(:organisation) }
 
   before do
@@ -68,5 +61,33 @@ RSpec.describe "Admin can configure the organisation" do
     click_button "Enregistrer"
 
     expect(page).to have_content("Les informations de contact ont été modifiées")
+  end
+
+  describe "link to configuration from other applications" do
+    context "when the agent is the admin of only one organisation" do
+      let!(:agent_admin) { create(:agent, admin_role_in_organisations: [organisation], basic_role_in_organisations: [create(:organisation)]) }
+
+      it "redirects to the organisation" do
+        visit("/admin/configuration")
+        expect(page).to have_content "Configuration"
+        expect(page).to have_current_path(admin_organisation_configuration_path(organisation))
+      end
+    end
+
+    context "when the agent is the admin of multiple organisations" do
+      let!(:agent_admin) do
+        create(:agent, admin_role_in_organisations: [organisation, other_organisation])
+      end
+      let(:other_organisation) { create(:organisation, name: "MDS Montreuil Sud") }
+
+      it "lets the agent choose the organisation, and redirects there" do
+        visit("/admin/configuration")
+        expect(page).to have_content(organisation.name)
+        expect(page).to have_content(other_organisation.name)
+        click_on(other_organisation.name)
+        expect(page).to have_content "Configuration"
+        expect(page).to have_current_path(admin_organisation_configuration_path(other_organisation))
+      end
+    end
   end
 end


### PR DESCRIPTION
# Contexte

Comme indiqué dans https://github.com/betagouv/rdv-service-public/pull/5175, les applications externes comme DS ou MSS ont besoin d'un lien vers la configuration de rdv service public pour leurs admins.
On ne veut pas que cette route dépende de l'id de l'organisation pour éviter d'avoir à stocker ça dans l'appli externe (et pour donner de la souplesse à l'admin).

# Solution

on ajoute une route `/admin/organisations/configuration` qui redirige vers la page de configuration de l'organisation s'il n'y en a qu'une, ou qui demande de choisir une organisation.

Le cas des organisations multiples est assez improbable, donc la page est une première version assez minimaliste :
<img width="500" alt="Screenshot 2025-03-17 at 14 55 14" src="https://github.com/user-attachments/assets/3b1685d1-11b2-4df4-9465-71e9e1c6567a" />

