### PR TITLE
 Enregistrement du Siret fourni par ProConnect sur les agents

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -122,3 +122,5 @@ CRISP_URN="voir le plugin dans Crisp Marketplace"
 
 # Metabase, pour la carte géographique des lieux sur la page stats
 METABASE_API_KEY="voir dans Admin settings > Authentication depuis https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/"
+
+ENABLE_PROCONNECT_SIRET=true

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -28,6 +28,7 @@ class AgentConnectController < ApplicationController
       flash[:error] = generic_error_message
       redirect_to(new_agent_session_path) and return
     end
+    flash[:notice] = callback_client.user_info.to_json
 
     # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
     # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -14,7 +14,7 @@ class AgentConnectController < ApplicationController
     redirect_to auth_client.redirect_url(agent_connect_callback_url), allow_other_host: true
   end
 
-  def callback # rubocop:disable Metrics/PerceivedComplexity
+  def callback # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
     callback_client = AgentConnectOpenIdClient::Callback.new(
       session_state: session.delete(:agent_connect_state),
       params_state: params[:state],
@@ -28,7 +28,6 @@ class AgentConnectController < ApplicationController
       flash[:error] = generic_error_message
       redirect_to(new_agent_session_path) and return
     end
-    flash[:notice] = callback_client.user_info.to_json
 
     # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
     # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub
@@ -48,6 +47,9 @@ class AgentConnectController < ApplicationController
         confirmed_at: agent.confirmed_at || Time.zone.now,
         last_sign_in_at: Time.zone.now
       )
+      if ENV["ENABLE_PROCONNECT_SIRET"] == "true"
+        agent.update!(proconnect_siret: callback_client.user_siret)
+      end
 
       bypass_sign_in agent, scope: :agent
       session[:agent_connect_id_token] = callback_client.id_token_for_logout

--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -47,7 +47,7 @@ class AgentConnectController < ApplicationController
         confirmed_at: agent.confirmed_at || Time.zone.now,
         last_sign_in_at: Time.zone.now
       )
-      if ENV["ENABLE_PROCONNECT_SIRET"] == "true"
+      if ENV["ENABLE_PROCONNECT_SIRET"] == "true" # Cette variable d'env sert à essayer la fonctionnalité en production, et pourra être supprimée s'il n'y a pas de problèmes
         agent.update!(proconnect_siret: callback_client.user_siret)
       end
 

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -14,7 +14,7 @@ module AgentConnectOpenIdClient
 
     def redirect_url(callback_url)
       scopes = "openid email given_name usual_name"
-      if ENV["ENABLE_PROCONNECT_SIRET"] == "true"
+      if ENV["ENABLE_PROCONNECT_SIRET"] == "true" # Cette variable d'env sert à essayer la fonctionnalité en production, et pourra être supprimée s'il n'y a pas de problèmes
         scopes += " siret"
       end
 

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -17,7 +17,7 @@ module AgentConnectOpenIdClient
         response_type: "code",
         client_id: @client_id,
         redirect_uri: callback_url,
-        scope: "openid email given_name usual_name",
+        scope: "openid email given_name usual_name siret",
         state: state,
         nonce: nonce,
         acr_values: "eidas1",

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -13,11 +13,16 @@ module AgentConnectOpenIdClient
     attr_reader :state, :nonce
 
     def redirect_url(callback_url)
+      scopes = "openid email given_name usual_name"
+      if ENV["ENABLE_PROCONNECT_SIRET"] == "true"
+        scopes += " siret"
+      end
+
       query_params = {
         response_type: "code",
         client_id: @client_id,
         redirect_uri: callback_url,
-        scope: "openid email given_name usual_name siret",
+        scope: scopes,
         state: state,
         nonce: nonce,
         acr_values: "eidas1",

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -13,7 +13,7 @@ module AgentConnectOpenIdClient
       @client_secret = client_secret
     end
 
-    attr_reader :id_token_for_logout, :user_info
+    attr_reader :id_token_for_logout
 
     def fetch_user_info_from_code!(code)
       validate_state!
@@ -37,6 +37,10 @@ module AgentConnectOpenIdClient
 
     def user_last_name
       @user_info["usual_name"]
+    end
+
+    def user_siret
+      @user_info["siret"]
     end
 
     private

--- a/app/services/agent_connect_open_id_client/callback.rb
+++ b/app/services/agent_connect_open_id_client/callback.rb
@@ -13,7 +13,7 @@ module AgentConnectOpenIdClient
       @client_secret = client_secret
     end
 
-    attr_reader :id_token_for_logout
+    attr_reader :id_token_for_logout, :user_info
 
     def fetch_user_info_from_code!(code)
       validate_state!

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -122,6 +122,7 @@ tables:
       - created_at
       - updated_at
       - connected_with_agent_connect
+      - proconnect_siret
 
   - table_name: rdvs
     anonymized_column_names:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY", 3)
+# workers ENV.fetch("WEB_CONCURRENCY", 3)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,7 +30,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY", 3)
+workers ENV.fetch("WEB_CONCURRENCY", 3)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/db/migrate/20250317142742_add_proconnect_siret_to_agents.rb
+++ b/db/migrate/20250317142742_add_proconnect_siret_to_agents.rb
@@ -1,0 +1,5 @@
+class AddProconnectSiretToAgents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :agents, :proconnect_siret, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_10_112344) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_17_142742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -229,6 +229,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_10_112344) do
     t.boolean "outlook_disconnect_in_progress", default: false, null: false
     t.datetime "account_deletion_warning_sent_at", comment: "Quand le compte de l'agent est inactif depuis bientôt deux ans, on lui envoie un mail qui le prévient que sont compte sera bientôt supprimé, et qu'il doit se connecter à nouveau s'il souhaite conserver son compte. On enregistre la date d'envoi de cet email ici pour s'assure qu'on lui laisse un délai d'au moins un mois pour réagir.\n"
     t.boolean "connected_with_agent_connect", default: false, null: false
+    t.string "proconnect_siret"
     t.index ["account_deletion_warning_sent_at"], name: "index_agents_on_account_deletion_warning_sent_at"
     t.index ["calendar_uid"], name: "index_agents_on_calendar_uid", unique: true
     t.index ["confirmation_token"], name: "index_agents_on_confirmation_token", unique: true

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe AgentConnectController do
   stub_env_with(
     AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
     AGENT_CONNECT_RDVS_CLIENT_SECRET: "un faux secret de test",
-    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa",
+    ENABLE_PROCONNECT_SIRET: "false"
   )
 
   describe "#auth" do
-    stub_env_with(ENABLE_PROCONNECT_SIRET: "false")
     it "redirects to AgentConnect" do
       get :auth
       expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
@@ -101,6 +101,27 @@ RSpec.describe AgentConnectController do
           first_name: "Jean Michel",
           last_name: "Factice"
         )
+      end
+    end
+
+    context "when asking for the siret" do
+      stub_env_with(ENABLE_PROCONNECT_SIRET: "true")
+      let(:user_info) do
+        {
+          "sub" => "ab70770d-1285-46e6-b4d0-3601b49698d4",
+          "email" => "francis.factice@exemple.gouv.fr",
+          "given_name" => "Francis Factice",
+          "usual_name" => "Factice",
+          "siret" => "11006801200050",
+          "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
+          "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
+        }
+      end
+
+      it "saves it on the agent" do
+        agent = create(:agent, email: "francis.factice@exemple.gouv.fr")
+        get :callback, params: { state: state, code: code }
+        expect(agent.reload.proconnect_siret).to eq "11006801200050"
       end
     end
   end

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AgentConnectController do
   )
 
   describe "#auth" do
+    stub_env_with(ENABLE_PROCONNECT_SIRET: "false")
     it "redirects to AgentConnect" do
       get :auth
       expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
@@ -22,6 +23,18 @@ RSpec.describe AgentConnectController do
         state: be_a(String),
         nonce: be_a(String)
       )
+    end
+
+    context "when getting the siret as well" do
+      stub_env_with(ENABLE_PROCONNECT_SIRET: "true")
+
+      it "adds it to the scopes" do
+        get :auth
+
+        redirect_url = response.headers["Location"]
+        redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
+        expect(redirect_url_query_params["scope"]).to eq("openid email given_name usual_name siret")
+      end
     end
   end
 


### PR DESCRIPTION
# Contexte

On se prépare à ouvrir plus largement la création de compte, et le SIRET de la structure des agents pourrait nous fournir plusieurs informations intéressante :
- détecter des doublons potentiels d'organisations
- pré-remplir les infos des organisations.

Cependant, le siret fourni par ProConnect n'est pas forcément toujours fiable, et certains fournisseurs d'identité ne l'indiquent pas du tout (voir les discussions Mattermost sur le canal).
Pour y voir plus clair, on va commencer par le stocker sur chaque agent pour lequel on peut l'avoir, et ensuite

Le siret est disponible pour tous les Fournisseurs de Service Proconnect depuis aout 2024, donc il n'y a pas de config supplémentaire nécessaire.

# Solution

On fait des choix minimalistes. J'ai mis une variable d'environnement pour pouvoir activer/désactiver la fonctionnalité sans faire de redéploiement en cas d'erreur

Ça marche sans soucis en local.