### PR TITLE
Appliquer la regexp de validation `email` sur `notification_email`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,9 @@ class User < ApplicationRecord
   validates :number_of_children, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :ants_pre_demande_number, ants_pre_demande_number_format: true
 
+  EMAIL_REGEXP = Devise.email_regexp
+  validates :notification_email, format: { with: EMAIL_REGEXP }, allow_blank: true
+
   validate :birth_date_validity
 
   # Hooks

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -400,4 +400,18 @@ RSpec.describe User, type: :model do
       expect { user.soft_delete }.to change { user.annotations.count }.to(0)
     end
   end
+
+  describe "when notification_email is not valid" do
+    it "does not allow invalid email with single letter domain name" do
+      user = build(:user, :without_devise_email, notification_email: "test@domain.a")
+      expect(user).not_to be_valid
+      expect(user.errors[:notification_email]).to include("n'est pas valide")
+    end
+
+    it "does not allow invalid email that starts with a dot" do
+      user = build(:user, :without_devise_email, notification_email: ".test@domain.com")
+      expect(user).not_to be_valid
+      expect(user.errors[:notification_email]).to include("n'est pas valide")
+    end
+  end
 end


### PR DESCRIPTION
Nous avons reçu des webhooks invalides coté rdvi car l'email stocké pour un usager dans `notification_email` avait un domaine invalide (une seule lettre).
J'ai remarqué que la regexp de devise sur les emails a changé récemment (https://github.com/betagouv/rdv-service-public/pull/4945). J'avais moi aussi fait des modifs dessus il y a pas si longtemps. Afin de ne pas dupliquer de code et éviter les oublis je récupère cette regexp et j'applique une validation de format au champ `notification_email` du model user.
Si besoin je peux extraire le code de la regexp de l'initializer de devise pour le mettre dans un fichier dédié (dans un concern qui serait appelé dans le model User et dans l'initializer devise par exemple).