### PR TITLE
Suppression du champ `text_search_terms` qui n'est plus utilisé

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -65,7 +65,6 @@ tables:
       - created_through
       - invitation_accepted_at
       - invitation_created_at
-      - text_search_terms
       - text_search_terms_with_notification_email
       - deleted_at
       - invitation_limit

--- a/db/migrate/20250318141146_remove_unusedtext_search_terms.rb
+++ b/db/migrate/20250318141146_remove_unusedtext_search_terms.rb
@@ -1,0 +1,19 @@
+class RemoveUnusedtextSearchTerms < ActiveRecord::Migration[7.1]
+  def up
+    safety_assured { remove_column :users, :text_search_terms }
+  end
+
+  def down
+    col_definition = <<~COLUMN
+      setweight(to_tsvector('simple', translate(lower(coalesce("users"."last_name", '')), 'àâäéèêëïîôöùûüÿç', 'aaaeeeeiioouuuyc')), 'A') ||
+      setweight(to_tsvector('simple', translate(lower(coalesce("users"."first_name", '')), 'àâäéèêëïîôöùûüÿç', 'aaaeeeeiioouuuyc')), 'B') ||
+      setweight(to_tsvector('simple', translate(lower(coalesce("users"."birth_name", '')), 'àâäéèêëïîôöùûüÿç', 'aaaeeeeiioouuuyc')), 'C') ||
+      setweight(to_tsvector('simple', coalesce("users"."email", '')), 'D') ||
+      setweight(to_tsvector('simple', coalesce("users"."phone_number_formatted", '')), 'D') ||
+      setweight(to_tsvector('simple', coalesce("users"."id"::text, '')), 'D')
+    COLUMN
+
+    add_column :users, :text_search_terms, :virtual, type: :tsvector, as: col_definition, stored: true
+    add_index :users, :text_search_terms, using: :gin, name: "index_users_text_search_terms"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_17_142742) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_18_141146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -801,7 +801,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_17_142742) do
     t.integer "logement"
     t.string "ants_pre_demande_number"
     t.string "rdv_invitation_token"
-    t.virtual "text_search_terms", type: :tsvector, as: "(((((setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(last_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(first_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(birth_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'C'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(phone_number_formatted, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text)), 'D'::\"char\"))", stored: true
     t.datetime "rdv_invitation_token_updated_at"
     t.string "notification_email", comment: "Used for notifications only, multiple users can share the same email notification address"
     t.virtual "text_search_terms_with_notification_email", type: :tsvector, as: "((((((setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(last_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(first_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, translate(lower((COALESCE(birth_name, ''::character varying))::text), 'àâäéèêëïîôöùûüÿç'::text, 'aaaeeeeiioouuuyc'::text)), 'C'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(notification_email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(email, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(phone_number_formatted, ''::character varying))::text), 'D'::\"char\")) || setweight(to_tsvector('simple'::regconfig, COALESCE((id)::text, ''::text)), 'D'::\"char\"))", stored: true
@@ -820,7 +819,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_17_142742) do
     t.index ["rdv_invitation_token"], name: "index_users_on_rdv_invitation_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["responsible_id"], name: "index_users_on_responsible_id"
-    t.index ["text_search_terms"], name: "index_users_text_search_terms", using: :gin
     t.index ["text_search_terms_with_notification_email"], name: "index_users_text_search_terms_with_notification_email", using: :gin
   end
 


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-service-public/pull/5101
On enlève l'ancien champ `text_search_terms` qui n'est plus utilisé.
J'ai bypass la procédure de strong_migration. Vu qu'on supprime un champ de la table `User` Je peux merge cette PR en dehors des heures ouvrées (comme je l'avais fait pour l'ajout du champ qui a remplacé celui ci).