### PR TITLE
Fusion de la sélection de service et de motif

### DIFF
--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -40,6 +40,10 @@ module Users::CreneauxWizardConcern
     @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq(&:name_with_location_type)
   end
 
+  def motifs_grouped_by_service
+    @motifs_grouped_by_service ||= matching_motifs.group_by(&:service).sort
+  end
+
   # Retourne une liste d'organisations et leur prochaine dispo, ordonnées par date de prochaine dispo
   def next_availability_by_motifs_organisations
     @next_availability_by_motifs_organisations ||= matching_motifs.to_h do |motif|

--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -40,8 +40,8 @@ module Users::CreneauxWizardConcern
     @unique_motifs_by_name_and_location_type ||= matching_motifs.uniq(&:name_with_location_type)
   end
 
-  def motifs_grouped_by_service
-    @motifs_grouped_by_service ||= matching_motifs.group_by(&:service).sort
+  def motifs_grouped_by_service_id
+    @motifs_grouped_by_service_id ||= matching_motifs.group_by(&:service_id)
   end
 
   # Retourne une liste d'organisations et leur prochaine dispo, ordonnées par date de prochaine dispo
@@ -60,7 +60,7 @@ module Users::CreneauxWizardConcern
   end
 
   def services
-    @services ||= matching_motifs.includes(:service).map(&:service).uniq.sort_by(&:name)
+    @services ||= matching_motifs.includes(:service).map(&:service).uniq.sort_by { |service| I18n.transliterate(service.name.downcase) }
   end
 
   def follow_up_motifs?

--- a/app/views/search/_banner.html.slim
+++ b/app/views/search/_banner.html.slim
@@ -1,5 +1,5 @@
 section.py-2.rdv-background-color-alt-blue-ecume
   .fr-container
     .fr-col-12.fr-col-lg-10.fr-col-offset-lg-1
-      h1.fr-mb-3w.rdv-color-active-blue
+      h1.fr-my-3v.rdv-color-active-blue
         = render(current_domain.search_banner_template_name, context: context)

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -5,10 +5,10 @@
   - else
     - if context.first_matching_motif.collectif?
       - content_for :title, "Sélectionnez l’atelier"
-      h1.fr-h3 = "Inscrivez-vous à l'atelier de votre choix :"
+      p.fr-text--lg = "Inscrivez-vous à l'atelier de votre choix :"
     - else
       - content_for :title, "Sélectionnez le créneau"
-      h1.fr-h3 Sélectionnez un créneau&nbsp;:
+      p.fr-text--lg Sélectionnez un créneau&nbsp;:
     - if context.first_matching_motif.collectif?
       ul.fr-raw-list
         - context.available_collective_rdvs.includes(:agents_rdvs, :agents, :motif).each do |rdv|

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -4,8 +4,8 @@
 - if context.shown_lieux.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h1.fr-h3 = t(".select_lieu")
-  p = t(".lieu_available", count: context.shown_lieux.count)
+  p.fr-text--lg = t(".select_lieu")
+  p.fr-text--sm = t(".lieu_available", count: context.shown_lieux.count)
   ul.fr-raw-list
     - context.next_availability_by_lieux.each do |lieu, next_availability|
       - motif = next_availability.motif

--- a/app/views/search/_motif_card.html.slim
+++ b/app/views/search/_motif_card.html.slim
@@ -1,0 +1,22 @@
+/ locals(context: ,#motif:)
+
+li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
+  .fr-card__body
+    .fr-card__content
+      .fr-card__title
+        = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))
+      .fr-card__start
+        ul.fr-badges-group
+          - case motif.location_type
+          - when "phone"
+            li.fr-badge.fr-badge--blue-cumulus.fr-icon-phone-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+          - when "home"
+            li.fr-badge.fr-badge--blue-cumulus.fr-icon-home-4-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+          - when "public_office"
+            li.fr-badge.fr-badge--blue-cumulus.fr-icon-building-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+          - when "visio"
+            li.fr-badge.fr-badge--blue-cumulus.fr-icon-mac-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+          - else
+            li.fr-badge.fr-badge--blue-cumulus = motif.human_attribute_value(:location_type)
+          - if motif.collectif?
+            li.fr-badge.fr-badge--purple-glycine.fr-icon-team-fill.fr-badge--icon-left = "RDV collectif"

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -3,7 +3,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h1.fr-h3 Sélectionnez le motif de votre RDV&nbsp;:
+  p.fr-text--lg Sélectionnez le motif de votre RDV&nbsp;:
   ul.fr-raw-list
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       = render "search/motif_card", context: context, motif: motif

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,8 +1,5 @@
 - content_for :title, "Sélectionnez le motif"
 
-// Nous mettons un lien simple qui est beaucoup plus accessible en attendant la PR qui fusionne la sélection du service et du motif
-.fr-mb-4w
-  = link_to "Retour à la sélection du service", path_to_service_selection(params), class: "fr-link fr-icon-arrow-go-back-line fr-link--icon-left"
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -3,7 +3,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h1.fr-h2 Sélectionnez le motif de votre RDV&nbsp;:
+  h1.fr-h3 Sélectionnez le motif de votre RDV&nbsp;:
   ul.fr-raw-list
     - context.unique_motifs_by_name_and_location_type.each do |motif|
       = render "search/motif_card", context: context, motif: motif

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -6,24 +6,6 @@
   h1.fr-h2 Sélectionnez le motif de votre RDV&nbsp;:
   ul.fr-raw-list
     - context.unique_motifs_by_name_and_location_type.each do |motif|
-      li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
-        .fr-card__body
-          .fr-card__content
-            .fr-card__title
-              = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))
-            .fr-card__start
-              ul.fr-badges-group
-                - case motif.location_type
-                - when "phone"
-                  li.fr-badge.fr-badge--blue-cumulus.fr-icon-phone-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                - when "home"
-                  li.fr-badge.fr-badge--blue-cumulus.fr-icon-home-4-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                - when "public_office"
-                  li.fr-badge.fr-badge--blue-cumulus.fr-icon-building-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                - when "visio"
-                  li.fr-badge.fr-badge--blue-cumulus.fr-icon-mac-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                - else
-                  li.fr-badge.fr-badge--blue-cumulus = motif.human_attribute_value(:location_type)
-                - if motif.collectif?
-                  li.fr-badge.fr-badge--purple-glycine.fr-icon-team-fill.fr-badge--icon-left = "RDV collectif"
+      = render "search/motif_card", context: context, motif: motif
+
 = render "search/referent_booking_card", context: context

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -4,7 +4,7 @@
 - if context.next_availability_by_motifs_organisations.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h1.fr-h3 Sélectionnez la structure avec laquelle prendre RDV&nbsp;:
+  p.fr-text--lg Sélectionnez la structure avec laquelle prendre RDV&nbsp;:
   ul.fr-raw-list
     - context.next_availability_by_motifs_organisations.each do |organisation, next_availability|
       li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -5,11 +5,10 @@
 - else
   h2 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
-    - only_one_service = context.motifs_grouped_by_service.size == 1
     - context.motifs_grouped_by_service.each do |service, motifs|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
         .fr-card__body
-        = accordion.with_section(title: service.name, expanded: only_one_service) do
+        = accordion.with_section(title: service.name) do
           ul.fr-raw-list
             .fr-card__title
             - motifs.sort.each do |motif|

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -5,13 +5,13 @@
 - else
   h2 Sélectionnez le service puis le motif pour lequel voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
-    - context.unique_motifs_by_name_and_location_type.group_by(&:service).sort.each do |service, motifs|
+    - context.motifs_grouped_by_service.each do |service, motifs|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
         .fr-card__body
         = accordion.with_section(title: service.name) do
           ul.fr-raw-list
             .fr-card__title
-            - motifs.each do |motif|
+            - motifs.sort.each do |motif|
               li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
                 .fr-card__body
                   .fr-card__content
@@ -32,3 +32,4 @@
                           li.fr-badge.fr-badge--blue-cumulus = motif.human_attribute_value(:location_type)
                         - if motif.collectif?
                           li.fr-badge.fr-badge--purple-glycine.fr-icon-team-fill.fr-badge--icon-left = "RDV collectif"
+= render "search/referent_booking_card", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -10,26 +10,6 @@
         .fr-card__body
         = accordion.with_section(title: service.name) do
           ul.fr-raw-list
-            .fr-card__title
             - motifs.sort.each do |motif|
-              li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
-                .fr-card__body
-                  .fr-card__content
-                    .fr-card__title
-                      = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))
-                    .fr-card__start
-                      ul.fr-badges-group
-                        - case motif.location_type
-                        - when "phone"
-                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-phone-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                        - when "home"
-                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-home-4-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                        - when "public_office"
-                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-building-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                        - when "visio"
-                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-mac-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
-                        - else
-                          li.fr-badge.fr-badge--blue-cumulus = motif.human_attribute_value(:location_type)
-                        - if motif.collectif?
-                          li.fr-badge.fr-badge--purple-glycine.fr-icon-team-fill.fr-badge--icon-left = "RDV collectif"
+              = render "search/motif_card", context: context, motif: motif
 = render "search/referent_booking_card", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -4,12 +4,14 @@
   = render "search/nothing_to_show", context: context
 - else
   p.fr-text--lg Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
-  = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
+  // Nous n’utilisons pas le composant du DSFR view component car nous avons changé la typo des titres d’accordéon
+  .fr-accordions-group.fr-mb-5w[data-fr-group="true"]
     - context.services.each do |service|
-      .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
-        .fr-card__body
-        = accordion.with_section(title: service.name) do
-          ul.fr-raw-list
-            - context.motifs_grouped_by_service_id[service.id].sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
-              = render "search/motif_card", context: context, motif: motif
+      section.fr-accordion
+        h2.fr-accordion__title
+          button.fr-accordion__btn.fr-text--lead type="button" aria-expanded="false" aria-controls="fr-accordion-#{service.id}" = service.name
+        .fr-collapse id="fr-accordion-#{service.id}"
+          - context.motifs_grouped_by_service_id[service.id].sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
+            = render "search/motif_card", context: context, motif: motif
+
 = render "search/referent_booking_card", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -3,7 +3,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
+  h2.fr-h3 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
     - context.motifs_grouped_by_service.each do |service, motifs|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -5,10 +5,11 @@
 - else
   h2 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
+    - only_one_service = context.motifs_grouped_by_service.size == 1
     - context.motifs_grouped_by_service.each do |service, motifs|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
         .fr-card__body
-        = accordion.with_section(title: service.name) do
+        = accordion.with_section(title: service.name, expanded: only_one_service) do
           ul.fr-raw-list
             .fr-card__title
             - motifs.sort.each do |motif|

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -3,7 +3,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2.fr-h3 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
+  p.fr-text--lg Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
     - context.services.each do |service|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -5,11 +5,11 @@
 - else
   h2.fr-h3 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
-    - context.motifs_grouped_by_service.each do |service, motifs|
+    - context.services.each do |service|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
         .fr-card__body
         = accordion.with_section(title: service.name) do
           ul.fr-raw-list
-            - motifs.sort.each do |motif|
+            - context.motifs_grouped_by_service_id[service.id].sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
               = render "search/motif_card", context: context, motif: motif
 = render "search/referent_booking_card", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -3,11 +3,32 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2 Sélectionnez le service avec qui vous voulez prendre un RDV&nbsp;:
-  - context.services.each do |service|
-    .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
-      .fr-card__body
-        .fr-card__content
-          .fr-card__title
-            = link_to service.name, prendre_rdv_path(context.query_params.merge(service_id: service.id))
-= render "search/referent_booking_card", context: context
+  h2 Sélectionnez le service puis le motif pour lequel voulez prendre un RDV&nbsp;:
+  = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
+    - context.unique_motifs_by_name_and_location_type.group_by(&:service).sort.each do |service, motifs|
+      .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
+        .fr-card__body
+        = accordion.with_section(title: service.name) do
+          ul.fr-raw-list
+            .fr-card__title
+            - motifs.each do |motif|
+              li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
+                .fr-card__body
+                  .fr-card__content
+                    .fr-card__title
+                      = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))
+                    .fr-card__start
+                      ul.fr-badges-group
+                        - case motif.location_type
+                        - when "phone"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-phone-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - when "home"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-home-4-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - when "public_office"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-building-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - when "visio"
+                          li.fr-badge.fr-badge--blue-cumulus.fr-icon-mac-fill.fr-badge--icon-left = motif.human_attribute_value(:location_type)
+                        - else
+                          li.fr-badge.fr-badge--blue-cumulus = motif.human_attribute_value(:location_type)
+                        - if motif.collectif?
+                          li.fr-badge.fr-badge--purple-glycine.fr-icon-team-fill.fr-badge--icon-left = "RDV collectif"

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -3,7 +3,7 @@
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else
-  h2 Sélectionnez le service puis le motif pour lequel voulez prendre un RDV&nbsp;:
+  h2 Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV&nbsp;:
   = dsfr_accordion(classes: "fr-mb-7v") do |accordion|
     - context.motifs_grouped_by_service.each do |service, motifs|
       .fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "public pages", js: true do
           address: "Paris 75001"
         )
         visit path
-        expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
+        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
 
         expect_page_to_be_axe_clean(path)
       end

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe "public pages", js: true do
           address: "Paris 75001"
         )
         visit path
-        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
 
         expect_page_to_be_axe_clean(path)
       end

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "agents can prescribe rdvs" do
       go_to_prescription_page
       expect(page).to have_content("Nouveau RDV par prescription")
 
-      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
       expect(page).to have_content(motif_mds.service.name)
       expect(page).to have_content(motif_autre_service.service.name)
 
@@ -115,7 +115,7 @@ RSpec.describe "agents can prescribe rdvs" do
         go_to_prescription_page
         expect(page).to have_content("Nouveau RDV par prescription")
         # Selection du service et du motif
-        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
 
         find("button", text: motif_collectif.service.name).click # Ouverture de l’accordéon du service
 
@@ -223,7 +223,7 @@ RSpec.describe "agents can prescribe rdvs" do
       expect(page).to have_content("Nouveau RDV par prescription")
       expect(page).to have_content("pour #{user.full_name}")
       # Select Service
-      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
 
       find("button", text: motif_mds.service.name).click # Ouverture de l’accordéon du service
 

--- a/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_prescribe_rdvs_spec.rb
@@ -51,16 +51,17 @@ RSpec.describe "agents can prescribe rdvs" do
     it "works (happy path)", js: true do
       go_to_prescription_page
       expect(page).to have_content("Nouveau RDV par prescription")
-      # Select Service
-      expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
+
+      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
       expect(page).to have_content(motif_mds.service.name)
       expect(page).to have_content(motif_autre_service.service.name)
-      find("a", text: motif_mds.service.name).ancestor(".fr-card__title").click
-      # Select Motif
-      expect(page).to have_content("Sélectionnez le motif de votre RDV")
+
+      find("button", text: motif_mds.service.name).click # Ouverture de l’accordéon du service
       expect(page).to have_content(motif_mds.name)
       expect(page).to have_content(motif_insertion.name)
+
       find("a", text: motif_insertion.name).ancestor(".fr-card__title").click
+
       # Select Lieu
       expect(page).to have_content(mission_locale_paris_sud.name)
       expect(page).to have_content(mission_locale_paris_nord.name)
@@ -113,18 +114,18 @@ RSpec.describe "agents can prescribe rdvs" do
       it "works", js: true do
         go_to_prescription_page
         expect(page).to have_content("Nouveau RDV par prescription")
-        # Select Service
-        expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
-        expect(page).to have_content(motif_collectif.service.name)
-        find("a", text: motif_collectif.service.name).ancestor(".fr-card__title").click
-        # Select Motif
-        expect(page).to have_content("Sélectionnez le motif de votre RDV")
+        # Selection du service et du motif
+        expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+
+        find("button", text: motif_collectif.service.name).click # Ouverture de l’accordéon du service
+
         expect(page).to have_content(motif_mds.name)
         expect(page).to have_content(motif_collectif.name)
         find("a", text: motif_collectif.name).ancestor(".fr-card__title").click
-        # Select Lieu
+
+        # Selection du lieu
         find(".fr-card__title", text: /#{mds_paris_nord.name}/).ancestor(".fr-card__body").find("a").click
-        # Select créneau
+        # Selection du créneau
         first(:link, "S'inscrire").click
         # Display User selection
         find(".select2-selection[aria-labelledby=select2-user_ids_-container]").click
@@ -179,22 +180,22 @@ RSpec.describe "agents can prescribe rdvs" do
     # il n'était pas validé car le `user_ids` de l'ancien restant dans l'URL.
     it "allows going back to change the user", js: true do
       go_to_prescription_page
-      # Select Service
-      find("a", text: motif_mds.service.name).ancestor(".fr-card__title").click
-      # Select Motif
+      # Selection du service
+      find("button", text: motif_mds.service.name).click
+      # Selection du motif
       find("a", text: motif_insertion.name).ancestor(".fr-card__title").click
-      # Select Lieu
+      # Selection du Lieu
       find(".fr-card__title", text: /#{mission_locale_paris_nord.name}/).ancestor(".fr-card__body").find("a").click
-      # Select créneau
+      # Selection du créneau
       first(:link, "11:00").click
-      # Display User selection
+      # Afficher la sélection de l’usager
       click_on "Créer un usager"
       fill_in :user_first_name, with: "Jean-Paul"
       fill_in :user_last_name, with: "Orvoir"
       click_on "Créer usager"
       expect(page).to have_content("Jean-Paul")
       click_on "Continuer"
-      # go back to user selection
+      # retour à la sélection de l’usager
       page.all("a").find { _1.text == "modifier" && _1[:href].include?("user_selection") }.click
       click_on "Créer un usager"
       fill_in :user_first_name, with: "Jean-Pierre"
@@ -222,9 +223,10 @@ RSpec.describe "agents can prescribe rdvs" do
       expect(page).to have_content("Nouveau RDV par prescription")
       expect(page).to have_content("pour #{user.full_name}")
       # Select Service
-      find(".fr-card__title", text: /#{motif_mds.service.name}/).ancestor(".fr-card__body").find("a").click
-      # Select Motif
-      expect(page).to have_content("Sélectionnez le motif de votre RDV")
+      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+
+      find("button", text: motif_mds.service.name).click # Ouverture de l’accordéon du service
+
       find(".fr-card__title", text: /#{motif_mds.name}/).ancestor(".fr-card__body").find("a").click
       # Select Lieu
       find(".fr-card__title", text: /#{mds_paris_nord.name}/).ancestor(".fr-card__body").find("a").click
@@ -330,28 +332,28 @@ RSpec.describe "agents can prescribe rdvs" do
       visit root_path
       within(".left-side-menu") { click_on "Trouver un RDV" }
       click_link "Élargir la recherche"
-      # Select Service
-      find("a", text: motif_mds.service.name).ancestor(".fr-card__title").click
-      # Select Motif
+      # Selection du service
+      find("button", text: motif_mds.service.name).click
+      # Selection du motif
       find("a", text: motif_insertion.name).ancestor(".fr-card__title").click
-      # Select Lieu
+      # Selection du lieu
       find(".fr-card__title", text: /#{mission_locale_paris_nord.name}/).ancestor(".fr-card__body").find("a").click
-      # Select créneau
+      # Selection du créneau
       first(:link, "11:00").click
-      # Display User selection
+      # Afficher la sélection de l’usager
       find(".select2-selection[aria-labelledby=select2-user_ids_-container]").click
       find(".select2-search__field").send_keys("terre")
       expect(page).to have_content("TERRE Miss - 20/07/**** - 06******44 - m******e@example.com")
       first(".select2-results ul.select2-results__options li").click
       click_on "Continuer"
-      # Display Récapitulatif
+      # Affichage du récapitulatif
       # les infos de l'usager sont affichées dans le recap
       expect(page).to have_content("Usager : TERRE Miss - 20/07/1985 - 06 11 22 33 44 - miss_terre@example.com")
       expect do
         click_button "Confirmer le rdv"
         expect(page).to have_content("Rendez-vous confirmé")
       end.to change(Rdv, :count).by(1)
-      # Display Confirmation
+      # Affichage de la confirmation
       expect(page).to have_content("Rendez-vous confirmé")
       created_rdv = Rdv.last
       expect(created_rdv.users.first).to eq(user_in_organisation_mystere)

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
   it "shows the online booking forms, until the creneau selection" do
     login_as(agent, scope: :agent)
     visit public_link_to_org_path(organisation_id: organisation.id)
-    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
     find("button", text: agent.services.first.name).click
     click_link("Accompagnement Formation")
     expect(page).to have_content("Sélectionnez un lieu de RDV")
@@ -23,6 +23,6 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
   it "works on the RDV_MAIRIE domain" do
     login_as(agent, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
-    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
   end
 end

--- a/spec/features/agents/agent_can_test_online_booking_spec.rb
+++ b/spec/features/agents/agent_can_test_online_booking_spec.rb
@@ -12,9 +12,8 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
   it "shows the online booking forms, until the creneau selection" do
     login_as(agent, scope: :agent)
     visit public_link_to_org_path(organisation_id: organisation.id)
-    expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
-    click_link(agent.services.first.name)
-    expect(page).to have_content("Sélectionnez le motif de votre RDV :")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+    find("button", text: agent.services.first.name).click
     click_link("Accompagnement Formation")
     expect(page).to have_content("Sélectionnez un lieu de RDV")
     click_on(organisation.lieux.first.name)
@@ -24,6 +23,6 @@ RSpec.describe "Agents can try the user-facing online booking pages" do
   it "works on the RDV_MAIRIE domain" do
     login_as(agent, scope: :agent)
     visit "http://www.rdv-mairie-test.localhost/#{public_link_to_org_path(organisation_id: organisation.id)}"
-    expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
   end
 end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe "User can search for rdvs" do
     it "shows the service selection" do
       visit root_path(departement: "92")
 
-      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
       expect(page).to have_content(service.name)
       expect(page).to have_content(other_service.name)
     end
@@ -434,13 +434,13 @@ RSpec.describe "User can search for rdvs" do
 
   def choose_service(service)
     expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
-    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
 
     find("a", text: service.name).click
   end
 
   def choose_motif(motif)
-    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
     find("button", text: motif.service.name).click
     find("a", text: motif.name).click
   end

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe "User can search for rdvs" do
     it "default", js: true do
       visit root_path
       execute_search
-      choose_service(motif.service)
       choose_motif(motif)
       choose_lieu(lieu)
 
@@ -344,7 +343,7 @@ RSpec.describe "User can search for rdvs" do
     it "shows the service selection" do
       visit root_path(departement: "92")
 
-      expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
+      expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
       expect(page).to have_content(service.name)
       expect(page).to have_content(other_service.name)
     end
@@ -435,13 +434,14 @@ RSpec.describe "User can search for rdvs" do
 
   def choose_service(service)
     expect_page_h1("Prenez rendez-vous en ligne\navec votre département le 92")
-    expect(page).to have_content("Sélectionnez le service avec qui vous voulez prendre un RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
 
     find("a", text: service.name).click
   end
 
   def choose_motif(motif)
-    expect(page).to have_content("Sélectionnez le motif de votre RDV")
+    expect(page).to have_content("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+    find("button", text: motif.service.name).click
     find("a", text: motif.name).click
   end
 
@@ -545,7 +545,6 @@ RSpec.describe "User can search for rdvs" do
       lieu_id: lieu&.id,
       longitude: "",
       motif_name_with_location_type: "vaccination-public_office",
-      service_id: service.id,
       street_ban_id: ""
     )
   end

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Search", type: :request do
 
       it "show text to invite to select motif" do
         get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-        expect(response.body).to include("Sélectionnez le service avec qui vous voulez prendre un RDV")
+        expect(response.body).to include("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
       end
 
       context "lorsqu’il n’y a pas de motif de suivi associé aux services" do

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Search", type: :request do
 
       it "show text to invite to select motif" do
         get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
-        expect(response.body).to include("Sélectionnez le service puis le motif pour lequel voulez prendre un RDV")
+        expect(response.body).to include("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
       end
 
       context "lorsqu’il n’y a pas de motif de suivi associé aux services" do


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5185.osc-secnum-fr1.scalingo.io/) 

# Contexte

Afin de simplifier un peu l’utilisation du parcours de prise de RDV, on fusionne l’étape de sélection du service et du motif. 

# Solution

- On utilise un accordéon DSFR.
- L’étape de sélection du motif continuera de servir lorsqu’il n’y a qu’un seul service (ou qu’on passe en paramètre l’id du service).
- On supprime le lien de retour à la sélection du service sur la page de sélection de motif qui n’a plus de sens.

## Captures d'écran

Avant | Après
:- | -:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/c41e1086-b28d-4f3b-b17b-38fef2215727" /> | <img width="448" alt="image" src="https://github.com/user-attachments/assets/deaa5ad8-46ad-450e-9896-260eaf1891c2" />