### PR TITLE
Faciliter le retour vers l'application intégrée après la prise de rdv

### DIFF
--- a/app/views/agents/rdv_plans/rdv.html.slim
+++ b/app/views/agents/rdv_plans/rdv.html.slim
@@ -30,4 +30,4 @@
         .fr-mt-4w
           = link_to "Modifier", edit_admin_organisation_rdv_path(@rdv.organisation, @rdv), class: "fr-btn fr-btn--secondary", target: :blank
     - if @rdv_plan.return_url
-      = link_to "Retour sur #{@rdv_plan.oauth_application.name}", @rdv_plan.return_url, class: "float-right"
+      = link_to "Retour sur #{@rdv_plan.oauth_application.name}", @rdv_plan.return_url, class: "float-right fr-btn"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,40 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
+      "fingerprint": "d93227729f1a070feb92d7048272b7c5b0535fc7505c7ba5ab3c6c9c6e510fca",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/agents/rdv_plans/rdv.html.slim",
+      "line": 33,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Retour sur #{RdvPlan.find(params[:id]).oauth_application.name}\", RdvPlan.find(params[:id]).return_url, :class => \"float-right fr-btn\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Agents::RdvPlansController",
+          "method": "rdv",
+          "line": 86,
+          "file": "app/controllers/agents/rdv_plans_controller.rb",
+          "rendered": {
+            "name": "agents/rdv_plans/rdv",
+            "file": "app/views/agents/rdv_plans/rdv.html.slim"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "agents/rdv_plans/rdv"
+      },
+      "user_input": "RdvPlan.find(params[:id]).return_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
       "fingerprint": "dbe0369e2d4d1c53275ed53753eb214ac4f86b713b15cbe7035590a5fd0139ab",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
@@ -26,40 +60,6 @@
       "location": {
         "type": "template",
         "template": "agents/rdv_plans/edit_starts_at"
-      },
-      "user_input": "RdvPlan.find(params[:id]).return_url",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "eb06341fb0ece8eb672553f39d23c6f20622a266bd155402f243287541ba2f19",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/agents/rdv_plans/rdv.html.slim",
-      "line": 33,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"Retour sur #{RdvPlan.find(params[:id]).oauth_application.name}\", RdvPlan.find(params[:id]).return_url, :class => \"float-right\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Agents::RdvPlansController",
-          "method": "rdv",
-          "line": 86,
-          "file": "app/controllers/agents/rdv_plans_controller.rb",
-          "rendered": {
-            "name": "agents/rdv_plans/rdv",
-            "file": "app/views/agents/rdv_plans/rdv.html.slim"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "agents/rdv_plans/rdv"
       },
       "user_input": "RdvPlan.find(params[:id]).return_url",
       "confidence": "Weak",


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1414" alt="Screenshot 2025-03-19 at 09 18 40" src="https://github.com/user-attachments/assets/65f50f0b-aae4-4376-b3b8-6b99afe18c63" />|<img width="1395" alt="Screenshot 2025-03-19 at 09 18 06" src="https://github.com/user-attachments/assets/6a10e7ac-d006-4a0f-8731-ecd17fb426c2" />

En faisant des tests, on a vu qu'il y avait parfois une hésitation à retourner sur l'application principale après une prise de rdv par intégration, donc on fait remonter ce cta dans la hiérarchie de l'information de la page.

Les équipes de Démarches Simplifiées et de Mon Suivi Social nous ont confirmé qu'elles préfèreraient que ce cta soit davantage mis en avant.



