### PR TITLE
Ouverture de compte en autonomie pour les CCAS connectés à MSS

### DIFF
--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -28,7 +28,7 @@ class Agents::TerritoriesController < AgentAuthController
     params.require(:compte).permit(
       territory: %i[name departement_number],
       organisation: %i[name],
-      agent: %i[id service_ids]
+      agent: [:id, { service_ids: [] }]
     )
   end
 

--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -22,7 +22,7 @@ class Agents::TerritoriesController < AgentAuthController
   def compte_params
     params[:compte][:agent] = {
       id: current_agent.id,
-      service_ids: Agent::TerritoryPolicy.default_services(current_agent), # A terme, on espère qu'on n'aura pas besoin de fournir un service dès l'ouverture
+      service_ids: [Agent::TerritoryPolicy.default_service(current_agent).id],
     }
 
     params.require(:compte).permit(

--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -1,0 +1,38 @@
+class Agents::TerritoriesController < AgentAuthController
+  layout "application"
+  def new
+    authorize(Territory.new, policy_class: Agent::TerritoryPolicy)
+    @compte_form = Compte.new({}, current_domain)
+  end
+
+  def create
+    authorize(Territory.new, policy_class: Agent::TerritoryPolicy)
+    @compte_form = Compte.new(compte_params, current_domain)
+    @compte_form.agent = current_agent
+
+    if @compte_form.save!
+      redirect_to admin_organisation_configuration_path(@compte_form.organisation)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def compte_params
+    params[:compte][:agent] = {
+      id: current_agent.id,
+      service_ids: Agent::TerritoryPolicy.default_services(current_agent), # A terme, on espère qu'on n'aura pas besoin de fournir un service dès l'ouverture
+    }
+
+    params.require(:compte).permit(
+      territory: %i[name departement_number],
+      organisation: %i[name],
+      agent: %i[id service_ids]
+    )
+  end
+
+  def pundit_user
+    current_agent
+  end
+end

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -1,4 +1,4 @@
-# Utilisé uniquement au niveau du SuperAdmin, pour ouvrir un compte
+# Permet d'ouvrir un "compte", c'est à dire un nouveau territoire avec une organisation, et quelques infos supplémentaires
 class Compte
   include ActiveModel::Model
 
@@ -7,24 +7,26 @@ class Compte
   def initialize(attributes, current_domain = nil)
     @attributes = attributes
     @current_domain = current_domain
-  end
+    self.territory = Territory.new(@attributes[:territory] || {})
 
-  def save!
-    self.territory = Territory.new(@attributes[:territory])
-    self.organisation = Organisation.new(@attributes[:organisation].merge(
+    self.organisation = Organisation.new((@attributes[:organisation] || {}).merge(
                                            territory: territory,
                                            verticale: @current_domain&.verticale
                                          ))
-    self.lieu = Lieu.new(@attributes[:lieu].merge(
+    self.lieu = Lieu.new((@attributes[:lieu] || {}).merge(
                            organisation: organisation,
                            name: organisation.name,
                            availability: :enabled
                          ))
+  end
 
+  def save!
     ActiveRecord::Base.transaction do
       territory.save!
       organisation.save!
-      lieu.save!
+      if lieu.address
+        lieu.save!
+      end
 
       self.agent = find_or_invite_agent(organisation)
 

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -1,4 +1,13 @@
 module AgentsHelper
+  def may_need_onboarding_help?
+    # TODO: ajouter un commentaire pour expliquer le contournement de problèmes de perf
+    current_organisation.rdvs.limit(5).pluck(:id).count < 5
+  end
+
+  def meet_the_team_url
+    "https://cal.com/team/rdv-service-public/temps-d-echanges"
+  end
+
   def current_agent?(agent)
     agent.id == current_agent.id
   end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -1,7 +1,8 @@
 module AgentsHelper
   def may_need_onboarding_help?
-    # TODO: ajouter un commentaire pour expliquer le contournement de problèmes de perf
-    current_organisation.rdvs.limit(5).pluck(:id).count < 5
+    # Pour éviter d'avoir des problèmes de perfs en faisant un COUNT(*) sur tous les rdvs de l'organisation,
+    # on limite à 5 puisque c'est le nombre qu'on considère comme un bon indicateur que l'organisation a réussi à configurer son compte
+    current_organisation.rdvs.limit(5).count < 5
   end
 
   def meet_the_team_url

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -30,7 +30,7 @@ class Agent::TerritoryPolicy
     if verified_by_mss?(agent)
       Service.find_by(name: "Action Sociale").id
     else
-      raise NotImplementedError, "Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement d'agent sans motifs (voir https://github.com/betagouv/rdv-service-public/pull/5182)"
+      raise NotImplementedError, "Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement sans service (ni pour les agents ni pour les motifs) (voir https://github.com/betagouv/rdv-service-public/pull/5182)"
     end
   end
 

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -12,6 +12,28 @@ class Agent::TerritoryPolicy
   alias update? territorial_admin?
   alias edit? territorial_admin?
 
+  def new?
+    return false if @current_agent.agent_territorial_access_rights.any?
+
+    self.class.verified_by_mss?(@current_agent)
+  end
+  alias create? new?
+
+  # On espère que cette méthode est temporaire, et qu'on pourra ouvrir ça aux autres applications oauth
+  def self.verified_by_mss?(agent)
+    mss_oauth_application = Doorkeeper::Application.find_by(name: "Mon Suivi Social")
+    agent.access_tokens.find_by(application_id: mss_oauth_application&.id)
+  end
+
+  def self.default_services(agent)
+    # Pour le moment on propose cette fonctionnalité uniquement pour MSS, donc on met uniquement le service social
+    if verified_by_mss?(agent)
+      Service.find_by(name: "Action Sociale").id
+    else
+      raise NotImplementedError, "Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement d'agent sans motifs (voir https://github.com/betagouv/rdv-service-public/pull/5182)"
+    end
+  end
+
   def show?
     territorial_admin? ||
       allow_to_manage_teams? ||

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -25,10 +25,10 @@ class Agent::TerritoryPolicy
     agent.access_tokens.find_by(application_id: mss_oauth_application&.id)
   end
 
-  def self.default_services(agent)
+  def self.default_service(agent)
     # Pour le moment on propose cette fonctionnalité uniquement pour MSS, donc on met uniquement le service social
     if verified_by_mss?(agent)
-      Service.find_by(name: "Action Sociale").id
+      Service.find_by!(name: "Action Sociale")
     else
       raise NotImplementedError, <<~MSG
         Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement sans service (ni pour les agents ni pour les motifs)

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -30,7 +30,10 @@ class Agent::TerritoryPolicy
     if verified_by_mss?(agent)
       Service.find_by(name: "Action Sociale").id
     else
-      raise NotImplementedError, "Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement sans service (ni pour les agents ni pour les motifs) (voir https://github.com/betagouv/rdv-service-public/pull/5182)"
+      raise NotImplementedError, <<~MSG
+        Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement sans service (ni pour les agents ni pour les motifs)
+        (voir https://github.com/betagouv/rdv-service-public/pull/5182)"
+      MSG
     end
   end
 

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -7,76 +7,83 @@
   = settings_icon(class: "fr-mr-1w")
   | Configuration
 
-.fr-grid-row.fr-mt-4w
+.fr-container-fluid
+  - if may_need_onboarding_help?
+    .fr-callout.fr-p-2w
+      p.fr-callout__text
+        = icon("fr-icon-lightbulb-line", class: "fr-mr-3v")
+        | Besoin d'aide pour configurer votre organisation ? Nous pouvons vous aider
+        = external_link_to("Contacter l'équipe", meet_the_team_url, class: "fr-btn fr-btn--secondary fr-ml-1w")
+  .fr-grid-row.fr-grid-row--gutters.fr-mt-4w
 
-  .fr-col-12.fr-col-md-4.fr-mb-2w
-    .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md.fr-m-2w
-      .fr-tile__body
-        .fr-tile__content
-          h3.fr-tile__title
-            = link_to(admin_organisation_agents_path(current_organisation)) do
-              = icon("fr-icon-user-fill",class: "fr-mr-1w")
-              | Agents
-          p.fr-tile__desc
-            = @agents_scope.limit(3).map(&:full_name).join(", ")
-            - if @agents_scope.count > 3
-              - autres_count = @agents_scope.count - 3
-              = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
-
-  .fr-col-4.fr-mb-2w
-    .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md.fr-m-2w
-      .fr-tile__body
-        .fr-tile__content
-          h3.fr-tile__title
-            = link_to(admin_organisation_motifs_path(current_organisation)) do
-              = motif_icon(class: "fr-mr-1w")
-              | Motifs de rendez-vous
-          p.fr-tile__desc
-            - if @motif_names.blank?
-              i Aucun motif
-            - else
-              = @motif_names[0..2].join(", ")
-              - if @motif_names.count > 3
-                - autres_count = @motif_names.count - 3
+    .fr-col-12.fr-col-md-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+        .fr-tile__body
+          .fr-tile__content
+            h3.fr-tile__title
+              = link_to(admin_organisation_agents_path(current_organisation)) do
+                = icon("fr-icon-user-fill",class: "fr-mr-1w")
+                | Agents
+            p.fr-tile__desc
+              = @agents_scope.limit(3).map(&:full_name).join(", ")
+              - if @agents_scope.count > 3
+                - autres_count = @agents_scope.count - 3
                 = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
 
-  .fr-col-4.fr-mb-2w
-    .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md.fr-m-2w
-      .fr-tile__body
-        .fr-tile__content
-          h3.fr-tile__title
-            = link_to(admin_organisation_lieux_path(current_organisation)) do
-              = lieu_icon(class: "fr-mr-1w")
-              | Lieux
-          p.fr-tile__desc
-            - if current_organisation.lieux.none?
-              i Aucun lieu
-            - else
-              = @lieu_names[0..2].join(", ")
-              - if @lieu_names.count > 3
-                - autres_count = @lieu_names.count - 3
-                = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
+    .fr-col-12.fr-col-md-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+        .fr-tile__body
+          .fr-tile__content
+            h3.fr-tile__title
+              = link_to(admin_organisation_motifs_path(current_organisation)) do
+                = motif_icon(class: "fr-mr-1w")
+                | Motifs de rendez-vous
+            p.fr-tile__desc
+              - if @motif_names.blank?
+                i Aucun motif
+              - else
+                = @motif_names[0..2].join(", ")
+                - if @motif_names.count > 3
+                  - autres_count = @motif_names.count - 3
+                  = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
 
-  .fr-col-4.fr-mb-2w
-    .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md.fr-m-2w
-      .fr-tile__body
-        .fr-tile__content
-          h3.fr-tile__title
-            = link_to("Informations de contact", admin_organisation_path(current_organisation))
-          p.fr-tile__desc
-            - infos =[@organisation.phone_number, @organisation.email, @organisation.website].compact
-            - if infos.present?
-              = infos.join(" ")
-            - else
-              i Pas d'informations de contact
+    .fr-col-12.fr-col-md-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+        .fr-tile__body
+          .fr-tile__content
+            h3.fr-tile__title
+              = link_to(admin_organisation_lieux_path(current_organisation)) do
+                = lieu_icon(class: "fr-mr-1w")
+                | Lieux
+            p.fr-tile__desc
+              - if current_organisation.lieux.none?
+                i Aucun lieu
+              - else
+                = @lieu_names[0..2].join(", ")
+                - if @lieu_names.count > 3
+                  - autres_count = @lieu_names.count - 3
+                  = " et #{autres_count} #{'autre'.pluralize(autres_count)}"
 
-  .fr-col-4.fr-mb-2w
-    .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md.fr-m-2w
-      .fr-tile__body
-        .fr-tile__content
-          h3.fr-tile__title
-            = link_to("Réservation en ligne", admin_organisation_online_booking_path(current_organisation))
+    .fr-col-12.fr-col-md-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+        .fr-tile__body
+          .fr-tile__content
+            h3.fr-tile__title
+              = link_to("Informations de contact", admin_organisation_path(current_organisation))
+            p.fr-tile__desc
+              - infos =[@organisation.phone_number, @organisation.email, @organisation.website].compact
+              - if infos.present?
+                = infos.join(" ")
+              - else
+                i Pas d'informations de contact
 
-/ Un bricolage pour éviter que le footer déborde sur les tuiles
-br.fr-my-2w
-br.fr-my-2w
+    .fr-col-12.fr-col-md-4.fr-mb-2w
+      .fr-tile.fr-tile--horizontal.fr-enlarge-link.fr-tile--md
+        .fr-tile__body
+          .fr-tile__content
+            h3.fr-tile__title
+              = link_to("Réservation en ligne", admin_organisation_online_booking_path(current_organisation))
+
+  / Un bricolage pour éviter que le footer déborde sur les tuiles
+  br.fr-my-2w
+  br.fr-my-2w

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -6,20 +6,19 @@
   .fr-col-12.fr-col-md-6.fr-p-1w
     .card
       .card-body
-        h2.fr-h6 Votre structure utilise déjà #{current_domain.name} et vous souhaitez disposer d’un accès ?
+        h2.fr-h6 Votre organisation utilise déjà #{current_domain.name} ?
         p Vos collègues peuvent vous inviter depuis le menu <b>Configuration > Agents > Ajouter un agent</b>.
 
   .fr-col-12.fr-col-md-6.fr-p-1w.fr-pb-8w
     .card
       .card-body
-        h2.fr-h6 Votre structure n’utilise pas #{current_domain.name} et vous souhaitez créer un compte ?
+        h2.fr-h6 Votre organisation n’utilise pas encore #{current_domain.name} ?
         - policy = Agent::TerritoryPolicy.new(current_agent, Territory.new)
         - if policy.new?
-          p Vous pouvez ouvrir un espace pour votre structure
-          / ou alors "ouvrir un espace pour ma structure ?"
+          p Vous pouvez ouvrir un espace pour votre organisation.
           = link_to "Ouvrir un espace", new_agents_territory_path, class: "fr-btn"
         - else
-          p Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et créer le compte de votre structure.
+          p Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et ouvrir un espace pour votre organisation.
 
           ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md
             li

--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -13,8 +13,14 @@
     .card
       .card-body
         h2.fr-h6 Votre structure n’utilise pas #{current_domain.name} et vous souhaitez créer un compte ?
-        p Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et créer le compte de votre structure.
+        - policy = Agent::TerritoryPolicy.new(current_agent, Territory.new)
+        - if policy.new?
+          p Vous pouvez ouvrir un espace pour votre structure
+          / ou alors "ouvrir un espace pour ma structure ?"
+          = link_to "Ouvrir un espace", new_agents_territory_path, class: "fr-btn"
+        - else
+          p Nous vous invitons à contacter notre équipe. Nous organiserons un temps d’échanges pour vous présenter la solution et créer le compte de votre structure.
 
-        ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md
-          li
-            = link_to "Rencontrer notre équipe", "https://cal.com/team/rdv-service-public/temps-d-echanges", class: "fr-btn"
+          ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md
+            li
+              = link_to "Rencontrer notre équipe", meet_the_team_url, class: "fr-btn"

--- a/app/views/agents/territories/new.html.slim
+++ b/app/views/agents/territories/new.html.slim
@@ -1,0 +1,11 @@
+.fr-grid-row.fr-mb-8w
+  .fr-col-12.fr-col-md-6.fr-col-offset-md-3
+    .card
+      .card-body
+        h1 Nouvel espace
+        = form_for @compte_form, url: agents_territories_path, builder: Dsfr::FormBuilder, as: :compte do |f|
+          = f.fields_for :organisation, @compte_form.organisation do |ff|
+            = ff.dsfr_text_field :name, label: "Nom de votre organisation", hint: "par exemple : CCAS de Montreuil", autocomplete: "organization", required: true
+          = f.fields_for :territory, @compte_form.territory do |ff|
+            = ff.dsfr_text_field :name, label: "Nom du territoire", hint: "par exemple : Commune de Montreuil ou Communauté de communes de Saint-Clément", required: true
+          = f.submit "Enregistrer", class: "fr-btn float-right"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
           get "search"
         end
       end
+      resources :territories, only: %i[new create]
       resources :exports, only: %i[index] do
         get :download
       end

--- a/db/seeds/ccas.rb
+++ b/db/seeds/ccas.rb
@@ -1,4 +1,4 @@
-service = Service.create!(name: "Action Sociale", short_name: "AS CCAS")
+service = Service.create!(name: "Action Sociale", short_name: "Action Sociale")
 
 Compte.new(
   {

--- a/db/seeds/ccas.rb
+++ b/db/seeds/ccas.rb
@@ -64,3 +64,15 @@ agent = Agent.new(
 )
 agent.skip_confirmation!
 agent.save!
+
+application = Doorkeeper::Application.new(
+  name: "Mon Suivi Social",
+  uid: "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg",
+  redirect_uri: "http://localhost:4567/auth/rdvservicepublic/callback\nhttp://127.0.0.1:4567/auth/rdvservicepublic/callback",
+  post_logout_redirect_uri: "http://localhost:4567/",
+  logo_base64: ""
+)
+
+test_secret = "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg" # Pour le développement en local uniquement
+application.secret_strategy.store_secret(application, :secret, test_secret)
+application.save!

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -7,8 +7,11 @@ OmniAuth.config.request_validation_phase = nil
 
 # Cette classe est une application Sinatra minimaliste qui utilise l'oauth de RDV Service Public pour les tests
 class MonSuiviSocial < Sinatra::Base
+  base_url = "http://www.rdv-mairie.localhost:3000"
+  app_id = "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg"
+
   use OmniAuth::Builder do
-    provider :rdv_service_public, "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg", "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg", scope: "write", base_url: "http://www.rdv-mairie.localhost:3000"
+    provider :rdv_service_public, app_id, "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg", scope: "write", base_url: base_url
   end
 
   set :sessions, expire_after: 600 # temps en secondes
@@ -51,7 +54,7 @@ class MonSuiviSocial < Sinatra::Base
     session.delete(:email)
     session.delete(:access_token)
 
-    redirect to(Capybara.app_host + OmniAuth::Strategies::RdvServicePublic.sign_out_path("fake_app_id"))
+    redirect to(base_url + OmniAuth::Strategies::RdvServicePublic.sign_out_path(app_id))
   end
 
   get "/favicon.ico" do

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -8,7 +8,7 @@ OmniAuth.config.request_validation_phase = nil
 # Cette classe est une application Sinatra minimaliste qui utilise l'oauth de RDV Service Public pour les tests
 class MonSuiviSocial < Sinatra::Base
   use OmniAuth::Builder do
-    provider :rdv_service_public, "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg", "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg", scope: "write", base_url: "http://www.rdv-mairie.localhost:3000/"
+    provider :rdv_service_public, "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg", "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg", scope: "write", base_url: "http://www.rdv-mairie.localhost:3000"
   end
 
   set :sessions, expire_after: 600 # temps en secondes

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -1,0 +1,63 @@
+# Ce script remplace une version locale de Mon Suivi Social pour tester les intégrations
+# Usage  bundle exec ruby scripts/mon_suivi_social_local.rb
+require "sinatra"
+require "omniauth-rdv-service-public"
+
+OmniAuth.config.request_validation_phase = nil
+
+# Cette classe est une application Sinatra minimaliste qui utilise l'oauth de RDV Service Public pour les tests
+class MonSuiviSocial < Sinatra::Base
+  use OmniAuth::Builder do
+    provider :rdv_service_public, "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg", "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg", scope: "write", base_url: "http://www.rdv-mairie.localhost:3000/"
+  end
+
+  set :sessions, expire_after: 600 # temps en secondes
+
+  # Décommentez cette ligne pour avoir des logs sur stdout
+  # enable :logging
+
+  get "/" do
+    status 200
+    if session[:email]
+
+      # Votre email est #{session[:email]}, votre token est #{session[:access_token]}, et votre refresh_token est #{session[:refresh_token]}
+      <<-HTML
+        <h1>Mon Suivi Social (test)</h1>
+        Vous êtes connecté.
+        <br />
+        <a href="http://www.rdv-mairie.localhost:3000/admin/organisations/configuration">Vérifier ma Configuration sur RDV Service Public</a>
+        <br />
+        <a href="/logout">Déconnexion</a>
+      HTML
+    else
+      <<-HTML
+        <h1>Mon Suivi Social (test)</h1>
+        <form action="/auth/rdvservicepublic" method="post">
+          <button type="submit">Se connecter avec RDV Service Public</button>
+        </form
+      HTML
+    end
+  end
+
+  get "/auth/rdvservicepublic/callback" do
+    session[:email] = request.env["omniauth.auth"]["info"]["agent"]["email"]
+    session[:access_token] = request.env["omniauth.auth"]["credentials"]["token"]
+    session[:refresh_token] = request.env["omniauth.auth"]["credentials"]["refresh_token"]
+
+    redirect to("/")
+  end
+
+  get "/logout" do
+    session.delete(:email)
+    session.delete(:access_token)
+
+    redirect to(Capybara.app_host + OmniAuth::Strategies::RdvServicePublic.sign_out_path("fake_app_id"))
+  end
+
+  get "/favicon.ico" do
+    status 204
+    body ""
+  end
+end
+
+MonSuiviSocial.run!

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe "Un agent vérifié via une application externe peut créer un territoire" do
+  let(:application) do
+    create(:oauth_application, name: "Mon Suivi Social")
+  end
+
+  before do
+    create(:service, name: "Action Sociale")
+  end
+
+  context "quand l'agent a déjà été créé via une connexion ProConnect" do
+    let(:agent) { create(:agent, :no_services) }
+
+    before { login_as(agent, scope: :agent) }
+
+    context "et qu'il s'est connecté via une application externe" do
+      let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+
+      it "permet de créer un territoire et une organisation" do
+        visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
+
+        click_on "Ouvrir un espace"
+
+        fill_in("Nom de votre organisation", with: "CCAS de Montreuil")
+        fill_in("Nom du territoire", with: "Commune de Montreuil")
+        click_on "Enregistrer"
+
+        expect(page).to have_content "Configuration"
+        expect(agent.reload.organisations.last.name).to eq "CCAS de Montreuil"
+      end
+    end
+
+    context "mais que son compte n'est pas vérifié par une organisation externe" do
+      it "ne permet pas de créer un territoire" do
+        visit "/admin/organisations/configuration" # Les pages de paramètres des applications externes mènent à cette url
+        expect(page).to have_content "Rencontrer notre équipe"
+        expect(page).not_to have_content "Ouvrir un espace"
+      end
+    end
+  end
+end


### PR DESCRIPTION
<img width="1400" alt="Screenshot 2025-03-24 at 16 00 14" src="https://github.com/user-attachments/assets/e44f5456-08e1-4bf3-aef6-a6cf494ce304" />


**Objectif : permettre aux admins de structures utilisant Mon Suivi Social d’utiliser l’intégration sans nécessiter de synchronisation avec l’équipe déploiement RDV Service Public**

# Contexte

## Pour les intégrations
Pour embarquer un nouveau CCAS sur notre intégration, l'équipe de Mon Suivi Social doit se synchroniser avec nous pour qu'on crée un compte au CCAS via le formulaire du super admin.
C'est assez chronophage, et ça complique considérablement le processus d'ouverture de l'intégration à une nouvelle organisation


Via nos premiers tests, on a confirmé que l'intégration dans son état actuel rend service aux CCAS, même s'il y a encore des choses à améliorer (notamment permettre la prise de rendez-vous pour un autre agent).

On souhaiterait donc éviter que l'équipe MSS ai besoin de nous solliciter (et nous attendre) pour ouvrir l'intégration à un nouveau CCAS.
On a le même problème pour Démarches Simplifiées, et bientôt pour la Coop de l'inclusion numérique.

voir https://www.figma.com/board/48oOvV5GodMOfgxuVsPo4X/Ouverture-de-compte-self-service-pour-les-CCAS


## En dehors des intégrations

On équipe de plus en plus de petites structures, pour lesquelles ce n'est pas forcément nécessaire de mobiliser du temps de notre équipe, surtout si elles peuvent prendre en main l'outil de manière autonome.


## Blocages historiques

Historiquement, on ne permettait pas la création de compte en autonomie pour plusieurs raisons : 
- sécurité : on ne voulait pas permettre à n’importe qui de proposer de la prise de rdv au nom de l’état
- accompagnement : on voulait aider les agents à paramétrer leur organisation correctement
- relation avec les administrations : on voulait nouer une relation avec l'administration qu'on équipe pour avoir un partenariat sur le long terme
- modèle centré sur les grandes administrations : quand on équipait principalement des Conseils Départements, l'ouverture d'un nouveau compte était un évènement rare, qui ne nécessitait pas d'automatisation

## Levées de ces blocages

- sécurité : Dans le cadre de MSS, si les agents ont un compte MSS, ça veut dire qu'ils sont des agents du service public à qui on peut faire confiance pour qu'ils utilisent RDV SP à bon escient
- accompagement : Depuis la sortie de la page configuration (https://github.com/betagouv/rdv-service-public/pull/5175), l'équipe déploiement voit que les agents réussissent à configurer leur compte en autonomie beaucoup plus facilement
- relation avec les administrations : Il faut qu'on prévoie comment remplacer la visio initiale (voir la partie solution)
- modèle centré sur les grandes administrations : maintenant qu'on équipe les mairies, les ccas et d'autres structures locales, on a beaucoup plus de petits comptes.

# Solution

Cette PR ouvre la création de compte en autonomie pour les agents connectés via Mon Suivi Social, et pose les bases pour pouvoir plus tard élargir ce fonctionnement à d'autres cas.

## Ajout d'une bannière de contact sur la page configuration

Avant | Après
:- | -:
<img width="1418" alt="Screenshot 2025-03-21 at 17 42 36" src="https://github.com/user-attachments/assets/3824fc05-b6c2-4334-b43e-1e5fe911e54a" />|<img width="1424" alt="Screenshot 2025-03-21 at 17 47 44" src="https://github.com/user-attachments/assets/c493a96b-69fe-49d9-9b1c-45fd20428731" />

## Formulaire de création de compte ouvert aux agents qui utilisent MSS

On réutilise une version bridée du formulaire du super admin. Les motifs d'exemple "Suivi de dossier" sont créés, mais peuvent être modifiés.

Voici un récapitulatif des écrans successifs d'ouverture de compte depuis les paramètres de Mon Suivi Social pour un agent qui n'a jamais utilisé RDV Service Public, et qui n'a aucun compte dessus : 

### Configuration de Mon Suivi Social
<img width="800" alt="Screenshot 2025-03-24 at 15 51 10" src="https://github.com/user-attachments/assets/35c3a1b8-fc9d-4b8a-978e-953d03f3e3f7" />

### Connexion à RDV Service Public via ProConnect
Et création de l'agent à la volée
<img width="800" alt="Screenshot 2025-03-24 at 15 51 31" src="https://github.com/user-attachments/assets/19fccad6-8cd4-4a06-985f-de9c433cde31" />

### Retour OAuth sur Mon Suivi Social, lien vers la configuration

Le lien du bouton pointe vers `https://rdv.anct.gouv.fr/admin/organisations/configuration`, qui dirige soit vers la configuration d'une organisation existante, soit vers la page d'accueil qui permet de créer un territoire et une organisation

<img width="800" alt="Screenshot 2025-03-24 at 15 52 34" src="https://github.com/user-attachments/assets/2f1d73c8-76b4-4279-9c5e-e3cb7df1a225" />

### Page d'accueil des agents sans territoire ni organisation

NB : un agent qui se connecte via ProConnect depuis cette landing voit une page similaire, mais avec le CTA "Rencontrer notre équipe" à la place de "Ouvrir un compte"

<img width="800" alt="Screenshot 2025-03-24 at 15 59 46" src="https://github.com/user-attachments/assets/cc77bea8-3637-4d76-861c-64c2a908fde1" />

### Formulaire d'ouverture de compte

On a essayé de mettre des exemples parlant pour clarifier la définition d'organisation et de territoire ici

<img width="800" alt="Screenshot 2025-03-24 at 16 00 14" src="https://github.com/user-attachments/assets/e44f5456-08e1-4bf3-aef6-a6cf494ce304" />

### Page de configuration

L'agent peut soit commencer à configurer sont compte, soit nous contacter

<img width="800" alt="Screenshot 2025-03-24 at 16 01 00" src="https://github.com/user-attachments/assets/37215670-d65e-42a7-be61-7772db81cba5" />

## Implications sur nos processus de déploiement

La visio avec notre équipe de déploiement devient un moment possible après la création du compte plutôt qu'un blocage.

## Petites hésitations sur le vocabulaire

"Territoire", "structure", "organisation", "espace", "compte" : on a cinq mots en compétition pour des sens proches, mais parfois légèrement différents. J'hésite entre "ouvrir un compte" ou "ouvrir un espace" comme CTA dans ce parcours, et je suis très preneur de votre avis.

# Recommandations de review

## Détail des commits

Vous pouvez lire les trois commits successivement :
- le premier ajoute la bannière sur la page configuration, et réorganise un peu son layout pour que tout soit bien aligné sur desktop aussi bien que sur mobile
- le deuxième ajoute une petite appli qui permet de tester en local (voir la section suivante).
- le troisième ajoute le formulaire de création de compte

## Pour tester en local

J'ai ajouté une petite appli Sinatra (similaire à celle utilisée dans les specs pour l'oauth) pour tester les intégrations en local. Après avoir refait un `rails db:seed`, vous pouvez la lancer avec `bundle exec ruby scripts/mon_suivi_social_local.rb` (voir `scripts/mon_suivi_social.rb`).

Vous pouvez ensuite vous connecter depuis http://localhost:4567, puis utiliser le compte `bob-sans-orga@demo.rdv-solidarites.fr` avec le mot de passe `Rdvservicepublictest1!`


# Prochaines étapes

- On va mettre en place un fonctionnement similaire pour les Conums qui ont des comptes via la Coop de la médiation numérique.
- Pour avoir le même fonctionnement avec Démarches Simplifiées, c'est plus complexe parce qu'on n'est pas sûr de que lservice utiliser. On pourra soit créer un service générique (solution court terme), soit modifier le produit pour que les services soient une option de configuration tardive, et pas une étape obligatoire dès l'ouverture de compte (solution long terme). Cette deuxième solution peut se découper en deux étapes : rendre les services optionnels pour les motifs (débuté dans https://github.com/betagouv/rdv-service-public/pull/5182), puis rendre les services optionnels pour les agents.
- Avec la création de comptes en autonomie, on crée le risque de territoires en doublon. On pourra mitiger ça en vérifiant s'il existe déjà un agent avec le même siret avec une interface dans ce genre sur la page d'accueil des agents sans orga :
<img width="500" alt="Screenshot 2025-03-24 at 15 40 36" src="https://github.com/user-attachments/assets/6a7a1358-3369-488f-a216-fc811d9ed005" />


- On pourra commencer à autoriser la création de territoire pour les agents "vérifiés" (c'est à dire dont on sait que c'est des agents du service public qui ont le droit d'utiliser notre produit). Je ne sais pas encore si le siret fourni par ProConnect est toujours fiable (le modèle utilisé par ProConnect pour vérifier ça est encore à ses premiers pas), mais l'adresse email est fiable. Une première piste assez simple serait donc d'autoriser la création de territoire pour tous les agents qui ont une adresse email en `*.gouv.fr` (ou un sous-domaine plus restreint si on ne veut pas ouvrir les vannes trop largement trop vite).
