### PR TITLE
Éviter que les exports bloquent les autres jobs

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,6 +1,10 @@
 class ExportJob < ApplicationJob
   queue_as :exports
 
+  # Les exports ne sont pas urgents, et ils sont longs à exécuter,
+  # donc il est raisonnable qu'ils laissent la priorité aux autres jobs.
+  queue_with_priority 10
+
   private
 
   def redis_key(export_id)


### PR DESCRIPTION
# Contexte

Notre health check `health/jobs_queues` vient d'être down pendant 20 minutes.

Ce health check détecte quand une ou plusieurs queues sont dans l'état suivant :
- plus de 10 jobs en attente
- 5 secondes plus tard, ce nombre de jobs en attente a augmenté

Cela indique donc que pendant 20 minutes, les jobs s'empilaient plus vite qu'ils ne se dépilaient. Pendant cette période, j'ai consulté les jobs "Running" (en cours d'exécution) sur le dashboard GoodJob. Il s'agissait principalement de `ParticipationsExportPageJob` ([voir screenshot](https://github.com/user-attachments/assets/6940f4d2-716c-4cdd-9642-f21e64481938)).

Chacun de ces jobs met entre 5 et 10 secondes à s'exécuter. Leur particularité est donc qu'ils sont assez longs à exécuter, et qu'ils peuvent arriver par gros lots. Ce matin nous avons eu [4 fois 182 jobs d'export](https://github.com/user-attachments/assets/8e2e93b0-c667-4b75-bdb4-4a44e63ca88b), sur une période de 30 minutes).

# Solution

Nous avons plusieurs stratégies possibles pour éviter la congestion générée par les exports : 
1. diminuer la priorité des jobs d'exports pour qu'ils soient "choisis en dernier" par le scheduler, et donc que les autres jobs aient la priorité.
2. dédier certains threads à certaines queues ([voir excellentes explications sur le README de GoodJob](https://github.com/bensheldon/good_job?tab=readme-ov-file#optimize-queues-threads-and-processes))
3. En complément de 1 : diminuer la taille du batch d'export. Aujourd'hui on fait des paquets de 200 et ça met 5-10 secondes à s'exécuter ; si on faisait des paquets de 100, ça mettrait 3-6 secondes et donc il y aurait plus de "roulement". Mais le temps d'exécution n'est pas exactement proportionnel à la taille du batch (on utilise du pré-loading, on écrit dans Redis, etc), donc la "bonne" taille est difficile à trouver.

Dans cette PR je propose de faire le plus simplet et efficace : affecter une priorité moindre aux jobs d'export (stratégie 1). La stratégie 2 a d'autres avantages mais est plus complexe. Les avantages de la stratégie 3 sont moins clairs.

## Le health check

Avec cette nouvelle config, on peut se demander si le health check ne va pas continuer à se déclencher pour nous dire que la queue `exports` est congestionnée. La réponse est : il ne va se déclencher que si quelqu'un lance un gros export pendant le `sleep 5`, ce qui peut arriver, mais ce serait pas de chance. On pourra alors réfléchir à affiner nos configs de queues, ou alors notre algo de détection de health check.