### PR TITLE
[Support] Ajout de champs PaperTrail pour User et Agent

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -3,7 +3,12 @@ class SoftDeleteError < StandardError; end
 class Agent < ApplicationRecord
   # Mixins
   has_paper_trail(
-    only: %w[email first_name last_name starts_at invitation_sent_at invitation_accepted_at]
+    only: %w[
+      email unconfirmed_email
+      first_name last_name
+      proconnect_siret
+      invitation_sent_at invitation_accepted_at
+    ]
   )
 
   include Outlook::Connectable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,15 @@ class User < ApplicationRecord
   # Mixins
   has_paper_trail(
     only: %w[
-      email first_name last_name birth_name created_at confirmed_at invitation_accepted_at invited_through
-      created_through address phone_number birth_date caisse_affiliation affiliation_number family_situation
-      number_of_children notify_by_sms notify_by_email city_code post_code city_name
+      email notification_email first_name last_name birth_name
+      created_at confirmed_at invitation_accepted_at deleted_at
+      invited_through created_through
+      address phone_number birth_date
+      responsible_id
+      caisse_affiliation affiliation_number family_situation number_of_children
+      notify_by_sms notify_by_email
+      city_code post_code city_name
+      ants_pre_demande_number
     ]
   )
 


### PR DESCRIPTION
# Contexte

Lors de l'investigation de [ce ticket](https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_e0d22651-48a7-4597-8f5c-e2f91f86b9e9/), nous aurions été heureux d'avoir accès à l'historique des changements de responsable pour un proche. Or, le champ `responsible_id` n'est pas dans la liste des champs suivis dans PaperTrail.

Pour rappel, le paramètre `:only` permet de définir à la fois les champs : 
- dont le changement déclenche une création de version
- dont la valeur est inclue dans les données de la version

Donc les champ non listés dans `:only` ne sont pas enregistrés.

# Solution

J'ai donc ajouté `responsible_id` dans la liste, et par acquis de conscience, j'ai parcouru les autres attributes de `users` et j'ai aussi ajouté : 
- `ants_pre_demande_number`
- `notification_email`
- `deleted_at`

Et par la même occasion, j'ai ajouté ces champs pour `agents` : 
- `unconfirmed_email`
- `proconnect_siret`

J'ai aussi un peu groupé les attributs pour améliorer leur lisibilité. :broom: 