### PR TITLE
Ajout des titres de page pour des enjeux d’accessibilité

### DIFF
--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -1,4 +1,6 @@
 class Users::RdvWizardStepsController < UserAuthController
+  layout "application_base"
+
   RDV_PERMITTED_PARAMS = [:starts_at, :motif_id, :context, { user_ids: [] }].freeze
   EXTRA_PERMITTED_PARAMS = [
     *WebSearchContext::ADDRESS_SELECTION_PARAMS,

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -7,6 +7,7 @@ class Users::RdvsController < UserAuthController
   after_action :allow_iframe
 
   layout "application_narrow", only: %i[show]
+  layout "application_base", only: %i[index]
 
   include TokenInvitable
   prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -1,4 +1,6 @@
 class Users::UsersController < UserAuthController
+  layout "application_base"
+
   def edit
     @user = current_user
     authorize(@user, policy_class: User::UserPolicy)

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -1,3 +1,5 @@
+- content_for :title, "Création de compte sur #{current_domain.name}"
+
 .fr-container
   .fr-grid-row.fr-grid-row--center
     .fr-col-xs-12.fr-col-md-8.fr-py-5w

--- a/app/views/admin/territories/show.html.slim
+++ b/app/views/admin/territories/show.html.slim
@@ -1,3 +1,5 @@
+- content_for :title, "Espace Admin - #{current_territory.name}"
+
 = link_to(root_path, class: "pt-1 pb-4") do
   i.fa.fa-arrow-left
   |< Retour à l'accueil

--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,4 +1,6 @@
-h1.rdv-text-align-center.text-dark.mt-0.font-weight-bold.mb-4 Connexion à #{current_domain.name}
+- content_for :title, "Connexion agent à #{current_domain.name}"
+
+h1.rdv-text-align-center.text-dark.mt-0.font-weight-bold.mb-4 Connexion agent à #{current_domain.name}
 
 - if display_agent_connect_button?
   = render "common/proconnect_button"

--- a/app/views/search/_creneau_selection.html.slim
+++ b/app/views/search/_creneau_selection.html.slim
@@ -4,8 +4,10 @@
     = render "search/nothing_to_show", context: context
   - else
     - if context.first_matching_motif.collectif?
+      - content_for :title, "Sélectionnez l’atelier"
       h1.fr-h3 = "Inscrivez-vous à l'atelier de votre choix :"
     - else
+      - content_for :title, "Sélectionnez le créneau"
       h1.fr-h3 Sélectionnez un créneau&nbsp;:
     - if context.first_matching_motif.collectif?
       ul.fr-raw-list

--- a/app/views/search/_lieu_selection.html.slim
+++ b/app/views/search/_lieu_selection.html.slim
@@ -1,3 +1,5 @@
+- content_for :title, "Sélectionnez le lieu"
+
 = render "search/selected_motif_recap", context: context
 - if context.shown_lieux.empty?
   = render "search/nothing_to_show", context: context

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -1,3 +1,5 @@
+- content_for :title, "Sélectionnez le motif"
+
 // Nous mettons un lien simple qui est beaucoup plus accessible en attendant la PR qui fusionne la sélection du service et du motif
 .fr-mb-4w
   = link_to "Retour à la sélection du service", path_to_service_selection(params), class: "fr-link fr-icon-arrow-go-back-line fr-link--icon-left"

--- a/app/views/search/_organisation_selection.html.slim
+++ b/app/views/search/_organisation_selection.html.slim
@@ -1,3 +1,5 @@
+- content_for :title, "Sélectionnez la structure"
+
 = render "search/selected_motif_recap", context: context
 - if context.next_availability_by_motifs_organisations.empty?
   = render "search/nothing_to_show", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -1,3 +1,5 @@
+- content_for :title, "Sélectionnez le service"
+
 - if context.unique_motifs_by_name_and_location_type.empty?
   = render "search/nothing_to_show", context: context
 - else

--- a/app/views/users/rdv_wizard_steps/step1.html.slim
+++ b/app/views/users/rdv_wizard_steps/step1.html.slim
@@ -1,10 +1,13 @@
 /# locals: (current_step:, max_step:, next_step:)
 
-.fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
-  = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step, next_title: next_step[:title])
-  .card
-    = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
-    .card-body
-      = render "users/users/form", user: current_user, rdv_wizard: @rdv_wizard, service: @rdv_wizard.service
-      .col
-        = link_to "Revenir en arrière", prendre_rdv_path(@rdv_wizard.to_query), class: "btn btn-link"
+- content_for :title, current_step[:title]
+
+.fr-container.fr-pt-3w
+  .fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
+    = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step, next_title: next_step[:title])
+    .card
+      = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
+      .card-body
+        = render "users/users/form", user: current_user, rdv_wizard: @rdv_wizard, service: @rdv_wizard.service
+        .col
+          = link_to "Revenir en arrière", prendre_rdv_path(@rdv_wizard.to_query), class: "btn btn-link"

--- a/app/views/users/rdv_wizard_steps/step2.html.slim
+++ b/app/views/users/rdv_wizard_steps/step2.html.slim
@@ -1,26 +1,29 @@
 /# locals: (current_step:, max_step:, next_step:)
 
-.fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
-  = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step, next_title: next_step[:title])
-  .card
-    = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
-    .card-body
-      = form_for @rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv)), method: :post, builder: Dsfr::FormBuilder do |f|
+- content_for :title, current_step[:title]
 
-        = f.hidden_field :motif_id
-        = f.hidden_field :starts_at
+.fr-container.fr-pt-3w
+  .fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
+    = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step, next_title: next_step[:title])
+    .card
+      = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
+      .card-body
+        = form_for @rdv, url: users_rdv_wizard_step_path(step: 2, **@rdv_wizard.to_query.except(:rdv)), method: :post, builder: Dsfr::FormBuilder do |f|
 
-        div Pour qui prenez-vous rendez-vous ?
-        - if current_domain == Domain::RDV_MAIRIE
-          .fr-mt-2w
-            - current_user.available_users_for_rdv.each do |user|
-              = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: (user.id.in?(@rdv.user_ids)), name: "rdv[user_ids][]" }, user.id, nil
-        - else
-          - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: (user.id.in?(@rdv.user_ids) || current_user.id == user.id)} }
-          = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "rdv[user_ids][]"
+          = f.hidden_field :motif_id
+          = f.hidden_field :starts_at
 
-        .form-group
-          = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
-        .rdv-text-align-right
-          = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-btn fr-btn--secondary fr-mr-2w"
-          = f.submit "Continuer", class: "fr-btn"
+          div Pour qui prenez-vous rendez-vous ?
+          - if current_domain == Domain::RDV_MAIRIE
+            .fr-mt-2w
+              - current_user.available_users_for_rdv.each do |user|
+                = f.dsfr_check_box "user_ids_#{user.id}", { label: user.full_name, hint: birth_date_and_age(user), checked: (user.id.in?(@rdv.user_ids)), name: "rdv[user_ids][]" }, user.id, nil
+          - else
+            - users = current_user.available_users_for_rdv.map { |user| {label: user.full_name, hint: birth_date_and_age(user), value: user.id, checked: (user.id.in?(@rdv.user_ids) || current_user.id == user.id)} }
+            = f.dsfr_radio_buttons :users, users, legend: "", required: true, rich: true, name: "rdv[user_ids][]"
+
+          .form-group
+            = link_to "Ajouter un proche", new_relative_path(ants_pre_demande_number_required: @rdv.requires_ants_predemande_number?, ants_meeting_point_id: @rdv_wizard.lieu_id), data: { modal: true }
+          .rdv-text-align-right
+            = link_to "Revenir en arrière", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), class: "fr-btn fr-btn--secondary fr-mr-2w"
+            = f.submit "Continuer", class: "fr-btn"

--- a/app/views/users/rdv_wizard_steps/step3.html.slim
+++ b/app/views/users/rdv_wizard_steps/step3.html.slim
@@ -1,11 +1,14 @@
 /# locals: (current_step:, max_step:, next_step: nil)
 
-.fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
-  = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step)
-  .card
-    = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
-    .card-body.rdv-text-align-right
-      - if @rdv_wizard.rdv.collectif?
-        = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"}
-      - else
-        = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"}
+- content_for :title, current_step[:title]
+
+.fr-container.fr-pt-3w
+  .fr-col-lg-8.fr-col-offset-lg-2.fr-col-md-10.fr-col-offset-md-1
+    = dsfr_stepper(title: current_step[:title], value: current_step[:stepper_index], max: max_step)
+    .card
+      = render "rdv_wizard_summary", rdv_wizard: @rdv_wizard
+      .card-body.rdv-text-align-right
+        - if @rdv_wizard.rdv.collectif?
+          = link_to "Confirmer ma participation", users_rdv_participations_path(@rdv_wizard.rdv), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"}
+        - else
+          = link_to "Confirmer mon RDV", users_rdvs_path(@rdv_wizard.to_query), method: :post, class: "btn btn-primary", data: { disable_with: "Veuillez patienter…"}

--- a/app/views/users/rdvs/index.html.slim
+++ b/app/views/users/rdvs/index.html.slim
@@ -1,41 +1,44 @@
-.row.mt-3.justify-content-center
-  .col-md-6
-    h1.mb-3 Vos rendez-vous
-    .rdv-button-group-before-card.mb-3
-      - if params[:past].present?
-        = link_to "Voir vos prochains RDV", users_rdvs_path, class: "fr-btn fr-btn--secondary"
+- content_for :title, "Vos rendez-vous"
+
+.fr-container.fr-pt-3w
+  .row.mt-3.justify-content-center
+    .col-md-6
+      h1.mb-3 Vos rendez-vous
+      .rdv-button-group-before-card.mb-3
+        - if params[:past].present?
+          = link_to "Voir vos prochains RDV", users_rdvs_path, class: "fr-btn fr-btn--secondary"
+        - else
+          = link_to "Voir vos RDV passés", users_rdvs_path(past: true), class: "fr-btn fr-btn--secondary"
+        - if current_domain.provides_address_selection?
+          = render "prendre_rdv_button"
+
+      - if @rdvs.any?
+            - @rdvs.each do |rdv|
+              .card
+                .card-body
+                  = render "rdv", rdv: rdv
+            .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
+
       - else
-        = link_to "Voir vos RDV passés", users_rdvs_path(past: true), class: "fr-btn fr-btn--secondary"
-      - if current_domain.provides_address_selection?
-        = render "prendre_rdv_button"
-
-    - if @rdvs.any?
-          - @rdvs.each do |rdv|
-            .card
-              .card-body
-                = render "rdv", rdv: rdv
-          .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
-
-    - else
-      .card
-        .card-body
-          .rdv-text-align-center.fr-my-4v
-            p.fr-mb-2v.fr-text--lead= no_rdv_for_users
-            .fr-col-4.fr-col-offset-4
-              = dsfr_svg (image_path "custom-artworks/calendar_cross.svg"), custom: true, class: "fr-responsive-img"
-  .col-md-6
-    h1.mb-3 Vos référents
-    - if current_user.referent_agents.any?
-      - current_user.referent_agents.each do |agent|
         .card
           .card-body
-            = agent.full_name_and_service
-          .card-footer.rdv-text-align-right
-            = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
-    - else
-      | Vous n'avez pas de référents
+            .rdv-text-align-center.fr-my-4v
+              p.fr-mb-2v.fr-text--lead= no_rdv_for_users
+              .fr-col-4.fr-col-offset-4
+                = dsfr_svg (image_path "custom-artworks/calendar_cross.svg"), custom: true, class: "fr-responsive-img"
+    .col-md-6
+      h1.mb-3 Vos référents
+      - if current_user.referent_agents.any?
+        - current_user.referent_agents.each do |agent|
+          .card
+            .card-body
+              = agent.full_name_and_service
+            .card-footer.rdv-text-align-right
+              = render "prendre_rdv_button", text: "Prendre un RDV de suivi", link: prendre_rdv_path(referent_ids: [agent.id], departement: agent.agent_territorial_access_rights.first.territory.departement_number)
+      - else
+        | Vous n'avez pas de référents
 
-.row.mt-3.justify-content-center
-  .rdv-text-align-center.my-5
-    = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
-      img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"
+  .row.mt-3.justify-content-center
+    .rdv-text-align-center.my-5
+      = link_to "https://voxusagers.numerique.gouv.fr/Demarches/2484?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=b4053638f7a51e868dea83f4361ebc23" do
+        img src="https://voxusagers.numerique.gouv.fr/static/bouton-blanc.svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche"

--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -1,24 +1,27 @@
-.row.justify-content-md-center
-  .col-md-6
-    .card
-      .card-body
-        h1.card-title = t(".my_informations")
-        = render "form", user: @user
-  .col-md-6
-    .card
-      .card-body
-        h2.card-title = t(".my_relatives")
-        ul.list-group.mb-2
-          - if @user.relatives.empty?
-            li.list-group-item
-              em = t(".no_relatives")
-          - @user.relatives.order(:birth_date).each do |relative|
-            li.list-group-item
-              .row
-                .col
-                  => relative.full_name
-                  = "(#{age(relative)})" if relative.birth_date
-                .col-auto.rdv-text-align-right
-                  = link_to t("admin.rdvs.show.update"), edit_relative_path(relative)
-        .rdv-text-align-right
-          = link_to t(".add_relative"), new_relative_path, class: "fr-btn fr-btn--secondary", data: { modal: true }
+- content_for :title, "Mes informations"
+
+.fr-container.fr-pt-3w
+  .row.justify-content-md-center
+    .col-md-6
+      .card
+        .card-body
+          h1.card-title = t(".my_informations")
+          = render "form", user: @user
+    .col-md-6
+      .card
+        .card-body
+          h2.card-title = t(".my_relatives")
+          ul.list-group.mb-2
+            - if @user.relatives.empty?
+              li.list-group-item
+                em = t(".no_relatives")
+            - @user.relatives.order(:birth_date).each do |relative|
+              li.list-group-item
+                .row
+                  .col
+                    => relative.full_name
+                    = "(#{age(relative)})" if relative.birth_date
+                  .col-auto.rdv-text-align-right
+                    = link_to t("admin.rdvs.show.update"), edit_relative_path(relative)
+          .rdv-text-align-right
+            = link_to t(".add_relative"), new_relative_path, class: "fr-btn fr-btn--secondary", data: { modal: true }

--- a/app/views/users/users/edit.html.slim
+++ b/app/views/users/users/edit.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "Mes informations"
+- content_for :title, t(".my_informations")
 
 .fr-container.fr-pt-3w
   .row.justify-content-md-center

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "public pages", js: true do
       let!(:po_pour_autre_service_motif) { create(:plage_ouverture, motifs: [autre_service_motif], lieu: lieu) }
 
       it "root path is accessible" do
-        expect_page_to_be_axe_clean(root_path)
+        expect_page_to_be_axe_clean(root_path, check_title: false)
       end
 
       it "root path with a city_code page is accessible" do

--- a/spec/features/accessibility/public_pages_spec.rb
+++ b/spec/features/accessibility/public_pages_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "public pages", js: true do
       let!(:po_pour_autre_service_motif) { create(:plage_ouverture, motifs: [autre_service_motif], lieu: lieu) }
 
       it "root path is accessible" do
-        expect_page_to_be_axe_clean(root_path, check_title: false)
+        expect_page_to_be_axe_clean(root_path)
       end
 
       it "root path with a city_code page is accessible" do

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -51,10 +51,10 @@ RSpec.configure do |config|
   end
 end
 
-def expect_page_to_be_axe_clean(path, excluding_selector: nil, check_title: true)
+def expect_page_to_be_axe_clean(path, excluding_selector: nil)
   visit path
   expect(page).to have_current_path(path)
-  expect_page_to_have_title if check_title
+  expect_page_to_have_title
 
   if excluding_selector
     expect(page).to be_axe_clean.excluding(excluding_selector)
@@ -66,5 +66,9 @@ end
 # Pour des questions d’accessibilité, chaque page doit avoir un titre explicite
 # suivi du nom de l’application (sauf pour la page d’accueil)
 def expect_page_to_have_title
-  expect(page).to have_title(/.* - RDV Solidarités/)
+  if page.current_path == "/"
+    expect(page).to have_title("RDV Solidarités")
+  else
+    expect(page).to have_title(/.* - RDV Solidarités/)
+  end
 end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -51,13 +51,20 @@ RSpec.configure do |config|
   end
 end
 
-def expect_page_to_be_axe_clean(path, excluding_selector: nil)
+def expect_page_to_be_axe_clean(path, excluding_selector: nil, check_title: true)
   visit path
   expect(page).to have_current_path(path)
+  expect_page_to_have_title if check_title
 
   if excluding_selector
     expect(page).to be_axe_clean.excluding(excluding_selector)
   else
     expect(page).to be_axe_clean
   end
+end
+
+# Pour des questions d’accessibilité, chaque page doit avoir un titre explicite
+# suivi du nom de l’application (sauf pour la page d’accueil)
+def expect_page_to_have_title
+  expect(page).to have_title(/.* - RDV Solidarités/)
 end


### PR DESCRIPTION
# Contexte

Pour des questions d’accessibilité, nous devons avoir des titres sur chaque page du produit.

# Solution

- Ajout d’un test qui permet de vérifier automatiquement qu’on a défini un titre.
- On définit tous les titres manquants sur l’interface usager.


