### PR TITLE
Réduire la complexité et le temps d'exécution de la recherche de créneaux

### DIFF
--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,6 +1,4 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
-  MAX_RELEVANT_CRENEAUX_COUNT_LIMIT = 200
-
   def creneau_availability
     payload = if params[:total_count] == "true"
                 { creneau_availability_count:, limit_reached: relevant_limit_reached?(creneau_availability_count) }
@@ -48,7 +46,9 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def relevant_limit_reached?(count)
-    count >= params.fetch(:max_relevant_creneaux_count_limit, MAX_RELEVANT_CRENEAUX_COUNT_LIMIT)
+    return false if params[:max_relevant_creneaux_count_limit].blank?
+
+    count >= params[:max_relevant_creneaux_count_limit].to_i
   end
 
   def creneaux_available_for_motif(motif, lieu = nil)

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -21,34 +21,34 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
 
   def creneau_availability_count
     @creneau_availability_count ||= begin
-      available_creneaux_count = 0
+      counter = 0
       invitation_search_context.matching_motifs.each do |motif|
         if motif.phone?
-          creneaux_available_for_motif(motif).size
+          counter += creneaux_available_for_motif(motif).all_creneaux.size
         else
           motif.lieux.each do |lieu|
-            available_creneaux_count += creneaux_available_for_motif(motif, lieu).size
-            break if relevant_limit_reached?(available_creneaux_count)
+            counter += creneaux_available_for_motif(motif, lieu).all_creneaux.size
+            break if relevant_limit_reached?(counter)
           end
         end
-        break if relevant_limit_reached?(available_creneaux_count)
+        break if relevant_limit_reached?(counter)
       end
-      available_creneaux_count
+      counter
     end
   end
 
   def creneau_available?
     invitation_search_context.matching_motifs.any? do |motif|
       if motif.phone?
-        creneaux_available_for_motif(motif).any?
+        creneaux_available_for_motif(motif).creneaux.any?
       else
-        motif.lieux.any? { |lieu| creneaux_available_for_motif(motif, lieu).any? }
+        motif.lieux.any? { |lieu| creneaux_available_for_motif(motif, lieu).creneaux.any? }
       end
     end
   end
 
   def relevant_limit_reached?(count)
-    count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
+    count >= params.fetch(:max_relevant_creneaux_count_limit, MAX_RELEVANT_CRENEAUX_COUNT_LIMIT)
   end
 
   def creneaux_available_for_motif(motif, lieu = nil)
@@ -57,7 +57,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
       motif: motif,
       lieu: lieu,
       geo_search: invitation_search_context.geo_search
-    ).creneaux
+    )
   end
 
   def invitation_search_context

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -3,7 +3,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
 
   def creneau_availability
     payload = if params[:total_count] == "true"
-                { creneau_availability_count:, limit_reached: creneau_availability_count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT }
+                { creneau_availability_count:, limit_reached: relevant_limit_reached?(creneau_availability_count) }
               else
                 { creneau_availability: creneau_available? }
               end
@@ -20,19 +20,21 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def creneau_availability_count
-    available_creneaux_count = 0
-    invitation_search_context.matching_motifs.each do |motif|
-      if motif.phone?
-        creneaux_available_for_motif(motif).size
-      else
-        motif.lieux.each do |lieu|
-          available_creneaux_count += creneaux_available_for_motif(motif, lieu).size
-          break if available_creneaux_count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
+    @creneau_availability_count ||= begin
+      available_creneaux_count = 0
+      invitation_search_context.matching_motifs.each do |motif|
+        if motif.phone?
+          creneaux_available_for_motif(motif).size
+        else
+          motif.lieux.each do |lieu|
+            available_creneaux_count += creneaux_available_for_motif(motif, lieu).size
+            break if relevant_limit_reached?(available_creneaux_count)
+          end
         end
+        break if relevant_limit_reached?(available_creneaux_count)
       end
-      break if available_creneaux_count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
+      available_creneaux_count
     end
-    available_creneaux_count
   end
 
   def creneau_available?
@@ -43,6 +45,10 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
         motif.lieux.any? { |lieu| creneaux_available_for_motif(motif, lieu).any? }
       end
     end
+  end
+
+  def relevant_limit_reached?(count)
+    count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
   end
 
   def creneaux_available_for_motif(motif, lieu = nil)

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -46,9 +46,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def relevant_limit_reached?(count)
-    return false if params[:max_relevant_creneaux_count_limit].blank?
-
-    count >= params[:max_relevant_creneaux_count_limit].to_i
+    params[:max_relevant_creneaux_count_limit].present? && count >= params[:max_relevant_creneaux_count_limit].to_i
   end
 
   def creneaux_available_for_motif(motif, lieu = nil)

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,7 +1,10 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
+  INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
+  MAX_RELEVANT_CRENEAUX_COUNT_LIMIT = 200
+
   def creneau_availability
     payload = if params[:total_count] == "true"
-                { creneau_availability_count: }
+                { creneau_availability_count:, limit_reached: creneau_availability_count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT }
               else
                 { creneau_availability: creneau_available? }
               end
@@ -18,13 +21,19 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def creneau_availability_count
-    invitation_search_context.matching_motifs.sum do |motif|
+    available_creneaux_count = 0
+    invitation_search_context.matching_motifs.each do |motif|
       if motif.phone?
         creneaux_available_for_motif(motif).size
       else
-        motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
+        motif.lieux.each do |lieu|
+          available_creneaux_count += creneaux_available_for_motif(motif, lieu).size
+          break if available_creneaux_count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
+        end
       end
+      break if available_creneaux_count >= MAX_RELEVANT_CRENEAUX_COUNT_LIMIT
     end
+    available_creneaux_count
   end
 
   def creneau_available?
@@ -58,7 +67,6 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def invitation_link_params
-    # invitation_token sert uniquement à retrouver l'usager
-    params.permit(InvitationSearchContext::INVITATION_PARAMS + %i[invitation_token])
+    params.permit(INVITATION_LINK_PARAMS)
   end
 end

--- a/app/controllers/api/rdvinsertion/invitations_controller.rb
+++ b/app/controllers/api/rdvinsertion/invitations_controller.rb
@@ -1,5 +1,4 @@
 class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseController
-  INVITATION_LINK_PARAMS = (InvitationSearchContext::INVITATION_PARAMS + %i[address latitude longitude invitation_token]).freeze
   MAX_RELEVANT_CRENEAUX_COUNT_LIMIT = 200
 
   def creneau_availability
@@ -67,6 +66,7 @@ class Api::Rdvinsertion::InvitationsController < Api::V1::AgentAuthBaseControlle
   end
 
   def invitation_link_params
-    params.permit(INVITATION_LINK_PARAMS)
+    # invitation_token sert uniquement à retrouver l'usager
+    params.permit(InvitationSearchContext::INVITATION_PARAMS + %i[invitation_token])
   end
 end


### PR DESCRIPTION
# Contexte

Notre nouvelle automatisation de comptage de créneaux fonctionne correctement mais elle représente une complexité élevée dont la majorité du temps d'exécution pourrait être évité.

À cause de cela nous recevons (et causons chez vous) des timeouts sur environ 1% des requêtes envoyées quotidiennement. 
Cela reste assez aléatoire, les temps de réponse restent variables.

Par exemple, la récupération du nombre de créneaux dispo de l'orga 3557 pour le motif 22561 prend régulièrement près d'une minute et s'expose donc à des timeouts. 
Elle possède 155 lieux, donc cette boucle : 
```ruby
motif.lieux.sum { |lieu| creneaux_available_for_motif(motif, lieu).size }
```
itère 155 fois avec pour chaque itération des temps de réponse proche de la seconde. Voici le résultats des onzes premiers passage avec la somme totale, et le temps d'execution : 
```
#1 Sum 23 : 0.8018 secondes
#2 Sum 46 : 0.5285 secondes
#3 Sum 69 : 0.7483 secondes
#4 Sum 92 : 0.2525 secondes
#5 Sum 115 : 0.4962 secondes
#6 Sum 138 : 0.3717 secondes
#7 Sum 161 : 0.2317 secondes
#8 Sum 184 : 1.3091 secondes
#9 Sum 207 : 0.4902 secondes
#10 Sum 230 : 0.2521 secondes
#11 Sum 253 : 0.3123 secondes
```

Comme vous le voyez, dès la 9ème itération nous avons déjà obtenu un nombre conséquent de créneaux, rendant beaucoup moins utile l'itération sur les autres lieux pour récupérer le reste des créneaux. 

En effet sachant que la fonctionnalité que nous allons construire en front consiste à informer les agents lorsqu'une catégorie approche d'un état d'indisponibilité il n'est pas essentiel pour nous de connaître la quantité totale de créneaux disponible à un instant T, juste savoir qu'il y en a plus qu'un certain seuil. 

# Solution

Je vous propose donc dans un premier temps de limiter le nombre maximal de créneaux à retourner. 
