### PR TITLE
Envoyer par défaut des notifications aux agents pour les rdvs

### DIFF
--- a/app/mailers/agents/absence_mailer.rb
+++ b/app/mailers/agents/absence_mailer.rb
@@ -3,6 +3,7 @@ class Agents::AbsenceMailer < ApplicationMailer
 
   before_action do
     @absence = params[:absence]
+    @display_link_to_agent_preferences = true
   end
 
   default to: -> { @absence.agent.email }

--- a/app/mailers/agents/plage_ouverture_mailer.rb
+++ b/app/mailers/agents/plage_ouverture_mailer.rb
@@ -4,6 +4,7 @@ class Agents::PlageOuvertureMailer < ApplicationMailer
 
   before_action do
     @plage_ouverture = params[:plage_ouverture]
+    @display_link_to_agent_preferences = true
   end
 
   default to: -> { @plage_ouverture.agent.email }

--- a/app/mailers/agents/rdv_mailer.rb
+++ b/app/mailers/agents/rdv_mailer.rb
@@ -6,6 +6,7 @@ class Agents::RdvMailer < ApplicationMailer
     @rdv = params[:rdv]
     @agent = params[:agent]
     @author = params[:author]
+    @display_link_to_agent_preferences = true
   end
 
   default to: -> { @agent.email }

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -26,7 +26,7 @@ html
                   td.aligncenter.content-block
                     = link_to mentions_legales_url do
                       span> Mentions Légales
-                  - if @agent
+                  - if @display_link_to_agent_preferences
                     = "Vous pouvez changer la fréquence de ces mails depuis "
                     = link_to agents_preferences_url do
                       span> vos préférences

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -26,3 +26,7 @@ html
                   td.aligncenter.content-block
                     = link_to mentions_legales_url do
                       span> Mentions Légales
+                  - if @agent
+                    = "Vous pouvez changer la fréquence de ces mails depuis "
+                    = link_to agents_preferences_url do
+                      span> vos préférences

--- a/db/migrate/20250325140105_change_agent_default_notification_level.rb
+++ b/db/migrate/20250325140105_change_agent_default_notification_level.rb
@@ -1,0 +1,5 @@
+class ChangeAgentDefaultNotificationLevel < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :agents, :rdv_notifications_level, from: "others", to: "all"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_18_141146) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_25_140105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -215,7 +215,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_18_141146) do
     t.string "uid", default: ""
     t.text "tokens"
     t.boolean "allow_password_change", default: false
-    t.enum "rdv_notifications_level", default: "others", enum_type: "agents_rdv_notifications_level"
+    t.enum "rdv_notifications_level", default: "all", enum_type: "agents_rdv_notifications_level"
     t.integer "unknown_past_rdv_count", default: 0
     t.boolean "display_saturdays", default: false, comment: "Indique si l'agent veut que les samedis s'affichent quand il consulte un calendrier (pas forcément le sien). Cela n'affecte pas ce que voient les autres agents. Modifiable par le bouton en bas de la vue calendrier.\n"
     t.boolean "display_cancelled_rdv", default: true, comment: "Indique si l'agent veut que les rdv annulés s'affichent quand il consulte un calendrier (pas forcément le sien). Cela n'affecte pas ce que voient les autres agents. Modifiable par le bouton en bas de la vue calendrier\n"

--- a/spec/features/agents/cancel_rdv_spec.rb
+++ b/spec/features/agents/cancel_rdv_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Agent can cancel a RDV", js: true do
-  let(:rdv) { create(:rdv) }
-  let(:agent) { rdv.agents.first }
+  let(:rdv) { create(:rdv, agents: [agent], organisation: organisation) }
+  let(:agent) { create(:agent, rdv_notifications_level: :others, basic_role_in_organisations: [organisation]) }
+  let(:organisation) { create(:organisation) }
 
   before do
     rdv.participations.first.update!(send_lifecycle_notifications: false)

--- a/spec/mailers/agents/rdv_mailer_spec.rb
+++ b/spec/mailers/agents/rdv_mailer_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Agents::RdvMailer, type: :mailer do
       expect(mail.to).to eq([agent.email])
     end
 
+    it "shows a link to the agent's email preference" do
+      expect(mail.html_part.body.to_s).to include("/agents/preferences")
+    end
+
     context "in 2 hours" do
       let(:rdv) { create(:rdv, starts_at: t + 10.minutes, agents: [agent]) }
 

--- a/spec/models/concerns/participation/status_changeable_spec.rb
+++ b/spec/models/concerns/participation/status_changeable_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Participation::StatusChangeable, type: :concern do
   before { stub_netsize_ok }
 
   describe "Participation change status" do
-    let(:agent) { create :agent }
+    let(:agent) { create(:agent, rdv_notifications_level: :others) }
     let(:rdv) { create :rdv, :collectif, starts_at: Time.zone.tomorrow, agents: [agent] }
     let!(:webhook_endpoint) { create(:webhook_endpoint, organisation: rdv.organisation, subscriptions: ["rdv"]) }
     let(:participation1) { create(:participation, rdv: rdv) }

--- a/spec/services/notifiers/rdv_cancelled_spec.rb
+++ b/spec/services/notifiers/rdv_cancelled_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Notifiers::RdvCancelled, type: :service do
   end
 
   context "cancellation by agent (default notification level : others)" do
+    let!(:agent1) { create(:agent, rdv_notifications_level: :others) }
     let!(:author) { agent1 }
     let!(:new_status) { :revoked }
 
@@ -101,6 +102,7 @@ RSpec.describe Notifiers::RdvCancelled, type: :service do
 
     before do
       agent1.update!(rdv_notifications_level: "none")
+      agent2.update!(rdv_notifications_level: "others")
     end
 
     context "starts in more than 2 days" do

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
 
   let(:user1) { create(:user) }
   let(:user2) { create(:user) }
-  let(:agent1) { create(:agent) }
-  let(:agent2) { create(:agent) }
+  let(:agent1) { create(:agent, rdv_notifications_level: :others) }
+  let(:agent2) { create(:agent, rdv_notifications_level: :others) }
   let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, agents: [agent1, agent2], users: [user1, user2], organisation: motif.organisation) }
   let(:token1) { "123456" }
   let(:token2) { "56789" }

--- a/spec/services/notifiers/rdv_updated_spec.rb
+++ b/spec/services/notifiers/rdv_updated_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Notifiers::RdvUpdated, type: :service do
   context "update without agent change" do
     subject { described_class.perform_with(rdv, agent1, old_agent_ids: [agent1.id, agent2.id]) }
 
-    let(:agent1) { build(:agent, first_name: "Sean", last_name: "PAUL") }
-    let(:agent2) { build(:agent) }
+    let(:agent1) { build(:agent, first_name: "Sean", last_name: "PAUL", rdv_notifications_level: :others) }
+    let(:agent2) { build(:agent, rdv_notifications_level: :others) }
     let(:rdv) { create(:rdv, starts_at: starts_at_initial, agents: [agent1, agent2], users: [user1, user2]) }
 
     before do


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1252" alt="Screenshot 2025-03-25 at 15 07 53" src="https://github.com/user-attachments/assets/8843105d-20c6-422a-bb2f-568082e99c6e" />|<img width="1267" alt="Screenshot 2025-03-25 at 15 08 04" src="https://github.com/user-attachments/assets/812976eb-3966-4c95-acd7-1dec0fd167fb" />

# Contexte


Dans le support, on a parfois des agents qui demandent comment ils peuvent avoir leurs rdvs ajoutés à leur calendrier. Le premier niveau de réponse est qu'ils peuvent recevoir des emails de notification avec des ics (qui sont parfois ajotués par défaut à leur calendrier en fonctio nde leur client mail).
Cependant, il faut aller activer cette option depuis une page de préférence cachée assez profondément dans l'appli. Ça serait beaucoup plus simple si ce paramètre était activé par défaut (et facile à désactiver si nécessaire).

On en avait déjà discuté avec Matis en décembre en ce disant que c'était nécessaire de changer ça pour faciliter l'onboarding.

Plus récemment, lors d'un test de l'intégration avec Démarches Simplifiées, on s'est retrouvés à changer ce paramètre au moment de l'ouverture de compte (pour le ministère de la culture), donc ça vaut le coup d'automatiser ça.

C'est cohérent avec ce qu'on a fait historiquement, vu que cette PR est le prolongement de https://github.com/betagouv/rdv-service-public/pull/3772 (et aussi https://github.com/betagouv/rdv-service-public/issues/1059, https://github.com/betagouv/rdv-service-public/pull/903). On a toujours envoyé plus de notifs aux agents, parce qu'on se rend de plus en plus compte qu'elles sont utiles.

# Solution

On change la valeur par défaut, et surtout on ajoute à la fin du mail un lien pour changer ses préférences de notifications, au cas où les agents ne souhaitent pas recevoir tous ces mails.


Avant | Après
:- | -:
<img width="661" alt="Screenshot 2025-03-25 at 15 19 40" src="https://github.com/user-attachments/assets/dd72b044-8593-4cf3-8802-530c975745d8" />|<img width="684" alt="Screenshot 2025-03-25 at 15 19 25" src="https://github.com/user-attachments/assets/7b01a1a9-2d01-4962-8df0-8425e4378c5d" />

