### PR TITLE
Utiliser les queues comme mécanisme de scheduling des jobs

### DIFF
--- a/app/jobs/ants/sync_appointment_job.rb
+++ b/app/jobs/ants/sync_appointment_job.rb
@@ -12,6 +12,8 @@ module Ants
     # useful to debug tests and avoid retries
     # discard_on(StandardError) { |_job, ex| raise ex }
 
+    queue_as :latency_5m
+
     def perform(ants_pre_demande_number:, obsolete_meeting_point_id: nil)
       @ants_pre_demande_number = ants_pre_demande_number
       @obsolete_meeting_point_id = obsolete_meeting_point_id

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,3 @@
 class ApplicationJob < ActiveJob::Base
   include DefaultJobBehaviour
-
-  queue_as :default
 end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -2,8 +2,11 @@ module DefaultJobBehaviour
   extend ActiveSupport::Concern
 
   MAX_ATTEMPTS = 20
+  PRIORITY_OF_RETRIES = 20
 
   included do
+    queue_as :latency_5m
+
     # This retry_on means:
     # "retry 20 times with an exponential backoff, then mark job as discarded"
     #
@@ -13,7 +16,7 @@ module DefaultJobBehaviour
     # total:    1s, 17s, 98s, 6m, 16m, 38m, 78m, 146m ,4h,   7h,   11h, 16h, 1d, 1d11h, 2d,  2d19h, 3d18h, 5d,  6d12h, 8d8h
     # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8 days
     # it therefore takes more than 8 days for a job to be discarded
-    retry_on(StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS, queue: :low_priority)
+    retry_on(StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
 
     before_perform :set_sentry_context
   end

--- a/app/jobs/concerns/default_job_behaviour.rb
+++ b/app/jobs/concerns/default_job_behaviour.rb
@@ -2,7 +2,6 @@ module DefaultJobBehaviour
   extend ActiveSupport::Concern
 
   MAX_ATTEMPTS = 20
-  PRIORITY_OF_RETRIES = 20
 
   included do
     # This retry_on means:
@@ -14,7 +13,7 @@ module DefaultJobBehaviour
     # total:    1s, 17s, 98s, 6m, 16m, 38m, 78m, 146m ,4h,   7h,   11h, 16h, 1d, 1d11h, 2d,  2d19h, 3d18h, 5d,  6d12h, 8d8h
     # sum: (1..20).map { _1 ** 4 }.sum.to_f / 60 / 60 / 24 ~= 8 days
     # it therefore takes more than 8 days for a job to be discarded
-    retry_on(StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS, priority: PRIORITY_OF_RETRIES)
+    retry_on(StandardError, wait: :polynomially_longer, attempts: MAX_ATTEMPTS, queue: :low_priority)
 
     before_perform :set_sentry_context
   end

--- a/app/jobs/create_crisp_ticket_job.rb
+++ b/app/jobs/create_crisp_ticket_job.rb
@@ -1,4 +1,6 @@
 class CreateCrispTicketJob < ApplicationJob
+  queue_as :latency_30s
+
   def perform(nickname:, email:, phone:, subject:, message:, role:, domain:)
     conversation = client.website.create_new_conversation(website_id)
 

--- a/app/jobs/create_zammad_ticket_job.rb
+++ b/app/jobs/create_zammad_ticket_job.rb
@@ -1,4 +1,6 @@
 class CreateZammadTicketJob < ApplicationJob
+  queue_as :latency_30s
+
   def perform(sender_role:, email:, subject:, body:, tags: [])
     ZammadApiClient.create_ticket(sender_role:, email:, subject:, body:, tags:)
   end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -1,6 +1,4 @@
 class CronJob < ApplicationJob
-  queue_as :cron
-
   class FileAttenteJob < CronJob
     def perform
       FileAttente.send_notifications
@@ -11,7 +9,7 @@ class CronJob < ApplicationJob
     def perform
       Rdv.not_cancelled.day_after_tomorrow.find_each do |rdv|
         run_at = rdv.starts_at - 48.hours
-        RdvUpcomingReminderJob.set(wait_until: run_at).perform_later(rdv)
+        RdvUpcomingReminderJob.set(wait_until: run_at, queue: :low_priority).perform_later(rdv)
       end
     end
   end

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -1,5 +1,9 @@
 class CronJob < ApplicationJob
+  queue_as :latency_whenever
+
   class FileAttenteJob < CronJob
+    queue_as :latency_30s
+
     def perform
       FileAttente.send_notifications
     end
@@ -9,7 +13,7 @@ class CronJob < ApplicationJob
     def perform
       Rdv.not_cancelled.day_after_tomorrow.find_each do |rdv|
         run_at = rdv.starts_at - 48.hours
-        RdvUpcomingReminderJob.set(wait_until: run_at, queue: :low_priority).perform_later(rdv)
+        RdvUpcomingReminderJob.set(wait_until: run_at, queue: :latency_5m).perform_later(rdv)
       end
     end
   end

--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -1,4 +1,4 @@
-class CronJob::SynchronizeCrm < ApplicationJob
+class CronJob::SynchronizeCrm < CronJob
   # Base de données "Activation"
   # ID récupéré dans l’URL de la page
   # Cf: https://developers.notion.com/reference/retrieve-a-database

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,5 +1,5 @@
 class ExportJob < ApplicationJob
-  queue_as :exports
+  queue_as :low_priority
 
   private
 

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,5 +1,5 @@
 class ExportJob < ApplicationJob
-  queue_as :low_priority
+  queue_as :latency_whenever
 
   private
 

--- a/app/jobs/fail_on_purpose_job.rb
+++ b/app/jobs/fail_on_purpose_job.rb
@@ -3,7 +3,7 @@ class FailOnPurposeError < StandardError; end
 class FailOnPurposeJob < ApplicationJob
   # self.log_arguments = false
 
-  # retry_on(StandardError, wait: 20.seconds, attempts: 3, priority: DefaultJobBehaviour::PRIORITY_OF_RETRIES)
+  # retry_on(StandardError, wait: 20.seconds, attempts: 3, queue: :low_priority)
 
   # discard_on(FailOnPurposeError) { |_job, error| Sentry.capture_exception(error) }
 

--- a/app/jobs/fail_on_purpose_job.rb
+++ b/app/jobs/fail_on_purpose_job.rb
@@ -1,9 +1,11 @@
 class FailOnPurposeError < StandardError; end
 
 class FailOnPurposeJob < ApplicationJob
+  queue_as :latency_30s
+
   # self.log_arguments = false
 
-  # retry_on(StandardError, wait: 20.seconds, attempts: 3, queue: :low_priority)
+  # retry_on(StandardError, wait: 20.seconds, attempts: 3, priority: DefaultJobBehaviour::PRIORITY_OF_RETRIES)
 
   # discard_on(FailOnPurposeError) { |_job, error| Sentry.capture_exception(error) }
 

--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -1,12 +1,10 @@
 module Outlook
   class MassCreateEventJob < ApplicationJob
-    queue_as :outlook_sync
-
     def perform(agent)
       Sentry.set_user({ id: agent.id, role: "Agent", email: agent.email })
 
       agent.agents_rdvs.joins(:rdv).where(rdv: { starts_at: 1.month.ago.. }).find_each do |agents_rdv|
-        Outlook::SyncEventJob.perform_later_for(agents_rdv)
+        Outlook::SyncEventJob.perform_later_for(agents_rdv, queue: :low_priority)
       end
     end
   end

--- a/app/jobs/outlook/mass_create_event_job.rb
+++ b/app/jobs/outlook/mass_create_event_job.rb
@@ -4,7 +4,7 @@ module Outlook
       Sentry.set_user({ id: agent.id, role: "Agent", email: agent.email })
 
       agent.agents_rdvs.joins(:rdv).where(rdv: { starts_at: 1.month.ago.. }).find_each do |agents_rdv|
-        Outlook::SyncEventJob.perform_later_for(agents_rdv, queue: :low_priority)
+        Outlook::SyncEventJob.perform_later_for(agents_rdv, queue: :latency_5m)
       end
     end
   end

--- a/app/jobs/outlook/mass_destroy_event_job.rb
+++ b/app/jobs/outlook/mass_destroy_event_job.rb
@@ -1,5 +1,7 @@
 module Outlook
   class MassDestroyEventJob < ApplicationJob
+    queue_as :latency_5m
+
     def perform(agent)
       Sentry.set_user({ id: agent.id, role: "Agent", email: agent.email })
 

--- a/app/jobs/outlook/mass_destroy_event_job.rb
+++ b/app/jobs/outlook/mass_destroy_event_job.rb
@@ -1,7 +1,5 @@
 module Outlook
   class MassDestroyEventJob < ApplicationJob
-    queue_as :outlook_sync
-
     def perform(agent)
       Sentry.set_user({ id: agent.id, role: "Agent", email: agent.email })
 

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -8,7 +8,9 @@ module Outlook
       key: -> { "Outlook::SyncEventJob-#{arguments.first}" }
     )
 
-    def self.perform_later_for(agents_rdv, queue: :default)
+    queue_as :latency_30s
+
+    def self.perform_later_for(agents_rdv, queue: :latency_30s)
       if agents_rdv.outlook_id.nil? && !agents_rdv.destroyed?
         agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
       end

--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -1,7 +1,5 @@
 module Outlook
   class SyncEventJob < ApplicationJob
-    queue_as :outlook_sync
-
     include GoodJob::ActiveJobExtensions::Concurrency
     good_job_control_concurrency_with(
       perform_limit: 1,
@@ -10,13 +8,13 @@ module Outlook
       key: -> { "Outlook::SyncEventJob-#{arguments.first}" }
     )
 
-    def self.perform_later_for(agents_rdv)
+    def self.perform_later_for(agents_rdv, queue: :default)
       if agents_rdv.outlook_id.nil? && !agents_rdv.destroyed?
         agents_rdv.update_columns(outlook_create_in_progress: true) # rubocop:disable Rails/SkipsModelValidations
       end
       # En cas de suppression du agents_rdv, on ne pourra pas le désérialiser au moment de l'exécution du job.
       # On aura donc besoin du outlook_id et de l'agent pour supprimer l'event dans Outlook
-      perform_later(agents_rdv.id, agents_rdv.outlook_id, agents_rdv.agent)
+      set(queue:).perform_later(agents_rdv.id, agents_rdv.outlook_id, agents_rdv.agent)
     end
 
     def perform(agents_rdv_id, outlook_id, agent)

--- a/app/jobs/rdv_upcoming_reminder_job.rb
+++ b/app/jobs/rdv_upcoming_reminder_job.rb
@@ -1,10 +1,12 @@
 class RdvUpcomingReminderJob < ApplicationJob
+  queue_as :latency_5m
+
   # Ces jobs sont enqueued 48 heures avant le début du RDV
   # La stratégie de retries par défaut jusqu’à 8 jours ne convient donc pas
   # Ce retry_on a précédence sur celui du DefaultJobBehaviour
   # Les handlers retry_on et discard_on sont parcourus de bas en haut du code puis en remontant les classes parentes
   # (1..14).map { (_1 ** 4) * 1.15 }.sum.to_f / 60 / 60 ~= 41 heures
-  retry_on StandardError, wait: :polynomially_longer, attempts: 14, queue: :low_priority
+  retry_on StandardError, wait: :polynomially_longer, attempts: 14, priority: DefaultJobBehaviour::PRIORITY_OF_RETRIES
 
   class TooLateError < StandardError; end
 

--- a/app/jobs/rdv_upcoming_reminder_job.rb
+++ b/app/jobs/rdv_upcoming_reminder_job.rb
@@ -1,12 +1,10 @@
 class RdvUpcomingReminderJob < ApplicationJob
-  queue_as :reminders
-
   # Ces jobs sont enqueued 48 heures avant le début du RDV
   # La stratégie de retries par défaut jusqu’à 8 jours ne convient donc pas
   # Ce retry_on a précédence sur celui du DefaultJobBehaviour
   # Les handlers retry_on et discard_on sont parcourus de bas en haut du code puis en remontant les classes parentes
   # (1..14).map { (_1 ** 4) * 1.15 }.sum.to_f / 60 / 60 ~= 41 heures
-  retry_on StandardError, wait: :polynomially_longer, attempts: 14, priority: DefaultJobBehaviour::PRIORITY_OF_RETRIES
+  retry_on StandardError, wait: :polynomially_longer, attempts: 14, queue: :low_priority
 
   class TooLateError < StandardError; end
 

--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -1,6 +1,4 @@
 class SmsJob < ApplicationJob
-  queue_as :sms
-
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
 

--- a/app/jobs/sms_job.rb
+++ b/app/jobs/sms_job.rb
@@ -1,4 +1,6 @@
 class SmsJob < ApplicationJob
+  queue_as :latency_30s
+
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
 

--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -1,8 +1,6 @@
 # cf /docs/interconnexions/brevo.md
 
 class TransferEmailReplyJob < ApplicationJob
-  queue_as :mailers
-
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
 

--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -1,6 +1,8 @@
 # cf /docs/interconnexions/brevo.md
 
 class TransferEmailReplyJob < ApplicationJob
+  queue_as :latency_30s
+
   # Pour éviter de fuiter des données personnelles dans les logs
   self.log_arguments = false
 

--- a/app/jobs/trigger_webhook_job.rb
+++ b/app/jobs/trigger_webhook_job.rb
@@ -1,6 +1,4 @@
 class TriggerWebhookJob < ApplicationJob
-  queue_as :trigger_webhook
-
   self.log_arguments = false
 
   def perform(webhook_endpoint_id)

--- a/app/jobs/trigger_webhook_job.rb
+++ b/app/jobs/trigger_webhook_job.rb
@@ -1,4 +1,6 @@
 class TriggerWebhookJob < ApplicationJob
+  queue_as :latency_whenever
+
   self.log_arguments = false
 
   def perform(webhook_endpoint_id)

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -3,7 +3,6 @@ class OutgoingWebhookError < StandardError; end
 class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
-  queue_as :webhook
   discard_on(ActiveRecord::RecordNotFound) { |_job, error| Sentry.capture_exception(error) }
 
   # Pour éviter de fuiter des données personnelles dans les logs

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -3,6 +3,8 @@ class OutgoingWebhookError < StandardError; end
 class WebhookJob < ApplicationJob
   TIMEOUT = 10
 
+  queue_as :latency_30s
+
   discard_on(ActiveRecord::RecordNotFound) { |_job, error| Sentry.capture_exception(error) }
 
   # Pour éviter de fuiter des données personnelles dans les logs

--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -2,6 +2,8 @@
 class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
   include DefaultJobBehaviour
 
+  queue_as :latency_30s
+
   # Only discard DeserializationError if it is caused by a ActiveRecord::RecordNotFound.
   # We don't want to discard a job when deserialization failed because of a DB failure for example.
   rescue_from ActiveJob::DeserializationError do |exception|

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -26,7 +26,7 @@ class WebhookEndpoint < ApplicationRecord
   end
 
   def trigger_for(record)
-    WebhookJob.perform_later(record.generate_webhook_payload(:created), id)
+    WebhookJob.set(queue: :low_priority).perform_later(record.generate_webhook_payload(:created), id)
   end
 
   def partially_hidden_secret

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -26,7 +26,7 @@ class WebhookEndpoint < ApplicationRecord
   end
 
   def trigger_for(record)
-    WebhookJob.set(queue: :low_priority).perform_later(record.generate_webhook_payload(:created), id)
+    WebhookJob.set(queue: :latency_whenever).perform_later(record.generate_webhook_payload(:created), id)
   end
 
   def partially_hidden_secret

--- a/app/services/notifiers/rdv_upcoming_reminder.rb
+++ b/app/services/notifiers/rdv_upcoming_reminder.rb
@@ -6,10 +6,10 @@ class Notifiers::RdvUpcomingReminder < Notifiers::RdvBase
   end
 
   def notify_user_by_mail(user)
-    user_mailer(user).rdv_upcoming_reminder.deliver_later(queue: :mailers_low, priority: 10)
+    user_mailer(user).rdv_upcoming_reminder.deliver_later(queue: :latency_5m)
   end
 
   def notify_user_by_sms(user)
-    Users::RdvSms.rdv_upcoming_reminder(@rdv, user, @participations_tokens_by_user_id[user.id]).deliver_later(queue: :sms_low, priority: 10)
+    Users::RdvSms.rdv_upcoming_reminder(@rdv, user, @participations_tokens_by_user_id[user.id]).deliver_later(queue: :latency_5m)
   end
 end

--- a/app/sms/users/base_sms.rb
+++ b/app/sms/users/base_sms.rb
@@ -12,8 +12,8 @@ class Users::BaseSms < ApplicationSms
 
   attr_reader :content
 
-  def deliver_later(queue: :sms, priority: 0)
-    SmsJob.set(queue: queue, priority: priority).perform_later(
+  def deliver_later(queue: :latency_30s)
+    SmsJob.set(queue: queue).perform_later(
       sender_name: @rdv.domain.sms_sender_name,
       phone_number: @user.phone_number_formatted,
       content: content,

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -5,8 +5,7 @@ Rails.application.configure do
   config.cleanup_preserved_jobs_before_seconds_ago = 604_800 # 1 semaine
   config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) } # this is never called !
   config.good_job.execution_mode = :external
-  config.good_job.queues = "*"
-  config.good_job.max_threads = 5
+  config.good_job.queues = "latency_30s:1; latency_5m,latency_30s:2; *:2"
   config.good_job.shutdown_timeout = 25 # seconds
 
   # See https://github.com/bensheldon/good_job/pull/883

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
       phone_number: "0611223344"
     )
 
-    perform_enqueued_jobs(queue: :latency_30s)
+    perform_enqueued_jobs(only: ApplicationMailerDeliveryJob)
     expect(email_sent_to(agent.email).subject).to include("Nouvelle participation au RDV collectif sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")

--- a/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
+++ b/spec/features/prescripteurs/can_add_a_user_to_a_rdv_collectif_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "prescripteur can add a user to a RDV collectif" do
       phone_number: "0611223344"
     )
 
-    perform_enqueued_jobs(queue: "mailers")
+    perform_enqueued_jobs(queue: :latency_30s)
     expect(email_sent_to(agent.email).subject).to include("Nouvelle participation au RDV collectif sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
     expect(created_rdv.created_by_prescripteur?).to be(true)
     expect(created_rdv.participations.first.created_by_prescripteur?).to be(true)
 
-    perform_enqueued_jobs(queue: "mailers")
+    perform_enqueued_jobs(queue: :latency_30s)
     expect(email_sent_to(agent.email).subject).to include("Nouveau RDV ajouté sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")

--- a/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
+++ b/spec/features/prescripteurs/can_create_rdv_for_a_user_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "prescripteur can create RDV for a user" do
     expect(created_rdv.created_by_prescripteur?).to be(true)
     expect(created_rdv.participations.first.created_by_prescripteur?).to be(true)
 
-    perform_enqueued_jobs(queue: :latency_30s)
+    perform_enqueued_jobs(only: ApplicationMailerDeliveryJob)
     expect(email_sent_to(agent.email).subject).to include("Nouveau RDV ajouté sur votre agenda RDV Solidarités")
     expect(email_sent_to("alex@prescripteur.fr").subject).to include("RDV confirmé")
     expect(email_sent_to("alex@prescripteur.fr").body).to include("RDV Aide Numérique")

--- a/spec/jobs/outlook/mass_create_event_job_spec.rb
+++ b/spec/jobs/outlook/mass_create_event_job_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Outlook::MassCreateEventJob do
 
   it "syncs future rdvs to outlook" do
     described_class.perform_now(agent)
-    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv1.agents_rdvs.first)
-    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv2.agents_rdvs.first)
-    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(recent_past_rdv.agents_rdvs.first)
-    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(distant_past_rdv.agents_rdvs.first)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv1.agents_rdvs.first, queue: :low_priority)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv2.agents_rdvs.first, queue: :low_priority)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(recent_past_rdv.agents_rdvs.first, queue: :low_priority)
+    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(distant_past_rdv.agents_rdvs.first, queue: :low_priority)
   end
 end

--- a/spec/jobs/outlook/mass_create_event_job_spec.rb
+++ b/spec/jobs/outlook/mass_create_event_job_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Outlook::MassCreateEventJob do
 
   it "syncs future rdvs to outlook" do
     described_class.perform_now(agent)
-    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv1.agents_rdvs.first, queue: :low_priority)
-    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv2.agents_rdvs.first, queue: :low_priority)
-    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(recent_past_rdv.agents_rdvs.first, queue: :low_priority)
-    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(distant_past_rdv.agents_rdvs.first, queue: :low_priority)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv1.agents_rdvs.first, queue: :latency_5m)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(future_rdv2.agents_rdvs.first, queue: :latency_5m)
+    expect(Outlook::SyncEventJob).to have_received(:perform_later_for).with(recent_past_rdv.agents_rdvs.first, queue: :latency_5m)
+    expect(Outlook::SyncEventJob).not_to have_received(:perform_later_for).with(distant_past_rdv.agents_rdvs.first, queue: :latency_5m)
   end
 end

--- a/spec/models/concerns/outlook/event_serializer_and_listener_unit_spec.rb
+++ b/spec/models/concerns/outlook/event_serializer_and_listener_unit_spec.rb
@@ -5,12 +5,11 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
     describe "when a rdv is created, updated and deleted" do
       it "doesn't enqueue a sync job" do
-        expect(Outlook::SyncEventJob).not_to receive(:perform_later)
-        rdv = create(:rdv, agents: [agent])
-
-        rdv.update!(starts_at: rdv.starts_at + 1.hour)
-
-        rdv.destroy
+        expect do
+          rdv = create(:rdv, agents: [agent])
+          rdv.update!(starts_at: rdv.starts_at + 1.hour)
+          rdv.destroy
+        end.not_to have_enqueued_job(Outlook::SyncEventJob)
       end
     end
   end
@@ -20,17 +19,18 @@ RSpec.describe Outlook::EventSerializerAndListener do
 
     describe "when a rdv is created, updated and deleted" do
       it "queues a sync job for each change" do
-        allow(Outlook::SyncEventJob).to receive(:perform_later)
+        rdv = nil
+        expect do
+          rdv = create(:rdv, agents: [agent])
+        end.to have_enqueued_job(Outlook::SyncEventJob)
 
-        rdv = create(:rdv, agents: [agent])
+        expect do
+          rdv.update!(starts_at: rdv.starts_at + 1.hour)
+        end.to have_enqueued_job(Outlook::SyncEventJob)
 
-        expect(Outlook::SyncEventJob).to have_received(:perform_later)
-
-        rdv.update!(starts_at: rdv.starts_at + 1.hour)
-        expect(Outlook::SyncEventJob).to have_received(:perform_later).twice
-
-        rdv.destroy
-        expect(Outlook::SyncEventJob).to have_received(:perform_later).thrice
+        expect do
+          rdv.destroy
+        end.to have_enqueued_job(Outlook::SyncEventJob)
       end
     end
 
@@ -38,16 +38,18 @@ RSpec.describe Outlook::EventSerializerAndListener do
       let!(:rdv) { create(:rdv, agents: [agent]) }
 
       it "queues a sync job for each change" do
-        allow(Outlook::SyncEventJob).to receive(:perform_later)
-        participation = create(:participation, rdv: rdv)
+        participation = nil
+        expect do
+          participation = create(:participation, rdv: rdv)
+        end.to have_enqueued_job(Outlook::SyncEventJob)
 
-        expect(Outlook::SyncEventJob).to have_received(:perform_later)
+        expect do
+          participation.update!(status: Participation::CANCELLED_STATUSES.first)
+        end.to have_enqueued_job(Outlook::SyncEventJob)
 
-        participation.update!(status: Participation::CANCELLED_STATUSES.first)
-        expect(Outlook::SyncEventJob).to have_received(:perform_later).twice
-
-        participation.destroy
-        expect(Outlook::SyncEventJob).to have_received(:perform_later).thrice
+        expect do
+          participation.destroy
+        end.to have_enqueued_job(Outlook::SyncEventJob)
       end
     end
 
@@ -55,13 +57,14 @@ RSpec.describe Outlook::EventSerializerAndListener do
       let!(:rdv) { create(:rdv) }
 
       it "queues a sync job for each change" do
-        allow(Outlook::SyncEventJob).to receive(:perform_later)
+        agent_participation = nil
+        expect do
+          agent_participation = create(:agents_rdv, agent: agent, rdv: rdv)
+        end.to have_enqueued_job(Outlook::SyncEventJob)
 
-        agent_participation = create(:agents_rdv, agent: agent, rdv: rdv)
-        expect(Outlook::SyncEventJob).to have_received(:perform_later)
-
-        agent_participation.destroy
-        expect(Outlook::SyncEventJob).to have_received(:perform_later).twice
+        expect do
+          agent_participation.destroy
+        end.to have_enqueued_job(Outlook::SyncEventJob)
       end
     end
 
@@ -70,15 +73,14 @@ RSpec.describe Outlook::EventSerializerAndListener do
         let!(:rdv) { create(:rdv, agents: [agent]) }
 
         it "enqueues a single job after the transaction is committed" do
-          allow(Outlook::SyncEventJob).to receive(:perform_later)
-
-          ActiveRecord::Base.transaction do
-            rdv.update!(starts_at: rdv.starts_at + 1.hour)
-            create(:participation, rdv: rdv)
-            expect(Outlook::SyncEventJob).not_to have_received(:perform_later)
-          end
-
-          expect(Outlook::SyncEventJob).to have_received(:perform_later).once
+          expect do
+            ActiveRecord::Base.transaction do
+              expect do
+                rdv.update!(starts_at: rdv.starts_at + 1.hour)
+                create(:participation, rdv: rdv)
+              end.not_to have_enqueued_job(Outlook::SyncEventJob) # Rien n'est enqueued à l'intérieur de la transaction
+            end
+          end.to have_enqueued_job(Outlook::SyncEventJob) # un job est enqueued quand la transaction est committed
         end
       end
     end

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Handling an email reply from a user" do
     it "enqueues the job that handles transferring the email" do
       expect do
         receive_brevo_callback
-      end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:mailers)
+      end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:default)
     end
   end
 

--- a/spec/requests/inbound_email_spec.rb
+++ b/spec/requests/inbound_email_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Handling an email reply from a user" do
     it "enqueues the job that handles transferring the email" do
       expect do
         receive_brevo_callback
-      end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:default)
+      end.to have_enqueued_job(TransferEmailReplyJob).with({ "Subject" => "Dummy email" }).on_queue(:latency_30s)
     end
   end
 


### PR DESCRIPTION
Note : le nom de la branche contient `step-1` car je comptais définir `config.good_job.queues` dans un second temps, mais finalement on peut faire ça tout de suite.

# Conseil de review

Je pense qu'il est nécessaire de lire le guide de GoodJob "Doing your best job with GoodJob"[^1] pour comprendre cette PR, car elle en applique les recommandations. 

# Contexte

Cette solution remplace celle proposée dans #5189 (tout le contexte initial y est détaillé).

Notre usage actuel des queues et des priorités est le suivant :
- nous avons des queues par type de job, mais que ces queues n'ont aucune utilité particulière car nous configurons GoodJob pour qu'il dépile n'importe quelle queue sans distinction (`config.good_job.queues = "*"`).
- Nous définissons `priority: 20` pour les retries et `priority: 10` pour les mails et SMS de rappel

# Solution

Après lecture de ce guide synthétique mais complet dans le README de Goodjob[^1], il semble que nous pouvons améliorer notre stratégie actuelle en mettant en place la stratégie recommandée. Cette stratégie nous permet de définir des bases saines pour notre gestion du scheduling des jobs, plutôt que de se limiter à modifier la priorité des jobs d'exports.

Cette PR reprend donc les 3 queues proposées : 
- `latency_30s` : e-mails et SMS (sauf batch), webhook (sauf batch), synchro Outlook, création de ticket de support
- `latency_5m` : notifications de rappel, synchro ANTS, synchro en masse des RDVs sur Outlook (au moment de l'activation)
- `latency_whenever` : exports, webhooks déclenchés en masse, longs jobs de cron (suppressions, chauffage de cache)

Ces 3 queues sont combinées à la config suivante : `"latency_30s:1; latency_5m,latency_30s:2; *:2"`. Cette config commande la création de 3 pools de threads : 
- un pool de 1 thread qui ne traite que des jobs dans `latency_30s`
- un pool de 2 threads qui ne traite que des jobs dans `latency_30s` ou `latency_5m`
- un pool de 2 thread qui traite les jobs de n'importe quelle queue

Avec cette config, on s'assure d'avoir au moins toujours 1 thread entièrement réservé à dépiler les jobs de petite taille **et** urgents : `latency_30s`. Nous avons 5 threads au total (1 + 2 + 2) pour dépiler cette pile `latency_30s`, ce qui favorise un dépilage rapide de cette queue. Concernant `latency_30s`, on s'assure d'avoir entre 2 et 4 threads. Et enfin, pour les exports et les gros jobs de cron, nous avons au maximum 2 threads. Cela signifie que les exports vont devenir plus lents, car le batch ne va pouvoir traiter que 2 pages en simultané. Je pense que c'est une bonne nouvelle car cela diminue la pression mise par les exports sur notre base de prod.

Détail important : nous avons actuellement 2 containers de `jobs` sur notre instance `production-rdv-solidarites`, et 1 seul container pour les autres instances. Cela signifie que sur `production-rdv-solidarites`, chacun des 2 container applique le comportement décrit ci-dessus. Pour rappel, GoodJob met un lock qui garantie qu'un job ne peut pas être dépilé par plusieurs workers en même temps.

Et enfin dernier sujet : je conserve l'usage d'une priorité de `20` pour les retries, sachant que les jobs restent dans leur queue. Cela permet de conserver les règles de priorité des queues ci-dessus, tout en s'assurant que les retries passent en dernier de leur queue. :shrug: 

Bien sûr, ces réglages sont faits au doigt mouillé tant qu'on a pas plus de stats sur les perfs de nos workers, mais la mise en place de cette stratégie me semble être rentable, car on suit les recommandations générales et la config reste assez simple donc compréhensible.

J'attends vos retours sur ces choix, je pense qu'il y a beaucoup à discuter, si on a le temps en l'envie ! :wink: 

[^1]: https://github.com/bensheldon/good_job?tab=readme-ov-file#doing-your-best-job-with-goodjob