### PR TITLE
Ne pas remonter les timeouts Outlook dans Sentry

### DIFF
--- a/app/jobs/outlook/sync_event_job.rb
+++ b/app/jobs/outlook/sync_event_job.rb
@@ -37,7 +37,7 @@ module Outlook
 
     def capture_sentry_warning_for_retry?(exception)
       # Ces erreurs se produisent parfois à la première exécution, puis le job passe au retry.
-      if exception.class.in?([Outlook::ApiClient::RefreshTokenError, Outlook::ApiClient::RateLimitingError])
+      if exception.class.in?([Outlook::ApiClient::RefreshTokenError, Outlook::ApiClient::RateLimitingError, Typhoeus::Errors::TimeoutError])
         executions > 3
       else
         super


### PR DESCRIPTION
Issue Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/162801

Nous avions déjà une logique pour les erreurs métier Outlook non fatales, on peut se comporter pareil pour `Typhoeus::Errors::TimeoutError`.

L'erreur ne remonte qu'à partir de la 4ème exécution.