### PR TITLE
Cacher la recherche d'agents et de motifs quand elle n'est pas nécessaire

### DIFF
--- a/app/controllers/admin/motifs_controller.rb
+++ b/app/controllers/admin/motifs_controller.rb
@@ -9,6 +9,7 @@ class Admin::MotifsController < AgentAuthController
 
     unfiltered_motifs = policy_scope(current_organisation.motifs, policy_scope_class: Agent::MotifPolicy::Scope)
     @filtered_motifs = filtered(unfiltered_motifs, params)
+    @need_search = enough_motifs_to_need_search?(unfiltered_motifs)
 
     @motifs_page = @filtered_motifs
       .active(@current_tab == :active)
@@ -151,4 +152,8 @@ class Admin::MotifsController < AgentAuthController
     @agent_can_create_motif ||= Agent::MotifPolicy.new(current_agent, Motif.new(organisation: current_organisation)).create?
   end
   helper_method :agent_can_create_motif?
+
+  def enough_motifs_to_need_search?(motif_scope)
+    motif_scope.limit(10).count == 10
+  end
 end

--- a/app/helpers/agents_helper.rb
+++ b/app/helpers/agents_helper.rb
@@ -5,6 +5,10 @@ module AgentsHelper
     current_organisation.rdvs.limit(5).count < 5
   end
 
+  def needs_agent_search?
+    current_organisation.agents.active.limit(10).count == 10
+  end
+
   def meet_the_team_url
     "https://cal.com/team/rdv-service-public/temps-d-echanges"
   end

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -132,8 +132,4 @@ module MotifsHelper
   def instruction_for_rdv_to_html(motif)
     auto_link(simple_format(motif.instruction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
   end
-
-  def needs_motif_search?
-    current_organisation.motifs.limit(10).count == 10
-  end
 end

--- a/app/helpers/motifs_helper.rb
+++ b/app/helpers/motifs_helper.rb
@@ -132,4 +132,8 @@ module MotifsHelper
   def instruction_for_rdv_to_html(motif)
     auto_link(simple_format(motif.instruction_for_rdv, {}, wrapper_tag: "span"), html: { target: "_blank" })
   end
+
+  def needs_motif_search?
+    current_organisation.motifs.limit(10).count == 10
+  end
 end

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -9,11 +9,12 @@
 
 = simple_form_for "", url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   .container-fluid.bg-white.rounded
-    .m-3.d-flex.justify-content-end
-      - search = params[:term].blank? && "d-none"
-      div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
-      = f.input :term, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
-      = f.button :submit, t("helpers.search")
+    - if needs_agent_search?
+      .m-3.d-flex.justify-content-end
+        - search = params[:term].blank? && "d-none"
+        div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
+        = f.input :term, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false
+        = f.button :submit, t("helpers.search")
     table.table
       thead
         tr

--- a/app/views/admin/agents/index.html.slim
+++ b/app/views/admin/agents/index.html.slim
@@ -10,7 +10,7 @@
 = simple_form_for "", url: admin_organisation_agents_path(current_organisation), html: { method: :get, class: "form-inline" }, wrapper: :inline_form do |f|
   .container-fluid.bg-white.rounded
     - if needs_agent_search?
-      .m-3.d-flex.justify-content-end
+      .fr-my-2w.d-flex.justify-content-end
         - search = params[:term].blank? && "d-none"
         div= link_to t("helpers.reset"), admin_organisation_agents_path(current_organisation), class: "btn btn-link #{search}"
         = f.input :term, placeholder: "Prénom, Nom, Email", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:term] }, required: false

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -15,6 +15,7 @@
 
     - need_search = needs_motif_search?
     - if need_search
+      / Le margin-bottom négatif compense la hauteur des onglets
       .fr-mt-2w.d-flex.justify-content-end[style="margin-bottom: -32px"]
         - if [params[:search], params[:online_filter], params[:service_filter], params[:location_type_filter]].compact_blank.any?
           div = link_to "Réinitialiser", admin_organisation_motifs_path(current_organisation, current_tab: @current_tab), class: "btn btn-link"

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -13,7 +13,8 @@
 
   .container-fluid.card
 
-    - if needs_motif_search?
+    - need_search = needs_motif_search?
+    - if need_search
       .fr-mt-2w.d-flex.justify-content-end[style="margin-bottom: -32px"]
         - if [params[:search], params[:online_filter], params[:service_filter], params[:location_type_filter]].compact_blank.any?
           div = link_to "Réinitialiser", admin_organisation_motifs_path(current_organisation, current_tab: @current_tab), class: "btn btn-link"
@@ -48,23 +49,26 @@
           th
             div
               = Motif.human_attribute_name("bookable_by")
-            div
-              - options = options_for_select(["En ligne", "Hors ligne"], params[:online_filter])
-              = select_tag("online_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
+            - if need_search
+              div
+                - options = options_for_select(["En ligne", "Hors ligne"], params[:online_filter])
+                = select_tag("online_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           - if display_sectorisation_level?
             th= Motif.human_attribute_name("sectorisation_level")
           th
             div
               = Motif.human_attribute_name("service")
-            div
-              - options = options_from_collection_for_select(current_territory.services, :id, :short_name, params[:service_filter])
-              = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
+            - if need_search
+              div
+                - options = options_from_collection_for_select(current_territory.services, :id, :short_name, params[:service_filter])
+                = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           th
             div
               = Motif.human_attribute_name("location_type")
-            div
-              - options = options_for_select(Motif.location_types.map{|l| [Motif.human_attribute_value(:location_type, l[0]), l[1]] }, params[:location_type_filter])
-              = select_tag("location_type_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
+              - if need_search
+                div
+                  - options = options_for_select(Motif.location_types.map{|l| [Motif.human_attribute_value(:location_type, l[0]), l[1]] }, params[:location_type_filter])
+                  = select_tag("location_type_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           th= Motif.human_attribute_name(:default_duration)
           th
       tbody

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -13,13 +13,14 @@
 
   .container-fluid.card
 
-    .m-3.d-flex.justify-content-end
-      - if [params[:search], params[:online_filter], params[:service_filter], params[:location_type_filter]].compact_blank.any?
-        div = link_to "Réinitialiser", admin_organisation_motifs_path(current_organisation, current_tab: @current_tab), class: "btn btn-link"
-      = f.input :search, placeholder: "ex. Être appelé par la MDS", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
-      = f.button :submit, "Rechercher"
+    - if needs_motif_search?
+      .fr-mt-2w.d-flex.justify-content-end[style="margin-bottom: -32px"]
+        - if [params[:search], params[:online_filter], params[:service_filter], params[:location_type_filter]].compact_blank.any?
+          div = link_to "Réinitialiser", admin_organisation_motifs_path(current_organisation, current_tab: @current_tab), class: "btn btn-link"
+        = f.input :search, placeholder: "ex. Être appelé par la MDS", label: false, input_html: { autocomplete: "off", class: "search-form-control", value: params[:search] }, required: false
+        = f.button :submit, "Rechercher"
 
-    ul.nav.nav-tabs
+    ul.nav.nav-tabs.fr-mt-2w
       - [[:active, "Actifs", @filtered_motifs.active.count], [:archived, "Archivés", @filtered_motifs.archived.count]].each do |value, label, count|
         li.nav-item
           ruby:

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -13,8 +13,7 @@
 
   .container-fluid.card
 
-    - need_search = needs_motif_search?
-    - if need_search
+    - if @need_search
       / Le margin-bottom négatif compense la hauteur des onglets
       .fr-mt-2w.d-flex.justify-content-end[style="margin-bottom: -32px"]
         - if [params[:search], params[:online_filter], params[:service_filter], params[:location_type_filter]].compact_blank.any?
@@ -50,7 +49,7 @@
           th
             div
               = Motif.human_attribute_name("bookable_by")
-            - if need_search
+            - if @need_search
               div
                 - options = options_for_select(["En ligne", "Hors ligne"], params[:online_filter])
                 = select_tag("online_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
@@ -59,14 +58,14 @@
           th
             div
               = Motif.human_attribute_name("service")
-            - if need_search
+            - if @need_search
               div
                 - options = options_from_collection_for_select(current_territory.services, :id, :short_name, params[:service_filter])
                 = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           th
             div
               = Motif.human_attribute_name("location_type")
-              - if need_search
+              - if @need_search
                 div
                   - options = options_for_select(Motif.location_types.map{|l| [Motif.human_attribute_value(:location_type, l[0]), l[1]] }, params[:location_type_filter])
                   = select_tag("location_type_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1426" alt="Screenshot 2025-03-25 at 17 50 57" src="https://github.com/user-attachments/assets/3f7525dd-5e35-4f34-993a-f476ddd4c35d" />|<img width="1420" alt="Screenshot 2025-03-25 at 17 51 21" src="https://github.com/user-attachments/assets/80bb34c2-e7ab-42be-bc62-2b3d4c47c113" />
<img width="1422" alt="Screenshot 2025-03-25 at 17 51 42" src="https://github.com/user-attachments/assets/dedda233-7d79-4d21-b12f-52a496cb1cd9" />|<img width="1425" alt="Screenshot 2025-03-25 at 17 51 55" src="https://github.com/user-attachments/assets/2cfe558d-ad81-4a93-9f64-846c5421e212" />

# Contexte

Dans le cadre de l'amélioration de l'embarquement maintenant qu'il est en faisable en autonomie par des agents sans intervention de notre équipe déploiement, cette PR enlève la recherche d'agents et de motif des pages de configuration lorsqu'elle n'est pas nécessaire.

On fait déjà la même chose pour la pagination : on ne l'affiche que s'il y a plusieurs pages

# Solution

"Pas nécessaire" est un peu arbitraire, mais pour cette première version, je suis parti sur cacher la recherche quand il y a moins de 10 éléments.
Dans le cas des motifs, on cache aussi les selects qui permettent de trier par type de réservation, de service ou de location type.

Au passage j'ai aussi ajusté les marges pour que ça soit aligné un peu plus joliment quand on affiche la barre de recherche

Avant | Après
:- | -:
<img width="1421" alt="Screenshot 2025-03-25 at 18 00 05" src="https://github.com/user-attachments/assets/2201dbae-0873-49c4-abc9-ca1dc8509b2e" />|<img width="1424" alt="Screenshot 2025-03-25 at 17 59 37" src="https://github.com/user-attachments/assets/cfa7b068-8921-44ba-913a-6b7b74335acf" />
<img width="1427" alt="Screenshot 2025-03-25 at 17 56 59" src="https://github.com/user-attachments/assets/504c750a-4764-4857-b790-689223e116c8" />|<img width="1425" alt="Screenshot 2025-03-25 at 17 56 43" src="https://github.com/user-attachments/assets/0ef340b3-5d7d-4f14-a7e1-0cd3d48f148a" />
