### PR TITLE
Stocker les jobs réussis pendant moins longtemps

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
   config.active_job.default_priority = 0
 
   config.good_job.preserve_job_records = true
-  config.cleanup_preserved_jobs_before_seconds_ago = 604_800 # 1 semaine
+  config.cleanup_preserved_jobs_before_seconds_ago = ENV.fetch("GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO", 1.week.in_seconds)
   config.good_job.on_thread_error = ->(exception) { Sentry.capture_exception(exception) } # this is never called !
   config.good_job.execution_mode = :external
   config.good_job.queues = "latency_30s:1; latency_5m,latency_30s:2; *:2"


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5202.osc-secnum-fr1.scalingo.io/) 

# Contexte

Actuellement, nous conservons les jobs réussis pendant 1 semaine sur toutes les instances.

Or, sur l'instance `production-rdv-solidarites`, nous avons environ 700 000 jobs par semaine, et donc l'affichage du dashboard GoodJob est très lent, au minimum 15-20 secondes et parfois jusqu'à 30-60 secondes donc en timeout.

# Solution

Je propose d'utiliser une variable d'ENV pour définir le temps de conservation des jobs réussis. Nous pouvons utiliser le nom officiel `GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO` ([voir README](https://github.com/bensheldon/good_job?tab=readme-ov-file#good_job-cleanup_preserved_jobs)).

Je propose de ne pas définir de variable d'ENV en démo ni sur l'instance `production-rdv-mairie`, mais de passer à 3 jours sur `production-rdv-solidarites`. Je me dis que dans le pire des cas, si on a vraiment besoin d'investiguer, on a les backups : en théorie on pourrait donc passer à 1 jour, mais c'est peut-être pas pratique. Peut-être 2 jours ?