### PR TITLE
Liste des RDV - Indiquer "RDV par téléphone" en mode impression

### DIFF
--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -23,8 +23,7 @@
         .pl-3.pt-2
           .fa.fa-phone>
           |> RDV par téléphone
-          - participants_phones = rdv.participations.map(&:user).filter_map(&:phone_number_formatted)
-          - participants_phones.each do |phone_number|
+          - rdv.participations.map(&:user).map(&:user_to_notify).compact.filter_map(&:phone_number_formatted).each do |phone_number|
             |> -
             = phone_to(phone_number)
 

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -23,7 +23,7 @@
         .pl-3.pt-2
           .fa.fa-phone>
           |> RDV par téléphone
-          - rdv.participations.map(&:user).map(&:user_to_notify).compact.filter_map(&:phone_number_formatted).each do |phone_number|
+          - rdv.participations.filter_map { |p| p.user.user_to_notify&.phone_number_formatted }.each do |phone_number|
             |> -
             = phone_to(phone_number)
 

--- a/app/views/admin/rdvs/print/_rdv.html.slim
+++ b/app/views/admin/rdvs/print/_rdv.html.slim
@@ -13,11 +13,20 @@
           = rdv.motif_name
         .rdv-status.px-2.py-2 class="rdv-status-#{rdv.status}" id="rdv-#{rdv.id}-status"
           = rdv.human_attribute_value(:status).upcase
-      - if rdv.motif.visio?
+      - case rdv.motif.location_type.to_sym
+      - when :visio
         .pl-3.pt-2
           .fa.fa-video-camera>
           |> RDV par visioconférence
           = link_to("rejoindre la visioconférence", rdv.visio_url, target: :_blank)
+      - when :phone
+        .pl-3.pt-2
+          .fa.fa-phone>
+          |> RDV par téléphone
+          - participants_phones = rdv.participations.map(&:user).filter_map(&:phone_number_formatted)
+          - participants_phones.each do |phone_number|
+            |> -
+            = phone_to(phone_number)
 
       .card-body
         - rdv.participations.each do |participation|


### PR DESCRIPTION
# Contexte

Le support nous remonte un besoin de distinguer les RDVs par téléphone, car ce sont des cas où les agents ont besoin de faire la démarche d'appeler les usagers. C'est similaire aux RDVs par visio, où l'agent a besoin du lien. À l'inverse, pour un RDV sur place, on a moins besoin de mettre la modalité (aka. "location type") en avant, car l'usager va venir de lui-même.

On pourrait argumenter qu'il serait bon d'afficher la modalité quelle qu'elle soit, pour avoir un layout cohérent pour chaque RDV. Qu'en dîtes-vous ?

Je laisse @NesserineZarouri compléter le contexte si nécessaire. 

# Solution

J'ai essayé d'utiliser des icônes DSFR mais elles ne s'affichent pas du tout quand on demande une impression de la page. Je suis donc resté sur FontAwesome.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/705bdfe0-3cb9-4762-b69e-38bf514666c6) | ![image](https://github.com/user-attachments/assets/bc7cba31-6898-4188-abc0-aabec351e25b)