### PR TITLE
Afficher la liste des orgas sur la page d'un territoire sur super-admin

### DIFF
--- a/app/controllers/super_admins/application_controller.rb
+++ b/app/controllers/super_admins/application_controller.rb
@@ -34,6 +34,19 @@ module SuperAdmins
     end
     # End Pundit configuration for Administrate
 
+    # Copié et adapté depuis Administrate::ApplicationController#destroy
+    # Le code d'Administrate est buggé et ne trouve pas les raisons de
+    # l'échec d'une suppression. Cette version basée sur
+    # ActiveRecord::RecordNotDestroyed corrige ce bug.
+    def destroy
+      requested_resource.destroy!
+      flash[:notice] = translate_with_resource("destroy.success")
+    rescue ActiveRecord::RecordNotDestroyed => e
+      flash[:error] = e.record.errors.full_messages.join("<br/>")
+    ensure
+      redirect_to after_resource_destroyed_path(requested_resource)
+    end
+
     private
 
     def super_admin_not_authorized(exception)

--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -34,9 +34,9 @@ class TerritoryDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     name
-    organisations
-    roles
     departement_number
+    roles
+    organisations
     created_at
     updated_at
   ].freeze

--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -11,6 +11,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     id: Field::Number,
     departement_number: Field::String,
     name: Field::String,
+    organisations: Field::HasMany.with_options(sort_by: :name, direction: :asc),
     admin_agents: Field::HasMany,
     roles: Field::HasMany,
     created_at: Field::DateTime,
@@ -33,6 +34,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     name
+    organisations
     roles
     departement_number
     created_at


### PR DESCRIPTION
La liste des orgas d'un territoire est une information essentielle, donc on l'affiche.

# Avant

![image](https://github.com/user-attachments/assets/1156e2cb-ded5-4414-a6cf-03db952cdb98)



# Après

![image](https://github.com/user-attachments/assets/343e86ff-5b47-478e-bcde-7de0f0f9218c)


# Question pénible

Faut-il permettre de supprimer une organisation depuis le super-admin ? Actuellement c'est proposé (on affiche les boutons "Supprimer"), même si en général la suppression est impossible car on a des éléments associés : 

![image](https://github.com/user-attachments/assets/9b85277c-a66d-48c5-a8fe-42d60e88e8e1)

Je pense qu'on peut laisser la suppression pour le moment.
