### PR TITLE
Ouverture de compte en autonomie pour les agents qui utilisent des applications OAuth autorisées

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -296,3 +296,7 @@ RSpec/NoExpectationExample:
 Rails/RedundantActiveRecordAllMethod:
   Exclude:
     - "db/migrate/**"
+
+RSpec/PredicateMatcher:
+  Exclude:
+    - "spec/policies/**/*"

--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -22,7 +22,7 @@ class Agents::TerritoriesController < AgentAuthController
   def compte_params
     params[:compte][:agent] = {
       id: current_agent.id,
-      service_ids: [Agent::TerritoryPolicy.default_service(current_agent).id],
+      service_ids: OauthApplication.default_service_ids_for(agent),
     }
 
     params.require(:compte).permit(

--- a/app/controllers/agents/territories_controller.rb
+++ b/app/controllers/agents/territories_controller.rb
@@ -22,7 +22,7 @@ class Agents::TerritoriesController < AgentAuthController
   def compte_params
     params[:compte][:agent] = {
       id: current_agent.id,
-      service_ids: OauthApplication.default_service_ids_for(agent),
+      service_ids: OauthApplication.default_service_ids_for(current_agent),
     }
 
     params.require(:compte).permit(

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -1,0 +1,12 @@
+class OauthApplication < Doorkeeper::Application
+  belongs_to :default_service, class_name: "Service", optional: true
+
+  def self.agent_is_verified_by_an_application?(agent)
+    # Les applications qui ont un default_service_id permettent la création de territoire
+    default_service_ids_for(agent).present?
+  end
+
+  def self.default_service_ids_for(agent)
+    OauthApplication.joins(:access_tokens).where(oauth_access_tokens: { resource_owner_id: agent.id }).pluck(:default_service_id).compact
+  end
+end

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -7,6 +7,6 @@ class OauthApplication < Doorkeeper::Application
   end
 
   def self.default_service_ids_for(agent)
-    OauthApplication.joins(:access_tokens).where(oauth_access_tokens: { resource_owner_id: agent.id }).pluck(:default_service_id).compact
+    OauthApplication.joins(:access_tokens).where(oauth_access_tokens: { resource_owner_id: agent.id }).pluck(:default_service_id).uniq.compact
   end
 end

--- a/app/policies/agent/territory_policy.rb
+++ b/app/policies/agent/territory_policy.rb
@@ -15,27 +15,9 @@ class Agent::TerritoryPolicy
   def new?
     return false if @current_agent.agent_territorial_access_rights.any?
 
-    self.class.verified_by_mss?(@current_agent)
+    OauthApplication.agent_is_verified_by_an_application?(@current_agent)
   end
   alias create? new?
-
-  # On espère que cette méthode est temporaire, et qu'on pourra ouvrir ça aux autres applications oauth
-  def self.verified_by_mss?(agent)
-    mss_oauth_application = Doorkeeper::Application.find_by(name: "Mon Suivi Social")
-    agent.access_tokens.find_by(application_id: mss_oauth_application&.id)
-  end
-
-  def self.default_service(agent)
-    # Pour le moment on propose cette fonctionnalité uniquement pour MSS, donc on met uniquement le service social
-    if verified_by_mss?(agent)
-      Service.find_by!(name: "Action Sociale")
-    else
-      raise NotImplementedError, <<~MSG
-        Il faut définir les services par défaut pour les applications autre que mss, ou permettre le fonctionnement sans service (ni pour les agents ni pour les motifs)
-        (voir https://github.com/betagouv/rdv-service-public/pull/5182)"
-      MSG
-    end
-  end
 
   def show?
     territorial_admin? ||

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -18,7 +18,7 @@ Doorkeeper.configure do
   #
   # access_token_class "Dookeeper::AccessToken"
   # access_grant_class "Doorkeeper::AccessGrant"
-  # application_class "Doorkeeper::Application"
+  application_class "OauthApplication"
   #
   # Don't forget to include Doorkeeper ORM mixins into your custom models:
   #

--- a/db/migrate/20250326131017_add_oauth_applications_default_service_id.rb
+++ b/db/migrate/20250326131017_add_oauth_applications_default_service_id.rb
@@ -1,0 +1,22 @@
+class AddOauthApplicationsDefaultServiceId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :oauth_applications, :default_service_id, :bigint
+    add_index :oauth_applications, :default_service_id, algorithm: :concurrently
+    add_foreign_key :oauth_applications, :services, validate: false, column: :default_service_id
+
+    change_column_comment :oauth_applications, :default_service_id, from: nil, to: <<~COMMENT
+      Indique le service qui sera ajouté au territoire par défaut si un agent qui utilise cette application ouvre un nouvel espace.
+      Cette colonne indique aussi que les agents qui utilisent cette application sont autorisés à ouvrir un nouvel espace.
+    COMMENT
+
+    up_only do
+      app = OauthApplication.find_by(name: "Mon Suivi Social")
+      service = Service.find_by(name: "Action Sociale")
+      if app && service
+        app.update(default_service_id: service.id)
+      end
+    end
+  end
+end

--- a/db/migrate/20250327092827_validate_oauth_application_default_service.rb
+++ b/db/migrate/20250327092827_validate_oauth_application_default_service.rb
@@ -1,0 +1,5 @@
+class ValidateOauthApplicationDefaultService < ActiveRecord::Migration[7.1]
+  def change
+    validate_foreign_key :oauth_applications, :services
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_25_140105) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_27_092827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -499,6 +499,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_25_140105) do
     t.datetime "updated_at", null: false
     t.text "logo_base64"
     t.text "post_logout_redirect_uri"
+    t.bigint "default_service_id", comment: "Indique le service qui sera ajouté au territoire par défaut si un agent qui utilise cette application ouvre un nouvel espace.\nCette colonne indique aussi que les agents qui utilisent cette application sont autorisés à ouvrir un nouvel espace.\n"
+    t.index ["default_service_id"], name: "index_oauth_applications_on_default_service_id"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
@@ -887,6 +889,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_25_140105) do
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "agents", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_applications", "services", column: "default_service_id"
   add_foreign_key "organisations", "territories"
   add_foreign_key "participations", "rdvs"
   add_foreign_key "participations", "users"

--- a/spec/factories/oauth_application.rb
+++ b/spec/factories/oauth_application.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :oauth_application, class: Doorkeeper::Application do
+  factory :oauth_application, class: OauthApplication do
     name { "Démarches Simplifiées" }
     uid { "fake_app_id" }
     logo_base64 { "" }

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -1,10 +1,6 @@
 RSpec.describe "Un agent vérifié via une application externe peut créer un territoire" do
   let(:application) do
-    create(:oauth_application, name: "Mon Suivi Social")
-  end
-
-  before do
-    create(:service, name: "Action Sociale")
+    create(:oauth_application, name: "Mon Suivi Social", default_service: create(:service, name: "Action Sociale"))
   end
 
   context "quand l'agent a déjà été créé via une connexion ProConnect" do

--- a/spec/policies/agent/agent_territorial_access_right_policy_spec.rb
+++ b/spec/policies/agent/agent_territorial_access_right_policy_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/PredicateMatcher
 RSpec.describe Agent::AgentTerritorialAccessRightPolicy do
   let(:territory) { create(:territory) }
   let(:agent_territorial_access_right) { create(:agent_territorial_access_right, territory: territory) }
@@ -34,4 +33,3 @@ RSpec.describe Agent::AgentTerritorialAccessRightPolicy do
     end
   end
 end
-# rubocop:enable RSpec/PredicateMatcher

--- a/spec/policies/agent/motif_policy_spec.rb
+++ b/spec/policies/agent/motif_policy_spec.rb
@@ -1,4 +1,3 @@
-# rubocop:disable RSpec/PredicateMatcher
 RSpec.describe Agent::MotifPolicy do
   subject { described_class }
 
@@ -89,4 +88,3 @@ RSpec.describe Agent::MotifPolicy do
     end
   end
 end
-# rubocop:enable RSpec/PredicateMatcher

--- a/spec/policies/agent/territory_policy_spec.rb
+++ b/spec/policies/agent/territory_policy_spec.rb
@@ -77,14 +77,14 @@ RSpec.describe Agent::TerritoryPolicy, type: :policy do
       let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
 
       it "authorizes the creation" do
-        expect(subject.create?).to be_truthy # rubocop:disable RSpec/PredicateMatcher
+        expect(subject.create?).to be_truthy
       end
 
       context "when the agent already has a territory" do
         let(:agent) { create(:agent, :with_territory_access_rights, basic_role_in_organisations: [create(:organisation)]) }
 
         it "doesn't authorize the creation" do
-          expect(subject.create?).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+          expect(subject.create?).to be_falsey
         end
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe Agent::TerritoryPolicy, type: :policy do
       let(:agent) { create(:agent) }
 
       it "doesn't authorize the creation" do
-        expect(subject.create?).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+        expect(subject.create?).to be_falsey
       end
     end
   end

--- a/spec/policies/agent/territory_policy_spec.rb
+++ b/spec/policies/agent/territory_policy_spec.rb
@@ -63,6 +63,40 @@ RSpec.describe Agent::TerritoryPolicy, type: :policy do
       it_behaves_like "not permit actions", :territory, :update?, :edit?, :allow_to_manage_teams?, :allow_to_manage_access_rights?
     end
   end
+
+  describe "#create?" do
+    subject { described_class.new(agent, territory) }
+
+    let(:territory) { Territory.new }
+    let(:agent) { create(:agent) }
+
+    context "when the agent was connected from an authorized OAuth application" do
+      let(:application) { create(:oauth_application, default_service: service) }
+      let(:service) { create(:service) }
+
+      let!(:oauth_token) { create(:access_token, resource_owner_id: agent.id, application:) }
+
+      it "authorizes the creation" do
+        expect(subject.create?).to be_truthy # rubocop:disable RSpec/PredicateMatcher
+      end
+
+      context "when the agent already has a territory" do
+        let(:agent) { create(:agent, :with_territory_access_rights, basic_role_in_organisations: [create(:organisation)]) }
+
+        it "doesn't authorize the creation" do
+          expect(subject.create?).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+        end
+      end
+    end
+
+    context "when the agent only logged in from the homepage with ProConnect" do
+      let(:agent) { create(:agent) }
+
+      it "doesn't authorize the creation" do
+        expect(subject.create?).to be_falsey # rubocop:disable RSpec/PredicateMatcher
+      end
+    end
+  end
 end
 
 RSpec.describe Agent::TerritoryPolicy::Scope, type: :policy do


### PR DESCRIPTION

# Contexte

Cette PR est la suite directe de https://github.com/betagouv/rdv-service-public/pull/5188. Elle permet d'activer la création de compte en autonomie pour n'importe quelle application OAuth en précisant quel est le service par défaut qui sera créé pour cette application.

Autrement dit, pour autoriser la création de compte en autonomie pour les Conums qui utilisent l'espace coop, on va faire la commande suivante dans la console rails : 
```
OauthApplication.find_by(name: "La Coop de la médiation numérique").update(default_service: Service.find_by(name: "Conseiller Numérique")
```

On ne veut pas tout de suite ouvrir la création de compte pour toutes les applications oauth (par exemple pour RDV Insertion, vu qu'un agent qui utilise RDVI n'est pas forcément légitime pour ouvrir un nouveau territoire)

# Solution

On stocke le service par défaut sur la table des oauth applications (en attendant de ne pas avoir besoin des services).
Au passage, on en fait un vrai modèle qui hérite du modèle Doorkeeper par défaut.
La responsabilité de savoir si l'agent est vérifié et son service par défaut sont donc délégués à cette nouvelle classe.

