### PR TITLE
Correction des doublons de motif dans la prise de RDV

### DIFF
--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -11,7 +11,7 @@
         h2.fr-accordion__title
           button.fr-accordion__btn.fr-text--lead type="button" aria-expanded="false" aria-controls="fr-accordion-#{service.id}" = service.name
         .fr-collapse id="fr-accordion-#{service.id}"
-          - context.motifs_grouped_by_service_id[service.id].sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
+          - context.motifs_grouped_by_service_id[service.id].uniq(&:name_with_location_type).sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
             = render "search/motif_card", context: context, motif: motif
 
 = render "search/referent_booking_card", context: context


### PR DESCRIPTION
# Contexte

Dans #5185 nous avons créé une petite régression. Nous n’avons pas concervé le `uniq` ce qui génère beaucoup de doublons dans l’affichage des cartes.

# Solution

On remet le uniq

