### PR TITLE
Correction : ajout du service id dans la recherche

### DIFF
--- a/app/views/search/_motif_card.html.slim
+++ b/app/views/search/_motif_card.html.slim
@@ -1,10 +1,10 @@
-/ locals(context: ,#motif:)
+/ locals(context:, motif:, service_id:)
 
 li.fr-card.fr-enlarge-link.fr-card--horizontal.fr-mb-2w
   .fr-card__body
     .fr-card__content
       .fr-card__title
-        = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type))
+        = link_to motif.name, prendre_rdv_path(context.query_params.merge(motif_name_with_location_type: motif.name_with_location_type, service_id: service_id))
       .fr-card__start
         ul.fr-badges-group
           - case motif.location_type

--- a/app/views/search/_motif_selection.html.slim
+++ b/app/views/search/_motif_selection.html.slim
@@ -6,6 +6,6 @@
   p.fr-text--lg Sélectionnez le motif de votre RDV&nbsp;:
   ul.fr-raw-list
     - context.unique_motifs_by_name_and_location_type.each do |motif|
-      = render "search/motif_card", context: context, motif: motif
+      = render "search/motif_card", context: context, motif: motif, service_id: context.service.id
 
 = render "search/referent_booking_card", context: context

--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -12,6 +12,6 @@
           button.fr-accordion__btn.fr-text--lead type="button" aria-expanded="false" aria-controls="fr-accordion-#{service.id}" = service.name
         .fr-collapse id="fr-accordion-#{service.id}"
           - context.motifs_grouped_by_service_id[service.id].uniq(&:name_with_location_type).sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
-            = render "search/motif_card", context: context, motif: motif
+            = render "search/motif_card", context: context, motif: motif, service_id: service.id
 
 = render "search/referent_booking_card", context: context

--- a/spec/features/users/online_booking/default_spec.rb
+++ b/spec/features/users/online_booking/default_spec.rb
@@ -545,7 +545,8 @@ RSpec.describe "User can search for rdvs" do
       lieu_id: lieu&.id,
       longitude: "",
       motif_name_with_location_type: "vaccination-public_office",
-      street_ban_id: ""
+      street_ban_id: "",
+      service_id: service&.id
     )
   end
 end


### PR DESCRIPTION
# Contexte

Dans le cadre de #5185 nous avons introduit un bug. Si deux services ont un motif de RDV avec le même nom, lorsqu’on clique sur le motif, on revient sur la page service/motif sélection, mais avec affiché uniquement le motif en question et les différents services qui ont ce motif. En re-cliquant sur le motif, on est dans une boucle infinie.

https://github.com/user-attachments/assets/3da1e9eb-19f2-41e7-a9f1-84170bf8f3d1

# Solution

On ajoute donc l’ID du service pour pouvoir passer à l’étape suivante.

Dans une prochaine PR je vais ajouter des tests pour couvrir ce cas ainsi que celui-ci : #5207 