### PR TITLE
Sauvegarder le whodunnit PaperTrail pour les appels API

### DIFF
--- a/app/controllers/api/v1/agent_auth_base_controller.rb
+++ b/app/controllers/api/v1/agent_auth_base_controller.rb
@@ -3,7 +3,9 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
   include DeviseTokenAuth::Concerns::SetUserByToken
 
   skip_before_action :verify_authenticity_token
-  before_action :authenticate_agent, :log_api_call_in_database
+  before_action :authenticate_agent
+  before_action :log_api_call_in_database
+  before_action :set_paper_trail_whodunnit
 
   def pundit_user
     AgentOrganisationContext.new(current_agent, current_organisation)
@@ -110,6 +112,10 @@ class Api::V1::AgentAuthBaseController < Api::V1::BaseController
       OpenSSL::HMAC.hexdigest("SHA256", ENV.fetch("SHARED_SECRET_FOR_AGENTS_AUTH"), payload.to_json),
       request.headers["X-Agent-Auth-Signature"]
     )
+  end
+
+  def user_for_paper_trail
+    "#{current_agent.name_for_paper_trail} (via API)"
   end
 
   def log_api_call_in_database

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe "/api/v1/users" do
           organisations: [my_organisation]
         )
       end
+
+      it "saves whodunnit" do
+        post "/api/v1/users", headers:, params:, as: :json
+        expect(User.last.versions.last.whodunnit).to eq("[Agent] #{myself.full_name} (via API)")
+      end
     end
 
     context "when passing arbitrary referent_agent_ids" do


### PR DESCRIPTION
Le support de RDV Insertion m'a demandé qui avait créé un usager, mais l'usager a été créé par API, et j'ai constaté que nous ne définissons pas le whodunnit dans nos controller d'API ! :fearful: 

Je trouve ça étonnant qu'on n'ai pas déjà réglé ce problème ; est-ce qu'il y a une raison de ne pas le faire ?

# Côté technique

Pour les tests, j'ai essayé d'ajouter un test plus "généraliste" à base de controller anonyme, mais je ne suis pas parvenu à mes fins même avec [la belle doc RSpec](https://rspec.info/features/7-0/rspec-rails/controller-specs/anonymous-controller/). Si jamais vous voulez essayer, j'avais ça :

```ruby
RSpec.describe Api::V1::AgentAuthBaseController, type: :controller do
  controller(described_class) do
    def create_service
      Service.create!(name: "RSA", short_name: "RSA")
    end
  end

  let!(:current_agent) { create(:agent, first_name: "Alain", last_name: "Sertion") }

  before do
    routes.draw do
      # post "create_service" => "anonymous#create_service"
      post "create_service" => "api/v1/agent_auth_base#create_service"
    end

    sign_in current_agent
  end

  it "uses the current agent" do
    expect { post :create_service }.to change(Service, :count).by(1)
    expect(Service.last.versions.first.whodunnit).to eq("[Agent] Alain Sertion")
  end
end
```