### PR TITLE
Corrige une flaky spec lié aux dates (plages sur agenda)

### DIFF
--- a/spec/features/agents/agent_has_a_calendar_spec.rb
+++ b/spec/features/agents/agent_has_a_calendar_spec.rb
@@ -45,11 +45,14 @@ RSpec.describe "Agent calendar displays rdvs and plages", js: true do
     click_button "Mois"
     expect(page).to have_content("Ceci est le libellé de la plage")
 
-    # On vérifie que la plage n'est pas affichée sur le mois suivant :
+    # On vérifie que la plage n'est pas affichée deux mois plus tard :
     # cela permet de s'assurer que la spec n'est pas en faux-positif
     # à cause de race conditions liées aux appels Ajax.
     find(".fc-next-button").click
+    find(".fc-next-button").click
     expect(page).not_to have_content("Ceci est le libellé de la plage")
+    # On revient au mois courant pour re-vérifier
+    find(".fc-prev-button").click
     find(".fc-prev-button").click
     expect(page).to have_content("Ceci est le libellé de la plage")
   end


### PR DESCRIPTION
La spec échouait car on est aujourd'hui le lundi 31 mars, et que la spec crée une plage le lendemain, donc mardi 1er avril (la bonne blague :clown_face: ). La spec vérifie ensuite qu'on n'affiche pas la plage le mois prochain (avril), car lors de l'implémentation je n'ai pas pensé au cas présent :

![image](https://github.com/user-attachments/assets/9d73e719-40f9-4521-9dea-1a5937fafe6f)

Je vois deux solutions : 
1. ne pas faire ces vérifications de faux positifs
2. se déplacer **deux mois** plutôt qu'un pour éviter ce risque d'affichage d'un mois sur l'autre

J'ai choisi la 2 pour le moment, si ça nous embête encore on pourra choisir la 1.