### PR TITLE
Nettoyage de la logique de collecte du siret

### DIFF
--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -14,7 +14,7 @@ class AgentConnectController < ApplicationController
     redirect_to auth_client.redirect_url(agent_connect_callback_url), allow_other_host: true
   end
 
-  def callback # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+  def callback # rubocop:disable Metrics/PerceivedComplexity
     callback_client = AgentConnectOpenIdClient::Callback.new(
       session_state: session.delete(:agent_connect_state),
       params_state: params[:state],
@@ -42,14 +42,12 @@ class AgentConnectController < ApplicationController
         connected_with_agent_connect: true,
         first_name: callback_client.user_first_name,
         last_name: callback_client.user_last_name,
+        proconnect_siret: callback_client.user_siret,
         invitation_token: nil, # Pour désactiver les anciens liens d'invitation
         invitation_accepted_at: agent.invitation_accepted_at || Time.zone.now,
         confirmed_at: agent.confirmed_at || Time.zone.now,
         last_sign_in_at: Time.zone.now
       )
-      if ENV["ENABLE_PROCONNECT_SIRET"] == "true" # Cette variable d'env sert à essayer la fonctionnalité en production, et pourra être supprimée s'il n'y a pas de problèmes
-        agent.update!(proconnect_siret: callback_client.user_siret)
-      end
 
       bypass_sign_in agent, scope: :agent
       session[:agent_connect_id_token] = callback_client.id_token_for_logout

--- a/app/services/agent_connect_open_id_client/auth.rb
+++ b/app/services/agent_connect_open_id_client/auth.rb
@@ -13,10 +13,7 @@ module AgentConnectOpenIdClient
     attr_reader :state, :nonce
 
     def redirect_url(callback_url)
-      scopes = "openid email given_name usual_name"
-      if ENV["ENABLE_PROCONNECT_SIRET"] == "true" # Cette variable d'env sert à essayer la fonctionnalité en production, et pourra être supprimée s'il n'y a pas de problèmes
-        scopes += " siret"
-      end
+      scopes = "openid email given_name usual_name siret"
 
       query_params = {
         response_type: "code",

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -2,8 +2,7 @@ RSpec.describe AgentConnectController do
   stub_env_with(
     AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
     AGENT_CONNECT_RDVS_CLIENT_SECRET: "un faux secret de test",
-    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa",
-    ENABLE_PROCONNECT_SIRET: "false"
+    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
   )
 
   describe "#auth" do
@@ -19,22 +18,10 @@ RSpec.describe AgentConnectController do
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",
         response_type: "code",
-        scope: "openid email given_name usual_name",
+        scope: "openid email given_name usual_name siret",
         state: be_a(String),
         nonce: be_a(String)
       )
-    end
-
-    context "when getting the siret as well" do
-      stub_env_with(ENABLE_PROCONNECT_SIRET: "true")
-
-      it "adds it to the scopes" do
-        get :auth
-
-        redirect_url = response.headers["Location"]
-        redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
-        expect(redirect_url_query_params["scope"]).to eq("openid email given_name usual_name siret")
-      end
     end
   end
 
@@ -88,40 +75,21 @@ RSpec.describe AgentConnectController do
           "email" => "jean.michel.factice@exemple.gouv.fr",
           "given_name" => "Jean Michel Factice",
           "usual_name" => "Factice",
-          "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
-          "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
-        }
-      end
-
-      it "sets the proper first and last name for the agent" do
-        agent = create(:agent, email: "jean.michel.factice@exemple.gouv.fr")
-        get :callback, params: { state: state, code: code }
-
-        expect(agent.reload).to have_attributes(
-          first_name: "Jean Michel",
-          last_name: "Factice"
-        )
-      end
-    end
-
-    context "when asking for the siret" do
-      stub_env_with(ENABLE_PROCONNECT_SIRET: "true")
-      let(:user_info) do
-        {
-          "sub" => "ab70770d-1285-46e6-b4d0-3601b49698d4",
-          "email" => "francis.factice@exemple.gouv.fr",
-          "given_name" => "Francis Factice",
-          "usual_name" => "Factice",
           "siret" => "11006801200050",
           "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
           "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
         }
       end
 
-      it "saves it on the agent" do
-        agent = create(:agent, email: "francis.factice@exemple.gouv.fr")
+      it "sets the proper first and last name and siret for the agent" do
+        agent = create(:agent, email: "jean.michel.factice@exemple.gouv.fr")
         get :callback, params: { state: state, code: code }
-        expect(agent.reload.proconnect_siret).to eq "11006801200050"
+
+        expect(agent.reload).to have_attributes(
+          first_name: "Jean Michel",
+          last_name: "Factice",
+          proconnect_siret: "11006801200050"
+        )
       end
     end
   end


### PR DESCRIPTION
Dans le cadre de https://github.com/betagouv/rdv-service-public/pull/5181, on avait ajouté une varaible d'environnement pour pouvoir désactiver facilement la collecte du siret en production en cas de problème.

Depuis quelques semaines, ça tourne sans soucis, donc on peut enlever cette variable d'env.