### PR TITLE
Nettoyage des vérifications sur les invitations

### DIFF
--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -12,7 +12,7 @@ module TokenInvitable
   private
 
   def store_invitation_in_session_and_redirect
-    return true if params[:invitation_token].blank?
+    return if params[:invitation_token].blank?
 
     invitation = Invitation.new(current_url_params)
     return redirect_with_error(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?

--- a/app/controllers/concerns/token_invitable.rb
+++ b/app/controllers/concerns/token_invitable.rb
@@ -12,6 +12,8 @@ module TokenInvitable
   private
 
   def store_invitation_in_session_and_redirect
+    return true if params[:invitation_token].blank?
+
     invitation = Invitation.new(current_url_params)
     return redirect_with_error(t("devise.invitations.invitation_token_invalid")) unless invitation.token_valid?
     return redirect_with_error(t("devise.invitations.current_user_mismatch")) if current_user_mismatch?(invitation.user)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,7 +2,7 @@ class SearchController < ApplicationController
   layout "application_base"
 
   include TokenInvitable
-  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
+  prepend_before_action :store_invitation_in_session_and_redirect, only: %i[search_rdv]
 
   # utilisé par le Pas-de-Calais pour prendre rdv depuis leur site : https://www.pasdecalais.fr/Solidarite-Sante/Enfance-et-famille/La-Protection-Maternelle-et-Infantile/Prendre-rendez-vous-en-ligne-en-MDS-PMI-ou-service-social
   after_action :allow_iframe
@@ -96,15 +96,6 @@ class SearchController < ApplicationController
   end
 
   private
-
-  def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return true if params[:invitation_token].blank?
-
-    if params[:action] != "search_rdv"
-      Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
-    end
-    store_invitation_in_session_and_redirect
-  end
 
   def redirect_to_organisation_search(organisation)
     if organisation

--- a/app/controllers/users/participations_controller.rb
+++ b/app/controllers/users/participations_controller.rb
@@ -4,7 +4,6 @@ class Users::ParticipationsController < UserAuthController
   layout "application_narrow"
 
   include TokenInvitable
-  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
   def index
     @rdv = policy_scope(Rdv, policy_scope_class: User::RdvPolicy::Scope).find(params[:rdv_id])
@@ -20,13 +19,6 @@ class Users::ParticipationsController < UserAuthController
   end
 
   private
-
-  def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return true if params[:invitation_token].blank?
-
-    Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
-    store_invitation_in_session_and_redirect
-  end
 
   def set_rdv
     @rdv = Rdv.find(params[:rdv_id])

--- a/app/controllers/users/rdv_wizard_steps_controller.rb
+++ b/app/controllers/users/rdv_wizard_steps_controller.rb
@@ -11,7 +11,6 @@ class Users::RdvWizardStepsController < UserAuthController
   after_action :allow_iframe
 
   include TokenInvitable
-  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
 
   def new
     @rdv_wizard = rdv_wizard_for(current_user, query_params)
@@ -37,13 +36,6 @@ class Users::RdvWizardStepsController < UserAuthController
   end
 
   protected
-
-  def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return true if params[:invitation_token].blank?
-
-    Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
-    store_invitation_in_session_and_redirect
-  end
 
   def steps
     steps = {

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -10,7 +10,7 @@ class Users::RdvsController < UserAuthController
   layout "application_base", only: %i[index]
 
   include TokenInvitable
-  prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
+  prepend_before_action :store_invitation_in_session_and_redirect, only: %i[show creneaux]
 
   def index
     authorize(Rdv, policy_class: User::RdvPolicy)
@@ -96,15 +96,6 @@ class Users::RdvsController < UserAuthController
   end
 
   private
-
-  def store_invitation_in_session_and_redirect_for_allowlisted_actions
-    return true if params[:invitation_token].blank?
-
-    unless params[:action].in?(%w[show creneaux])
-      Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
-    end
-    store_invitation_in_session_and_redirect
-  end
 
   def build_creneau
     @starts_at = Time.zone.parse(params[:starts_at])

--- a/spec/controllers/concerns/token_invitable_spec.rb
+++ b/spec/controllers/concerns/token_invitable_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe TokenInvitable, type: :controller do
   controller(ApplicationController) do
     include TokenInvitable
-    prepend_before_action :store_invitation_in_session_and_redirect_for_allowlisted_actions
+    prepend_before_action :store_invitation_in_session_and_redirect
 
     def fake_action
       render plain: "ok"
@@ -9,17 +9,6 @@ RSpec.describe TokenInvitable, type: :controller do
 
     def fake_action_not_using_invitation
       render plain: "ok"
-    end
-
-    private
-
-    def store_invitation_in_session_and_redirect_for_allowlisted_actions
-      return true if params[:invitation_token].blank?
-
-      unless params[:action].in?(["fake_action"])
-        Sentry.capture_message("Invitation used unexpectedly on #{params[:controller]}##{params[:action]}")
-      end
-      store_invitation_in_session_and_redirect
     end
   end
 
@@ -201,26 +190,6 @@ RSpec.describe TokenInvitable, type: :controller do
           expect(flash[:error]).to eq("L’utilisateur connecté ne correspond pas à l’utilisateur invité. Déconnectez-vous et réessayez.")
         end
       end
-    end
-  end
-
-  context "when using an invitation on an unexpected action" do
-    let(:token) { user.set_rdv_invitation_token! }
-    let(:params) { { invitation_token: token } }
-
-    it "stores the token in the session and notifies Sentry" do
-      get :fake_action_not_using_invitation, params: params
-
-      expect(request.session[:invitation]).to eq(params.merge(expires_at: Time.zone.parse("2022-08-03 10:32:00")))
-
-      expect(sentry_events.last.message).to eq "Invitation used unexpectedly on anonymous#fake_action_not_using_invitation"
-    end
-
-    it "doesn't notify Sentry if there is no invitation token" do
-      get :fake_action_not_using_invitation
-      expect(response.body).to eq "ok"
-
-      expect(sentry_events).to be_empty
     end
   end
 end

--- a/spec/features/users/user_can_manage_collective_rdv_spec.rb
+++ b/spec/features/users/user_can_manage_collective_rdv_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       click_button("Se connecter")
       click_button("Continuer")
+      expect(page).to have_content("Choix de l’usager")
       click_button("Continuer")
       stub_request(:post, "https://example.com/")
       click_on("Confirmer ma participation")
@@ -127,7 +128,7 @@ RSpec.describe "Adding a user to a collective RDV" do
       expect_webhooks_for(logged_user)
     end
 
-    it "with an invited user (Token), redirect to rdv with invitaiton_token refreshed" do
+    it "with an invited user (Token), redirect to rdv with invitation_token refreshed" do
       motif.update!(bookable_by: "agents_and_prescripteurs_and_invited_users")
       params.merge!(invitation_token: invitation_token)
       visit prendre_rdv_path(params)
@@ -150,7 +151,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       it "do not display revoked or full rdvs for reservation (invitation error)" do
         params.merge!(invitation_token: invitation_token)
-        visit root_path(params)
+        visit prendre_rdv_path(params)
 
         rdv.status = "revoked"
         rdv.save
@@ -162,7 +163,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         create(:participation, rdv: rdv2)
         create(:participation, rdv: rdv2)
         rdv2.save
-        visit root_path(params)
+        visit prendre_rdv_path(params)
         expect(page).to have_content("Malheureusement, aucun créneau correspondant à votre invitation n'a été trouvé.")
         expect(page).to have_content("Toutes nos excuses pour cela.")
       end
@@ -170,7 +171,7 @@ RSpec.describe "Adding a user to a collective RDV" do
       it "correctly display message of participation already existing" do
         params.merge!(invitation_token: invitation_token)
         create(:participation, rdv: rdv, user: user)
-        visit root_path(params)
+        visit prendre_rdv_path(params)
         select_motif
         select_lieu
         expect(page).to have_content("Vous êtes déjà inscrit pour cet atelier")
@@ -180,7 +181,7 @@ RSpec.describe "Adding a user to a collective RDV" do
         params.merge!(invitation_token: invitation_token)
         create(:participation, rdv: rdv, user: user, status: "excused")
 
-        visit root_path(params)
+        visit prendre_rdv_path(params)
         select_motif
         select_lieu
         expect_confirm_participation.not_to change { rdv.reload.users.count }
@@ -191,7 +192,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       it "display rdv with cancelled tag when participation is excused or rdv is revoked", js: true do
         params.merge!(invitation_token: invitation_token)
-        visit root_path(params)
+        visit prendre_rdv_path(params)
 
         create(:participation, rdv: rdv, user: user, status: "excused")
 
@@ -211,7 +212,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       it "doesnt send notifications email to user if notif is unchecked" do
         params.merge!(invitation_token: invitation_token)
-        visit root_path(params)
+        visit prendre_rdv_path(params)
         select_motif
         select_lieu
         expect_confirm_participation(notif: false).to change { rdv.reload.users.count }.from(0).to(1)
@@ -222,7 +223,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       it "can cancel collective rdv participation, with mail notifications only", js: true do
         params.merge!(invitation_token: invitation_token)
-        visit root_path(params)
+        visit prendre_rdv_path(params)
 
         participation = create(:participation, rdv: rdv, user: user, status: "unknown")
 
@@ -244,7 +245,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
       it "can cancel collective rdv participation, without notifications", js: true do
         params.merge!(invitation_token: invitation_token)
-        visit root_path(params)
+        visit prendre_rdv_path(params)
 
         participation = create(:participation, rdv: rdv, user: user, status: "unknown")
         participation.send_lifecycle_notifications = false
@@ -271,7 +272,7 @@ RSpec.describe "Adding a user to a collective RDV" do
 
         params.merge!(invitation_token: invitation_token)
 
-        visit root_path(params)
+        visit prendre_rdv_path(params)
         select_motif
         select_lieu
         expect_confirm_participation.to change { rdv.reload.users.count }.from(2).to(3)


### PR DESCRIPTION
# Contexte

Dans le cadre de https://github.com/betagouv/rdv-service-public/pull/5157, on avait ajouté des vérifications pour clarifiers quels endpoints utilisent des invitations.
On n'a eu aucune notification dans sentry correspondant à ces vérifications, donc on peut maintenant les supprimer.

Ça ajoute pas mal de clarté, et ça montre surtout qu'on n'a que 3 endpoints sur lesquels on utilise le paramètre `invitation_token`.

# Solution

J'ai mis à jour quelques specs qui ne reflétaient pas comment les invitations sont utilisées (voir aussi https://github.com/gip-inclusion/rdv-insertion/blob/staging/app/services/invitations/compute_link.rb).