### PR TITLE
Empêche le futur domaine d'être indexé

### DIFF
--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,0 +1,9 @@
+class RobotsController < ApplicationController
+  layout false
+
+  respond_to :text
+
+  def robots
+    @domain_is_public = current_domain.in?([Domain::RDV_SOLIDARITES, Domain::RDV_AIDE_NUMERIQUE, Domain::RDV_MAIRIE])
+  end
+end

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -4,6 +4,15 @@ class RobotsController < ApplicationController
   respond_to :text
 
   def robots
-    @domain_is_public = current_domain.in?([Domain::RDV_SOLIDARITES, Domain::RDV_AIDE_NUMERIQUE, Domain::RDV_MAIRIE])
+    @domain_is_public = domain_is_public?
+  end
+
+  private
+
+  def domain_is_public?
+    return false if ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
+    return false if URI.parse(request.url).host&.ends_with?("rdv.numerique.gouv.fr")
+
+    true
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -82,6 +82,25 @@ class Domain
       allow_agent_creation_with_agent_connect: true,
       secretariat_email: "secretariat-auto@rdv-service-public.fr"
     ),
+
+    RDV_NUMERIQUE_GOUV_FR = new(
+      id: "RDV_NUMERIQUE_GOUV_FR",
+      logo_path: "logos/logo_rdv_service_public.svg",
+      public_logo_path: "/logo_rdv_service_public.png",
+      dark_logo_path: "logos/logo_sombre_rdv_service_public.svg",
+      name: "RDV Service Public",
+      presentation_for_agents_template_name: nil, # C'est la homepage qui joue ce rôle pour ce domaine
+      address_selection_template_name: nil,
+      search_banner_template_name: "search/banners/rdv_mairie",
+      online_reservation_with_public_link: true,
+      can_sync_to_outlook: false,
+      sms_sender_name: "RDV S.P.",
+      france_connect_enabled: true,
+      support_email: "support@rdv-service-public.fr", # TODO: Configurer SPF, DKIM, DMARC
+      verticale: :rdv_mairie,
+      allow_agent_creation_with_agent_connect: true,
+      secretariat_email: "secretariat-auto@rdv-service-public.fr" # TODO: réfléchir à cette boite auto
+    ),
   ].freeze
 
   def provides_address_selection?
@@ -97,6 +116,7 @@ class Domain
       RDV_SOLIDARITES => ENV["AGENT_CONNECT_RDVS_CLIENT_ID"],
       RDV_AIDE_NUMERIQUE => ENV["AGENT_CONNECT_RDVAN_CLIENT_ID"],
       RDV_MAIRIE => ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"],
+      RDV_NUMERIQUE_GOUV_FR => ENV["AGENT_CONNECT_RDV_NUMERIQUE_GOUV_FR_CLIENT_ID"],
     }.fetch(self)
   end
 
@@ -105,6 +125,7 @@ class Domain
       RDV_SOLIDARITES => ENV["AGENT_CONNECT_RDVS_CLIENT_SECRET"],
       RDV_AIDE_NUMERIQUE => ENV["AGENT_CONNECT_RDVAN_CLIENT_SECRET"],
       RDV_MAIRIE => ENV["AGENT_CONNECT_RDVSP_CLIENT_SECRET"],
+      RDV_NUMERIQUE_GOUV_FR => ENV["AGENT_CONNECT_RDV_NUMERIQUE_GOUV_FR_CLIENT_SECRET"],
     }.fetch(self)
   end
 
@@ -120,18 +141,21 @@ class Domain
           RDV_SOLIDARITES => "staging.rdv-solidarites.fr", # sous-domaine pas configuré
           RDV_AIDE_NUMERIQUE => "staging.rdv-aide-numerique.fr", # sous-domaine pas configuré
           RDV_MAIRIE => "staging.rdv-service-public.fr",
+          RDV_NUMERIQUE_GOUV_FR => "staging.rdv.numerique.gouv.fr", # sous-domaine pas configuré
         }.fetch(self)
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
         {
           RDV_SOLIDARITES => "demo.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "demo.rdv-aide-numerique.fr",
           RDV_MAIRIE => "demo.rdv.anct.gouv.fr",
+          RDV_NUMERIQUE_GOUV_FR => "demo.rdv.numerique.gouv.fr",
         }.fetch(self)
       else
         {
           RDV_SOLIDARITES => "www.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique.fr",
           RDV_MAIRIE => "rdv.anct.gouv.fr",
+          RDV_NUMERIQUE_GOUV_FR => "www.rdv.numerique.gouv.fr",
         }.fetch(self)
       end
     when :development
@@ -139,12 +163,14 @@ class Domain
         RDV_SOLIDARITES => "www.rdv-solidarites.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique.localhost",
         RDV_MAIRIE => "www.rdv-mairie.localhost",
+        RDV_NUMERIQUE_GOUV_FR => "www.rdv-numerique-gouv-fr.localhost",
       }.fetch(self)
     when :test
       {
         RDV_SOLIDARITES => "www.rdv-solidarites-test.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique-test.localhost",
         RDV_MAIRIE => "www.rdv-mairie-test.localhost",
+        RDV_NUMERIQUE_GOUV_FR => "www.rdv-numerique-gouv-fr-test.localhost",
       }.fetch(self)
     else
       raise "Rails.env not recognized: #{Rails.env.inspect}"

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -82,25 +82,6 @@ class Domain
       allow_agent_creation_with_agent_connect: true,
       secretariat_email: "secretariat-auto@rdv-service-public.fr"
     ),
-
-    RDV_NUMERIQUE_GOUV_FR = new(
-      id: "RDV_NUMERIQUE_GOUV_FR",
-      logo_path: "logos/logo_rdv_service_public.svg",
-      public_logo_path: "/logo_rdv_service_public.png",
-      dark_logo_path: "logos/logo_sombre_rdv_service_public.svg",
-      name: "RDV Service Public",
-      presentation_for_agents_template_name: nil, # C'est la homepage qui joue ce rôle pour ce domaine
-      address_selection_template_name: nil,
-      search_banner_template_name: "search/banners/rdv_mairie",
-      online_reservation_with_public_link: true,
-      can_sync_to_outlook: false,
-      sms_sender_name: "RDV S.P.",
-      france_connect_enabled: true,
-      support_email: "support@rdv-service-public.fr", # TODO: Configurer SPF, DKIM, DMARC
-      verticale: :rdv_mairie,
-      allow_agent_creation_with_agent_connect: true,
-      secretariat_email: "secretariat-auto@rdv-service-public.fr" # TODO: réfléchir à cette boite auto
-    ),
   ].freeze
 
   def provides_address_selection?
@@ -116,7 +97,6 @@ class Domain
       RDV_SOLIDARITES => ENV["AGENT_CONNECT_RDVS_CLIENT_ID"],
       RDV_AIDE_NUMERIQUE => ENV["AGENT_CONNECT_RDVAN_CLIENT_ID"],
       RDV_MAIRIE => ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"],
-      RDV_NUMERIQUE_GOUV_FR => ENV["AGENT_CONNECT_RDV_NUMERIQUE_GOUV_FR_CLIENT_ID"],
     }.fetch(self)
   end
 
@@ -125,7 +105,6 @@ class Domain
       RDV_SOLIDARITES => ENV["AGENT_CONNECT_RDVS_CLIENT_SECRET"],
       RDV_AIDE_NUMERIQUE => ENV["AGENT_CONNECT_RDVAN_CLIENT_SECRET"],
       RDV_MAIRIE => ENV["AGENT_CONNECT_RDVSP_CLIENT_SECRET"],
-      RDV_NUMERIQUE_GOUV_FR => ENV["AGENT_CONNECT_RDV_NUMERIQUE_GOUV_FR_CLIENT_SECRET"],
     }.fetch(self)
   end
 
@@ -141,21 +120,18 @@ class Domain
           RDV_SOLIDARITES => "staging.rdv-solidarites.fr", # sous-domaine pas configuré
           RDV_AIDE_NUMERIQUE => "staging.rdv-aide-numerique.fr", # sous-domaine pas configuré
           RDV_MAIRIE => "staging.rdv-service-public.fr",
-          RDV_NUMERIQUE_GOUV_FR => "staging.rdv.numerique.gouv.fr", # sous-domaine pas configuré
         }.fetch(self)
       elsif ENV["RDV_SOLIDARITES_INSTANCE_NAME"] == "DEMO"
         {
           RDV_SOLIDARITES => "demo.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "demo.rdv-aide-numerique.fr",
           RDV_MAIRIE => "demo.rdv.anct.gouv.fr",
-          RDV_NUMERIQUE_GOUV_FR => "demo.rdv.numerique.gouv.fr",
         }.fetch(self)
       else
         {
           RDV_SOLIDARITES => "www.rdv-solidarites.fr",
           RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique.fr",
           RDV_MAIRIE => "rdv.anct.gouv.fr",
-          RDV_NUMERIQUE_GOUV_FR => "www.rdv.numerique.gouv.fr",
         }.fetch(self)
       end
     when :development
@@ -163,14 +139,12 @@ class Domain
         RDV_SOLIDARITES => "www.rdv-solidarites.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique.localhost",
         RDV_MAIRIE => "www.rdv-mairie.localhost",
-        RDV_NUMERIQUE_GOUV_FR => "www.rdv-numerique-gouv-fr.localhost",
       }.fetch(self)
     when :test
       {
         RDV_SOLIDARITES => "www.rdv-solidarites-test.localhost",
         RDV_AIDE_NUMERIQUE => "www.rdv-aide-numerique-test.localhost",
         RDV_MAIRIE => "www.rdv-mairie-test.localhost",
-        RDV_NUMERIQUE_GOUV_FR => "www.rdv-numerique-gouv-fr-test.localhost",
       }.fetch(self)
     else
       raise "Rails.env not recognized: #{Rails.env.inspect}"

--- a/app/views/robots/robots.text.erb
+++ b/app/views/robots/robots.text.erb
@@ -1,6 +1,7 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-agent: *
 Disallow: /
+<% if @domain_is_public %>
 Allow: /$
 Allow: /mds
 Allow: /accessibility
@@ -9,3 +10,4 @@ Allow: /cgu
 Allow: /politique_de_confidentialite
 Allow: /domaines
 Allow: /aide
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -406,4 +406,6 @@ Rails.application.routes.draw do
 
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
+
+  get "robots.txt" => "robots#robots"
 end

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -24,14 +24,16 @@ RSpec.describe "/robots.txt" do
   end
 
   it "sert un robots.txt privé pour le domaine rdv.numerique.gouv.fr" do
-    get "http://www.rdv-solidarites-test.localhost/robots.txt"
+    # Ces domaines sont officiels et donc crawlables
+    get "https://www.rdv-solidarites.fr/robots.txt"
     expect(response.body).to eq(public_robots)
-    get "http://www.rdv-aide-numerique-test.localhost/robots.txt"
+    get "https://www.rdv-aide-numerique.fr/robots.txt"
     expect(response.body).to eq(public_robots)
-    get "http://www.rdv-mairie-test.localhost/robots.txt"
+    get "https://rdv.anct.gouv.fr/robots.txt"
     expect(response.body).to eq(public_robots)
 
-    get "http://www.rdv-numerique-gouv-fr-test.localhost/robots.txt"
+    # Ce domaine n'est pas encore public et donc non crawlables
+    get "https://www.rdv.numerique.gouv.fr/robots.txt"
     expect(response.body).to eq(private_robots)
   end
 end

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "/robots.txt" do
+  let(:public_robots) do
+    <<~ROBOTS
+      # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+      User-agent: *
+      Disallow: /
+      Allow: /$
+      Allow: /mds
+      Allow: /accessibility
+      Allow: /mentions_legales
+      Allow: /cgu
+      Allow: /politique_de_confidentialite
+      Allow: /domaines
+      Allow: /aide
+    ROBOTS
+  end
+
+  let(:private_robots) do
+    <<~ROBOTS
+      # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+      User-agent: *
+      Disallow: /
+    ROBOTS
+  end
+
+  it "sert un robots.txt privé pour le domaine rdv.numerique.gouv.fr" do
+    get "http://www.rdv-solidarites-test.localhost/robots.txt"
+    expect(response.body).to eq(public_robots)
+    get "http://www.rdv-aide-numerique-test.localhost/robots.txt"
+    expect(response.body).to eq(public_robots)
+    get "http://www.rdv-mairie-test.localhost/robots.txt"
+    expect(response.body).to eq(public_robots)
+
+    get "http://www.rdv-numerique-gouv-fr-test.localhost/robots.txt"
+    expect(response.body).to eq(private_robots)
+  end
+end


### PR DESCRIPTION
# Contexte

Nous comptons migrer `rdv.anct.gouv.fr` vers `www.rdv.numerique.gouv.fr` dans un futur proche.

Nous avons déjà fait pointer `www.rdv.numerique.gouv.fr` vers notre app Scalingo, mais nous préférons éviter que le domaine ne soit trouvable via moteur de recherche tant que nous n'avons pas fini de le configurer, voir TODO sur [la fiche Notion](https://www.notion.so/rdvs/Domaine-rdv-numerique-gouv-fr-1ba2b05ced418054b15bd71eb4de9ba6).

# Solution

On fait en sorte que `/robots.txt` ne déclare pas les pages publiques pour ce nouveau domaine.
