### PR TITLE
Utiliser la config de domaine "RDV_MAIRIE" par défaut

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -201,7 +201,7 @@ class Domain
   def self.find_matching(domain_name)
     return review_app_domain if ENV["IS_REVIEW_APP"] == "true"
 
-    ALL_BY_HOST_NAME.fetch(domain_name) { RDV_SOLIDARITES }
+    ALL_BY_HOST_NAME.fetch(domain_name) { RDV_MAIRIE }
   end
 
   # Les review apps utilisent un host de Scalingo, elles ne permettent

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe AgentConnectController do
   stub_env_with(
     AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
-    AGENT_CONNECT_RDVS_CLIENT_SECRET: "un faux secret de test",
-    AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+    AGENT_CONNECT_RDVSP_CLIENT_SECRET: "un faux secret de test",
+    AGENT_CONNECT_RDVSP_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
   )
 
   describe "#auth" do

--- a/spec/features/agents/users/agent_can_create_user_spec.rb
+++ b/spec/features/agents/users/agent_can_create_user_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Agent can create user" do
       fill_in :user_last_name, with: "Green"
       fill_in :user_email, with: "ceelo@green.com"
       click_button "Créer"
-      expect(page).to have_content("Un usager avec le même email a déjà un compte sur RDV Solidarités")
+      expect(page).to have_content("Un usager avec le même email a déjà un compte sur RDV Service Public")
       click_link "Importer cet usager"
       expect_page_title("Cee-Lo GREEN")
       expect(page).to have_content("L'usager a été associé à votre organisation.")

--- a/spec/requests/prendre_rdv_spec.rb
+++ b/spec/requests/prendre_rdv_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe "Search", type: :request do
   describe "GET /" do
     context "without params" do
       it "is successful" do
-        get root_path
+        get "http://www.rdv-solidarites-test.localhost/"
         expect(response).to be_successful
       end
 
       it "render adress_selection template" do
-        get root_path
+        get "http://www.rdv-solidarites-test.localhost/"
         expect(response).to render_template("search/address_selection/_rdv_solidarites")
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe "Search", type: :request do
         it "render motif_selection template" do
           motif = create(:motif, service: agent.services.first, follow_up: true, organisation: organisation)
           create(:plage_ouverture, agent: agent, motifs: [motif], organisation: organisation)
-          get prendre_rdv_path(referent_ids: [agent.id], service: agent.services.first.id, departement: organisation.territory.departement_number)
+          get prendre_rdv_url(referent_ids: [agent.id], service: agent.services.first.id, departement: organisation.territory.departement_number, host: "www.rdv-solidarites-test.localhost")
           expect(response).to render_template("search/_motif_selection")
         end
       end
@@ -41,13 +41,13 @@ RSpec.describe "Search", type: :request do
       let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif, other_motif], organisation: organisation) }
 
       it "show text to invite to select motif" do
-        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+        get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
         expect(response.body).to include("Sélectionnez le service puis le motif pour lequel vous voulez prendre un RDV")
       end
 
       context "lorsqu’il n’y a pas de motif de suivi associé aux services" do
         it "n’affiche pas l’invitation à se connecter pour prendre un RDV de suivi" do
-          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
           expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
@@ -57,7 +57,7 @@ RSpec.describe "Search", type: :request do
         let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true, bookable_by:) }
 
         it "affiche l’invitation à se connecter pour prendre un RDV de suivi" do
-          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
           expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
 
@@ -65,7 +65,7 @@ RSpec.describe "Search", type: :request do
           let(:bookable_by) { :agents }
 
           it "n’affiche pas l’invitation à se connecter" do
-            get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+            get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
             expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
           end
         end
@@ -80,13 +80,13 @@ RSpec.describe "Search", type: :request do
       let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif, other_motif], organisation: organisation) }
 
       it "show text to invite to select motif" do
-        get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+        get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
         expect(response.body).to include("Sélectionnez le motif de votre RDV")
       end
 
       context "lorsqu’il n’y a pas de motif de suivi associé aux services" do
         it "n’affiche pas l’invitation à se connecter" do
-          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
           expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
       end
@@ -96,7 +96,7 @@ RSpec.describe "Search", type: :request do
         let!(:follow_up_motif) { create(:motif, organisation: organisation, service: motif.service, follow_up: true, bookable_by:) }
 
         it "affiche l’invitation à se connecter pour prendre un RDV de suivi" do
-          get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+          get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
           expect(response.body).to include("Pour prendre un RDV de suivi avec un de vos agents référents")
         end
 
@@ -104,7 +104,7 @@ RSpec.describe "Search", type: :request do
           let(:bookable_by) { :agents }
 
           it "n’affiche pas l’invitation à se connecter" do
-            get root_path(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001")
+            get root_url(departement: "75", city_code: "75056", latitude: "48.859", longitude: "2.347", address: "Paris 75001", host: "www.rdv-solidarites-test.localhost")
             expect(response.body).not_to include("Pour prendre un RDV de suivi avec un de vos agents référents")
           end
         end
@@ -114,7 +114,7 @@ RSpec.describe "Search", type: :request do
 
   describe "GET /prendre_rdv" do
     it "is successful" do
-      get prendre_rdv_path
+      get "http://www.rdv-solidarites-test.localhost/prendre_rdv"
       expect(response).to be_successful
     end
   end


### PR DESCRIPTION
# Contexte

Nous comptons migrer `rdv.anct.gouv.fr` vers `www.rdv.numerique.gouv.fr` dans un futur proche.

Nous avons déjà fait pointer `www.rdv.numerique.gouv.fr` vers notre app Scalingo, mais par défaut le domaine détecté dans notre code est RDV Solidarités.

Cette PR fait en sorte d'utiliser la config de notre instance "officielle" (cette sur laquelle pointe `rdv.anct.gouv.fr`) par défaut.


# Avant


![image](https://github.com/user-attachments/assets/db8d82f0-6bca-43a9-bfc8-c91a509ffa7e)

# Après


![image](https://github.com/user-attachments/assets/e43e8bb3-f330-48c8-98e5-550803878e84)