### PR TITLE
Correctif pour la prise de rendez-vous avec des territoires sans numéro de département

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -90,9 +90,7 @@ class SearchController < ApplicationController
   end
 
   def prescripteur
-    redirect_to prendre_rdv_path(
-      prescripteur: 1
-    )
+    redirect_to prendre_rdv_path(prescripteur: 1)
   end
 
   private

--- a/app/services/concerns/users/creneaux_wizard_concern.rb
+++ b/app/services/concerns/users/creneaux_wizard_concern.rb
@@ -3,7 +3,7 @@ module Users::CreneauxWizardConcern
 
   # *** Method that outputs the current step for the user to complete its rdv journey ***
   def current_step
-    if departement.blank?
+    if departement.blank? && query_params[:public_link_organisation_id].blank?
       :address_selection
     elsif !service_selected?
       :service_selection

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -1,6 +1,6 @@
 class WebSearchContext < SearchContext
   include Users::CreneauxWizardConcern
-  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude
+  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude, :departement
 
   # departement est un cas particulier parce qu'il est aussi utilisé en dehors de addresse selection pour
   # passer cette première étape
@@ -23,6 +23,7 @@ class WebSearchContext < SearchContext
     @address = query_params[:address]
     @city_code = query_params[:city_code]
     @street_ban_id = query_params[:street_ban_id]
+    @departement = query_params[:departement]
 
     # User choices
     @service_id = query_params[:service_id]
@@ -38,10 +39,6 @@ class WebSearchContext < SearchContext
 
   def prescripteur?
     @prescripteur
-  end
-
-  def departement
-    @departement ||= @query_params[:departement] || public_link_organisation&.departement_number
   end
 
   def organisation_id

--- a/spec/support/shared_context/search_context.rb
+++ b/spec/support/shared_context/search_context.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples "SearchContext" do
 
   before do
     allow(Users::GeoSearch).to receive(:new)
-      .with(departement: departement_number, city_code: city_code, street_ban_id: nil)
+      .with(departement: departement_number.presence, city_code: city_code, street_ban_id: nil)
       .and_return(geo_search)
   end
 

--- a/spec/support/shared_context/search_context.rb
+++ b/spec/support/shared_context/search_context.rb
@@ -35,6 +35,17 @@ RSpec.shared_examples "SearchContext" do
       end
     end
 
+    context "when using a direct link to an organisation with a territory without departement number" do
+      let!(:query_params) { { public_link_organisation_id: organisation.id } }
+      let(:departement_number) { nil }
+      let(:city_code) { nil }
+      let!(:organisation) { create(:organisation, territory: create(:territory, departement_number: "")) }
+
+      it "returns service selection" do
+        expect(subject.current_step).to eq(:service_selection)
+      end
+    end
+
     context "with an address but several matching motifs" do
       let!(:geo_search) { instance_double(Users::GeoSearch, available_motifs: Motif.where(id: [motif.id, motif2.id])) }
       let!(:query_params) { { address: address, departement: departement_number, city_code: city_code } }

--- a/spec/support/shared_context/search_context.rb
+++ b/spec/support/shared_context/search_context.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples "SearchContext" do
 
   before do
     allow(Users::GeoSearch).to receive(:new)
-      .with(departement: departement_number.presence, city_code: city_code, street_ban_id: nil)
+      .with(departement: departement_number, city_code: city_code, street_ban_id: nil)
       .and_return(geo_search)
   end
 
@@ -37,7 +37,7 @@ RSpec.shared_examples "SearchContext" do
 
     context "when using a direct link to an organisation with a territory without departement number" do
       let!(:query_params) { { public_link_organisation_id: organisation.id } }
-      let(:departement_number) { "" }
+      let(:departement_number) { nil }
       let(:city_code) { nil }
       let!(:organisation) { create(:organisation, territory: create(:territory, departement_number: "")) }
 

--- a/spec/support/shared_context/search_context.rb
+++ b/spec/support/shared_context/search_context.rb
@@ -37,12 +37,12 @@ RSpec.shared_examples "SearchContext" do
 
     context "when using a direct link to an organisation with a territory without departement number" do
       let!(:query_params) { { public_link_organisation_id: organisation.id } }
-      let(:departement_number) { nil }
+      let(:departement_number) { "" }
       let(:city_code) { nil }
       let!(:organisation) { create(:organisation, territory: create(:territory, departement_number: "")) }
 
-      it "returns service selection" do
-        expect(subject.current_step).to eq(:service_selection)
+      it "returns motif selection" do
+        expect(subject.current_step).to eq(:motif_selection)
       end
     end
 


### PR DESCRIPTION
# Contexte

Dans le cadre de https://github.com/betagouv/rdv-service-public/pull/5188, on permet la création de territoires sans remplir le champs `departement_number`, ce qui fait qu'il est blank (chaine vide).
Dans le cadre de la prise de rdv en ligne, ça pose problème puisque ça fait qu'on reste bloqués sur la section recherche d'adresse, qui en plus pour rdv service public est la homepage.


# Solution

On change la logique du sélectionneur d'étape.
Il y aurait des correctifs plus propres à faire dans le cadre d'un beau refacto de cette logique (genre sortir la selection d'adresse du wizard de créneau), mais c'est un chantier bien plus ambitieux.

