### PR TITLE
Catégorisation des territoires

### DIFF
--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -11,7 +11,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     id: Field::Number,
     departement_number: Field::String,
     name: Field::String,
-    category: Field::String,
+    category: Field::Select.with_options(collection: %w[État Département Intercommunalité Commune Région Opérateur Association Inconnu]),
     organisations: Field::HasMany.with_options(sort_by: :name, direction: :asc),
     admin_agents: Field::HasMany,
     roles: Field::HasMany,

--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -11,6 +11,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     id: Field::Number,
     departement_number: Field::String,
     name: Field::String,
+    category: Field::String,
     organisations: Field::HasMany.with_options(sort_by: :name, direction: :asc),
     admin_agents: Field::HasMany,
     roles: Field::HasMany,
@@ -26,6 +27,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     departement_number
+    category
     name
   ].freeze
 
@@ -35,6 +37,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     id
     name
     departement_number
+    category
     roles
     organisations
     created_at
@@ -48,6 +51,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     name
     admin_agents
     departement_number
+    category
   ].freeze
 
   def display_resource(territory)

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -298,6 +298,7 @@ tables:
       - enable_waiting_room_mail_field
       - enable_waiting_room_color_field
       - visible_users_throughout_the_territory
+      - category
 
   # Tables sans données personnelles
   - table_name: agent_roles

--- a/db/migrate/20250401130505_add_categories_to_territories.rb
+++ b/db/migrate/20250401130505_add_categories_to_territories.rb
@@ -1,0 +1,11 @@
+class AddCategoriesToTerritories < ActiveRecord::Migration[7.1]
+  def change
+    add_column :territories, :category, :string
+
+    change_column_comment :territories, :category, from: nil, to: <<~COMMENT
+      La catégorie permet classifier les différents territoires principalement pour faire des statistiques dans metabase,
+      et pour avoir un suivi approprié de chaque territoire pour notre équipe déploiement et support. Par exemple, les besoins d'une commune
+      ne seront pas les mêmes que ceux d'un service de l'état.
+    COMMENT
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -425,7 +425,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_01_130505) do
     t.integer "min_public_booking_delay", default: 1800, null: false, comment: "Permet de savoir combien de secondes il y aura au minimum entre la prise de rdv par un usager ou un prescripteur et le début du rdv. Par exemple si la valeur est 1800, et qu'il est 10h, le premier rdv qui pourra être pris (s'il y a une plage d'ouverture libre) sera à 10h30, puisque 1800 = 30 x 60. Cela permet à l'agent d'être prévenu suffisamment à l'avance.\n"
     t.integer "max_public_booking_delay", default: 7889238, null: false, comment: "Permet de savoir combien de temps à l'avance il est possible de prendre rdv pour un usager ou un prescripteur. Le délai est mesuré en secondes. Cela évite que des gens prennent des rdv dans trop longtemps, et évite aux agents de s'engager à assurer des rdv alors qu'ils ne connaissent pas leur emploi du temps suffisamment à l'avance.\n"
     t.datetime "deleted_at", comment: "Permet de savoir à quelle date le motif a été soft-deleted\n"
-    t.bigint "service_id"
+    t.bigint "service_id", null: false
     t.text "restriction_for_rdv", comment: "Instructions à accepter avant la prise du rendez-vous par l'usager\n"
     t.text "instruction_for_rdv", comment: "Indications affichées à l'usager après la confirmation du rendez-vous. Apparait dans le mail de confirmation pour l'usager.\n"
     t.boolean "for_secretariat", default: false, comment: "Permet aux agents du secrétariat d'assurer des rdv pour ce motif\n"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_27_092827) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_01_130505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -425,7 +425,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_27_092827) do
     t.integer "min_public_booking_delay", default: 1800, null: false, comment: "Permet de savoir combien de secondes il y aura au minimum entre la prise de rdv par un usager ou un prescripteur et le début du rdv. Par exemple si la valeur est 1800, et qu'il est 10h, le premier rdv qui pourra être pris (s'il y a une plage d'ouverture libre) sera à 10h30, puisque 1800 = 30 x 60. Cela permet à l'agent d'être prévenu suffisamment à l'avance.\n"
     t.integer "max_public_booking_delay", default: 7889238, null: false, comment: "Permet de savoir combien de temps à l'avance il est possible de prendre rdv pour un usager ou un prescripteur. Le délai est mesuré en secondes. Cela évite que des gens prennent des rdv dans trop longtemps, et évite aux agents de s'engager à assurer des rdv alors qu'ils ne connaissent pas leur emploi du temps suffisamment à l'avance.\n"
     t.datetime "deleted_at", comment: "Permet de savoir à quelle date le motif a été soft-deleted\n"
-    t.bigint "service_id", null: false
+    t.bigint "service_id"
     t.text "restriction_for_rdv", comment: "Instructions à accepter avant la prise du rendez-vous par l'usager\n"
     t.text "instruction_for_rdv", comment: "Indications affichées à l'usager après la confirmation du rendez-vous. Apparait dans le mail de confirmation pour l'usager.\n"
     t.boolean "for_secretariat", default: false, comment: "Permet aux agents du secrétariat d'assurer des rdv pour ce motif\n"
@@ -739,6 +739,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_27_092827) do
     t.boolean "enable_waiting_room_color_field", default: false
     t.boolean "visible_users_throughout_the_territory", default: false
     t.boolean "enable_birth_date_field", default: false
+    t.string "category", comment: "La catégorie permet classifier les différents territoires principalement pour faire des statistiques dans metabase,\net pour avoir un suivi approprié de chaque territoire pour notre équipe déploiement et support. Par exemple, les besoins d'une commune\nne seront pas les mêmes que ceux d'un service de l'état.\n"
     t.index ["departement_number"], name: "index_territories_on_departement_number", where: "((departement_number)::text <> ''::text)"
   end
 

--- a/scripts/territory_categories.rb
+++ b/scripts/territory_categories.rb
@@ -1,0 +1,14 @@
+# Usage:
+# - mettre le fichier territories.csv dans tmp pour les territoires de rdv solidarites
+# - exécuter: scalingo --app=production-rdv-solidarites --region=osc-secnum-fr1 run --file=tmp/territories.csv "scripts/territory_categories.rb"
+#
+# - mettre le fichier territories.csv dans tmp pour les territoires de rdv service public
+# - exécuter: scalingo --app=production-rdv-mairie --region=osc-secnum-fr1 run --file=tmp/territories.csv "scripts/territory_categories.rb"
+
+require "csv"
+
+territories = CSV.read("/tmp/uploads/territories.csv", headers: true, col_sep: ",", liberal_parsing: true)
+territories.each do |territory_line|
+  territory = Territory.find(territory_line["ID"])
+  territory.update!(category: territory_line["Catégorie"])
+end


### PR DESCRIPTION
voir https://www.notion.so/rdvs/Cat-goriser-les-anciens-et-nouveaux-territoires-pour-des-stats-plus-fines-1c32b05ced41807eb536e360c1ecfcc6

Je recopie ici les infos dispo sur notion pour garder un historique plus long terme  sur github

## Définition du problème

Avoir de la donnée non triée nous oblige fréquemment à un tri manuel fastidieux, que ce soit pour produire des rapports précis destinés à nos sponsors ou pour établir des estimations de facturation fiables.

### Pourquoi ce problème est important ?

- **Rapports plus précis :** une catégorisation claire dès le départ permet de générer des rapports plus précis et pertinents pour les sponsors ou pour l'analyse interne.
- **Meilleure compréhension des données :** la distinction entre différents types de données (SMS, etc.) facilite l'identification des tendances et des informations clés.
- **Gain de temps :** éviter la catégorisation manuelle représente un gain de temps considérable et réduit le risque d'erreurs.
- **Prise de décision éclairée :** des données bien organisées et catégorisées facilitent la prise de décisions basées sur des informations fiables.

### La solution

Catégoriser nos compte en mettant à jour nos comptes anciens et en implémentant les mécanismes nécessaires pour que la catégorisation soit incluse lors de toute nouvelle création de compte, qu'elle soit initiée par nos chargés de déploiement ou par les utilisateurs en self-service.


## Première implémentation

On ajoute la colonne, on la rend éditable depuis le super admin, (on fait pas encore un enum pour garder de la flexibilité) et on ajoute un script pour faire le backfill à partir du fichier csv fait par Matis
