### PR TITLE
Petit correctif pour la page de login des agents

### DIFF
--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title do
-  .fr-h1.fr-mt-0.fr-mb-4w Connexion agent à #{current_domain.name}
+  .fr-h1 Connexion agent à #{current_domain.name}
 
 - if display_agent_connect_button?
   = render "common/proconnect_button"

--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :title do
-  h1.fr-mt-0.fr-mb-4w Connexion agent à #{current_domain.name}
+  .fr-h1.fr-mt-0.fr-mb-4w Connexion agent à #{current_domain.name}
 
 - if display_agent_connect_button?
   = render "common/proconnect_button"

--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -1,6 +1,5 @@
-- content_for :title, "Connexion agent à #{current_domain.name}"
-
-h1.rdv-text-align-center.text-dark.mt-0.font-weight-bold.mb-4 Connexion agent à #{current_domain.name}
+- content_for :title do
+  h1.fr-mt-0.fr-mb-4w Connexion agent à #{current_domain.name}
 
 - if display_agent_connect_button?
   = render "common/proconnect_button"


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="1291" alt="Screenshot 2025-04-01 at 16 27 22" src="https://github.com/user-attachments/assets/c85e954f-169f-4f8c-b496-0a7f9adc44d1" />|<img width="1352" alt="Screenshot 2025-04-01 at 16 29 02" src="https://github.com/user-attachments/assets/87794b7d-80ac-4339-90b4-f5768fecfb03" />

Un titre en double s'était glissé dans les modifs de #5193

On corrige ça et on en profite pour utiliser des classes dsfr plutôt que bootstrap.