### PR TITLE
Permettre de choisir la catégorie de territoire dès la création de compte

### DIFF
--- a/app/controllers/super_admins/comptes_controller.rb
+++ b/app/controllers/super_admins/comptes_controller.rb
@@ -30,7 +30,7 @@ module SuperAdmins
 
     def compte_params
       params.require(:compte).permit(
-        territory: %i[name departement_number],
+        territory: %i[name departement_number category],
         organisation: %i[name ants_connectable],
         lieu: %i[address latitude longitude],
         agent: %i[id first_name last_name email service_ids]

--- a/app/dashboards/territory_dashboard.rb
+++ b/app/dashboards/territory_dashboard.rb
@@ -11,7 +11,7 @@ class TerritoryDashboard < Administrate::BaseDashboard
     id: Field::Number,
     departement_number: Field::String,
     name: Field::String,
-    category: Field::Select.with_options(collection: %w[État Département Intercommunalité Commune Région Opérateur Association Inconnu]),
+    category: Field::Select.with_options(collection: Compte::CATEGORIES),
     organisations: Field::HasMany.with_options(sort_by: :name, direction: :asc),
     admin_agents: Field::HasMany,
     roles: Field::HasMany,

--- a/app/form_models/compte.rb
+++ b/app/form_models/compte.rb
@@ -2,6 +2,8 @@
 class Compte
   include ActiveModel::Model
 
+  CATEGORIES = %w[État Département Intercommunalité Commune Région Opérateur Association Inconnu].freeze
+
   attr_accessor :territory, :organisation, :lieu, :agent
 
   def initialize(attributes, current_domain = nil)

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -16,6 +16,7 @@ section.main-content__body
   = simple_form_for([namespace, page.resource], html: { class: "form" }) do |f|
     = f.simple_fields_for :territory do |ff|
       = ff.input :name, label: "Nom du territoire"
+      = ff.input :category, as: :select, collection: Compte::CATEGORIES, label: "Catégorie du territoire"
 
     = f.simple_fields_for :organisation do |ff|
       div[style="margin: 8px 0"]

--- a/spec/features/super_admin/creating_a_new_account_spec.rb
+++ b/spec/features/super_admin/creating_a_new_account_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
     click_link "Ouverture de compte"
 
     fill_in("Nom du territoire", with: "France Rénov")
+    select("Commune", from: "Catégorie du territoire")
     fill_in("Nom de la première organisation", with: "Agence de Romainville")
     fill_in("Adresse du premier lieu", with: "Place de la mairie, Romainville, 93230")
 
@@ -45,7 +46,8 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
 
     new_territory = Territory.last
     expect(new_territory).to have_attributes(
-      name: "France Rénov"
+      name: "France Rénov",
+      category: "Commune"
     )
 
     new_agent = new_territory.admin_agents.first
@@ -91,6 +93,7 @@ RSpec.describe "Creating a new account for a new project, which can be a mairie"
       click_link "Ouverture de compte"
 
       fill_in("Nom du territoire", with: "Romainville")
+      select("Commune", from: "Catégorie du territoire")
       fill_in("Nom de la première organisation", with: "Mairie de Romainville")
       fill_in("Adresse du premier lieu", with: "Place de la mairie, Romainville, 93230")
 


### PR DESCRIPTION
Suite de #5217

On ajoute un select "Catégorie du territoire" sur la page de création de compte.

# Avant

![image](https://github.com/user-attachments/assets/bd5bc05e-b8fe-49b6-8725-7a0f6b662d85)


# Après

![image](https://github.com/user-attachments/assets/5ab64bb0-0567-4275-af16-b0f41328e718)
