### PR TITLE
Suppression d’une route de stats inutilisé (et inutilisable)

### DIFF
--- a/app/controllers/admin/organisations/stats_controller.rb
+++ b/app/controllers/admin/organisations/stats_controller.rb
@@ -23,11 +23,6 @@ class Admin::Organisations::StatsController < AgentAuthController
     render json: stats.chart_json
   end
 
-  def users
-    skip_authorization
-    render json: Stat.new(users: policy_scope(User, policy_scope_class: Agent::UserPolicy::Scope)).users_group_by_week
-  end
-
   private
 
   def rdv_scope

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,7 +249,6 @@ Rails.application.routes.draw do
           resources :stats, only: :index do
             collection do
               get :rdvs
-              get :users
             end
           end
         end


### PR DESCRIPTION
# Contexte

En faisant des modifications sur la page de stats côté agent, je me suis aperçu que nous avions une route qui n’était : 
1. Jamais appelé (d’après Coverband sur RDVS et RDVSP)
2. Dysfonctionnant (la méthode `.users_group_by_week` n’existe pas)

# Solution

=> 🗑️ 


