### PR TITLE
Ajout du fil d’ariane sur la page de stats agents

### DIFF
--- a/app/views/admin/organisations/stats/index.html.slim
+++ b/app/views/admin/organisations/stats/index.html.slim
@@ -6,25 +6,28 @@
 - content_for :title do
   div.mb-0.pb-0 Statistiques de #{current_organisation.name}
 
-.card.mb-5.mt-4
+- content_for :fil_ariane do
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: "Statistiques de #{current_organisation.name}"
+
+.card.fr-mb-5v
   .card-body
     = render "stats/rdv_counters_with_links", rdvs: @stats.rdvs, breadcrumb_page: "organisation_stats"
     p.text-muted.mt-2 Les exports se font dorénavant uniquement depuis les listes de RDVs, suivez les liens ci-dessus pour y accéder
 
-.card.mb-5
+.card.fr-mb-5v
   .card-body
     = link_to "stats", rdvs_admin_organisation_stats_path(@organisation, departement: @departement, format: :json)
     = self_anchor "rdvs"
       h4.card-title RDV créés (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, departement: @departement), stacked: true
 
-.card.mb-5
+.card.fr-mb-5v
   .card-body
     = self_anchor "rdvs-service"
       h4.card-title RDV créés par service (#{@stats.rdvs.count})
     = column_chart rdvs_admin_organisation_stats_path(@organisation, by_service: true, departement: @departement), stacked: true
 
-.card.mb-5
+.card.fr-mb-5v
   .card-body
     = self_anchor "rdvs-type"
       h4.card-title RDV par type (#{@stats.rdvs.count})


### PR DESCRIPTION
# Contexte

Nous uniformisons (et DSFRisons) les éléments de navigation côté agent.

# Solution

On ajoute donc le fil d’ariane DSFR et on en profite pour corriger les marges.