### PR TITLE
Ajout d’infos de debug lors des échecs de callbacks FranceConnect

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -23,17 +23,22 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     http_host = env["HTTP_HOST"]
     provider = env["omniauth.error.strategy"].class.name.demodulize
 
-    Sentry.set_context(
-      "omniauth_env",
-      {
-        http_host: http_host,
-        provider: provider,
-        full_env: env.transform_values { |value| value.is_a?(String) ? value : value.inspect },
-      }
-    )
+    # NOTE: ne pas utiliser 'auth' dans le nom du contexte sinon Sentry le scrubbe
+    Sentry.set_context(:omni_failure, { http_host:, provider: })
 
     Sentry.capture_exception(env["omniauth.error"])
 
     OmniauthCallbacksController.action(:failure).call(env)
+  end
+
+  before_callback_phase do |env|
+    # cf https://github.com/betagouv/rdv-service-public/issues/4637
+    Sentry.set_context(
+      :omni_callback, # NOTE: ne pas utiliser 'auth' dans le nom du contexte sinon Sentry le scrubbe
+      {
+        state_from_session: env["rack.session"]["omniauth.state"],
+        state_from_params: Rack::Request.new(env).params["state"],
+      }
+    )
   end
 end


### PR DESCRIPTION
# Contexte

cf https://github.com/betagouv/rdv-service-public/issues/4637

L’erreur [CSRF lors du callback FranceConnect](https://sentry.incubateur.net/organizations/betagouv/issues/107368/?environment=production&project=74&query=is%3Aunresolved+csrf&referrer=issue-stream&sort=trends&statsPeriod=7d&stream_index=0) se produit trop souvent. 

Il semble que la comparaison de `state` entre ce qui est renvoyé par FC et ce que le navigateur a stocké en session échoue fréquemment.

Si j’ai bien compris, le `state` est une valeur aléatoire qui permet d’éviter les CSRF, c’est l’équivalent Rails du `csrf_token` .

On manque de contexte pour comprendre le problème ici

# Solution

J’ai appris [ici](https://docs.sentry.io/security-legal-pii/scrubbing/server-side-scrubbing/) que Sentry scrubbe les contextes contenant `auth`.

ça explique pourquoi on ne voyait pas le context `omniauth_env` pourtant bien défini dans le `on_failure` de omniauth.

J’ai utilisé le hook `before_callback_phase` pour mettre en contexte Sentry la valeur de session du `state` avant qu’elle ne soit détruite lors de la comparaison cf https://github.com/omniauth/omniauth_openid_connect/blob/master/lib/omniauth/strategies/openid_connect.rb#L378

<img width="829" alt="image" src="https://github.com/user-attachments/assets/64d2ae89-6b4f-488a-83f8-60363ae80bec" />

(ici j’ai forcé l’erreur à se produire même en cas d’égalité)

cf [l’erreur sentry en dev](https://sentry.incubateur.net/organizations/betagouv/issues/107368/?environment=production&project=74&query=is%3Aunresolved+csrf&referrer=issue-stream&sort=trends&statsPeriod=7d&stream_index=0)

# Note pour dev

en local il se produit un message bizarre qui me dit que le mapping devise n’a pas été trouvé et qui cache un peu la « vraie erreur ».

Pour corriger en local je rajoute 

```rb
    env["devise.mapping"] = Devise.mappings[:user]
```

dans `config/initializers/omniauth.rb#on_failure` 