### PR TITLE
fix(api): Do not remove referent inadvertently

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -69,10 +69,13 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
 
     attrs -= User::FranceconnectFrozenFieldsConcern::FROZEN_FIELDS if @user&.logged_once_with_franceconnect?
 
+    permitted_params = params.permit(*attrs, organisation_ids: [])
+
+    return permitted_params if params[:referent_agent_ids].nil?
+
     referents_i_can_modify = Agent::AgentPolicy::Scope.new(pundit_user, @user.referent_agents).resolve
     referents_i_cant_modify = @user.referent_agents - referents_i_can_modify
 
-    permitted_params = params.permit(*attrs, organisation_ids: [])
     permitted_params.merge(referent_agent_ids: authorized_referent_ids + referents_i_cant_modify.map(&:id))
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::UsersController < Api::V1::AgentAuthBaseController
 
     permitted_params = params.permit(*attrs, organisation_ids: [])
 
-    return permitted_params if params[:referent_agent_ids].nil?
+    return permitted_params unless params.key?(:referent_agent_ids)
 
     referents_i_can_modify = Agent::AgentPolicy::Scope.new(pundit_user, @user.referent_agents).resolve
     referents_i_cant_modify = @user.referent_agents - referents_i_can_modify

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe "/api/v1/users" do
         end.to change { existing_user.reload.last_name }
         expect(existing_user.reload.last_name).to eq("Fastoche")
       end
+
+      it "does not modify user agent referents" do
+        existing_user.referent_agents << myself
+        put "/api/v1/users/#{existing_user.id}", headers:, params:, as: :json
+        expect(existing_user.reload.referent_agents).to eq([myself])
+      end
     end
 
     context "when passing arbitrary referent_agent_ids" do


### PR DESCRIPTION
# Contexte

Un comportement inattendu a été introduit suite à #5050 . 
En effet, si on met à jour un usager via API (`put api/v1/:user_id`) et que l'on ne passe pas de `referent_agent_ids` dans le payload, les référents de l'usager peuvent être enlevés.
Plus précisément, tous les référents assignés que l'agent peut modifier seront enlevés puisque `authorized_agent_ids` ne renverra aucun agent, et donc la ligne `permitted_params.merge(referent_agent_ids: authorized_referent_ids + referents_i_cant_modify.map(&:id))` renverra uniquement les référents déjà assignés que l'on ne peut pas modifier.

# Solution

Je fais un quick fix pour ne pas modifier les référents lorsque `referent_agent_ids` n'est pas passé dans la requête. J'ajoute un test pour vérifier que c'est bien la cas.

En fonction de l'usage qui est fait de l'API je me dis qu'il pourrait être envisageable à terme de ne plus permettre le passage de `referent_agent_ids` pour l'update d'un usager. De notre côté, pour mettre à jour les référents d'un usager existant, nous passons uniquement par les endpoints `api/v1/referents_assignation#create` et `api/v1/referents_assignations#destroy` 