### PR TITLE
Corrections date de naissance dans le formulaire de fusion d’usagers

### DIFF
--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -33,9 +33,12 @@ class MergeUsersForm
   end
 
   def available_attributes
-    return %i[first_name last_name birth_date responsible_id] if user1&.relative? || user2&.relative?
-
-    ATTRIBUTES + optional_attributes
+    attrs = ATTRIBUTES + optional_attributes
+    if user1&.relative? || user2&.relative?
+      # cette intersection permet d’éviter d’exposer des champs optionnels à tort
+      attrs &= %i[first_name last_name birth_date responsible_id]
+    end
+    attrs
   end
 
   def attribute_comparison(attribute)

--- a/app/form_models/merge_users_form.rb
+++ b/app/form_models/merge_users_form.rb
@@ -3,7 +3,7 @@ class MergeUsersForm
 
   ATTRIBUTES = %i[
     email
-    first_name last_name birth_name birth_date phone_number responsible_id
+    first_name last_name birth_name phone_number responsible_id
     address
   ].freeze
 

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -55,5 +55,27 @@ RSpec.describe MergeUsersForm, type: :form do
 
       it { is_expected.not_to include(:birth_date) }
     end
+
+    context "un des deux usagers à fusionner est un proche" do
+      context "les dates de naissance sont disponibles sur le territoire" do
+        let(:territory) { create(:territory, enable_birth_date_field: true) }
+        let(:organisation) { create(:organisation, territory:) }
+        let(:user1) { create(:user, :relative, organisations: [organisation]) }
+        let(:user2) { create(:user, organisations: [organisation]) }
+        let(:form) { described_class.new(organisation, user1:, user2:) }
+
+        it { is_expected.to match_array(%i[first_name last_name birth_date responsible_id]) }
+      end
+
+      context "les dates de naissance ne sont pas disponibles sur le territoire" do
+        let(:territory) { create(:territory, enable_birth_date_field: false) }
+        let(:organisation) { create(:organisation, territory:) }
+        let(:user1) { create(:user, :relative, organisations: [organisation]) }
+        let(:user2) { create(:user, organisations: [organisation]) }
+        let(:form) { described_class.new(organisation, user1:, user2:) }
+
+        it { is_expected.to match_array(%i[first_name last_name responsible_id]) } # no birth_date
+      end
+    end
   end
 end

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe MergeUsersForm, type: :form do
       let(:organisation) { create(:organisation, territory:) }
       let(:user1) { create(:user, organisations: [organisation]) }
       let(:user2) { create(:user, organisations: [organisation]) }
-      let(:form) { described_class.new(organisation, user1: user1, user2: user2) }
+      let(:form) { described_class.new(organisation, user1:, user2:) }
 
       it { is_expected.to include(:birth_date) }
     end
@@ -51,7 +51,7 @@ RSpec.describe MergeUsersForm, type: :form do
       let(:organisation) { create(:organisation, territory:) }
       let(:user1) { create(:user, organisations: [organisation]) }
       let(:user2) { create(:user, organisations: [organisation]) }
-      let(:form) { described_class.new(organisation, user1: user1, user2: user2) }
+      let(:form) { described_class.new(organisation, user1:, user2:) }
 
       it { is_expected.not_to include(:birth_date) }
     end

--- a/spec/form_models/merge_users_form_spec.rb
+++ b/spec/form_models/merge_users_form_spec.rb
@@ -32,4 +32,28 @@ RSpec.describe MergeUsersForm, type: :form do
     merge_users_form = described_class.new(organisation, user1: user1, user2: user2, **merge_users_params)
     expect(merge_users_form).to be_invalid
   end
+
+  describe "#available_attributes" do
+    subject { form.available_attributes }
+
+    context "les dates de naissance sont disponibles sur le territoire" do
+      let(:territory) { create(:territory, enable_birth_date_field: true) }
+      let(:organisation) { create(:organisation, territory:) }
+      let(:user1) { create(:user, organisations: [organisation]) }
+      let(:user2) { create(:user, organisations: [organisation]) }
+      let(:form) { described_class.new(organisation, user1: user1, user2: user2) }
+
+      it { is_expected.to include(:birth_date) }
+    end
+
+    context "les dates de naissance ne sont pas disponibles sur le territoire" do
+      let(:territory) { create(:territory, enable_birth_date_field: false) }
+      let(:organisation) { create(:organisation, territory:) }
+      let(:user1) { create(:user, organisations: [organisation]) }
+      let(:user2) { create(:user, organisations: [organisation]) }
+      let(:form) { described_class.new(organisation, user1: user1, user2: user2) }
+
+      it { is_expected.not_to include(:birth_date) }
+    end
+  end
 end


### PR DESCRIPTION
# Contexte

Clarisse nous a averti que la date de naissance apparait en double sur la page de fusion des usagers :  cf https://zammad10.ethibox.fr/#ticket/zoom/22885

Il y a en effet un bug depuis #5165 qui a introduit un nouveau booléen sur les `territories.enable_birth_date_field`.

Il y avait en fait déjà des incohérences dans l’affichage ou non de la date de naissance avant cette PR mais elle met en exergue certaines de ces incohérences.

# Questions existentielles

> [!WARNING]
> Je ne suis pas tout à fait sûr du sens dans lequel il faut corriger : 

1. faire disparaître toute trace de dates de naissance sur les territoires où c’est désactivé
2. préserver le comportement hybride pré-existant : la date apparaît sur la fiche usager mais n’est pas modifiable, elle apparaît aussi sur la page de fusion

Je suis parti vers 1. mais je ne suis pas ~~tout à fait~~ du tout sûr de moi

Après réflexion, la fusion d’usagers va nécessairement mener à une fusion de tous les attributs de l’usager, y compris ceux optionnels par territoire : date de naissance, logement. 

Les annotations (ex-remarques) sont maintenant cloisonnées par territoires donc elles ne posent pas ce même souci. Pour qu’on ait vraiment le choix il faudrait cloisonner par territoire tous les champs optionnels par territoire.

La question se transforme donc en : **veut on montrer les valeurs des champs désactivés sur un territoire avant de les fusionner ?** 

Je ne sais pas trop quoi en penser 🤔 