### PR TITLE
Prise en compte des codes `street_ban_id` temporaire de l'api de geocoding

### DIFF
--- a/app/javascript/components/places-inputs.js
+++ b/app/javascript/components/places-inputs.js
@@ -57,8 +57,8 @@ class PlacesInput {
       return { street_ban_id: feature.properties.id, street_name: feature.properties.name }
     }
     if (feature.properties.type === "housenumber") {
-      // 5 chars for city insee code, 1 for _, 4 for street fantoir
-      return { street_ban_id: feature.properties.id.substring(0,10) }
+      // 5 chars for city insee code, 1 for _, 4 (or more) for street fantoir
+      return { street_ban_id: feature.properties.id.split("_").slice(0, 2).join("_") }
     }
 
     return {}
@@ -92,7 +92,7 @@ class PlacesInput {
     `
   }
 
-  // exemple de name : 52 Avenue Jean Jaurès, city : Paris, postcode : 75019. 
+  // exemple de name : 52 Avenue Jean Jaurès, city : Paris, postcode : 75019.
   // District et context ont été supprimé afin de récupérer des adresses plus courtes. Exemple district: Paris 19e Arrondissement, context: 75, Paris, Île-de-France
   getDetails = ({ name, city, postcode }) => {
     let attributes = [postcode]

--- a/app/lib/geo_coding.rb
+++ b/app/lib/geo_coding.rb
@@ -9,8 +9,8 @@ class GeoCoding
 
     {
       city_code: feature.dig("properties", "citycode"),
-      # 5 chars for city insee code, 1 for _, 4 for street fantoir
-      street_ban_id: feature.dig("properties", "id").first(10),
+      # 5 chars for city insee code, 1 for _, 4 (or more) for street fantoir
+      street_ban_id: feature.dig("properties", "id").split("_").first(2).join("_"),
     }
   end
 

--- a/spec/lib/geo_coding_spec.rb
+++ b/spec/lib/geo_coding_spec.rb
@@ -11,4 +11,102 @@ RSpec.describe GeoCoding do
       expect(described_class.new.find_geo_coordinates("03 Rue Lambert, Paris, 75018")).to eq([2.372095, 48.88393])
     end
   end
+
+  describe "#get_geolocation_results" do
+    let(:geo_coding) { described_class.new }
+    let(:address) { "20 avenue de Ségur, Paris, 75007" }
+    let(:departement_number) { "75" }
+
+    context "avec un identifiant de rue contenant trois parties" do
+      before do
+        stub_request(
+          :get,
+          "https://api-adresse.data.gouv.fr/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+        ).to_return(
+          status: 200,
+          body: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [2.372095, 48.88393] },
+                properties: {
+                  id: "75056_qehkqd_00053",
+                  citycode: "75056",
+                  context: "75, Paris, Île-de-France",
+                },
+              },
+            ],
+          }.to_json,
+          headers: {}
+        )
+      end
+
+      it "supprime tout ce qui se trouve après le deuxième underscore" do
+        result = geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(result).to include(
+          city_code: "75056",
+          street_ban_id: "75056_qehkqd"
+        )
+      end
+    end
+
+    context "avec un identifiant de rue contenant deux parties" do
+      before do
+        stub_request(
+          :get,
+          "https://api-adresse.data.gouv.fr/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+        ).to_return(
+          status: 200,
+          body: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [2.372095, 48.88393] },
+                properties: {
+                  id: "75056_1234",
+                  citycode: "75056",
+                  context: "75, Paris, Île-de-France",
+                },
+              },
+            ],
+          }.to_json,
+          headers: {}
+        )
+      end
+
+      it "conserve l'identifiant tel quel" do
+        result = geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(result).to include(
+          city_code: "75056",
+          street_ban_id: "75056_1234"
+        )
+      end
+    end
+
+    context "quand aucun résultat n'est trouvé" do
+      before do
+        stub_request(
+          :get,
+          "https://api-adresse.data.gouv.fr/search/?q=20%20avenue%20de%20S%C3%A9gur,%20Paris,%2075007"
+        ).to_return(
+          status: 200,
+          body: {
+            type: "FeatureCollection",
+            features: [],
+          }.to_json,
+          headers: {}
+        )
+      end
+
+      it "retourne nil" do
+        result = geo_coding.get_geolocation_results(address, departement_number)
+
+        expect(result).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Nous avons identifier des problèmes de sectorisation dans certains cas pour RDVI (mais ca concerne la secto dans son ensemble)
Les codes `street_ban_id` peuvent avoir plus de 10 caractères quand ils sont attribués de manière temporaire.
https://doc.adresse.data.gouv.fr/utiliser-la-base-adresse-nationale/adresses-et-fantoir

Or nous ne les prenions pas en compte avec le systéme actuel (qui drop les caractères à partir de 10)
Pour éviter les soucis dans le futur on supprime tout les caractères à partir du 2eme underscore.
Les codes valides auparavant le reste.
exemples :
13215_8397_000053 donnera tojours 13215_8397
13215_ua2jq7_00012 donnera 13215_ua2jq7 (au lieu de 13215_ua2j avant ce fix)
Avec le fix le matching de la secto se fait correctement puisque les street_ban_id correspondent désormais.
