### PR TITLE
WIP ajout d’un avertissement lié à la synchro lors du changement de niveau de notif email

### DIFF
--- a/app/controllers/agents/preferences_controller.rb
+++ b/app/controllers/agents/preferences_controller.rb
@@ -4,26 +4,33 @@ class Agents::PreferencesController < AgentAuthController
   before_action { @active_agent_preferences_menu_item = :notifications }
 
   def show
-    @agent = current_agent
-    authorize(@agent, policy_class: Agent::AgentPolicy)
+    @form = Admin::PreferencesForm.new(agent: current_agent)
+    authorize(@form.agent, policy_class: Agent::AgentPolicy)
   end
 
   def update
-    @agent = current_agent
-    authorize(@agent, policy_class: Agent::AgentPolicy)
+    @form = Admin::PreferencesForm.new(agent: current_agent)
+    authorize(@form.agent, policy_class: Agent::AgentPolicy)
 
-    if @agent.update(update_params)
+    if @form.submit(update_params)
       redirect_to agents_preferences_path, flash: { success: t(".update.done") }
     else
       render :show
     end
   end
 
+  private
+
   def pundit_user
     AgentContext.new(current_agent)
   end
 
   def update_params
-    params.require(:agent).permit(:rdv_notifications_level, :plage_ouverture_notification_level, :absence_notification_level)
+    params.require(:agent).permit(
+      :rdv_notifications_level,
+      :plage_ouverture_notification_level,
+      :absence_notification_level,
+      :ignore_benign_errors
+    )
   end
 end

--- a/app/form_models/admin/preferences_form.rb
+++ b/app/form_models/admin/preferences_form.rb
@@ -1,0 +1,44 @@
+class Admin::PreferencesForm
+  include BenignErrors
+  include ActiveModel::Model
+
+  attr_reader :agent
+
+  delegate(
+    :rdv_notifications_level,
+    :rdv_notifications_level_changed?,
+    :plage_ouverture_notification_level,
+    :absence_notification_level,
+    :errors,
+    to: :agent
+  )
+
+  validate :warn_ics_sync
+
+  def initialize(agent:)
+    @agent = agent
+  end
+
+  def submit(params)
+    params_form = params.dup.to_h.symbolize_keys
+    params_agent = params_form.slice!(:ignore_benign_errors)
+
+    assign_attributes(params_form)
+    agent.assign_attributes(params_agent)
+    return unless valid?
+
+    agent.save
+  end
+
+  def warn_ics_sync
+    return if ignore_benign_errors || !rdv_notifications_level_changed? || rdv_notifications_level == "all"
+
+    add_benign_error(
+      <<~TXT
+        Si vous avez un calendrier externe (par exemple Outlook) synchronisé avec RDV Solidarités
+        via email, nous vous conseillons de recevoir un email de notification pour chaque changement
+        pour éviter de rater des synchronisations.
+      TXT
+    )
+  end
+end

--- a/app/views/agents/preferences/show.html.slim
+++ b/app/views/agents/preferences/show.html.slim
@@ -1,7 +1,7 @@
 - content_for :title, t(".title")
 
-= simple_form_for(@agent, url: agents_preferences_path) do |f|
-  = render "devise/shared/error_messages", resource: @agent
+= simple_form_for(@form, url: agents_preferences_path, method: :put, as: "agent") do |f|
+  = render "model_errors", model: @form, f:
 
   p.lead.font-weight-bold= t(".rdv_notifications_header")
   = f.collection_radio_buttons :rdv_notifications_level, Agent.human_attribute_values(:rdv_notifications_level), :last, :first do |b|


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5234.osc-secnum-fr1.scalingo.io/)  `martine@demo.rdv-solidarites.fr` : `Rdvservicepublictest1!`

> [!WARNING]
> WIP - ne pas review

# Contexte

Plusieurs tickets récents sur Zammad provenaient d’agents indiquant que leur calendrier externes (outlook ou autres) n’étaient pas correctement synchronisés ou alors partiellement.
Pour plusieurs de ces agents j’ai vu que leurs préférences d’emails n’étaient pas à chaque modif mais dans les 24 dernières heures, ce qui peut expliquer le problème.

J’ai constaté que le défaut était bien à chaque modification.
Ces agents avaient donc modifié volontairement leurs préférences.

Je pense qu’actuellement c’est difficile de comprendre le lien entre emails de notifs et synchro dans un calendrier externe.


# Solution

<img width="694" alt="image" src="https://github.com/user-attachments/assets/66716c31-89da-43fa-8055-a534162d35f8" />
