### PR TITLE
améliorations du mail de confirmation pour les changements d’adresse email

### DIFF
--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -21,10 +21,10 @@ class CustomDeviseMailer < Devise::Mailer
 
   def confirmation_instructions(record, token, opts = {})
     @token = token
-    if record.confirmed_at.nil?
-      devise_mail(record, :confirmation_instructions_signup, opts)
-    else
+    if record.unconfirmed_email.present? && record.confirmed_at.present?
       devise_mail(record, :confirmation_instructions_email_update, opts)
+    else
+      devise_mail(record, :confirmation_instructions_signup, opts)
     end
   end
 

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -19,6 +19,15 @@ class CustomDeviseMailer < Devise::Mailer
     end
   end
 
+  def confirmation_instructions(record, token, opts = {})
+    @token = token
+    if record.confirmed_at.nil?
+      devise_mail(record, :confirmation_instructions_signup, opts)
+    else
+      devise_mail(record, :confirmation_instructions_email_update, opts)
+    end
+  end
+
   private
 
   def domain

--- a/app/views/devise/mailer/confirmation_instructions.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions.html.slim
@@ -1,4 +1,9 @@
-h1 Merci pour votre inscription !
-p <strong>Nous vous invitons à confirmer votre adresse email</strong> et compléter votre inscription en utilisant le lien suivant&nbsp;:
+h1 Confirmation de votre adresse email
+p
+  |> Cet email nous permet de confirmer que vous recevez bien les emails à l’adresse
+  span{style="white-space: nowrap;"}
+    => @resource.unconfirmed_email
+p
+  | Pour confirmer confirmer et utiliser cette adresse email sur #{domain.name}, veuillez cliquer sur ce bouton :
 .btn-wrapper
-  = link_to "Confirmer mon compte", confirmation_url(@resource, confirmation_token: @token), class:"btn btn-primary"
+  = link_to "Confirmer mon adresse email", confirmation_url(@resource, confirmation_token: @token), class:"btn btn-primary"

--- a/app/views/devise/mailer/confirmation_instructions_email_update.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions_email_update.html.slim
@@ -4,6 +4,6 @@ p
   span{style="white-space: nowrap;"}
     => @resource.unconfirmed_email
 p
-  | Pour confirmer confirmer et utiliser cette adresse email sur #{domain.name}, veuillez cliquer sur ce bouton :
+  | Pour confirmer et utiliser cette adresse email sur #{domain.name}, veuillez cliquer sur ce bouton :
 .btn-wrapper
   = link_to "Confirmer mon adresse email", confirmation_url(@resource, confirmation_token: @token), class:"btn btn-primary"

--- a/app/views/devise/mailer/confirmation_instructions_email_update.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions_email_update.html.slim
@@ -1,4 +1,4 @@
-h1 Confirmation de votre adresse email
+h1 Confirmation de votre nouvelle adresse email
 p
   |> Cet email nous permet de confirmer que vous recevez bien les emails à l’adresse
   span{style="white-space: nowrap;"}

--- a/app/views/devise/mailer/confirmation_instructions_signup.html.slim
+++ b/app/views/devise/mailer/confirmation_instructions_signup.html.slim
@@ -1,0 +1,4 @@
+h1 Merci pour votre inscription !
+p <strong>Nous vous invitons à confirmer votre adresse email</strong> et compléter votre inscription en utilisant le lien suivant&nbsp;:
+.btn-wrapper
+  = link_to "Confirmer mon compte", confirmation_url(@resource, confirmation_token: @token), class:"btn btn-primary"

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -54,8 +54,10 @@ fr:
         accept: "Accepter l'invitation"
         accept_until: "Cette invitation est valable jusqu'au %{due_date}."
         ignore: "Si vous n'acceptez pas cette invitation, ignorez cet email. Aucun compte ne sera créé sans votre autorisation."
-      confirmation_instructions:
-        subject: "Instructions de confirmation de votre adresse email"
+      confirmation_instructions_email_update:
+        subject: "Instructions de confirmation de votre nouvelle adresse email"
+      confirmation_instructions_signup:
+        subject: "Instructions de confirmation"
       reset_password_instructions:
         subject: "Instructions pour changer le mot de passe"
       unlock_instructions:

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -55,7 +55,7 @@ fr:
         accept_until: "Cette invitation est valable jusqu'au %{due_date}."
         ignore: "Si vous n'acceptez pas cette invitation, ignorez cet email. Aucun compte ne sera créé sans votre autorisation."
       confirmation_instructions:
-        subject: "Instructions de confirmation"
+        subject: "Instructions de confirmation de votre adresse email"
       reset_password_instructions:
         subject: "Instructions pour changer le mot de passe"
       unlock_instructions:

--- a/spec/features/agents/account/change_email_spec.rb
+++ b/spec/features/agents/account/change_email_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Agents can change their email" do
     expect(page).to have_content("Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse email")
     perform_enqueued_jobs
     open_email(new_email)
-    current_email.click_link("Confirmer mon compte")
+    current_email.click_link("Confirmer mon adresse email")
 
     expect(page).to have_content("Votre compte a été validé")
     expect(agent.reload.email).to eq(new_email)

--- a/spec/features/agents/users/agent_can_update_user_spec.rb
+++ b/spec/features/agents/users/agent_can_update_user_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Agent can update user" do
     click_button "Enregistrer"
     # When the user has already a pwd, changing email send a confirmation email
     open_email("jeanne@reynolds.com")
-    expect(current_email.subject).to eq I18n.t("devise.mailer.confirmation_instructions.subject")
+    expect(current_email.subject).to eq "Instructions de confirmation de votre nouvelle adresse email"
     expect_page_title("jeanne REYNOLDS")
     expect(page).to have_content("En attente de confirmation pour jeanne@reynolds.com")
   end

--- a/spec/mailers/previews/custom_devise_mailer_preview.rb
+++ b/spec/mailers/previews/custom_devise_mailer_preview.rb
@@ -1,6 +1,9 @@
 class CustomDeviseMailerPreview < ActionMailer::Preview
   def confirmation_instructions
-    CustomDeviseMailer.confirmation_instructions(Agent.first, {})
+    agent = Agent.first
+    agent.readonly!
+    agent.unconfirmed_email = "alain-nouveau@rdv-insertion.fr"
+    CustomDeviseMailer.confirmation_instructions(agent, {})
   end
 
   def reset_password_instructions

--- a/spec/mailers/previews/custom_devise_mailer_preview.rb
+++ b/spec/mailers/previews/custom_devise_mailer_preview.rb
@@ -1,9 +1,23 @@
 class CustomDeviseMailerPreview < ActionMailer::Preview
-  def confirmation_instructions
-    agent = Agent.first
+  def confirmation_instructions_signup
+    agent = Agent.new(
+      email: "ancien_email@demo.rdv-insertion.fr",
+      confirmed_at: nil,
+      confirmation_token: "abcd1234"
+    )
     agent.readonly!
-    agent.unconfirmed_email = "alain-nouveau@rdv-insertion.fr"
-    CustomDeviseMailer.confirmation_instructions(agent, {})
+    CustomDeviseMailer.confirmation_instructions(agent, agent.confirmation_token)
+  end
+
+  def confirmation_instructions_email_update
+    agent = Agent.new(
+      email: "ancien_email@demo.rdv-insertion.fr",
+      confirmed_at: 2.days.ago,
+      unconfirmed_email: "alain-nouveau@demo.rdv-insertion.fr",
+      confirmation_token: "abcd1234"
+    )
+    agent.readonly!
+    CustomDeviseMailer.confirmation_instructions(agent, agent.confirmation_token)
   end
 
   def reset_password_instructions


### PR DESCRIPTION
# Contexte

Ça suit entre autres [ce ticket zammad](https://zammad10.ethibox.fr/#ticket/zoom/22891) dans lequel une conseillère numérique avait perdu l’accès à son compte suite à un changement d’email. 

Je me suis rendu compte que l’email qu’on envoie lorsqu’un agent demande à changer son email porte à confusion. Il parle « d’inscription » et de « confirmation de compte » plutôt que de changement d’adresse email.

# Solution

Côté agent, cet email est envoyé : 
- changement de son propre email d’agent
- changement de l’email d’un usager
- en revanche, j’ai vérifié, à l’invitation initiale par un autre agent, c’est un autre email qui est envoyé.

Côté usager cet email est envoyé :
- lors de l’inscription initiale
- lors d’un changement d’adresse email. 

Il faut donc garder le contenu actuel dans le cas d’inscription initiale d’un usager.

J’ai overridé la méthode `CustomDeviseMailer#confirmation_instructions` pour utiliser deux templates différents pour l’email : 
- `confirmation_instructions_signup` = l’actuel
- `confirmation_instructions_email_change` = le nouvel email

Une piste alternative aurait été de faire des conditions directement au niveau du template existante de mail `confirmation_instructions.html.slim` mais ça ne permet pas de modifier le sujet de l’email, ce qui me paraît ici utile.

## Captures d'écran

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/3ec371f6-5d29-477a-b73a-085bf038c61c" />
