### PR TITLE
Arrêter d’envoyer des webhooks pendant les seeds

### DIFF
--- a/app/models/concerns/webhook_deliverable.rb
+++ b/app/models/concerns/webhook_deliverable.rb
@@ -21,12 +21,16 @@ module WebhookDeliverable
   end
 
   def generate_payload_and_send_webhook(action)
+    return unless Rails.configuration.x.webhooks_enabled
+
     subscribed_webhook_endpoints.each do |endpoint|
       WebhookJob.perform_later(generate_webhook_payload(action), endpoint.id)
     end
   end
 
   def generate_payload_and_send_webhook_for_destroy
+    return unless Rails.configuration.x.webhooks_enabled
+
     # Prépare les données à envoyer, avant de supprimer l'objet
     payloads = subscribed_webhook_endpoints.index_with do |_endpoint|
       generate_webhook_payload(:destroyed)

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,8 @@ module Lapin
 
     config.x.rack_attack.limit = 50
 
+    config.x.webhooks_enabled = true
+
     config.exceptions_app = routes # Permet les pages d'erreur custom
 
     config.active_record.async_query_executor = :global_thread_pool

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -118,4 +118,6 @@ Rails.application.configure do
   config.hosts << "www.rdv-solidarites.localhost" # http://rdv-solidarites.localhost:3000/
   config.hosts << "www.rdv-aide-numerique.localhost" # http://rdv-aide-numerique.localhost:3000/
   config.hosts << "www.rdv-mairie.localhost" # http://rdv-mairie.localhost:3000/
+
+  # config.x.webhooks_enabled = false
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,8 @@
 # Keep rdv_insertion seed loading in first as rdv-insertion need specific ids for linking rdv-s and rdv-i models
 # Check this pr : https://github.com/betagouv/rdv-insertion/pull/690
+
+Rails.configuration.x.webhooks_enabled = false
+
 load Rails.root.join("db/seeds/rdv_insertion.rb")
 load Rails.root.join("db/seeds/medico_social.rb")
 load Rails.root.join("db/seeds/cnfs.rb")

--- a/spec/models/concerns/webhook_deliverable_spec.rb
+++ b/spec/models/concerns/webhook_deliverable_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe WebhookDeliverable, type: :concern do
       end
     end
 
-    context "when the webhook endpoint is triggered by the model changes but webhook callbacks are disabled explicitly" do
+    context "when the webhook endpoint is triggered by the model changes but webhook callbacks are disabled explicitly on this record" do
       context "on creation" do
         let!(:rdv) { build(:rdv, organisation: organisation) }
 
@@ -62,6 +62,26 @@ RSpec.describe WebhookDeliverable, type: :concern do
         expect do
           rdv.destroy
         end.not_to have_enqueued_job
+      end
+    end
+
+    context "when the webhook endpoint is triggered by the model changes but webhook callbacks are disabled in the config" do
+      before { Rails.configuration.x.webhooks_enabled = false }
+
+      context "on creation" do
+        let!(:rdv) { build(:rdv, organisation: organisation) }
+
+        it "does not send webhook" do
+          expect { rdv.save }.not_to have_enqueued_job
+        end
+      end
+
+      it "does not send webhook on update" do
+        expect { rdv.update(status: :excused) }.not_to have_enqueued_job
+      end
+
+      it "does not send webhook on deletion" do
+        expect { rdv.destroy }.not_to have_enqueued_job
       end
     end
 

--- a/spec/models/concerns/webhook_deliverable_spec.rb
+++ b/spec/models/concerns/webhook_deliverable_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe WebhookDeliverable, type: :concern do
 
     context "when the webhook endpoint is triggered by the model changes but webhook callbacks are disabled in the config" do
       before { Rails.configuration.x.webhooks_enabled = false }
+      after { Rails.configuration.x.webhooks_enabled = true }
 
       context "on creation" do
         let!(:rdv) { build(:rdv, organisation: organisation) }


### PR DESCRIPTION
# Contexte

Lorsqu’on lance les seeds en local (ou sur la CI j’imagine) ça enqueue quelques WebhookJob inutiles.

# Solution

Je propose ici de rajouter une config rails custom `Rails.configuration.x.webhooks_enabled` qu’on peut désactiver à certains moments.