### PR TITLE
FranceConnect CSRF: ajout d’infos de debug stockées dans Redis

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -30,15 +30,4 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 
     OmniauthCallbacksController.action(:failure).call(env)
   end
-
-  before_callback_phase do |env|
-    # cf https://github.com/betagouv/rdv-service-public/issues/4637
-    Sentry.set_context(
-      :omni_callback, # NOTE: ne pas utiliser 'auth' dans le nom du contexte sinon Sentry le scrubbe
-      {
-        state_from_session: env["rack.session"]["omniauth.state"],
-        state_from_params: Rack::Request.new(env).params["state"],
-      }
-    )
-  end
 end

--- a/lib/omniauth/strategies/franceconnect.rb
+++ b/lib/omniauth/strategies/franceconnect.rb
@@ -22,6 +22,43 @@ module OmniAuth
           email: user_info.email,
         }
       end
+
+      def request_phase
+        res = super # call super before so that session state is set
+        Redis.with_connection do |redis|
+          key = self.class.redis_key_for_state(session["omniauth.state"])
+          redis.hsetnx key, "created_at", Time.zone.now.to_s
+          redis.hsetnx key, "user_agent", request.user_agent
+          redis.expireat key, 2.days.from_now
+        end
+        res
+      end
+
+      def callback_phase
+        # cf https://github.com/betagouv/rdv-service-public/issues/4637
+        request = Rack::Request.new(env)
+        state_from_params = request.params["state"]
+        state_from_session = env["rack.session"]["omniauth.state"]
+        if state_from_session != state_from_params
+          redis_key = self.class.redis_key_for_state(state_from_params)
+          redis_data = Redis.with_connection { |r| r.hgetall redis_key }
+          Sentry.set_context(
+            :omni_callback, # NOTE: ne pas utiliser 'auth' dans le nom du contexte sinon Sentry le scrubbe
+            {
+              state_from_session:,
+              state_from_params:,
+              current_user_agent: request.user_agent,
+              stored_state_created_at: redis_data&.fetch("created_at", nil),
+              stored_state_user_agent: redis_data&.fetch("user_agent", nil),
+            }
+          )
+        end
+        super
+      end
+
+      def self.redis_key_for_state(state)
+        state.present? && "omniauth:franceconnect:state:#{state}"
+      end
     end
   end
 end


### PR DESCRIPTION
# Contexte

cf #3437 

On aimerait en savoir plus et explorer des hypothèses : 

- changement de navigateur entre le clic sur le bouton et le retour de FC
- expiration de la clé car plus de 8h entre le clic et le retour

# Solution

Je propose ici de rajouter des données de debug lorsque l’exception se produit : 

- le datetime de création du `state` retourné par FranceConnect. Cela correspond au moment où l’usager a cliqué sur le bouton FranceConnect depuis la page de connexion. (c’est la `request_phase`)
- le user-agent à ce même moment de clic initial
- le user-agent au moment de l’exception, donc au retour de FranceConnect (c’est la `callback_phase`)

<img width="823" alt="image" src="https://github.com/user-attachments/assets/74cee3f8-9a6e-4c94-a873-b9a55b496512" />


Pour faire ça je surcharge la stratégie Omniauth FranceConnect. Avant la `request` je stocke dans redis les infos. Avant le callback, je vais chercher dans Redis ces infos précédemment stockées et je les mets en contexte extra d’une éventuelle erreur sentry.

# Tests

Il n’y a pas de tests automatiques de tout ça, ça me paraît compliqué à mettre en place.

En local j’ai testé : 
- un parcours sans erreur
- un parcours avec erreur + la clé est retrouvée dans redis => on a toutes les infos comme sur le screenshot
- un parcours avec erreur + la clé n’est pas retrouvée dans redis => on a seulement une partie des infos dans Redis (j’ai fait un flushall manuellement pour tester ça) 
