### PR TITLE
a11y: correction de la liste sélection service/motif

### DIFF
--- a/app/views/search/_service_selection.html.slim
+++ b/app/views/search/_service_selection.html.slim
@@ -11,7 +11,8 @@
         h2.fr-accordion__title
           button.fr-accordion__btn.fr-text--lead type="button" aria-expanded="false" aria-controls="fr-accordion-#{service.id}" = service.name
         .fr-collapse id="fr-accordion-#{service.id}"
-          - context.motifs_grouped_by_service_id[service.id].uniq(&:name_with_location_type).sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
-            = render "search/motif_card", context: context, motif: motif, service_id: service.id
+          ul.fr-raw-list
+            - context.motifs_grouped_by_service_id[service.id].uniq(&:name_with_location_type).sort_by { |motif| I18n.transliterate(motif.name.downcase)}.each do |motif|
+              = render "search/motif_card", context: context, motif: motif, service_id: service.id
 
 = render "search/referent_booking_card", context: context


### PR DESCRIPTION
# Contexte

En faisant l’audit interne d’accessibilité, nous nous sommes rendu compte que les éléments des listes n’étaient pas dans les `ul`.

# Solution

On rajoute la balise manquante.
