### PR TITLE
Correctif pour les agents avec des majuscules dans leur email ProConnect

### DIFF
--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -31,7 +31,7 @@ class AgentConnectController < ApplicationController
 
     # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
     # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub
-    agent = Agent.active.find_by(email: callback_client.user_email)
+    agent = Agent.active.find_by(email: callback_client.user_email.downcase) # Certains agents ont des majuscultes dans leur email ProConnect, mais on les enlève automatiquement sur la table agents
 
     if current_domain.allow_agent_creation_with_agent_connect
       agent ||= Agent.new(email: callback_client.user_email, password: SecureRandom.base64(32))

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -92,5 +92,30 @@ RSpec.describe AgentConnectController do
         )
       end
     end
+
+    context "when the agent has a capital letter in their ProConnect email address" do
+      let(:user_info) do
+        {
+          "sub" => "ab70770d-1285-46e6-b4d0-3601b49698d4",
+          "email" => "JEAN.MICHEL.FACTICE@exemple.gouv.fr",
+          "given_name" => "Jean Michel Factice",
+          "usual_name" => "Factice",
+          "siret" => "11006801200050",
+          "aud" => "4ec41582-1d60-4f12-a63b-d8abaace16ba",
+          "exp" => 1717595030, "iat" => 1717594970, "iss" => "https://fca.integ01.dev-agentconnect.fr/api/v2",
+        }
+      end
+
+      it "finds the right agent and updates them" do
+        agent = create(:agent, email: "JEAN.MICHEL.FACTICE@exemple.gouv.fr")
+        get :callback, params: { state: state, code: code }
+
+        expect(agent.reload).to have_attributes(
+          first_name: "Jean Michel",
+          last_name: "Factice",
+          proconnect_siret: "11006801200050"
+        )
+      end
+    end
   end
 end

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe AgentConnectController do
       end
 
       it "finds the right agent and updates them" do
-        agent = create(:agent, email: "JEAN.MICHEL.FACTICE@exemple.gouv.fr")
+        agent = create(:agent, email: "JEAN.MICHEL.FACTICE@exemple.gouv.fr") # même si on crée l'agent avec des majuscule dans l'email, il sera persisté en base avec des minuscules
         get :callback, params: { state: state, code: code }
 
         expect(agent.reload).to have_attributes(


### PR DESCRIPTION
# Contexte

Correctif pour https://sentry.incubateur.net/organizations/betagouv/issues/154731/ (et pour https://zammad10.ethibox.fr/#ticket/zoom/23098).
Si un agent a des majuscules dans son email ProConnect, le `find_by email:` ne  renvoie rien, mais on a quand même une erreur ActiveRecord::RecordInvalid

# Solution

on downcase l'email dans le find_by


