### PR TITLE
Indiquer l'adresse email à utiliser sur ProConnect quand un agent est invité à se créer un compte

### DIFF
--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -7,7 +7,7 @@
         h2 Se créer un compte avec ProConnect
         .rdv-text-align-center
           - if display_agent_connect_button?
-            = render "common/proconnect_button_dsfr", locals: { login_hint: resource.email }
+            = render "common/proconnect_button_dsfr", login_hint: resource.email
 
         p.fr-mt-3w.fr-hr-or = "ou"
 

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -3,8 +3,6 @@
 .fr-container
   .fr-grid-row.fr-grid-row--center
     .fr-col-xs-12.fr-col-md-8.fr-py-5w
-      h1.fr-pb-3w Création de compte sur #{current_domain.name}
-
       - if display_agent_connect_button?
         h2 Se créer un compte avec ProConnect
         .rdv-text-align-center

--- a/app/views/admin/territories/invitations_devise/edit.html.slim
+++ b/app/views/admin/territories/invitations_devise/edit.html.slim
@@ -9,7 +9,7 @@
         h2 Se créer un compte avec ProConnect
         .rdv-text-align-center
           - if display_agent_connect_button?
-            = render "common/proconnect_button_dsfr"
+            = render "common/proconnect_button_dsfr", locals: { login_hint: resource.email }
 
         p.fr-mt-3w.fr-hr-or = "ou"
 

--- a/app/views/common/_proconnect_button_dsfr.html.slim
+++ b/app/views/common/_proconnect_button_dsfr.html.slim
@@ -1,7 +1,8 @@
+/# locals: (login_hint: nil)
 form.fr-connect-group[action="#{agent_connect_auth_path}" method="get"]
 
-  - if locals[:login_hint]
-    input[type="hidden" value="#{locals[:login_hint]}" name="login_hint"]
+  - if login_hint
+    input[type="hidden" value="#{login_hint}" name="login_hint"]
   button.fr-connect.fr-proconnect
     span.fr-connect__login
       | S’identifier avec

--- a/app/views/common/_proconnect_button_dsfr.html.slim
+++ b/app/views/common/_proconnect_button_dsfr.html.slim
@@ -1,4 +1,7 @@
-form.fr-connect-group[action="/agent_connect/auth" method="get"]
+form.fr-connect-group[action="#{agent_connect_auth_path}" method="get"]
+
+  - if locals[:login_hint]
+    input[type="hidden" value="#{locals[:login_hint]}" name="login_hint"]
   button.fr-connect.fr-proconnect
     span.fr-connect__login
       | S’identifier avec

--- a/spec/controllers/agent_connect_controller_spec.rb
+++ b/spec/controllers/agent_connect_controller_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe AgentConnectController do
 
   describe "#auth" do
     it "redirects to AgentConnect" do
-      get :auth
+      get :auth, params: { login_hint: "francis.factice@exemple.gouv.fr" }
       expect(response).to redirect_to(start_with("https://fca.integ01.dev-agentconnect.fr/api/v2/authorize?"))
 
       redirect_url = response.headers["Location"]
       redirect_url_query_params = Rack::Utils.parse_query(URI.parse(redirect_url).query)
 
       expect(redirect_url_query_params.symbolize_keys).to match(
+        login_hint: "francis.factice@exemple.gouv.fr",
         acr_values: "eidas1",
         client_id: "ec41582-1d60-4f11-a63b-d8abaece16aa",
         redirect_uri: "http://test.host/agent_connect/callback",

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Agent can accept invitation" do
     it "sets the login_hint to make sure the agent uses ProConnect with the right email and avoids getting stuck" do
       agent.deliver_invitation
       visit accept_agent_invitation_path(invitation_token: agent.raw_invitation_token)
+      expect(page).to have_content "Se créer un compte avec ProConnect"
       find(".fr-connect__brand").click
       begin
         click_button("ProConnect")

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe "Agent can accept invitation" do
   context "when using ProConnect" do
     stub_env_with(
       AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
-      AGENT_CONNECT_RDVSP_CLIENT_SECRET: "un faux secret de test",
-      AGENT_CONNECT_RDVSP_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+      AGENT_CONNECT_RDVS_CLIENT_SECRET: "un faux secret de test",
+      AGENT_CONNECT_RDVS_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
     )
 
     it "sets the login_hint to make sure the agent uses ProConnect with the right email and avoids getting stuck" do

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -1,6 +1,24 @@
 RSpec.describe "Agent can accept invitation" do
   let(:agent) { create(:agent) }
 
+  context "when using ProConnect" do
+    it "sets the login_hint to make sure the agent uses ProConnect with the right email and avoids getting stuck" do
+      agent.deliver_invitation
+      visit accept_agent_invitation_path(invitation_token: agent.raw_invitation_token)
+      find(".fr-connect__brand").click
+      begin
+        click_button("ProConnect")
+      rescue ActionController::RoutingError
+        # Capybara essaye de suivre une redirection vers "https://fca.integ01.dev-agentconnect.fr/api/v2/authorize
+        # ce qui n'est pas possible dans l'env de test (il ignore le host et il cherche /api/v2/authorize dans nos routes).
+      end
+
+      redirect_url_query_params = Rack::Utils.parse_query(URI.parse(page.current_url).query)
+
+      expect(redirect_url_query_params["login_hint"]).to eq agent.email
+    end
+  end
+
   context "when password is secure" do
     it "accepts the invitation" do
       agent.deliver_invitation

--- a/spec/features/agents/account/agent_can_accept_invit_spec.rb
+++ b/spec/features/agents/account/agent_can_accept_invit_spec.rb
@@ -2,6 +2,12 @@ RSpec.describe "Agent can accept invitation" do
   let(:agent) { create(:agent) }
 
   context "when using ProConnect" do
+    stub_env_with(
+      AGENT_CONNECT_BASE_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2",
+      AGENT_CONNECT_RDVSP_CLIENT_SECRET: "un faux secret de test",
+      AGENT_CONNECT_RDVSP_CLIENT_ID: "ec41582-1d60-4f11-a63b-d8abaece16aa"
+    )
+
     it "sets the login_hint to make sure the agent uses ProConnect with the right email and avoids getting stuck" do
       agent.deliver_invitation
       visit accept_agent_invitation_path(invitation_token: agent.raw_invitation_token)


### PR DESCRIPTION
# Contexte

Lorsqu'un agent est invité à rejoindre une organisation, il reçoit un mail qui le redirige vers cette page.
<img width="1412" alt="Screenshot 2025-04-16 at 11 51 09" src="https://github.com/user-attachments/assets/7792bdd7-3304-4284-9596-2637c83f8252" />

S'il utilise ensuite ProConnect, il est possible qu'il utilise une adresse mail différente de celle qui a reçu l'invitation. Dans ce cas il sera bloqué et ne pourra pas rejoindre son organisation
![Uploading Screenshot 2025-04-16 at 11.51.46.png…]()


# Solution

On utilise l'option login_hint de ProConnect pour pré-remplir l'adresse email que l'agent est censé utiliser.
Ça ne marchera pas dans tous les cas (l'agent peut effacer l'adresse email et en utiliser une autre), mais ça devrait déjà limiter le nombre d'erreurs et de demande au support qu'on a pour ce problème.
<img width="1317" alt="Screenshot 2025-04-16 at 11 51 37" src="https://github.com/user-attachments/assets/c736452a-50c2-4e88-b3fb-883340e87cc2" />


