### PR TITLE
a11y: ajout de l’attribut autocomplete form info usagers

### DIFF
--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -12,6 +12,6 @@ section.rdv-background-color-alt-blue-ecume.fr-pt-4w.fr-pb-8w
         / TODO: change input name to address and change whereInput in application.js
         = f.label :where, "Saisissez votre adresse", class: "fr-label"
         .fr-search-bar.fr-search-bar--lg[role="search"]
-          = f.text_field :where, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input", required: true, value: context.address, data: { "address-autocomplete": "on" }
+          = f.text_field :where, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input", required: true, value: context.address, data: { "address-autocomplete": "on" }, autocomplete: "street-address"
           = button_tag :button, id: "search_submit", class: "fr-btn" do
             | Rechercher

--- a/app/views/users/registrations/edit.html.slim
+++ b/app/views/users/registrations/edit.html.slim
@@ -6,7 +6,7 @@
       .fr-alert.fr-alert--info.fr-mb-3w
         | Vous pouvez ici changer l'email et le mot de passe de votre compte #{current_domain.name}, et pas ceux de FranceConnect
     = form_for resource, as: resource_name, url: registration_path(resource_name), remote: request.xhr?, html: { method: :put }, builder: Dsfr::FormBuilder do |f|
-      = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
+      = f.dsfr_email_field :email, value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), autocomplete: "email"
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         .form-text.rdv-color-text-mention-grey.mb-2
           | En attente de confirmation pour #{resource.unconfirmed_email}

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -15,11 +15,11 @@
       = render "devise/shared/dsfr_error_messages", resource: resource
       .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
         .fr-col-6
-          = f.dsfr_text_field :first_name, label: "Prénom", required: true
+          = f.dsfr_text_field :first_name, label: "Prénom", required: true, autocomplete: "given-name"
         .fr-col-6
-          = f.dsfr_text_field :last_name, label: "Nom", required: true
+          = f.dsfr_text_field :last_name, label: "Nom", required: true, autocomplete: "family-name"
       = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true
-      = f.dsfr_phone_field :phone_number, label: "Numéro de téléphone", hint: "Vous recevrez les rappels et les informations du RDV sur ce numéro."
+      = f.dsfr_phone_field :phone_number, label: "Numéro de téléphone", hint: "Vous recevrez les rappels et les informations du RDV sur ce numéro.", autocomplete: "tel"
 
       .form-group
         small

--- a/app/views/users/relatives/_form_fields.html.slim
+++ b/app/views/users/relatives/_form_fields.html.slim
@@ -1,9 +1,9 @@
 .fr-grid-row.fr-grid-row--gutters.fr-mb-5v
-  .fr-col-md-6= f.dsfr_text_field :first_name
-  .fr-col-md-6= f.dsfr_text_field :last_name
+  .fr-col-md-6= f.dsfr_text_field :first_name, autocomplete: "given-name"
+  .fr-col-md-6= f.dsfr_text_field :last_name, autocomplete: "family-name"
 - if f.object.ants_pre_demande_number_required
   = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), input_html: {style: "text-transform: uppercase;"}
   = f.hidden_field :ants_pre_demande_number_required, value: "true"
   = f.hidden_field :ants_meeting_point_id
 - if current_domain != Domain::RDV_MAIRIE # TODO: trouver un moyen d'avoir le contexte du rdv_wizard, pour ensuite se baser sur current_territory.enable_birth_date_field?
-  = f.dsfr_text_field :birth_date, type: :date, input_html: { type: "date" }
+  = f.dsfr_text_field :birth_date, type: :date, input_html: { type: "date" }, autocomplete: "bday"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -14,7 +14,7 @@
 
     = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
       = render "devise/shared/error_messages", resource: resource
-      = f.dsfr_email_field :email, autofocus: true, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email"
+      = f.dsfr_email_field :email, autofocus: true, hint: "Format attendu : nom@domaine.fr", require: true, label: "Adresse email", autocomplete: "email"
       = render "common/form/current_password_input", f:, forgotten_password_link: true
 
       .rdv-text-align-center

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -7,13 +7,13 @@ ruby:
 = form_for user, url: form_url, method: form_method, builder: Dsfr::FormBuilder do |f|
   = render "model_errors", model: user, f: f
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
-    .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?
-    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?, autocomplete: "given-name"
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, autocomplete: "familiy-name"
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
     - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?
     - if !current_user.signed_in_with_invitation_token? && rdv_wizard&.rdv&.territory&.enable_birth_date_field?
-      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, type: "date", disabled: user.logged_once_with_franceconnect?
+      .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_date, type: "date", disabled: user.logged_once_with_franceconnect?, autocomplete: "bday"
   - if rdv_wizard&.rdv&.requires_ants_predemande_number?
     = f.dsfr_text_field :ants_pre_demande_number, required: true, hint: t("simple_form.hints.user.ants_pre_demande_number_html"), style: "text-transform: uppercase;"
   - if user.logged_once_with_franceconnect?
@@ -22,12 +22,12 @@ ruby:
   - if current_user.signed_in_with_invitation_token?
     - if user.email.present?
       / Pour des raisons historiques on garde le champ email
-      = f.dsfr_email_field :email, disabled: user.email.present? && !user.email_changed?, required: true
+      = f.dsfr_email_field :email, disabled: user.email.present? && !user.email_changed?, required: true, autocomplete: "email"
     - else
       / Nous ne voulons pas perdre d'informations si l'utilisateur a déjà un email de notification, donc le champ est requis
       / L'utilisateur peut définir un email de notification s'il n'en a pas encore, mais ce n'est pas obligatoire
       = f.dsfr_email_field :notification_email, required: user.notification_email.present?
-  = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?
+  = f.dsfr_phone_field :phone_number, as: :tel, required: rdv_wizard&.motif&.phone?, autocomplete: "tel"
   - if user.phone_number.present? && !user.phone_number_mobile?
     .fr-alert.fr-alert--warning.fr-mb-1w Vous ne recevrez pas de SMS avec ce numéro non-mobile
   div.mb-2 Préférences de notifications
@@ -35,10 +35,10 @@ ruby:
   div= f.dsfr_check_box :notify_by_sms
   - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
-    = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }
+    = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address"
 
   - if territories.map(&:enable_address_details).any?
-    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }
+    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }, autocomplete: "street-address"
 
   = f.hidden_field :city_code
   = f.hidden_field :post_code

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -8,7 +8,7 @@ ruby:
   = render "model_errors", model: user, f: f
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
     .fr-col-12.fr-col-md-6= f.dsfr_text_field :first_name, disabled: user.logged_once_with_franceconnect?, autocomplete: "given-name"
-    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, autocomplete: "familiy-name"
+    .fr-col-12.fr-col-md-6= f.dsfr_text_field :last_name, autocomplete: "family-name"
   .fr-grid-row.fr-grid-row--gutters.fr-mb-3v
     - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
       .fr-col-12.fr-col-md-6= f.dsfr_text_field :birth_name, placeholder: "Nom de naissance", disabled: user.logged_once_with_franceconnect?


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit interne d’accessibilité, nous nous sommes rendus compte que nous n’avions pas défini les attributs autocomplete sur les champs de données personnelles utilisateur conformément à la [règle 11.13 du RGAA](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#11.13). 

# Solution

On définit l’attribut autocomplete sur tous les champs de données personnelles des utilisateurs.
