### PR TITLE
Ne pas anonymiser les RDV collectifs ayant encore des participants

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -331,7 +331,9 @@ class User < ApplicationRecord
 
     Anonymizer.anonymize_record!(self)
     receipts.each { |r| Anonymizer.anonymize_record!(r) }
-    rdvs.each { |r| Anonymizer.anonymize_record!(r) }
+    rdvs
+      .select { |r| r.users.where(deleted_at: nil).where.not(id:).empty? }
+      .each { |r| Anonymizer.anonymize_record!(r) }
     annotations.destroy_all
     versions.destroy_all
     update_columns(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe User, type: :model do
       expect(user.versions).to be_empty
     end
 
+    it "n’anonymise pas les RDV collectifs avec d’autres participants" do
+      user1 = create(:user)
+      user2 = create(:user)
+      rdv = create(:rdv, users: [user1, user2], context: "des détails sur le RDV")
+      user1.soft_delete
+      expect(rdv.reload.context).to eq("des détails sur le RDV")
+      user2.soft_delete
+      expect(rdv.reload.context).to match %([valeur unique anonymisée \\d+])
+    end
+
     it "is hidden user by default" do
       user = create(:user)
       user.soft_delete


### PR DESCRIPTION
fix [#5264](https://github.com/betagouv/rdv-service-public/issues/5264)

