### PR TITLE
Éviter des requêtes inutiles sur la page de liste des usagers

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,6 +28,8 @@ class Admin::UsersController < AgentAuthController
     @users = @users.merge(Agent.find(agent_id).users) if agent_id.present?
     @users = @users.search_by_text(search_params) if search_params.present?
     @users = @users.ordered_by_last_name.page(page_number)
+    @users = @users.includes(:responsible)
+    @users.load # Ce préchargement permet d'éviter de déclencher des requêtes inutiles depuis la vue
   end
 
   def search

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -34,9 +34,10 @@
             th Téléphone
             th Email
         tbody id="users-list"
+          / On dédoublonne ici les résultats de la page courante.
           / En effet, on rencontre ce problème : Casecommons/pg_search#238
           / Le uniq est un solution qui casse parfois le décompte, mais ça paraît acceptable !
-          - @users.includes(:responsible).uniq.each do |user|
+          - @users.uniq.each do |user|
             - cache([current_organisation.id, user], expires_in: 7.days)
               = render partial: "admin/users/user", locals: { user: user }
 


### PR DESCRIPTION
# Problème

J'ai remarqué que la page d'index des usagers déclenchait 6 requêtes : 

1. `@users.any?` (index.html.slim:27) déclenche `SELECT 1 AS one FROM 🐌`
2. `@users.includes(:responsible).uniq` (index.html.slim:39) déclenche `SELECT "users".* FROM  🐌`
3. `@users.empty?` (index.html.slim:43) déclenche `SELECT 1 AS one FROM 🐌`
4. `@users.total_pages` (index.html.slim:45) déclenche `SELECT COUNT(*) FROM 🐌`
5. `page_entries_info @users` (index.html.slim:49) déclenche `SELECT COUNT(*) FROM 🐌`
6. `page_entries_info @users` (index.html.slim:49) déclenche `SELECT "users".* FROM 🐌`

L'émoji escargot (🐌) sert à représenter la sous-requête générée par la gem `pg_search` : `SELECT "users"."id" AS pg_search_id, (ts_rank((...`. Cette requête est coûteuse car elle doit ordonner par ordre de pertinence textuelle tous les usagers de l'orga courante (ou du territoire courant dans les Hauts-de-Seine, voir #3429).

# Solution

Nous pouvons limiter à seulement 2 requêtes : 
1. Une requête pour charger les usagers de la page courante
2. Une requête pour compter le nombre total de résultat : cette requête est nécessaire pour la pagination, et est déclenchée à un appel à `@users.total_pages`. Cette méthode de Kaminari [mémoïze le décompte total](https://github.com/kaminari/kaminari/blob/f96e022d0d7540c2e6455debb7992a9a6244a9cb/kaminari-activerecord/lib/kaminari/activerecord/active_record_relation_methods.rb#L17) et est ensuite capable de calculer le nombre de page à partir de ce décompte total

Afin d'éviter tous les appels superflus, il suffit de charger explicitement les usagers de le page courante en appelant `@users.load` dans le contrôleur (avant que la vue ne soit rendered).

Résultat sur ma machine en recherchant "last" dans les usagers de Martine Validay : on passe de 300ms à 150ms.

# Avant

![image](https://github.com/user-attachments/assets/1c1a95d2-da66-440c-953f-2eea82556e09)

# Après

![image](https://github.com/user-attachments/assets/13430502-a0c3-4000-bb01-84b56d99ee1e)
