### PR TITLE
Améliorations du message d’erreur AJAX sur le calendrier agent

### DIFF
--- a/app/javascript/components/calendar.js
+++ b/app/javascript/components/calendar.js
@@ -150,12 +150,25 @@ class CalendarRdvSolidarites {
   }
 
   handleAjaxError = (response) => {
-    if (response.xhr.status === 401) {
-      window.location = this.calendarEl.attributes["data-sign-in-path"].value;
-      return;
+    if (this.ajaxErrorHandledAt) {
+      const secondsSinceLast = (Date.now() - this.ajaxErrorHandledAt) / 1000;
+      if (secondsSinceLast < 60) return
     }
+    this.ajaxErrorHandledAt = Date.now()
 
-    alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr.`);
+    switch (response.xhr.status) {
+      case 401:
+        window.location = this.calendarEl.attributes["data-sign-in-path"].value;
+        break;
+      case 500:
+        alert(`Le chargement du calendrier a échoué; un rapport d’erreur a été transmis à l’équipe.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
+        break;
+      case 0:
+        alert(`Le chargement du calendrier a échoué, probablement car votre connexion internet a été coupée.\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`);
+        break;
+      default:
+        alert(`Le chargement du calendrier a échoué avec une erreur ${response.xhr.status}\nRechargez la page, et si ce problème persiste, contactez-nous à support@rdv-service-public.fr`)
+    }
   }
 }
 


### PR DESCRIPTION
# Contexte

Une agent se plaint de voir ce message fréquemment.

<img width="459" alt="image" src="https://github.com/user-attachments/assets/6808a9c4-6ad4-4768-a487-ed8b2fc43e66" />

Le message étant générique et avec peu de contexte c’est délicat de l’aider.

Aussi en testant j’ai remarqué que quand la connexion avec le serveur est impossible (en stoppant le serveur par ex), le message d’erreur apparaît trois fois de suite - alors que la requête n’est fait et n’échoue qu’une fois 🤷 je suppose que c’est un bug de fullCalendar ou un mauvais usage de notre part.  

# Solution

Je rend le message moins générique avec différents cas : 

- 500 = le message actuel « un rapport nous a été envoyé »
- 0 = « vous êtes probablement déconnecté »
- 401 = comme aujourd’hui, redirection vers sign in
- autre erreur = on affiche le code HTTP dans le message

La prochaine fois qu’on reçoit une capture d’écran on aura plus de contexte pour investiguer.

Aussi je tente une correction pour le bug du triple message avec un debouncer maison à 60s. N’hésitez pas à me dire si vous pensez que ce n’est pas très fiable, je peux le retirer de cette PR

# Tests

Il n’y a à ma connaissance pas de test sur ce message d’erreur et je n’ai pas pris le temps ici d’en ajouter 🙈 