### PR TITLE
refacto : CreneauxSearch accepte duration_in_min 

### DIFF
--- a/app/controllers/api/ants/editor_controller.rb
+++ b/app/controllers/api/ants/editor_controller.rb
@@ -100,10 +100,8 @@ class Api::Ants::EditorController < Api::Ants::BaseController
     end
 
     def time_slots_for_lieu_and_motif(lieu:, motif:)
-      # on change en mémoire, la durée par défaut du motif pour rechercher des créneaux
-      # d'une durée adaptée au nombre de participants au Rdv
-      motif.default_duration_in_min *= users_count
-      CreneauxSearch::ForUser.new(lieu:, motif:, date_range:)
+      duration_in_min = motif.default_duration_in_min * users_count
+      CreneauxSearch::ForUser.new(lieu:, motif:, date_range:, duration_in_min:)
         .creneaux
         .map { creneau_to_time_slot(_1) }
         .uniq
@@ -124,7 +122,7 @@ class Api::Ants::EditorController < Api::Ants::BaseController
           lieu_id: creneau.lieu_id,
           motif_id: creneau.motif.id,
           public_link_organisation_id: creneau.motif.organisation_id,
-          duration: creneau.motif.default_duration_in_min
+          duration: creneau.duration_in_min
         ),
       }
     end

--- a/app/controllers/users/rdvs_controller.rb
+++ b/app/controllers/users/rdvs_controller.rb
@@ -21,15 +21,13 @@ class Users::RdvsController < UserAuthController
   def create
     lieu = new_rdv_extra_params[:lieu_id].present? ? Lieu.find(new_rdv_extra_params[:lieu_id]) : nil
     motif = Motif.find(rdv_params[:motif_id])
-    # Nous modifions en mémoire la durée par défaut du motif
-    # Cela permet d'effectuer une recherche de créneaux, avec une durée différente
-    motif.default_duration_in_min = params[:duration] if params[:duration]
     @creneau = CreneauxSearch::ForUser.creneau_for(
       user: current_user,
       starts_at: Time.zone.parse(rdv_params[:starts_at]),
       motif: motif,
       lieu: lieu,
-      geo_search: @geo_search
+      geo_search: @geo_search,
+      duration_in_min: duration_in_min_for(motif:)
     )
     ActiveRecord::Base.transaction do
       if @creneau.present?
@@ -160,5 +158,13 @@ class Users::RdvsController < UserAuthController
 
   def rdv_params
     params.permit(:starts_at, :motif_id, :context, user_ids: [])
+  end
+
+  def duration_in_min_for(motif:)
+    if params[:duration]
+      params[:duration].to_i
+    else
+      motif.default_duration_in_min
+    end
   end
 end

--- a/app/form_models/user_rdv_wizard.rb
+++ b/app/form_models/user_rdv_wizard.rb
@@ -17,7 +17,7 @@ module UserRdvWizard
         @rdv = Rdv.new({
           user_ids: [user&.id],
         }.merge(@attributes.slice(:starts_at, :user_ids, :motif_id)))
-        @rdv.duration_in_min = @attributes[:duration]&.to_i || @rdv.motif&.default_duration_in_min
+        @rdv.duration_in_min = duration_in_min
         @rdv.organisation_id = @rdv.motif.organisation_id
       end
     end
@@ -31,15 +31,13 @@ module UserRdvWizard
     end
 
     def creneau
-      motif = @rdv.motif
-      motif.default_duration_in_min = @attributes[:duration].to_i if @attributes[:duration]
-
       @creneau ||= CreneauxSearch::ForUser.creneau_for(
         user: @user,
         motif: motif,
         lieu: lieu,
         starts_at: @rdv.starts_at,
-        geo_search: geo_search
+        geo_search: geo_search,
+        duration_in_min:
       )
     end
 
@@ -64,6 +62,14 @@ module UserRdvWizard
     end
 
     def lieu_id = @attributes[:lieu_id]
+
+    def duration_in_min
+      if @attributes[:duration]
+        @attributes[:duration].to_i
+      else
+        motif.default_duration_in_min
+      end
+    end
 
     private
 

--- a/app/services/creneaux_search/for_user.rb
+++ b/app/services/creneaux_search/for_user.rb
@@ -1,19 +1,21 @@
 class CreneauxSearch::ForUser
-  def initialize(motif:, date_range: nil, user: nil, lieu: nil, geo_search: nil)
+  def initialize(motif:, date_range: nil, user: nil, lieu: nil, geo_search: nil, duration_in_min: nil)
     @user = user
     @motif = motif
     @lieu = lieu
     @date_range = date_range
     @geo_search = geo_search
+    @duration_in_min = duration_in_min
   end
 
-  def self.creneau_for(motif:, starts_at:, user: nil, lieu: nil, geo_search: nil)
+  def self.creneau_for(motif:, starts_at:, user: nil, lieu: nil, geo_search: nil, duration_in_min: nil)
     search = new(
       user: user,
       motif: motif,
       lieu: lieu,
       date_range: (starts_at.to_date..(starts_at + 1.day).to_date),
-      geo_search: geo_search
+      geo_search: geo_search,
+      duration_in_min:
     )
 
     search.all_creneaux.select { _1.starts_at == starts_at }.sample
@@ -24,7 +26,7 @@ class CreneauxSearch::ForUser
 
     from = [date_range.begin, @motif.start_booking_delay].max
 
-    CreneauxSearch::NextAvailability.find(motif, @lieu, attributed_agents, from: from, to: @motif.end_booking_delay)
+    CreneauxSearch::NextAvailability.find(motif, @lieu, attributed_agents, from: from, to: @motif.end_booking_delay, duration_in_min:)
   end
 
   def creneaux
@@ -47,12 +49,15 @@ class CreneauxSearch::ForUser
 
     return [] if reduced_date_range.blank?
 
-    CreneauxSearch::Calculator.available_slots(motif:, lieu: @lieu, date_range: reduced_date_range, agents: attributed_agents)
+    CreneauxSearch::Calculator.available_slots(
+      motif:, lieu: @lieu, date_range: reduced_date_range, agents: attributed_agents,
+      **duration_in_min.present? ? { duration_in_min: } : {}
+    )
   end
 
   private
 
-  attr_reader :motif, :date_range
+  attr_reader :motif, :date_range, :duration_in_min
 
   def reduced_date_range
     @reduced_date_range ||= CreneauxSearch::Range.reduce_range_to_delay(motif, date_range) # réduit le range en fonction du délai min du motif

--- a/app/services/creneaux_search/next_availability.rb
+++ b/app/services/creneaux_search/next_availability.rb
@@ -1,5 +1,5 @@
 class CreneauxSearch::NextAvailability
-  def self.find(motif, lieu, agents, from:, to: nil)
+  def self.find(motif, lieu, agents, from:, to: nil, duration_in_min: nil)
     from = from.to_datetime # rubocop:disable Style/DateTime
     to = to&.to_datetime || (from + 6.months) # rubocop:disable Style/DateTime
 
@@ -9,7 +9,7 @@ class CreneauxSearch::NextAvailability
 
       max_creneau_date = [to, date + 7.days].min
 
-      creneaux = CreneauxSearch::Calculator.available_slots(motif:, lieu:, date_range: date..max_creneau_date, agents:)
+      creneaux = CreneauxSearch::Calculator.available_slots(motif:, lieu:, date_range: date..max_creneau_date, agents:, duration_in_min:)
       # NOTE: We build the whole list of creneaux of the week just to return the first one.
       return creneaux.min if creneaux.any?
     end

--- a/app/services/search_context.rb
+++ b/app/services/search_context.rb
@@ -73,12 +73,14 @@ class SearchContext
   end
 
   def creneaux_search_for(lieu, motif)
+    duration_in_min = motif.default_duration_in_min
     CreneauxSearch::ForUser.new(
       user: @user,
       motif: motif,
       lieu: lieu,
       date_range: date_range,
-      geo_search: geo_search
+      geo_search: geo_search,
+      duration_in_min:
     )
   end
 

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe SearchController, type: :controller do
   let!(:rsa_orientation) { create(:motif_category, name: "RSA orientation sur site", short_name: "rsa_orientation") }
   let!(:rsa_orientation_on_phone_platform) { create(:motif_category, name: "RSA orientation sur plateforme téléphonique", short_name: "rsa_orientation_on_phone_platform") }
 
-  let!(:motif) { create(:motif, name: "RSA orientation 1", service: service, motif_category: rsa_orientation, organisation: organisation) }
-  let!(:motif2) { create(:motif, name: "RSA orientation 2", service: service, motif_category: rsa_orientation_on_phone_platform, organisation: organisation) }
-  let!(:motif3) { create(:motif, name: "RSA orientation 3", service: service, organisation: other_org) }
-  let!(:motif4) { create(:motif, name: "Motif numéro 4", service: service, organisation: other_org) }
+  let!(:motif) { create(:motif, name: "RSA orientation 1", service: service, motif_category: rsa_orientation, organisation: organisation, default_duration_in_min: 30) }
+  let!(:motif2) { create(:motif, name: "RSA orientation 2", service: service, motif_category: rsa_orientation_on_phone_platform, organisation: organisation, default_duration_in_min: 30) }
+  let!(:motif3) { create(:motif, name: "RSA orientation 3", service: service, organisation: other_org, default_duration_in_min: 30) }
+  let!(:motif4) { create(:motif, name: "Motif numéro 4", service: service, organisation: other_org, default_duration_in_min: 30) }
 
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
   let!(:plage_ouverture2) { create(:plage_ouverture, motifs: [motif2], lieu: lieu2, organisation: organisation) }
@@ -162,7 +162,8 @@ RSpec.describe SearchController, type: :controller do
           motif: motif,
           lieu: lieu,
           date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 29)),
-          geo_search: geo_search
+          geo_search: geo_search,
+          duration_in_min: 30
         ).and_return(creneaux_search)
       end
 
@@ -198,7 +199,8 @@ RSpec.describe SearchController, type: :controller do
           motif: motif,
           lieu: lieu,
           date_range: (Date.new(2019, 7, 22)..Date.new(2019, 7, 28)),
-          geo_search: geo_search
+          geo_search: geo_search,
+          duration_in_min: 30
         ).and_return(creneaux_search)
       end
 

--- a/spec/controllers/users/rdvs_controller_spec.rb
+++ b/spec/controllers/users/rdvs_controller_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe Users::RdvsController, type: :controller do
           expect(flash[:error]).to eq "Vous n’avez pas les droits suffisants pour accéder à cette page ou effectuer cette action"
         end
       end
+
+      context "when a duration is passed" do
+        let(:motif) { create(:motif, organisation:, default_duration_in_min: 30) }
+
+        it "uses the duration passed" do
+          post :create, params: params.merge(duration: "60")
+          expect(Rdv.count).to eq(1)
+          expect(Rdv.last.duration_in_min).to eq(60)
+        end
+      end
     end
 
     describe "when there is no available creneau" do

--- a/spec/form_models/user_rdv_wizard_spec.rb
+++ b/spec/form_models/user_rdv_wizard_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe UserRdvWizard do
   let!(:organisation) { create(:organisation) }
   let!(:user) { create(:user) }
   let!(:user_for_rdv) { create(:user) }
-  let!(:motif) { create(:motif, organisation: organisation) }
+  let!(:motif) { create(:motif, organisation: organisation, default_duration_in_min: 30) }
   let!(:lieu) { create(:lieu, organisation: organisation) }
   let!(:creneau) { build(:creneau, :respects_booking_delays, motif: motif, starts_at: Time.zone.parse("2020-10-20 09h30")) }
   let!(:plage_ouverture) { create(:plage_ouverture, motifs: [motif], lieu: lieu, organisation: organisation) }
@@ -31,9 +31,28 @@ RSpec.describe UserRdvWizard do
         motif: motif,
         lieu: lieu,
         starts_at: Time.zone.parse("2020-10-20 09h30"),
-        geo_search: mock_geo_search
+        geo_search: mock_geo_search,
+        duration_in_min: 30
       ).and_return(returned_creneau)
       rdv_wizard = UserRdvWizard::Step1.new(user, attributes)
+      expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
+      expect(rdv_wizard.creneau).to eq returned_creneau
+    end
+
+    it "avec un duration_in_min différent de celui du motif" do
+      returned_creneau = Creneau.new
+      allow(Users::GeoSearch).to receive(:new)
+        .with(departement: "62", city_code: "62100")
+        .and_return(mock_geo_search)
+      allow(CreneauxSearch::ForUser).to receive(:creneau_for).with(
+        user: user,
+        motif: motif,
+        lieu: lieu,
+        starts_at: Time.zone.parse("2020-10-20 09h30"),
+        geo_search: mock_geo_search,
+        duration_in_min: 60
+      ).and_return(returned_creneau)
+      rdv_wizard = UserRdvWizard::Step1.new(user, attributes.merge(duration: 60))
       expect(rdv_wizard.rdv.user_ids).to eq [user_for_rdv.id]
       expect(rdv_wizard.creneau).to eq returned_creneau
     end

--- a/spec/services/creneaux_search/for_user_spec.rb
+++ b/spec/services/creneaux_search/for_user_spec.rb
@@ -224,4 +224,23 @@ RSpec.describe CreneauxSearch::ForUser, type: :service do
       it { is_expected.to be_nil }
     end
   end
+
+  context "with duration_in_min argument" do
+    let(:creneaux_search) { described_class.new(user: user, motif:, lieu:, date_range:, duration_in_min: 60) }
+    let(:user) { create(:user) }
+    let(:motif) { create(:motif, organisation:, default_duration_in_min: 30) }
+
+    it "passes down to calculator" do
+      allow(CreneauxSearch::Calculator).to receive(:available_slots)
+        .with(motif:, lieu:, date_range:, agents: [], duration_in_min: 60)
+        .and_return([creneau_double])
+      expect(creneaux_search.creneaux).to eq [creneau_double]
+    end
+
+    it "passes down to NextAvailability" do
+      allow(CreneauxSearch::NextAvailability).to receive(:find)
+        .with(motif, lieu, [], hash_including(duration_in_min: 60))
+      creneaux_search.next_availability
+    end
+  end
 end

--- a/spec/services/creneaux_search/next_availability_spec.rb
+++ b/spec/services/creneaux_search/next_availability_spec.rb
@@ -147,5 +147,42 @@ RSpec.describe CreneauxSearch::NextAvailability, type: :service do
         expect(next_creneau.starts_at).to eq(other_agent_start_day + 9.hours)
       end
     end
+
+    context "argument duration_in_min : motif de 30 min + 1 PO de 30 min + 1 PO de 1h30" do
+      let!(:motif) { create(:motif, default_duration_in_min: 30, organisation:) }
+      let!(:plage_ouverture1) do
+        create(
+          :plage_ouverture,
+          motifs: [motif],
+          lieu:,
+          agent:,
+          organisation:,
+          first_day: today + 8.days,
+          start_time: Tod::TimeOfDay.parse("09:30"),
+          end_time: Tod::TimeOfDay.parse("10:00")
+        )
+      end
+      let!(:plage_ouverture2) do
+        create(
+          :plage_ouverture,
+          motifs: [motif],
+          lieu:,
+          agent:,
+          organisation:,
+          first_day: today + 16.days,
+          start_time: Tod::TimeOfDay.parse("08:30"),
+          end_time: Tod::TimeOfDay.parse("10:00")
+        )
+      end
+
+      specify do
+        next_available_default = described_class.find(motif, lieu, [], from: today)
+        expect(next_available_default.starts_at).to eq((today + 8.days).at(Tod::TimeOfDay.parse("09:30")))
+        next_available_30min = described_class.find(motif, lieu, [], from: today, duration_in_min: 30)
+        expect(next_available_30min.starts_at).to eq((today + 8.days).at(Tod::TimeOfDay.parse("09:30")))
+        next_available_1h00 = described_class.find(motif, lieu, [], from: today, duration_in_min: 60)
+        expect(next_available_1h00.starts_at).to eq((today + 16.days).at(Tod::TimeOfDay.parse("08:30")))
+      end
+    end
   end
 end

--- a/spec/support/shared_context/search_context.rb
+++ b/spec/support/shared_context/search_context.rb
@@ -3,7 +3,7 @@ RSpec.shared_examples "SearchContext" do
   let!(:organisation) { create(:organisation) }
   let!(:service) { create(:service) }
   let!(:rsa_orientation) { create(:motif_category, name: "RSA orientation sur site", short_name: "rsa_orientation") }
-  let!(:motif) { create(:motif, name: "RSA orientation sur site", motif_category: rsa_orientation, organisation: organisation) }
+  let!(:motif) { create(:motif, name: "RSA orientation sur site", motif_category: rsa_orientation, organisation: organisation, default_duration_in_min: 30) }
   let!(:rsa_orientation_on_phone_platform) { create(:motif_category, name: "RSA orientation sur plateforme téléphonique", short_name: "rsa_orientation_on_phone_platform") }
   let!(:motif2) { create(:motif, name: "RSA orientation sur plateforme téléphonique", motif_category: rsa_orientation_on_phone_platform, organisation: organisation, service: motif.service) }
   let!(:departement_number) { "75" }
@@ -152,14 +152,15 @@ RSpec.shared_examples "SearchContext" do
           motif: motif,
           lieu: lieu,
           date_range: search_context.date_range,
-          geo_search: geo_search
+          geo_search: geo_search,
+          duration_in_min: 30
         )
         search_context.creneaux_search
       end
     end
 
     context "when lieu is nil" do
-      let!(:motif) { create(:motif, :by_phone, organisation: organisation) }
+      let!(:motif) { create(:motif, :by_phone, organisation: organisation, default_duration_in_min: 30) }
 
       it "returns a CreneauxSearch::ForUser using no lieu and the selected motif" do
         create(:plage_ouverture, lieu: nil, motifs: [motif], organisation: organisation)
@@ -173,7 +174,8 @@ RSpec.shared_examples "SearchContext" do
           motif: motif,
           lieu: nil,
           date_range: search_context.date_range,
-          geo_search: geo_search
+          geo_search: geo_search,
+          duration_in_min: 30
         )
         search_context.creneaux_search
       end


### PR DESCRIPTION
# Contexte

Fait suite à #5255

Et préliminaire à https://github.com/betagouv/rdv-service-public/pull/5083 où on va vouloir chercher des créneaux dont la durée ne correspond pas à la durée par défaut du motif

# Solution

à lire [commit par commit](https://github.com/betagouv/rdv-service-public/pull/5271/commits/215eb4c18a50b076c7cef7aa1b933c3264c4e774) : 

on refacto d’abord ces deux classes pour accepter et utiliser `duration_in_min`
- CreneauxSearch::NextAvailability 
- CreneauxSearch::ForUser 

Puis on modifie les appels faits depuis les classes suivantes pour ne plus hacker `motif.default_duration_in_min` :

- UserRdvWizard 
- Api::Ants::EditorController 
- Users::RdvsController 
