### PR TITLE
Script pour lister les TLD les plus bloqués par Brevo à partir du CSV

### DIFF
--- a/scripts/blocked_contacts_stats.rb
+++ b/scripts/blocked_contacts_stats.rb
@@ -1,0 +1,69 @@
+# usage : bundle exec ruby scripts/blocked_contacts_stats.rb --path ~/Downloads/blocked-2025-04-28.csv
+# download CSV from https://app-smtp.brevo.com/block
+
+require "csv"
+require "optparse"
+require "pry"
+
+options = Struct.new(:path).new
+OptionParser.new do |opts|
+  opts.on("-p", "--path PATH") { |o| options.path = o }
+end.parse!
+
+IGNORED_DOMAINS = %w[
+  aliceadsl.fr
+  aol.com
+  bbox.fr
+  cedis.fr
+  deleted.rdv-solidarites.fr
+  domaine.fr
+  ecloud.com
+  email.com
+  free.fr
+  gail.com
+  gamail.com
+  gamil.com
+  gemail.com
+  gmail.co
+  gmail.com
+  gmail.coml
+  gmail.comm
+  gmail.fr
+  gmail.om
+  gmal.com
+  gmx.fr
+  hotmail.com
+  hotmail.fr
+  icloud.com
+  laposte.fr
+  laposte.net
+  live.com
+  live.fr
+  mail.com
+  mail.ru
+  msn.com
+  neuf.fr
+  numericable.fr
+  orange.fr
+  outlook.com
+  outlook.fr
+  sfr.fr
+  test.fr
+  wahoo.com
+  wanadoo.fr
+  yahoo.com
+  yahoo.fr
+  yahou.com
+].freeze
+
+rows = CSV.read(options.path, col_sep: ";", headers: true)
+# binding.pry
+rows
+  .select { _1["Reason"].include?("hard bounce") }
+  .map { _1["Contact"].split("@").last }
+  .reject { IGNORED_DOMAINS.include?(_1) }
+  .tally
+  .select { |_k, v| v > 10 }
+  .sort_by(&:last)
+  .reverse
+  .each { |domain, count| puts "#{count}\t#{domain}" }


### PR DESCRIPTION
# Contexte

https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_3ae5151f-5ec5-4f63-9e67-af71ea38209e/

Je m’apprête à faire un batch de déblocage d’emails agents pour résoudre des problèmes.

# Solution

Brevo permet d’exporter un CSV avec tous les emails bloqués 
Ce script permet de sortir la liste des domaines fréquents suspects
