### PR TITLE
Noms raccourcis des services ne sont plus uniques

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -135,15 +135,15 @@ class Agent < ApplicationRecord
   end
 
   def reverse_full_name_and_service
-    services.present? ? "#{reverse_full_name_or_email} (#{services_short_names})" : full_name
+    services.present? ? "#{reverse_full_name_or_email} (#{services_names})" : full_name
   end
 
   def full_name_and_service
-    services.present? ? "#{full_name_or_email} (#{services_short_names})" : full_name
+    services.present? ? "#{full_name_or_email} (#{services_names})" : full_name
   end
 
-  def services_short_names
-    services.map(&:short_name).join(", ")
+  def services_names
+    services.map(&:name).join(", ")
   end
 
   def complete?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -19,7 +19,8 @@ class Service < ApplicationRecord
   has_many :territories, through: :territory_services
 
   # Validations
-  validates :name, :short_name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, :short_name, presence: true
+  validates :name, uniqueness: { case_sensitive: false }
 
   # Scopes
   default_scope { order(Arel.sql("unaccent(LOWER(services.name))")) }

--- a/app/services/admin_changes_agent_services.rb
+++ b/app/services/admin_changes_agent_services.rb
@@ -21,7 +21,7 @@ class AdminChangesAgentServices
   def removed_services_dont_have_plages
     removed_services.each do |removed_service|
       if @agent.plage_ouvertures.any? { |plage| plage.motifs.any? { |motif| motif.service == removed_service } }
-        errors.add(:service_ids, "Le retrait du service n'a pu aboutir car l'agent a toujours des plages d'ouverture actives sur le service : #{removed_service.short_name}")
+        errors.add(:service_ids, "Le retrait du service n'a pu aboutir car l'agent a toujours des plages d'ouverture actives sur le service : #{removed_service.name}")
       end
     end
   end

--- a/app/services/admin_creates_agent.rb
+++ b/app/services/admin_creates_agent.rb
@@ -56,7 +56,7 @@ class AdminCreatesAgent
     services = Service.where(id: service_ids)
 
     if agent.services.to_set != services.to_set
-      I18n.t("activerecord.warnings.models.agent_role.different_services", services: services.map(&:short_name).join(", "), agent_services: agent.services_short_names)
+      I18n.t("activerecord.warnings.models.agent_role.different_services", services: services.map(&:name).join(", "), agent_services: agent.services_names)
     end
   end
 

--- a/app/views/admin/agents/_agent.html.slim
+++ b/app/views/admin/agents/_agent.html.slim
@@ -24,7 +24,7 @@ tr id="agent_#{agent.id}"
     = agent.email
   td
     - agent.services.each do |service|
-      .badge.badge-primary= service.short_name
+      .badge.badge-primary= service.name
   td.text-nowrap
     span>= agent_role.human_attribute_value(:access_level)
     - if agent_role.admin?

--- a/app/views/admin/motifs/index.html.slim
+++ b/app/views/admin/motifs/index.html.slim
@@ -60,7 +60,7 @@
               = Motif.human_attribute_name("service")
             - if @need_search
               div
-                - options = options_from_collection_for_select(current_territory.services, :id, :short_name, params[:service_filter])
+                - options = options_from_collection_for_select(current_territory.services, :id, :name, params[:service_filter])
                 = select_tag("service_filter", options, include_blank: "Tous", class: "js-submit-on-change select2-input")
           th
             div

--- a/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
+++ b/app/views/admin/referent_assignations/_referent_assignation_row.html.slim
@@ -2,7 +2,7 @@ tr id="agent_#{agent.id}"
   td
     span.mr-2= agent.reverse_full_name
   td
-    = agent.services_short_names
+    = agent.services_names
   td.text-right
     div.mr-3
       - if action == :remove

--- a/app/views/admin/territories/sectorisation_tests/_attribution.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/_attribution.html.slim
@@ -4,7 +4,7 @@
     - if Configuration::AgentPolicy.new(AgentContext.new(current_agent), attribution.agent).show?
       | L’agent #{attribution.agent.full_name_and_service}
     - else
-      | Un agent (#{attribution.agent.services_short_names})
+      | Un agent (#{attribution.agent.services_names})
     span<> dans l'organisation
     b>= attribution.organisation.name
   - if sectorisation_test_form.available_motifs_from_attributed_agent(attribution.agent, attribution.organisation).empty?
@@ -27,7 +27,7 @@
     ul
       - sectorisation_test_form.available_motifs_from_attributed_organisation(attribution.organisation).to_a.group_by(&:service).each do |service, motifs|
         li
-          = t("sectorisation_tests.available_motifs_in_service_count", count: motifs.count, service: service.short_name)
+          = t("sectorisation_tests.available_motifs_in_service_count", count: motifs.count, service: service.name)
           ul
             - motifs.each do |motif|
               li= motif_name_and_location_type(motif)

--- a/app/views/admin/territories/sectorisation_tests/search.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/search.html.slim
@@ -53,7 +53,7 @@ do |f|
               ul
                 - @sectorisation_test_form.available_motifs_from_departement_organisations.to_a.group_by { [_1.organisation, _1.service] }.each do |tuple, motifs|
                   - organisation, service = tuple
-                  li= t("sectorisation_tests.departement_motifs_count", count: motifs.count, organisation: organisation.name, service: service.short_name)
+                  li= t("sectorisation_tests.departement_motifs_count", count: motifs.count, organisation: organisation.name, service: service.name)
                   ul
                     - motifs.each do |motif|
                       li= motif_name_and_location_type(motif)
@@ -65,7 +65,7 @@ do |f|
           ul
             - @sectorisation_test_form.available_motifs_unique_names_and_location_types_by_service.each do |service, motifs|
               li
-                | Service #{service.short_name}: #{motifs.count} motifs disponibles
+                | Service #{service.name}: #{motifs.count} motifs disponibles
                 ul
                   - motifs.each do |motif|
                     li= motif_name_and_location_type(motif)

--- a/app/views/admin/territories/sectors/show.html.slim
+++ b/app/views/admin/territories/sectors/show.html.slim
@@ -105,13 +105,13 @@
           .pl-2.py-1.border-left
             - services_of_attributed_agents = all_attributions.map(&:agent).map(&:services).flatten.uniq
             - services_of_attributed_agents.each do |service|
-              span> Service #{service.short_name}
+              span> Service #{service.name}
               span.text-muted.ml-1
                 - service_motifs = Motif.sectorisation_level_agent.where(organisation: organisation, service: service)
                 = t( \
                   "sectors.motifs_with_agent_level_sectorisation_in_service", \
                   count: service_motifs.count, \
-                  service: service.short_name, \
+                  service: service.name, \
                   motifs: service_motifs.map(&:name).to_sentence.truncate(100) \
                 )
               ul.pl-3.mb-3

--- a/app/views/agents/mailer/invitation_instructions.html.erb
+++ b/app/views/agents/mailer/invitation_instructions.html.erb
@@ -3,7 +3,7 @@
 
 <p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
 
-<p><%= t("devise.mailer.invitation_instructions_for_agents.body", inviter: inviter_name, service: @resource.services_short_names, domain_name: domain.name) %></p>
+<p><%= t("devise.mailer.invitation_instructions_for_agents.body", inviter: inviter_name, service: @resource.services_names, domain_name: domain.name) %></p>
 
 <p><%= link_to t("devise.mailer.invitation_instructions_for_agents.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
 

--- a/app/views/layouts/_left_menu.html.slim
+++ b/app/views/layouts/_left_menu.html.slim
@@ -21,7 +21,7 @@ nav.left-side-menu-wrapper
                 div.d-flex.flex-column
                   = current_organisation.name
                   - if navigation_scoped_by_agent_services?(current_agent, current_organisation)
-                    span= current_agent.services_short_names
+                    span= current_agent.services_names
               - if current_agent.organisations.count > 1
                 div.d-flex.align-items-center
                   i.fa.fa-angle-down.menu-arrow.mt-1

--- a/db/migrate/20250428091319_remove_index_services_short_name.rb
+++ b/db/migrate/20250428091319_remove_index_services_short_name.rb
@@ -1,0 +1,5 @@
+class RemoveIndexServicesShortName < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :services, "lower(short_name)", unique: true, name: "index_services_on_lower_short_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -702,7 +702,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_02_123003) do
     t.datetime "updated_at", null: false
     t.string "short_name", null: false
     t.index "lower((name)::text)", name: "index_services_on_lower_name", unique: true
-    t.index "lower((short_name)::text)", name: "index_services_on_lower_short_name", unique: true
     t.index ["name"], name: "index_services_on_name"
   end
 


### PR DESCRIPTION
> [!NOTE]
> Cette PR est surtout un support de discussion pour récolter vos retours @francois-ferrandis et @victormours 

# Contexte

On [nous demande](https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_7144be43-ff2e-49ef-b832-ce4ba4db53e2/) de créer des services « avocat droit travail » et « avocat droit administratif ».

J’ai envie de mettre « avocat » comme nom court pour les SMS mais c’est interdit car ce short_name doit être unique

Il me semble que l’unicité encourage à mettre des noms plus longs en rajoutant des suffixes ou des préfixes

# Solution

Supprimer la contrainte d’unicité

Il faudrait vérifier qu’on ne fait pas un `find_by(short_name:)` qque part