### PR TITLE
Specs: arrondir Rdv.starts_at à la minute près

### DIFF
--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     motif { build(:motif, organisation: organisation, service: agents.first.services.first) }
 
     duration_in_min { motif.default_duration_in_min }
-    starts_at { 3.days.from_now }
+    starts_at { 3.days.from_now.round.change(sec: 0) } # les Rdv créés dans l’app ont une précision à la minute
 
     status { "unknown" }
 


### PR DESCRIPTION
# Contexte

J’essaie d’introduire une failing spec pour cette issue : https://github.com/betagouv/rdv-service-public/issues/5170

Je me suis rendu compte que le `starts_at` par défaut des Rdv créés par la factory dans les specs n’est pas réaliste : il a une précision à la milliseconde alors que les Rdv créés dans l’appli ont une précision à la minute 

_cette phrase est approximative, en fait les secondes et millisecondes sont à 0_.

Cela créé des soucis pour ma spec à venir car `starts_at_was != starts_at` alors qu’il n’y a eu aucun changement.

# Solution

Je force ici les secondes à 0 avec `change(sec: 0)` et les millisecondes à 0 avec `round`

Je fais ça dans une PR préliminaire pour m’assurer que ça ne casse pas des specs existantes