### PR TITLE
Amélioration du health check de congestion des jobs_queues

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -7,15 +7,21 @@ class HealthController < ApplicationController
   end
 
   def jobs_queues
-    counts1 = compute_enqueued_jobs_count_by_queue
-    queues_with_many_jobs = counts1.select { |_queue, count| count > 10 }
-    return render(status: :ok, json: {}) if queues_with_many_jobs.none?
+    queues = [
+      { name: "latency_30s", pending_jobs_threshold: 10, delay: 30.seconds },
+      { name: "latency_5m", pending_jobs_threshold: 10, delay: 5.minutes },
+      { name: "latency_whenever", pending_jobs_threshold: 30, delay: nil },
+    ]
+    queues.each do |queue|
+      query = GoodJob::Job.where(executions_count: 0).where(queue_name: queue[:name])
+      if queue[:delay]
+        query = query.where("scheduled_at < ?", Time.zone.now - (queue[:delay] / 10)) # le petit délai évite de compter les jobs qui viennent d’être enqueued
+      end
+      queue[:pending_jobs_count] = query.count
+    end
+    congested_queues = queues.select { _1[:pending_jobs_count] >= _1[:pending_jobs_threshold] }
 
-    sleep(5) # leave some time for some jobs to be performed
-    counts2 = compute_enqueued_jobs_count_by_queue
-    congested_queues = queues_with_many_jobs.select { |queue, count1| counts2.fetch(queue, 0) >= count1 }.keys
-
-    return render(status: :service_unavailable, json: { congested_queues: }) if congested_queues
+    return render(status: :service_unavailable, json: { congested_queues: }) if congested_queues.any?
 
     render(status: :ok, json: {})
   end
@@ -39,15 +45,5 @@ class HealthController < ApplicationController
     else
       render status: :ok, json: context
     end
-  end
-
-  private
-
-  def compute_enqueued_jobs_count_by_queue
-    GoodJob::Job
-      .group(:queue_name)
-      .where("scheduled_at < ?", Time.zone.now)
-      .where(finished_at: nil)
-      .count
   end
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -10,7 +10,7 @@ class HealthController < ApplicationController
     queues = [
       { name: "latency_30s", pending_jobs_threshold: 10, delay: 30.seconds },
       { name: "latency_5m", pending_jobs_threshold: 10, delay: 5.minutes },
-      { name: "latency_whenever", pending_jobs_threshold: 10, delay: 6.hours },
+      { name: "latency_whenever", pending_jobs_threshold: 10, delay: 1.hour },
     ]
     queues.each do |queue|
       queue[:pending_jobs_count] = GoodJob::Job

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -10,14 +10,14 @@ class HealthController < ApplicationController
     queues = [
       { name: "latency_30s", pending_jobs_threshold: 10, delay: 30.seconds },
       { name: "latency_5m", pending_jobs_threshold: 10, delay: 5.minutes },
-      { name: "latency_whenever", pending_jobs_threshold: 30, delay: nil },
+      { name: "latency_whenever", pending_jobs_threshold: 10, delay: 6.hours },
     ]
     queues.each do |queue|
-      query = GoodJob::Job.where(executions_count: 0).where(queue_name: queue[:name])
-      if queue[:delay]
-        query = query.where("scheduled_at < ?", Time.zone.now - (queue[:delay] / 10)) # le petit délai évite de compter les jobs qui viennent d’être enqueued
-      end
-      queue[:pending_jobs_count] = query.count
+      queue[:pending_jobs_count] = GoodJob::Job
+        .where(finished_at: nil) # finished_at is set upon success or final failure
+        .where(queue_name: queue[:name])
+        .where("scheduled_at < ?", Time.zone.now - queue[:delay]) # scheduled_at is updated at each retry
+        .count
     end
     congested_queues = queues.select { _1[:pending_jobs_count] >= _1[:pending_jobs_threshold] }
 


### PR DESCRIPTION
# Contexte

On a eu le message d’alerte updown un peu trop souvent au sujet de la congestion des jobs sur RDVSP.

C’était globalement des faux positifs. Il y avait une quinzaine de jobs dans un état bizarre. C’était exclusivement des jobs d’envoi de mails dans des états incohérents :
- pas de finished_at (donc derniere failure pas atteinte)
- un scheduled_at dans le passé lointain
- parfois des nombres d’`executions_count` ahurissants > 10_000 
- souvent des `InterruptError` qui se produisent normalement lors d’une déconnexion abrupte du worker

Je les ai supprimé sans trop cherché à comprendre et on verra si ça se reproduit.

A la relecture de cette route, le check qu’on fait me parait compliqué et pas tout à fait adapté.
Suite au renommage des queues (Merci ! 🙇 ) on peut faire plus lisible et plus robuste à mon avis

# Solution

Je propose de déclarer en dur les queues à vérifier et les latences acceptables pour chacune.
Puis de vérifier s’il y a +de 10 jobs (ou retries) en attente d’éxecution depuis trop longtemps sur ces queues.

ℹ️ Il n’y a aucun tests sur ce ce code 🙈 j’ai fait des simulations en local et j’ai lancé le bout de code dans des sandboxes des prod pour vérifier que ça n’allait pas exploser tout de suite