### PR TITLE
Ne plus envoyer de SMS de confirmation pour les usagers prenant RDV en ligne

### DIFF
--- a/app/services/notifiers/rdv_created.rb
+++ b/app/services/notifiers/rdv_created.rb
@@ -4,7 +4,11 @@ class Notifiers::RdvCreated < Notifiers::RdvBase
   end
 
   def notify_user_by_sms(user)
-    Users::RdvSms.rdv_created(@rdv, user, @participations_tokens_by_user_id[user.id]).deliver_later
+    # Nous n'envoyons pas de SMS de confirmation si le rendez-vous a été pris en ligne par l’usager sauf si le RDV
+    # est dans moins de 2 jours (car l’usager n’aura pas de SMS de rappel)
+    if !@rdv.created_by_user? || @rdv.starts_at < 2.days.from_now
+      Users::RdvSms.rdv_created(@rdv, user, @participations_tokens_by_user_id[user.id]).deliver_later
+    end
   end
 
   protected

--- a/app/services/notifiers/rdv_created.rb
+++ b/app/services/notifiers/rdv_created.rb
@@ -5,8 +5,9 @@ class Notifiers::RdvCreated < Notifiers::RdvBase
 
   def notify_user_by_sms(user)
     # Nous n'envoyons pas de SMS de confirmation si le rendez-vous a été pris en ligne par l’usager sauf si le RDV
-    # est dans moins de 2 jours (car l’usager n’aura pas de SMS de rappel)
-    if !@rdv.created_by_user? || @rdv.starts_at < 2.days.from_now
+    # est dans moins de 2 jours (car l’usager n’aura pas de SMS de rappel) ou que l’usager n’a pas confirmé son compte
+    # (cas notamment pour la prise de RDV par invitation)
+    if !(@rdv.created_by_user? && user.confirmed?) || @rdv.starts_at < 2.days.from_now
       Users::RdvSms.rdv_created(@rdv, user, @participations_tokens_by_user_id[user.id]).deliver_later
     end
   end

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
     stub_netsize_ok
     allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(Agents::RdvMailer).to receive(:with).and_call_original
+    allow(Users::RdvSms).to receive(:rdv_created).and_call_original
+    allow(Devise.token_generator).to receive(:generate).and_return(token1, token2)
   end
 
   context "modifié par un agent" do
@@ -42,6 +44,12 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
       subject
     end
 
+    it "l'utilisateur reçoit un SMS de confirmation" do
+      expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user1, token1)
+      expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user2, token2)
+      subject
+    end
+
     it "l'attribut participations_tokens_by_user_id retourne les tokens pour les utilisateurs correspondants" do
       notifier = described_class.new(rdv, user1)
       notifier.perform
@@ -58,6 +66,12 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user2, token: token2 })
       expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent1, author: user1 })
       expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent2, author: user1 })
+      subject
+    end
+
+    it "l'utilisateur reçoit un SMS de confirmation" do
+      expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user1, token1)
+      expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user2, token2)
       subject
     end
   end
@@ -88,7 +102,7 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
       let(:starts_at) { 1.day.from_now }
 
       it "l'utilisateur reçoit un SMS de confirmation" do
-        expect(Users::RdvSms).to receive(:rdv_created).and_call_original
+        expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user1, token1)
         subject
       end
     end

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
     allow(Agents::RdvMailer).to receive(:with).and_call_original
   end
 
-  context "edited by agent" do
+  context "modifié par un agent" do
     subject { described_class.perform_with(rdv, agent1) }
 
     let(:starts_at) { 3.days.from_now }
     let(:motif) { build(:motif) }
 
-    it "triggers sending mail to users and other agents" do
+    it "déclenche l'envoi d'emails aux utilisateurs et aux autres agents" do
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user1, token: token1 })
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user2, token: token2 })
       expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent2, author: agent1 })
@@ -30,11 +30,11 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
     end
   end
 
-  context "starts in more than 2 days" do
+  context "commence dans plus de 2 jours" do
     let(:starts_at) { 3.days.from_now }
     let(:motif) { build(:motif) }
 
-    it "triggers sending mail to users and agents" do
+    it "déclenche l'envoi d'emails aux utilisateurs et aux agents" do
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user1, token: token1 })
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user2, token: token2 })
       expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent1, author: user1 })
@@ -42,19 +42,18 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
       subject
     end
 
-    it "participations_tokens_by_user_id attribute outputs the tokens for matching users" do
-      # keep this stubbing test as its important to check matching token and users
+    it "l'attribut participations_tokens_by_user_id retourne les tokens pour les utilisateurs correspondants" do
       notifier = described_class.new(rdv, user1)
       notifier.perform
       expect(notifier.participations_tokens_by_user_id).to eq({ user1.id => token1, user2.id => token2 })
     end
   end
 
-  context "starts today or tomorrow" do
+  context "commence aujourd'hui ou demain" do
     let(:starts_at) { 2.hours.from_now }
     let(:motif) { build(:motif) }
 
-    it "triggers sending mails to both user and agents" do
+    it "déclenche l'envoi d'emails aux utilisateurs et aux agents" do
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user1, token: token1 })
       expect(Users::RdvMailer).to receive(:with).with({ rdv: rdv, user: user2, token: token2 })
       expect(Agents::RdvMailer).to receive(:with).with({ rdv: rdv, agent: agent1, author: user1 })
@@ -63,13 +62,35 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
     end
   end
 
-  context "with visible and not notified motif" do
+  context "avec un motif visible et non notifié" do
     let(:starts_at) { 3.days.from_now }
     let(:motif) { build(:motif, :visible_and_not_notified) }
 
-    it "does not send emails to users" do
+    it "n'envoie pas d'emails aux utilisateurs" do
       expect(Users::RdvMailer).not_to receive(:with)
       subject
+    end
+  end
+
+  context "le rendez-vous est pris par un utilisateur" do
+    subject { described_class.perform_with(rdv, user1) }
+
+    let(:rdv) { create(:rdv, starts_at: starts_at, motif: motif, agents: [agent1], users: [user1], organisation: motif.organisation, created_by: user1) }
+    let(:starts_at) { 3.days.from_now }
+    let(:motif) { build(:motif) }
+
+    it "l'utilisateur ne reçoit pas de SMS de confirmation" do
+      expect(Users::RdvSms).not_to receive(:rdv_created)
+      subject
+    end
+
+    context "le rendez-vous est pris moins de 48h avant" do
+      let(:starts_at) { 1.day.from_now }
+
+      it "l'utilisateur reçoit un SMS de confirmation" do
+        expect(Users::RdvSms).to receive(:rdv_created).and_call_original
+        subject
+      end
     end
   end
 end

--- a/spec/services/notifiers/rdv_created_spec.rb
+++ b/spec/services/notifiers/rdv_created_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
     allow(Users::RdvMailer).to receive(:with).and_call_original
     allow(Agents::RdvMailer).to receive(:with).and_call_original
     allow(Users::RdvSms).to receive(:rdv_created).and_call_original
-    allow(Devise.token_generator).to receive(:generate).and_return(token1, token2)
   end
 
   context "modifié par un agent" do
@@ -100,6 +99,15 @@ RSpec.describe Notifiers::RdvCreated, type: :service do
 
     context "le rendez-vous est pris moins de 48h avant" do
       let(:starts_at) { 1.day.from_now }
+
+      it "l'utilisateur reçoit un SMS de confirmation" do
+        expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user1, token1)
+        subject
+      end
+    end
+
+    context "l’utilisateur n'a pas confirmé son compte" do
+      let(:user1) { create(:user, confirmed_at: nil) }
 
       it "l'utilisateur reçoit un SMS de confirmation" do
         expect(Users::RdvSms).to receive(:rdv_created).with(rdv, user1, token1)


### PR DESCRIPTION
# Contexte

Aujourd’hui, nous envoyons des SMS de confirmation aux usagers pour tous les RDVs pris, que le RDV soit pris par un agent, un prescripteur ou l’usager.
Nous considérons aujourd’hui que le SMS de confirmation n’est pas utile lorsque c’est l’usager qui prend RDV en ligne, et que nous pouvons faire l’économie de ce SMS. En effet : 
- C’est l’usager lui-même qui a initié cette prise de RDV
- Il a eu une alerte dans le produit lui indiquant que son RDV a bien été confirmé
- Il a reçu un mail de confirmation (et nous savons qu’il est en mesure de consulter ses mails, car il a validé son adresse mail à l’inscription)

# Solution

On envoie plus le SMS de confirmation lorsque le `created_by` est un `User` et que le RDV est dans + de 48h. En effet, pour les RDV à moins de 48h, l’usager ne reçoit pas de SMS de confirmation. On souhaite donc qu’il conserve les infos pratiques et le lien de modification de son RDV.
