### PR TITLE
corrections de marges sur la page agents/home

### DIFF
--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -1,15 +1,14 @@
-.fr-container
-  h1.fr-h3.fr-pb-2w Bienvenue !
-  p.fr-py-1w Pour commencer, aidez-nous à en savoir plus :
+h1.fr-h3.fr-pb-2w Bienvenue !
+p.fr-py-1w Pour commencer, aidez-nous à en savoir plus :
 
-.fr-grid-row
-  .fr-col-12.fr-col-md-6.fr-p-1w
+.fr-grid-row.fr-grid-row--gutters
+  .fr-col-12.fr-col-md-6
     .card
       .card-body
         h2.fr-h6 Votre organisation utilise déjà #{current_domain.name} ?
         p Vos collègues peuvent vous inviter depuis le menu <b>Configuration > Agents > Ajouter un agent</b>.
 
-  .fr-col-12.fr-col-md-6.fr-p-1w.fr-pb-8w
+  .fr-col-12.fr-col-md-6.fr-pb-8w
     .card
       .card-body
         h2.fr-h6 Votre organisation n’utilise pas encore #{current_domain.name} ?


### PR DESCRIPTION
# Contexte

Je n’ai pas pu m’empêcher de relever des petits défauts d’alignements sur la nouvelle page qui accueille les agents n’ayant encore accès a aucune orga pendant la démo de @victormours sur le nouvel embarquement asynchrone.

# Solution

Correction des marges ! 

avant|après
-|-
![image](https://github.com/user-attachments/assets/07eb1b19-a20b-45b9-80b8-2a1f03e61e5d) | ![image](https://github.com/user-attachments/assets/d5755807-bdb8-4e41-b7fb-6e656e392326)
![image](https://github.com/user-attachments/assets/5b4012be-7295-4b04-a4bb-0eb87cbd0005) | ![image](https://github.com/user-attachments/assets/502c2ef7-5f28-4863-985c-e98e7c603277)

