### PR TITLE
Ajout du nom du lieu dans les SMS de rappel et dans les SMS de confirmation -48h

### DIFF
--- a/app/helpers/rdvs_helper.rb
+++ b/app/helpers/rdvs_helper.rb
@@ -42,7 +42,7 @@ module RdvsHelper
   end
 
   def human_location(rdv)
-    text = rdv.address_complete
+    text = rdv.full_address
     text = safe_join([text, "Adresse non renseignée"], " - ") if rdv.address.blank?
     safe_join([text, unavailability_tag(rdv.lieu)])
   end

--- a/app/models/concerns/rdv/address_concern.rb
+++ b/app/models/concerns/rdv/address_concern.rb
@@ -12,7 +12,7 @@ module Rdv::AddressConcern
     result || ""
   end
 
-  def address_complete
+  def full_address
     result = case motif.location_type.to_sym
              when :public_office
                lieu&.full_name

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -11,19 +11,27 @@ class Users::RdvSms < Users::BaseSms
   end
 
   def rdv_created(rdv, user, token)
-    complete_address = @rdv.starts_at < 2.days.from_now
+    address_format = if @rdv.starts_at < 2.days.from_now
+                       :full
+                     else
+                       :short
+                     end
 
-    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}.\n#{rdv_footer(rdv, user, token, complete_address:)}"
+    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}.\n#{rdv_footer(rdv, user, token, address_format:)}"
   end
 
   def rdv_updated(rdv, user, token)
-    complete_address = @rdv.starts_at < 2.days.from_now
+    address_format = if @rdv.starts_at < 2.days.from_now
+                       :full
+                     else
+                       :short
+                     end
 
-    @content = "RDV modifié: #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token, complete_address:)}"
+    @content = "RDV modifié: #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token, address_format:)}"
   end
 
   def rdv_upcoming_reminder(rdv, user, token)
-    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token, complete_address: true)}"
+    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token, address_format: :full)}"
   end
 
   def rdv_cancelled(rdv, _user, token)
@@ -55,8 +63,8 @@ class Users::RdvSms < Users::BaseSms
     I18n.l(rdv.starts_at, format: rdv.home? ? :short_sms_approx : :short_sms)
   end
 
-  def rdv_footer(rdv, user, token, complete_address: false)
-    details = rdv_location(rdv, complete_address:)
+  def rdv_footer(rdv, user, token, address_format: :short)
+    details = rdv_location(rdv, address_format:)
 
     if user.relatives.present? && !rdv.collectif?
       users_full_names = rdv.users.map(&:full_name).sort.to_sentence
@@ -76,13 +84,15 @@ class Users::RdvSms < Users::BaseSms
     details + links
   end
 
-  def rdv_location(rdv, complete_address: false)
+  def rdv_location(rdv, address_format: :short)
     case rdv.motif.location_type
     when "public_office"
-      if complete_address
-        rdv.address_complete
-      else
+      if address_format == :full
+        rdv.full_address
+      elsif address_format == :short
         rdv.address
+      else
+        raise "Format d'adresse inconnu : #{address_format}"
       end
     when "phone"
       "Par tél"

--- a/app/sms/users/rdv_sms.rb
+++ b/app/sms/users/rdv_sms.rb
@@ -11,15 +11,19 @@ class Users::RdvSms < Users::BaseSms
   end
 
   def rdv_created(rdv, user, token)
-    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}.\n#{rdv_footer(rdv, user, token)}"
+    complete_address = @rdv.starts_at < 2.days.from_now
+
+    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}.\n#{rdv_footer(rdv, user, token, complete_address:)}"
   end
 
   def rdv_updated(rdv, user, token)
-    @content = "RDV modifié: #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token)}"
+    complete_address = @rdv.starts_at < 2.days.from_now
+
+    @content = "RDV modifié: #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token, complete_address:)}"
   end
 
   def rdv_upcoming_reminder(rdv, user, token)
-    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token)}"
+    @content = "RDV #{rdv_title(rdv)} #{starts_at(rdv)}\n#{rdv_footer(rdv, user, token, complete_address: true)}"
   end
 
   def rdv_cancelled(rdv, _user, token)
@@ -51,8 +55,8 @@ class Users::RdvSms < Users::BaseSms
     I18n.l(rdv.starts_at, format: rdv.home? ? :short_sms_approx : :short_sms)
   end
 
-  def rdv_footer(rdv, user, token)
-    details = rdv_location(rdv)
+  def rdv_footer(rdv, user, token, complete_address: false)
+    details = rdv_location(rdv, complete_address:)
 
     if user.relatives.present? && !rdv.collectif?
       users_full_names = rdv.users.map(&:full_name).sort.to_sentence
@@ -72,10 +76,14 @@ class Users::RdvSms < Users::BaseSms
     details + links
   end
 
-  def rdv_location(rdv)
+  def rdv_location(rdv, complete_address: false)
     case rdv.motif.location_type
     when "public_office"
-      rdv.address
+      if complete_address
+        rdv.address_complete
+      else
+        rdv.address
+      end
     when "phone"
       "Par tél"
     when "home"

--- a/app/views/mailers/common/_rdv_overview.html.slim
+++ b/app/views/mailers/common/_rdv_overview.html.slim
@@ -42,7 +42,7 @@
     div.row-result
       span.title Ceci est un rendez-vous à domicile à l'adresse :
       div.alignright
-        = rdv.address_complete
+        = rdv.full_address
   - elsif rdv.motif.visio?
     div.row-result
       span.title = "RDV par visioconférence"
@@ -52,7 +52,7 @@
     div.row-result
       span.title Adresse :
       span.float-right
-        = rdv.address_complete
+        = rdv.full_address
       .clear
   - if rdv.motif.instruction_for_rdv.present? && for_role == :user
     .div.row-result.no-border

--- a/spec/sms/users/rdv_sms_spec.rb
+++ b/spec/sms/users/rdv_sms_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe Users::RdvSms, type: :service do
       let(:pmi) { build(:service, short_name: "PMI") }
       let(:motif) { build(:motif, service: pmi, organisation:) }
       let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
-      let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 123, name: "Ne Doit pas s'afficher") }
+      let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at:, id: 123, name: "Ne Doit pas s'afficher") }
       let(:user) { build(:user) }
       let(:token) { "12345" }
+      let(:starts_at) { Time.zone.local(2021, 12, 10, 13, 10) }
 
       it do
         expect(subject).to include("RDV PMI vendredi 10/12 13h10")
@@ -17,6 +18,22 @@ RSpec.describe Users::RdvSms, type: :service do
         expect(subject).to include("Infos/annulation")
         expect(subject).to include("www.rdv-solidarites-test.localhost/r/123/12345")
         expect(subject).not_to include("Ne Doit pas s'afficher")
+      end
+
+      context "when rdv is in the following 2 days" do
+        let(:starts_at) { 1.day.from_now }
+
+        it do
+          expect(subject).to include("MDS Centre")
+        end
+      end
+
+      context "when rdv is in more than 2 days" do
+        let(:starts_at) { 3.days.from_now }
+
+        it do
+          expect(subject).not_to include("MDS Centre")
+        end
       end
     end
 
@@ -72,15 +89,32 @@ RSpec.describe Users::RdvSms, type: :service do
     let(:motif) { build(:motif, service: pmi) }
     let(:organisation) { build(:organisation) }
     let(:lieu) { build(:lieu, name: "MDS Centre", address: "10 rue d'ici, Paris, 75016") }
-    let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at: Time.zone.local(2021, 12, 10, 13, 10), id: 124) }
+    let(:rdv) { build(:rdv, motif: motif, organisation: organisation, lieu: lieu, starts_at:, id: 124) }
     let(:token) { "2345" }
     let(:user) { build(:user) }
+    let(:starts_at) { Time.zone.local(2021, 12, 10, 13, 10) }
 
     it do
       expect(subject).to include("RDV modifié: PMI vendredi 10/12 13h10")
       expect(subject).to include("10 rue d'ici, Paris, 75016")
       expect(subject).to include("Infos/annulation")
       expect(subject).to include("www.rdv-solidarites-test.localhost/r/124/2345")
+    end
+
+    context "when rdv is in the following 2 days" do
+      let(:starts_at) { 1.day.from_now }
+
+      it do
+        expect(subject).to include("MDS Centre")
+      end
+    end
+
+    context "when rdv is in more than 2 days" do
+      let(:starts_at) { 3.days.from_now }
+
+      it do
+        expect(subject).not_to include("MDS Centre")
+      end
     end
   end
 
@@ -154,6 +188,7 @@ RSpec.describe Users::RdvSms, type: :service do
 
     it do
       expect(subject).to include("RDV PMI vendredi 10/12 13h10")
+      expect(subject).to include("MDS Centre")
       expect(subject).to include("10 rue d'ici, Paris, 75016")
       expect(subject).to include("Infos/annulation")
       expect(subject).to include("www.rdv-solidarites-test.localhost/r/140/7777")


### PR DESCRIPTION
# Contexte

Pour certains lieux de RDV, l’adresse n’est pas suffisante pour s’y rendre, car le nom du lieu apporte des informations importantes.

# Solution

Afin de faciliter l’arrivée des usagers au lieu de RDV, on ajoute la mention du nom du lieu : 
- Dans le SMS de rappel
- Dans le SMS de confirmation (ou de modification) si le RDV est à moins de 48h (parce qu'il n’y aura pas de rappel) 


