### PR TITLE
Amélioration de la gestion des erreurs lors de la création d'un rdv plan

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -308,3 +308,6 @@ Rails/RedundantActiveRecordAllMethod:
 RSpec/PredicateMatcher:
   Exclude:
     - "spec/policies/**/*"
+
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false

--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
 
       user = find_or_build_user(user_params)
 
+      user.save!
       RdvPlan.create!(
         planning_agent: current_agent,
         user: user,

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -14,7 +14,6 @@ class RdvPlan < ApplicationRecord
   delegate :organisation, to: :motif
 
   validate :return_url_is_authorized
-  validates :user_id, :planning_agent_id, presence: true
 
   # TODO: mettre en commun avec les motifs et ajouter une validation de synchro
   enum :location_type, { public_office: "public_office", phone: "phone", home: "home", visio: "visio" }

--- a/app/models/rdv_plan.rb
+++ b/app/models/rdv_plan.rb
@@ -14,6 +14,7 @@ class RdvPlan < ApplicationRecord
   delegate :organisation, to: :motif
 
   validate :return_url_is_authorized
+  validates :user_id, :planning_agent_id, presence: true
 
   # TODO: mettre en commun avec les motifs et ajouter une validation de synchro
   enum :location_type, { public_office: "public_office", phone: "phone", home: "home", visio: "visio" }

--- a/spec/factories/rdv_plan.rb
+++ b/spec/factories/rdv_plan.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :rdv_plan do
-    user
-    planning_agent { association(:agent) }
+    user { create(:user) }
+    planning_agent { create(:agent) }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
   end

--- a/spec/models/rdv_plan_spec.rb
+++ b/spec/models/rdv_plan_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RdvPlan do
     let(:agent) { create(:agent) }
 
     it "can only be in a a whitelisted domain name from the corresponding oauth application" do
-      rdv_plan = build(:rdv_plan, oauth_application: application, user: user, planning_agent: agent)
+      rdv_plan = build(:rdv_plan, oauth_application: application)
       rdv_plan.return_url = "nimportequoi.fr/asdf"
       expect(rdv_plan).not_to be_valid
 
@@ -36,8 +36,7 @@ RSpec.describe RdvPlan do
     end
 
     it "needs to be a http url" do
-      rdv_plan = build(:rdv_plan, oauth_application: application, return_url: "javascript:alert(1)",
-                                  user: user, planning_agent: agent)
+      rdv_plan = build(:rdv_plan, oauth_application: application, return_url: "javascript:alert(1)")
       expect(rdv_plan).not_to be_valid
 
       rdv_plan.return_url = "ssh://test.gouv.fr"

--- a/spec/models/rdv_plan_spec.rb
+++ b/spec/models/rdv_plan_spec.rb
@@ -1,17 +1,4 @@
 RSpec.describe RdvPlan do
-  describe "validations on associations" do
-    it "verifies that the user and the agent are persisted" do
-      invalid_user = User.new
-      invalid_agent = Agent.new
-      plan = described_class.new(
-        user: invalid_user,
-        planning_agent: invalid_agent
-      )
-      expect(plan).not_to be_valid
-      expect(plan.errors.to_hash.keys).to match_array(%i[user_id planning_agent_id])
-    end
-  end
-
   describe "#return_url" do
     let(:application) do
       create(:oauth_application,

--- a/spec/models/rdv_plan_spec.rb
+++ b/spec/models/rdv_plan_spec.rb
@@ -1,12 +1,27 @@
 RSpec.describe RdvPlan do
+  describe "validations on associations" do
+    it "verifies that the user and the agent are persisted" do
+      invalid_user = User.new
+      invalid_agent = Agent.new
+      plan = described_class.new(
+        user: invalid_user,
+        planning_agent: invalid_agent
+      )
+      expect(plan).not_to be_valid
+      expect(plan.errors.to_hash.keys).to match_array(%i[user_id planning_agent_id])
+    end
+  end
+
   describe "#return_url" do
     let(:application) do
       create(:oauth_application,
              redirect_uri: "http://localhost:4567/omniauth/rdvservicepublic/callback\nhttps://demo.demarches-simplifiees.fr/omniauth/rdvservicepublic/callback")
     end
+    let(:user) { create(:user) }
+    let(:agent) { create(:agent) }
 
     it "can only be in a a whitelisted domain name from the corresponding oauth application" do
-      rdv_plan = build(:rdv_plan, oauth_application: application)
+      rdv_plan = build(:rdv_plan, oauth_application: application, user: user, planning_agent: agent)
       rdv_plan.return_url = "nimportequoi.fr/asdf"
       expect(rdv_plan).not_to be_valid
 
@@ -21,7 +36,8 @@ RSpec.describe RdvPlan do
     end
 
     it "needs to be a http url" do
-      rdv_plan = build(:rdv_plan, oauth_application: application, return_url: "javascript:alert(1)")
+      rdv_plan = build(:rdv_plan, oauth_application: application, return_url: "javascript:alert(1)",
+                                  user: user, planning_agent: agent)
       expect(rdv_plan).not_to be_valid
 
       rdv_plan.return_url = "ssh://test.gouv.fr"

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -75,6 +75,20 @@ RSpec.describe "RDV Plan API" do
       end
     end
 
+    context "when some of the params are missing" do
+      let(:params) do
+        { user: { first_name: "Francis" } }
+      end
+
+      it "returns an error message and doesn't create the rdv plan" do
+        post "/api/v1/rdv_plans", headers: headers, params: params, as: :json
+        expect(RdvPlan.last).to be_nil
+        expect(User.last).to be_nil
+        expect(response.status).to eq 422
+        expect(parsed_response_body["errors"]["last_name"]).to be_present
+      end
+    end
+
     context "when passing a user email" do
       let(:params) do
         { user: { email: "francis@factice.com", first_name: "Francois" } }


### PR DESCRIPTION
# Contexte

Lors des tests pour l'intégration avec l'espace Coop, il y a des rdv_plans qui ont été créés avec des user_ids nil, et je ne suis pas sûr que comment c'est possible.
Ça cause une erreur à l'étape suivant, lorsqu'on essaye d'afficher un rdv_plan sans user.

# Solution

On ajoute un test au niveau de l'endpoint de création, et des validations sur le modèle.
On aura un message d'erreur correct plutôt que des rdvs_plans dans un état invalide.

Si on essaye de créer un rdv_plan avec un user invalide, la validation automatique du belongs_to va fonctionner, puisque le user est présent en mémoire, mais va échouer à l'étape suivante puisque le user n'est pas persisté.

Je suis un peu étonné d'avoir besoin de faire la validation sur les `_id` à la main, peut-être que je suis en train de passer d'une manière plus élégante de faire ça avec activerecord.
