### PR TITLE
Correctif pour les majuscules dans les emails des usagers lors de la création de rdv plans

### DIFF
--- a/app/controllers/agent_connect_controller.rb
+++ b/app/controllers/agent_connect_controller.rb
@@ -31,7 +31,7 @@ class AgentConnectController < ApplicationController
 
     # Agent Connect recommande de faire la réconciliation sur l'email et non pas sur le sub
     # voir https://github.com/numerique-gouv/agentconnect-documentation/blob/main/doc_fs/donnees_fournies.md#le-champ-sub
-    agent = Agent.active.find_by(email: callback_client.user_email.downcase) # Certains agents ont des majuscultes dans leur email ProConnect, mais on les enlève automatiquement sur la table agents
+    agent = Agent.active.find_by(email: callback_client.user_email)
 
     if current_domain.allow_self_onboarding
       agent ||= Agent.new(email: callback_client.user_email, password: SecureRandom.base64(32))

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -44,6 +44,7 @@ class Agent < ApplicationRecord
 
   # Attributes
   auto_strip_attributes :email, :first_name, :last_name
+  normalizes :email, with: ->(email) { email.downcase }
 
   enum :rdv_notifications_level, {
     all: "all",       # notify of all rdv changes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,7 @@ class User < ApplicationRecord
   # Hooks
   before_save :set_email_to_null_if_blank
   before_save :clear_notification_email_if_email_present
+  normalizes :email, with: ->(email) { email.downcase }
 
   # Scopes
   default_scope { where(deleted_at: nil) }

--- a/app/services/upsert_user_for_franceconnect_service.rb
+++ b/app/services/upsert_user_for_franceconnect_service.rb
@@ -8,7 +8,7 @@ class UpsertUserForFranceconnectService < BaseService
 
   def perform
     @user = User.find_by(franceconnect_openid_sub: omniauth_info.sub) \
-      || User.find_by(email: omniauth_info.email.downcase)
+      || User.find_by(email: omniauth_info.email)
     @new_user = @user.nil?
     if @user.nil?
       create_new_user

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe "RDV Plan API" do
         expect(User.all.to_a).to eq [user]
         expect(RdvPlan.last.user).to eq user
       end
+
+      context "when the email is un uppercase" do
+        let(:params) do
+          { user: { email: "FRANCIS@FACTICE.COM", first_name: "Francois" } }
+        end
+
+        it "creates the rdv plan with the existing user" do
+          post "/api/v1/rdv_plans", headers: headers, params: params, as: :json
+          expect(response.status).to eq 201
+          expect(User.all.to_a).to eq [user]
+          expect(RdvPlan.last.user).to eq user
+        end
+      end
     end
 
     context "when passing all possible params" do


### PR DESCRIPTION
Un correctif similaire à ce qui a déjà été fait dans https://github.com/betagouv/rdv-service-public/pull/5247 et https://github.com/betagouv/rdv-service-public/pull/5253, mais avec une solution plus systématique, qui utilise la nouvelle méthode `normalizes` qu'on a grâce à Rails 7.1 🎉  (merci @francois-ferrandis pour l'upgrade 😍 )
