### PR TITLE
Ajout d'un lien vers le rdv dans l'api

### DIFF
--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -17,7 +17,7 @@ class RdvBlueprint < Blueprinter::Base
   end
 
   field :url_for_agents do |rdv, _options|
-    Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv, host: rdv.domain.host_name)
+    Rails.application.routes.url_helpers.agents_rdv_url(rdv, host: rdv.domain.host_name)
   end
 
   association :organisation, blueprint: OrganisationBlueprint

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -16,6 +16,10 @@ class RdvBlueprint < Blueprinter::Base
     created_by_type_map[rdv.created_by_type]
   end
 
+  field :url_for_agent do |rdv, _options|
+    Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv, host: rdv.domain.host_name)
+  end
+
   association :organisation, blueprint: OrganisationBlueprint
   association :motif, blueprint: MotifBlueprint
   # DEPRECATED : Nous laissons l'association `:users` le temps que le 92, 26, 62, 64, et data-insertion mettent à jours leur système.

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -16,7 +16,7 @@ class RdvBlueprint < Blueprinter::Base
     created_by_type_map[rdv.created_by_type]
   end
 
-  field :url_for_agent do |rdv, _options|
+  field :url_for_agents do |rdv, _options|
     Rails.application.routes.url_helpers.admin_organisation_rdv_url(rdv.organisation, rdv, host: rdv.domain.host_name)
   end
 

--- a/app/controllers/agents/rdvs_controller.rb
+++ b/app/controllers/agents/rdvs_controller.rb
@@ -1,0 +1,13 @@
+class Agents::RdvsController < AgentAuthController
+  def show
+    @rdv = policy_scope(Rdv, policy_scope_class: Agent::RdvPolicy::Scope).find(params[:id])
+    authorize(@rdv, policy_class: Agent::RdvPolicy)
+    redirect_to admin_organisation_rdv_path(@rdv.organisation, @rdv)
+  end
+
+  private
+
+  def pundit_user
+    current_agent
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
         resource :webcal_sync, only: %i[show update], controller: :webcal_sync
         resource :outlook_sync, only: %i[show destroy], controller: :outlook_sync
       end
+      resources :rdvs, only: %i[show]
       resources :rdv_plans, only: %i[show] do
         member do
           get :edit_starts_at

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -2,11 +2,11 @@ RSpec.describe RdvBlueprint do
   subject(:json) { JSON.parse(rendered) }
 
   let(:rendered) { described_class.render(rdv, { root: :rdv }) }
-  let(:rdv) { build(:rdv) }
+  let(:rdv) { create(:rdv) }
 
   describe "status" do
     let(:motif) { create(:motif) }
-    let(:rdv) { build(:rdv, status: "revoked", motif: motif) }
+    let(:rdv) { create(:rdv, status: "revoked", motif: motif, organisation: motif.organisation) }
 
     it do
       expect(json.dig("rdv", "status")).to eq "revoked"
@@ -27,7 +27,7 @@ RSpec.describe RdvBlueprint do
 
   describe "users (DEPRECATED)" do
     let(:user) { build(:user, first_name: "Jean") }
-    let(:rdv) { build(:rdv, users: [user]) }
+    let(:rdv) { create(:rdv, users: [user]) }
 
     it do
       expect(json.dig("rdv", "users").first["first_name"]).to eq "Jean"
@@ -35,13 +35,24 @@ RSpec.describe RdvBlueprint do
   end
 
   describe "participations contains user" do
-    let(:user) { build(:user, first_name: "Jean") }
-    let(:rdv) { build(:rdv, participations: [participation]) }
-    let(:participation) { build(:participation, status: "seen", user: user) }
+    let(:user) { create(:user, first_name: "Jean") }
+    let(:rdv) { create(:rdv, participations: [participation]) }
+    let(:participation) { create(:participation, user: user) }
+
+    before { participation.update(status: "seen") } # On fait cette modification après les créations pour éviter qu'elle soit override par les callbacks
 
     it do
       expect(json.dig("rdv", "participations").first["status"]).to eq "seen"
       expect(json.dig("rdv", "participations").first["user"]["first_name"]).to eq "Jean"
+    end
+  end
+
+  describe "url_for_agent" do
+    let(:rdv) { create(:rdv, organisation: organisation) }
+    let(:organisation) { create(:organisation) }
+
+    it "allows api clients to display a direct link to the rdv for the agent" do
+      expect(json.dig("rdv", "url_for_agent")).to eq "http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}"
     end
   end
 end

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe RdvBlueprint do
     end
   end
 
-  describe "url_for_agent" do
+  describe "url_for_agents" do
     let(:rdv) { create(:rdv, organisation: organisation) }
     let(:organisation) { create(:organisation) }
 
     it "allows api clients to display a direct link to the rdv for the agent" do
-      expect(json.dig("rdv", "url_for_agent")).to eq "http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}"
+      expect(json.dig("rdv", "url_for_agents")).to eq "http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}"
     end
   end
 end

--- a/spec/blueprint/rdv_blueprint_spec.rb
+++ b/spec/blueprint/rdv_blueprint_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RdvBlueprint do
     let(:organisation) { create(:organisation) }
 
     it "allows api clients to display a direct link to the rdv for the agent" do
-      expect(json.dig("rdv", "url_for_agents")).to eq "http://www.rdv-solidarites-test.localhost/admin/organisations/#{organisation.id}/rdvs/#{rdv.id}"
+      expect(json.dig("rdv", "url_for_agents")).to eq "http://www.rdv-solidarites-test.localhost/agents/rdvs/#{rdv.id}"
     end
   end
 end

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -134,4 +134,17 @@ RSpec.describe "Agent can list RDVs" do
       end
     end
   end
+
+  describe "via la route qui n'utilise pas d'id d'organisation" do
+    context "quand l'agent a accès au rdv" do
+      it "redirige vers la page actuelle" do
+        visit agents_rdv_path(rdv.id)
+        raise "todo : finir cette spec"
+      end
+    end
+
+    context "quand l'agent n'a pas accès au rendez-vous" do
+      visit agents_rdv_path(rdv.id)
+    end
+  end
 end

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -149,9 +149,7 @@ RSpec.describe "Agent can list RDVs" do
       let(:rdv) { create(:rdv, agents: [current_agent]) }
 
       it "affiche une erreur" do
-        expect do
-          visit agents_rdv_path(rdv.id)
-        end.to raise_error(ActiveRecord::RecordNotFound)
+        expect { visit agents_rdv_path(rdv.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end

--- a/spec/features/agents/agent_can_list_rdvs_spec.rb
+++ b/spec/features/agents/agent_can_list_rdvs_spec.rb
@@ -137,14 +137,22 @@ RSpec.describe "Agent can list RDVs" do
 
   describe "via la route qui n'utilise pas d'id d'organisation" do
     context "quand l'agent a accès au rdv" do
-      it "redirige vers la page actuelle" do
+      let(:rdv) { create(:rdv, agents: [current_agent], organisation: organisation) }
+
+      it "redirige vers la page de détails du rdv dans le contexte de son organisation" do
         visit agents_rdv_path(rdv.id)
-        raise "todo : finir cette spec"
+        expect(page).to have_current_path(admin_organisation_rdv_path(rdv.organisation_id, rdv))
       end
     end
 
     context "quand l'agent n'a pas accès au rendez-vous" do
-      visit agents_rdv_path(rdv.id)
+      let(:rdv) { create(:rdv, agents: [current_agent]) }
+
+      it "affiche une erreur" do
+        expect do
+          visit agents_rdv_path(rdv.id)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2950,6 +2950,7 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/10",
                           "users": [
                             {
                               "id": 22,
@@ -3191,6 +3192,7 @@
                           ],
                           "starts_at": "2022-01-01 08:00:00 +0100",
                           "status": "unknown",
+                          "url_for_agents": "http://www.rdv-solidarites-test.localhost/agents/rdvs/14",
                           "users": [
                             {
                               "id": 26,


### PR DESCRIPTION
Suite à une demande de l'équipe technique de l'espace coop, mais qu'on avait déjà eu de la part de Démarches Simplifiées et Mon Suivi Social, cette PR ajoute à l'api de rdvs un lien qu'on peut afficher aux agents pour qu'ils puissent consulter les détails du rendez-vous et le modifier.

On avait aussi envisagé un lien à afficher pour l'usager, mais c'est plus compliqué : dans la plupart des cas, l'usager ne s'est pas authentifié lors de la création du rendez-vous (les créations de rendez-vous par intégration sont faites par l'agent), donc si on lui fournit un lien, il faudrait ajouter un token qui permette de d'authentifier. Le fait d'exposer ce token à tous les agents via l'api est pas anodin en terme de sécurité, puisqu'il permettrait à des agents de faire des actions au nom de l'usager.
On garde donc cette possibilité d'évolution pour plus tard.
