### PR TITLE
Retirer les lundis de pentecote des jours fériés

### DIFF
--- a/app/services/off_days.rb
+++ b/app/services/off_days.rb
@@ -30,7 +30,7 @@ class OffDays
     Date.new(2025, 5, 1),
     Date.new(2025, 5, 8),
     Date.new(2025, 5, 29),
-    Date.new(2025, 6, 9),
+    # Date.new(2025, 6, 9), # le lundi de pentecôte est une journée de solidarité optionnellement fériée
     Date.new(2025, 7, 14),
     Date.new(2025, 8, 15),
     Date.new(2025, 11, 1),
@@ -42,7 +42,7 @@ class OffDays
     Date.new(2026, 5, 1),
     Date.new(2026, 5, 8),
     Date.new(2026, 5, 14),
-    Date.new(2026, 5, 25),
+    # Date.new(2026, 5, 25), # le lundi de pentecôte est une journée de solidarité optionnellement fériée
     Date.new(2026, 7, 14),
     Date.new(2026, 8, 15),
     Date.new(2026, 11, 1),


### PR DESCRIPTION
Le lundi de Pentecôte est optionnellement férié. Certains agents travaillent ce jour là.

On le retire donc de la liste des jours fériés pour ne pas bloquer les agents.

Prévenir Éva une fois déployé