### PR TITLE
a11y: correction des attributs alt/title pour les éléments transverses

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -307,17 +307,17 @@ hr[aria-hidden="true"]
       | Ils nous font confiance
     .rdv-logos-partenaires-wrapper
       .rdv-logo-partenaire
-        = image_tag "rdv_mairie/partenaire-ministere-justice.svg", alt: "Logo Ministère de la Justice"
+        = image_tag "rdv_mairie/partenaire-ministere-justice.svg", alt: "Ministère de la Justice"
       .rdv-logo-partenaire
-        = image_tag "rdv_mairie/partenaire-msa.png", alt: "Logo MSA : Santé Famille Retraite Services"
+        = image_tag "rdv_mairie/partenaire-msa.png", alt: "MSA : Santé Famille Retraite Services"
       .rdv-logo-partenaire
-        = image_tag "rdv_mairie/partenaire-asp.png", alt: "Logo ASP : Agence de Services et de Paiement"
+        = image_tag "rdv_mairie/partenaire-asp.png", alt: "ASP : Agence de Services et de Paiement"
       .rdv-logo-partenaire
-        = image_tag "rdv_mairie/partenaire-62.jpg", alt: "Logo du département Pas-de-Calais"
+        = image_tag "rdv_mairie/partenaire-62.jpg", alt: "Département Pas-de-Calais"
       .rdv-logo-partenaire
-        = image_tag "rdv_mairie/partenaire-wavignies.jpg", alt: "Logo de la ville de Wavignies : un W vert dans un cercle"
+        = image_tag "rdv_mairie/partenaire-wavignies.jpg", alt: "Ville de Wavignies"
       .rdv-logo-partenaire
-        = image_tag "rdv_mairie/partenaire-mdph.png", alt: "Logo MDPH : Maison Départementale des Personnes Handicapées"
+        = image_tag "rdv_mairie/partenaire-mdph.png", alt: "MDPH : Maison Départementale des Personnes Handicapées"
 
 .fr-container.fr-py-8w
   .fr-grid-row.fr-grid-row--center

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -21,7 +21,7 @@ html lang="fr"
 
     = dsfr_header logo_text: "République<br>Française".html_safe, html_attributes: {id: "header"} do |header|
       ruby:
-        header.with_operator_image title: "Accueil - RDV #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: "RDV #{current_domain.name}"
+        header.with_operator_image title: "Accueil - #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: ""
         if current_user.present? && !current_user.signed_in_with_invitation_token?
           header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, classes: "fr-icon-calendar-fill"
           header.with_tool_link title: "Vos informations", path: users_informations_path
@@ -84,8 +84,8 @@ html lang="fr"
           h2.fr-footer__partners-title Nos partenaires
           .fr-footer__partners-logos
             .fr-footer__partners-sub
-              = link_to(image_tag("logos/logo_dinum.svg", alt: "Logo de la Dinum", style: "height: 5.625rem"), "https://www.numerique.gouv.fr/dinum/", class: "fr-footer__partners-link" )
-              = link_to(image_tag("logos/logo_anct.png", alt: "Logo de l'ANCT", style: "height: 5.625rem"), "https://agence-cohesion-territoires.gouv.fr/", class: "fr-footer__partners-link" )
+              = link_to(image_tag("logos/logo_dinum.svg", alt: "DINUM - Direction Interministérielle du Numérique", style: "height: 5.625rem"), "https://www.numerique.gouv.fr/dinum/", class: "fr-footer__partners-link" )
+              = link_to(image_tag("logos/logo_anct.png", alt: "ANCT - Agence Nationale de la Cohésion des Territoires", style: "height: 5.625rem"), "https://agence-cohesion-territoires.gouv.fr/", class: "fr-footer__partners-link" )
 
         .fr-footer__bottom
           ul.fr-footer__bottom-list


### PR DESCRIPTION
# Contexte

Suite à l’audit réalisé par la BIN, nous corrigeons les éléments suivants : 

<img width="816" alt="image" src="https://github.com/user-attachments/assets/ea5767ad-4241-4d17-92d8-2eb2365bccab" />
<img width="786" alt="image" src="https://github.com/user-attachments/assets/bd4ce149-f5a7-442a-b739-4c609f191f72" />
<img width="835" alt="image" src="https://github.com/user-attachments/assets/46178cf2-4299-46ac-8b16-d45f6e923591" />


