### PR TITLE
Fix : nom du service dans le footer

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -62,7 +62,7 @@ html lang="fr"
               = image_tag current_domain.dark_logo_path, alt: current_domain.name, class: "fr-footer__logo", width: "150"
           .fr-footer__content
             p.fr-footer__content-desc
-              |> RDV Service Public est un service porté par la
+              |> #{current_domain.name} est un service porté par la
               => link_to "Direction Interministérielle du Numérique (DINUM)", "https://www.numerique.gouv.fr/dinum/", target: "_blank", rel: "noopener"
               |> et
               = link_to "l’Agence Nationale de la Cohésion des Territoires (ANCT)", "https://agence-cohesion-territoires.gouv.fr/", target: "_blank", rel: "noopener"


### PR DESCRIPTION
# Contexte

En travaillant sur le retour de l’audit d’accessibilité, je me suis aperçu que le footer affichait toujours « RDV Service Public » et non le nom du service courant.

# Solution

On corrige donc en affichant le nom du service courant.
