### PR TITLE
Fix : liens dans le footer

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -71,7 +71,13 @@ html lang="fr"
               = link_to "En savoir plus…", domaines_path
             ul.fr-footer__content-list
               li.fr-footer__content-item
-                = link_to "anct.gouv.fr", "https://agence-cohesion-territoires.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener"
+                = link_to "info.gouv.fr", "https://info.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener external", title: "info.gouv.fr - nouvelle fenêtre"
+              li.fr-footer__content-item
+                = link_to "service-public.fr", "https://service-public.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener external", title: "service-public.fr - nouvelle fenêtre"
+              li.fr-footer__content-item
+                = link_to "legifrance.gouv.fr", "https://legifrance.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener external", title: "legifrance.gouv.fr - nouvelle fenêtre"
+              li.fr-footer__content-item
+                = link_to "data.gouv.fr", "https://data.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener external", title: "data.gouv.fr - nouvelle fenêtre"
 
         .fr-footer__partners
           h2.fr-footer__partners-title Nos partenaires


### PR DESCRIPTION
# Contexte

Le footer de notre service doit comporter 4 liens de références de l'écosystème institutionnel qui sont imposés à tous les services numériques de l’état. 

# Solution

On met donc les 4 liens obligatoires. 
Les liens vers le site de l’ANCT (et celui de la DINUM) sont déjà présents dans le footer.

Cela corrige par la même occasion un petit souci d’accessibilité 

<img width="871" alt="image" src="https://github.com/user-attachments/assets/94cebdba-f6b1-4450-bc4a-49262452cd3e" />

