### PR TITLE
Api des RDV Plan : Permettre de réutiliser un usager créé pour un autre rdv plan

### DIFF
--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -42,8 +42,8 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
 
       user = User.find(user_params[:id])
 
-      unless user.organisation_ids.intersect?(current_agent.organisation_ids)
-        # L'agent et l'usager n'ont pas d'organisations en commun
+      # La présence de current_organisation dans Agent::UserPolicy nous empêche de réutiliser la policy directement ici
+      unless user.organisation_ids.intersect?(current_agent.organisation_ids) || RdvPlan.where(planning_agent: current_agent, user: user).any?
         raise Pundit::NotAuthorizedError
       end
 

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "RDV Plan API" do
             post "/api/v1/rdv_plans", headers: headers, params: params_for_second_call, as: :json
           end.to change(RdvPlan, :count).by(1)
 
-          expect(parsed_response_body["user_id"]).to eq first_rdv_plan.user_id
+          expect(parsed_response_body.dig("rdv_plan", "user_id")).to eq first_rdv_plan.user_id
         end
       end
     end

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -41,6 +41,23 @@ RSpec.describe "RDV Plan API" do
           last_name: "Factice"
         )
       end
+
+      context "when reusing the user id for a second rdv_plan, even if the first was not completed" do
+        before do
+          post "/api/v1/rdv_plans", headers: headers, params: params, as: :json
+        end
+
+        it "links the user to the second rdv plan as well" do
+          first_rdv_plan = RdvPlan.first
+
+          params_for_second_call = { user: { id: first_rdv_plan.user_id } }
+          expect do
+            post "/api/v1/rdv_plans", headers: headers, params: params_for_second_call, as: :json
+          end.to change(RdvPlan, :count).by(1)
+
+          expect(parsed_response_body["user_id"]).to eq first_rdv_plan.user_id
+        end
+      end
     end
 
     context "when passing a user id" do


### PR DESCRIPTION
# Contexte

On peut avoir le cas suivant :
- un usager est créé par api pour un rdv plan
- l'appli client enregistre l'id de cet usager
- la prise de rendez-vous n'est pas finalisée
- plus tard, l'agent recommence une prsie de rdv via rdv plan pour cet usager
- l'appli cliente essaye de réutiliser l'id de l'usager qui a été créé
- elle a une erreur parce qu'il n'y a pas d'orga en commun entre l'agent et l'usager, donc on lève une erreur de permission

L'équipe technique de la coop a eu cette erreur lors du développement.
On s'est dit que le plus simple serait de considérer que si il y a déjà un rdv plan liant cet usager à cet agent, c'est correct de permettre d'en créer un autre.

# Solution

J'ai ajouté la vérification dans le controller qui gère la création, mais l'implém qui m'aurait semblé plus naturelle aurait été d'utiliser la `Agents::UserPolicy`. Malheureusement, cette policy utilise la `current_organisation` qui n'est pas utilisable ici (techniquement on peut même avoir des agents qui créent des rdv plans avant d'avoir une organisation).

A la limite, on peut essayer de voir le côté positif et se dire que ça nous évite d'ajouter de la complexité dans une policy déjà complexe ? 🤷 
