### PR TITLE
Fix : correction d’un lien incohérent dans le footer

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -67,8 +67,9 @@ html lang="fr"
               |> et
               = link_to "l’Agence Nationale de la Cohésion des Territoires (ANCT)", "https://agence-cohesion-territoires.gouv.fr/", target: "_blank", rel: "noopener"
               '
-            p.fr-footer__content-desc
-              = link_to "En savoir plus…", domaines_path
+            - if current_domain == Domain::RDV_AIDE_NUMERIQUE
+              p.fr-footer__content-desc
+                = link_to "En savoir plus concernant #{Domain::RDV_AIDE_NUMERIQUE.name} et #{Domain::RDV_SOLIDARITES.name}…", domaines_path
             ul.fr-footer__content-list
               li.fr-footer__content-item
                 = link_to "info.gouv.fr", "https://info.gouv.fr", class: "fr-footer__content-link", target: "_blank", rel: "noopener external", title: "info.gouv.fr - nouvelle fenêtre"


### PR DESCRIPTION
# Contexte

Lors de l’audit d’accessibilité, il a été remonté que nous avions un lien « En savoir plus… » dans le footer.
Ce lien comporte un problème d’accessibilité, car il n’est pas explicite. Et en y regardant de plus près, je me suis rendu compte que la page vers laquelle cela renvoyait ne concernait que RDV Aide Numérique et n’avait pas de sens ailleurs. 

# Solution

- On rend explicite le texte du lien
- On affiche le lien que sur RDV Aide Numérique

<img width="837" alt="image" src="https://github.com/user-attachments/assets/196a534e-0d39-43e1-8c22-46b69df50c1c" />
