### PR TITLE
a11y: les pages d’accueil doivent avoir un titre dédié

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -1,5 +1,8 @@
 - contact_team_url = Agents::PagesController::CONTACT_TEAM_URL
 
+- content_for :title do
+  | Accueil
+
 .fr-py-8w.rdv-background-color-alt-blue-ecume
   .fr-container
     .fr-grid-row.fr-grid-row--gutters.fr-grid-row--center

--- a/app/views/search/search_rdv.html.slim
+++ b/app/views/search/search_rdv.html.slim
@@ -1,3 +1,6 @@
+- content_for :title do
+  | Accueil
+
 = render "prescription_banner"
 
 = render "banner", context: @context

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -64,11 +64,7 @@ def expect_page_to_be_axe_clean(path, excluding_selector: nil)
 end
 
 # Pour des questions d’accessibilité, chaque page doit avoir un titre explicite
-# suivi du nom de l’application (sauf pour la page d’accueil)
+# suivi du nom de l’application
 def expect_page_to_have_title
-  if page.current_path == "/"
-    expect(page).to have_title("RDV Solidarités")
-  else
-    expect(page).to have_title(/.* - RDV Solidarités/)
-  end
+  expect(page).to have_title(/.* - RDV Solidarités/)
 end


### PR DESCRIPTION
# Contexte

Suite à l’audit de la BIN, nous avons ce retour :

<img width="832" alt="image" src="https://github.com/user-attachments/assets/d9cc1f61-9302-4e25-9cde-37a0060e48dc" />

# Solution

- Dans les tests, on force également la page d’accueil à avoir un titre.
- On ajoute le titre accueil sur les pages d’accueil des 3 instances

