### PR TITLE
Fix : a11y ajout du role main

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -39,7 +39,7 @@ html lang="fr"
           header.with_tool_link title: "Se connecter", path: new_user_session_path, classes: "fr-fi-account-fill"
         end
 
-    main#content
+    main#content[role="main"]
       - if content_for :main_content
         = yield :main_content
       - else


### PR DESCRIPTION
# Contexte

Suite à l’audit de la BIN, nous avons eu ce retour

<img width="823" alt="image" src="https://github.com/user-attachments/assets/4aec86e7-bdc9-4853-be22-3abf675394b9" />

# Solution

On ajoute l’attribut role manquant
