### PR TITLE
a11y: corrections des boutons En savoir plus sur les landing RDVS et RDV Aide Num

### DIFF
--- a/app/views/search/address_selection/_rdv_aide_numerique.html.slim
+++ b/app/views/search/address_selection/_rdv_aide_numerique.html.slim
@@ -36,4 +36,4 @@ section.rdv-background-color-alt-green-menthe.fr-py-8w
       .fr-col-12.fr-col-md-9
         .fr-text--xl.mb-2.rdv-color-text-action-high-blue-ecume Vous êtes Conseiller numérique ?
         p Faciliter la prise de rendez-vous avec vos apprenants.
-        = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"
+        = link_to "En savoir plus", presentation_agent_path, class: "fr-btn fr-btn--secondary", title: "En savoir plus sur la prise de rendez-vous pour les agents"

--- a/app/views/search/address_selection/_rdv_solidarites.html.slim
+++ b/app/views/search/address_selection/_rdv_solidarites.html.slim
@@ -9,4 +9,4 @@ section.rdv-background-color-alt-green-menthe.fr-py-4w.rdv-text-align-center.rdv
       .fr-col-12.fr-col-md-9
         .fr-text--lg.mb-2.rdv-color-text-action-high-blue-ecume Vous êtes un agent ?
         p Nous nous engageons à réduire le nombre de rendez-vous manqués dans les services sociaux départementaux.
-        = link_to "En savoir plus", presentation_agent_path, class: "btn btn-tertiary"
+        = link_to "En savoir plus", presentation_agent_path, class: "fr-btn fr-btn--secondary", title: "En savoir plus sur la prise de rendez-vous pour les agents"


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité réalisé par la BIN, il a été révélé que le bouton « En savoir plus » sur la landing RDV Solidarité n’étais pas assez explicite et avait un contraste insuffisant au focus.

# Solution

- On change le bouton pour un bouton DSFR secondary qui corrige le problème de focus
- On ajoute un `title` pour rendre le bouton + explicite

