### PR TITLE
Suppression d'un bouton obsolete

### DIFF
--- a/app/views/agents/pages/home.html.slim
+++ b/app/views/agents/pages/home.html.slim
@@ -16,7 +16,6 @@
           - if Agent::TerritoryPolicy.new(current_agent, Territory.new).new?
             p Vous pouvez ouvrir un espace pour votre organisation.
             = link_to "Ouvrir un espace", new_agents_territory_path, class: "fr-btn"
-            = link_to "Demander une démo", meet_the_team_url, class: "fr-btn--secondary"
           - else
             p Vous pouvez demander à ouvrir un espace pour votre organisation. Notre équipe fera les vérifications nécessaires et vous ouvrira un espace.
             ul.fr-btns-group.fr-btns-group--center.fr-btns-group--inline-md


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="651" alt="Screenshot 2025-05-14 at 17 54 16" src="https://github.com/user-attachments/assets/9aba96b5-2468-4794-8a80-5d58f9230f85" />|<img width="630" alt="Screenshot 2025-05-14 at 17 54 24" src="https://github.com/user-attachments/assets/becfdb87-a359-4bb1-ba15-dcb694666f89" />


Je me suis trompé dans un rebase de https://github.com/betagouv/rdv-service-public/pull/5267 et j'avais laissé traîner ce bouton pas fini 😱 (et dont on cherchait à se débarasser)


