### PR TITLE
Amélioration de l'appli locale pour tester les intégrations

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -283,9 +283,7 @@ class Agent < ApplicationRecord
   def domain
     @domain ||= if organisations.where(verticale: :rdv_aide_numerique).any?
                   Domain::RDV_AIDE_NUMERIQUE
-                elsif organisations.where(verticale: :rdv_mairie).any?
-                  Domain::RDV_MAIRIE
-                elsif ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"].present?
+                elsif organisations.where(verticale: :rdv_mairie).any? || ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"].present?
                   Domain::RDV_MAIRIE
                 else
                   Domain::RDV_SOLIDARITES

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -285,6 +285,8 @@ class Agent < ApplicationRecord
                   Domain::RDV_AIDE_NUMERIQUE
                 elsif organisations.where(verticale: :rdv_mairie).any?
                   Domain::RDV_MAIRIE
+                elsif ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"].present?
+                  Domain::RDV_MAIRIE
                 else
                   Domain::RDV_SOLIDARITES
                 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -283,7 +283,7 @@ class Agent < ApplicationRecord
   def domain
     @domain ||= if organisations.where(verticale: :rdv_aide_numerique).any?
                   Domain::RDV_AIDE_NUMERIQUE
-                elsif organisations.where(verticale: :rdv_mairie).any? || ENV["AGENT_CONNECT_RDVSP_CLIENT_ID"].present?
+                elsif organisations.where(verticale: :rdv_mairie).any?
                   Domain::RDV_MAIRIE
                 else
                   Domain::RDV_SOLIDARITES

--- a/db/seeds/ccas.rb
+++ b/db/seeds/ccas.rb
@@ -66,12 +66,13 @@ agent = Agent.new(
 agent.skip_confirmation!
 agent.save!
 
-application = Doorkeeper::Application.new(
+application = OauthApplication.new(
   name: "Mon Suivi Social",
   uid: "Gcz6Hrp8fmqI-4ubjjsJeTcyZg_JF0v_XYsibL7a_Fg",
   redirect_uri: "http://localhost:4567/auth/rdvservicepublic/callback\nhttp://127.0.0.1:4567/auth/rdvservicepublic/callback",
   post_logout_redirect_uri: "http://localhost:4567/",
-  logo_base64: ""
+  logo_base64: "",
+  default_service: service
 )
 
 test_secret = "development-kLbob_cr6Z58h9DTHjUvOhi44cImr2QA4XOQZJHKTCg" # Pour le développement en local uniquement

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -61,7 +61,7 @@ class MonSuiviSocial < Sinatra::Base
 
   post "/prendre_rdv" do
     response = Faraday.post(
-      base_url + "/api/v1/rdv_plans",
+      "#{base_url}/api/v1/rdv_plans",
       {
         user: {
           first_name: "Francis",

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -30,6 +30,8 @@ class MonSuiviSocial < Sinatra::Base
         <br />
         <a href="http://www.rdv-mairie.localhost:3000/admin/organisations/configuration">Vérifier ma Configuration sur RDV Service Public</a>
         <br />
+        <form method="post" action="/prendre_rdv"><button>Prendre RDV avec Françis Factice</button></form>
+
         <a href="/logout">Déconnexion</a>
       HTML
     else
@@ -55,6 +57,26 @@ class MonSuiviSocial < Sinatra::Base
     session.delete(:access_token)
 
     redirect to(base_url + OmniAuth::Strategies::RdvServicePublic.sign_out_path(app_id))
+  end
+
+  post "/prendre_rdv" do
+    response = Faraday.post(
+      base_url + "/api/v1/rdv_plans",
+      {
+        user: {
+          first_name: "Francis",
+          last_name: "Factice",
+        },
+      }.to_json,
+      {
+        "Content-Type": "application/json",
+        Authorization: "Bearer #{session[:access_token]}",
+      }
+    )
+
+    parsed_response = JSON.parse(response.body)
+    redirect_url = parsed_response.dig("rdv_plan", "url").gsub(".localhost", ".localhost:3000")
+    redirect to(redirect_url)
   end
 
   get "/favicon.ico" do


### PR DESCRIPTION
Une petite amélioration incrémentale pour tester les intégrations : l'appli locale lancée avec `bundle exec ruby scripts/mon_suivi_social_local.rb` permet maintenant de faire une prise de rendez-vous

~~J'ajoute aussi une couche de sécurité sur le choix du domaine par défaut pour les agents qui n'ont pas d'organisation, puisque ça devenait un problème en local pour tester.
Si on a une variable d'env qui correspond à RDVSP, on fait de RDVSP le domaine par défaut.~~