### PR TITLE
Bugfix: les RDVs honorés sont barrés et les lapins ne le sont pas

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -33,7 +33,7 @@ function eventClassNames(info) {
   let extendedProps = info.event.extendedProps;
   const customCssClasses = [];
 
-  if(["seen", "excused", "revoked"].includes(extendedProps.status)) {
+  if(["noshow", "excused", "revoked"].includes(extendedProps.status)) {
     customCssClasses.push("rdv-fc-event-barre");
   }
 


### PR DESCRIPTION
Retour ce matin au support : 

> Bonjour,
> Est-ce normal que depuis ce matin, les rendez-vous honorés soient barrés et les non excusés ne le sont pas ?
> Merci.


C'est une erreur d'inattention dans #5187, on est passés de

```scss
.fc-event-excused,
.fc-event-noshow,
.fc-event-revoked {
text-decoration: line-through
```

à

```js
  if(["seen", "excused", "revoked"].includes(extendedProps.status)) {
    customCssClasses.push("rdv-fc-event-barre");
  }
```

ce qui fait que les `noshow` ne sont plus barrés et les `seen` sont barrés. :grimacing: 