### PR TITLE
Fix: agd username pull requests reminder

### DIFF
--- a/.github/workflows/pull_requests_reminder.yml
+++ b/.github/workflows/pull_requests_reminder.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           webhook-url: ${{ secrets.PR_REMINDER_WEBHOOK_URL }}
           provider: slack
-          github-provider-map: "francois-ferrandis:francois.ferrandis,victormours:victor.mours,aminedhobb:amine.dhobb,Holist:romain.neuville,Michaelvilleneuve:michael.villeneuve,AntoineGirard:antoine.girard,Teodora-Stanki:teodora.stankiewicz"
+          github-provider-map: "francois-ferrandis:francois.ferrandis,victormours:victor.mours,aminedhobb:amine.dhobb,Holist:romain.neuville,Michaelvilleneuve:michael.villeneuve,AntoineGirard:agd,Teodora-Stanki:teodora.stankiewicz"
           channel: "startup-rdv-service-public-dev"


### PR DESCRIPTION
# Contexte

Mon nom d’utilisateur est incorrect pour le reminder de PR Mattermost. Je le corrige histoire d’être notifié à nouveau.