### PR TITLE
Bugfix: afficher les événements courts à la suite

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -16,7 +16,15 @@ const defaultFullCalendarConfig = () => ({
   slotMaxTime: '20:00:00',
   eventClassNames: eventClassNames,
   eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
-  timeZone: "Europe/Paris" // This is a hack to make sure that the events will be shown at the proper time in the calendar.
+
+  // Avec la valeur par défaut (15), les RDVs de 15 minutes sont affichés côte-à-côte, car :
+  //   1. FullCalendar estime que c'est plus lisible de "gonfler" un peu l'affichage d'un événement très court (augmenter sa hauteur).
+  //   2. FullCalendar affiche côte-à-côte des événements qui se chevauchent.
+  //   3. Les événements de 15 minutes se chevauchent une fois gonflés.
+  // Nous disons donc ici à FullCalendar de ne pas gonfler les événements courts.
+  eventMinHeight: 9,
+
+  // This is a hack to make sure that the events will be shown at the proper time in the calendar.
   // If this is removed, there is a bug that causes the events in the calendar to be show at the wrong
   // time for agents that are not in the Paris timezone.
   // The proper fix for this would be to make sure we store all rdvs with the right timezone, but that's a much bigger project.
@@ -27,6 +35,7 @@ const defaultFullCalendarConfig = () => ({
   // There is one case for which this fix would fail: if the local time of the user and the agent is not the same (for example the agent is
   // in the métropole and the user is at la réunion), they will not see the same time
   // for the rdv. This seems unlikely for now.
+  timeZone: "Europe/Paris"
 })
 
 function eventClassNames(info) {


### PR DESCRIPTION
Encore un truc cassé dans #5187, car la v5 de FullCalendar change un peu de comportement.

Pour tester j'ai modifié les seeds `medico_social.rb` ligne 757, j'ai fait en sorte de créer 4 RDVs de 15 minutes par heure :

```ruby
rdv_attributes = 1000.times.flat_map do |i|
  day = 2.years.ago.beginning_of_day + i.days
  (9..16).map do |hour|
    i = 0
    4.times.map do
      starts_at = day + hour.hours + i.minutes
      hash = {
        created_at: now,
        updated_at: now,
        starts_at: starts_at,
        ends_at: starts_at + 15.minutes,
        motif_id: motif_org_paris_nord_pmi_securite.id,
        lieu_id: lieu_org_paris_nord_bd_aubervilliers.id,
        organisation_id: org_paris_nord.id,
        context: "Context #{day} #{hour}",
        created_by_type: "Agent",
        created_by_id: agent_org_paris_nord_pmi_martine.id,
      }
      i += 15
      hash
    end
  end.flatten
end
```

# Avant

![image](https://github.com/user-attachments/assets/586aba8c-301b-46e0-b079-ac7a528666eb)

# Après

![image](https://github.com/user-attachments/assets/85b3de90-34af-49ba-8b32-9bdb477a3c66)
 