### PR TITLE
Validation de l’email à la création d’un ticket Crisp

### DIFF
--- a/app/jobs/create_crisp_ticket_job.rb
+++ b/app/jobs/create_crisp_ticket_job.rb
@@ -2,7 +2,12 @@ class CreateCrispTicketJob < ApplicationJob
   queue_as :latency_30s
 
   def perform(nickname:, email:, phone:, subject:, message:, role:, domain:)
-    return if email == "testing@example.com"
+    # On ne crée pas de ticket si l’email n’a pas un format correct
+    # Placé ici suite à un problème de spam, il faudra à terme remonter cette validation dans le formulaire
+    return unless email =~ URI::MailTo::EMAIL_REGEXP
+    # Nous avons ajouté la ligne suivante suite à du spam
+    # On laisse cette ligne en attendant d’avoir un système de captcha
+    return if email =~ /.*@example\.com$/
 
     conversation = client.website.create_new_conversation(website_id)
 

--- a/spec/jobs/create_crisp_ticket_job_spec.rb
+++ b/spec/jobs/create_crisp_ticket_job_spec.rb
@@ -1,0 +1,53 @@
+# rubocop:disable RSpec/AnyInstance, RSpec/StubbedMock
+RSpec.describe CreateCrispTicketJob do
+  describe "#perform" do
+    let(:client) { instance_double(Crisp::Client) }
+    let(:website) { instance_double(Crisp::WebsiteResource) }
+
+    it "crée un ticket" do
+      allow_any_instance_of(described_class).to receive(:client).and_return(client)
+      allow(client).to receive(:website).and_return(website)
+      expect(website).to receive(:create_new_conversation).with(ENV.fetch("CRISP_WEBSITE_ID")).and_return({ "session_id" => "12345" })
+      expect(website).to receive(:send_message_in_conversation).with(
+        ENV.fetch("CRISP_WEBSITE_ID"),
+        "12345",
+        {
+          "type" => "text",
+          "from" => "user",
+          "origin" => ENV.fetch("CRISP_URN"),
+          "content" => "message\n\n---\nMessage envoyé depuis le formulaire de contact\n",
+        }
+      )
+      expect(website).to receive(:update_conversation_metas).with(
+        ENV.fetch("CRISP_WEBSITE_ID"),
+        "12345",
+        {
+          nickname: "nickname",
+          email: "plop@unusager.fr",
+          phone: "061234567",
+          segments: %w[role domain],
+          subject: "subject",
+          device: {
+            locales: ["fr"],
+          },
+        }
+      )
+      described_class.perform_now(email: "plop@unusager.fr", nickname: "nickname", phone: "061234567", subject: "subject", message: "message", role: "role", domain: "domain")
+    end
+
+    context "quand l’email n’a pas un format correct" do
+      it "ne crée pas de ticket" do
+        expect_any_instance_of(described_class).not_to receive(:client)
+        described_class.perform_now(email: "invalid_email", nickname: "nickname", phone: "061234567", subject: "subject", message: "message", role: "role", domain: "domain")
+      end
+    end
+
+    context "quand l’email est de type @example.com" do
+      it "ne crée pas de ticket" do
+        expect_any_instance_of(described_class).not_to receive(:client)
+        described_class.perform_now(email: "toto@example.com", nickname: "nickname", phone: "061234567", subject: "subject", message: "message", role: "role", domain: "domain")
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/AnyInstance, RSpec/StubbedMock

--- a/spec/jobs/create_crisp_ticket_job_spec.rb
+++ b/spec/jobs/create_crisp_ticket_job_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe CreateCrispTicketJob do
     let(:client) { instance_double(Crisp::Client) }
     let(:website) { instance_double(Crisp::WebsiteResource) }
 
+    stub_env_with(CRISP_WEBSITE_ID: "abcde", CRISP_URN: "urn:crisp:1234567890")
+
     it "crée un ticket" do
       allow_any_instance_of(described_class).to receive(:client).and_return(client)
       allow(client).to receive(:website).and_return(website)


### PR DESCRIPTION
# Contexte

On ajoute un validateur pour éviter d’ouvrir des tickets Crisp avec des emails invalides.
On fait cela ici pour résoudre le problème de spam, mais on remontera la validation dans le formulaire.