### PR TITLE
Script pour supprimer en masse des conversations Crisp

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,29 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "5e49c97564dd5bd05b5bc9a38faaf23c0c404cc707b798d4632845745720d0a4",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "scripts/clean_crisp_tickets.rb",
+      "line": 42,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "connection.delete(\"/v1/website/#{WEBSITE_ID}/conversation/#{conversation[\"session_id\"]}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Cleaner",
+        "method": "fetch_conversations_and_delete"
+      },
+      "user_input": "conversation[\"session_id\"]",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "d93227729f1a070feb92d7048272b7c5b0535fc7505c7ba5ab3c6c9c6e510fca",

--- a/scripts/clean_crisp_tickets.rb
+++ b/scripts/clean_crisp_tickets.rb
@@ -38,6 +38,8 @@ class Cleaner
     puts "found #{conversations.count}, among which #{conversations_to_delete.count} will be deleted…"
 
     conversations_to_delete.each do |conversation|
+      raise unless conversation["session_id"].match?(/^[\da-z\-_]+$/) # prevent injections, brakeman false positive
+
       puts "deleting conversation #{conversation['session_id']} with #{conversation['meta']['nickname']}"
       res = connection.delete "/v1/website/#{WEBSITE_ID}/conversation/#{conversation['session_id']}"
       puts "delete res : #{JSON.parse(res.body)}"

--- a/scripts/clean_crisp_tickets.rb
+++ b/scripts/clean_crisp_tickets.rb
@@ -1,0 +1,58 @@
+# rails runner scripts/clean_crisp_tickets.rb
+
+class Cleaner
+  WEBSITE_ID = ENV.fetch("CRISP_WEBSITE_ID").freeze
+
+  def run
+    total_deleted_count = nil
+    total_deleted_count = fetch_paginated_routine(page_number: 1) while total_deleted_count != 0
+  end
+
+  def should_delete_conversation?(conversation)
+    (
+      conversation["meta"]["nickname"] == "anonymous" &&
+      conversation["last_message"].starts_with?("20 ")
+    ) || conversation["meta"]["nickname"].include?("LmMqtzme")
+  end
+
+  def fetch_paginated_routine(page_number:, total_deleted_count: 0)
+    conversations_count, deleted_count = fetch_conversations_and_delete(page_number:)
+    total_deleted_count += deleted_count
+    if conversations_count > 0
+      fetch_paginated_routine(page_number: page_number + 1, total_deleted_count:)
+    else
+      total_deleted_count
+    end
+  end
+
+  def fetch_conversations_and_delete(page_number:)
+    puts "\ngetting page #{page_number}…"
+    response = connection.get(
+      "/v1/website/#{WEBSITE_ID}/conversations/#{page_number}",
+      filter_date_start: (Time.zone.today - 1.day).iso8601
+    )
+    raise "got #{response.status} from GET" if [200, 206].exclude?(response.status)
+
+    conversations = JSON.parse(response.body)["data"]
+    conversations_to_delete = conversations.filter { should_delete_conversation?(_1) }
+    puts "found #{conversations.count}, among which #{conversations_to_delete.count} will be deleted…"
+
+    conversations_to_delete.each do |conversation|
+      puts "deleting conversation #{conversation['session_id']} with #{conversation['meta']['nickname']}"
+      res = connection.delete "/v1/website/#{WEBSITE_ID}/conversation/#{conversation['session_id']}"
+      puts "delete res : #{JSON.parse(res.body)}"
+      raise "got status #{res.status} instead of 200." if res.status != 200
+    end
+    [conversations.count, conversations_to_delete.count]
+  end
+
+  def connection
+    @connection ||= Faraday.new(url: "https://api.crisp.chat/") do |faraday|
+      faraday.headers["Authorization"] = "Basic #{Base64.strict_encode64("#{ENV.fetch('CRISP_IDENTIFIER')}:#{ENV.fetch('CRISP_KEY')}")}"
+      faraday.headers["X-Crisp-Tier"] = "plugin"
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+end
+
+Cleaner.new.run if $PROGRAM_NAME == __FILE__

--- a/scripts/clean_crisp_tickets.rb
+++ b/scripts/clean_crisp_tickets.rb
@@ -38,8 +38,6 @@ class Cleaner
     puts "found #{conversations.count}, among which #{conversations_to_delete.count} will be deleted…"
 
     conversations_to_delete.each do |conversation|
-      raise unless conversation["session_id"].match?(/^[\da-z\-_]+$/) # prevent injections, brakeman false positive
-
       puts "deleting conversation #{conversation['session_id']} with #{conversation['meta']['nickname']}"
       res = connection.delete "/v1/website/#{WEBSITE_ID}/conversation/#{conversation['session_id']}"
       puts "delete res : #{JSON.parse(res.body)}"


### PR DESCRIPTION
# Contexte

On a pris une salve de spam / tentatives d’injection via Crisp ce matin
On est en train de mettre en place des protections pour éviter que ça n’arrive jusqu’à Crisp.
On a du supprimer des centaines de tickets crisp et ce n’est pas possible via l’interface (pas de bulk close).

# Solution

La gem wrapper d’api crisp est cassée pour la méthode `search_conversations` 😬 ça fait une route error.

J’ai donc du avec joie recoder les requêtes via faraday et gérer la pagination.

Le script ne prend pas de paramètre mais demande à être modifié avant d’être executé pour adapter la méthode `﻿﻿should_delete_conversation?`