### PR TITLE
Throttling par IP sur api/v1/rdvs via rack-attack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -71,8 +71,6 @@ module Lapin
       end
     end
 
-    config.x.rack_attack.limit = 50
-
     config.exceptions_app = routes # Permet les pages d'erreur custom
 
     config.active_record.async_query_executor = :global_thread_pool

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -79,8 +79,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  config.x.rack_attack.limit = 2
-
   config.active_record.encryption.primary_key = "test"
   config.active_record.encryption.deterministic_key = "test"
   config.active_record.encryption.key_derivation_salt = "test"

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,6 +15,6 @@ class Rack::Attack
       "Retry-After" => (match_data[:period] - (now % match_data[:period])).to_s,
     }
 
-    [429, headers, [{ errors: ["Limite d'appels API atteinte. Merci de patienter.\n"] }.to_json]]
+    [429, headers, [{ errors: ["Limite d'appels API atteinte. Merci de patienter."] }.to_json]]
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,8 @@
 class Rack::Attack
-  throttle("API throttling by IP", limit: Rails.env.test? ? 2 : 50, period: 60) do |request|
-    request.ip if request.path.match(%r{api/v1/})
+  throttle("API throttling by IP", limit: Rails.env.test? ? 2 : 20, period: 60) do |request|
+    if request.path.match(%r{api/v1/rdvs}) && request.get?
+      "#{request.ip}-api-rdvs-org-#{params[:organisation_id]}"
+    end
   end
 
   # cf https://github.com/rack/rack-attack/tree/6-stable?tab=readme-ov-file#ratelimit-headers-for-well-behaved-clients

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,9 +1,9 @@
 class Rack::Attack
-  throttle("requests by ip", limit: Rails.configuration.x.rack_attack.limit, period: 60) do |request|
-    public_api_controllers = %w[public_link]
-    request.ip if request.path.match("api/v1/(#{public_api_controllers.join('|')})|public_api/public_link")
+  throttle("API throttling by IP", limit: Rails.env.test? ? 2 : 50, period: 60) do |request|
+    request.ip if request.path.match(%r{api/v1/})
   end
 
+  # cf https://github.com/rack/rack-attack/tree/6-stable?tab=readme-ov-file#ratelimit-headers-for-well-behaved-clients
   self.throttled_responder = lambda do |request|
     match_data = request.env["rack.attack.match_data"]
     now = match_data[:epoch_time]

--- a/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdvs_request_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
 
         run_test!
       end
+
+      it_behaves_like "an endpoint protected against floods that returns 429 - too_many_requests", :get, "/api/v1/rdvs"
     end
   end
 

--- a/spec/support/api_spec_shared_examples.rb
+++ b/spec/support/api_spec_shared_examples.rb
@@ -33,13 +33,13 @@ module ApiSpecSharedExamples
     end
   end
 
-  RSpec.shared_context "an endpoint that returns 429 - too_many_requests" do |method, path|
+  RSpec.shared_context "an endpoint protected against floods that returns 429 - too_many_requests" do |method, path|
     response 429, "Renvoie 'too_many_requests' quand la limite d'appels est atteinte" do
       schema "$ref" => "#/components/schemas/error_too_many_request"
 
       before do
-        Rack::Attack.enabled = true
-        Rack::Attack.reset!
+        Rack::Attack.enabled = true # it is disabled in a before(:suite) in rails_helper.rb
+        Rack::Attack.reset! # this clears the recorded count by IP
         3.times do
           send(method, path)
         end

--- a/spec/support/api_spec_shared_examples.rb
+++ b/spec/support/api_spec_shared_examples.rb
@@ -33,22 +33,6 @@ module ApiSpecSharedExamples
     end
   end
 
-  RSpec.shared_context "an endpoint that returns 429 - too_many_requests" do |method, path|
-    response 429, "Renvoie 'too_many_requests' quand la limite d'appels est atteinte" do
-      schema "$ref" => "#/components/schemas/error_too_many_request"
-
-      before do
-        Rack::Attack.enabled = true
-        Rack::Attack.reset!
-        3.times do
-          send(method, path)
-        end
-      end
-
-      run_test!
-    end
-  end
-
   RSpec.shared_context "rdv_mairie_api_authentication", :rdv_mairie_api_authentication do
     stub_env_with ANTS_RDV_API_URL: "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api",
                   ANTS_RDV_OPT_AUTH_TOKEN: "fake-token",

--- a/spec/support/api_spec_shared_examples.rb
+++ b/spec/support/api_spec_shared_examples.rb
@@ -34,7 +34,7 @@ module ApiSpecSharedExamples
   end
 
   RSpec.shared_context "an endpoint protected against floods that returns 429 - too_many_requests" do |method, path|
-    response 429, "Renvoie 'too_many_requests' quand la limite d'appels est atteinte" do
+    response 429, "Renvoie 'too_many_requests' quand la limite d'appels est atteinte (50 requêtes par périodes de 60 secondes)" do
       schema "$ref" => "#/components/schemas/error_too_many_request"
 
       before do

--- a/spec/support/api_spec_shared_examples.rb
+++ b/spec/support/api_spec_shared_examples.rb
@@ -33,6 +33,22 @@ module ApiSpecSharedExamples
     end
   end
 
+  RSpec.shared_context "an endpoint that returns 429 - too_many_requests" do |method, path|
+    response 429, "Renvoie 'too_many_requests' quand la limite d'appels est atteinte" do
+      schema "$ref" => "#/components/schemas/error_too_many_request"
+
+      before do
+        Rack::Attack.enabled = true
+        Rack::Attack.reset!
+        3.times do
+          send(method, path)
+        end
+      end
+
+      run_test!
+    end
+  end
+
   RSpec.shared_context "rdv_mairie_api_authentication", :rdv_mairie_api_authentication do
     stub_env_with ANTS_RDV_API_URL: "https://int.api-coordination.rendezvouspasseport.ants.gouv.fr/api",
                   ANTS_RDV_OPT_AUTH_TOKEN: "fake-token",

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -3003,7 +3003,7 @@
                   "example": {
                     "value": {
                       "errors": [
-                        "Limite d'appels API atteinte. Merci de patienter.\n"
+                        "Limite d'appels API atteinte. Merci de patienter."
                       ]
                     }
                   }

--- a/swagger/v1/api.json
+++ b/swagger/v1/api.json
@@ -2994,6 +2994,25 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Renvoie 'too_many_requests' quand la limite d'appels est atteinte (50 requêtes par périodes de 60 secondes)",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "example": {
+                    "value": {
+                      "errors": [
+                        "Limite d'appels API atteinte. Merci de patienter.\n"
+                      ]
+                    }
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/error_too_many_request"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
# Contexte

On a reçu des salves de tentatives d’intrusion sur une nouvelle route de formulaire de contact publique. On aimerait se protéger par différents moyens dont du throttling par IP.

On a aussi reçu des salves de requêtes API d’un partenaire envoyées par erreur et qui ont fait chuter notre rpm. 

Le throttling rack-attack a déjà été utilisé, uniquement sur des routes d’api `public_links` qui n’existent plus cf https://github.com/betagouv/rdv-service-public/commit/33003af68184f74fa1e3c151e798187e9ab67583#r157146133 . Il n’y a donc actuellement aucun throttling ni sur l’API ni sur les routes web. 

# Solution

Je propose ici d’activer une nouvelle règle de throttling :
- max 50 requetes par minute par IP
- uniquement sur une route d’API : `/api/v1/rdvs`
- renvoie une 429 avec des infos dans le header sur jusqu’à quand l’IP est throttled (au max une minute plus tard donc)

TODO : 
- [ ] en fait ce n’est pas assez souple si MSS a plus de 50 visiteurs qui accèdent chacun à leur liste de RDV en même temps 🤔 