### PR TITLE
a11y: suppression d’une liste de 1 élément

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -237,8 +237,8 @@ hr[aria-hidden="true"]
         p
           |> Notre API puissante et flexible permet d’intégrer facilement notre brique de rendez-vous dans vos applications.
           | Accédez à un flux de données en temps réel pour une expérience enrichie et personnalisée.
-        ul.fr-btns-group.fr-btns-group--center.rdv-btns-group--left-md.fr-btns-group--inline-md.fr-mb-0
-          li= link_to "Consulter la documentation technique", "https://aide.rdv-service-public.fr/documentation-technique/api", class: "fr-btn fr-btn--secondary"
+        .fr-btns-group.fr-btns-group--center.rdv-btns-group--left-md.fr-btns-group--inline-md.fr-mb-0
+          = link_to "Consulter la documentation technique", "https://aide.rdv-service-public.fr/documentation-technique/api", class: "fr-btn fr-btn--secondary"
       .fr-col-12.fr-col-md-5.rdv-text-align-center
         = image_tag "rdv_mairie/api.svg", alt: "", class: "rdv-height-md-0 rdv-min-height-md-100"
 


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité de la BIN 

<img width="834" alt="image" src="https://github.com/user-attachments/assets/300c8835-c95b-4069-9334-42d65ed740d7" />

# Solution

On supprime les balises ul/li, mais on garde une div pour styliser correctement le bouton notamment en mobile.
