### PR TITLE
a11y: correction du title dans le numéro de version

### DIFF
--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -104,6 +104,6 @@ html lang="fr"
             li.fr-footer__bottom-item
               = link_to "Code Source sur GitHub", "https://github.com/betagouv/rdv-service-public", class: "fr-footer__bottom-link", target: "_blank", rel: "noopener"
             li.fr-footer__bottom-item
-              = link_to ENV["RDV_SOLIDARITES_VERSION"], "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", class: "fr-footer__bottom-link", title: "Aller au code source de #{current_domain.name}", target: "_blank", rel: "noopener"
+              = link_to ENV["RDV_SOLIDARITES_VERSION"], "https://github.com/betagouv/rdv-service-public/commit/#{ENV['CONTAINER_VERSION']}", class: "fr-footer__bottom-link", title: "#{ENV['RDV_SOLIDARITES_VERSION']} - Aller au code source de #{current_domain.name}", target: "_blank", rel: "noopener"
             li.fr-footer__bottom-item
               = link_to "Budget", budget_path, class: "fr-footer__bottom-link", target: "_blank", rel: "noopener"


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité effectué par la BIN, cette erreur a été relevé sur le lien du numéro de version dans le footer 

<img width="839" alt="image" src="https://github.com/user-attachments/assets/6515b972-ef61-46ae-ba8b-6ecef1329108" />


