### PR TITLE
Corrige la nomenclature d'affichage des RDVs sur l'agenda

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -42,7 +42,20 @@ function eventClassNames(info) {
   let extendedProps = info.event.extendedProps;
   const customCssClasses = [];
 
-  if(["noshow", "excused", "revoked"].includes(extendedProps.status)) {
+  // La nomenclature visuelle pour l'affichage des RDVs selon le statut est la suivante :
+  // - RDV à renseigner / futur (unknown)   -> aucun effet
+  // - RDV honoré (seen)                    -> transparent
+  // - RDV non excusé, aka lapin (noshow)   -> barré
+  // - RDV annulé par l'usager (excused)    -> transparent + barré
+  // - RDV annulé par le service (revoked)  -> transparent + barré
+  if(extendedProps.status === "seen") {
+    customCssClasses.push("rdv-fc-event-transparent");
+  }
+  else if (extendedProps.status === "noshow") {
+    customCssClasses.push("rdv-fc-event-barre");
+  }
+  else if (extendedProps.status === "excused" || extendedProps.status === "revoked") {
+    customCssClasses.push("rdv-fc-event-transparent");
     customCssClasses.push("rdv-fc-event-barre");
   }
 

--- a/app/javascript/stylesheets/components/_calendar.scss
+++ b/app/javascript/stylesheets/components/_calendar.scss
@@ -71,10 +71,13 @@ $rdvs-fc-header-bg-color: $gray-200;
 }
 
 .rdv-fc-event-barre {
-  opacity: 0.7;
   .fc-event-title {
     text-decoration: line-through;
   }
+}
+
+.rdv-fc-event-transparent {
+  opacity: 0.7;
 }
 
 .rdv-fc-event-waiting {


### PR DESCRIPTION
Une autre "subtilité" perdue dans #5187, où j'ai voulu simplifier. :grimacing: 

La nomenclature attendue est la suivante : 

```
  // - RDV à renseigner / futur (unknown)   -> aucun effet
  // - RDV honoré (seen)                    -> transparent
  // - RDV non excusé, aka lapin (noshow)   -> barré
  // - RDV annulé par l'usager (excused)    -> transparent + barré
  // - RDV annulé par le service (revoked)  -> transparent + barré
```

Avant la MAJ de FullCalendar, ces règles étaient exprimées ainsi, en CSS :


```scss
.fc-event-excused,
.fc-event-seen,
.fc-event-revoked {
  opacity: 0.7;
}

.fc-event-excused,
.fc-event-noshow,
.fc-event-revoked {
  .fc-content .fc-title {
    text-decoration: line-through;
  }
}
```

mais j'avais décidé de "clarifier" les choses en évitant d'utiliser des classes CSS interpolées à la volée, et donc je suis passé à un système de classes CSS de helper ajoutées par le JS. Le problème c'est que j'avais lu seulement la moitié des règles ci-dessus, et donc j'ai implémenté ça comme ça :

```js
// le JS
  if(["noshow", "excused", "revoked"].includes(extendedProps.status)) {
    customCssClasses.push("rdv-fc-event-barre");
  }

// le CSS
.rdv-fc-event-barre {
  opacity: 0.7;
  text-decoration: line-through;
}
```

Ce qui avait donc pour effet d'afficher en transparent **et** barré les RDVs annulés, ce qui n'est pas la nomenclature attendue ci-dessus.

Cette PR devrait rétablir la nomenclature avec respect pour les combinaisons de transparences **et** de barrés.

# Captures d'écran

Ces captures montrent 5 RDVs dans ces statuts respectifs :
- `unknown`
- `seen`
- `noshow`
- `excused`
- `revoked`


Avant la MAJ | Après la MAJ | Après la MAJ
-|-|-
-|avant le fix de cette PR|Après le fix de cette PR
![image](https://github.com/user-attachments/assets/b284257d-f56b-467e-ac7f-7d530768a91a) | ![image](https://github.com/user-attachments/assets/a6601c82-3068-423a-a835-1253ecefc806) | ![image](https://github.com/user-attachments/assets/0a8a245b-1908-403b-9a6c-8ac2438c10b5)
