### PR TITLE
Mise à jour du mail de confirmation d'ouverture d'espace, et changement du lien de contact sur la page configuration

### DIFF
--- a/app/javascript/stylesheets/mail.scss
+++ b/app/javascript/stylesheets/mail.scss
@@ -252,11 +252,24 @@ html,
 
 .btn-primary {
   background-color: $primary;
+  border: solid;
+  border-color: $primary;
   padding: 0.8em 0.9em;
   color: $white;
   text-decoration: none;
-  font-weight: bold;
-  font-size: 18px;
+  font-weight: 500;
+  font-size: 16px;
+}
+
+.btn-secondary {
+  border: solid;
+  border-color: $primary;
+  background-color: $white;
+  padding: 0.8em 0.9em;
+  color: $primary;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 16px;
 }
 
 .btn-wrapper {

--- a/app/javascript/stylesheets/mail.scss
+++ b/app/javascript/stylesheets/mail.scss
@@ -264,6 +264,7 @@ html,
 .btn-secondary {
   border: solid;
   border-color: $primary;
+  border-width: 1px;
   background-color: $white;
   padding: 0.8em 0.9em;
   color: $primary;

--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -13,7 +13,7 @@
       p.fr-callout__text
         = icon("fr-icon-lightbulb-line", class: "fr-mr-3v")
         | Besoin d'aide pour configurer votre organisation ? Nous pouvons vous aider
-        = external_link_to("Contacter l'équipe", meet_the_team_url, class: "fr-btn fr-btn--secondary fr-ml-1w")
+        = external_link_to("Contacter l'équipe", "https://cal.com/team/rdv-service-public/accompagnement", class: "fr-btn fr-btn--secondary fr-ml-1w")
   .fr-grid-row.fr-grid-row--gutters.fr-mt-4w
 
     .fr-col-12.fr-col-md-4.fr-mb-2w

--- a/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
@@ -4,7 +4,7 @@ p = t("mailers.common.hello")
 p
   = "Nous avons le plaisir de vous confirmer l’ouverture de votre espace "
   b = domain.name
-  = "Vous êtes l'"
+  = ". Vous êtes l'"
   b administrateur de votre espace
   = ", à ce titre, vous pouvez dès maintenant :"
   ul

--- a/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
+++ b/app/views/mailers/agents/territory_creation_request_mailer/accepted.html.slim
@@ -1,9 +1,21 @@
+- tutoriel_url = "https://scribehow.com/embed/Tutoriel__Configurer_son_Espace_RDV_Service_Public__WRoFB835RG-lulLQNrSTHQ?as=scrollable"
 p = t("mailers.common.hello")
 
-p= t("agents.territory_creation_request_mailer.accepted.body1", domain_name: domain.name)
-p= t("agents.territory_creation_request_mailer.accepted.body2", organisation_name: @organisation.name)
+p
+  = "Nous avons le plaisir de vous confirmer l’ouverture de votre espace "
+  b = domain.name
+  = "Vous êtes l'"
+  b administrateur de votre espace
+  = ", à ce titre, vous pouvez dès maintenant :"
+  ul
+    li Paramétrer vos organisations, vos services, et inviter vos agents ;
+    li Configurer vos motifs de rendez-vous.
+
+p Pour bien démarrer, #{link_to("consultez notre tutoriel", tutoriel_url)} pour configurer votre espace, et retrouvez toutes les ressources utiles dans notre #{link_to("centre d'aide", "https://aide.rdv-service-public.fr/")}.
 
 .btn-wrapper
-  = link_to "Commencer", admin_organisation_agent_agenda_url(@organisation, @agent),  class: "btn btn-primary"
+  = link_to "Accéder à mon espace", admin_organisation_agent_agenda_url(@organisation, @agent),  class: "btn btn-primary"
+.btn-wrapper
+  = link_to "Consulter le tutoriel", tutoriel_url,  class: "btn btn-secondary"
 
 = t("mailers.common.farewell_html", domain_name: domain.name)

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -65,9 +65,7 @@ fr:
         attachments: Le mail de l'usager⋅e avait en pièce jointe "%{attachment_names}". Il nous est impossible de vous transmettre ce fichier. Vous pouvez contacter l'usager⋅e pour qu'iel l'envoie à votre adresse.
     territory_creation_request_mailer:
       accepted:
-        title: "Votre espace %{domain_name} est ouvert"
-        body1: "Votre demande d'ouverture d'espace sur %{domain_name} a été acceptée."
-        body2: "Vous pouvez dès à présent gérer vos rendez-vous pour %{organisation_name}"
+        title: "Votre espace %{domain_name} est ouvert 🚀"
   users:
     file_attente_mailer:
       new_creneau_available:

--- a/spec/features/territory_admins/opening_an_account_spec.rb
+++ b/spec/features/territory_admins/opening_an_account_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Un agent peut créer un territoire, en faisant vérifier son com
         )
 
         open_email(agent.email)
-        expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert"
+        expect(current_email.subject).to eq "Votre espace RDV Service Public est ouvert 🚀"
 
         visit super_admins_territory_creation_requests_url(host: "http://www.rdv-mairie-test.localhost")
 


### PR DESCRIPTION
Avant | Après
:- | -:
<img width="631" alt="Screenshot 2025-05-15 at 17 04 26" src="https://github.com/user-attachments/assets/1b993a26-e2c3-420d-b2b9-e5e7d3f69f95" />|<img width="682" alt="Screenshot 2025-05-15 at 17 04 09" src="https://github.com/user-attachments/assets/0429497e-867f-4ea3-93ca-c882acbf814c" />

On améliore le mail qui est envoyé aux agents une fois qu'on accepte leur demande d'ouverture d'espace.


Lien figma : https://www.figma.com/design/qKzmEmKOb11pRjnzJthXQV/Interface-Agent?node-id=371-272&t=PVFKtWefMZV4aZym-0



