### PR TITLE
Ajout d'une route vers l'agenda et amélioration du guide d'implémentation des intégrations

### DIFF
--- a/app/controllers/agents/agendas_controller.rb
+++ b/app/controllers/agents/agendas_controller.rb
@@ -1,0 +1,21 @@
+class Agents::AgendasController < AgentAuthController
+  def show
+    skip_authorization # On appelle un policy_scope, donc pas besoin d'authorization
+
+    accessible_organisations = policy_scope(Organisation, policy_scope_class: Agent::OrganisationPolicy::Scope)
+
+    if accessible_organisations.count == 0
+      redirect_to authenticated_agent_root_path
+    elsif accessible_organisations.count == 1
+      redirect_to admin_organisation_agent_agenda_path(accessible_organisations.first, current_agent)
+    elsif accessible_organisations.count > 1
+      redirect_to admin_organisations_path
+    end
+  end
+
+  private
+
+  def pundit_user
+    AgentContext.new(current_agent)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,7 +299,7 @@ Rails.application.routes.draw do
   authenticated :agent do
     root to: "agents/pages#home", as: :authenticated_agent_root
   end
-  get "agents/agenda", to: "agents/pages#home"
+  get "agents/agenda", to: "agents/agendas#show"
 
   scope path: "prescripteur", as: "prescripteur", controller: "prescripteur_rdv_wizard" do
     get "start"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,7 @@ Rails.application.routes.draw do
   authenticated :agent do
     root to: "agents/pages#home", as: :authenticated_agent_root
   end
+  get "agents/agenda", to: "agents/pages#home"
 
   scope path: "prescripteur", as: "prescripteur", controller: "prescripteur_rdv_wizard" do
     get "start"

--- a/docs/guide_integration.md
+++ b/docs/guide_integration.md
@@ -35,6 +35,10 @@ Elle passe par les endpoints `https://demo.rdv.anct.gouv.fr/oauth/authorize` et 
 
 Contactez notre équipe technique à l'adresse support@rdv-service-public.fr pour demander la création d'une appli OAuth et préparer votre intégration.
 
+### Lien vers l'agenda
+
+Les agents peuvent accéder à leur agenda RDV Service Public via le lien `https://rdv.anct.gouv.fr/agents/agenda`
+
 ### Configuration
 
 Vous pouvez proposer aux agents de vérifier leur configuration via le lien `https://rdv.anct.gouv.fr/admin/organisations/configuration`.
@@ -82,4 +86,7 @@ Après ce premier appel, vous pouvez faire des requêtes sur le RDV Plan pour sa
 
 ### Obtenir des informations sur les rendez-vous après leur création
 
-A venir
+
+Vous pouvez utiliser l'endpoint `/api/v1/rdvs` pour obtenir une liste de rendez-vous. Il est possible de filtrer cette liste par agent et ou par usager.
+[La documentation Swagger](https://rdv.anct.gouv.fr/api-docs/index.html) donne plus d'informations sur cet endpoint.
+L'api renvoie sur chaque rendez-vous un attribut `url_for_agents`, qui indique l'url de ce rendez-vous pour les agents (les usagers ne peuvent pas y accéder via cette url).

--- a/docs/guide_integration.md
+++ b/docs/guide_integration.md
@@ -6,6 +6,25 @@ Vous pouvez ajouter un bouton "Prendre rendez-vous" dans votre application méti
 
 Ce bouton déclenchera une connexion par OAuth avec RDV Service Public, puis redirigera l'agent vers un formulaire de prise de rendez-vous.
 
+## Interface recommandée
+
+Vous pouvez vous inspirer des interfaces proposées par Démarches Simplifiées ou Mon Suivi Social pour cette intégration.
+
+Le parcours utilisateur pour les agents est généralement en deux temps :
+
+### Activation de la prise de rendez-vous depuis une page de paramètres
+
+Depuis les paramètres de votre application, vous pouvez proposer aux agents qui utilisent votre application d'activer la prise de rendez-vous.
+
+Les agents n'auront pas besoin d'un compte préexistant sur RDV Service Public. Leur compte sera créé à la volée quand ils utiliseront ProConnect sur RDV Service Public.
+
+Vous pouvez ensuite afficher un lien pour vérifier la configuration sur RDV Service Public, qui leur permettra de décider de leur motifs de rendez-vous, d'inviter des collègues à travailler avec eux, etc...
+
+### Ajout d'un bouton de prise de rendez-vous
+
+Depuis la page d'un usager ou d'un dossier, vous pouvez proposer un bouton de prise de rendez-vous qui récupèrera automatiquement les informations de l'usager.
+
+
 ## Implémentation
 
 ### Connexion OAuth
@@ -15,6 +34,11 @@ La connexion OAuth vous permettra d'obtenir un token d'api pour faire des appels
 Elle passe par les endpoints `https://demo.rdv.anct.gouv.fr/oauth/authorize` et `https://demo.rdv.anct.gouv.fr/oauth/token` lors du développement.
 
 Contactez notre équipe technique à l'adresse support@rdv-service-public.fr pour demander la création d'une appli OAuth et préparer votre intégration.
+
+### Configuration
+
+Vous pouvez proposer aux agents de vérifier leur configuration via le lien `https://rdv.anct.gouv.fr/admin/organisations/configuration`.
+Ils seront redirigés vers la création d'un nouvel espace ou la configuration de leur espace existant.
 
 ### Prise de rendez-vous
 
@@ -55,3 +79,7 @@ Vous obtiendrez une réponse à ce format :
 Vous pouvez ensuite rediriger votre agent à l'url indiquée pour qu'il prenne le rendez-vous.
 
 Après ce premier appel, vous pouvez faire des requêtes sur le RDV Plan pour savoir si le rendez-vous associé a été crée: `GET /api/v1/rdv_plans/23`.
+
+### Obtenir des informations sur les rendez-vous après leur création
+
+A venir

--- a/spec/features/agents/navigation_to_the_agenda_spec.rb
+++ b/spec/features/agents/navigation_to_the_agenda_spec.rb
@@ -1,22 +1,43 @@
 RSpec.describe "Route vers l'agenda" do
-  context "when the agent is not signed i" do
+  context "when the agent is not signed in" do
     it "redirects to the sign in page" do
       visit "/agents/agenda"
-      raise "TODO: continuer ici"
+
+      expect(page).to have_content "Vous devez vous connecter pour continuer"
+      expect(page).to have_current_path("/agents/sign_in")
     end
   end
 
   context "when the agent is signed in" do
+    before { login_as(agent, scope: :agent) }
+
     context "and they don't have any organisation" do
-      it "redirects to the page to create a new organisation"
+      let(:agent) { create(:agent, basic_role_in_organisations: []) }
+
+      it "shows the page to create a new organisation" do
+        visit "/agents/agenda"
+        expect(page).to have_content "Vous pouvez demander à ouvrir un espace pour votre organisation"
+      end
     end
 
     context "and they have one organisation" do
-      it "shows the agenda for this organisation"
+      let(:organisation) { create(:organisation) }
+      let(:agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      it "shows the agenda for this organisation" do
+        visit "/agents/agenda"
+        expect(page).to have_content "Votre agenda"
+        expect(page).to have_current_path("/admin/organisations/#{organisation.id}/agent_agendas/#{agent.id}")
+      end
     end
 
     context "and they have multiple organisations" do
-      it "redirections to the list of organisations"
+      let(:agent) { create(:agent, basic_role_in_organisations: [create(:organisation), create(:organisation)]) }
+
+      it "redirections to the list of organisations" do
+        visit "/agents/agenda"
+        expect(page).to have_content "Choisissez une organisation"
+      end
     end
   end
 end

--- a/spec/features/agents/navigation_to_the_agenda_spec.rb
+++ b/spec/features/agents/navigation_to_the_agenda_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "Route vers l'agenda" do
+  context "when the agent is not signed i" do
+    it "redirects to the sign in page" do
+      visit "/agents/agenda"
+      raise "TODO: continuer ici"
+    end
+  end
+
+  context "when the agent is signed in" do
+    context "and they don't have any organisation" do
+      it "redirects to the page to create a new organisation"
+    end
+
+    context "and they have one organisation" do
+      it "shows the agenda for this organisation"
+    end
+
+    context "and they have multiple organisations" do
+      it "redirections to the list of organisations"
+    end
+  end
+end


### PR DESCRIPTION
Actuellement on n’a pas de route vers laquelle on peut diriger les agents pour qu’ils accèdent directement à leur agenda s’ils ne sont pas connectés.
On peut les envoyer vers `/agents/sign_in`, mais s’ils sont déjà connectés ils auront le message d’erreur “Votre connexion est déjà active”.

Depuis les applis partenaires, on veut pouvoir fournir un lien aux agents vers leur agenda.
On voudra que ce lien fonctionne même s’ils n’ont pas encore créé d’organisation, et sans avoir à enregistrer une organisation par défaut pour chaque agent, donc la route `/organisation/#{organisation_id}/agent_agendas/#{agent_id}` ne répond pas à ce besoin.

Cette PR propose donc une route `/agents/agenda`, qui répond à ces besoins.

Une fois de plus, c'est l'intégration avec l'espace Coop qui nous pousse à ajouter cette fonctionnalité, mais je pense qu'elle a du sens pour toutes les autres intégrations.

J'en profite pour étoffer un tout petit peu le guide d'implémentation des intégrations.
