### PR TITLE
Permettre d'utiliser les tables de jointure dans metabase

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -11,17 +11,11 @@ tables:
     truncated: true
   - table_name: good_job_processes
     truncated: true
-  - table_name: agent_territorial_roles
-    truncated: true
-  - table_name: motifs_plage_ouvertures
-    truncated: true
   - table_name: referent_assignations
     truncated: true
   - table_name: user_profiles
     truncated: true
   - table_name: annotations
-    truncated: true
-  - table_name: motif_categories_territories
     truncated: true
   - table_name: schema_migrations
     truncated: true
@@ -305,6 +299,9 @@ tables:
   - table_name: agent_roles
     non_anonymized_column_names:
       - access_level
+  - table_name: agent_territorial_roles
+  - table_name: motif_categories_territories
+  - table_name: motifs_plage_ouvertures
   - table_name: agents_rdvs
     non_anonymized_column_names:
       - outlook_id

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -11,10 +11,6 @@ tables:
     truncated: true
   - table_name: good_job_processes
     truncated: true
-  - table_name: referent_assignations
-    truncated: true
-  - table_name: user_profiles
-    truncated: true
   - table_name: annotations
     truncated: true
   - table_name: schema_migrations
@@ -296,12 +292,14 @@ tables:
       - category
 
   # Tables sans données personnelles
-  - table_name: agent_roles
-    non_anonymized_column_names:
-      - access_level
   - table_name: agent_territorial_roles
   - table_name: motif_categories_territories
   - table_name: motifs_plage_ouvertures
+  - table_name: user_profiles
+  - table_name: referent_assignations
+  - table_name: agent_roles
+    non_anonymized_column_names:
+      - access_level
   - table_name: agents_rdvs
     non_anonymized_column_names:
       - outlook_id

--- a/lib/anonymizer/lib/anonymizer.rb
+++ b/lib/anonymizer/lib/anonymizer.rb
@@ -32,16 +32,22 @@ module Anonymizer
 
   def self.exhaustivity_errors(config: nil)
     config ||= default_config
-    errors = (
-      db_connection.tables.to_set -
-      config.table_names.to_set
-    ).map { "missing rules for table #{_1}" }
-    config.table_configs.each do |table_config|
-      errors += Anonymizer::Table
-        .new(table_config:)
-        .unidentified_column_names
-        .map { "missing rule for column #{table_config.table_name}.#{_1}" }
+    errors = []
+
+    db_connection.tables.each do |table_name|
+      table_config = config.table_config_by_name(table_name)
+
+      if table_config
+        errors + Anonymizer::Table
+          .new(table_config:)
+          .unidentified_column_names
+          .map { "missing rule for column #{table_config.table_name}.#{_1}" }
+
+      else
+        errors << "missing rules for table #{table_name}"
+      end
     end
+
     errors
   end
 

--- a/lib/anonymizer/lib/anonymizer/config.rb
+++ b/lib/anonymizer/lib/anonymizer/config.rb
@@ -46,9 +46,7 @@ module Anonymizer
     end
 
     def validate
-      validate_table_name_present &&
-        validate_rules_or_truncated &&
-        validate_not_both_rules_and_truncated
+      validate_table_name_present && validate_not_both_rules_and_truncated
     end
 
     def validate_table_name_present

--- a/lib/anonymizer/lib/anonymizer/config.rb
+++ b/lib/anonymizer/lib/anonymizer/config.rb
@@ -55,12 +55,6 @@ module Anonymizer
       @errors << "table config should contain a name"
     end
 
-    def validate_rules_or_truncated
-      return true if truncated? || anonymized_column_names.present? || non_anonymized_column_names.present?
-
-      @errors << "table #{table_name} should have anonymization rules or be truncated"
-    end
-
     def validate_not_both_rules_and_truncated
       return true if !truncated? || (anonymized_column_names.blank? && non_anonymized_column_names.blank?)
 

--- a/spec/anonymizer/config_spec.rb
+++ b/spec/anonymizer/config_spec.rb
@@ -40,22 +40,6 @@ RSpec.describe Anonymizer::Config do
     end
   end
 
-  context "a table does not have rules nor is truncated" do
-    let(:raw_config) do
-      {
-        "tables" => [
-          {
-            "table_name" => "users",
-          },
-        ],
-      }
-    end
-
-    it "raises an error upon initialization" do
-      expect { described_class.new(raw_config) }.to raise_error(Anonymizer::ConfigError, "table users should have anonymization rules or be truncated")
-    end
-  end
-
   context "a table has both anonymization rules and is truncated" do
     let(:raw_config) do
       {


### PR DESCRIPTION
# Contexte

Dans le cadre d'exploration sur les créations de comptes dans metabase, j'avais besoin de faire une jointure sur la table `agent_territorial_roles`, mais elle est malheureusement tronquée.

# Solution

Je me suis rendu compte que dans https://github.com/betagouv/rdv-service-public/pull/4362, on s'était mis à tronquer toutes les tables de jointures.
C'était une limitation liée à comment les règles de validations étaient écrites. En les refactorant légèrement, on peut éviter cette limitation.
