### PR TITLE
a11y : ajout autocomplete, hint et suppression asterix form contact

### DIFF
--- a/app/views/aide/demandes_support/new.html.slim
+++ b/app/views/aide/demandes_support/new.html.slim
@@ -10,7 +10,7 @@
 
 .fr-grid-row.fr-mb-4w
   .fr-col-12.fr-col-md-8
-    = form_for @form, url: aide_demande_support_path, method: :POST, builder: Dsfr::FormBuilder do |f|
+    = form_for @form, url: aide_demande_support_path, method: :POST, builder: Dsfr::FormBuilder, display_required_tags: false do |f|
       - if @form.role.present?
         = f.hidden_field :role, value: @form.role
         .fr-input-group
@@ -32,6 +32,7 @@
         .fr-callout.fr-my-2w
           | Avez-vous consulté les pages de documentation ? Elles contiennent de nombreuses informations pour aider les agents.
           div= link_to "Documentation #{current_domain.name}", "https://aide.rdv-service-public.fr", class: "fr-btn fr-btn--secondary", target: "_blank"
+      p.fr-hint-text Sauf mention contraire, tous les champs sont obligatoires.
       = f.dsfr_text_field :sujet, value: @form.sujet, label: "La raison de votre message", required: true
       - if @form.role_usager?
         .fr-callout.fr-my-2w
@@ -42,14 +43,14 @@
       = f.dsfr_text_area :message, rows: 5, label: "Votre message", required: true
       .fr-grid-row.fr-grid-row--gutters.fr-mb-2w
         .fr-col-12.fr-col-md-6
-          = f.dsfr_text_field :first_name, label: "Votre prénom", required: true
+          = f.dsfr_text_field :first_name, label: "Votre prénom", required: true, autocomplete: "given-name"
         .fr-col-12.fr-col-md-6
-          = f.dsfr_text_field :last_name, label: "Votre nom de famille", required: true
+          = f.dsfr_text_field :last_name, label: "Votre nom de famille", required: true, autocomplete: "family-name"
       .fr-grid-row.fr-grid-row--gutters.fr-mb-2w
         .fr-col-12.fr-col-md-6
-          = f.dsfr_email_field :email, label: "Votre email", required: true
+          = f.dsfr_email_field :email, label: "Votre email", hint: "Format attendu : nom@domaine.fr", required: true, autocomplete: "email"
         .fr-col-12.fr-col-md-6
-          = f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone (facultatif)"
+          = f.dsfr_phone_field :phone_number, label: "Votre numéro de téléphone", hint: "Facultatif", autocomplete: "tel"
 
       ul.fr-btns-group.fr-btns-group--inline
         li


### PR DESCRIPTION
# Contexte

Suite à l’audit d’accessibilité, on corrige les éléments suivant sur le formulaire de contact 

<img width="836" alt="image" src="https://github.com/user-attachments/assets/14a5f147-1595-465f-a6a6-3ec0cec1c165" />

# Solution

J’ai pris le parti de retirer les asterix car il n’y a qu’un champ qui est facultatif et il est écrit

# Captures d’écran 

## Avant 

<img width="908" alt="image" src="https://github.com/user-attachments/assets/fbcfc9f0-8e56-44b0-949d-fdc7173bdeaf" />

## Après
<img width="927" alt="image" src="https://github.com/user-attachments/assets/f75f9a97-5a56-4c33-8f99-e872a2099d07" />

