### PR TITLE
Ajuste l'alignement du calendrier sur la dernière étape d'un RdvPlan

### DIFF
--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -3,7 +3,8 @@
     = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 3, step_title: "Usager", next_step_title: ""
 .row.fr-mb-16w
   .col-12.col-md-4
-    = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: true
+    .mt-4
+      = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: true
     = link_to edit_motif_agents_rdv_plan_path(@rdv_plan) do
       = back_icon(class: "fr-mr-1w")
       = "retour"

--- a/app/views/agents/rdv_plans/edit_user.html.slim
+++ b/app/views/agents/rdv_plans/edit_user.html.slim
@@ -3,7 +3,7 @@
     = render "agents/rdv_plans/header", rdv_plan: @rdv_plan, current_step: 3, step_title: "Usager", next_step_title: ""
 .row.fr-mb-16w
   .col-12.col-md-4
-    .mt-4
+    .fr-mt-4w
       = render "agents/rdv_plans/calendar", rdv_plan: @rdv_plan, single_day: true
     = link_to edit_motif_agents_rdv_plan_path(@rdv_plan) do
       = back_icon(class: "fr-mr-1w")


### PR DESCRIPTION
Le mini calendrier s'affiche trop haut sur la dernière étape car sur cette étape nous n'affichons pas le nom de l'étape suivante. J'ajoute du padding comme solution simple, ça règle le problème en desktop et mobile, ça me semble proportionné comme fix.


Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/3079fb1f-9bed-4fa3-826d-9c3148b01f15) | ![image](https://github.com/user-attachments/assets/b755498b-b5b3-4ceb-a1b7-fc9f9a373cb9)
![image](https://github.com/user-attachments/assets/8325249a-b2ac-416e-b3b3-f9a79af7e3d7) | ![image](https://github.com/user-attachments/assets/e04817c5-590f-4aa1-a6f6-2cabce9ff764)

