### PR TITLE
Contact form validation email

### DIFF
--- a/app/form_models/demande_support_form.rb
+++ b/app/form_models/demande_support_form.rb
@@ -5,6 +5,7 @@ class DemandeSupportForm
 
   validates(*ATTRIBUTES.excluding(:phone_number), presence: true)
   validates :message, length: { maximum: 3_000 * 3 } # 3 000 caractères ~= 1 page A4
+  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   def initialize(current_domain:, role: nil, sujet: nil, first_name: nil, last_name: nil, phone_number: nil, email: nil, message: nil)
     @current_domain = current_domain

--- a/spec/form_models/demande_support_form_spec.rb
+++ b/spec/form_models/demande_support_form_spec.rb
@@ -81,4 +81,27 @@ RSpec.describe DemandeSupportForm do
       form.submit
     end
   end
+
+  context "le mail n'est pas valide" do
+    let(:attributes) do
+      {
+        current_domain: Domain::RDV_MAIRIE,
+        role: "usager",
+        sujet: "Je suis perdue",
+        first_name: "Jeanne",
+        last_name: "Jacques",
+        phone_number: "0603040506",
+        email: "cecin’estpasunemail",
+        message: "Je suis perdue, aidez-moi !\nJe ne retrouve pas mon mot de passe. Merci. JJ." * 10_000,
+      }
+    end
+
+    it { is_expected.not_to be_valid }
+
+    it "n’appele pas CreateZammadTicket" do
+      expect(CreateZammadTicketJob).not_to receive(:perform_later)
+      expect(CreateCrispTicketJob).not_to receive(:perform_later)
+      form.submit
+    end
+  end
 end

--- a/spec/form_models/demande_support_form_spec.rb
+++ b/spec/form_models/demande_support_form_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe DemandeSupportForm do
       expect(CreateZammadTicketJob).not_to receive(:perform_later)
       expect(CreateCrispTicketJob).not_to receive(:perform_later)
       form.submit
+      expect(form.errors[:message]).to include("est trop long (pas plus de 9000 caractères)")
     end
   end
 
@@ -92,7 +93,7 @@ RSpec.describe DemandeSupportForm do
         last_name: "Jacques",
         phone_number: "0603040506",
         email: "cecin’estpasunemail",
-        message: "Je suis perdue, aidez-moi !\nJe ne retrouve pas mon mot de passe. Merci. JJ." * 10_000,
+        message: "Je suis perdue, aidez-moi !\nJe ne retrouve pas mon mot de passe. Merci. JJ.",
       }
     end
 
@@ -102,6 +103,7 @@ RSpec.describe DemandeSupportForm do
       expect(CreateZammadTicketJob).not_to receive(:perform_later)
       expect(CreateCrispTicketJob).not_to receive(:perform_later)
       form.submit
+      expect(form.errors[:email]).to include("n'est pas valide")
     end
   end
 end


### PR DESCRIPTION
# Contexte

Suite à : https://github.com/betagouv/rdv-service-public/pull/5323
Nous remontons la validation de l’adresse email dans le formulaire de contact.

# Solution

J’ai choisi de ne pas retirer la validation qui est dans le job, car elle ne nous pose pas de problème et que nous allons certainement retirer le support de Crisp prochainement.

