### PR TITLE
On ajoute la date de creation du dernier RDV dans le CRM

### DIFF
--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -24,9 +24,9 @@ class CronJob::SynchronizeCrm < CronJob
         rdv_count = ids.blank? ? nil : Rdv.where(organisation: ids).count
         last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
         if last_rdv
-          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DERNIER RDV" => { start: last_rdv.created_at&.strftime("%Y-%m-%d") } })
+          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DATE CREATION DERNIER RDV" => { start: last_rdv.created_at&.strftime("%Y-%m-%d") } })
         else
-          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DERNIER RDV" => nil })
+          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DATE CREATION DERNIER RDV" => nil })
         end
       end
     end

--- a/app/jobs/cron_job/synchronize_crm.rb
+++ b/app/jobs/cron_job/synchronize_crm.rb
@@ -22,7 +22,12 @@ class CronJob::SynchronizeCrm < CronJob
       page.results.each do |notion_page|
         ids = organisations_ids(notion_page.properties["COMPTE PROD"].url)
         rdv_count = ids.blank? ? nil : Rdv.where(organisation: ids).count
-        client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count })
+        last_rdv = Rdv.where(organisation: ids).order(created_at: :desc).first
+        if last_rdv
+          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DERNIER RDV" => { start: last_rdv.created_at&.strftime("%Y-%m-%d") } })
+        else
+          client.update_page(page_id: notion_page.id, properties: { "NOMBRE DE RDV" => rdv_count, "DERNIER RDV" => nil })
+        end
       end
     end
   end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
       class: "CronJob::WarnAboutExpiringAzureAppSecrets",
     },
     synchronize_crm: {
-      cron: "every day at 00:30 Europe/Paris",
+      cron: "every day at 08:00 Europe/Paris",
       class: "CronJob::SynchronizeCrm",
     },
   }

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
   let(:territory) { create(:territory) }
   let(:organisation_a) { create(:organisation, territory: territory) }
   let(:organisation_b) { create(:organisation, territory: territory) }
+  let(:organisation_c) { create(:organisation, territory: territory) }
   let!(:rdv_a) { create(:rdv, organisation: organisation_a) }
-  let!(:rdv_b) { create(:rdv, organisation: organisation_b) }
+  let!(:rdv_b) { create(:rdv, organisation: organisation_b, created_at: Date.yesterday) }
 
   before do
     allow(Notion::Client).to receive(:new).and_return(notion_client)
@@ -34,30 +35,40 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
     context "quand la variable COMPTE PROD de la page Notion est un territory" do
       let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/territories/#{territory.id}" }
 
-      it "le nombre de RDV est mis à jour dans la page Notion avec la somme des RDV de l'espace" do
+      it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l'espace" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 2 })
+        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 2, "DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } })
       end
     end
 
     context "quand la variable COMPTE PROD de la page Notion est une organisation" do
       let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/#{organisation_a.id}" }
 
-      it "le nombre de RDV est mis à jour dans la page Notion avec la somme des RDV de l’organisation" do
+      it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l’organisation" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 1 })
+        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 1, "DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } })
+      end
+
+      context "quand l’organisation n’a pas encore de RDV" do
+        let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/#{organisation_c.id}" }
+
+        it "le nombre de RDV est mis à jour dans la page Notion avec 0 et la date du dernier RDV est nulle" do
+          described_class.new.perform
+
+          expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 0, "DERNIER RDV" => nil })
+        end
       end
     end
 
     context "quand la variable COMPTE PROD de la page Notion est une organisation inconnue" do
       let(:compte_prod_url) { "https://demo.rdv-solidarites.fr/organisations/26739" }
 
-      it "retourne un compte nul" do
+      it "retourne un compte nul et une date nulle" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => nil })
+        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => nil, "DERNIER RDV" => nil })
       end
     end
   end

--- a/spec/jobs/cron_job/synchronize_crm_spec.rb
+++ b/spec/jobs/cron_job/synchronize_crm_spec.rb
@@ -38,7 +38,10 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l'espace" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 2, "DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } })
+        expect(notion_client).to have_received(:update_page).with(
+          page_id: "page_id",
+          properties: { "NOMBRE DE RDV" => 2, "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } }
+        )
       end
     end
 
@@ -48,7 +51,10 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       it "le nombre de RDV et la date du dernier RDV sont mis à jour dans la page Notion avec la somme des RDV de l’organisation" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 1, "DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } })
+        expect(notion_client).to have_received(:update_page).with(
+          page_id: "page_id",
+          properties: { "NOMBRE DE RDV" => 1, "DATE CREATION DERNIER RDV" => { start: rdv_a.created_at.strftime("%Y-%m-%d") } }
+        )
       end
 
       context "quand l’organisation n’a pas encore de RDV" do
@@ -57,7 +63,7 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
         it "le nombre de RDV est mis à jour dans la page Notion avec 0 et la date du dernier RDV est nulle" do
           described_class.new.perform
 
-          expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 0, "DERNIER RDV" => nil })
+          expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => 0, "DATE CREATION DERNIER RDV" => nil })
         end
       end
     end
@@ -68,7 +74,7 @@ RSpec.describe CronJob::SynchronizeCrm, type: :job do
       it "retourne un compte nul et une date nulle" do
         described_class.new.perform
 
-        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => nil, "DERNIER RDV" => nil })
+        expect(notion_client).to have_received(:update_page).with(page_id: "page_id", properties: { "NOMBRE DE RDV" => nil, "DATE CREATION DERNIER RDV" => nil })
       end
     end
   end


### PR DESCRIPTION
# Contexte

Suite à la demande de l’équipe déploiement, on ajoute la date de création du dernier RDV dans le CRM et on change l’heure d’exécution du job :

> Comme évoqué, on aimerait injecter dans le CRM la date du dernier RDV planifié dans un territoire. 
> - « date de création du dernier RDV planifié »
> 
> Chaque carte dispose d’une propriété « DERNIER RDV » dans laquelle injecter la donnée tirée de la prod. 

> PS : est-ce possible de lancer l'actualisation des données (NBR RDV + DATE DERNIER RDV) à 08h00 chaque jour (aujourd'hui, à 00h30 je crois)
On va déclencher des choses automatiquement (rien encore, mais plus tard) peut-être des mails. On enverrait donc des email à 00h30 ça pourrait être bizarre. 



