### PR TITLE
a11y: aria-hidden pour les astérisques

### DIFF
--- a/app/views/dsfr/rdv_mairie/homepage.html.slim
+++ b/app/views/dsfr/rdv_mairie/homepage.html.slim
@@ -293,10 +293,13 @@ hr[aria-hidden="true"]
         .rdv-font-weight-bold
           | RENDEZ-VOUS PLANIFIÉS
         div
-          | DANS 995 STRUCTURES*
+          | DANS 995 STRUCTURES
+          span[aria-hidden="true"]
+            | *
 
 .fr-container.fr-py-3w.rdv-text-align-center
-  |> *Données concernant les 24 derniers mois.
+  span[aria-hidden="true"] *
+  |> Données concernant les 24 derniers mois.
   |> Pour plus d’informations,
   = link_to "consulter nos statistiques ici", stats_path, class: "rdv-white-space-nowrap"
   | .


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5338.osc-secnum-fr1.scalingo.io/) 

# Contexte

Suite à l’audit d’accessibilité, il a été revelé le point suivant : 

<img width="842" alt="image" src="https://github.com/user-attachments/assets/b94cccb7-b3e8-4fb0-9b7a-43af96974093" />

# Solution

Contrairement à la proposition faite dans l’audit, je propose simplement de cacher les astérisques pour les lecteurs d’écran. La précision sur les données étant l’élément suivant dans le DOM, cela ne semble pas poser de souci de ne pas utiliser l’attribut `aria-describedby`.

EDIT : Sophie confirme que c’est conforme du fait que ça soit deux éléments successifs.
