### PR TITLE
Clarifier le parcours pour renommer une orga

### DIFF
--- a/app/views/admin/organisations/configurations/show.html.slim
+++ b/app/views/admin/organisations/configurations/show.html.slim
@@ -71,6 +71,8 @@
             h3.fr-tile__title
               = link_to("Informations de contact", admin_organisation_path(current_organisation))
             p.fr-tile__desc
+              = @organisation.name
+              br
               - infos =[@organisation.phone_number, @organisation.email, @organisation.website].compact
               - if infos.present?
                 = infos.join(" ")


### PR DESCRIPTION
# Contexte

Nous avons reçu cette [demande au support](https://app.crisp.chat/website/df852917-bfc0-4524-83c8-953865c6465d/inbox/session_f425ed33-2187-4ab6-b1ee-0f9f1a638cf8/) : 

> Bonjour,
> je souhaiterais modifier le nom d'une de mes organisations ?
> Je vous remercie

Cela semble indiquer qu'il n'est pas intuitif de trouver l'endroit où l'on peut renommer son orga.

En effet, il faut aller dans "Configuration", puis "Informations de contact", puis "Modifier". Le point mystique ici est "Informations de contact", puisque le nom de l'orga est bien plus qu'un info de contact, c'est une information essentielle affichée aux agents également.

# Solution

Idéalement, il faudrait mettre l'écran de renommage ailleurs que dans "Informations de contact". Mais ça demande une réflexion un peu plus poussée, et donc plus coûteuse en termes de temps.

Je propose donc de faire un tout petit changement qui peut aider un peu : **afficher le nom de l'organisation dans la card "Informations de contact"** (voir screenshtos).

Ma logique : si quelqu'un cherche l'endroit où modifier le nom de l'orga, iel va chercher les endroits où ce nom apparaît. Actuellement, quand on arrive sur la home de config, le nom de l'orga n'est affiché nulle part. En l'affichant dans "Informations de contact", on donne un indice : c'est peut-être ici que je peux modifier le nom.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/fdaa2e4f-ba66-473c-9687-d2c10acda909) | ![image](https://github.com/user-attachments/assets/90753f6e-ee59-48f8-9ed9-36d96b9f3a08)
