### PR TITLE
a11y: contact form uniformisation et correction bouton modifier

### DIFF
--- a/app/views/aide/demandes_support/new.html.slim
+++ b/app/views/aide/demandes_support/new.html.slim
@@ -16,12 +16,12 @@
         .fr-input-group
           .fr-input-group__text
             - if @form.role_agent?
-              | Vous êtes un·e agent du service public
+              |> Vous êtes un·e agent du service public
             - elsif @form.role_usager?
-              | Vous êtes un·e particulier
+              |> Vous êtes un·e particulier
             - else
               - raise "Role not supported"
-            = link_to "modifier…", aide_aiguillage_role_path, class: "fr-link fr-link--secondary fr-ml-1w fr-text--sm"
+            = link_to "modifier", aide_aiguillage_role_path, class: "fr-link fr-link--icon-right fr-icon-pencil-line", title: "Modifier votre choix"
       - else
         = f.dsfr_select :role,
           [["Vous êtes un·e particulier", :usager], ["Vous êtes un·e agent du service public", :agent]],

--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -16,7 +16,7 @@
       .fr-mb-4w
         |> Votre situation :
         b=> @form.raison_label
-        = link_to "modifier", aide_aiguillage_usager_path, class: "fr-link fr-link--icon-right fr-icon-pencil-line"
+        = link_to "modifier", aide_aiguillage_usager_path, class: "fr-link fr-link--icon-right fr-icon-pencil-line", title: "Modifier votre choix"
 
     - if @form.raison_creneaux?
       h6 Étapes pour prendre un RDV


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité, les points suivants ont été relevés : 

<img width="836" alt="image" src="https://github.com/user-attachments/assets/9b229455-a5e0-4215-8f34-00a8dd2c1e52" />

# Solution

On ajoute l’attribut `title` et on en profite pour uniformiser les liens de modification de sélection.
