### PR TITLE
a11y: clarifier les titres utilisés dans l’aide avant contact

### DIFF
--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -9,6 +9,7 @@
 .fr-grid-row.fr-mb-4w
   .fr-col-12.fr-col-md-8
     - if @form.raison.blank?
+      - content_for :subtitle, "Choix de la raison"
       = form_for @form, url: aide_aiguillage_usager_path, method: :GET, builder: Dsfr::FormBuilder do |f|
         = f.dsfr_radio_buttons :raison, @form.raisons_options, legend: "Veuillez sélectionner la raison qui correspond le mieux à votre situation :"
         = f.submit "Valider", class: "fr-btn"
@@ -19,6 +20,7 @@
         = link_to "modifier", aide_aiguillage_usager_path, class: "fr-link fr-link--icon-right fr-icon-pencil-line", title: "Modifier votre choix"
 
     - if @form.raison_creneaux?
+      - content_for :subtitle, "Prendre un RDV"
       h6 Étapes pour prendre un RDV
       ol
         - if current_domain == Domain::RDV_MAIRIE
@@ -44,6 +46,7 @@
         = link_to "Consulter l’annuaire du Service Public", "https://lannuaire.service-public.fr/", class: "fr-btn fr-btn--secondary", target: "_blank"
 
     - if @form.raison_annuler?
+      - content_for :subtitle, "Annuler votre RDV"
       .fr-accordions-group.fr-mb-4w
         section.fr-accordion
           h2.fr-accordion__title

--- a/app/views/common/_meta.html.slim
+++ b/app/views/common/_meta.html.slim
@@ -2,7 +2,10 @@ meta name="viewport" content="width=device-width, initial-scale=1.0"
 meta content="text/html; charset=UTF-8" http-equiv="Content-Type"
 title
   - if content_for? :title
-    = "#{strip_tags(content_for(:title))} - #{current_domain.name}"
+    - if content_for? :subtitle
+      = "#{strip_tags(content_for(:subtitle))} - #{strip_tags(content_for(:title))} - #{current_domain.name}"
+    - else
+      = "#{strip_tags(content_for(:title))} - #{current_domain.name}"
   - else
     | #{current_domain.name}
 


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité, les points suivants ont été relevés :

<img width="816" alt="image" src="https://github.com/user-attachments/assets/0c07432a-f16d-4f43-86e0-e61d620265a1" />

# Solution

On ajoute un « subtitle » permettant d’avoir un `title` différent pour chaque étape.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/9103b441-f157-49a9-9059-722c38ea5e33" />


