### PR TITLE
tech: simplification du layout flash DSFR

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,16 +14,16 @@ module ApplicationHelper
     end
   end
 
-  def alert_dsfr_class_for(alert)
+  def alert_dsfr_type_for(alert)
     case alert
     when :success
-      "fr-alert--success"
+      :success
     when :alert
-      "fr-alert--warning"
+      :warning
     when :error
-      "fr-alert--error"
+      :error
     when :notice
-      "fr-alert--info"
+      :info
     else
       raise ArgumentError, "alert should be a key among :success, :alert, :error or :notice"
     end

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -126,14 +126,6 @@
   background-image: none;
 }
 
-// reset CSS des styles par défaut des navigateurs sur les dialogs
-.rdv-dialog-reset {
-  border: none;
-  position: relative;
-  padding: 0;
-  width: auto;
-}
-
 // pour pouvoir aligner le groupe de boutons à gauche sur desktop mais centré sur mobile
 .rdv-btns-group--left-md,
 .rdv-btns-group--left-md li {

--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -1,0 +1,4 @@
+- %i[success notice error alert].each do |type|
+  - if flash[type]
+    = dsfr_alert type: alert_dsfr_type_for(type), size: :sm, classes: "fr-pb-1w fr-my-2w", close_button: true, html_attributes: { role: "alert" } do
+      = sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune)

--- a/app/views/layouts/_flash_dsfr.html.slim
+++ b/app/views/layouts/_flash_dsfr.html.slim
@@ -1,8 +1,0 @@
-- %i[success notice error alert].each do |type|
-  - if flash[type]
-    dialog.rdv-dialog-reset.fr-my-2w open=true
-      .fr-alert.fr-alert--sm.fr-pb-1w class=alert_dsfr_class_for(type)
-        p.fr-mb-0= sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune)
-        form method="dialog"
-          button.fr-btn--close.fr-btn type="submit" title="Masquer le message"
-            | Masquer le message

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -7,7 +7,7 @@
         = yield :breadcrumbs
       - if content_for :title
         h1= yield :title
-      = render "layouts/flash_dsfr"
+      = render "layouts/flash"
       = yield
 
 = render template: "layouts/application_base"

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -13,7 +13,7 @@ html lang="fr"
       main.content-page[style="flex-grow: 1;"]
         .content
           = content_for :fil_ariane
-          .fr-mx-2w= render "layouts/flash_dsfr"
+          .fr-mx-2w= render "layouts/flash"
           .container-fluid
             - if content_for :title
               .page-title-box

--- a/app/views/layouts/application_agent_config.html.slim
+++ b/app/views/layouts/application_agent_config.html.slim
@@ -49,7 +49,7 @@ html lang="fr"
             .p-3.flex-grow-1
               .row
                 .col-md-10.offset-md-1
-                  = render "layouts/flash_dsfr"
+                  = render "layouts/flash"
                   - if content_for :title
                     .text-center.m-auto
                       h1.card-title.text-dark-50.text-center.mt-0.font-weight-bold.mb-4

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -44,7 +44,7 @@ html lang="fr"
         = yield :main_content
       - else
         .fr-container
-          = render "layouts/flash_dsfr"
+          = render "layouts/flash"
         = yield
 
     #modal-holder

--- a/app/views/layouts/application_configuration.html.slim
+++ b/app/views/layouts/application_configuration.html.slim
@@ -10,7 +10,7 @@ html lang="fr"
 
       .container.px-4#icon-grid
         = content_for(:breadcrumbs)
-        = render "layouts/flash_dsfr"
+        = render "layouts/flash"
         = yield
 
     #modal-holder

--- a/app/views/layouts/application_narrow.html.slim
+++ b/app/views/layouts/application_narrow.html.slim
@@ -3,7 +3,7 @@
     .fr-col-md-8.m-auto
       - if content_for :title
         h1= yield :title
-      = render "layouts/flash_dsfr"
+      = render "layouts/flash"
       = yield
 
 = render template: "layouts/application"

--- a/spec/views/flash_spec.rb
+++ b/spec/views/flash_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe "layouts/_flash_dsfr", type: :view do
+RSpec.describe "layouts/_flash", type: :view do
   it "sanitizes JS out of links" do
     notice = <<~HTML
       <a href="javascript:alert('hi');">Cliquez ici</a>
     HTML
-    render(partial: "layouts/flash_dsfr", locals: { flash: { notice: notice } })
+    render(partial: "layouts/flash", locals: { flash: { notice: notice } })
     expect(rendered).to include("<a>Cliquez ici</a>")
   end
 
@@ -28,7 +28,7 @@ RSpec.describe "layouts/_flash_dsfr", type: :view do
       <em>Less important</em>
     HTML
 
-    render(partial: "layouts/flash_dsfr", locals: { flash: { notice: notice } })
+    render(partial: "layouts/flash", locals: { flash: { notice: notice } })
     expect(rendered.squish).to include(expected_output.squish)
   end
 end


### PR DESCRIPTION
# Contexte

En travaillant sur les retours de l’audit d’accessibilité, je me suis rendu compte que nous pouvions grandement simplifier le code qui génère les « flash » en utilisant la Gem `dsfr_view_components`. 

# Solution

- Utilisation du `view_component`
- Suppression du `dialog` qui ne semble pas être pertinent ici (certainement un héritage des anciens flashs)
- Renommage du fichier `flash_dsfr` en `flash` maintenant que l’ancien flash a été supprimé
