### PR TITLE
tech: suppression de Bootstrap Reboot côté usager

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -7,7 +7,7 @@
 // import bootstrap file by file so we can remove unwanted rules component by component
 // cf https://github.com/twbs/bootstrap/blob/v4.3.1/scss/bootstrap.scss
 @import "~bootstrap/scss/root";
-@import "~bootstrap/scss/reboot";
+//@import "~bootstrap/scss/reboot";
 //@import "~bootstrap/scss/type";
 @import "~bootstrap/scss/images";
 @import "~bootstrap/scss/code";

--- a/app/views/prescripteur_rdv_wizard/confirmation.html.slim
+++ b/app/views/prescripteur_rdv_wizard/confirmation.html.slim
@@ -6,7 +6,7 @@
         span.fr-icon--lg.fr-icon-success-fill[aria-hidden="true"]
         |< Rendez-vous confirmé
       - rdv = @prescripteur.rdv
-      ul.list-group.list-group-flush
+      ul.list-group.list-group-flush.fr-mt-0
         li.list-group-item
           span.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]
           = rdv_title(rdv)

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -1,5 +1,5 @@
 .card
-  ul.list-group.list-group-flush
+  ul.list-group.list-group-flush.fr-mt-0
     li.list-group-item
       .row
         .col

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -1,4 +1,4 @@
-ul.list-group.list-group-flush
+ul.list-group.list-group-flush.fr-mt-0
   li.list-group-item
     .row
       .col

--- a/app/views/users/rdvs/_rdv.html.slim
+++ b/app/views/users/rdvs/_rdv.html.slim
@@ -1,4 +1,4 @@
-ul.list-group.list-group-flush.fr-mb-3w
+ul.list-group.list-group-flush.fr-mb-3w.fr-mt-0
   li.list-group-item.fr-pl-0.fr-pb-2w
     .fr-mb-1w
       span.fr-icon.fr-icon-calendar-fill.fr-mr-1w[aria-hidden="true"]


### PR DESCRIPTION
# Contexte

J’ai constaté qu’une marge indésirable était présente à chaque fois que nous utilisions le composant DSFR alert.

## Comportement actuel 

<img width="724" alt="image" src="https://github.com/user-attachments/assets/1074c6a9-1cd3-4e1e-bdb1-51917671a0cc" />

## Comportement attendu

<img width="377" alt="image" src="https://github.com/user-attachments/assets/149b50f1-f34b-442a-9be3-f8ccc4677598" />


# Solution

Cette marge est provoquée par Bootstrap Reboot. J’ai tenté de le supprimer côté usager et côté agent.

- Côté usager : tout semble ok à part une petite marge dans le résumé du parcours de prise de RDV. Je propose donc de le supprimer et de corriger les petites marges dans cette PR.
- Côté agent : il y a pas mal de petits éléments qui sont cassés, car nous avons encore pas mal de Bootstrap (notamment les tableaux). Je propose ainsi de le laisser côté agent pour le moment.


