### PR TITLE
a11y: les callouts doivent avoir un paragraphe

### DIFF
--- a/app/views/aide/demandes_support/new.html.slim
+++ b/app/views/aide/demandes_support/new.html.slim
@@ -30,15 +30,17 @@
           required: true
       - if @form.role_agent?
         .fr-callout.fr-my-2w
-          | Avez-vous consulté les pages de documentation ? Elles contiennent de nombreuses informations pour aider les agents.
+          p
+            | Avez-vous consulté les pages de documentation ? Elles contiennent de nombreuses informations pour aider les agents.
           div= link_to "Documentation #{current_domain.name}", "https://aide.rdv-service-public.fr", class: "fr-btn fr-btn--secondary", target: "_blank"
       p.fr-hint-text Sauf mention contraire, tous les champs sont obligatoires.
       = f.dsfr_text_field :sujet, value: @form.sujet, label: "La raison de votre message", required: true
       - if @form.role_usager?
         .fr-callout.fr-my-2w
-          |> Pour toute demande de prise de RDV ou d’annulation, de disponibilités, ou de transmission de documents, veuillez contactez directement l’organisation concernée via
-          = link_to "l’annuaire du Service Public", "https://lannuaire.service-public.fr/", target: "_blank"
-          |. Par contre, si vous rencontrez un problème technique lors de la prise de RDV, vous êtes au bon endroit, n’hésitez à nous en parler ici !
+          p
+            |> Pour toute demande de prise de RDV ou d’annulation, de disponibilités, ou de transmission de documents, veuillez contactez directement l’organisation concernée via
+            = link_to "l’annuaire du Service Public", "https://lannuaire.service-public.fr/", target: "_blank"
+            |. Par contre, si vous rencontrez un problème technique lors de la prise de RDV, vous êtes au bon endroit, n’hésitez à nous en parler ici !
 
       = f.dsfr_text_area :message, rows: 5, label: "Votre message", required: true
       .fr-grid-row.fr-grid-row--gutters.fr-mb-2w

--- a/app/views/aide/pages/aiguillage_usager.html.slim
+++ b/app/views/aide/pages/aiguillage_usager.html.slim
@@ -36,7 +36,7 @@
         = link_to "Faire une recherche de RDV depuis l’accueil", root_path, class: "fr-btn"
 
       .fr-callout.fr-mb-2w
-        ' Si vous ne trouvez pas de créneaux, nous vous invitons à contacter l’organisation avec laquelle vous souhaitez prendre RDV
+        p Si vous ne trouvez pas de créneaux, nous vous invitons à contacter l’organisation avec laquelle vous souhaitez prendre RDV
 
       p
         ' Vous pouvez chercher les coordonnées de l’organisation avec laquelle vous souhaitez prendre RDV dans l’annuaire des services publics :
@@ -55,8 +55,9 @@
             p
               ' Vous pouvez annuler votre rendez-vous depuis les liens présents dans le SMS et/ou l’e-mail que vous avez reçu.
             .fr-callout.fr-mb-2w
-              ' Si le rendez-vous a lieu dans moins de 4 heures, vous ne pouvez plus annuler le RDV.
-              ' Nous vous invitons à contacter directement le service pour l'informer de votre absence.
+              p
+                ' Si le rendez-vous a lieu dans moins de 4 heures, vous ne pouvez plus annuler le RDV.
+                ' Nous vous invitons à contacter directement le service pour l'informer de votre absence.
             p
               ' Vous trouverez ci-dessous plus de détails et des captures d’écran sur le fonctionnement de l’annulation depuis les SMS ou les emails.
         section.fr-accordion

--- a/app/views/stats/territories.html.slim
+++ b/app/views/stats/territories.html.slim
@@ -13,11 +13,12 @@
         li = link_to "Statistiques - #{territory}", stats_territory_path(territory:)
 
     .fr-callout.fr-my-8w
-      - if ENV["APP"] == "production-rdv-solidarites"
-        | Les structures dont les statistiques sont accessibles ici sont celles de RDV Solidarités et RDV Aide Numérique.&#32;
-        | Vous pouvez consulter les statistiques des structures de l'instance RDV Service Public sur&#32;
-        = link_to "rdv.anct.gouv.fr/stats/territories", "https://rdv.anct.gouv.fr/stats/territories", title: "Page de statistiques RDV Service Public - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"
-      - else
-        | Les structures dont les statistiques sont accessibles ici sont celles de RDV Service Public.&#32;
-        | Vous pouvez consulter les statistiques des structures de RDV Solidarités et RDV Aide Numérique sur&#32;
-        = link_to "rdv-solidarites.fr/stats/territories", "https://rdv-solidarites.fr/stats/territories", title: "Page de statistiques RDV Solidarités et RDV Aide Némurique - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"
+      p
+        - if ENV["APP"] == "production-rdv-solidarites"
+          | Les structures dont les statistiques sont accessibles ici sont celles de RDV Solidarités et RDV Aide Numérique.&#32;
+          | Vous pouvez consulter les statistiques des structures de l'instance RDV Service Public sur&#32;
+          = link_to "rdv.anct.gouv.fr/stats/territories", "https://rdv.anct.gouv.fr/stats/territories", title: "Page de statistiques RDV Service Public - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"
+        - else
+          | Les structures dont les statistiques sont accessibles ici sont celles de RDV Service Public.&#32;
+          | Vous pouvez consulter les statistiques des structures de RDV Solidarités et RDV Aide Numérique sur&#32;
+          = link_to "rdv-solidarites.fr/stats/territories", "https://rdv-solidarites.fr/stats/territories", title: "Page de statistiques RDV Solidarités et RDV Aide Némurique - Nouvelle fenêtre", class: "fr-link", target: "_blank", rel: "noopener external"


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité, les points suivants ont été relevés :

<img width="870" alt="image" src="https://github.com/user-attachments/assets/1c418e59-c0b7-4382-9610-de18e463fbef" />

# Solution

On ajoute des balises `p` dans tous les `callout` où elle est manquante.
