### PR TITLE
Fix: titre dans le parcours de prise de RDV

### DIFF
--- a/app/views/search/search_rdv.html.slim
+++ b/app/views/search/search_rdv.html.slim
@@ -1,12 +1,11 @@
-- content_for :title do
-  | Accueil
-
 = render "prescription_banner"
 
 = render "banner", context: @context
 
 / Adress selection partials have multiple sections
 - if @context.current_step == :address_selection
+  - content_for :title do
+    | Accueil
   // On fait du spécifique pour la bannière de la page de sélection d'adresse en attendant qu’on fasse la refonte au DSFR
   = render(current_domain.address_selection_template_name, context: @context)
 - else


### PR DESCRIPTION
# Contexte

Dans [cette PR](https://github.com/betagouv/rdv-service-public/pull/5313), j'ai introduit une petite coquille. En ajoutant le titre accueil sur la landing de RDV-S, j'ai modifié le titre dans le parcours de prise de RDV.

<img width="514" alt="image" src="https://github.com/user-attachments/assets/f557e86d-c48e-4937-8790-83e5cdaea8a5" />

Afin que le parcours de recherche de créneau reprenne son nom original, je déplace la condition.


