### PR TITLE
a11y: rendre + explicite les liens dans la prise de RDV

### DIFF
--- a/app/views/admin/prescription/recapitulatif.html.slim
+++ b/app/views/admin/prescription/recapitulatif.html.slim
@@ -16,7 +16,7 @@ main.container
                   | Usager :&nbsp;
                   = UsersHelper.reverse_full_name_and_notification_coordinates(@rdv_wizard.participation.user)
                 .col-auto
-                  = link_to "modifier", user_selection_admin_organisation_prescription_path(@rdv_wizard.query_params)
+                  = link_to "modifier", user_selection_admin_organisation_prescription_path(@rdv_wizard.query_params), title: "Modifier l'usager"
             - if current_territory.enable_context_field
               li.list-group-item
                 .row
@@ -25,7 +25,7 @@ main.container
                     |> Contexte :
                     = @rdv_wizard.context&.strip&.truncate_words(6)&.presence || "N/A"
                   .col-auto
-                    = link_to "modifier", user_selection_admin_organisation_prescription_path(@rdv_wizard.query_params)
+                    = link_to "modifier", user_selection_admin_organisation_prescription_path(@rdv_wizard.query_params), title: "Modifier le contexte"
 
           .row.mt-2
             .col.text-right

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -20,7 +20,7 @@ div id="creneaux-lieu-#{lieu&.id}"
               .fr-grid-row
                 - creneaux_for_date.each_value do |creneaux|
                   - creneaux.sort.each do |creneau|
-                    = link_to context.wizard_after_creneau_selection_path(motif_id: creneau.motif.id, starts_at: creneau.starts_at), "data-turbolinks": false, class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center", aria: { label: "Choisir le créneau de #{l(creneau.starts_at, format: '%H:%M')}"} do
+                    = link_to context.wizard_after_creneau_selection_path(motif_id: creneau.motif.id, starts_at: creneau.starts_at), "data-turbolinks": false, class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center", aria: { label: "Choisir le créneau du #{l(creneau.starts_at, format: '%A %d %b')} à #{l(creneau.starts_at, format: '%H:%M')}"} do
                       = l(creneau.starts_at, format: "%H:%M")
                       - if creneau.motif.follow_up?
                         br

--- a/app/views/search/_selected_motif_recap.html.slim
+++ b/app/views/search/_selected_motif_recap.html.slim
@@ -7,7 +7,7 @@
           | Motif :&nbsp;
           = context.first_matching_motif.name
         .col-auto
-          = link_to "modifier", path_to_service_selection(params)
+          = link_to "modifier", path_to_service_selection(params), title: "Modifier le motif"
     - case context.first_matching_motif.location_type
     - when Motif.location_types[:phone]
       li.list-group-item
@@ -30,7 +30,7 @@
               | Nombre de pré-demandes ANTS à déposer :&nbsp;
               = context.ants_pre_demandes_count
             .col-auto
-              = link_to "modifier", path_to_ants_pre_demandes_count_selection(params)
+              = link_to "modifier", path_to_ants_pre_demandes_count_selection(params), title: "Modifier le nombre de pré-demandes ANTS"
       - if context.lieu
         li.list-group-item
           .row
@@ -39,6 +39,6 @@
               | Lieu :&nbsp;
               = context.lieu.full_name
             .col-auto
-              = link_to "modifier", path_to_organisation_selection(params)
+              = link_to "modifier", path_to_organisation_selection(params), title: "Modifier le lieu"
     - else
       = raise "unrecognized location_type: #{rdv_wizard.motif.location_type.inspect}"

--- a/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
+++ b/app/views/users/rdv_wizard_steps/_rdv_wizard_summary.html.slim
@@ -6,7 +6,7 @@ ul.list-group.list-group-flush
         | Motif :&nbsp;
         = rdv_wizard.motif.name
       .col-auto
-        = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections)
+        = link_to "modifier", path_to_motif_selection(rdv_wizard.params_to_selections), title: "Modifier le motif"
 
   - case rdv_wizard.motif.location_type
   - when Motif.location_types[:phone]
@@ -29,7 +29,7 @@ ul.list-group.list-group-flush
             span.fr-icon-check-line.fr-mr-1w.rdv-color-text-default-success
             | Nombre de pré-demandes ANTS à déposer : #{rdv_wizard.ants_pre_demandes_count}
           .col-auto
-            = link_to "modifier", path_to_ants_pre_demandes_count_selection(rdv_wizard.params_to_selections)
+            = link_to "modifier", path_to_ants_pre_demandes_count_selection(rdv_wizard.params_to_selections), title: "Modifier le nombre de pré-demandes ANTS"
     li.list-group-item
       .row
         .col
@@ -37,7 +37,7 @@ ul.list-group.list-group-flush
           | Lieu :&nbsp;
           = rdv_wizard.creneau.lieu.full_name
         .col-auto
-          = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections)
+          = link_to "modifier", path_to_lieu_selection(rdv_wizard.params_to_selections), title: "Modifier le lieu"
   - else
     = raise "unrecognized location_type: #{rdv_wizard.motif.location_type.inspect}"
 
@@ -48,7 +48,7 @@ ul.list-group.list-group-flush
         | Date du rendez-vous :&nbsp;
         = rdv_starts_at_and_duration(rdv_wizard.rdv, :human)
       .col-auto
-        = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections)
+        = link_to "modifier", path_to_creneau_selection(rdv_wizard.params_to_selections), title: "Modifier la date du rendez-vous"
   - if rdv_wizard.is_a?(UserRdvWizard::Step3)
     li.list-group-item
       .row
@@ -58,7 +58,7 @@ ul.list-group.list-group-flush
           = users_to_sentence(rdv_wizard.users)
         .col-auto
           - step = current_user&.signed_in_with_invitation_token? ? 1 : 2 # Les usagers connectés par invitation ont une étape de moins
-          = link_to "modifier", new_users_rdv_wizard_step_path(step: , **@rdv_wizard.to_query)
+          = link_to "modifier", new_users_rdv_wizard_step_path(step: , **@rdv_wizard.to_query), title: "Modifier les usagers"
     li.list-group-item
       .row
         .col
@@ -74,7 +74,7 @@ ul.list-group.list-group-flush
           span> 📞 Téléphone&nbsp;:
           = user_notifiable_by_sms_text(current_user)
         .col-auto
-          = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query)
+          = link_to "modifier", new_users_rdv_wizard_step_path(step: 1, **@rdv_wizard.to_query), title: "Modifier les informations de contact"
   - if @rdv_wizard.respond_to?(:prescripteur) && @rdv_wizard.prescripteur.present?
     li.list-group-item
       .row
@@ -83,4 +83,4 @@ ul.list-group.list-group-flush
           | Prescripteur :&nbsp;
           = @rdv_wizard.prescripteur.full_name
         .col-auto
-          = link_to "modifier", prescripteur_new_prescripteur_path
+          = link_to "modifier", prescripteur_new_prescripteur_path, title: "Modifier le prescripteur"


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité, les points suivants ont été relevés :

<img width="825" alt="image" src="https://github.com/user-attachments/assets/f1098751-5684-48e9-9d81-de316f9c43f8" />

# Solution

- On ajoute des `title` sur les liens « modifier » du résumé du parcours de prise de RDV
- On rend plus explicite les boutons de choix de créneau en ajoutant la date
