### PR TITLE
a11y autofocus creneau selection

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -108,7 +108,7 @@ class SearchController < ApplicationController
     params.permit(
       *WebSearchContext::ADDRESS_SELECTION_PARAMS,
       *WebSearchContext::USER_CHOICE_PARAMS,
-      :motif_category_short_name, :date, :public_link_organisation_id, :prescripteur,
+      :motif_category_short_name, :date, :public_link_organisation_id, :prescripteur, :autofocus,
       organisation_ids: [], referent_ids: [], external_organisation_ids: []
     ).to_h.deep_symbolize_keys
   end

--- a/app/services/web_invitation_search_context.rb
+++ b/app/services/web_invitation_search_context.rb
@@ -1,6 +1,6 @@
 class WebInvitationSearchContext < InvitationSearchContext
   include Users::CreneauxWizardConcern
-  attr_reader :errors, :query_params, :organisation_ids, :motif_category_short_name
+  attr_reader :errors, :query_params, :organisation_ids, :motif_category_short_name, :autofocus
 
   def initialize(user:, query_params: {})
     super
@@ -21,6 +21,10 @@ class WebInvitationSearchContext < InvitationSearchContext
 
     # creneau_selection
     @motif_id = query_params[:motif_id]
+
+    # Pour des questions d’accessibilité, on met le focus sur le premier ou le dernier créneau lorsqu’on clique
+    # sur les boutons semaine précédente ou semaine suivante.
+    @autofocus = query_params.delete(:autofocus)
   end
 
   # dupliqué de WebSearchContext

--- a/app/services/web_search_context.rb
+++ b/app/services/web_search_context.rb
@@ -1,6 +1,6 @@
 class WebSearchContext < SearchContext
   include Users::CreneauxWizardConcern
-  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude, :departement, :ants_pre_demandes_count
+  attr_reader :errors, :query_params, :address, :city_code, :street_ban_id, :latitude, :longitude, :departement, :ants_pre_demandes_count, :autofocus
 
   # departement est un cas particulier parce qu'il est aussi utilisé en dehors de addresse selection pour
   # passer cette première étape
@@ -32,6 +32,10 @@ class WebSearchContext < SearchContext
     @user_selected_organisation_id = query_params[:user_selected_organisation_id]
     @motif_id = query_params[:motif_id]
     @ants_pre_demandes_count = query_params[:ants_pre_demandes_count]
+
+    # Pour des questions d’accessibilité, on met le focus sur le premier ou le dernier créneau lorsqu’on clique
+    # sur les boutons semaine précédente ou semaine suivante.
+    @autofocus = query_params.delete(:autofocus)
   end
 
   def invitation?

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -18,17 +18,15 @@ div id="creneaux-lieu-#{lieu&.id}"
               br
               = l(date, format: "%d %b")
 
-            - if !creneaux_by_date[date].nil? && creneaux_by_date[date].first.respects_max_public_booking_delay?
+            - if creneaux_by_date[date]&.first&.respects_max_public_booking_delay?
               .fr-grid-row
                 - creneaux_by_date[date].sort.each do |creneau|
-                  ruby:
-                    autofocus = if (@context.autofocus == "first" && creneau == creneaux.min) || (@context.autofocus == "last" && creneau == creneaux.max)
-                                  true
-                                else
-                                  false
-                                end
-                  = link_to context.wizard_after_creneau_selection_path(motif_id: creneau.motif.id, starts_at: creneau.starts_at), "data-turbolinks": false, class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center", aria: { label: "Choisir le créneau du #{l(creneau.starts_at, format: '%A %d %b')} à #{l(creneau.starts_at, format: '%H:%M')}"}, autofocus: autofocus do
-                    - first_creneau = false
+                  - autofocus = (@context.autofocus == "first" && creneau == creneaux.min) || (@context.autofocus == "last" && creneau == creneaux.max)
+                  = link_to context.wizard_after_creneau_selection_path(motif_id: creneau.motif.id, starts_at: creneau.starts_at),
+                          class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center",
+                          data: { turbolinks: false },
+                          aria: { label: "Choisir le créneau du #{l(creneau.starts_at, format: '%A %d %b')} à #{l(creneau.starts_at, format: '%H:%M')}"},
+                          autofocus: do
                     = l(creneau.starts_at, format: "%H:%M")
                     - if creneau.motif.follow_up?
                       br
@@ -42,7 +40,10 @@ div id="creneaux-lieu-#{lieu&.id}"
 
         - if next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center
-            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at, autofocus: "first")), class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-s-line", data: { disable_with: "Veuillez patienter…" }, autofocus: @context.autofocus ? true : false do
+            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at, autofocus: "first")),
+                    class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-s-line",
+                    data: { disable_with: "Veuillez patienter…" },
+                    autofocus: @context.autofocus.present? do
               .d-flex.align-items-center
                 div
                   | Prochaine disponibilité le

--- a/app/views/search/_creneaux.html.slim
+++ b/app/views/search/_creneaux.html.slim
@@ -3,38 +3,46 @@ div id="creneaux-lieu-#{lieu&.id}"
     - previous_from_date = date_range.begin - 7.days
     - if date_range.begin > Time.zone.today
       .col-12.col-md-auto.mb-2.mb-md-0.d-flex.align-items-center.justify-content-center
-        = link_to "", prendre_rdv_path(query_params.merge(date: previous_from_date)), class: "fr-btn fr-icon-arrow-left-s-line fr-hidden fr-unhidden-md", aria: { label: "Semaine précédente" }
-        = link_to "sem. précédente", prendre_rdv_path(query_params.merge(date: previous_from_date)), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md", aria: { label: "Semaine précédente" }
+        = link_to "", prendre_rdv_path(query_params.merge(date: previous_from_date, autofocus: "last")), class: "fr-btn fr-icon-arrow-left-s-line fr-hidden fr-unhidden-md", aria: { label: "Semaine précédente" }
+        = link_to "sem. précédente", prendre_rdv_path(query_params.merge(date: previous_from_date, autofocus: "last")), class: "fr-btn fr-btn--icon-left fr-icon-arrow-left-s-line fr-hidden-md", aria: { label: "Semaine précédente" }
 
     .col
       .row
+        ruby:
+          creneaux_by_date = creneaux.group_by { |c| c.starts_at.to_date }
+
         - date_range.each do |date|
           .fr-col-6.fr-col-md-3.fr-col-lg.fr-pl-1w.fr-pr-1w
             p.rdv-text-align-center
               strong= l(date, format: "%A")
               br
               = l(date, format: "%d %b")
-            - creneaux_for_date = creneaux.group_by { |c| c.starts_at.to_date }.select { |k, v| k == date }
 
-            - if creneaux_for_date.any? && creneaux_for_date[date].first.respects_max_public_booking_delay?
+            - if !creneaux_by_date[date].nil? && creneaux_by_date[date].first.respects_max_public_booking_delay?
               .fr-grid-row
-                - creneaux_for_date.each_value do |creneaux|
-                  - creneaux.sort.each do |creneau|
-                    = link_to context.wizard_after_creneau_selection_path(motif_id: creneau.motif.id, starts_at: creneau.starts_at), "data-turbolinks": false, class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center", aria: { label: "Choisir le créneau du #{l(creneau.starts_at, format: '%A %d %b')} à #{l(creneau.starts_at, format: '%H:%M')}"} do
-                      = l(creneau.starts_at, format: "%H:%M")
-                      - if creneau.motif.follow_up?
-                        br
-                        small= creneau.agent.short_name
+                - creneaux_by_date[date].sort.each do |creneau|
+                  ruby:
+                    autofocus = if (@context.autofocus == "first" && creneau == creneaux.min) || (@context.autofocus == "last" && creneau == creneaux.max)
+                                  true
+                                else
+                                  false
+                                end
+                  = link_to context.wizard_after_creneau_selection_path(motif_id: creneau.motif.id, starts_at: creneau.starts_at), "data-turbolinks": false, class: "fr-col-12 fr-btn fr-btn--tertiary fr-mb-1w rdv-justify-content-center", aria: { label: "Choisir le créneau du #{l(creneau.starts_at, format: '%A %d %b')} à #{l(creneau.starts_at, format: '%H:%M')}"}, autofocus: autofocus do
+                    - first_creneau = false
+                    = l(creneau.starts_at, format: "%H:%M")
+                    - if creneau.motif.follow_up?
+                      br
+                      small= creneau.agent.short_name
             - elsif context.after_max_public_booking_delay?(date)
               p.rdv-text-align-center.rdv-color-text-mention-grey
                 | Date fermée à la reservation
-            - elsif creneaux.any?
+            - elsif creneaux_by_date[date].nil?
               p.rdv-text-align-center.fr-text--sm
                 | Pas de créneau disponible
 
         - if next_availability
           .position-absolute.h-100.w-100.bg-overlay.d-flex.align-items-center.justify-content-center
-            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at)), class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-s-line", data: { disable_with: "Veuillez patienter…" } do
+            = link_to prendre_rdv_path(query_params.merge(date: next_availability.starts_at, autofocus: "first")), class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-s-line", data: { disable_with: "Veuillez patienter…" }, autofocus: @context.autofocus ? true : false do
               .d-flex.align-items-center
                 div
                   | Prochaine disponibilité le
@@ -42,5 +50,5 @@ div id="creneaux-lieu-#{lieu&.id}"
                   strong= l(next_availability.starts_at, format: :human)
     - if params[:date].blank? || !context.after_max_public_booking_delay?(params[:date].to_date + 6.days)
       .col-12.col-md-auto.mt-2.mt-md-0.d-flex.align-items-center.justify-content-center
-        = link_to "", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class: "fr-btn fr-icon-arrow-right-s-line fr-hidden fr-unhidden-md", aria: { label: "semaine suivante"}
-        = link_to "sem. prochaine", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day)), class:  "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md", aria: { label: "semaine suivante"}
+        = link_to "", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day, autofocus: "first")), class: "fr-btn fr-icon-arrow-right-s-line fr-hidden fr-unhidden-md", aria: { label: "semaine suivante"}
+        = link_to "sem. prochaine", prendre_rdv_path(query_params.merge(date: date_range.end + 1.day, autofocus: "first")), class:  "fr-btn fr-btn--icon-right fr-icon-arrow-right-s-line fr-hidden-md", aria: { label: "semaine suivante"}


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5349.osc-secnum-fr1.scalingo.io/) 

# Contexte

Dans le cadre de l’audit d’accessibilité, il a été révélé que lors de la sélection de créneau, l’usager qui clique sur semaine précédente ou suivante et qui fait de la navigation au clavier (ou utilise un lecteur d’écran) se retrouve perdu.
En effet, vu que nous changeons de page, le focus revient tout en haut de la page à chaque changement de semaine.

# Solution

On ajoute un paramètre qui permet de mettre le focus au premier créneau si on a cliqué sur semaine suivante et au dernier créneau si on a cliqué sur semaine précédente.
Ainsi l’usager qui entend « lien, Semaine précédente » et qui cliques dessus entendra juste après « Choisir le créneau du xx à xxhxx » plutôt que d’entendre de nouveau le titre de la page et de devoir naviguer pour retrouver la sélection de créneau.

## Captures d'écran

### Avant

https://github.com/user-attachments/assets/22addada-1a05-4294-a827-2148e89700c4 

### Après

https://github.com/user-attachments/assets/111bdc05-a5c5-446e-95a0-ff629a5c6812
