### PR TITLE
a11y: correction dir attr pour l’autocomplete d’adresse

### DIFF
--- a/app/views/admin/rdv_wizard_steps/step3.html.slim
+++ b/app/views/admin/rdv_wizard_steps/step3.html.slim
@@ -32,8 +32,8 @@ ruby:
             small.form-text.text-muted data={"rdv-lieu-target": "select_lieu_link"}
               = t(".existing_lieu_hint_html")
       - elsif @rdv.home?
-        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", input_html: { data: { "address-autocomplete": "on" } }
+        = f.input :address, label: "Lieu (RDV à domicile)",  disabled: true, hint: "L'adresse utilisée est celle de #{@rdv.user_for_home_rdv.full_name}", input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }
       - elsif @rdv.phone?
-        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", input_html: { data: { "address-autocomplete": "on" } }
+        = f.input :address, label: "Lieu (RDV téléphonique)",  disabled: true, hint: "Il n'y a pas d'adresse car le RDV est téléphonique", input_html: { data: { "address-autocomplete": "on", dir: "ltr" } }
       = f.association :agents, collection: @rdv.motif.authorized_agents, label_method: :reverse_full_name_and_service, input_html: { multiple: true, class: "select2-input", data: { "auto-select-sole-option": true } }
       = render "actions", rdv_wizard_form: @rdv_wizard, submit_value: "Continuer", f: f

--- a/app/views/admin/rdvs/edit.html.slim
+++ b/app/views/admin/rdvs/edit.html.slim
@@ -54,7 +54,7 @@
                     = t(".existing_lieu_hint_html")
 
             - elsif @rdv_form.motif.home?
-              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { data: { "address-autocomplete": "on" } }
+              = f.input :address, label: "Lieu (RDV à domicile)", disabled: true, input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }
             = f.association :agents,
               collection: @rdv_form.motif.authorized_agents,
               selected: @rdv_form.selected_agent_ids || @rdv.agent_ids,

--- a/app/views/admin/territories/sectorisation_tests/search.html.slim
+++ b/app/views/admin/territories/sectorisation_tests/search.html.slim
@@ -14,7 +14,7 @@ do |f|
         :where, \
         label: "Adresse", \
         placeholder: "ex : 21 rue Anatole France, Calais", \
-        input_html: { data: { "address-autocomplete": "on" } }
+        input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }
       .row.align-items-center.bg-light.py-2.mb-2
         .col-lg-2 Infos de la Base Adresse
         .col-lg-2= f.input :departement, readonly: true, label: "Département"

--- a/app/views/admin/territories/zones/_form.html.slim
+++ b/app/views/admin/territories/zones/_form.html.slim
@@ -30,12 +30,14 @@
       label: "Rechercher une commune", \
       input_html: { \
         data: { "address-type": "municipality", "address-autocomplete": "on" }, \
+        dir: "ltr", \
       }
   - elsif zone.level_street?
     = f.input :street_label, \
       label: "Rechercher une rue", \
       input_html: { \
         data: { "address-type": "street", "address-autocomplete": "on" }, \
+        dir: "ltr", \
       }
   .row
     .col-6

--- a/app/views/admin/users/_responsible_form_fields.html.slim
+++ b/app/views/admin/users/_responsible_form_fields.html.slim
@@ -48,14 +48,14 @@
     | L'usager ayant validé son compte, vous ne pouvez plus modifier ses préférences
 
 - unless current_domain == Domain::RDV_MAIRIE
-  = f.input :address, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" } }))
+  = f.input :address, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }))
 
   = f.input :city_code, as: :hidden, **input_opts
   = f.input :post_code, as: :hidden, **input_opts
   = f.input :city_name, as: :hidden, **input_opts
 
 - if current_territory.enable_address_details
-  = f.input :address_details, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" } }))
+  = f.input :address_details, **(input_opts.deep_merge(input_html: { data: { "address-autocomplete": "on" }, dir: "ltr" }))
 
 - if current_territory.enable_case_number
   = f.input :case_number, **input_opts

--- a/app/views/fields/places_field/_form.html.slim
+++ b/app/views/fields/places_field/_form.html.slim
@@ -1,4 +1,4 @@
 .field-unit__label
   = f.label field.attribute
 .field-unit__field
-  = f.text_field field.attribute, data: { "address-autocomplete": "on" }
+  = f.text_field field.attribute, data: { "address-autocomplete": "on" }, dir: "ltr"

--- a/app/views/search/address_selection/_search_form_section.html.slim
+++ b/app/views/search/address_selection/_search_form_section.html.slim
@@ -12,6 +12,6 @@ section.rdv-background-color-alt-blue-ecume.fr-pt-4w.fr-pb-8w
         / TODO: change input name to address and change whereInput in application.js
         = f.label :where, "Saisissez votre adresse", class: "fr-label"
         .fr-search-bar.fr-search-bar--lg[role="search"]
-          = f.text_field :where, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input", required: true, value: context.address, data: { "address-autocomplete": "on" }, autocomplete: "street-address"
+          = f.text_field :where, placeholder: "ex : 21 rue Anatole France, Calais", name: "address", class: "fr-input", required: true, value: context.address, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
           = button_tag :button, id: "search_submit", class: "fr-btn" do
             | Rechercher

--- a/app/views/super_admins/comptes/new.html.slim
+++ b/app/views/super_admins/comptes/new.html.slim
@@ -27,7 +27,7 @@ section.main-content__body
         = ff.input :ants_connectable, as: :boolean, label: "Autoriser le branchement au moteur de recherche de l'ANTS", hint: "En cochant cette case, vous permettrez à cette organisation (probablement une mairie) d'apparaitre sur https://rendezvouspasseport.ants.gouv.fr/"
 
     = f.simple_fields_for :lieu do |ff|
-      = ff.input :address, label: "Adresse du premier lieu", hint: "Le nom du lieu sera le même que celui de l'organisation", input_html: { data: { "address-autocomplete": "on" }}, required: false
+      = ff.input :address, label: "Adresse du premier lieu", hint: "Le nom du lieu sera le même que celui de l'organisation", input_html: { data: { "address-autocomplete": "on" }, dir: "ltr"}, required: false
       = ff.input :latitude, as: :hidden
       = ff.input :longitude, as: :hidden
 

--- a/app/views/users/users/_form.html.slim
+++ b/app/views/users/users/_form.html.slim
@@ -35,10 +35,10 @@ ruby:
   div= f.dsfr_check_box :notify_by_sms
   - unless current_user.signed_in_with_invitation_token? || current_domain == Domain::RDV_MAIRIE
     - address_value = rdv_wizard.present? && user.address.nil? ? rdv_wizard.to_query[:where] : user.address
-    = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address"
+    = f.dsfr_text_field :address, value: address_value, required: rdv_wizard&.motif&.home?, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 
   - if territories.map(&:enable_address_details).any?
-    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }, autocomplete: "street-address"
+    = f.dsfr_text_field :address_details, data: { "address-autocomplete": "on" }, autocomplete: "street-address", dir: "ltr"
 
   = f.hidden_field :city_code
   = f.hidden_field :post_code


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité, les points suivants ont été relevés :

<img width="856" alt="image" src="https://github.com/user-attachments/assets/2f667bda-0d18-4315-a4f7-4e68f33ece8c" />

# Solution

L’outil que nous utilisons pour l’autocompletion d’adresse set par défaut l’attribut `dir` à `auto`.
On se débarrassera de ce comportement quand nous changerons d’autocomplete d’adresse (cf #5103) mais en attendant on définit l’attribut `dir` pour résoudre le problème.
