### PR TITLE
Bugfix: retries infinis de ApplicationMailerDeliveryJob

### DIFF
--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -7,7 +7,8 @@ class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
   # Only discard DeserializationError if it is caused by a ActiveRecord::RecordNotFound.
   # We don't want to discard a job when deserialization failed because of a DB failure for example.
   rescue_from ActiveJob::DeserializationError do |exception|
-    if exception.cause.instance_of?(ActiveRecord::RecordNotFound)
+    case exception.cause
+    when ActiveRecord::RecordNotFound, GoodJob::InterruptError
       Rails.logger.error(exception.message)
     else
       Sentry.capture_exception(exception)
@@ -21,3 +22,9 @@ class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
     super && executions > 2
   end
 end
+
+GoodJob::Job.where(finished_at: nil).where("executions_count > 22").each do |job|
+  job.discard_job
+end
+
+GoodJob::Job.find("37668c6c-71bf-4c68-a18e-65e334cda498").discard_job

--- a/app/mailers/application_mailer_delivery_job.rb
+++ b/app/mailers/application_mailer_delivery_job.rb
@@ -7,6 +7,11 @@ class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
   # Only discard DeserializationError if it is caused by a ActiveRecord::RecordNotFound.
   # We don't want to discard a job when deserialization failed because of a DB failure for example.
   rescue_from ActiveJob::DeserializationError do |exception|
+    Rails.logger.error("ActiveJob::DeserializationError rescue block executing...")
+    Rails.logger.error("exception.inspect: #{exception.inspect}")
+    Rails.logger.error("exception.cause.inspect: #{exception.cause.inspect}")
+    Rails.logger.error("executions: #{executions}")
+
     case exception.cause
     when ActiveRecord::RecordNotFound, GoodJob::InterruptError
       Rails.logger.error(exception.message)
@@ -22,9 +27,3 @@ class ApplicationMailerDeliveryJob < ActionMailer::MailDeliveryJob
     super && executions > 2
   end
 end
-
-GoodJob::Job.where(finished_at: nil).where("executions_count > 22").each do |job|
-  job.discard_job
-end
-
-GoodJob::Job.find("37668c6c-71bf-4c68-a18e-65e334cda498").discard_job

--- a/spec/jobs/application_mailer_delivery_job_spec.rb
+++ b/spec/jobs/application_mailer_delivery_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ApplicationMailerDeliveryJob do
     MyMailer.a_sample_email(absence).deliver_later
     absence.destroy!
     expect { perform_enqueued_jobs }.not_to raise_error
+    expect(sentry_events).to be_empty
   end
 
   # Sometimes we have DB failures, these should not cause the job to be discarded


### PR DESCRIPTION
# Contexte

Nous observons le comportement suivant : lorsque un job de type `ApplicationMailerDeliveryJob` atteint son 20ème retry, il part en retry infinis : 

![image](https://github.com/user-attachments/assets/0ceb1b37-2066-46ab-9149-0fce2a571542)

Nous reproduisons ce comportement en allant sur un job qui en est à son 19ème essai et en cliquand tu "Reschedule" pour déclencher l'essai final.

L'erreur remontée, qui semble déclencher chaque nouveau retry, est :

>  GoodJob::InterruptError: Interrupted after starting perform at '2025-05-22 16:00:25 +0200'

On peut voir que `GoodJob::InterruptError` est levée dans un `around_perform` avant le perform du job, si la valeur `CurrentThread.execution_interrupted` est présente. Nous ne avons pas pourquoi cette valeur est à true chez nous.

# Solution

Voici mon hypothèse sur ce qu'il se passe : l'erreur `GoodJob::InterruptError` est levée lors du processus de désérialisation (je ne sais pas pourquoi), ce qui [déclenche une levée de `ActiveJob::DeserializationError`](https://github.com/rails/rails/blob/ad858b91a9a4bc94950708955e44c654a1f3789b/activejob/lib/active_job/arguments.rb#L45). Cette exception est alors gérée dans notre `rescue_from ActiveJob::DeserializationError`, qui appelle alors `retry_job`.

Le fix consiste donc à ne pas retry si l'erreur source est une `GoodJob::InterruptError`.

J'ajoute également du log pour obtenir plus d'infos sur l'état des choses en prod.