### PR TITLE
a11y: correction du titre de la page confirmation email

### DIFF
--- a/app/views/users/registrations/pending.html.slim
+++ b/app/views/users/registrations/pending.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, t("devise.invitations.invitation.title")
+- content_for :title, "Confirmez votre adresse e-mail"
 
 .card
   .card-body


### PR DESCRIPTION
# Contexte

Dans le cadre de l’audit d’accessibilité, les points suivants ont été relevés :

<img width="876" alt="image" src="https://github.com/user-attachments/assets/1ba01a39-ebe2-4db3-99f7-423e9072d6e1" />

# Solution

On ajuste le titre de la page. Étant donné que nous étions dans la dynamique d’inliné les éléments (surtout quand ils sont utilisé une fois) j’ai retiré l’usage de i18n ici. J’ai laissé la clef car elle est encore utilisée ailleurs.

## Avant

<img width="906" alt="image" src="https://github.com/user-attachments/assets/7ca858ca-14df-477d-9a94-44d90e372703" />

## Après

<img width="885" alt="image" src="https://github.com/user-attachments/assets/7b095fe0-9803-42af-a57c-4c139faf2a34" />
