### PR TITLE
Mise à jour DSFR View Components v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,7 +134,7 @@ gem "groupdate", "~> 6.1"
 gem "rails_autolink"
 # ActionView helper to render currently active links
 gem "active_link_to"
-gem "dsfr-view-components"
+gem "dsfr-view-components", "~> 3.0"
 gem "dsfr-form_builder", "= 0.0.7" # On fixe la version tant qu’on est pas en 1.0
 
 # Easily create styled HTML emails in Rails.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       descendants_tracker (~> 0.0.1)
     common_french_passwords (0.0.1)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.3)
     coverband (6.1.4)
       redis (>= 3.0)
     crack (0.4.5)
@@ -242,13 +242,13 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    drb (2.2.1)
-    dsfr-assets (1.13.0.1)
+    drb (2.2.3)
+    dsfr-assets (1.13.1)
     dsfr-form_builder (0.0.7)
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
-    dsfr-view-components (2.1.2)
+    dsfr-view-components (3.0.1)
       dsfr-assets (~> 1.13)
       html-attributes-utils (~> 1)
       view_component (~> 3)
@@ -729,9 +729,9 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     version_gem (1.1.3)
-    view_component (3.21.0)
+    view_component (3.23.1)
       activesupport (>= 5.2.0, < 8.1)
-      concurrent-ruby (~> 1.0)
+      concurrent-ruby (~> 1)
       method_source (~> 1.0)
     virtus (2.0.0)
       axiom-types (~> 0.1)
@@ -796,7 +796,7 @@ DEPENDENCIES
   doorkeeper-i18n
   dotenv-rails
   dsfr-form_builder (= 0.0.7)
-  dsfr-view-components
+  dsfr-view-components (~> 3.0)
   factory_bot
   faker
   foreman

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -50,5 +50,5 @@
         = t(".create_absence_for", full_name: @agent.full_name_or_email)
 
 - unless current_territory.visioplainte?
-  = dsfr_alert type: :info, size: :sm, classes: "fr-mb-2v" do
+  = dsfr_alert type: :info, size: :sm, html_attributes: { class: "fr-mb-2v" } do
     |< Les jours fériés sont automatiquement considérés comme indisponibles.

--- a/app/views/admin/motifs/form/_configuration_principale.html.slim
+++ b/app/views/admin/motifs/form/_configuration_principale.html.slim
@@ -47,7 +47,7 @@ p
     p Choisissez le nombre de participants :
 
     - if disabled
-      = dsfr_alert type: :warning, size: :sm, classes: "fr-mb-2v" do
+      = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
         | Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le nombre de participants
 
     = label_tag do

--- a/app/views/admin/motifs/form/_location_types.html.slim
+++ b/app/views/admin/motifs/form/_location_types.html.slim
@@ -1,5 +1,5 @@
 - if disabled
-  = dsfr_alert type: :warning, size: :sm, classes: "fr-mb-2v" do
+  = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
     | Ce motif est déjà utilisé dans au moins un RDV, il n'est pas possible de changer le type
 
 .d-flex.flex-column

--- a/app/views/admin/territories/sectors/index_map.html.slim
+++ b/app/views/admin/territories/sectors/index_map.html.slim
@@ -9,7 +9,7 @@
 .row
   .col-md-12
     .card
-      = dsfr_alert type: :warning, size: :sm, classes: "fr-mb-2v" do
+      = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mb-2v" } do
         | Cette carte n'affiche pas correctement les secteurs qui se chevauchent ni les rues dans le détail
       div.position-relative
         #js-zones-map[

--- a/app/views/admin/users/_responsible_information.html.slim
+++ b/app/views/admin/users/_responsible_information.html.slim
@@ -12,7 +12,7 @@ ul.list-unstyled.mb-5
   li.mb-2
     = object_attribute_tag(user, :phone_number, clickable_user_phone_number(user))
     - if user.phone_number.present? && DuplicateUsersFinderService.find_duplicate_based_on_phone_number(user, current_organisation).present?
-      = dsfr_alert type: :warning, size: :sm, classes: "fr-mt-1v" do
+      = dsfr_alert type: :warning, size: :sm, html_attributes: { class: "fr-mt-1v" } do
         span> D'autres usagers utilisent ce numéro de téléphone.
         = link_to "voir la liste", admin_organisation_users_path(current_organisation, "search": user.phone_number), class: "fr-link"
 

--- a/app/views/common/_fil_ariane.html.slim
+++ b/app/views/common/_fil_ariane.html.slim
@@ -1,6 +1,6 @@
 /# locals: (titles_and_paths:, current_page_title:)
 
-= dsfr_breadcrumbs(classes: "fr-mb-0 fr-ml-2w") do |b|
+= dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
   - titles_and_paths.each do |title, path|
     = b.with_breadcrumb label: title, href: path
   = b.with_breadcrumb label: current_page_title

--- a/app/views/layouts/_flash.html.slim
+++ b/app/views/layouts/_flash.html.slim
@@ -1,4 +1,4 @@
 - %i[success notice error alert].each do |type|
   - if flash[type]
-    = dsfr_alert type: alert_dsfr_type_for(type), size: :sm, classes: "fr-pb-1w fr-my-2w", close_button: true, html_attributes: { role: "alert" } do
+    = dsfr_alert type: alert_dsfr_type_for(type), size: :sm, close_button: true, html_attributes: { class: "fr-pb-1w fr-my-2w", role: "alert" } do
       = sanitize(flash[type], tags: %w[a br strong em], scrubber: :prune)

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -23,20 +23,20 @@ html lang="fr"
       ruby:
         header.with_operator_image title: "Accueil - #{current_domain.name}", src: asset_path(current_domain.dark_logo_path), alt: ""
         if current_user.present? && !current_user.signed_in_with_invitation_token?
-          header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, classes: "fr-icon-calendar-fill"
+          header.with_tool_link title: "Vos rendez-vous", path: users_rdvs_path, html_attributes: { class: "fr-icon-calendar-fill" }
           header.with_tool_link title: "Vos informations", path: users_informations_path
           header.with_tool_link title: "Votre compte", path: edit_user_registration_path
-          header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, classes: "fr-icon-lock-fill", html_attributes: { "data-method": "delete" }
+          header.with_tool_link title: "Déconnexion", path: destroy_user_session_path, html_attributes: { "data-method": "delete", class: "fr-icon-lock-fill" }
         elsif current_agent
           header.with_tool_link title: "Espace Agent", path: root_path
           header.with_tool_link title: current_agent.full_name, path: edit_agent_registration_path
         elsif current_domain == Domain::RDV_MAIRIE && request.path == "/"
-          header.with_tool_link title: "Centre d’aide", path: "https://aide.rdv-service-public.fr", classes: "fr-icon-questionnaire-line"
-          header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, classes: "fr-icon-admin-line"
-          header.with_tool_link title: "Connexion Usager", path: new_user_session_path, classes: "fr-icon-account-line"
+          header.with_tool_link title: "Centre d’aide", path: "https://aide.rdv-service-public.fr", html_attributes: { class: "fr-icon-questionnaire-line" }
+          header.with_tool_link title: "Connexion Agent", path: new_agent_session_path, html_attributes: { class: "fr-icon-admin-line" }
+          header.with_tool_link title: "Connexion Usager", path: new_user_session_path, html_attributes: { class: "fr-icon-account-line" }
         elsif !stats_path?
           header.with_tool_link title: "Espace Agent", path: new_agent_session_path
-          header.with_tool_link title: "Se connecter", path: new_user_session_path, classes: "fr-fi-account-fill"
+          header.with_tool_link title: "Se connecter", path: new_user_session_path,html_attributes: { class: "fr-fi-account-fill" }
         end
 
     main#content[role="main"]


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5360.osc-secnum-fr1.scalingo.io/) 

# Contexte

Nous avons sorti la 3.0 de DSFR View Components, qui a un breaking change. Afin de pouvoir bénéficier des futurs changements de la Gem, on la met à jour maintenant et on change les appels contenant le breaking change.

L’attribut `classes` des composants est supprimé au profit de `class` contenu dans `html_attributes` : https://github.com/betagouv/dsfr-view-components/pull/229

Testé en local et en review app tout semble conforme.
