### PR TITLE
Première utilisation du DSFR pour les tableaux

### DIFF
--- a/app/helpers/absences_helper.rb
+++ b/app/helpers/absences_helper.rb
@@ -3,9 +3,9 @@ module AbsencesHelper
 
   def absence_tag(absence)
     if absence.expired?
-      tag.span("Passée", class: "badge badge-light")
+      tag.span("Passée", class: "fr-badge fr-badge--sm fr-mx-1w")
     elsif absence.starts_at.today? || an_ocurrence_after_today?(absence)
-      tag.span("En cours", class: "badge badge-info")
+      tag.span("En cours", class: "fr-badge fr-badge--info fr-badge--sm fr-badge--no-icon fr-mx-1w")
     end
   end
 

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -119,3 +119,9 @@ header.header {
 li.nav-item {
   padding-bottom: 0; // Pour les onglets bootstrap
 }
+
+// Les groupes de boutons DSFR ont une marge de 1rem en bas par défaut
+// Quand nous sommes dans un tableau, on ne veut pas de marge
+.fr-table .fr-btns-group .fr-btn {
+  margin-bottom: 0;
+}

--- a/app/views/admin/absences/_absence.html.slim
+++ b/app/views/admin/absences/_absence.html.slim
@@ -11,15 +11,15 @@ tr
       br
       = sanitize(display_recurrence(absence).join("<br/>"))
   td
-    .d-flex
-      div.mr-3= link_to edit_admin_organisation_absence_path(current_organisation, absence),
-                title: t("helpers.edit") do
-        i.fa.fa-edit
-      div.mr-3= link_to new_admin_organisation_agent_absence_path(current_organisation, absence.agent, duplicate_absence_id: absence),
-              title: t("helpers.clone") do
-        i.fa.fa-clone
-      div.mr-3= link_to( admin_organisation_absence_path(current_organisation, absence),
+    .fr-btns-group.fr-btns-group--sm.fr-btns-group--inline
+      = link_to "", edit_admin_organisation_absence_path(current_organisation, absence),
+              title: t("helpers.edit"),
+              class: "fr-btn fr-btn--tertiary fr-icon-edit-fill"
+      = link_to "", new_admin_organisation_agent_absence_path(current_organisation, absence.agent, duplicate_absence_id: absence),
+              title: t("helpers.clone"),
+              class: "fr-btn fr-btn--tertiary fr-icon-clipboard-fill"
+      = link_to "", admin_organisation_absence_path(current_organisation, absence),
               method: :delete,
               title: t("helpers.delete"),
-              data: { confirm: t(".confirm_delete_absence")} ) do
-        i.fa.fa-trash-alt
+              data: { confirm: t(".confirm_delete_absence")},
+                class: "fr-btn fr-btn--tertiary fr-icon-delete-bin-fill"

--- a/app/views/admin/absences/index.html.slim
+++ b/app/views/admin/absences/index.html.slim
@@ -19,16 +19,21 @@
         = active_link_to "Passées", admin_organisation_agent_absences_path(current_organisation, @agent.id, current_tab: "expired"), class: "nav-link", active: :exact
 
   - if @absences.any?
-    table.table
-      thead
-        tr
-          th Description
-          th Dates
-          th Actions
-      tbody
-        = render @absences
-    .d-flex.justify-content-center
-      = paginate @absences, theme: "twitter-bootstrap-4"
+    .fr-table.fr-mx-2w
+      .fr-table__wrapper
+        .fr-table__container
+          .fr-table__content
+            table
+              thead
+                tr
+                  th Description
+                  th Dates
+                  th Actions
+              tbody
+                = render @absences
+      .fr-table__footer
+        .fr-table__footer--middle
+          = paginate @absences
 
   - else
     .row.justify-content-md-center.p-2.mt-3
@@ -43,7 +48,7 @@
           i.fa.fa-circle.fa-stack-2x.text-primary
           i.far.fa-calendar.fa-stack-1x.text-white
   .rdv-text-align-center.py-2
-    = link_to new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "btn btn-primary" do
+    = link_to new_admin_organisation_agent_absence_path(current_organisation, @agent.id), class: "fr-btn" do
       - if @agent == current_agent
         = t(".create_absence")
       - else

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "First" page
+/ - available local variables
+/   url:           url to the first page
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+
+- if current_page.first?
+  = content_tag("a", "Première page", title: "Première page", role: "link", class: "fr-pagination__link fr-pagination__link--first", aria: { disabled: true })
+- else
+  = link_to "Première page", url, title: "Première page", role: "link", class: "fr-pagination__link fr-pagination__link--first"

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,8 @@
+/ Non-link tag that stands for skipped pages...
+/ - available local variables
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+
+span.fr-pagination__link …

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Last" page
+/ - available local variables
+/   url:           url to the last page
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+
+- if current_page.last?
+  = content_tag("a", "Dernière page", title: "Dernière page", role: "link", class: "fr-pagination__link fr-pagination__link--last", aria: { disabled: true })
+- else
+  = link_to "Dernière page", url, title: "Dernière page", role: "link", class: "fr-pagination__link fr-pagination__link--last"

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Previous" page
+/ - available local variables
+/   url:           url to the previous page
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+
+- if current_page.last?
+  = content_tag("a", "Suivante", title: "Suivante", role: "link", class: "fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label", aria: { disabled: true })
+- else
+  = link_to "Suivante", url, title: "Suivante", role: "link", class: "fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,13 @@
+/ Link showing page number
+/ - available local variables
+/   page:          a page object for "this" page
+/   url:           url to this page
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+
+- if page.current?
+  = content_tag("a", page, title: "Page #{page}", class: "fr-pagination__link fr-pagination__link--current", aria: { current: "page" })
+- else
+  = link_to page, url, title: "Page #{page}", class: "fr-pagination__link"

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,21 @@
+/ The container tag
+/ - available local variables
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+/   paginator:     the paginator that renders the pagination tags inside
+
+= paginator.render do
+  / - unless current_page.out_of_range?
+  nav.fr-pagination role="navigation" aria-label="Pagination" class="fr-pagination"
+    ul.fr-pagination__list
+      = first_page_tag
+      = prev_page_tag
+      - each_page do |page|
+        - if page.display_tag?
+          = page_tag page
+        - elsif !page.was_truncated?
+          = gap_tag
+      = next_page_tag
+      = last_page_tag

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,12 @@
+/ Link to the "Previous" page
+/ - available local variables
+/   url:           url to the previous page
+/   current_page:  a page object for the currently displayed page
+/   total_pages:   total number of pages
+/   per_page:      number of items to fetch per page
+/   remote:        data-remote
+
+- if current_page.first?
+  = content_tag("a", "Précédente", title: "Précédente", role: "link", class: "fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label", aria: { disabled: true })
+- else
+  = link_to "Précédente", url, title: "Précédente", role: "link", class: "fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"

--- a/spec/helpers/absences_helper_spec.rb
+++ b/spec/helpers/absences_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AbsencesHelper do
       today = Time.zone.parse("2020-12-24 13:56")
       travel_to(today)
       absence = build(:absence, first_day: today.beginning_of_day, end_day: today.end_of_day)
-      expect(absence_tag(absence)).to eq("<span class=\"badge badge-info\">En cours</span>")
+      expect(absence_tag(absence)).to eq("<span class=\"fr-badge fr-badge--info fr-badge--sm fr-badge--no-icon fr-mx-1w\">En cours</span>")
     end
 
     it "return En cours when absence have an occurrence today" do
@@ -15,7 +15,7 @@ RSpec.describe AbsencesHelper do
                        end_day: today.end_of_day - 1.week,
                        recurrence: Montrose.every(:week, until: today + 1.month, starts: today.beginning_of_day - 1.week))
 
-      expect(absence_tag(absence)).to eq("<span class=\"badge badge-info\">En cours</span>")
+      expect(absence_tag(absence)).to eq("<span class=\"fr-badge fr-badge--info fr-badge--sm fr-badge--no-icon fr-mx-1w\">En cours</span>")
     end
 
     it "return nil when absence is for the future" do
@@ -31,7 +31,7 @@ RSpec.describe AbsencesHelper do
       today = Time.zone.parse("2020-12-24 13:56")
       travel_to(today)
       absence = build(:absence, first_day: today - 3.days, end_day: today - 3.days)
-      expect(absence_tag(absence)).to eq("<span class=\"badge badge-light\">Passée</span>")
+      expect(absence_tag(absence)).to eq("<span class=\"fr-badge fr-badge--sm fr-mx-1w\">Passée</span>")
     end
   end
 end


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5361.osc-secnum-fr1.scalingo.io/) 

(Sur le compte de Martine, j'ai mis pleins d’indispo pour que vous puissiez voir la pagination)

# Contexte

Nous essayons de nous débarasser petit à petit de Bootstrap et Font Awesome pour tout passer au DSFR.
L’idée de cette PR est de mettre en place les bases de l’utilisation du DSFR dans les tableaux pour pouvoir migrer petit à petit tous les tableaux.

Pour cette première PR, j'ai décidé de faire le changement sur le tabeau des indisponibilités.

# Solution

- Passage du tableau des indisponibilités au DSFR.
- Utilisation de boutons d’actions (et d’icônes) au DSFR.
- Création du thème kaminari pour la pagination en utilisant le DSFR

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/98dd5ad5-6dbf-400c-915a-a4736d211c70) | ![image](https://github.com/user-attachments/assets/a429525f-a263-4279-a91c-363eb6786be4)

