### PR TITLE
Fix : correction du titre page RDV et ajout fil d’ariane DSFR

### DIFF
--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -1,16 +1,19 @@
 - content_for(:menu_item) { @agent ? "menu-agendas" : "menu-rdvs-list" }
 
-- content_for :title do
-  ol.breadcrumb.m-0.p-0
+- content_for :fil_ariane do
+  = dsfr_breadcrumbs(html_attributes: { class: "fr-mb-0 fr-ml-2w" }) do |b|
+    = b.with_breadcrumb label: "Accueil", href: root_path
     - if @agent
-      li.breadcrumb-item.p-0
-        - if @agent != current_agent
-          = link_to "Agenda de #{@agent.full_name}", admin_organisation_agent_agenda_path(current_organisation, @agent)
-        - else
-          = link_to "Votre agenda", admin_organisation_agent_agenda_path(current_organisation, current_agent)
-    li.breadcrumb-item.p-0.ml-2
-      span> RDV
-      span>= rdv_title_for_agent(@rdv)
+      - if @agent != current_agent
+        = b.with_breadcrumb label: "Agenda de #{@agent.full_name}", href: admin_organisation_agent_agenda_path(current_organisation, @agent)
+      - else
+        = b.with_breadcrumb label: "Votre agenda", href: admin_organisation_agent_agenda_path(current_organisation, current_agent)
+    - else
+      = b.with_breadcrumb label: "Liste des RDV", href: admin_organisation_rdvs_path(current_organisation)
+    = b.with_breadcrumb label: "RDV #{rdv_title_for_agent(@rdv)}"
+
+- content_for :title do
+  = "RDV #{rdv_title_for_agent(@rdv)}"
 
 .row.justify-content-md-center
   .col-md-11


### PR DESCRIPTION
Closes #3151 

# Contexte

J’ai voulu corriger le titre de la page de RDV côté agent pour des questions de lisibilité et d’accessibilité. J’en ai profité pour mettre en place le fil d’ariane DSFR dans notre volonté d’uniformisation de l’interface agent.

## Captures d'écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/ce264d4b-2b48-478d-b356-7f113fd3316c) | ![image](https://github.com/user-attachments/assets/6991cde6-c37d-4bda-b7a5-7c1494330003)
![image](https://github.com/user-attachments/assets/2d271cb2-7fca-475b-95bc-c50aaa19fa8b) | ![image](https://github.com/user-attachments/assets/2320a17c-08b1-4c8e-8066-6a9e7ef81909)
