### PR TITLE
a11y: ajout des attributs d’autocomplete manquant login agent

### DIFF
--- a/app/views/agents/sessions/new.html.slim
+++ b/app/views/agents/sessions/new.html.slim
@@ -10,7 +10,7 @@ p.text-muted.mb-2 Entrez votre email et votre mot de passe.
 = form_for resource, as: resource_name, url: session_path(resource_name), builder: Dsfr::FormBuilder do |f|
   = render "devise/shared/error_messages", resource: resource
   .form-group
-    = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr"
+    = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", autocomplete: "email"
     = render "common/form/current_password_input", f:, forgotten_password_link: true
 
   .form-group.mb-0.rdv-text-align-center

--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -2,7 +2,7 @@
   .text-center.w-75.m-auto
     h4.text-dark-50.text-center.mt-0.font-weight-bold Mot de passe oublié ?
     p.text-muted.mb-4 Entrez votre email pour recevoir un lien de réinitialisation de mot de passe
-  = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true, autofocus: true
+  = f.dsfr_email_field :email, label: "Adresse email", hint: "Format attendu : nom@domaine.fr", required: true, autofocus: true, autocomplete: "email"
   .text-center
     = f.submit "Envoyer", class: "fr-btn"
 


### PR DESCRIPTION
# Contexte

Dans le cadre de la mise en accessibilité on ajoute les attributs d’autocomplete manquant dans les formulaires liés à la connexion des agents.

![image](https://github.com/user-attachments/assets/47abf171-b645-48cb-9c74-49b1d2a38270)


