### PR TITLE
a11y: ajout des liens d’évitements côté agent

### DIFF
--- a/app/views/layouts/_agent_footer.html.slim
+++ b/app/views/layouts/_agent_footer.html.slim
@@ -1,4 +1,4 @@
-footer.footer
+footer.footer#footer
   .container-fluid
     .row
       .col-md-12

--- a/app/views/layouts/application_agent.html.slim
+++ b/app/views/layouts/application_agent.html.slim
@@ -4,13 +4,16 @@ html lang="fr"
     = yield :html_head_prepend
     = render "common/head_agent"
   body
+    - links = [dsfr_link_to("Contenu", "#main"), link_to("Pied de page", "#footer")]
+    = dsfr_skiplink label: "Accès rapide", links: links, html_attributes: { "data-turbolinks": "false" }
+
     = render "layouts/agent_header"
     / doit être dans <body> et pas dans <head>
     = render "layouts/headway_widget"
 
     .content-and-left-menu-wrapper
       = render "layouts/left_menu"
-      main.content-page[style="flex-grow: 1;"]
+      main#main.content-page[style="flex-grow: 1;" role="main"]
         .content
           = content_for :fil_ariane
           .fr-mx-2w= render "layouts/flash"

--- a/app/views/layouts/application_base.html.slim
+++ b/app/views/layouts/application_base.html.slim
@@ -13,11 +13,11 @@ html lang="fr"
     = content_for(:additional_scripts)
 
   body
-    = render "layouts/rdv_solidarites_instance_name"
-    = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
-
     - links = [dsfr_link_to("Contenu", "#content"), link_to("Pied de page", "#footer")]
     = dsfr_skiplink label: "Accès rapide", links: links, html_attributes: { "data-turbolinks": "false" }
+
+    = render "layouts/rdv_solidarites_instance_name"
+    = render "layouts/degraded_service", message: ENV["DEGRADED_SERVICE_MESSAGE_USERS"]
 
     = dsfr_header logo_text: "République<br>Française".html_safe, html_attributes: {id: "header"} do |header|
       ruby:


### PR DESCRIPTION
# Contexte

Dans le cadre de la conformité RGAA, nous ajoutons les liens d’évitements côté agent.

Je n’ai volontairement pas ajouté de lien d’évitement sur le layout qui sert à l’authentification, car je pense que ça fait parti des cas particuliers au vu de la taille de la page.
