### PR TITLE
Ajustement de l'affichage des RDVs de 10 minute

### DIFF
--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -17,11 +17,13 @@ const defaultFullCalendarConfig = () => ({
   eventClassNames: eventClassNames,
   eventMouseLeave: (info) => $(info.el).tooltip('hide'), // extra security
 
-  // Avec la valeur par défaut (15), les RDVs de 15 minutes sont affichés côte-à-côte, car :
+  // Avec la valeur par défaut (15), les RDVs de 10 minutes sont affichés côte-à-côte, car :
   //   1. FullCalendar estime que c'est plus lisible de "gonfler" un peu l'affichage d'un événement très court (augmenter sa hauteur).
   //   2. FullCalendar affiche côte-à-côte des événements qui se chevauchent.
-  //   3. Les événements de 15 minutes se chevauchent une fois gonflés.
-  // Nous disons donc ici à FullCalendar de ne pas gonfler les événements courts.
+  //   3. Les événements de 10 minutes se chevauchent une fois gonflés.
+  // Nous disons donc ici à FullCalendar de ne pas gonfler les événements courts, afin qu'ils
+  // soient affichés les uns en dessous des autres, pour une meilleure lisibilité.
+  // Nous gardons malgré tout une hauteur minimale de 8px car c'est la limite à laquelle on ne voit même plus le texte.
   eventMinHeight: 8,
 
   // This is a hack to make sure that the events will be shown at the proper time in the calendar.

--- a/app/javascript/components/calendar/utils.js
+++ b/app/javascript/components/calendar/utils.js
@@ -22,7 +22,7 @@ const defaultFullCalendarConfig = () => ({
   //   2. FullCalendar affiche côte-à-côte des événements qui se chevauchent.
   //   3. Les événements de 15 minutes se chevauchent une fois gonflés.
   // Nous disons donc ici à FullCalendar de ne pas gonfler les événements courts.
-  eventMinHeight: 9,
+  eventMinHeight: 8,
 
   // This is a hack to make sure that the events will be shown at the proper time in the calendar.
   // If this is removed, there is a bug that causes the events in the calendar to be show at the wrong


### PR DESCRIPTION
Cet ajustement est le même que celui effectué dans #5322 : on dit à FullCalendar de ne pas gonfler les événements courts, pour éviter qu'ils s'affichent en quinconce, ce que les agents trouvent illisible. 

Pour résumer, avant la MAJ en version 5, FullCalendar affichait les événements aussi courts qu'ils étaient : 

![image](https://github.com/user-attachments/assets/a3d40243-2c49-4fec-ad1a-3fb23cc3d570)
 
Mais dans la v5 la librairie fait le choix d'augmenter la taille des événements courts afin qu'ils restent cliquables et lisibles. Cela a pour effet de les afficher en quinconce : 

![image](https://github.com/user-attachments/assets/3252ccfd-aeb4-4fee-a3a5-c8d7dd1d5f1b) 

Avec l'ajustement de cette PR, les RDVs de 10 minute ne sont pas gonflés et donc pas affichés en quinconce, mais bien à la ligne : 

![image](https://github.com/user-attachments/assets/0c284212-663d-4d9a-a8e9-8ba05373a818)

Je ne pense pas qu'on nous demande d'aller encore plus loin, c'est à dire de nous demander d'afficher les RDVs de 5 minutes à la suite, pour deux raisons : 
- les motifs de moins de 5 minutes sont rarissimes ([cf metabase](https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyLCJ0eXBlIjoicXVlcnkiLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjQ3OSwiYnJlYWtvdXQiOltbImZpZWxkIiw1NjA4LHsiYmFzZS10eXBlIjoidHlwZS9JbnRlZ2VyIn1dXSwiYWdncmVnYXRpb24iOltbImNvdW50Il1dfX0sImRpc3BsYXkiOiJ0YWJsZSIsInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUucGl2b3QiOmZhbHNlfSwib3JpZ2luYWxfY2FyZF9pZCI6bnVsbCwidHlwZSI6InF1ZXN0aW9uIn0=))
- un RDV de 5 minute serait tellement plat qu'il serait difficile à cliquer et illisible, c'est donc bien qu'il soit gonflé !

# À faire plus tard

Ajouter des options de calendrier pour ajuster la hauteur d'affichage et l'échelle, et donc avoir un calendrier plus allongé en hauteur, qui prend tout l'écran et n'affiche que le 8h-17h nécessaire : 

![image](https://github.com/user-attachments/assets/e419316c-f2cf-4e24-9c20-02dc8eb778af)
