### PR TITLE
Passage du bandeau de service dégradé au DSFR

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
       actionview (>= 6.1, < 9.0)
       activemodel (>= 6.1, < 9.0)
       activesupport (>= 6.1, < 9.0)
-    dsfr-view-components (3.0.1)
+    dsfr-view-components (3.0.2)
       dsfr-assets (~> 1.13)
       html-attributes-utils (~> 1)
       view_component (~> 3)
@@ -729,7 +729,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     version_gem (1.1.3)
-    view_component (3.23.1)
+    view_component (3.23.2)
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1)
       method_source (~> 1.0)

--- a/app/javascript/stylesheets/application_agent.scss
+++ b/app/javascript/stylesheets/application_agent.scss
@@ -125,3 +125,14 @@ li.nav-item {
 .fr-table .fr-btns-group .fr-btn {
   margin-bottom: 0;
 }
+
+// << A SUPPRIMER À LA SUPPRESSION DE BOOTSTRAP REBOOT
+// Suppression d’une marge introduite par Bootstrap Reboot
+.fr-notice p {
+  margin-bottom: 0;
+}
+
+.fr-alert p {
+  margin: var(--text-spacing);
+}
+// >> A SUPPRIMER À LA SUPPRESSION DE BOOTSTRAP REBOOT

--- a/app/views/layouts/_degraded_service.html.slim
+++ b/app/views/layouts/_degraded_service.html.slim
@@ -1,6 +1,2 @@
 - if message.present?
-  .row
-    .col-md-12
-      .d-print-none.alert.fade.show.main-alert.alert-warning.m-0.rdv-text-align-center
-        span> ⚠️
-        = message
+  = dsfr_notice title: "Information", description: message, type: "warning"


### PR DESCRIPTION
# Contexte

Dans le cadre du passage de l’interface au DSFR et de notre volonté de supprimer les assets Bootstrap et Font Awesome, nous utilisons le bandeau de notice pour les alertes de service dégradé.

# Solution

- On met à jour `dsfr_view_components` pour corriger une typo dans la Gem : https://github.com/betagouv/dsfr-view-components/pull/236
- On corrige un petit problème de marge qui apparaît à cause de de Bootstrap Reboot
- On fait le même correctif pour les alertes DSFR

## Captures d’écran

Avant | Après
:- | -:
![image](https://github.com/user-attachments/assets/d47107ef-96d0-4436-9279-8e759089aeca) | ![image](https://github.com/user-attachments/assets/c8d41478-e3e8-42fe-8385-cb8d979f2707)
![image](https://github.com/user-attachments/assets/6e1a7dd2-c756-4cf3-a7f4-262e91713a2b) | ![image](https://github.com/user-attachments/assets/88c010bf-53ca-4619-8ed4-cb5250ad9489)