### PR TITLE
Suppression de coverband

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,6 @@ gem "sentry-rails"
 gem "skylight"
 # Block & throttle abusive requests
 gem "rack-attack"
-# Ruby production code coverage collection and reporting (line of code usage)
-gem "coverband"
 # Dépendance interne pour anonymiser les records AR
 gem "anonymizer", path: "lib/anonymizer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,8 +202,6 @@ GEM
     common_french_passwords (0.0.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
-    coverband (6.1.4)
-      redis (>= 3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -784,7 +782,6 @@ DEPENDENCIES
   climate_control
   common_french_passwords
   connection_pool
-  coverband
   crisp-api (~> 1.1)
   csv
   database_cleaner

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,9 +1,0 @@
-Coverband.configure do |config|
-  # L'interface web de Coverband nécessite un eval() en JS, ce que notre content_security_policy.rb interdit.
-  # En activant cette config, on fait en sorte d'utiliser un CSP spécifique pour l'interface de Coverband
-  # Voir : https://github.com/danmayer/coverband/pull/447
-  config.csp_policy = true
-
-  # default false. Experimental support for routes usage tracking.
-  config.track_routes = true
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,6 @@ Rails.application.routes.draw do
 
     authenticate :super_admin do
       mount GoodJob::Engine => "good_job"
-      mount Coverband::Reporters::Web.new, at: "/coverage"
     end
   end
   get "super_admin", to: redirect("super_admins", status: 301)


### PR DESCRIPTION
On a évoqué le sujet en point tech, coverband ne nous a pas permis d’apprendre beaucoup de choses.

On propose de le retirer pour éviter des problèmes futurs et une surface d’attaque potentielle.
