### PR TITLE
Ajout du support de SMS Factor

### DIFF
--- a/app/jobs/cron_job/notify_sms_factor_low_credits.rb
+++ b/app/jobs/cron_job/notify_sms_factor_low_credits.rb
@@ -1,19 +1,14 @@
 class CronJob::NotifySmsFactorLowCredits < CronJob
   def perform
     Redis.with_connection do |redis|
-      limit = ENV.fetch("SMS_FACTOR_LIMIT_ALERT", nil)
-
-      unless limit
-        Sentry.capture_message("Merci de définir la variable d’environnement SMS_FACTOR_LIMIT_ALERT")
-        break
-      end
+      limit = 300_000 # 10% des crédits attribués lors du dernier bon de commande
 
       remaining_credits = redis.get("SMS_FACTOR_REMAINING_CREDITS")
 
       break unless remaining_credits
 
       if remaining_credits.to_i < limit.to_i
-        Sentry.capture_message("Les nombres de crédits SMS Factor est inférieur à #{limit} (actuellement #{remaining_credits}).")
+        Sentry.capture_message("Le crédit SMS Factor est inférieur à #{limit} (actuellement #{remaining_credits}).")
       end
     end
   end

--- a/app/jobs/cron_job/notify_sms_factor_low_credits.rb
+++ b/app/jobs/cron_job/notify_sms_factor_low_credits.rb
@@ -1,0 +1,20 @@
+class CronJob::NotifySmsFactorLowCredits < CronJob
+  def perform
+    Redis.with_connection do |redis|
+      limit = ENV.fetch("SMS_FACTOR_LIMIT_ALERT", nil)
+
+      unless limit
+        Sentry.capture_message("Merci de définir la variable d’environnement SMS_FACTOR_LIMIT_ALERT")
+        break
+      end
+
+      remaining_credits = redis.get("SMS_FACTOR_REMAINING_CREDITS")
+
+      break unless remaining_credits
+
+      if remaining_credits.to_i < limit.to_i
+        Sentry.capture_message("Les nombres de crédits SMS Factor est inférieur à #{limit} (actuellement #{remaining_credits}).")
+      end
+    end
+  end
+end

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -93,6 +93,9 @@ class SmsSender < BaseService
       sms_factor_status = parsed_response["status"]
       if sms_factor_status == 1
         save_receipt(result: :delivered, sms_count: parsed_response["cost"])
+        Redis.with_connection do |redis|
+          redis.set("SMS_FACTOR_REMAINING_CREDITS", parsed_response["credits"])
+        end
       else
         error_message = parsed_response["message"] || "Unknown SMS Factor error"
         handle_failure(error_message: "SMS Factor error: #{error_message}")

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -24,6 +24,8 @@ class SmsSender < BaseService
 
   def perform
     case @provider.to_sym
+    when :sms_factor
+      send_with_smsfactor
     when :netsize
       send_with_netsize
     when :clever_technologies
@@ -64,6 +66,39 @@ class SmsSender < BaseService
       raise SmsSenderFailure, error_message
     else
       Sentry.capture_message(error_message)
+    end
+  end
+
+  # SMS Factor
+  # https://dev.smsfactor.com/fr/api/sms/envoi/message-unitaire
+  #
+  # Suite à un nouveau bon de commande émis par l’ANCT en mai 2025, SMS Factor devient le fournisseur par défaut
+  def send_with_smsfactor
+    request = Faraday.get(
+      "https://api.smsfactor.com/send",
+      {
+        to: @phone_number,
+        text: @content,
+        pushtype: "alert",
+        sender: @sender_name,
+      },
+      {
+        authorization: "Bearer #{@api_key}",
+        accept: "application/json",
+      }
+    )
+
+    if request.success?
+      parsed_response = JSON.parse(request.body)
+      sms_factor_status = parsed_response["status"]
+      if sms_factor_status == 1
+        save_receipt(result: :delivered, sms_count: parsed_response["cost"])
+      else
+        error_message = parsed_response["message"] || "Unknown SMS Factor error"
+        handle_failure(error_message: "SMS Factor error: #{error_message}")
+      end
+    else
+      handle_failure(error_message: "SMS Factor error: #{request.status} - #{request.body}")
     end
   end
 

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -25,7 +25,7 @@ class SmsSender < BaseService
   def perform
     case @provider.to_sym
     when :sms_factor
-      send_with_smsfactor
+      send_with_sms_factor
     when :netsize
       send_with_netsize
     when :clever_technologies
@@ -73,7 +73,7 @@ class SmsSender < BaseService
   # https://dev.smsfactor.com/fr/api/sms/envoi/message-unitaire
   #
   # Suite à un nouveau bon de commande émis par l’ANCT en mai 2025, SMS Factor devient le fournisseur par défaut
-  def send_with_smsfactor
+  def send_with_sms_factor
     request = Faraday.get(
       "https://api.smsfactor.com/send",
       {

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -80,5 +80,9 @@ Rails.application.configure do
       cron: "every minute",
       class: "CronJob::IGNHealthCheckJob",
     },
+    notify_sms_factor_low_credits: {
+      cron: "every day at 08:00 Europe/Paris",
+      class: "CronJob::NotifySmsFactorLowCredits",
+    },
   }
 end

--- a/spec/jobs/cron_job/notify_sms_factor_low_credits_spec.rb
+++ b/spec/jobs/cron_job/notify_sms_factor_low_credits_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe CronJob::NotifySmsFactorLowCredits, type: :job do
+  context "quand la variable SMS_FACTOR_LIMIT_ALERT n’est pas définie" do
+    stub_env_with(SMS_FACTOR_LIMIT_ALERT: nil)
+
+    it "envoie un Sentry pour demander à définir cette variable" do
+      expect(Sentry).to receive(:capture_message).with("Merci de définir la variable d’environnement SMS_FACTOR_LIMIT_ALERT")
+      described_class.new.perform
+    end
+  end
+
+  context "quand la variable SMS_FACTOR_LIMIT_ALERT est définie" do
+    stub_env_with(SMS_FACTOR_LIMIT_ALERT: "100")
+
+    context "quand la clef SMS_FACTOR_REMAINING_CREDITS n’existe pas" do
+      it "ne fait rien" do
+        expect(Sentry).not_to receive(:capture_message)
+        described_class.new.perform
+      end
+    end
+
+    context "quand la clef SMS_FACTOR_REMAINING_CREDITS est défini avec une valeur supérieure à SMS_FACTOR_LIMIT_ALERT" do
+      before do
+        Redis.with_connection do |redis|
+          redis.set("SMS_FACTOR_REMAINING_CREDITS", "1000")
+        end
+      end
+
+      it "ne fait rien" do
+        expect(Sentry).not_to receive(:capture_message)
+        described_class.new.perform
+      end
+    end
+
+    context "quand la clef SMS_FACTOR_REMAINING_CREDITS est défini avec une valeur inférieure à SMS_FACTOR_LIMIT_ALERT" do
+      before do
+        Redis.with_connection do |redis|
+          redis.set("SMS_FACTOR_REMAINING_CREDITS", "10")
+        end
+      end
+
+      it "ne fait rien" do
+        expect(Sentry).to receive(:capture_message).with("Les nombres de crédits SMS Factor est inférieur à 100 (actuellement 10).")
+        described_class.new.perform
+      end
+    end
+  end
+end

--- a/spec/jobs/cron_job/notify_sms_factor_low_credits_spec.rb
+++ b/spec/jobs/cron_job/notify_sms_factor_low_credits_spec.rb
@@ -1,47 +1,34 @@
 RSpec.describe CronJob::NotifySmsFactorLowCredits, type: :job do
-  context "quand la variable SMS_FACTOR_LIMIT_ALERT n’est pas définie" do
-    stub_env_with(SMS_FACTOR_LIMIT_ALERT: nil)
-
-    it "envoie un Sentry pour demander à définir cette variable" do
-      expect(Sentry).to receive(:capture_message).with("Merci de définir la variable d’environnement SMS_FACTOR_LIMIT_ALERT")
+  context "quand la clef SMS_FACTOR_REMAINING_CREDITS n’existe pas" do
+    it "ne fait rien" do
+      expect(Sentry).not_to receive(:capture_message)
       described_class.new.perform
     end
   end
 
-  context "quand la variable SMS_FACTOR_LIMIT_ALERT est définie" do
-    stub_env_with(SMS_FACTOR_LIMIT_ALERT: "100")
-
-    context "quand la clef SMS_FACTOR_REMAINING_CREDITS n’existe pas" do
-      it "ne fait rien" do
-        expect(Sentry).not_to receive(:capture_message)
-        described_class.new.perform
+  context "quand la clef SMS_FACTOR_REMAINING_CREDITS est définie avec une valeur supérieure à la limite" do
+    before do
+      Redis.with_connection do |redis|
+        redis.set("SMS_FACTOR_REMAINING_CREDITS", "400000")
       end
     end
 
-    context "quand la clef SMS_FACTOR_REMAINING_CREDITS est défini avec une valeur supérieure à SMS_FACTOR_LIMIT_ALERT" do
-      before do
-        Redis.with_connection do |redis|
-          redis.set("SMS_FACTOR_REMAINING_CREDITS", "1000")
-        end
-      end
+    it "ne fait rien" do
+      expect(Sentry).not_to receive(:capture_message)
+      described_class.new.perform
+    end
+  end
 
-      it "ne fait rien" do
-        expect(Sentry).not_to receive(:capture_message)
-        described_class.new.perform
+  context "quand la clef SMS_FACTOR_REMAINING_CREDITS est défini avec une valeur inférieure à la limite" do
+    before do
+      Redis.with_connection do |redis|
+        redis.set("SMS_FACTOR_REMAINING_CREDITS", "10")
       end
     end
 
-    context "quand la clef SMS_FACTOR_REMAINING_CREDITS est défini avec une valeur inférieure à SMS_FACTOR_LIMIT_ALERT" do
-      before do
-        Redis.with_connection do |redis|
-          redis.set("SMS_FACTOR_REMAINING_CREDITS", "10")
-        end
-      end
-
-      it "ne fait rien" do
-        expect(Sentry).to receive(:capture_message).with("Les nombres de crédits SMS Factor est inférieur à 100 (actuellement 10).")
-        described_class.new.perform
-      end
+    it "envoie un message d’alerte Sentry" do
+      expect(Sentry).to receive(:capture_message).with("Le crédit SMS Factor est inférieur à 300000 (actuellement 10).")
+      described_class.new.perform
     end
   end
 end

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SmsSender, type: :service do
 
     context "with smsfactor" do
       before do
-        stub_smsfactor_ok
+        stub_sms_factor_ok
         described_class.perform_with("RdvSoli", "0612345678", "content", "sms_factor", "key", receipt_params)
       end
 

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -68,6 +68,12 @@ RSpec.describe SmsSender, type: :service do
         expect(receipt).not_to be_nil
         expect(receipt).to have_attributes(event: "rdv_created", rdv: rdv, user: user, content: "content", sms_provider: "sms_factor")
       end
+
+      it "save remaining credits" do
+        Redis.with_connection do |redis|
+          expect(redis.get("SMS_FACTOR_REMAINING_CREDITS")).to eq("42")
+        end
+      end
     end
   end
 end

--- a/spec/services/sms_sender_spec.rb
+++ b/spec/services/sms_sender_spec.rb
@@ -44,21 +44,30 @@ RSpec.describe SmsSender, type: :service do
   end
 
   describe "receipt creation" do
-    before do
-      stub_netsize_ok
-      described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", receipt_params)
+    context "with netsize provider" do
+      before do
+        stub_netsize_ok
+        described_class.perform_with("RdvSoli", "0612345678", "content", "netsize", "key", receipt_params)
+      end
+
+      it do
+        receipt = Receipt.last
+        expect(receipt).not_to be_nil
+        expect(receipt).to have_attributes(event: "rdv_created", rdv: rdv, user: user, content: "content", sms_provider: "netsize")
+      end
     end
 
-    it do
-      receipt = Receipt.last
-      expect(receipt).not_to be_nil
-      expect(receipt).to have_attributes(
-        event: "rdv_created",
-        rdv: rdv,
-        user: user,
-        content: "content",
-        sms_provider: "netsize"
-      )
+    context "with smsfactor" do
+      before do
+        stub_smsfactor_ok
+        described_class.perform_with("RdvSoli", "0612345678", "content", "sms_factor", "key", receipt_params)
+      end
+
+      it do
+        receipt = Receipt.last
+        expect(receipt).not_to be_nil
+        expect(receipt).to have_attributes(event: "rdv_created", rdv: rdv, user: user, content: "content", sms_provider: "sms_factor")
+      end
     end
   end
 end

--- a/spec/support/sms_stubbing.rb
+++ b/spec/support/sms_stubbing.rb
@@ -12,6 +12,7 @@ def stub_smsfactor_ok
   stubbed_body = {
     status: 1,
     cost: 1,
+    credits: 42,
   }.to_json
 
   stub_request(:get, "https://api.smsfactor.com/send?pushtype=alert&sender=RdvSoli&text=content&to=0612345678")

--- a/spec/support/sms_stubbing.rb
+++ b/spec/support/sms_stubbing.rb
@@ -8,6 +8,16 @@ def stub_netsize_ok
     .to_return(status: 200, body: stubbed_body, headers: {})
 end
 
+def stub_smsfactor_ok
+  stubbed_body = {
+    status: 1,
+    cost: 1,
+  }.to_json
+
+  stub_request(:get, "https://api.smsfactor.com/send?pushtype=alert&sender=RdvSoli&text=content&to=0612345678")
+    .to_return(status: 200, body: stubbed_body, headers: {})
+end
+
 def expect_sms_enqueued(args)
   expect(SmsJob).to have_been_enqueued.with(hash_including(args))
 end

--- a/spec/support/sms_stubbing.rb
+++ b/spec/support/sms_stubbing.rb
@@ -8,7 +8,7 @@ def stub_netsize_ok
     .to_return(status: 200, body: stubbed_body, headers: {})
 end
 
-def stub_smsfactor_ok
+def stub_sms_factor_ok
   stubbed_body = {
     status: 1,
     cost: 1,


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5379.osc-secnum-fr1.scalingo.io/) 

Closes #5348 

# Contexte

Dans le cadre d’un nouveau marché, nous devons ajouter un nouveau provider de SMS.

# Solution

- On ajoute la fonction qui permet l’envoi de SMS avec ce fournisseur
- On utilise Faraday dans notre volonté d’uniformiser les communications avec les API externes
- Testé en local avec les crédits mis à disposition gratuitement 

# Déploiement

Pour le déploiement, je propose l’activation, je propose de faire une montée en charge progressive :
- On commence par la démo
- Puis un territoire
- Puis une instance

De cette manière, on peut vérifier que tout va bien sans impacter l’ensemble des usagers en cas de problème.

# Reste à faire

- [x] Attendre l’émission du bon de commande
- [ ] Attendre la mise à disposition des crédits sur un compte
- [x] Créer un système qui permet de nous alerter quand le nombre de crédit est bas (ouverture d’une Sentry)