### PR TITLE
Affichage du lien vers l'appli externe sur les détails du rdv

### DIFF
--- a/app/controllers/api/v1/rdv_plans_controller.rb
+++ b/app/controllers/api/v1/rdv_plans_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::RdvPlansController < Api::V1::AgentAuthBaseController
         planning_agent: current_agent,
         user: user,
         oauth_application: doorkeeper_token&.application,
-        return_url: params[:return_url]
+        return_url: params[:return_url],
+        dossier_url: params[:dossier_url]
       )
     end
     render json: RdvPlanBlueprint.render(rdv_plan, root: "rdv_plan"), status: :created

--- a/app/javascript/stylesheets/components/_utilities.scss
+++ b/app/javascript/stylesheets/components/_utilities.scss
@@ -111,6 +111,14 @@ a[disabled] {
   flex-direction: column;
 }
 
+.justify-content-space-between {
+  justify-content: space-between;
+}
+
+.align-items-start {
+  align-items: flex-start;
+}
+
 .rdv-flex-direction-row-md {
   @include media-breakpoint-up(md) {
     flex-direction: row;

--- a/app/views/admin/participations/_user_card.html.slim
+++ b/app/views/admin/participations/_user_card.html.slim
@@ -1,19 +1,18 @@
-.col-12
-  .card.light-gray-card
-    .card-body.p-2
-      .mb-1
-        = render "admin/users/identity", user: participation.user
-      - annotation = participation.user.annotation_for(current_territory)
-      - if current_territory.enable_notes_field? && annotation.present?
-        .participation_notes
-          i.fa.fa-info-circle.text-primary-blue.mr-2
-          = simple_format(annotation, {}, wrapper_tag: :span)
+.card.light-gray-card
+  .card-body.p-2
+    .mb-1
+      = render "admin/users/identity", user: participation.user
+    - annotation = participation.user.annotation_for(current_territory)
+    - if current_territory.enable_notes_field? && annotation.present?
+      .participation_notes
+        i.fa.fa-info-circle.text-primary-blue.mr-2
+        = simple_format(annotation, {}, wrapper_tag: :span)
+    div
+      = render "admin/participations/notifications_email", participation: participation
+    div
+      = render "admin/participations/notifications_sms", participation: participation
+    div
+    = render "admin/participations/notifications_lifecycle", participation: participation
+    - if participation.rdv.collectif?
       div
-        = render "admin/participations/notifications_email", participation: participation
-      div
-        = render "admin/participations/notifications_sms", participation: participation
-      div
-      = render "admin/participations/notifications_lifecycle", participation: participation
-      - if participation.rdv.collectif?
-        div
-        = render "admin/participations/participation_status_dropdown", participation: participation, agent: agent
+      = render "admin/participations/participation_status_dropdown", participation: participation, agent: agent

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -29,8 +29,8 @@
         = render "admin/rdvs/rdv_details", rdv: rdv
 
       ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right
-        - if @rdv.rdv_plan&.dossier_url
-          = link_to("Voir sur #{@rdv.rdv_plan.oauth_application&.name}", @rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-btn--sm")
+        - if rdv.rdv_plan&.dossier_url
+          = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-btn--sm")
         = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "fr-btn fr-btn--secondary fr-btn--sm "
         - if rdv.individuel?
           = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "fr-btn fr-btn--secondary fr-btn--sm"

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -16,7 +16,7 @@
       - else
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
   hr.my-0.mx-3
-  .card-body.py-3.row
+  .card-body.row
     .col-sm-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.justify-content-space-between.align-items-start
       div
         .d-flex.justify-content-between.flex-wrap.mb-1
@@ -28,14 +28,14 @@
               = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
         = render "admin/rdvs/rdv_details", rdv: rdv
 
-      ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right
+      ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right.fr-mb-0.fr-mt-2w
         - if rdv.rdv_plan&.dossier_url
           = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-btn--sm")
         = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "fr-btn fr-btn--secondary fr-btn--sm "
         - if rdv.individuel?
           = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "fr-btn fr-btn--secondary fr-btn--sm"
         - else
-          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "fr-btn fr-btn--secondary fr-btn--sm"
+          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "fr-btn fr-btn--secondary fr-btn--sm fr-mb-0"
 
   .mx-3
   - if rdv.users.any?

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -17,7 +17,7 @@
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
   hr.my-0.mx-3
   .card-body.py-3.row
-    .col-sm-12.d-flex.justify-content-space-between.align-items-start
+    .col-sm-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.justify-content-space-between.align-items-start
       div
         .d-flex.justify-content-between.flex-wrap.mb-1
           p.card-text

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -15,10 +15,12 @@
         = render "admin/rdvs/collective_rdv_status_dropdown", rdv: rdv
       - else
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
-  hr.my-0.mx-3
+  hr.fr-my-0.fr-pb-0.fr-mx-3
   .card-body.row
     .col-sm-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.justify-content-space-between.align-items-start
       div
+        - if rdv.rdv_plan&.dossier_url
+          = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mb-2w")
         .d-flex.justify-content-between.flex-wrap.mb-1
           p.card-text
             i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
@@ -28,9 +30,7 @@
               = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
         = render "admin/rdvs/rdv_details", rdv: rdv
 
-      ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right.fr-mb-0.fr-mt-2w
-        - if rdv.rdv_plan&.dossier_url
-          = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-btn--sm")
+      ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right.fr-mb-0
         = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "fr-btn fr-btn--secondary fr-btn--sm "
         - if rdv.individuel?
           = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "fr-btn fr-btn--secondary fr-btn--sm"

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -17,25 +17,25 @@
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
   hr.my-0.mx-3
   .card-body.py-3.row
-    .col-md-8.col-sm-12
-      .d-flex.justify-content-between.flex-wrap.mb-1
-        p.card-text
-          i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
-          = rdv_starts_at_and_duration(rdv, :time_only)
-          - if rdv.agents.first
-            |&nbsp;
-            = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
-      = render "admin/rdvs/rdv_details", rdv: rdv
+    .col-sm-12.d-flex.justify-content-space-between.align-items-start
+      div
+        .d-flex.justify-content-between.flex-wrap.mb-1
+          p.card-text
+            i.fa.fa-fw.fa-calendar.mr-1.text-primary-blue
+            = rdv_starts_at_and_duration(rdv, :time_only)
+            - if rdv.agents.first
+              |&nbsp;
+              = link_to "voir dans l'agenda", admin_organisation_agent_agenda_path(current_organisation, rdv.agents.first, selected_event_id: rdv.id, date: rdv.starts_at.to_date)
+        = render "admin/rdvs/rdv_details", rdv: rdv
 
-    .col-md-4.col-sm-12
-      div.d-flex.justify-content-end.mt-1
-        - if rdv.rdv_plan&.dossier_url
-          = link_to("Voir le dossier", rdv.rdv_plan&.dossier_url, class: "fr-btn fr-btn--tertiary mr-2")
-        = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "btn btn-outline-primary btn-sm mr-2"
+      ul.fr-btns-group.fr-btns-group--inline-sm.fr-btns-group--right
+        - if @rdv.rdv_plan&.dossier_url
+          = link_to("Voir sur #{@rdv.rdv_plan.oauth_application&.name}", @rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--secondary fr-btn--sm")
+        = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "fr-btn fr-btn--secondary fr-btn--sm "
         - if rdv.individuel?
-          = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary btn-sm"
+          = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "fr-btn fr-btn--secondary fr-btn--sm"
         - else
-          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "btn btn-outline-primary btn-sm"
+          = link_to t("admin.rdvs.show.duplicate"), new_admin_organisation_rdvs_collectif_path(current_organisation, motif_id: rdv.motif_id, duplicated_rdv_id: rdv.id), class: "fr-btn fr-btn--secondary fr-btn--sm"
 
   .mx-3
   - if rdv.users.any?

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -29,6 +29,8 @@
 
     .col-md-4.col-sm-12
       div.d-flex.justify-content-end.mt-1
+        - if rdv.rdv_plan&.dossier_url
+          = link_to("Voir le dossier", rdv.rdv_plan&.dossier_url, class: "fr-btn fr-btn--tertiary mr-2")
         = link_to t("admin.rdvs.show.update"), edit_admin_organisation_rdv_path(rdv.organisation, rdv, agent_id: local_assigns[:agent]&.id), class: "btn btn-outline-primary btn-sm mr-2"
         - if rdv.individuel?
           = link_to t("admin.rdvs.show.duplicate"), admin_organisation_creneaux_search_path(current_organisation, service_id: rdv.motif.service_id, motif_id: rdv.motif_id, from_date: rdv.starts_at + 1.day, user_ids: rdv.user_ids, context: rdv.context, lieu_ids: [rdv.lieu_id], commit: "commit"), class: "btn btn-outline-primary btn-sm"

--- a/app/views/admin/rdvs/_rdv.html.slim
+++ b/app/views/admin/rdvs/_rdv.html.slim
@@ -16,9 +16,9 @@
       - else
         = render "admin/rdvs/individual_rdv_status_dropdown", rdv: rdv
   hr.fr-my-0.fr-pb-0.fr-mx-3
-  .card-body.row
+  .card-body.row.fr-pb-0
     .col-sm-12.d-flex.flex-direction-column.rdv-flex-direction-row-md.justify-content-space-between.align-items-start
-      div
+      div.fr-pb-2w
         - if rdv.rdv_plan&.dossier_url
           = link_to("Voir sur #{rdv.rdv_plan.oauth_application&.name}", rdv.rdv_plan&.dossier_url, target: :_blank, class: "fr-btn fr-btn--tertiary fr-btn--sm fr-mb-2w")
         .d-flex.justify-content-between.flex-wrap.mb-1

--- a/app/views/admin/rdvs/index.html.slim
+++ b/app/views/admin/rdvs/index.html.slim
@@ -58,18 +58,18 @@
         input.custom-control-input[type="checkbox" id="show-users-details-switch" data-toggle="collapse" data-target=".users-details"]
         label.custom-control-label for="show-users-details-switch" Afficher plus de détails usagers
 
-    .row.justify-content-center.pb-3
-      .col-md-12.col-lg-8
+    .fr-grid-row.fr-pb-3w
+      .fr-col-12
         .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
         = render(partial: "rdv", collection: @rdvs_in_page, locals: { agent: nil })
         .d-flex.justify-content-center= paginate @rdvs, theme: "twitter-bootstrap-4"
   - else
-    .row.justify-content-center.pb-3
-      .col-md-12.col-lg-8
+    .fr-grid-row.fr-py-3w
+      .fr-col-12
         .card
           .card-body
-            .row.justify-content-md-center
-              .col-md-6.rdv-text-align-center.my-5
+            .fr-grid-row.justify-content-center
+              .fr-col-6.rdv-text-align-center.fr-mt-2w.fr-mb-5w
                 p.mb-2.lead
                   | Aucun RDV
                 span.fa-stack.fa-4x

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -15,15 +15,16 @@
 - content_for :title do
   = "RDV #{rdv_title_for_agent(@rdv)}"
 
-.row.justify-content-md-center
-  .col-md-11
+
+.row
+  .col-12
     / @agent is only used for links in breadcrumb and redirecting if update
     = render partial: "rdv", collection: [@rdv], locals: { agent: @agent }
 
-.row.justify-content-center
-  .col-md-11
+.row
+  .col-12
     = render "admin/receipts/receipts", rdv: @rdv
 
-.row.justify-content-center
-  .col-md-11
+.row
+  .col-md-12
     = render "admin/versions/resource_versions_row", resource_policy: policy(@rdv, policy_class: Agent::RdvPolicy), resource: @rdv

--- a/app/views/admin/rdvs/show.html.slim
+++ b/app/views/admin/rdvs/show.html.slim
@@ -15,7 +15,6 @@
 - content_for :title do
   = "RDV #{rdv_title_for_agent(@rdv)}"
 
-
 .row
   .col-12
     / @agent is only used for links in breadcrumb and redirecting if update

--- a/db/migrate/20250530124357_add_rdv_plan_dossier_url.rb
+++ b/db/migrate/20250530124357_add_rdv_plan_dossier_url.rb
@@ -1,0 +1,5 @@
+class AddRdvPlanDossierUrl < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rdv_plans, :dossier_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_02_123003) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_30_124357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pgcrypto"
@@ -605,6 +605,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_02_123003) do
     t.datetime "updated_at", null: false
     t.enum "location_type", enum_type: "location_type"
     t.bigint "oauth_application_id"
+    t.text "dossier_url"
     t.index ["lieu_id"], name: "index_rdv_plans_on_lieu_id"
     t.index ["motif_id"], name: "index_rdv_plans_on_motif_id"
     t.index ["oauth_application_id"], name: "index_rdv_plans_on_oauth_application_id"

--- a/docs/guide_integration.md
+++ b/docs/guide_integration.md
@@ -62,7 +62,7 @@ POST /api/v1/rdv_plans
         "birth_date": "1990-12-31"
     },
     "return_url": "https://monsuivisocial.incubateur.anct.gouv.fr/callback/123", // l'agent sera redirigé vers cette url après la page de confirmation du rdv.
-    "dossier_url": "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123" // sera affiché à l'agent (mais pas à l'usager) sur la page de détail du rdv et la pièce jointe ICS de l'email de confirmation. Pas encore implémenté
+    "dossier_url": "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123" // sera affiché à l'agent (mais pas à l'usager) sur la page de détail du rdv et la pièce jointe ICS de l'email de confirmation.
 }
 ```
 

--- a/scripts/mon_suivi_social_local.rb
+++ b/scripts/mon_suivi_social_local.rb
@@ -45,6 +45,11 @@ class MonSuiviSocial < Sinatra::Base
     end
   end
 
+  get "/francis_factice" do
+    status 200
+    "Francis Factice est un usager"
+  end
+
   get "/auth/rdvservicepublic/callback" do
     session[:email] = request.env["omniauth.auth"]["info"]["agent"]["email"]
     session[:access_token] = request.env["omniauth.auth"]["credentials"]["token"]
@@ -68,6 +73,7 @@ class MonSuiviSocial < Sinatra::Base
           first_name: "Francis",
           last_name: "Factice",
         },
+        dossier_url: "http://localhost:3010/francis_factice",
       }.to_json,
       {
         "Content-Type": "application/json",

--- a/spec/requests/api/v1/rdv_plan_spec.rb
+++ b/spec/requests/api/v1/rdv_plan_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe "RDV Plan API" do
             birth_date: "1990-12-31",
           },
           return_url: "https://demo.demarches-simplifiees.fr/callback/123",
+          dossier_url: "https://demo.demarches-simplifiees.fr/dossier/456",
         }
       end
 
@@ -158,6 +159,7 @@ RSpec.describe "RDV Plan API" do
         expect(rdv_plan).to have_attributes(
           planning_agent: agent,
           return_url: "https://demo.demarches-simplifiees.fr/callback/123",
+          dossier_url: "https://demo.demarches-simplifiees.fr/dossier/456",
           oauth_application_id: application.id
         )
 

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
             phone_number: "0611223344",
             address: "21 rue des Ardennes, 75019 Paris",
           },
-          return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123",
+          return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123/callback",
+          dossier_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123",
         }
       )
 
@@ -124,6 +125,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
             status: rdv.status,
             location_type: rdv.motif.location_type
           )
+          expect(parsed_response_body.dig("rdv_plan", "dossier_url")).to eq "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123"
           expect(Time.zone.parse(parsed_response_body.dig("rdv_plan", "rdv", "starts_at"))).to be_within(1.second).of(rdv.reload.starts_at)
         end
       end

--- a/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
+++ b/spec/requests/api/v1/swagger_doc/rdv_plans_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
             phone_number: "0611223344",
             address: "21 rue des Ardennes, 75019 Paris",
           },
-          return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123/callback",
-          dossier_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123",
+          return_url: "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123",
         }
       )
 
@@ -125,7 +124,6 @@ RSpec.describe "RDV authentified API", swagger_doc: "v1/api.json" do
             status: rdv.status,
             location_type: rdv.motif.location_type
           )
-          expect(parsed_response_body.dig("rdv_plan", "dossier_url")).to eq "https://monsuivisocial.incubateur.anct.gouv.fr/beneficiaires/123"
           expect(Time.zone.parse(parsed_response_body.dig("rdv_plan", "rdv", "starts_at"))).to be_within(1.second).of(rdv.reload.starts_at)
         end
       end


### PR DESCRIPTION
Cette PR n'est pas encore prête pour une review technique, je voudrais d'abord valider le placement du bouton avec Téo.

# Contexte

Dans le cadre des intégrations, on veut permettre aux agents de retrouver facilement le dossier lié à un rendez-vous, que ça soit sur Mon Suivi Social, Démarches Simplifiées, ou la coop de la médiation numérique, ou un autre service.

Quand un rdv est créé via une intégration, l'application partenaire nous envoie une url liée au rendez-vous. L'objectif est donc d'afficher cette url aux différents endroits où elle peut être utile :
- sur la page de détails du rendez-vous
- dans la pièce jointe ics ou le calendrier outlook : on a déjà un lien "Plus d'infos sur RDV Service Public", et on ajoute en dessous un lien "Voir sur Mon Suivi Social"

## Propositions d'écrans

J'ai mis le bouton avec les boutons d'action "Modifier" et "Dupliquer" que j'ai passé au dsfr, mais j'hésitais à mettre ça plus dans le style du lien "voir dans l'agenda", mais je trouvais ça un peu trop discret

### Mobile
Avant | Après
:- | -:
<img width="379" alt="Screenshot 2025-06-02 at 12 25 54" src="https://github.com/user-attachments/assets/5d3d9001-8ddb-41db-afe4-cceb18c10dd5" /> | ![Screenshot 2025-06-02 at 12 31 55](https://github.com/user-attachments/assets/928f3d62-80f5-4823-8139-d472a49fd84b)

### Laptop

Au passage j'ai mis la carte sur 12 colonnes à la place de 11

Avant | Après
:- | -:
<img width="1440" alt="Screenshot 2025-06-02 at 12 25 26" src="https://github.com/user-attachments/assets/f135f998-100c-4739-b7ba-2484639878e2" />|<img width="1434" alt="Screenshot 2025-06-02 at 12 32 58" src="https://github.com/user-attachments/assets/dc6ca14d-576b-41d9-955c-6dd1ed58f86e" />

### Liste des rdvs

Avant | Après
:- | -:
<img width="1172" alt="Screenshot 2025-06-02 at 12 34 30" src="https://github.com/user-attachments/assets/506d5cb2-9819-4ddf-ba17-2d31a0f640d0" />|<img width="1177" alt="Screenshot 2025-06-02 at 12 34 50" src="https://github.com/user-attachments/assets/5b106d1e-b34c-4feb-8599-7dd9a1a173f0" />


# Solution


Le paramètre est déjà envoyé par certaines applis partenaires, on se met à l'enregistrer et l'afficher.

# Checklist

- [ ] Extraire dans d'autres PRs les changements indépendants, si nécessaire
- [ ] Préparer des captures de l’interface avant et après


