### PR TITLE
Rails 7.1: `use_message_serializer_for_metadata = true`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -150,7 +150,7 @@ Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_support.use_message_serializer_for_metadata = true
+Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
 # Set the maximum size for Rails log files.


### PR DESCRIPTION
# Contexte

Le commentaire de cette config, indique que le nouveau format n’est pas lisible par les anciennes versions de Rails (< 7.1). À ce jour, nous tournons 100% en 7.1, donc nous pouvons activer sereinement cette config.

