### PR TITLE
Rails 7.1 : `belongs_to_required_validates_foreign_key = false`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -174,7 +174,7 @@ Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 #++
-# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can


### PR DESCRIPTION
# Contexte

Le changement de cette configuration nous semble safe, car nous avons correctement placé nos foreign keys en base. 
ActiveRecordDoctor nous permet de nous assurer que c’est bien le cas. 

Il est possible que nous ayons des remontés d’erreurs PG dans certains cas où précédemment nous avions un échec de validation, mais ces cas semblent rares. De plus, même si ces cas se présentent, l’intégrité des données est toujours assurée.
