### PR TITLE
Rails 7.1 : `before_committed_on_all_records = true`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -187,7 +187,7 @@ Rails.application.config.precompile_filter_parameters = true
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
 #++
-# Rails.application.config.active_record.before_committed_on_all_records = true
+Rails.application.config.active_record.before_committed_on_all_records = true
 
 ###
 # Disable automatic column serialization into YAML.


### PR DESCRIPTION
# Contexte

Nous n’utilisons pas la méthode `before_committed!`. Elle ne semble pas utilisée non plus dans nos gems.
Ce changement semble donc safe.
