### PR TITLE
Fixer la version de yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "lapin",
+  "version": "1.22.22",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js"


### PR DESCRIPTION
J'espérais pouvoir faire disparaître ce warning mais je me suis cru plus malin que les autres (#5028, #4987, #3969).

```
###### WARNING:
       Installing a default version (1.22.22) of Yarn
       This version is not pinned and can change over time, causing unexpected failures.
       
       Scalingo recommends leveraging the multi-buildpack with
       `https://github.com/Scalingo/nodejs-buildpack.git` and
       `https://github.com/Scalingo/ruby-buildpack.git`
       as it offers more comprehensive Node.js support, including the ability
       to customise the Node.js version.
```