### PR TITLE
ajout d’un fichier pour vérifier le domaine avec MS Azure

### DIFF
--- a/public/.well-known/microsoft-identity-association.json
+++ b/public/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "16ce4dde-3b7c-4f61-aeb0-756eebcdc1e0"
+    }
+  ]
+}


### PR DESCRIPTION
# Contexte

On envisage de créer une deuxième app MS Azure 365 Entra FooBar Y2K pour que les usagers de chaque instance voient un branding adapté.

Les conditions pour ajouter un « publisher domain » semblent avoir changé

![image](https://github.com/user-attachments/assets/38c50a70-1c52-46d1-afe4-cc3bb586c93a)

# Solution

ajout du fichier `.well-known/microsoft-identity-association.json`