### PR TITLE
Plage d’ouvertures : passage des fils d’ariane au DSFR

### DIFF
--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -4,7 +4,6 @@ class Admin::PlageOuverturesController < AgentAuthController
   before_action :set_plage_ouverture, only: %i[show edit update destroy]
   before_action :build_plage_ouverture, only: [:create]
   before_action :set_agent
-  before_action :set_previous_page_title, only: %i[show edit]
 
   def show
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
@@ -48,7 +47,6 @@ class Admin::PlageOuverturesController < AgentAuthController
       agent: @agent,
       **defaults
     )
-    set_previous_page_title
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
   end
 
@@ -104,14 +102,6 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def set_plage_ouverture
     @plage_ouverture = PlageOuverture.find(params[:id])
-  end
-
-  def set_previous_page_title
-    @previous_page_title = if current_agent == @plage_ouverture.agent
-                             "Plages d’ouverture"
-                           else
-                             "Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}"
-                           end
   end
 
   def build_plage_ouverture

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -108,9 +108,9 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def set_previous_page_title
     @previous_page_title = if current_agent == @plage_ouverture.agent
-                             "Vos plages d'ouverture"
+                             "Plages d’ouverture"
                            else
-                             "Plages d'ouverture de #{@plage_ouverture.agent.full_name_or_email}"
+                             "Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}"
                            end
   end
 

--- a/app/controllers/admin/plage_ouvertures_controller.rb
+++ b/app/controllers/admin/plage_ouvertures_controller.rb
@@ -4,6 +4,7 @@ class Admin::PlageOuverturesController < AgentAuthController
   before_action :set_plage_ouverture, only: %i[show edit update destroy]
   before_action :build_plage_ouverture, only: [:create]
   before_action :set_agent
+  before_action :set_previous_page_title, only: %i[show edit]
 
   def show
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
@@ -47,6 +48,7 @@ class Admin::PlageOuverturesController < AgentAuthController
       agent: @agent,
       **defaults
     )
+    set_previous_page_title
     authorize(@plage_ouverture, policy_class: Agent::PlageOuverturePolicy)
   end
 
@@ -102,6 +104,14 @@ class Admin::PlageOuverturesController < AgentAuthController
 
   def set_plage_ouverture
     @plage_ouverture = PlageOuverture.find(params[:id])
+  end
+
+  def set_previous_page_title
+    @previous_page_title = if current_agent == @plage_ouverture.agent
+                             "Vos plages d'ouverture"
+                           else
+                             "Plages d'ouverture de #{@plage_ouverture.agent.full_name_or_email}"
+                           end
   end
 
   def build_plage_ouverture

--- a/app/views/admin/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/plage_ouvertures/calendar.html.slim
@@ -3,9 +3,12 @@
 
 - content_for :title do
   - if current_agent == @agent
-    = t("admin.plage_ouvertures.index.your_plage_ouverture")
+    | Vos plages d'ouvertures
   - else
-    = t("admin.plage_ouvertures.index.plage_ouverture_of", full_name: @agent.full_name_and_service)
+    | Plages d'ouvertures de #{@agent.full_name_or_email}
+
+- content_for :fil_ariane do
+  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
 
 - content_for :breadcrumb do
   .text-right

--- a/app/views/admin/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/plage_ouvertures/calendar.html.slim
@@ -5,7 +5,7 @@
   - if current_agent == @agent
     | Vos plages d'ouvertures
   - else
-    | Plages d'ouvertures de #{@agent.full_name_or_email}
+    | Plages d'ouvertures de #{@agent.full_name_and_service}
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)

--- a/app/views/admin/plage_ouvertures/calendar.html.slim
+++ b/app/views/admin/plage_ouvertures/calendar.html.slim
@@ -3,9 +3,9 @@
 
 - content_for :title do
   - if current_agent == @agent
-    | Vos plages d'ouvertures
+    | Plages d’ouverture
   - else
-    | Plages d'ouvertures de #{@agent.full_name_and_service}
+    | Plages d’ouverture de #{@agent.full_name_and_service}
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)

--- a/app/views/admin/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/plage_ouvertures/edit.html.slim
@@ -6,15 +6,7 @@
   - else
     | Modifier la plage d'ouverture de #{@plage_ouverture.agent.full_name_or_email}
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0
-    li.breadcrumb-item
-      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
-        - if @plage_ouverture.agent == current_agent
-          | Vos plages d'ouverture
-        - else
-          | Plages d'ouverture de #{@plage_ouverture.agent.full_name_or_email}
-    li.breadcrumb-item.active
-      = link_to truncate(@plage_ouverture.title_with_default, length: 30), admin_organisation_plage_ouverture_path(@plage_ouverture.organisation, @plage_ouverture)
+- content_for :fil_ariane do
+  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], [@previous_page_title, admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/edit.html.slim
+++ b/app/views/admin/plage_ouvertures/edit.html.slim
@@ -7,6 +7,9 @@
     | Modifier la plage d'ouverture de #{@plage_ouverture.agent.full_name_or_email}
 
 - content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], [@previous_page_title, admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
+  - if current_agent == @plage_ouverture.agent
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
+  - else
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -5,7 +5,7 @@
   - if current_agent == @agent
     | Vos plages d'ouvertures
   - else
-    | Plages d'ouvertures de #{@agent.full_name_or_email}
+    | Plages d'ouvertures de #{@agent.full_name_and_service}
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -3,9 +3,12 @@
 
 - content_for :title do
   - if current_agent == @agent
-    = t(".your_plage_ouverture")
+    | Vos plages d'ouvertures
   - else
-    = t(".plage_ouverture_of", full_name: @agent.full_name_and_service)
+    | Plages d'ouvertures de #{@agent.full_name_or_email}
+
+- content_for :fil_ariane do
+  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)
 
 - content_for :breadcrumb do
   .text-right

--- a/app/views/admin/plage_ouvertures/index.html.slim
+++ b/app/views/admin/plage_ouvertures/index.html.slim
@@ -3,9 +3,9 @@
 
 - content_for :title do
   - if current_agent == @agent
-    | Vos plages d'ouvertures
+    | Plages d’ouverture
   - else
-    | Plages d'ouvertures de #{@agent.full_name_and_service}
+    | Plages d’ouverture de #{@agent.full_name_and_service}
 
 - content_for :fil_ariane do
   = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path]], current_page_title: yield(:title)

--- a/app/views/admin/plage_ouvertures/new.html.slim
+++ b/app/views/admin/plage_ouvertures/new.html.slim
@@ -7,15 +7,7 @@
   - else
     | Nouvelle plage d'ouverture pour #{@plage_ouverture.agent.full_name_or_email}
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0
-    li.breadcrumb-item
-      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
-        - if @plage_ouverture.agent == current_agent
-          | Vos plages d'ouverture
-        - else
-          | Plages d'ouverture de #{@plage_ouverture.agent.full_name_or_email}
-    li.breadcrumb-item.active
-      | Nouvelle plage
+- content_for :fil_ariane do
+  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], [@previous_page_title, admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/new.html.slim
+++ b/app/views/admin/plage_ouvertures/new.html.slim
@@ -8,6 +8,9 @@
     | Nouvelle plage d'ouverture pour #{@plage_ouverture.agent.full_name_or_email}
 
 - content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], [@previous_page_title, admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
+  - if current_agent == @plage_ouverture.agent
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
+  - else
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 = render "form", plage_ouverture: @plage_ouverture, agent: @agent

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -3,16 +3,8 @@
 - content_for :title do
   = truncate(@plage_ouverture.title_with_default, length: 40)
 
-- content_for :breadcrumb do
-  ol.breadcrumb.m-0.p-0
-    li.breadcrumb-item
-      = link_to admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent) do
-        - if @plage_ouverture.agent == current_agent
-          | Vos plages d'ouverture
-        - else
-          | Plages d'ouverture de #{@plage_ouverture.agent.full_name_or_email}
-    li.breadcrumb-item.active
-      = truncate(@plage_ouverture.title_with_default, length: 30)
+- content_for :fil_ariane do
+  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], [@previous_page_title, admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 .row.justify-content-center
   .col-md-6.mb-3

--- a/app/views/admin/plage_ouvertures/show.html.slim
+++ b/app/views/admin/plage_ouvertures/show.html.slim
@@ -4,7 +4,10 @@
   = truncate(@plage_ouverture.title_with_default, length: 40)
 
 - content_for :fil_ariane do
-  = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], [@previous_page_title, admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
+  - if current_agent == @plage_ouverture.agent
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
+  - else
+    = render "common/fil_ariane", titles_and_paths: [["Accueil", root_path], ["Plages d’ouverture de #{@plage_ouverture.agent.full_name_and_service}", admin_organisation_agent_plage_ouvertures_path(@plage_ouverture.organisation, @plage_ouverture.agent)]], current_page_title: yield(:title)
 
 .row.justify-content-center
   .col-md-6.mb-3

--- a/config/locales/views/plage_ouvertures.fr.yml
+++ b/config/locales/views/plage_ouvertures.fr.yml
@@ -2,8 +2,6 @@ fr:
   admin:
     plage_ouvertures:
       index:
-        your_plage_ouverture: Vos plages d'ouvertures
-        plage_ouverture_of: Plages d'ouverture de %{full_name}
         calendar_view: Vue calendrier
         list_view: Vue liste
         create_plage_ouverture: Créer une plage d'ouverture

--- a/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
+++ b/spec/features/agents/agent_can_crud_plage_ouvertures_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
 
   shared_examples "can crud own plage ouvertures" do
     it "works" do
-      expect_page_title("Vos plages d'ouverture")
+      expect_page_title("Plages d’ouverture")
       click_link "Permanence"
 
       expect_page_title("Permanence")
@@ -24,18 +24,18 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Libellé (facultatif)", with: "La belle plage"
       click_button("Enregistrer")
 
-      expect_page_title("Vos plages d'ouverture")
+      expect_page_title("Plages d’ouverture")
       click_on("La belle plage")
       click_link("Supprimer")
 
-      expect_page_title("Vos plages d'ouverture")
+      expect_page_title("Plages d’ouverture")
       expect(page).to have_content("Vous n'avez pas encore créé de plage d'ouverture")
 
       # Navigate back and forth between the list and the detail
       click_link "Créer une plage d'ouverture", match: :first
       expect_page_title("Nouvelle plage d'ouverture")
       click_link("Annuler")
-      expect_page_title("Vos plages d'ouverture")
+      expect_page_title("Plages d’ouverture")
       click_link "Créer une plage d'ouverture", match: :first
       expect_page_title("Nouvelle plage d'ouverture")
 
@@ -44,7 +44,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       check "Suivi bonjour"
       click_button "Créer la plage d'ouverture"
       expect(PlageOuverture.last.title).to eq("Accueil")
-      expect_page_title("Vos plages d'ouverture")
+      expect_page_title("Plages d’ouverture")
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     let(:agent) { create(:agent, :secretaire, basic_role_in_organisations: [organisation]) }
 
     it "cannot create plage_ouverture" do
-      expect_page_title("Vos plages d'ouverture")
+      expect_page_title("Plages d’ouverture")
       click_link "Créer une plage d'ouverture", match: :first
       expect(page).to have_content("Aucun motif disponible. Vous ne pouvez pas créer de plage d'ouverture.")
     end
@@ -98,7 +98,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
     it "can crud a plage_ouverture", js: true do
       visit admin_organisation_agent_plage_ouvertures_path(organisation, other_agent.id)
 
-      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)") # vue liste
+      expect_page_title("Plages d’ouverture de Jane FAROU (PMI)") # vue liste
       expect(page).to have_content "Permanence"
       click_link "Vue calendrier"
       expect(page).to have_content "Semaine" # necessary to make sure the calendar page has loaded
@@ -111,14 +111,14 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       fill_in "Libellé (facultatif)", with: "La belle plage"
       click_button("Enregistrer")
 
-      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
       click_on("La belle plage")
       expect(page).to have_content("La belle plage")
       accept_confirm do
         click_link("Supprimer")
       end
 
-      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
       expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
 
       click_link "Renseigner les disponibilités de Jane FAROU", match: :first
@@ -131,7 +131,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       expect(page).to have_content("Plage d'ouverture créée")
 
       expect(PlageOuverture.last.title).to eq("Accueil")
-      expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+      expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
     end
 
     context "when the motif doesn't require a lieu" do
@@ -141,7 +141,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
       it "still can crud a plage_ouverture" do
         visit admin_organisation_agent_plage_ouvertures_path(organisation, other_agent.id)
 
-        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
         click_link "Permanence"
 
         expect_page_title("Permanence")
@@ -151,11 +151,11 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         fill_in "Libellé (facultatif)", with: "La belle plage"
         click_button("Enregistrer")
 
-        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
         click_on("La belle plage")
         click_link("Supprimer")
 
-        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
         expect(page).to have_content("Jane FAROU n'a pas encore créé de plage d'ouverture")
 
         click_link "Renseigner les disponibilités de Jane FAROU", match: :first
@@ -165,7 +165,7 @@ RSpec.describe "Agent can CRUD plage d'ouverture" do
         check "Suivi bonjour"
         click_button "Créer la plage d'ouverture"
         expect(PlageOuverture.last.title).to eq("Accueil")
-        expect_page_title("Plages d'ouverture de Jane FAROU (PMI)")
+        expect_page_title("Plages d’ouverture de Jane FAROU (PMI)")
       end
     end
   end


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5392.osc-secnum-fr1.scalingo.io/) 

# Contexte

Dans notre volonté d’uniformiser les fils d’ariane, on passe au DSFR les fils d’ariane des plages d’ouverture.

# Solution

- Passage au DSFR des fils d’ariane des plages d’ouverture
- Passage de « Vos plages d’ouverture » à « Plages d’ouverture » pour être cohérent avec le menu et le reste de l’application
- Suppression des `s` à ouvertures
- Rétablissement du souligement des liens dans les fils d’ariane par soucis d’accessibilité (le contraste ne suffit pas pour indiquer qu’il s’agit d’un lien).

## Captures d'écran

Avant | Après
:- | -:
<img width="702" alt="image" src="https://github.com/user-attachments/assets/822ebbe9-5504-42a7-8f4e-1816fe8046b6" /> | <img width="748" alt="image" src="https://github.com/user-attachments/assets/95b598fd-53da-489d-9092-bdf37c01bf45" />
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/82fc3f55-18f1-4ee5-b333-3be843541267" /> | <img width="574" alt="image" src="https://github.com/user-attachments/assets/ad9eedd2-9eda-4356-a1b0-2dc7d73d7657" />
