### PR TITLE
ouvrir les liens de la page de synchro Outlook dans des nouvelles fenêtres

### DIFF
--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -132,7 +132,3 @@
   justify-content: flex-start;
   text-align: left;
 }
-
-.rdv-external-link-without-arrow[target="_blank"]::after {
-  display: none;
-}

--- a/app/javascript/stylesheets/components/_utilities_dsfr.scss
+++ b/app/javascript/stylesheets/components/_utilities_dsfr.scss
@@ -132,3 +132,7 @@
   justify-content: flex-start;
   text-align: left;
 }
+
+.rdv-external-link-without-arrow[target="_blank"]::after {
+  display: none;
+}

--- a/app/views/agents/outlook_sync/show.html.slim
+++ b/app/views/agents/outlook_sync/show.html.slim
@@ -18,7 +18,7 @@
     | Vous pouvez synchroniser automatiquement et en temps réel vos rendez-vous sur votre agenda Microsoft Office 365 en connectant votre compte grâce au bouton ci-dessous :
 
   div.rdv-text-align-center
-    = link_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", class: "mb-4 rdv-external-link-without-arrow", method: :post, target: "_blank", title: "S'identifier avec Microsoft - s’ouvre dans une nouvelle fenêtre" do
+    = link_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", class: "mb-4", method: :post do
       = image_tag("sign_in_with_microsoft.svg", alt: "S'identifier avec Microsoft")
 
   p
@@ -34,5 +34,5 @@
 
   p
     |> Si vous avez besoin d'aide, vous pouvez nous contacter via le
-    = link_to "formulaire de contact", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation Outlook"), target: "_blank", rel: "noopener", title: "formulaire de contact - s’ouvre dans une nouvelle fenêtre"
+    = link_to "formulaire de contact", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation Outlook")
     | .

--- a/app/views/agents/outlook_sync/show.html.slim
+++ b/app/views/agents/outlook_sync/show.html.slim
@@ -18,7 +18,7 @@
     | Vous pouvez synchroniser automatiquement et en temps réel vos rendez-vous sur votre agenda Microsoft Office 365 en connectant votre compte grâce au bouton ci-dessous :
 
   div.rdv-text-align-center
-    = link_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", class: "mb-4", method: :post do
+    = link_to "/omniauth/microsoft_graph?login_hint=#{current_agent.email}", class: "mb-4 rdv-external-link-without-arrow", method: :post, target: "_blank", title: "S'identifier avec Microsoft - s’ouvre dans une nouvelle fenêtre" do
       = image_tag("sign_in_with_microsoft.svg", alt: "S'identifier avec Microsoft")
 
   p
@@ -30,9 +30,9 @@
     | Retrouvez toutes les étapes à suivre en consultant notre documentation :
 
   .rdv-text-align-center.fr-mb-2w
-    = link_to "Consulter la documentation", "https://aide.rdv-service-public.fr/toutes-les-notions/synchronisation-outlook-microsoft-365", class: "fr-btn fr-btn--secondary"
+    = link_to "Consulter la documentation", "https://aide.rdv-service-public.fr/toutes-les-notions/synchronisation-outlook-microsoft-365", class: "fr-btn fr-btn--secondary", target: "_blank", rel: "noopener", title: "Consulter la documentation - s’ouvre dans une nouvelle fenêtre"
 
   p
     |> Si vous avez besoin d'aide, vous pouvez nous contacter via le
-    = link_to "formulaire de contact", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation Outlook")
+    = link_to "formulaire de contact", new_aide_demande_support_path(role: "agent", sujet: "Synchronisation Outlook"), target: "_blank", rel: "noopener", title: "formulaire de contact - s’ouvre dans une nouvelle fenêtre"
     | .


### PR DESCRIPTION
[Review app](https://demo-rdv-solidarites-pr5394.osc-secnum-fr1.scalingo.io/) 

# Contexte

Demandé par @Teodora-Stanki et @mekaidmekaid 

Je suis personnellement aligné sur le lien « Consulter la doc » car c’est un site externe (malheureusement).

J’ai en revanhce signalé que çe ne me semblait pas très pertinent sur les liens suivants, mais je n’ai pas un avis très fort : 

- « Se connecter avec MS »  car généralement les flows d’oauth se font dans la même tab ou une popup
- « Formulaire de contact » car il n’y a pas de changement de domaine

# Solution

target="_blank" partout ! 

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/ebf2d566-f7f7-4bad-9a19-bdea7beadb97" />

on ne peut pas customiser simplement le bouton « Se Connecter avec MS » donc pas facile d’ajouter la flêche pour indiquer que c’est un lien nouvelle fenêtre

J’ai ajouté des titles et des rel="noopener" comme indiqué dans la doc DSFR https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/lien/